### PR TITLE
[codex] Add Tauri notes MVP plan

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-tauri-note-mvp"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read
+`specs/001-tauri-note-mvp/plan.md`.
 <!-- SPECKIT END -->

--- a/specs/001-tauri-note-mvp/checklists/requirements.md
+++ b/specs/001-tauri-note-mvp/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Tauri Notes MVP
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-19  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in product requirements
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] Implementation constraints are isolated from user-facing requirements
+
+## Notes
+
+- Tauri and macOS constraints are intentionally isolated in "Platform Constraints for Planning" because the user explicitly requested a Tauri macOS MVP specification.
+- Meetings, realtime transcription, system audio, billing, calendar, chat, auth, sharing, and workspace functionality are explicitly out of scope.

--- a/specs/001-tauri-note-mvp/contracts/commands.md
+++ b/specs/001-tauri-note-mvp/contracts/commands.md
@@ -1,0 +1,443 @@
+# Command Contracts: Tauri Notes MVP
+
+The frontend communicates with the Rust backend through Tauri commands only. Commands return JSON-serializable DTOs and use structured errors with `code`, `message`, and optional `details`.
+
+## Shared Types
+
+```ts
+type ProcessingStatus =
+  | "draft"
+  | "recording"
+  | "validating"
+  | "transcribing"
+  | "generating"
+  | "ready"
+  | "failed"
+  | "recoverable";
+
+type RecordingState =
+  | "idle"
+  | "permission_denied"
+  | "recording"
+  | "paused"
+  | "finalizing"
+  | "validating"
+  | "invalid"
+  | "ready"
+  | "failed"
+  | "recoverable";
+
+type AppError = {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+};
+```
+
+## App Bootstrap
+
+### `bootstrap_app`
+
+Loads initial app state and performs recovery scan.
+
+**Request**: none
+
+**Response**:
+
+```ts
+type BootstrapResponse = {
+  folders: FolderDto[];
+  notes: NoteListItemDto[];
+  activeRecoveries: RecoverableRecordingDto[];
+  providerConfigured: boolean;
+};
+```
+
+**Errors**:
+- `storage_unavailable`
+- `migration_failed`
+- `recovery_scan_failed`
+
+## Folder Commands
+
+### `create_folder`
+
+**Request**:
+
+```ts
+type CreateFolderRequest = {
+  name: string;
+};
+```
+
+**Response**: `FolderDto`
+
+**Errors**:
+- `folder_name_required`
+- `folder_name_duplicate`
+- `storage_write_failed`
+
+### `list_folders`
+
+**Request**: none
+
+**Response**: `FolderDto[]`
+
+### `assign_note_to_folder`
+
+**Request**:
+
+```ts
+type AssignNoteToFolderRequest = {
+  noteId: string;
+  folderId: string;
+};
+```
+
+**Response**: `NoteDto`
+
+**Errors**:
+- `note_not_found`
+- `folder_not_found`
+- `storage_write_failed`
+
+### `remove_note_from_folder`
+
+**Request**:
+
+```ts
+type RemoveNoteFromFolderRequest = {
+  noteId: string;
+  folderId: string;
+};
+```
+
+**Response**: `NoteDto`
+
+## Note Commands
+
+### `create_note`
+
+Creates a draft note, optionally assigned to a folder.
+
+**Request**:
+
+```ts
+type CreateNoteRequest = {
+  folderId?: string;
+};
+```
+
+**Response**: `NoteDto`
+
+### `list_notes`
+
+Lists notes in reverse chronological order.
+
+**Request**:
+
+```ts
+type ListNotesRequest = {
+  folderId?: string;
+  limit?: number;
+  cursor?: string;
+};
+```
+
+**Response**:
+
+```ts
+type ListNotesResponse = {
+  notes: NoteListItemDto[];
+  nextCursor?: string;
+};
+```
+
+### `get_note`
+
+**Request**:
+
+```ts
+type GetNoteRequest = {
+  noteId: string;
+};
+```
+
+**Response**: `NoteDto`
+
+### `update_note`
+
+Autosaves editable note fields.
+
+**Request**:
+
+```ts
+type UpdateNoteRequest = {
+  noteId: string;
+  title?: string;
+  editedContent?: string;
+  activeTab?: "notes" | "transcription";
+};
+```
+
+**Response**: `NoteDto`
+
+**Errors**:
+- `note_not_found`
+- `storage_write_failed`
+
+## Recording Commands
+
+### `get_microphone_permission_state`
+
+**Request**: none
+
+**Response**:
+
+```ts
+type MicrophonePermissionResponse = {
+  state: "unknown" | "granted" | "denied" | "restricted";
+  recoveryHint?: string;
+};
+```
+
+### `start_recording`
+
+Requests or verifies microphone permission, creates a recording session, starts microphone capture, and begins writing a partial file.
+
+**Request**:
+
+```ts
+type StartRecordingRequest = {
+  noteId: string;
+};
+```
+
+**Response**:
+
+```ts
+type RecordingSessionDto = {
+  id: string;
+  noteId: string;
+  state: RecordingState;
+  startedAt: string;
+  elapsedMs: number;
+  deviceLabel?: string;
+  level: AudioLevelDto;
+};
+```
+
+**Errors**:
+- `microphone_permission_denied`
+- `microphone_unavailable`
+- `recording_already_active`
+- `audio_writer_failed`
+- `storage_write_failed`
+
+### `pause_recording`
+
+**Request**:
+
+```ts
+type PauseRecordingRequest = {
+  sessionId: string;
+};
+```
+
+**Response**: `RecordingSessionDto`
+
+### `resume_recording`
+
+**Request**:
+
+```ts
+type ResumeRecordingRequest = {
+  sessionId: string;
+};
+```
+
+**Response**: `RecordingSessionDto`
+
+### `get_recording_status`
+
+Returns elapsed time, state, and current audio level/waveform summary for UI polling or event reconciliation.
+
+**Request**:
+
+```ts
+type GetRecordingStatusRequest = {
+  sessionId: string;
+};
+```
+
+**Response**:
+
+```ts
+type RecordingStatusDto = {
+  sessionId: string;
+  state: RecordingState;
+  elapsedMs: number;
+  level: AudioLevelDto;
+  silenceWarning: boolean;
+  bytesWritten: number;
+};
+```
+
+### `finish_recording`
+
+Finalizes the audio file, validates it, and starts transcription/generation only when validation passes.
+
+**Request**:
+
+```ts
+type FinishRecordingRequest = {
+  sessionId: string;
+};
+```
+
+**Response**:
+
+```ts
+type FinishRecordingResponse = {
+  note: NoteDto;
+  recording: RecordingSessionDto;
+  validation: AudioValidationDto;
+  processingStarted: boolean;
+};
+```
+
+**Errors**:
+- `recording_not_found`
+- `audio_finalization_failed`
+- `audio_validation_failed`
+- `storage_write_failed`
+
+## Processing Commands
+
+### `retry_processing`
+
+Retries transcription and/or generation from the saved audio or transcript.
+
+**Request**:
+
+```ts
+type RetryProcessingRequest = {
+  noteId: string;
+  step?: "transcription" | "generation" | "all";
+};
+```
+
+**Response**: `NoteDto`
+
+**Errors**:
+- `note_not_found`
+- `audio_artifact_missing`
+- `provider_not_configured`
+- `transcription_failed`
+- `generation_failed`
+
+### `recover_recording`
+
+Attempts to recover an interrupted session after startup scan.
+
+**Request**:
+
+```ts
+type RecoverRecordingRequest = {
+  sessionId: string;
+  action: "validate" | "discard";
+};
+```
+
+**Response**: `NoteDto`
+
+## DTOs
+
+```ts
+type FolderDto = {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type NoteListItemDto = {
+  id: string;
+  title: string;
+  preview: string;
+  processingStatus: ProcessingStatus;
+  folderIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  durationMs?: number;
+};
+
+type NoteDto = NoteListItemDto & {
+  generatedContent?: string;
+  editedContent?: string;
+  transcript?: TranscriptDto;
+  recording?: RecordingSessionDto;
+  audio?: AudioArtifactDto;
+  activeTab?: "notes" | "transcription";
+  lastError?: string;
+};
+
+type TranscriptDto = {
+  id: string;
+  text: string;
+  language?: string;
+  status: "pending" | "running" | "succeeded" | "failed";
+  lastError?: string;
+};
+
+type AudioArtifactDto = {
+  id: string;
+  format: "wav";
+  durationMs: number;
+  sizeBytes: number;
+  checksum: string;
+  createdAt: string;
+};
+
+type AudioLevelDto = {
+  peak: number;
+  rms: number;
+  recentPeaks: number[];
+};
+
+type AudioValidationDto = {
+  fileExists: boolean;
+  nonZeroSize: boolean;
+  readableAudio: boolean;
+  expectedDurationMs: number;
+  actualDurationMs: number;
+  durationWithinTolerance: boolean;
+  nonSilentSignal: boolean;
+  peakAmplitude: number;
+  rmsAmplitude: number;
+  warnings: string[];
+};
+
+type RecoverableRecordingDto = {
+  sessionId: string;
+  noteId: string;
+  startedAt: string;
+  partialPathPresent: boolean;
+  finalPathPresent: boolean;
+  bytesFound: number;
+};
+```
+
+## Event Contract
+
+The backend may emit events to keep the UI responsive between command calls.
+
+```ts
+type BackendEvent =
+  | { type: "recording-level"; sessionId: string; level: AudioLevelDto; elapsedMs: number; silenceWarning: boolean }
+  | { type: "recording-state"; sessionId: string; state: RecordingState; message?: string }
+  | { type: "note-updated"; note: NoteDto }
+  | { type: "processing-state"; noteId: string; status: ProcessingStatus; message?: string };
+```
+
+Events are advisory. Commands and persisted state remain authoritative after reload.

--- a/specs/001-tauri-note-mvp/contracts/ui.md
+++ b/specs/001-tauri-note-mvp/contracts/ui.md
@@ -1,0 +1,93 @@
+# UI Contract: Tauri Notes MVP
+
+## Primary Window
+
+The MVP has one persistent desktop window.
+
+```text
+┌──────────────────┬──────────────────────────────────────────┐
+│ OS Notetaker     │ Notes list or selected note editor        │
+│ + New Folder     │                                          │
+│ All Notes        │                                          │
+│ Folder A         │                                          │
+│ Folder B         │                                          │
+└──────────────────┴──────────────────────────────────────────┘
+```
+
+## Sidebar Contract
+
+Required visible items:
+- App name: `OS Notetaker`
+- `+ New Folder`
+- `All Notes`
+- User folders
+
+Behavior:
+- Selecting `All Notes` shows all notes in reverse chronological order.
+- Selecting a folder filters the note list to notes assigned to that folder.
+- Creating a folder inserts it into the sidebar and selects it.
+- The sidebar must not show workspace, auth, billing, meetings, calendar, chat, sharing, or system audio controls.
+
+## Notes List Contract
+
+Empty state:
+- Shows a prominent create-note action.
+- Uses direct, non-marketing copy.
+- If a selected folder is empty, offers a clear create-note or assignment path.
+
+Populated state:
+- Shows note title or `New note` placeholder.
+- Shows enough preview/status metadata to identify the note.
+- Sorts by `created_at` in reverse chronological order.
+- Shows processing/retry status when a note is `recording`, `validating`, `transcribing`, `generating`, `failed`, or `recoverable`.
+
+## Note Editor Contract
+
+Required elements:
+- Large title field with placeholder `New note`.
+- Tabs: `Notes` and `Transcription`.
+- Editable generated note area under `Notes`.
+- Scrollable raw transcript under `Transcription`.
+- Folder assignment control.
+- Bottom recording controls with `Pause`, waveform/audio visualization, and `Done` while recording.
+
+Behavior:
+- Title and note body autosave.
+- Switching tabs does not lose edits.
+- If transcript is missing because processing failed, `Transcription` shows the failure and retry action when saved audio exists.
+- Ready notes keep raw transcript available even after note content is edited.
+
+## Recording Control Contract
+
+Idle/draft:
+- User can start microphone recording from a draft note.
+- If microphone permission is denied, UI shows the recovery path and does not pretend to record.
+
+Recording:
+- UI shows active state, elapsed time, live waveform/level movement, and reachable `Pause` and `Done`.
+- Sustained silence or no bytes written produces a visible warning before Done.
+- `Pause` toggles to resume behavior without losing previously recorded audio.
+
+Done/finalizing:
+- UI shows finalizing/validating before transcription.
+- The note does not advance to provider processing unless validation passes.
+
+Failed:
+- Local audio failures explain what failed.
+- Provider failures preserve audio and offer retry.
+
+Recoverable:
+- Startup surfaces recoverable recordings with validate/discard actions.
+
+## Visual Direction
+
+- Native-feeling macOS desktop utility, not a marketing page.
+- Use a Liquid Glass-inspired treatment as polish for the Tauri webview, not as a hard dependency on native SwiftUI `glassEffect`.
+- Apply restrained translucency, blur, subtle borders, and vibrancy-like foreground contrast to the sidebar, editor surfaces, and bottom recorder controls.
+- Keep glass styling functional: recording, paused, validating, transcribing, failed, and ready states must remain more legible than the visual effect.
+- Avoid heavy custom blur layers, opaque overlays, decorative gradients, and one-off glass surfaces that make the app feel busy or reduce accessibility.
+- Ensure the UI degrades cleanly to solid macOS-style surfaces if webview glass effects are unavailable, slow, or visually unclear.
+- Fluid but restrained transitions and immediate control feedback.
+- Stable sidebar/list/editor geometry.
+- Polished spacing and typography, with no nested card-heavy layout.
+- Recorder visualization near the bottom center of the note screen.

--- a/specs/001-tauri-note-mvp/data-model.md
+++ b/specs/001-tauri-note-mvp/data-model.md
@@ -1,0 +1,177 @@
+# Data Model: Tauri Notes MVP
+
+## Folder
+
+Local organizational container.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `name` | string | Yes | Unique among non-deleted folders after trimming |
+| `created_at` | timestamp | Yes | Local creation time |
+| `updated_at` | timestamp | Yes | Updated on rename or assignment changes |
+| `deleted_at` | timestamp | No | Soft delete for recovery-safe cleanup |
+
+**Relationships**:
+- Many-to-many with `Note` through `note_folders`.
+
+**Validation**:
+- Name must not be blank after trimming.
+- Duplicate active folder names are rejected or de-duplicated by UI before save.
+
+## Note
+
+User-created note record with generated and editable content.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `title` | string | Yes | Defaults to empty title rendered as `New note` placeholder |
+| `generated_content` | text | No | Last generated note body |
+| `edited_content` | text | No | User-edited note body, source of truth after edit |
+| `active_tab` | enum | No | UI preference: `notes` or `transcription` |
+| `processing_status` | enum | Yes | `draft`, `recording`, `validating`, `transcribing`, `generating`, `ready`, `failed`, `recoverable` |
+| `created_at` | timestamp | Yes | Used for reverse chronological listing |
+| `updated_at` | timestamp | Yes | Updated on edits and processing changes |
+| `last_error` | text | No | User-facing failure summary |
+
+**Relationships**:
+- Many-to-many with `Folder`.
+- Has many `RecordingSession`.
+- Has zero or one current `Transcript`.
+- Has many `GenerationResult` attempts.
+
+**Validation**:
+- A note may exist without audio in `draft`.
+- A note with `ready` status must have either generated or edited content.
+- Failed provider states must preserve links to any valid saved audio.
+
+## NoteFolder
+
+Join table for reversible folder assignment.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `note_id` | UUID string | Yes | References `Note` |
+| `folder_id` | UUID string | Yes | References `Folder` |
+| `assigned_at` | timestamp | Yes | Used for audit/debugging |
+
+**Validation**:
+- Unique `(note_id, folder_id)`.
+- Removing an assignment never deletes the note.
+
+## RecordingSession
+
+Capture lifecycle record for one recording attempt.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `note_id` | UUID string | Yes | References `Note` |
+| `status` | enum | Yes | `created`, `recording`, `paused`, `finalizing`, `validating`, `valid`, `invalid`, `recoverable`, `failed` |
+| `started_at` | timestamp | Yes | Set before audio writer starts |
+| `ended_at` | timestamp | No | Set when user selects Done or recovery finalizes |
+| `expected_elapsed_ms` | integer | Yes | Active recording time excluding pauses |
+| `device_label` | string | No | Best-effort microphone label |
+| `permission_state` | enum | Yes | `unknown`, `granted`, `denied`, `restricted` |
+| `partial_path` | string | No | App-local temporary path while recording |
+| `final_path` | string | No | App-local finalized path |
+| `file_size_bytes` | integer | No | Captured after finalization |
+| `duration_ms` | integer | No | Parsed from readable audio |
+| `checksum` | string | No | Integrity marker for finalized audio |
+| `peak_amplitude` | float | No | Validation summary |
+| `rms_amplitude` | float | No | Validation summary |
+| `silent_window_ms` | integer | No | Longest detected near-silent span |
+| `validation_summary` | JSON | No | Detailed check results |
+| `last_error` | text | No | Failure details |
+
+**Relationships**:
+- Belongs to one `Note`.
+- Produces zero or one `AudioArtifact`.
+- Has many `RecordingCheckpoint`.
+
+**State transitions**:
+- `created` -> `recording`
+- `recording` -> `paused` -> `recording`
+- `recording` or `paused` -> `finalizing` -> `validating`
+- `validating` -> `valid` or `invalid`
+- Any active state -> `recoverable` on restart if audio bytes exist
+- Any active state -> `failed` if no recoverable audio exists
+
+## RecordingCheckpoint
+
+Append-only checkpoint for observability and recovery.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `recording_session_id` | UUID string | Yes | References `RecordingSession` |
+| `kind` | enum | Yes | `start`, `pause`, `resume`, `done`, `file_write`, `validation`, `transcription`, `generation`, `completion`, `failure` |
+| `created_at` | timestamp | Yes | Event time |
+| `details` | JSON | No | Structured details for debugging |
+
+## AudioArtifact
+
+Finalized local audio file metadata.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `note_id` | UUID string | Yes | References `Note` |
+| `recording_session_id` | UUID string | Yes | References `RecordingSession` |
+| `path` | string | Yes | App-local finalized path |
+| `format` | string | Yes | MVP default `wav` |
+| `duration_ms` | integer | Yes | Parsed from readable file |
+| `size_bytes` | integer | Yes | Must be non-zero |
+| `checksum` | string | Yes | Integrity marker |
+| `created_at` | timestamp | Yes | Finalization time |
+
+**Validation**:
+- File must exist, be non-zero, readable as audio, and match expected duration within tolerance.
+- Audio must contain non-silent signal above configured threshold before provider processing.
+
+## Transcript
+
+Transcription result from saved audio.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `note_id` | UUID string | Yes | References `Note` |
+| `audio_artifact_id` | UUID string | Yes | References source audio |
+| `text` | text | Yes | Raw transcript exactly as provider returned after normalization |
+| `language` | string | No | Provider detected language if available |
+| `provider` | string | Yes | `mock`, `openai`, or configured provider key |
+| `status` | enum | Yes | `pending`, `running`, `succeeded`, `failed` |
+| `retry_count` | integer | Yes | Starts at zero |
+| `last_error` | text | No | Failure details |
+| `created_at` | timestamp | Yes | First attempt time |
+| `updated_at` | timestamp | Yes | Last status change |
+
+**Validation**:
+- Successful transcript text must not be blank.
+- Empty provider responses become failed states with retry available.
+
+## GenerationResult
+
+AI-generated note content derived from a transcript.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | UUID string | Yes | Stable local id |
+| `note_id` | UUID string | Yes | References `Note` |
+| `transcript_id` | UUID string | Yes | References source transcript |
+| `content` | text | No | Generated note content |
+| `title_suggestion` | string | No | Optional generated title |
+| `provider` | string | Yes | `mock`, `openai`, or configured provider key |
+| `prompt_version` | string | Yes | Tracks generation rules |
+| `status` | enum | Yes | `pending`, `running`, `succeeded`, `failed` |
+| `retry_count` | integer | Yes | Starts at zero |
+| `last_error` | text | No | Failure details |
+| `created_at` | timestamp | Yes | First attempt time |
+| `updated_at` | timestamp | Yes | Last status change |
+
+**Validation**:
+- Successful content must not be blank.
+- Generation prompt must instruct the provider to use only the transcript and optional user note context.
+- Generated note language should match source transcript language unless explicitly changed later.

--- a/specs/001-tauri-note-mvp/plan.md
+++ b/specs/001-tauri-note-mvp/plan.md
@@ -1,0 +1,140 @@
+# Implementation Plan: Tauri Notes MVP
+
+**Branch**: `001-tauri-note-mvp` | **Date**: 2026-05-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-tauri-note-mvp/spec.md`
+
+**Note**: This plan stops at Phase 2 planning. Implementation begins only after `/speckit-tasks` generates `tasks.md` and the user approves moving forward.
+
+## Summary
+
+Build a macOS-first Tauri v2 desktop MVP for local notes, folders, microphone-only voice capture, saved audio validation, batch transcription, and AI-generated note output. The frontend will be a simple React + TypeScript single-window app with the required sidebar/list/editor layout and a Liquid Glass-inspired macOS visual treatment. The Rust backend owns local persistence, recording session state, audio artifact lifecycle, validation, recovery scanning, and provider calls for transcription/generation so the webview receives only scoped commands and app data, not broad filesystem or shell access.
+
+The MVP intentionally excludes legacy Electron/Next concepts: meetings, realtime transcription, system audio, calendar, billing, chat, auth, sharing, workspaces, and account state.
+
+## Technical Context
+
+**Language/Version**: Rust stable with Tauri v2 backend; TypeScript with React and Vite frontend. Rust minimum should satisfy current Tauri v2 requirements, with `>=1.77.2` as the planned lower bound.
+**Primary Dependencies**: Tauri v2, Vite, React, TypeScript, `@tauri-apps/api`, scoped Tauri capabilities, SQLite via Rust `sqlx`, microphone capture via `cpal`, WAV writing/reading via `hound`, checksums via `sha2`, native macOS microphone permission/signing configuration, provider adapters for transcription and note generation.
+**Storage**: Local SQLite database under the app data directory for folders, notes, processing records, checkpoints, transcripts, generation metadata, and audio artifact metadata. Audio files stored separately under app-local data, e.g. `recordings/{note_id}/{session_id}.wav` plus temporary `.partial` files during capture.
+**Testing**: Rust `cargo test` for backend domain, storage, validation, and recovery logic; TypeScript unit tests for UI state reducers/components; Playwright or Tauri-compatible UI smoke tests where practical; manual macOS recording verification using the quickstart scenarios.
+**Target Platform**: macOS first Tauri desktop application. Other desktop platforms are not MVP targets.
+**Project Type**: Desktop app with local Rust backend and webview frontend.
+**Performance Goals**: Recording UI updates feel immediate; notes list remains responsive with 500 local notes; 10,000-character transcript scrolls without blocking note editing; audio validation completes before remote processing begins; 20 consecutive 30-second spoken recordings produce readable saved audio.
+**Constraints**: Microphone-only capture; no system audio; no realtime transcription; audio must be finalized and validated locally before transcription/generation; provider/network failures must not delete local audio; frontend permissions must be scoped through Tauri capabilities; no broad filesystem or shell access from the webview; Liquid Glass is a UI polish constraint for the React/Tauri frontend, not a dependency on native SwiftUI `glassEffect`, and must degrade cleanly where exact native glass is unavailable.
+**Scale/Scope**: Single local user, one primary window, flat folder list, local-only MVP data, no sync/import/export/search/tags/settings surface unless required to run provider credentials in development.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The project constitution currently contains placeholder principles only and defines no enforceable gates. This plan uses the feature specification as the controlling project guidance.
+
+Pre-design gate status: PASS, with no active constitution constraints.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-tauri-note-mvp/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── commands.md
+│   └── ui.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+package.json
+pnpm-lock.yaml
+vite.config.ts
+tsconfig.json
+index.html
+
+src/
+├── app/
+│   ├── App.tsx
+│   ├── routes.ts
+│   └── state/
+├── components/
+│   ├── sidebar/
+│   ├── notes-list/
+│   ├── note-editor/
+│   └── recorder/
+├── lib/
+│   ├── tauri.ts
+│   ├── format.ts
+│   └── validation.ts
+├── styles/
+│   └── app.css
+└── test/
+
+src-tauri/
+├── Cargo.toml
+├── tauri.conf.json
+├── Entitlements.plist
+├── capabilities/
+│   └── main.json
+├── migrations/
+├── src/
+│   ├── main.rs
+│   ├── lib.rs
+│   ├── commands.rs
+│   ├── app_paths.rs
+│   ├── db/
+│   │   ├── mod.rs
+│   │   ├── migrations.rs
+│   │   └── repositories.rs
+│   ├── domain/
+│   │   ├── folders.rs
+│   │   ├── notes.rs
+│   │   ├── recording.rs
+│   │   └── processing.rs
+│   ├── audio/
+│   │   ├── capture.rs
+│   │   ├── validation.rs
+│   │   ├── waveform.rs
+│   │   └── recovery.rs
+│   ├── providers/
+│   │   ├── transcription.rs
+│   │   ├── generation.rs
+│   │   └── mock.rs
+│   └── telemetry.rs
+└── tests/
+    ├── recording_validation.rs
+    ├── storage.rs
+    └── recovery.rs
+```
+
+**Structure Decision**: Use a standard Tauri v2 app layout with a lightweight React/Vite frontend in `src/` and Rust command/domain modules in `src-tauri/src/`. Persistence, recording, validation, provider calls, and recovery live in Rust to keep reliability-critical behavior outside the webview. The frontend renders the macOS-style notes workflow and invokes only scoped commands documented in `contracts/commands.md`.
+
+## UI Polish Direction
+
+The frontend should use a Liquid Glass-inspired macOS treatment as a polish layer over the required notes workflow. This means restrained translucency, blur, subtle borders, vibrancy-like foreground contrast, and immediate control feedback on the sidebar, editor surfaces, and bottom recorder controls. It does not mean rebuilding the app as SwiftUI, adding native `glassEffect` as an MVP requirement, or introducing decorative complexity that competes with recording reliability.
+
+Implementation tasks should keep the glass treatment scoped, accessible, and easy to disable or simplify. Exact native Liquid Glass behavior is a best-effort visual reference for the Tauri webview, while reliable recording, validation, recovery, and local persistence remain the core MVP priorities.
+
+## Phase 0: Research Decisions
+
+See [research.md](./research.md). All planning unknowns are resolved there.
+
+## Phase 1: Design Artifacts
+
+See [data-model.md](./data-model.md), [contracts/commands.md](./contracts/commands.md), [contracts/ui.md](./contracts/ui.md), and [quickstart.md](./quickstart.md).
+
+## Post-Design Constitution Check
+
+The constitution remains placeholder-only and imposes no additional gates.
+
+Post-design gate status: PASS.
+
+## Complexity Tracking
+
+No constitution violations are present.

--- a/specs/001-tauri-note-mvp/quickstart.md
+++ b/specs/001-tauri-note-mvp/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: Tauri Notes MVP
+
+This quickstart describes the expected build/run/debug path once implementation begins. It is intentionally a plan artifact; commands may be finalized by `/speckit-tasks` and implementation.
+
+## Prerequisites
+
+- macOS development machine.
+- Rust stable installed.
+- Node.js and pnpm installed.
+- Xcode command line tools installed.
+- Microphone available and not blocked by macOS privacy settings.
+- Optional provider credentials configured through local development environment variables when testing real transcription/generation.
+
+## Planned Commands
+
+```sh
+pnpm install
+pnpm tauri dev
+pnpm test
+pnpm test:rust
+pnpm test:ui
+pnpm tauri build -- --bundles app
+```
+
+Implementation should add scripts with these names or document any final equivalents in `README.md`.
+
+## macOS Permission Debug Path
+
+1. Confirm `src-tauri/tauri.conf.json` includes a microphone usage description for the app bundle.
+2. Confirm `src-tauri/Entitlements.plist` includes the audio input entitlement needed by signed/sandboxed builds.
+3. Run the dev app from `pnpm tauri dev`.
+4. Start a recording from a draft note and verify macOS prompts for microphone access if permission has not been granted.
+5. If permission is denied, verify the UI shows a recovery hint.
+6. For local reset during development, use macOS Privacy & Security settings or `tccutil reset Microphone <bundle-id>` when appropriate.
+
+## Manual Scenario: Reliable Voice Note
+
+1. Open the app.
+2. Create a note from the list or empty state.
+3. Start microphone recording.
+4. Speak for at least 60 seconds.
+5. Verify elapsed time, active state, and waveform movement.
+6. Click Done.
+7. Verify the app shows finalizing, validating, transcribing, generating, then ready.
+8. Verify the note contains generated content and the Transcription tab contains raw transcript.
+9. Verify a finalized audio artifact exists in app-local storage and has non-zero size.
+
+Expected result: saved readable audio, transcript, generated note, and persisted metadata.
+
+## Manual Scenario: Silent Input
+
+1. Create a note.
+2. Mute or disconnect microphone input if possible.
+3. Record for at least 10 seconds.
+4. Verify the UI warns that input appears silent.
+5. Click Done.
+
+Expected result: validation fails or warns before provider processing, and the app does not generate a note from unusable audio.
+
+## Manual Scenario: Provider Failure Retry
+
+1. Record a valid spoken note.
+2. Disable network before clicking Done, or configure a mock provider failure.
+3. Click Done.
+4. Verify audio finalization and validation still succeed locally.
+5. Verify note status becomes failed with retry available.
+6. Restore network/provider.
+7. Retry processing.
+
+Expected result: retry uses saved audio without requiring a new recording.
+
+## Manual Scenario: Interrupted Recording Recovery
+
+1. Start recording and speak until bytes are being written.
+2. Force quit the app before clicking Done.
+3. Reopen the app.
+4. Verify the startup recovery scan surfaces a recoverable recording or note.
+5. Choose validate if audio bytes are available.
+
+Expected result: recoverable audio is preserved and can be validated or discarded intentionally.
+
+## Manual Scenario: Folders and Editing
+
+1. Create two folders.
+2. Create multiple notes.
+3. Assign notes to folders.
+4. Verify All Notes shows every note in reverse chronological order.
+5. Verify each folder shows assigned notes only.
+6. Edit a generated note title and body.
+7. Restart the app.
+
+Expected result: folder assignments, edits, transcript, and processing states persist locally.

--- a/specs/001-tauri-note-mvp/research.md
+++ b/specs/001-tauri-note-mvp/research.md
@@ -1,0 +1,110 @@
+# Research: Tauri Notes MVP
+
+## Decision: Tauri v2 with React, TypeScript, and Vite
+
+**Rationale**: The MVP is macOS-first but should remain small, local, and simpler than the legacy Electron/Next app. Tauri v2 gives a native desktop shell, explicit frontend-to-backend command boundaries, and macOS bundle/signing configuration without carrying a full Electron runtime. React + TypeScript + Vite is enough for the required sidebar, notes list, editor, tabs, and recorder controls without needing SSR or a server-oriented framework.
+
+**Alternatives considered**:
+- Electron + Next.js: rejected because the legacy app already shows that this path encourages meetings, auth, providers, and web app complexity outside MVP scope.
+- Native SwiftUI: attractive for macOS feel, but would require a larger rewrite of provider/storage/UI patterns and would not use the requested Tauri direction.
+- Svelte/Solid: viable, but React is more likely to reuse local TypeScript testing and component knowledge from the legacy reference without porting its architecture.
+
+## Decision: Liquid Glass-inspired UI polish, not native SwiftUI Liquid Glass dependency
+
+**Rationale**: The app should feel modern and native on macOS, but the Tauri frontend runs in a webview and should not depend on SwiftUI-only `glassEffect` APIs for the MVP. The plan will treat Liquid Glass as a visual direction: restrained translucent surfaces, blur, subtle borders, vibrancy-like contrast, and polished interaction feedback for the sidebar, editor, and bottom recorder. This keeps the UI aligned with macOS while preserving Tauri architecture and recording reliability priorities.
+
+**Alternatives considered**:
+- Native SwiftUI Liquid Glass implementation: rejected for MVP because it would move the frontend away from the planned React/Tauri architecture.
+- Heavy custom blur/glass everywhere: rejected because it risks readability, performance, and visual complexity.
+- No glass treatment: rejected because the user wants a more fluid and polished macOS feel than the legacy app.
+
+## Decision: Rust backend owns recording, validation, recovery, and provider orchestration
+
+**Rationale**: Audio reliability is the top priority. A backend-controlled recording lifecycle can checkpoint start/pause/resume/done events, write to deterministic app-local paths, finalize files atomically, validate artifacts before network calls, and recover incomplete sessions on startup. The frontend remains responsible for display and commands, while Rust owns the failure-prone parts.
+
+**Alternatives considered**:
+- Browser `MediaRecorder` as the primary artifact writer: rejected as the sole capture strategy because chunk persistence, file finalization, exact duration validation, and crash recovery are weaker when the webview owns the recording artifact.
+- Hybrid web capture plus backend save: possible fallback for early spikes, but final MVP should not depend on the webview as the system of record for audio.
+- Porting legacy native system-audio helper: rejected because system audio and meeting capture are explicitly out of scope.
+
+## Decision: Microphone-only audio saved as local WAV/PCM for MVP reliability
+
+**Rationale**: WAV/PCM is larger than compressed formats but simpler to finalize, inspect, read, measure, and validate. For a local MVP, transparent validation is more important than storage efficiency. The app can derive duration from headers/samples, compute RMS/peak/silence windows, and send provider-compatible audio after validation.
+
+**Alternatives considered**:
+- WebM/Opus: compact but less direct for native macOS validation and provider compatibility.
+- M4A/AAC: practical long-term, but introduces encoder/container details that are not needed for MVP validation.
+- Raw PCM only: easy to analyze but inconvenient for playback and provider upload without wrapping metadata.
+
+## Decision: SQLite metadata via backend `sqlx` plus file-backed audio artifacts
+
+**Rationale**: Notes, folders, statuses, checkpoints, transcripts, generation results, retry history, and validation results are relational enough for SQLite. Audio should remain file-backed to avoid bloating the database and to preserve recoverable artifacts even when provider calls fail. The database records checksums, sizes, durations, and state transitions so recovery can reconcile metadata with files.
+
+**Alternatives considered**:
+- JSON files only: simpler initially, but harder to query reverse-chronological lists, folder membership, retry history, and 500-note responsiveness safely.
+- Audio blobs in SQLite: rejected because large binary writes complicate backup, validation, streaming/playback, and crash recovery.
+- Tauri SQL plugin from the frontend: rejected for MVP because storage writes should go through backend domain commands that also checkpoint recording and processing state.
+- External cloud database/storage: out of scope for local-only MVP.
+
+## Decision: Use `cpal` for microphone capture and `hound` for WAV validation
+
+**Rationale**: The backend needs direct access to microphone samples, byte-write progress, waveform summaries, silence detection, and recoverable local files. `cpal` is the standard Rust cross-platform audio I/O crate and can support the macOS-first MVP without introducing system-audio capture. `hound` keeps WAV writing and readable-file validation straightforward.
+
+**Alternatives considered**:
+- Browser `MediaRecorder`: useful as a reference for web recording patterns, but not authoritative enough for crash recovery and backend validation.
+- AVFoundation-specific Swift helper: possible if `cpal` cannot satisfy macOS behavior during implementation, but it adds bridging complexity and should be a fallback, not the initial plan.
+- FFmpeg-based recording: rejected for MVP because bundling and process management would add avoidable complexity.
+
+## Decision: Explicit recording sanity checks before transcription
+
+**Rationale**: The feature specification requires the app to avoid considering a recording successful until audio is locally finalized and readable. The validation pipeline will check microphone permission state, elapsed recording time, file existence, non-zero size, readable WAV structure, actual audio duration, expected-vs-actual duration tolerance, sample-level non-silence evidence, and validation metadata persistence.
+
+**Alternatives considered**:
+- File exists plus non-zero bytes only: rejected as insufficient because silent or truncated recordings would still pass.
+- Provider transcription as validation: rejected because network/provider success must be separate from local capture success.
+- Requiring user playback before upload: rejected because it creates unnecessary friction and still does not provide machine-checkable guarantees.
+
+## Decision: Recovery scan on startup reconciles sessions and artifacts
+
+**Rationale**: The app must survive closure, crash, and network failure after recording starts. On launch, Rust scans recording sessions with `recording`, `validating`, `transcribing`, `generating`, `failed`, and `recoverable` states, checks whether partial/final files exist, updates statuses, and exposes recoverable notes to the UI. Finalized audio remains retryable independent of transcription/generation status.
+
+**Alternatives considered**:
+- Store only current in-memory recorder state: rejected because crash recovery is a core requirement.
+- Delete incomplete files automatically: rejected because recoverability takes priority over cleanup.
+- Retry all failed provider calls automatically on startup: rejected for MVP to avoid surprise network usage; surface retry actions instead.
+
+## Decision: Tauri capabilities expose only the main window command surface
+
+**Rationale**: Tauri v2 capabilities constrain webview access to commands and plugins. The main window should receive only the app commands needed for notes, folders, recorder state, provider retry, and limited path/media display. No shell access, broad filesystem access, or remote-origin capabilities are required for MVP.
+
+**Alternatives considered**:
+- Use broad default capabilities and frontend filesystem APIs: rejected because PC-003 requires explicit scoping.
+- Multiple privileged windows: unnecessary for one-window MVP.
+- Remote web content: rejected because the MVP is a bundled local app.
+
+## Decision: macOS microphone permission and signing are first-class implementation tasks
+
+**Rationale**: macOS requires an `NSMicrophoneUsageDescription` usage string for microphone access, and sandboxed/signed builds need the audio input entitlement. Tauri’s macOS bundle configuration supports Info.plist additions and entitlements files. Implementation must include a repeatable dev/build command and a debug path for inspecting permission state and recording failures.
+
+**Alternatives considered**:
+- Wait until release packaging to handle entitlements: rejected because permission and recording failures must be testable during MVP development.
+- Assume browser prompt behavior is enough: rejected because native bundle metadata and signing affect macOS microphone access.
+
+## Decision: Provider adapters are backend services with mock-first tests
+
+**Rationale**: Transcription and generation are network-dependent and may use configurable remote providers. The MVP should separate local capture success from provider success, persist retry state, and include a mock provider for deterministic development/testing. The generated note must use only transcript and optional note context, preserve source language, and reject empty/malformed provider results.
+
+**Alternatives considered**:
+- Hard-code a single provider/model into UI code: rejected because credentials and network failures must remain backend-managed and retryable.
+- Realtime transcription: rejected by scope.
+- Generate notes from audio directly without transcript persistence: rejected because transcript review is required.
+
+## Sources Consulted
+
+- [Tauri v2 capabilities](https://v2.tauri.app/security/capabilities/)
+- [Tauri v2 capability reference](https://v2.tauri.app/reference/acl/capability/)
+- [Tauri Vite frontend guide](https://v2.tauri.app/start/frontend/vite/)
+- [Tauri macOS application bundle](https://v2.tauri.app/distribute/macos-application-bundle/)
+- [MDN MediaRecorder API](https://developer.mozilla.org/docs/Web/API/MediaRecorder)
+- [Apple NSMicrophoneUsageDescription](https://developer.apple.com/documentation/bundleresources/information-property-list/nsmicrophoneusagedescription)
+- [Apple Audio Input Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.device.audio-input)

--- a/specs/001-tauri-note-mvp/spec.md
+++ b/specs/001-tauri-note-mvp/spec.md
@@ -1,0 +1,175 @@
+# Feature Specification: Tauri Notes MVP
+
+**Feature Branch**: `001-tauri-note-mvp`  
+**Created**: 2026-05-19  
+**Status**: Draft  
+**Input**: User description: "Define the MVP for a simpler macOS OS Notetaker app built with Tauri. Scope is notes only: folders, all notes, note creation, microphone-only recording, reliable saved audio, batch transcription after recording, AI-generated note output, and transcript review. Exclude meetings, realtime transcription, system audio, billing, calendar, chat, auth, and sharing."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Capture a Reliable Voice Note (Priority: P1)
+
+A user opens the desktop app, creates a new note, records from the microphone, sees clear evidence that audio is being captured, stops recording, and receives an AI-generated note plus the full transcript.
+
+**Why this priority**: This is the MVP's core value. If microphone capture is not trustworthy, the rest of the app is not useful.
+
+**Independent Test**: Can be tested by recording a 60-second spoken note, stopping it, and verifying that the app saved a playable audio file, generated a transcript, and created a note from that transcript.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has granted microphone access and is on the new note screen, **When** they start recording and speak, **Then** the recording UI shows elapsed time, active waveform movement, and a non-idle recording state.
+2. **Given** the user has been recording for at least 10 seconds, **When** they select Done, **Then** the app finalizes the audio file, validates that it contains usable audio, transcribes it, and generates note content without requiring the user to copy/paste the transcript.
+3. **Given** the microphone is muted, disconnected, or producing no meaningful signal, **When** the user records, **Then** the app warns that audio capture appears silent before allowing them to generate a note.
+4. **Given** transcription or AI note generation fails after audio was saved, **When** the user views the note, **Then** the saved audio and recording metadata remain available for retry.
+
+---
+
+### User Story 2 - Organize Notes by Folder (Priority: P2)
+
+A user can use a simple sidebar to browse all notes, create folders, and view notes associated with each folder.
+
+**Why this priority**: The app needs enough structure to remain useful after more than a few notes, while avoiding the complexity of the legacy workspace, spaces, meeting, chat, and account model.
+
+**Independent Test**: Can be tested by creating two folders, creating multiple notes, assigning notes to folders, and verifying that All Notes and folder views show the correct lists.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app has no notes, **When** the user opens it, **Then** the sidebar shows "OS Notetaker", "+ New Folder", and "All Notes", while the main area shows an empty state and a prominent create-note action.
+2. **Given** the user has existing notes, **When** they select All Notes, **Then** the main area lists previous notes in reverse chronological order.
+3. **Given** the user creates a folder, **When** they assign a note to that folder, **Then** that note appears in the folder view and remains visible in All Notes.
+4. **Given** a folder is empty, **When** the user opens it, **Then** the main area communicates that no notes are in that folder yet and offers a clear path to create or assign a note.
+
+---
+
+### User Story 3 - Review and Edit Generated Notes (Priority: P3)
+
+A user can inspect the generated note and the transcript in the same note view, switch between "Notes" and "Transcription", edit the note title/content, and keep the transcript as source context.
+
+**Why this priority**: AI output will not always be perfect. The MVP must let users trust, inspect, and correct their notes.
+
+**Independent Test**: Can be tested by opening a generated note, switching tabs, editing the title and note body, closing/reopening the app, and verifying the changes persisted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a generated note exists, **When** the user opens it, **Then** the note title, generated note content, and tab switcher for "Notes" and "Transcription" are visible.
+2. **Given** the user switches to Transcription, **When** the transcript exists, **Then** the app displays the transcript exactly as returned by transcription, with readable scrolling.
+3. **Given** the user edits the title or note content, **When** the app autosaves, **Then** the edits persist locally and are visible after restart.
+4. **Given** no transcription exists because processing failed, **When** the user opens Transcription, **Then** the app explains the failure and offers retry if the audio file is available.
+
+---
+
+### User Story 4 - Recover from Interrupted Recording (Priority: P4)
+
+A user does not lose a recording if the app is closed, crashes, or loses network connectivity after audio capture started.
+
+**Why this priority**: Reliability is the main differentiator for the simplified MVP. Audio capture must be treated as more important than live transcription speed.
+
+**Independent Test**: Can be tested by starting a recording, force-quitting the app after audio is being written, reopening it, and verifying the app surfaces a recoverable draft or saved audio artifact.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app closes while recording, **When** it restarts, **Then** it detects the last recording session and shows whether audio can be recovered or discarded.
+2. **Given** audio was saved but transcription was not completed, **When** the app restarts, **Then** the note remains in a processing/retry state rather than disappearing.
+3. **Given** network access is unavailable after recording, **When** the user selects Done, **Then** audio finalization succeeds locally and transcription/generation can be retried later.
+
+### Edge Cases
+
+- Microphone permission is denied, revoked, or not yet requested.
+- The selected microphone is disconnected during recording.
+- The microphone is active but produces sustained silence or near-silence.
+- Recording starts but no bytes are written to disk within the expected startup window.
+- Recording duration and saved audio duration disagree beyond a small tolerance.
+- The audio file is too short to transcribe reliably.
+- Transcription returns empty text or text in a different language from the spoken audio.
+- AI note generation succeeds but returns content that is empty, malformed, or unrelated to the transcript.
+- The user creates many notes, long transcripts, or large audio files.
+- The app is closed during recording, transcription, or note generation.
+- Local disk write fails or available storage is insufficient.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The app MUST provide a single primary desktop window with a persistent left sidebar and a main content area.
+- **FR-002**: The sidebar MUST include the app name, "+ New Folder", "All Notes", and the user's folders.
+- **FR-003**: The All Notes view MUST list existing notes in reverse chronological order with enough identifying information for selection.
+- **FR-004**: The app MUST provide a prominent new-note action from the notes list/empty state.
+- **FR-005**: A new note screen MUST show a placeholder title, a "Notes | Transcription" switcher, note content area, recording controls, and a microphone activity visualization.
+- **FR-006**: The MVP MUST support microphone-only recording. System audio, meeting capture, live captions, and realtime transcription are out of scope.
+- **FR-007**: The app MUST request microphone permission before recording and explain how to recover when permission is denied.
+- **FR-008**: The app MUST display real-time recording evidence while recording, including elapsed time, active/paused state, and a visual audio-level indicator that responds to microphone input.
+- **FR-009**: The app MUST persist audio locally before attempting transcription or note generation.
+- **FR-010**: The app MUST run recording sanity checks before transcription: non-zero file size, minimum duration, detectable audio signal above a silence threshold, and successful readable-file validation.
+- **FR-011**: The app MUST warn the user and avoid generating a note when sanity checks indicate unusable audio.
+- **FR-012**: The app MUST support Pause and Resume without losing previously recorded audio.
+- **FR-013**: The Done action MUST finalize the recording, validate the saved audio, submit it for transcription, and generate note content from the resulting transcript.
+- **FR-014**: The generated note MUST be produced in the same language as the source audio unless the user later provides explicit formatting or language instructions.
+- **FR-015**: The generated note MUST use only the transcript and optional user-provided note context; it MUST NOT invent decisions, tasks, or facts not supported by the transcript.
+- **FR-016**: The note view MUST let the user switch between generated Notes and the raw Transcription.
+- **FR-017**: The user MUST be able to edit note title and generated note content after generation.
+- **FR-018**: The app MUST autosave note edits, folder changes, recording metadata, transcript text, and processing status locally.
+- **FR-019**: The app MUST preserve saved audio when transcription or AI generation fails, allowing retry without re-recording.
+- **FR-020**: The app MUST keep a processing status for each note: draft, recording, validating, transcribing, generating, ready, failed, or recoverable.
+- **FR-021**: The app MUST recover or surface incomplete recording sessions on restart when audio data was written before interruption.
+- **FR-022**: Folder assignment MUST be local, reversible, and must not remove the note from All Notes.
+- **FR-023**: The app MUST provide clear failure messages for microphone, file-write, transcription, and generation failures.
+- **FR-024**: The app MUST avoid showing legacy meeting, calendar, billing, chat, sharing, authentication, workspace, or system-audio controls in the MVP.
+- **FR-025**: The app MUST store user data locally by default for the MVP.
+
+### Reliability Requirements
+
+- **RR-001**: Recording MUST NOT be considered successful until an audio file has been finalized and verified as readable.
+- **RR-002**: The app MUST record session checkpoints at start, pause, resume, done, validation, transcription, generation, and completion.
+- **RR-003**: The app MUST compare expected elapsed recording time with actual saved audio duration and flag mismatches above tolerance.
+- **RR-004**: The app MUST detect sustained silence during active recording and make that state visible to the user before Done.
+- **RR-005**: The app MUST support retrying transcription/generation from saved audio without requiring a new recording.
+- **RR-006**: The app MUST make it visually obvious when it is listening, paused, validating, transcribing, generating, failed, or ready.
+
+### UX Requirements
+
+- **UX-001**: The interface MUST be simpler than the legacy app and preserve the provided structure: left sidebar, large main canvas, note list or note editor, and bottom recording controls.
+- **UX-002**: The visual design SHOULD feel fluid and native to macOS: fast transitions, immediate control feedback, polished spacing, and no page-like web chrome.
+- **UX-003**: The recording visualization SHOULD sit near the bottom center of the note screen and respond smoothly to microphone input.
+- **UX-004**: The Pause and Done controls MUST remain reachable while recording.
+- **UX-005**: The Transcription view MUST be scrollable for long transcripts.
+- **UX-006**: The app MUST handle empty states without explanatory marketing copy or onboarding screens.
+
+### Platform Constraints for Planning
+
+- **PC-001**: The MVP is planned as a Tauri desktop app targeting macOS first.
+- **PC-002**: macOS microphone permission, app entitlements/signing, and distribution constraints must be treated as first-class planning concerns.
+- **PC-003**: Tauri frontend-to-backend permissions must be explicitly scoped; the frontend should not receive broader file or shell access than required for notes, audio capture status, and local storage.
+- **PC-004**: The implementation plan must include a repeatable build/run/debug entrypoint for macOS and a way to inspect microphone permission and recording failures.
+
+### Key Entities *(include if feature involves data)*
+
+- **Folder**: A local organizational container with id, name, creation date, update date, and a list of assigned notes.
+- **Note**: A user-created record with id, title, generated content, optional user edits, folder assignments, created/updated timestamps, processing status, and links to transcript/audio metadata.
+- **Recording Session**: A capture lifecycle record with id, note id, start/end timestamps, pause intervals, status, device label if available, audio-level samples or summary statistics, file path, file size, duration, and validation results.
+- **Audio Artifact**: A finalized local audio file with path, format, duration, size, checksum or integrity marker, and creation timestamp.
+- **Transcript**: Text produced from the saved audio, with language if detected, provider metadata, processing status, and retry history.
+- **Generation Result**: AI-generated note content, prompt version, source transcript id, status, and error details when applicable.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In 20 consecutive manual recordings of at least 30 seconds each with audible speech, the app saves a readable audio file every time.
+- **SC-002**: For a valid 60-second recording, the user can complete capture, validation, transcription, and note generation without manually copying transcript text.
+- **SC-003**: When the microphone is muted or silent for 10 seconds during active recording, the app visibly warns the user before Done.
+- **SC-004**: When network access is disabled after recording, the audio remains saved locally and the note can be retried after network access returns.
+- **SC-005**: The notes list, folder selection, and note editor remain responsive with at least 500 local notes.
+- **SC-006**: A long transcript of at least 10,000 characters can be opened and scrolled without blocking note editing.
+- **SC-007**: A user can create a folder, create a voice note, generate the note, assign it to the folder, restart the app, and find the same note in both the folder and All Notes.
+- **SC-008**: At least 90% of first-time test users can identify whether the app is recording, paused, processing, or ready without reading documentation.
+- **SC-009**: In failure scenarios for permission denied, silent audio, transcription failure, and generation failure, the app shows a clear next step and preserves recoverable data.
+
+## Assumptions
+
+- The MVP targets a single local user on one Mac; accounts, sync, collaboration, sharing, and cloud note storage are out of scope.
+- The user provides any required AI/transcription credentials through local development configuration or a later settings surface; credential UX is not part of this spec unless required for MVP operation.
+- Batch transcription after recording is acceptable; realtime captions and incremental transcript display are intentionally excluded.
+- Audio is captured only from the microphone; system audio and meeting audio are excluded even if legacy code contains reference implementations.
+- The legacy app in `/legacy` is reference material only. New implementation should not preserve its workspace/auth/billing/calendar/meeting complexity.
+- Note generation may use a remote AI/transcription service, so the app must gracefully separate local capture success from network-dependent processing.
+- The MVP can use local storage only; import/export, search, tags, reminders, and advanced folder nesting are out of scope unless added later.


### PR DESCRIPTION
## Summary

- Adds the Spec Kit implementation plan for the Tauri notes MVP.
- Defines research decisions, local data model, Tauri command contracts, UI contract, and quickstart scenarios.
- Updates AGENTS.md to point agents at the current feature plan.

## Impact

This keeps the project aligned on the macOS-first Tauri architecture before implementation begins. The plan preserves the notes-only scope, prioritizes reliable microphone recording and local audio validation, and treats Liquid Glass as a frontend polish constraint rather than a native SwiftUI dependency.

## Validation

- `git diff --cached --check` before commit
- Planning artifacts checked for unresolved template placeholders
