### PR TITLE
Harden system audio capture and note layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 debug/
 release/
 src-tauri/gen/
+src-tauri/native/bin/
 *.rs.bk
 *.rlib
 *.prof*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 target/
 debug/
 release/
+.tauri-helper/
 src-tauri/gen/
 src-tauri/native/bin/
 *.rs.bk

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-tauri-note-mvp"
+  "feature_directory": "specs/002-system-audio-source-mode"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 <!-- SPECKIT START -->
+
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read
-`specs/001-tauri-note-mvp/plan.md`.
+`specs/002-system-audio-source-mode/plan.md`.
+
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The macOS bundle includes:
 - `NSAudioCaptureUsageDescription` in `src-tauri/Info.plist`
 - `com.apple.security.device.audio-input` in `src-tauri/Entitlements.plist`
 
-The `Microphone only` mode is the default. The `Microphone + system audio` mode uses a small macOS helper built by `src-tauri/build.rs` into `src-tauri/native/bin/` during `pnpm tauri:dev`, `pnpm test:rust`, or `pnpm tauri:build`. Generated helper binaries are ignored by git.
+The `Microphone only` mode is the default. The `Microphone + system audio` mode uses a small macOS helper built by `src-tauri/build.rs` into `.tauri-helper/` during `pnpm tauri:dev`, `pnpm test:rust`, or `pnpm tauri:build`. Generated helper binaries are ignored by git and kept outside `src-tauri` so Tauri dev does not restart on its own generated files.
 
 Local `pnpm tauri:build` output is ad-hoc signed unless a signing identity is configured. Before distribution, verify the signed bundle embeds the expected entitlements:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OS Notetaker
 
-macOS-first Tauri MVP for local notes, microphone-only recording, saved audio validation, batch transcription, and generated notes.
+macOS-first Tauri MVP for local notes, reliable local audio recording, saved audio validation, batch transcription, and generated notes.
 
 ## Development
 
@@ -43,13 +43,18 @@ The app data directory is resolved by Tauri at runtime. In development, inspect 
 
 - `notes.sqlite3`
 - `recordings/{note_id}/{session_id}.wav`
+- `recordings/{note_id}/{session_id}/microphone.wav`
+- `recordings/{note_id}/{session_id}/system.wav` when `Microphone + system audio` is selected
 
-## macOS Microphone Debugging
+## macOS Audio Permission Debugging
 
 The macOS bundle includes:
 
 - `NSMicrophoneUsageDescription` in `src-tauri/Info.plist`
+- `NSAudioCaptureUsageDescription` in `src-tauri/Info.plist`
 - `com.apple.security.device.audio-input` in `src-tauri/Entitlements.plist`
+
+The `Microphone only` mode is the default. The `Microphone + system audio` mode uses a small macOS helper built by `src-tauri/build.rs` into `src-tauri/native/bin/` during `pnpm tauri:dev`, `pnpm test:rust`, or `pnpm tauri:build`. Generated helper binaries are ignored by git.
 
 Local `pnpm tauri:build` output is ad-hoc signed unless a signing identity is configured. Before distribution, verify the signed bundle embeds the expected entitlements:
 
@@ -63,6 +68,8 @@ If permission is denied during local testing, reset it from macOS Privacy & Secu
 tccutil reset Microphone network.opensoftware.os-notetaker
 ```
 
+System-audio permission is checked when selecting `Microphone + system audio` and immediately before recording starts. If macOS blocks it, open Privacy & Security and allow audio capture for OS Notetaker or the OS Notetaker Audio Capture helper, then restart the app.
+
 ## Verification
 
 ```sh
@@ -74,3 +81,4 @@ pnpm tauri:build
 ```
 
 Manual recording reliability checks are tracked in `specs/001-tauri-note-mvp/manual-validation.md`.
+Source-mode validation scenarios are tracked in `specs/002-system-audio-source-mode/quickstart.md`.

--- a/specs/002-system-audio-source-mode/checklists/requirements.md
+++ b/specs/002-system-audio-source-mode/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Audio Source Modes for Notes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-19  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification intentionally defines batch-only microphone-plus-system capture and excludes realtime transcription, live captions, and a dedicated meetings surface.

--- a/specs/002-system-audio-source-mode/contracts/commands.md
+++ b/specs/002-system-audio-source-mode/contracts/commands.md
@@ -1,0 +1,401 @@
+# Command Contracts: Audio Source Modes for Notes
+
+The frontend communicates with the Rust backend through Tauri commands only. The backend remains authoritative for permission readiness, source start, file lifecycle, validation, transcription, generation, recovery, and retry.
+
+## Shared Types
+
+```ts
+type RecordingSourceMode = "microphone_only" | "microphone_plus_system";
+type RecordingSource = "microphone" | "system";
+
+type ProcessingStatus =
+  | "draft"
+  | "recording"
+  | "validating"
+  | "transcribing"
+  | "generating"
+  | "ready"
+  | "failed"
+  | "recoverable";
+
+type RecordingState =
+  | "idle"
+  | "permission_denied"
+  | "starting"
+  | "recording"
+  | "paused"
+  | "finalizing"
+  | "validating"
+  | "partially_valid"
+  | "invalid"
+  | "ready"
+  | "failed"
+  | "recoverable";
+
+type SourceState =
+  | "pending"
+  | "permission_denied"
+  | "unavailable"
+  | "starting"
+  | "recording"
+  | "paused"
+  | "finalizing"
+  | "finalized"
+  | "valid"
+  | "invalid"
+  | "recoverable"
+  | "failed";
+
+type AppError = {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+};
+```
+
+## Permission Commands
+
+### `check_recording_source_readiness`
+
+Checks permissions and source availability for the selected mode. This command is called when the user changes mode and again by `start_recording`.
+
+**Request**:
+
+```ts
+type CheckRecordingSourceReadinessRequest = {
+  sourceMode: RecordingSourceMode;
+};
+```
+
+**Response**:
+
+```ts
+type SourceReadinessDto = {
+  source: RecordingSource;
+  required: boolean;
+  ready: boolean;
+  permissionState:
+    | "unknown"
+    | "granted"
+    | "denied"
+    | "restricted"
+    | "unsupported";
+  deviceAvailable: boolean;
+  captureAvailable: boolean;
+  recoveryAction?:
+    | "open_microphone_settings"
+    | "open_system_audio_settings"
+    | "upgrade_macos"
+    | "restart_app";
+  message?: string;
+};
+
+type RecordingSourceReadinessDto = {
+  sourceMode: RecordingSourceMode;
+  ready: boolean;
+  checkedAt: string;
+  sources: SourceReadinessDto[];
+};
+```
+
+**Errors**:
+
+- `readiness_check_failed`
+
+## Recording Commands
+
+### `start_recording`
+
+Rechecks readiness, creates a source-mode recording session, starts all required sources, verifies source write evidence, and returns recording state only after startup is complete.
+
+**Request**:
+
+```ts
+type StartRecordingRequest = {
+  noteId: string;
+  sourceMode: RecordingSourceMode;
+};
+```
+
+**Response**: `RecordingSessionDto`
+
+**Errors**:
+
+- `note_not_found`
+- `recording_already_active`
+- `microphone_permission_denied`
+- `microphone_unavailable`
+- `system_audio_permission_denied`
+- `system_audio_unavailable`
+- `system_audio_unsupported`
+- `source_start_failed`
+- `source_write_evidence_missing`
+- `storage_write_failed`
+
+### `pause_recording`
+
+Pauses every active source in the selected mode.
+
+**Request**:
+
+```ts
+type PauseRecordingRequest = {
+  sessionId: string;
+};
+```
+
+**Response**: `RecordingSessionDto`
+
+**Errors**:
+
+- `recording_not_found`
+- `source_pause_failed`
+
+### `resume_recording`
+
+Resumes every paused source in the selected mode.
+
+**Request**:
+
+```ts
+type ResumeRecordingRequest = {
+  sessionId: string;
+};
+```
+
+**Response**: `RecordingSessionDto`
+
+**Errors**:
+
+- `recording_not_found`
+- `source_resume_failed`
+
+### `get_recording_status`
+
+Returns elapsed time, session state, and per-source write and level evidence.
+
+**Request**:
+
+```ts
+type GetRecordingStatusRequest = {
+  sessionId: string;
+};
+```
+
+**Response**:
+
+```ts
+type RecordingStatusDto = {
+  sessionId: string;
+  sourceMode: RecordingSourceMode;
+  state: RecordingState;
+  elapsedMs: number;
+  sources: SourceStatusDto[];
+  warnings: SourceWarningDto[];
+};
+```
+
+### `finish_recording`
+
+Finalizes every active source artifact, validates each artifact independently, and starts processing only when at least one selected source validates.
+
+**Request**:
+
+```ts
+type FinishRecordingRequest = {
+  sessionId: string;
+};
+```
+
+**Response**:
+
+```ts
+type FinishRecordingResponse = {
+  note: NoteDto;
+  recording: RecordingSessionDto;
+  validations: SourceValidationDto[];
+  processingStarted: boolean;
+  warnings: SourceWarningDto[];
+};
+```
+
+**Errors**:
+
+- `recording_not_found`
+- `audio_finalization_failed`
+- `no_valid_source_audio`
+- `storage_write_failed`
+
+## Processing Commands
+
+### `retry_processing`
+
+Retries transcription and/or generation from saved valid source artifacts and persisted source mode.
+
+**Request**:
+
+```ts
+type RetryProcessingRequest = {
+  noteId: string;
+  sessionId?: string;
+  step?: "transcription" | "generation" | "all";
+};
+```
+
+**Response**: `NoteDto`
+
+**Errors**:
+
+- `note_not_found`
+- `recording_not_found`
+- `source_artifact_missing`
+- `no_valid_source_audio`
+- `provider_not_configured`
+- `transcription_failed`
+- `generation_failed`
+
+### `recover_recording`
+
+Attempts to validate or discard an interrupted source-mode recording after startup scan.
+
+**Request**:
+
+```ts
+type RecoverRecordingRequest = {
+  sessionId: string;
+  action: "validate" | "discard";
+};
+```
+
+**Response**:
+
+```ts
+type RecoverRecordingResponse = {
+  note: NoteDto;
+  recording: RecordingSessionDto;
+  recoverableSources: RecoverableSourceDto[];
+  validations?: SourceValidationDto[];
+  processingStarted: boolean;
+};
+```
+
+## DTOs
+
+```ts
+type RecordingSessionDto = {
+  id: string;
+  noteId: string;
+  sourceMode: RecordingSourceMode;
+  state: RecordingState;
+  startedAt: string;
+  endedAt?: string;
+  elapsedMs: number;
+  sources: SourceStatusDto[];
+  warnings: SourceWarningDto[];
+  lastError?: string;
+};
+
+type SourceStatusDto = {
+  source: RecordingSource;
+  state: SourceState;
+  elapsedMs: number;
+  bytesWritten: number;
+  level: AudioLevelDto;
+  silenceWarning: boolean;
+  pathFinalized: boolean;
+  lastError?: string;
+};
+
+type SourceValidationDto = {
+  source: RecordingSource;
+  fileExists: boolean;
+  nonZeroSize: boolean;
+  readableAudio: boolean;
+  expectedDurationMs: number;
+  actualDurationMs?: number;
+  durationWithinTolerance: boolean;
+  nonSilentSignal: boolean;
+  peakAmplitude?: number;
+  rmsAmplitude?: number;
+  warnings: string[];
+  error?: string;
+};
+
+type SourceWarningDto = {
+  source: RecordingSource;
+  code: string;
+  message: string;
+};
+
+type TranscriptDto = {
+  id: string;
+  text: string;
+  sourceMode?: RecordingSourceMode;
+  source?: RecordingSource;
+  language?: string;
+  status: "pending" | "running" | "succeeded" | "failed";
+  lastError?: string;
+};
+
+type NoteDto = NoteListItemDto & {
+  generatedContent?: string;
+  editedContent?: string;
+  transcript?: TranscriptDto;
+  sourceTranscripts?: TranscriptDto[];
+  recording?: RecordingSessionDto;
+  audioSources?: AudioSourceArtifactDto[];
+  activeTab?: "notes" | "transcription";
+  lastError?: string;
+};
+
+type AudioSourceArtifactDto = {
+  id: string;
+  source: RecordingSource;
+  format: "wav";
+  durationMs: number;
+  sizeBytes: number;
+  checksum: string;
+  createdAt: string;
+};
+
+type RecoverableSourceDto = {
+  source: RecordingSource;
+  partialPathPresent: boolean;
+  finalPathPresent: boolean;
+  bytesFound: number;
+  lastError?: string;
+};
+```
+
+## Event Contract
+
+```ts
+type BackendEvent =
+  | {
+      type: "recording-level";
+      sessionId: string;
+      source: RecordingSource;
+      level: AudioLevelDto;
+      elapsedMs: number;
+      bytesWritten: number;
+      silenceWarning: boolean;
+    }
+  | {
+      type: "recording-state";
+      sessionId: string;
+      sourceMode: RecordingSourceMode;
+      state: RecordingState;
+      sources: SourceStatusDto[];
+      message?: string;
+    }
+  | { type: "note-updated"; note: NoteDto }
+  | {
+      type: "processing-state";
+      noteId: string;
+      sessionId?: string;
+      status: ProcessingStatus;
+      message?: string;
+    };
+```
+
+Events are advisory. Commands and persisted state remain authoritative after reload.

--- a/specs/002-system-audio-source-mode/contracts/ui.md
+++ b/specs/002-system-audio-source-mode/contracts/ui.md
@@ -1,0 +1,115 @@
+# UI Contract: Audio Source Modes for Notes
+
+The app remains a notes-first desktop utility with the same sidebar, notes list, editor, tabs, and bottom recorder layout from the MVP.
+
+## Recording Source Control
+
+Required control:
+
+- A compact segmented control with exactly two labels: `Microphone only` and `Microphone + system audio`.
+- Default selection for a new note is `Microphone only`.
+- The selected mode is visible before the user starts recording.
+
+Behavior:
+
+- Changing the selected mode triggers `check_recording_source_readiness`.
+- The control is disabled while a recording is active, paused, finalizing, validating, transcribing, or generating.
+- If readiness fails, the selected mode can remain visible, but Start is blocked and the recovery message identifies the failing source.
+- The control must not create a meetings page, meeting object, workspace switcher, calendar surface, or realtime transcript panel.
+
+## Permission and Readiness UI
+
+`Microphone only` readiness:
+
+- Shows microphone availability and permission issues.
+- Does not mention system audio unless the user selects the dual-source mode.
+
+`Microphone + system audio` readiness:
+
+- Shows readiness for both microphone and system audio.
+- If one source is denied, unavailable, or unsupported, Start is blocked.
+- Recovery actions identify the relevant macOS Privacy & Security area where practical.
+
+Start behavior:
+
+- Start performs a fresh backend readiness check.
+- If readiness changed since mode selection, the UI updates to the latest authoritative failure and does not enter recording state.
+
+## Active Recorder UI
+
+`Microphone only`:
+
+- Preserves the existing recorder layout, elapsed time, waveform, Pause, Resume, Done, silence warning, and validation states.
+
+`Microphone + system audio`:
+
+- Shows a shared elapsed timer and compact per-source evidence for `Microphone` and `System audio`.
+- Each source shows activity/level evidence, paused state, and bytes-written or equivalent local-write evidence.
+- Source warnings name the affected source.
+- Pause and Resume apply to both sources from the user's perspective.
+
+Mode changes:
+
+- The source mode control remains visible but disabled during the active lifecycle.
+- The disabled state should be obvious without hiding the selected mode.
+
+## Done, Validation, and Processing UI
+
+Done:
+
+- Shows finalizing per source before validation.
+- Shows validation per source before transcription begins.
+
+Partial validity:
+
+- If one source validates and another fails or is silent, the note can continue to transcription/generation from the valid source.
+- The UI shows a warning for the failed source and keeps the warning visible in the Transcription tab or note status area.
+
+No valid source:
+
+- The app does not generate a note.
+- The user sees validate/retry/discard options when recoverable audio exists.
+
+Provider failure:
+
+- Saved source artifacts remain available.
+- Retry uses saved artifacts and the persisted source mode.
+
+## Transcription Tab
+
+The Transcription tab shows the exact labeled transcript used for note generation.
+
+Required display behavior:
+
+- `Microphone` and `System audio` sections are visible for dual-source recordings when transcripts or failures exist.
+- Source-specific transcription failures are shown next to the affected source.
+- If only one source produced valid transcript text, the tab makes clear which source was used.
+
+## Notes Tab
+
+Generated content appends to existing note content for additional recordings in the same note.
+
+Required display behavior:
+
+- Existing user-edited content remains visible.
+- New generated content is appended in a readable section.
+- The UI does not replace earlier generated or edited content when a later recording finishes.
+
+## Recovery Banner
+
+Startup recovery surfaces source-aware recoverable recordings.
+
+Required display behavior:
+
+- Shows the session source mode.
+- Shows which sources have partial or finalized bytes.
+- Offers validate and discard actions.
+- Source failures are named directly.
+
+## Visual Direction
+
+- Preserve the current polished macOS, Liquid Glass-inspired Tauri treatment.
+- Keep the new source control visually quiet and functional.
+- Avoid marketing-like layout changes.
+- Avoid adding large panels that reduce the note editor's usable space.
+- Source activity indicators must remain legible when glass/translucency effects are active.

--- a/specs/002-system-audio-source-mode/data-model.md
+++ b/specs/002-system-audio-source-mode/data-model.md
@@ -1,0 +1,187 @@
+# Data Model: Audio Source Modes for Notes
+
+This feature extends the existing local SQLite model from `001-tauri-note-mvp`. Existing folder, note, provider, and editable note semantics remain unchanged.
+
+## RecordingSourceMode
+
+Capture scope selected for one recording session.
+
+| Value                    | User Label                  | Meaning                                                 |
+| ------------------------ | --------------------------- | ------------------------------------------------------- |
+| `microphone_only`        | `Microphone only`           | Capture only the microphone source                      |
+| `microphone_plus_system` | `Microphone + system audio` | Capture microphone and system audio as separate sources |
+
+**Validation**:
+
+- New recording sessions default to `microphone_only`.
+- Source mode cannot change after a recording session starts.
+- Retry and recovery use the mode persisted on the session.
+
+## RecordingSource
+
+One concrete audio source inside a recording session.
+
+| Value        | Required In Mode         | Meaning                                        |
+| ------------ | ------------------------ | ---------------------------------------------- |
+| `microphone` | Both modes               | User microphone input                          |
+| `system`     | `microphone_plus_system` | Audio produced by apps or the operating system |
+
+## RecordingSession
+
+Existing capture lifecycle record extended for source modes.
+
+| Field                 | Type        | Required | Notes                                                            |
+| --------------------- | ----------- | -------- | ---------------------------------------------------------------- |
+| `id`                  | UUID string | Yes      | Stable local id                                                  |
+| `note_id`             | UUID string | Yes      | References `Note`                                                |
+| `source_mode`         | enum        | Yes      | `microphone_only` or `microphone_plus_system`                    |
+| `status`              | enum        | Yes      | Existing statuses plus source-aware recovery and failure details |
+| `started_at`          | timestamp   | Yes      | Set before source startup begins                                 |
+| `ended_at`            | timestamp   | No       | Set after Done or recovery finalization                          |
+| `expected_elapsed_ms` | integer     | Yes      | Active recording time excluding pauses                           |
+| `permission_summary`  | JSON        | No       | Last readiness result for required sources                       |
+| `last_error`          | text        | No       | Session-level failure summary                                    |
+
+**Relationships**:
+
+- Belongs to one `Note`.
+- Has one or more `SourceArtifact`.
+- Has many `SourceCheckpoint`.
+
+**State transitions**:
+
+- `created` -> `starting`
+- `starting` -> `recording` only after every required source starts and writes evidence
+- `starting` -> `failed` or `recoverable` if startup fails
+- `recording` -> `paused` -> `recording`
+- `recording` or `paused` -> `finalizing` -> `validating`
+- `validating` -> `valid`, `partially_valid`, or `invalid`
+- Active states -> `recoverable` on restart when any source wrote bytes
+
+## SourceArtifact
+
+Local file metadata for one source in a recording session.
+
+| Field                  | Type        | Required | Notes                                                                                                                 |
+| ---------------------- | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | UUID string | Yes      | Stable local id                                                                                                       |
+| `note_id`              | UUID string | Yes      | References `Note`                                                                                                     |
+| `recording_session_id` | UUID string | Yes      | References `RecordingSession`                                                                                         |
+| `source`               | enum        | Yes      | `microphone` or `system`                                                                                              |
+| `status`               | enum        | Yes      | `pending`, `recording`, `paused`, `finalizing`, `finalized`, `valid`, `invalid`, `recoverable`, `discarded`, `failed` |
+| `partial_path`         | string      | No       | App-local `.partial` path while recording                                                                             |
+| `path`                 | string      | No       | Finalized app-local WAV path                                                                                          |
+| `format`               | string      | Yes      | MVP default `wav`                                                                                                     |
+| `expected_duration_ms` | integer     | Yes      | Active elapsed time for this source                                                                                   |
+| `duration_ms`          | integer     | No       | Parsed from readable audio                                                                                            |
+| `size_bytes`           | integer     | No       | Captured from filesystem                                                                                              |
+| `checksum`             | string      | No       | Integrity marker for finalized audio                                                                                  |
+| `peak_amplitude`       | float       | No       | Validation summary                                                                                                    |
+| `rms_amplitude`        | float       | No       | Validation summary                                                                                                    |
+| `silent_window_ms`     | integer     | No       | Longest near-silent span                                                                                              |
+| `last_error`           | text        | No       | Source-specific failure details                                                                                       |
+| `created_at`           | timestamp   | Yes      | Creation time                                                                                                         |
+| `updated_at`           | timestamp   | Yes      | Last state change                                                                                                     |
+
+**Validation**:
+
+- Exactly one `microphone` artifact exists for every session.
+- Exactly one `system` artifact exists when `source_mode` is `microphone_plus_system`.
+- `(recording_session_id, source)` is unique.
+- A source cannot be marked `valid` unless file existence, non-zero size, readable audio, duration tolerance, and signal checks pass.
+
+## SourceValidationResult
+
+Result of validating a source artifact independently.
+
+| Field                       | Type         | Required | Notes                                    |
+| --------------------------- | ------------ | -------- | ---------------------------------------- |
+| `source_artifact_id`        | UUID string  | Yes      | References `SourceArtifact`              |
+| `file_exists`               | boolean      | Yes      | Final or recoverable path exists         |
+| `non_zero_size`             | boolean      | Yes      | File has bytes                           |
+| `readable_audio`            | boolean      | Yes      | WAV parser can read metadata and samples |
+| `expected_duration_ms`      | integer      | Yes      | From session elapsed time                |
+| `actual_duration_ms`        | integer      | No       | From decoded audio                       |
+| `duration_within_tolerance` | boolean      | Yes      | Uses existing tolerance policy           |
+| `non_silent_signal`         | boolean      | Yes      | Signal exceeds configured floor          |
+| `peak_amplitude`            | float        | No       | Source peak                              |
+| `rms_amplitude`             | float        | No       | Source RMS                               |
+| `warnings`                  | string array | Yes      | Non-fatal issues                         |
+| `error`                     | string       | No       | Fatal validation issue                   |
+
+**Validation**:
+
+- Fatal validation for one source does not erase other source results.
+- Generation is allowed only when at least one source has a successful validation result.
+
+## SourceCheckpoint
+
+Append-only lifecycle event for a session or specific source.
+
+| Field                  | Type        | Required | Notes                                                                                                                                                             |
+| ---------------------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | UUID string | Yes      | Stable local id                                                                                                                                                   |
+| `recording_session_id` | UUID string | Yes      | References `RecordingSession`                                                                                                                                     |
+| `source_artifact_id`   | UUID string | No       | Present for source-specific events                                                                                                                                |
+| `source`               | enum        | No       | `microphone` or `system`                                                                                                                                          |
+| `kind`                 | enum        | Yes      | `permission_check`, `start`, `write_evidence`, `pause`, `resume`, `done`, `finalize`, `validation`, `transcription`, `generation`, `recovery`, `retry`, `failure` |
+| `created_at`           | timestamp   | Yes      | Event time                                                                                                                                                        |
+| `details`              | JSON        | No       | Structured diagnostic details                                                                                                                                     |
+
+## Transcript
+
+Existing transcript record extended for source labels.
+
+| Field                  | Type        | Required | Notes                                                                    |
+| ---------------------- | ----------- | -------- | ------------------------------------------------------------------------ |
+| `id`                   | UUID string | Yes      | Stable local id                                                          |
+| `note_id`              | UUID string | Yes      | References `Note`                                                        |
+| `recording_session_id` | UUID string | Yes      | References `RecordingSession`                                            |
+| `source_artifact_id`   | UUID string | No       | Present for source-specific transcript rows                              |
+| `source`               | enum        | No       | `microphone` or `system`; omitted only for a combined display transcript |
+| `text`                 | text        | Yes      | Source transcript text or combined labeled transcript                    |
+| `provider`             | string      | Yes      | `mock`, `openai`, or configured provider key                             |
+| `status`               | enum        | Yes      | `pending`, `running`, `succeeded`, `failed`                              |
+| `retry_count`          | integer     | Yes      | Starts at zero                                                           |
+| `last_error`           | text        | No       | Failure details                                                          |
+| `created_at`           | timestamp   | Yes      | First attempt time                                                       |
+| `updated_at`           | timestamp   | Yes      | Last status change                                                       |
+
+**Validation**:
+
+- Successful source transcript text must not be blank.
+- The displayed transcript for multi-source recordings must preserve source labels.
+- Provider failure for one source must not delete successful transcripts for another source.
+
+## GenerationResult
+
+Existing generation result extended to record source coverage.
+
+| Field             | Type | Required | Notes                                                  |
+| ----------------- | ---- | -------- | ------------------------------------------------------ |
+| `source_mode`     | enum | Yes      | Mode used for source context                           |
+| `source_coverage` | JSON | Yes      | Which sources were used, skipped, invalid, or failed   |
+| `content`         | text | No       | Generated note content to append to existing note body |
+
+**Validation**:
+
+- Generation uses only valid source transcripts and existing user note context.
+- New generated content appends to existing visible note content.
+- Missing or failed sources are represented as warnings, not invented content.
+
+## PermissionReadiness
+
+Transient backend response persisted as checkpoints and optionally summarized on the session.
+
+| Field         | Type             | Required    | Notes                                          |
+| ------------- | ---------------- | ----------- | ---------------------------------------------- |
+| `source_mode` | enum             | Yes         | Requested mode                                 |
+| `ready`       | boolean          | Yes         | True only when all required source checks pass |
+| `microphone`  | source readiness | Yes         | Permission, device, and recovery hint          |
+| `system`      | source readiness | Conditional | Required for `microphone_plus_system`          |
+| `checked_at`  | timestamp        | Yes         | Advisory timestamp only                        |
+
+**Validation**:
+
+- Readiness is rechecked immediately before `start_recording`.
+- A stale readiness result cannot authorize recording.

--- a/specs/002-system-audio-source-mode/plan.md
+++ b/specs/002-system-audio-source-mode/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Audio Source Modes for Notes
+
+**Branch**: `002-system-audio-source-mode` | **Date**: 2026-05-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-system-audio-source-mode/spec.md`
+
+**Note**: This plan stops at Phase 2 planning. Implementation begins only after `/speckit-tasks` generates `tasks.md` and the user approves moving forward.
+
+## Summary
+
+Extend the existing notes-only Tauri MVP with a recording source mode control for `Microphone only` and `Microphone + system audio`. The implementation will preserve the current microphone-only path as the default and add macOS-first system audio capture as a separate source with separate local artifacts, permission readiness, lifecycle checkpoints, validation results, transcripts, warnings, recovery, and retry behavior. Transcription and generation remain batch-only after local capture is finalized and validated.
+
+## Technical Context
+
+**Language/Version**: Rust stable with Tauri v2 backend; TypeScript with React and Vite frontend; Swift or Rust macOS native bridge code for system audio capture where direct Rust support is insufficient. Rust minimum remains `>=1.77.2`.
+**Primary Dependencies**: Existing Tauri v2, React, TypeScript, `@tauri-apps/api`, SQLite via `sqlx`, microphone capture via `cpal`, WAV validation via `hound`, checksums via `sha2`, provider adapters via `reqwest`. New native macOS system-audio capture should use Apple-supported system audio capture APIs and be owned by the Rust backend as a managed source, not called directly by the webview.
+**Storage**: Existing local SQLite database plus migrations for recording source mode, source artifacts, source validations, source checkpoints, and source-labeled transcripts. Audio files remain app-local and move from one artifact per session to source-specific paths such as `recordings/{note_id}/{session_id}/microphone.wav` and `recordings/{note_id}/{session_id}/system.wav`, with `.partial` files during capture.
+**Testing**: Existing `pnpm test`, `pnpm test:rust`, and `pnpm test:ui`; new Rust tests for source-mode state, source artifact validation, recovery, and retry; frontend tests for mode selection, permission blocking, per-source status, append behavior, and disabled mode switching while active; manual macOS validation for permissions and real system audio.
+**Target Platform**: macOS-first Tauri desktop app. `Microphone only` remains the reliable default path. `Microphone + system audio` is supported only when the host macOS version, app signing state, permissions, and capture bridge are ready.
+**Project Type**: Desktop app with local Rust backend and React webview frontend.
+**Performance Goals**: Recorder UI remains responsive while rendering per-source levels; microphone-only reliability from the MVP is preserved; dual-source capture writes local evidence for both sources in at least 9 of 10 manual recordings with audible input; validation finishes before provider processing begins; notes list remains responsive with 500 local notes.
+**Constraints**: Batch-only; no realtime transcript stream; no meeting object; no legacy workspace/auth/billing/calendar/chat/sharing surfaces; permissions are checked when selecting a mode and immediately before recording starts; multi-source start is atomic from the user's perspective; provider failures must not delete saved audio; one valid source may proceed with warnings for the failed source.
+**Scale/Scope**: Single local user, one primary window, two recording source modes, two audio sources maximum per recording session, local-only persistence.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+The project constitution currently contains placeholder principles only and defines no enforceable gates. This plan uses the feature specification as the controlling project guidance.
+
+Pre-design gate status: PASS, with no active constitution constraints.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-system-audio-source-mode/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── commands.md
+│   └── ui.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+package.json
+pnpm-lock.yaml
+vite.config.ts
+tsconfig.json
+
+src/
+├── app/
+│   ├── App.tsx
+│   └── state/
+├── components/
+│   ├── note-editor/
+│   ├── notes-list/
+│   ├── recorder/
+│   └── sidebar/
+├── lib/
+└── styles/
+
+src-tauri/
+├── Cargo.toml
+├── Entitlements.plist
+├── Info.plist
+├── capabilities/
+├── migrations/
+├── src/
+│   ├── audio/
+│   │   ├── capture.rs
+│   │   ├── recovery.rs
+│   │   ├── validation.rs
+│   │   ├── waveform.rs
+│   │   └── system_macos.rs
+│   ├── commands.rs
+│   ├── db/
+│   ├── domain/
+│   └── providers/
+├── native/
+│   └── mac-system-audio-recorder/
+└── tests/
+```
+
+**Structure Decision**: Keep the existing Tauri v2 layout. The frontend adds source-mode UI and per-source recorder state under `src/components/recorder/` and `src/app/state/`. The Rust backend remains authoritative for permissions, session state, audio lifecycle, validation, recovery, and provider calls. Any macOS system-audio helper or bridge is owned by `src-tauri` and exposed to the frontend only through typed Tauri commands.
+
+## Phase 0: Research Decisions
+
+See [research.md](./research.md). All planning unknowns are resolved there.
+
+## Phase 1: Design Artifacts
+
+See [data-model.md](./data-model.md), [contracts/commands.md](./contracts/commands.md), [contracts/ui.md](./contracts/ui.md), and [quickstart.md](./quickstart.md).
+
+## Post-Design Constitution Check
+
+The constitution remains placeholder-only and imposes no additional gates.
+
+Post-design gate status: PASS.
+
+## Complexity Tracking
+
+No constitution violations are present.

--- a/specs/002-system-audio-source-mode/quickstart.md
+++ b/specs/002-system-audio-source-mode/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Audio Source Modes for Notes
+
+This quickstart describes the expected build, run, and manual verification path once implementation begins. It is a planning artifact; `/speckit-tasks` should turn these scenarios into implementation tasks.
+
+## Prerequisites
+
+- macOS development machine.
+- Rust stable installed.
+- Node.js and pnpm installed.
+- Xcode command line tools installed.
+- Microphone available and not blocked by macOS privacy settings.
+- Audible system audio source for manual dual-source testing, such as a browser video or meeting playback.
+- Provider credentials configured through local environment variables when testing real transcription/generation.
+
+## Planned Commands
+
+```sh
+pnpm install
+pnpm tauri:dev
+pnpm test
+pnpm test:rust
+pnpm test:ui
+pnpm tauri:build
+```
+
+## macOS Permission Debug Path
+
+1. Confirm `src-tauri/Info.plist` includes `NSMicrophoneUsageDescription`.
+2. Confirm `src-tauri/Entitlements.plist` includes the microphone entitlement required by signed or sandboxed builds.
+3. Confirm the planned system-audio bridge has the permission metadata, signing behavior, and runtime checks required by the selected macOS capture API.
+4. Run the dev app with `pnpm tauri:dev`.
+5. Select `Microphone only` and verify microphone readiness.
+6. Select `Microphone + system audio` and verify microphone plus system-audio readiness.
+7. If permission is denied, verify Start is blocked and the UI names the failing source.
+8. During development, reset microphone permission with macOS Privacy & Security settings or `tccutil reset Microphone <bundle-id>` when appropriate. System-audio permissions should be reset and inspected through the relevant macOS Privacy & Security pane for the target macOS version.
+
+## Manual Scenario: Microphone-Only Regression
+
+1. Open the app.
+2. Create a note.
+3. Keep source mode set to `Microphone only`.
+4. Record at least 30 seconds of speech.
+5. Verify elapsed time, waveform movement, bytes-written evidence, Pause, Resume, and Done.
+6. Click Done.
+7. Verify local validation, transcription, generation, and editable note output.
+
+Expected result: existing microphone-only behavior remains reliable and saves a readable microphone audio artifact.
+
+## Manual Scenario: Permission Blocking
+
+1. Deny microphone permission or system-audio permission from macOS settings.
+2. Select the source mode requiring the denied permission.
+3. Attempt to start recording.
+
+Expected result: the app does not enter recording state, does not create misleading active UI, and shows a source-specific recovery message.
+
+## Manual Scenario: Microphone Plus System Audio
+
+1. Start audible system audio.
+2. Create a note.
+3. Select `Microphone + system audio`.
+4. Verify both sources show ready state.
+5. Start recording and speak while system audio continues.
+6. Verify per-source activity and local-write evidence.
+7. Pause and resume.
+8. Click Done.
+9. Verify both source artifacts finalize and validate independently.
+10. Verify the Transcription tab has source-labeled text.
+11. Verify generated note content uses valid source transcripts and appends to any existing note content.
+
+Expected result: saved readable local artifacts for both sources, source-labeled transcript, generated note, and persisted metadata.
+
+## Manual Scenario: One Silent or Failed Source
+
+1. Select `Microphone + system audio`.
+2. Make one source silent while the other contains audible content.
+3. Record and click Done.
+
+Expected result: validation marks the silent or failed source clearly, generation proceeds only from the valid source, and the UI shows a source-specific warning.
+
+## Manual Scenario: No Valid Source
+
+1. Select either mode.
+2. Record only silence or force both source artifacts to fail validation.
+3. Click Done.
+
+Expected result: the app does not generate a note and preserves recoverable artifact state for retry or discard when bytes exist.
+
+## Manual Scenario: Interrupted Dual-Source Recovery
+
+1. Select `Microphone + system audio`.
+2. Start recording while microphone and system audio are audible.
+3. Wait until both sources show bytes-written evidence.
+4. Force quit the app before clicking Done.
+5. Reopen the app.
+
+Expected result: recovery surfaces source-aware state, showing which sources have partial or finalized bytes and allowing validate or discard.
+
+## Manual Scenario: Provider Failure Retry
+
+1. Record a valid dual-source note.
+2. Disable network or configure a provider failure before processing.
+3. Verify local validation still succeeds.
+4. Restore provider configuration.
+5. Retry processing.
+
+Expected result: retry uses saved source artifacts and the persisted recording source mode without requiring a new recording.

--- a/specs/002-system-audio-source-mode/research.md
+++ b/specs/002-system-audio-source-mode/research.md
@@ -1,0 +1,108 @@
+# Research: Audio Source Modes for Notes
+
+## Decision: Keep Transcription and Generation Batch-Only
+
+The feature will not introduce realtime captions, live transcript streaming, or a meetings object. Capture writes local audio first, validates local artifacts, then runs transcription and note generation.
+
+**Rationale**: The current MVP reliability model depends on saved audio being the source of truth. Batch processing keeps failure recovery clear: provider failures can be retried from saved artifacts, and interrupted capture can be recovered or discarded intentionally.
+
+**Alternatives considered**:
+
+- Reuse the legacy realtime dual-stream meeting pipeline. Rejected because it reintroduces meetings, live streaming complexity, and failure modes outside the current notes MVP.
+- Mix microphone and system audio into one stream before transcription. Rejected because source failures and transcript provenance would be harder to diagnose.
+
+## Decision: Store Microphone and System Audio as Separate Source Artifacts
+
+`Microphone + system audio` sessions will create distinct local source artifacts for microphone and system audio. Each source has its own path, partial file, status, byte count, levels, validation result, transcript, and error details.
+
+**Rationale**: Separate artifacts allow independent validation, partial success, source-labeled transcription, source-specific warnings, and recovery when only one source survives an interruption.
+
+**Alternatives considered**:
+
+- One mixed WAV file. Rejected because it hides whether the microphone or system source failed.
+- Only store a mixed file plus debug metadata. Rejected because retry and source-labeled transcript quality would be worse.
+
+## Decision: Preserve the Existing Microphone Path as the Default
+
+`Microphone only` remains the default for new notes and should continue using the current Rust-managed microphone capture flow.
+
+**Rationale**: Microphone reliability is already the top MVP priority. The new system-audio work should not destabilize the known path.
+
+**Alternatives considered**:
+
+- Replace all capture with a new combined native recorder. Rejected because it expands the blast radius for a late MVP scope change.
+
+## Decision: Add macOS System Audio Through a Backend-Owned Native Bridge
+
+System audio capture will be implemented behind a Rust backend source abstraction. The backend may manage a small macOS native helper or bridge under `src-tauri/native/mac-system-audio-recorder/`, inspired by the legacy helper, but the frontend will never call it directly.
+
+**Rationale**: System audio capture is platform-specific and permission-sensitive. Keeping it behind the Tauri backend preserves scoped frontend capabilities and allows the backend to enforce atomic start, cleanup, logging, recovery, and artifact validation.
+
+**Alternatives considered**:
+
+- Frontend/browser audio APIs. Rejected because they cannot reliably capture system audio in the Tauri webview.
+- Port the full legacy Electron bridge. Rejected because it brings unnecessary process/socket/realtime behavior.
+- Make the native helper the owner of both microphone and system audio. Rejected for the first implementation because it risks regressing microphone-only capture.
+
+## Decision: Use Explicit Permission Readiness Before Mode Selection and Start
+
+The app will check readiness when the user selects a mode and again immediately before recording starts. A previous successful readiness result is advisory only.
+
+**Rationale**: macOS permissions can change outside the app. The start command must be authoritative and must block capture if any required source is not ready.
+
+**Alternatives considered**:
+
+- Check only at start. Rejected because users need early feedback when choosing `Microphone + system audio`.
+- Cache permission readiness for the whole session. Rejected because stale permission state can cause failed or misleading recording starts.
+
+## Decision: Treat Multi-Source Start as Atomic From the User's Perspective
+
+When `Microphone + system audio` starts, the backend must start all required sources and verify write evidence. If any required source cannot start or write evidence, the backend stops every started source, preserves recoverable artifacts, and reports a source-specific error.
+
+**Rationale**: The UI must not claim that a note is recording in a dual-source mode when only one required source actually started.
+
+**Alternatives considered**:
+
+- Start microphone even if system audio fails. Rejected for the initial start path because it contradicts the user-selected mode. Partial processing is allowed only after a recording attempt has produced finalized or recoverable source artifacts.
+
+## Decision: Process Any Valid Source After Finalization
+
+After Done or recovery validation, if at least one selected source validates, transcription and generation may continue from valid sources with warnings for failed or silent sources. If no source validates, generation is blocked.
+
+**Rationale**: This preserves user value when one source fails while still avoiding invented content for missing sources.
+
+**Alternatives considered**:
+
+- Require all selected sources to validate. Rejected because it would discard useful captured speech from the other source.
+- Generate from invalid or silent sources. Rejected because it weakens reliability and creates misleading notes.
+
+## Decision: Source-Labeled Transcript Sections Are Sufficient
+
+Transcription output will preserve source labels such as `Microphone` and `System audio`. Perfect chronological interleaving is not required for this feature.
+
+**Rationale**: Source labels satisfy the user need to distinguish speakers or media/system content while keeping the batch implementation tractable.
+
+**Alternatives considered**:
+
+- Full timestamp interleaving across sources. Deferred because it requires tighter clock alignment and is not required by the spec.
+
+## Decision: Recovery Scans Work Per Source
+
+Startup recovery will inspect source artifacts and checkpoints independently. Recoverable state should include which sources have partial files, finalized files, bytes, duration, validation results, and errors.
+
+**Rationale**: Dual-source recording can fail asymmetrically. Per-source recovery prevents one broken artifact from hiding usable audio in the other artifact.
+
+**Alternatives considered**:
+
+- Session-level recovery only. Rejected because it is too coarse for dual-source troubleshooting.
+
+## Decision: Keep UI Notes-First With a Compact Source Mode Control
+
+The recording source mode control belongs near the recorder controls in the note editor. It is disabled during active, paused, finalizing, validating, transcribing, and generating states.
+
+**Rationale**: The feature is part of note recording, not a separate meeting product. Keeping it close to the recorder makes the selected mode visible without adding a new surface.
+
+**Alternatives considered**:
+
+- A dedicated meeting mode page. Rejected by MVP scope.
+- A global settings-only source selector. Rejected because the selected mode must be visible at the moment a recording starts.

--- a/specs/002-system-audio-source-mode/spec.md
+++ b/specs/002-system-audio-source-mode/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Audio Source Modes for Notes
+
+**Feature Branch**: `002-system-audio-source-mode`  
+**Created**: 2026-05-19  
+**Status**: Draft  
+**Input**: User description: "Add a recording source mode control so notes can listen to microphone only or microphone plus system audio. This is a late MVP scope change inspired by the legacy macOS system-audio capture path. Realtime transcription is not required. The app must verify required permissions when the mode changes or when recording starts, and the implementation should be as reliable and failure-proof as possible."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Choose the Recording Source Before Capture (Priority: P1)
+
+A user can decide whether a note should record only their microphone or both microphone and system audio before starting capture. The app makes the selected mode visible and verifies that the permissions required for that mode are available before capture starts.
+
+**Why this priority**: The user must be able to intentionally capture meeting or system-source audio without accidentally changing the reliable microphone-only path that already works.
+
+**Independent Test**: Can be tested by switching between "Microphone only" and "Microphone + system audio" before recording, denying one required permission, and verifying that recording does not start until the required permission path is resolved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a draft note is open and no recording is active, **When** the user selects "Microphone only", **Then** the app verifies microphone readiness and keeps system-audio capture disabled.
+2. **Given** a draft note is open and no recording is active, **When** the user selects "Microphone + system audio", **Then** the app verifies both microphone readiness and system-audio readiness before recording can begin.
+3. **Given** a required permission for the selected mode is denied or unavailable, **When** the user tries to start recording, **Then** the app blocks capture, leaves the note editable, and shows a clear recovery action.
+4. **Given** recording has started in a selected mode, **When** the user interacts with the mode control, **Then** the app prevents changing modes until the current recording is finished or discarded.
+
+---
+
+### User Story 2 - Capture Notes from Microphone and System Audio (Priority: P1)
+
+A user can record a note while a meeting, video, or other system source is playing, and the generated note uses both the user's microphone and system audio after local capture completes.
+
+**Why this priority**: The main value of this feature is capturing information from meetings or other system sources while preserving the batch, saved-audio reliability model.
+
+**Independent Test**: Can be tested by playing audible system audio, speaking through the microphone, recording in "Microphone + system audio", selecting Done, and verifying that local audio artifacts, transcript text, and generated notes reflect both sources.
+
+**Acceptance Scenarios**:
+
+1. **Given** both required permissions are available and system audio is playing, **When** the user records in "Microphone + system audio", **Then** the app captures local audio evidence for both microphone and system sources.
+2. **Given** the user pauses and resumes while recording in "Microphone + system audio", **When** capture finishes, **Then** pause and resume apply consistently to both sources.
+3. **Given** capture finishes successfully, **When** the app transcribes the recording, **Then** transcript text is source-labeled so the user can distinguish microphone content from system-audio content.
+4. **Given** transcription succeeds for at least one usable source, **When** note generation runs, **Then** the generated note uses the available labeled transcript and does not discard prior note content.
+
+---
+
+### User Story 3 - Recover and Retry Multi-Source Recordings (Priority: P2)
+
+A user does not lose recoverable audio if the app closes, capture fails, or provider processing fails during a microphone-plus-system recording.
+
+**Why this priority**: Adding a second audio source increases failure modes. The feature must preserve the existing reliability principle that saved audio is more important than provider speed.
+
+**Independent Test**: Can be tested by starting a microphone-plus-system recording, force-quitting after bytes are written, reopening the app, and verifying that recoverable source artifacts are surfaced with validate, discard, and retry paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app closes during a microphone-plus-system recording, **When** it restarts, **Then** it surfaces recoverable state for each source that wrote audio bytes.
+2. **Given** one source validates and another source is silent or invalid, **When** the user finishes recording, **Then** the app preserves both source results, warns about the failed source, and can still process any valid source.
+3. **Given** transcription or note generation fails after audio validation, **When** the user retries, **Then** retry uses saved audio artifacts without requiring a new recording.
+
+### Edge Cases
+
+- Microphone permission is granted but system-audio permission is denied.
+- System-audio permission is granted but microphone permission is denied.
+- System-audio capture is unavailable because the macOS version or app signing state does not support it.
+- The user selects microphone-plus-system mode when no audible system source is playing.
+- Microphone input is silent but system audio contains usable signal.
+- System audio is silent but microphone input contains usable signal.
+- One source starts successfully but stops writing bytes before Done.
+- Pause or Resume succeeds for one source and fails for the other.
+- Expected elapsed duration and saved audio duration disagree for one source but not the other.
+- The app exits while one source has finalized audio and the other source only has partial audio.
+- Provider transcription succeeds for one source and fails for the other.
+- The user records multiple times into the same note; new generated content must append rather than replace previous note content.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The note editor MUST expose a clear recording source control before recording starts with exactly these user-facing choices: "Microphone only" and "Microphone + system audio".
+- **FR-002**: "Microphone only" MUST remain the default source mode for new notes and must preserve the current microphone-only behavior.
+- **FR-003**: The app MUST prevent source mode changes while a recording is active, paused, finalizing, validating, transcribing, or generating.
+- **FR-004**: The app MUST persist the selected source mode with the recording session so recovery and retry use the same mode that started the recording.
+- **FR-005**: Before starting "Microphone only" recording, the app MUST verify microphone permission and microphone device availability.
+- **FR-006**: Before starting "Microphone + system audio" recording, the app MUST verify microphone permission, microphone device availability, system-audio permission readiness, and system-audio capture availability.
+- **FR-007**: When a required permission is denied or unavailable, the app MUST NOT start capture, MUST NOT mark the note as recording, and MUST show a source-specific recovery message.
+- **FR-008**: When a required permission can be fixed through macOS settings, the app MUST provide a recovery action or instruction that identifies the relevant permission area.
+- **FR-009**: "Microphone + system audio" recording MUST capture microphone audio and system audio as distinct local source artifacts rather than mixing them into a single unlabeled stream.
+- **FR-010**: The app MUST show recording evidence for every active source in the selected mode, including elapsed time, source activity, paused state, and bytes-written or equivalent local-write evidence.
+- **FR-011**: Pause and Resume MUST apply to every active source in the selected mode; if one source cannot pause or resume, the app MUST stop the recording safely and preserve any recoverable audio.
+- **FR-012**: The Done action MUST finalize every active source artifact before transcription or note generation begins.
+- **FR-013**: The app MUST validate every finalized source artifact independently using local checks for file existence, non-zero size, readable audio, duration consistency, and non-silent signal.
+- **FR-014**: If at least one selected source validates successfully, the app MAY continue transcription and note generation from valid sources while warning about invalid or silent sources.
+- **FR-015**: If no selected source validates successfully, the app MUST NOT generate a note and MUST preserve recoverable source artifacts for retry or discard.
+- **FR-016**: Transcription output MUST preserve source labels for microphone and system audio.
+- **FR-017**: Generated notes MUST be based only on valid source transcripts and any existing user note context; they MUST NOT invent information for missing or failed sources.
+- **FR-018**: When a new recording is added to an existing note, generated content MUST append to the existing visible note content instead of replacing it.
+- **FR-019**: The raw Transcription tab MUST show the labeled source transcript used for generation and must make source failures visible when applicable.
+- **FR-020**: Recovery scanning MUST detect partial and finalized artifacts per source and surface enough information for the user to validate, retry, or discard recoverable audio intentionally.
+- **FR-021**: Retry processing MUST reuse saved source artifacts and the recording source mode without requiring the user to re-record.
+- **FR-022**: The feature MUST remain batch-only for this scope: no realtime captions, no live transcript stream, and no separate meeting object are required.
+- **FR-023**: The UI MUST remain notes-first and MUST NOT reintroduce legacy workspaces, auth, billing, calendar, chat, sharing, or a dedicated meetings product surface.
+- **FR-024**: This specification supersedes the previous MVP assumption that system audio is out of scope only for the new "Microphone + system audio" source mode.
+
+### Permission and Reliability Requirements
+
+- **PR-001**: Permission checks MUST run when the user selects a source mode and again immediately before recording starts.
+- **PR-002**: A stale successful permission check MUST NOT be treated as sufficient if the user starts recording later after permissions may have changed.
+- **PR-003**: Starting a multi-source recording MUST be atomic from the user's perspective: either all required sources start and write evidence, or the app stops all started sources and reports the failure.
+- **PR-004**: The app MUST record source-specific lifecycle checkpoints for start, pause, resume, done, validation, transcription, generation, failure, retry, and recovery.
+- **PR-005**: The app MUST preserve source artifacts and validation metadata even when provider transcription or note generation fails.
+- **PR-006**: The app MUST make it obvious which source failed when a permission, capture, validation, transcription, or generation error occurs.
+
+### Key Entities _(include if feature involves data)_
+
+- **Recording Source Mode**: The selected capture scope for a recording session. Valid values are microphone-only and microphone-plus-system-audio.
+- **Source Artifact**: A local audio artifact associated with a specific source, including source label, path, format, duration, size, checksum or integrity marker, validation status, and error details.
+- **Source Validation Result**: The result of validating one source artifact independently, including readability, duration consistency, signal evidence, and warnings.
+- **Labeled Transcript**: Transcript text grouped or annotated by source so generated notes can distinguish microphone speech from system audio.
+- **Recording Session**: The note-backed capture lifecycle that owns the selected source mode, source artifacts, checkpoints, processing status, retry state, and recovery state.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: In 20 consecutive microphone-only recordings of at least 30 seconds each, the app preserves the existing behavior and saves a readable microphone audio file every time.
+- **SC-002**: In 10 consecutive microphone-plus-system recordings with audible microphone input and audible system audio, the app saves readable local artifacts for both sources at least 9 times.
+- **SC-003**: When microphone permission or system-audio permission is denied, 100% of attempted recordings in the affected mode are blocked before capture starts and show a source-specific recovery message.
+- **SC-004**: When one source is silent and the other source contains usable audio, the app generates a note from the valid source and shows a warning for the silent source.
+- **SC-005**: When both selected sources are unusable, the app generates no note and preserves enough local state for retry or discard.
+- **SC-006**: A user can record twice into the same note using any supported source mode and see the second generated result appended to the previous note content.
+- **SC-007**: A force quit during microphone-plus-system capture surfaces recoverable source artifacts on restart whenever audio bytes were written before the interruption.
+- **SC-008**: At least 90% of test users can identify the selected source mode and whether microphone and system audio are actively being captured without reading documentation.
+
+## Assumptions
+
+- This is a late MVP scope change that extends note recording source options while preserving the simpler notes-only product shape.
+- Realtime transcription and live captions are intentionally excluded for this feature; all transcription and generation happen after local capture is finalized and validated.
+- "System audio" means audio produced by applications or the operating system on the user's Mac, such as meeting participants, browser video, or media playback.
+- System-audio capture is macOS-first and may require a minimum macOS version and correct app signing or permission metadata before it can work reliably.
+- The implementation may reuse ideas from the legacy native macOS helper, but the new app should keep the current local storage, validation, retry, and recovery model.
+- Source-labeled transcripts are sufficient for this feature; perfect chronological interleaving between microphone and system audio is not required.
+- The existing local provider configuration remains the transcription and note generation path unless a later feature changes provider settings.

--- a/specs/002-system-audio-source-mode/tasks.md
+++ b/specs/002-system-audio-source-mode/tasks.md
@@ -1,0 +1,142 @@
+# Tasks: Audio Source Modes for Notes
+
+**Input**: Design documents from `/specs/002-system-audio-source-mode/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+**Tests**: Required by the user request to keep the feature reliable; write behavior tests before implementation where practical.
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare shared code and configuration for source-aware recording.
+
+- [ ] T001 Verify ignored generated artifacts and native helper outputs in `.gitignore`
+- [ ] T002 [P] Add source-mode TypeScript DTOs and command wrappers in `src/lib/tauri.ts`
+- [ ] T003 [P] Add source-mode Rust DTOs and enums in `src-tauri/src/domain/types.rs`
+- [ ] T004 Add macOS system-audio usage text and helper build path planning in `src-tauri/Info.plist`, `src-tauri/tauri.conf.json`, and `src-tauri/build.rs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared persistence, capture abstractions, and processing support required by all stories.
+
+**CRITICAL**: No user story work begins until this phase is complete.
+
+- [ ] T005 [P] Add Rust repository tests for source-mode session persistence in `src-tauri/tests/source_modes.rs`
+- [ ] T006 [P] Add Rust processing tests for labeled transcript generation and valid-source filtering in `src-tauri/tests/source_processing.rs`
+- [ ] T007 Add SQLite migration for source mode, source artifacts, source checkpoints, and source-labeled transcripts in `src-tauri/migrations/002_source_modes.sql`
+- [ ] T008 Extend repository methods for source sessions, artifacts, checkpoints, recoveries, and transcripts in `src-tauri/src/db/repositories.rs`
+- [ ] T009 Add source-aware audio validation aggregation helpers in `src-tauri/src/audio/validation.rs`
+- [ ] T010 Add source-aware processing helpers for labeled transcripts, generation input, and retry in `src-tauri/src/domain/processing.rs`
+- [ ] T011 Run the foundational Rust tests and confirm the new tests fail before implementation, then pass after T007-T010
+
+---
+
+## Phase 3: User Story 1 - Choose the Recording Source Before Capture (Priority: P1)
+
+**Goal**: User can select `Microphone only` or `Microphone + system audio`, see readiness, and be blocked before capture if required permissions are unavailable.
+
+**Independent Test**: Switch modes before recording and verify readiness appears; simulate denied/unavailable source and verify recording does not start.
+
+### Tests for User Story 1
+
+- [ ] T012 [P] [US1] Add frontend tests for source mode selection, disabled mode changes while active, and readiness messages in `src/test/recorder-source-mode.test.tsx`
+- [ ] T013 [P] [US1] Add Rust command tests for readiness and blocked starts in `src-tauri/tests/source_readiness.rs`
+
+### Implementation for User Story 1
+
+- [ ] T014 [US1] Implement `check_recording_source_readiness` and source-mode start request handling in `src-tauri/src/commands.rs`
+- [ ] T015 [US1] Add macOS system-audio readiness module and unsupported fallback behavior in `src-tauri/src/audio/system_macos.rs`
+- [ ] T016 [US1] Wire Tauri command registration for readiness and source-mode recording in `src-tauri/src/lib.rs`
+- [ ] T017 [US1] Add source mode UI state and readiness flow in `src/app/App.tsx` and `src/app/state/app-state.ts`
+- [ ] T018 [US1] Add source mode segmented control and readiness/error display in `src/components/recorder/RecorderBar.tsx` and `src/components/note-editor/NoteEditor.tsx`
+- [ ] T019 [US1] Run US1 frontend and Rust tests, then mark the story complete only after they pass
+
+---
+
+## Phase 4: User Story 2 - Capture Notes from Microphone and System Audio (Priority: P1)
+
+**Goal**: User records in dual-source mode, local artifacts are created per source, validation happens per source, transcripts are labeled, and generated notes append.
+
+**Independent Test**: Record with audible mic and system audio, click Done, and verify two local artifacts, labeled transcript sections, and appended generated content.
+
+### Tests for User Story 2
+
+- [ ] T020 [P] [US2] Add Rust capture lifecycle tests for dual-source status, pause/resume, finalization, and validation aggregation in `src-tauri/tests/source_capture.rs`
+- [ ] T021 [P] [US2] Add frontend tests for per-source active indicators and source warnings in `src/test/recorder-source-status.test.tsx`
+
+### Implementation for User Story 2
+
+- [ ] T022 [US2] Refactor microphone capture into a source-aware active session in `src-tauri/src/audio/capture.rs`
+- [ ] T023 [US2] Add macOS helper source, build script, and process manager for system audio capture in `src-tauri/native/mac-system-audio-recorder/main.swift`, `src-tauri/build.rs`, and `src-tauri/src/audio/system_macos.rs`
+- [ ] T024 [US2] Implement dual-source start, pause, resume, status, finish, validation, and partial-source warnings in `src-tauri/src/audio/capture.rs` and `src-tauri/src/commands.rs`
+- [ ] T025 [US2] Persist source artifacts and source-labeled transcripts from finished recordings in `src-tauri/src/db/repositories.rs` and `src-tauri/src/domain/processing.rs`
+- [ ] T026 [US2] Render per-source levels, bytes, silence warnings, source labels, and labeled transcript content in `src/components/recorder/RecorderBar.tsx`, `src/components/recorder/Waveform.tsx`, and `src/components/note-editor/NoteEditor.tsx`
+- [ ] T027 [US2] Run US2 frontend and Rust tests, then mark the story complete only after they pass
+
+---
+
+## Phase 5: User Story 3 - Recover and Retry Multi-Source Recordings (Priority: P2)
+
+**Goal**: Interrupted dual-source recordings preserve recoverable source artifacts and retry uses saved source artifacts without re-recording.
+
+**Independent Test**: Start dual-source recording, force quit after bytes are written, reopen, validate recoverable sources, and retry failed processing from saved artifacts.
+
+### Tests for User Story 3
+
+- [ ] T028 [P] [US3] Add Rust recovery tests for source-aware partial/finalized artifacts in `src-tauri/tests/source_recovery.rs`
+- [ ] T029 [P] [US3] Add frontend recovery banner tests for source-aware recoveries in `src/test/recovery-source-mode.test.tsx`
+
+### Implementation for User Story 3
+
+- [ ] T030 [US3] Extend recovery scanning and discard/validate actions for source artifacts in `src-tauri/src/audio/recovery.rs` and `src-tauri/src/commands.rs`
+- [ ] T031 [US3] Extend retry processing to reuse valid source artifacts and persisted source mode in `src-tauri/src/domain/processing.rs`
+- [ ] T032 [US3] Render source-aware recovery information and retry warnings in `src/components/recorder/RecoveryBanner.tsx` and `src/components/note-editor/NoteEditor.tsx`
+- [ ] T033 [US3] Run US3 frontend and Rust tests, then mark the story complete only after they pass
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: End-to-end verification, docs, and app readiness.
+
+- [ ] T034 Update manual validation docs and quickstart references for source mode testing in `specs/002-system-audio-source-mode/quickstart.md` and `README.md`
+- [ ] T035 Run full frontend tests with `pnpm test`
+- [ ] T036 Run full Rust tests with `pnpm test:rust`
+- [ ] T037 Run TypeScript build/lint with `pnpm run lint`
+- [ ] T038 Run Tauri build with `pnpm tauri:build`
+- [ ] T039 Run `git diff --check` and final spec alignment review against `specs/002-system-audio-source-mode/spec.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **US1 and US2 (P1)**: Depend on Foundational. Implement US1 first because readiness and mode selection are required before dual-source capture.
+- **US3 (P2)**: Depends on source artifact lifecycle from US2.
+- **Polish**: Depends on selected user stories being complete.
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories after Foundational.
+- **US2**: Depends on US1 command and UI source-mode contract.
+- **US3**: Depends on US2 source artifacts and source-labeled processing.
+
+### Parallel Opportunities
+
+- T002 and T003 can be done in parallel.
+- T005 and T006 can be done in parallel.
+- T012 and T013 can be done in parallel.
+- T020 and T021 can be done in parallel.
+- T028 and T029 can be done in parallel.
+
+## Implementation Strategy
+
+1. Complete Setup and Foundational tasks.
+2. Complete US1 so source selection and permission blocking are testable.
+3. Complete US2 so dual-source recording and labeled generation are testable.
+4. Complete US3 so recovery and retry are source-aware.
+5. Run all verification commands before reporting readiness for user testing.

--- a/specs/002-system-audio-source-mode/tasks.md
+++ b/specs/002-system-audio-source-mode/tasks.md
@@ -9,10 +9,10 @@
 
 **Purpose**: Prepare shared code and configuration for source-aware recording.
 
-- [ ] T001 Verify ignored generated artifacts and native helper outputs in `.gitignore`
-- [ ] T002 [P] Add source-mode TypeScript DTOs and command wrappers in `src/lib/tauri.ts`
-- [ ] T003 [P] Add source-mode Rust DTOs and enums in `src-tauri/src/domain/types.rs`
-- [ ] T004 Add macOS system-audio usage text and helper build path planning in `src-tauri/Info.plist`, `src-tauri/tauri.conf.json`, and `src-tauri/build.rs`
+- [x] T001 Verify ignored generated artifacts and native helper outputs in `.gitignore`
+- [x] T002 [P] Add source-mode TypeScript DTOs and command wrappers in `src/lib/tauri.ts`
+- [x] T003 [P] Add source-mode Rust DTOs and enums in `src-tauri/src/domain/types.rs`
+- [x] T004 Add macOS system-audio usage text and helper build path planning in `src-tauri/Info.plist`, `src-tauri/tauri.conf.json`, and `src-tauri/build.rs`
 
 ---
 
@@ -22,13 +22,13 @@
 
 **CRITICAL**: No user story work begins until this phase is complete.
 
-- [ ] T005 [P] Add Rust repository tests for source-mode session persistence in `src-tauri/tests/source_modes.rs`
-- [ ] T006 [P] Add Rust processing tests for labeled transcript generation and valid-source filtering in `src-tauri/tests/source_processing.rs`
-- [ ] T007 Add SQLite migration for source mode, source artifacts, source checkpoints, and source-labeled transcripts in `src-tauri/migrations/002_source_modes.sql`
-- [ ] T008 Extend repository methods for source sessions, artifacts, checkpoints, recoveries, and transcripts in `src-tauri/src/db/repositories.rs`
-- [ ] T009 Add source-aware audio validation aggregation helpers in `src-tauri/src/audio/validation.rs`
-- [ ] T010 Add source-aware processing helpers for labeled transcripts, generation input, and retry in `src-tauri/src/domain/processing.rs`
-- [ ] T011 Run the foundational Rust tests and confirm the new tests fail before implementation, then pass after T007-T010
+- [x] T005 [P] Add Rust repository tests for source-mode session persistence in `src-tauri/tests/source_modes.rs`
+- [x] T006 [P] Add Rust processing tests for labeled transcript generation and valid-source filtering in `src-tauri/tests/source_processing.rs`
+- [x] T007 Add SQLite migration for source mode, source artifacts, source checkpoints, and source-labeled transcripts in `src-tauri/migrations/002_source_modes.sql`
+- [x] T008 Extend repository methods for source sessions, artifacts, checkpoints, recoveries, and transcripts in `src-tauri/src/db/repositories.rs`
+- [x] T009 Add source-aware audio validation aggregation helpers in `src-tauri/src/audio/validation.rs`
+- [x] T010 Add source-aware processing helpers for labeled transcripts, generation input, and retry in `src-tauri/src/domain/processing.rs`
+- [x] T011 Run the foundational Rust tests and confirm the new tests fail before implementation, then pass after T007-T010
 
 ---
 
@@ -40,17 +40,17 @@
 
 ### Tests for User Story 1
 
-- [ ] T012 [P] [US1] Add frontend tests for source mode selection, disabled mode changes while active, and readiness messages in `src/test/recorder-source-mode.test.tsx`
-- [ ] T013 [P] [US1] Add Rust command tests for readiness and blocked starts in `src-tauri/tests/source_readiness.rs`
+- [x] T012 [P] [US1] Add frontend tests for source mode selection, disabled mode changes while active, and readiness messages in `src/test/recorder-source-mode.test.tsx`
+- [x] T013 [P] [US1] Add Rust command tests for readiness and blocked starts in `src-tauri/tests/source_readiness.rs`
 
 ### Implementation for User Story 1
 
-- [ ] T014 [US1] Implement `check_recording_source_readiness` and source-mode start request handling in `src-tauri/src/commands.rs`
-- [ ] T015 [US1] Add macOS system-audio readiness module and unsupported fallback behavior in `src-tauri/src/audio/system_macos.rs`
-- [ ] T016 [US1] Wire Tauri command registration for readiness and source-mode recording in `src-tauri/src/lib.rs`
-- [ ] T017 [US1] Add source mode UI state and readiness flow in `src/app/App.tsx` and `src/app/state/app-state.ts`
-- [ ] T018 [US1] Add source mode segmented control and readiness/error display in `src/components/recorder/RecorderBar.tsx` and `src/components/note-editor/NoteEditor.tsx`
-- [ ] T019 [US1] Run US1 frontend and Rust tests, then mark the story complete only after they pass
+- [x] T014 [US1] Implement `check_recording_source_readiness` and source-mode start request handling in `src-tauri/src/commands.rs`
+- [x] T015 [US1] Add macOS system-audio readiness module and unsupported fallback behavior in `src-tauri/src/audio/system_macos.rs`
+- [x] T016 [US1] Wire Tauri command registration for readiness and source-mode recording in `src-tauri/src/lib.rs`
+- [x] T017 [US1] Add source mode UI state and readiness flow in `src/app/App.tsx` and `src/app/state/app-state.ts`
+- [x] T018 [US1] Add source mode segmented control and readiness/error display in `src/components/recorder/RecorderBar.tsx` and `src/components/note-editor/NoteEditor.tsx`
+- [x] T019 [US1] Run US1 frontend and Rust tests, then mark the story complete only after they pass
 
 ---
 
@@ -62,17 +62,17 @@
 
 ### Tests for User Story 2
 
-- [ ] T020 [P] [US2] Add Rust capture lifecycle tests for dual-source status, pause/resume, finalization, and validation aggregation in `src-tauri/tests/source_capture.rs`
-- [ ] T021 [P] [US2] Add frontend tests for per-source active indicators and source warnings in `src/test/recorder-source-status.test.tsx`
+- [x] T020 [P] [US2] Add Rust capture lifecycle tests for dual-source status, pause/resume, finalization, and validation aggregation in `src-tauri/tests/source_capture.rs`
+- [x] T021 [P] [US2] Add frontend tests for per-source active indicators and source warnings in `src/test/recorder-source-status.test.tsx`
 
 ### Implementation for User Story 2
 
-- [ ] T022 [US2] Refactor microphone capture into a source-aware active session in `src-tauri/src/audio/capture.rs`
-- [ ] T023 [US2] Add macOS helper source, build script, and process manager for system audio capture in `src-tauri/native/mac-system-audio-recorder/main.swift`, `src-tauri/build.rs`, and `src-tauri/src/audio/system_macos.rs`
-- [ ] T024 [US2] Implement dual-source start, pause, resume, status, finish, validation, and partial-source warnings in `src-tauri/src/audio/capture.rs` and `src-tauri/src/commands.rs`
-- [ ] T025 [US2] Persist source artifacts and source-labeled transcripts from finished recordings in `src-tauri/src/db/repositories.rs` and `src-tauri/src/domain/processing.rs`
-- [ ] T026 [US2] Render per-source levels, bytes, silence warnings, source labels, and labeled transcript content in `src/components/recorder/RecorderBar.tsx`, `src/components/recorder/Waveform.tsx`, and `src/components/note-editor/NoteEditor.tsx`
-- [ ] T027 [US2] Run US2 frontend and Rust tests, then mark the story complete only after they pass
+- [x] T022 [US2] Refactor microphone capture into a source-aware active session in `src-tauri/src/audio/capture.rs`
+- [x] T023 [US2] Add macOS helper source, build script, and process manager for system audio capture in `src-tauri/native/mac-system-audio-recorder/main.swift`, `src-tauri/build.rs`, and `src-tauri/src/audio/system_macos.rs`
+- [x] T024 [US2] Implement dual-source start, pause, resume, status, finish, validation, and partial-source warnings in `src-tauri/src/audio/capture.rs` and `src-tauri/src/commands.rs`
+- [x] T025 [US2] Persist source artifacts and source-labeled transcripts from finished recordings in `src-tauri/src/db/repositories.rs` and `src-tauri/src/domain/processing.rs`
+- [x] T026 [US2] Render per-source levels, bytes, silence warnings, source labels, and labeled transcript content in `src/components/recorder/RecorderBar.tsx`, `src/components/recorder/Waveform.tsx`, and `src/components/note-editor/NoteEditor.tsx`
+- [x] T027 [US2] Run US2 frontend and Rust tests, then mark the story complete only after they pass
 
 ---
 
@@ -84,15 +84,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T028 [P] [US3] Add Rust recovery tests for source-aware partial/finalized artifacts in `src-tauri/tests/source_recovery.rs`
-- [ ] T029 [P] [US3] Add frontend recovery banner tests for source-aware recoveries in `src/test/recovery-source-mode.test.tsx`
+- [x] T028 [P] [US3] Add Rust recovery tests for source-aware partial/finalized artifacts in `src-tauri/tests/source_recovery.rs`
+- [x] T029 [P] [US3] Add frontend recovery banner tests for source-aware recoveries in `src/test/recovery-source-mode.test.tsx`
 
 ### Implementation for User Story 3
 
-- [ ] T030 [US3] Extend recovery scanning and discard/validate actions for source artifacts in `src-tauri/src/audio/recovery.rs` and `src-tauri/src/commands.rs`
-- [ ] T031 [US3] Extend retry processing to reuse valid source artifacts and persisted source mode in `src-tauri/src/domain/processing.rs`
-- [ ] T032 [US3] Render source-aware recovery information and retry warnings in `src/components/recorder/RecoveryBanner.tsx` and `src/components/note-editor/NoteEditor.tsx`
-- [ ] T033 [US3] Run US3 frontend and Rust tests, then mark the story complete only after they pass
+- [x] T030 [US3] Extend recovery scanning and discard/validate actions for source artifacts in `src-tauri/src/audio/recovery.rs` and `src-tauri/src/commands.rs`
+- [x] T031 [US3] Extend retry processing to reuse valid source artifacts and persisted source mode in `src-tauri/src/domain/processing.rs`
+- [x] T032 [US3] Render source-aware recovery information and retry warnings in `src/components/recorder/RecoveryBanner.tsx` and `src/components/note-editor/NoteEditor.tsx`
+- [x] T033 [US3] Run US3 frontend and Rust tests, then mark the story complete only after they pass
 
 ---
 
@@ -100,12 +100,12 @@
 
 **Purpose**: End-to-end verification, docs, and app readiness.
 
-- [ ] T034 Update manual validation docs and quickstart references for source mode testing in `specs/002-system-audio-source-mode/quickstart.md` and `README.md`
-- [ ] T035 Run full frontend tests with `pnpm test`
-- [ ] T036 Run full Rust tests with `pnpm test:rust`
-- [ ] T037 Run TypeScript build/lint with `pnpm run lint`
-- [ ] T038 Run Tauri build with `pnpm tauri:build`
-- [ ] T039 Run `git diff --check` and final spec alignment review against `specs/002-system-audio-source-mode/spec.md`
+- [x] T034 Update manual validation docs and quickstart references for source mode testing in `specs/002-system-audio-source-mode/quickstart.md` and `README.md`
+- [x] T035 Run full frontend tests with `pnpm test`
+- [x] T036 Run full Rust tests with `pnpm test:rust`
+- [x] T037 Run TypeScript build/lint with `pnpm run lint`
+- [x] T038 Run Tauri build with `pnpm tauri:build`
+- [x] T039 Run `git diff --check` and final spec alignment review against `specs/002-system-audio-source-mode/spec.md`
 
 ---
 

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,5 +4,7 @@
 <dict>
   <key>NSMicrophoneUsageDescription</key>
   <string>OS Notetaker records microphone audio locally so it can transcribe and generate your notes.</string>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>OS Notetaker records system audio locally when you choose microphone plus system audio for a note.</string>
 </dict>
 </plist>

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -19,36 +19,52 @@ fn build_system_audio_helper() {
     }
     println!("cargo:rerun-if-changed={}", source.display());
 
-    let out_dir = manifest_dir.join("native").join("bin");
-    let app_dir = out_dir.join("OS Notetaker Audio Capture.app");
+    let helper_dir = manifest_dir
+        .parent()
+        .expect("src-tauri should have a repository parent")
+        .join(".tauri-helper");
+    let app_dir = helper_dir.join("OS Notetaker Audio Capture.app");
     let contents_dir = app_dir.join("Contents");
     let macos_dir = contents_dir.join("MacOS");
-    let _ = std::fs::remove_dir_all(&app_dir);
     std::fs::create_dir_all(&macos_dir).expect("system audio helper app dir should be created");
     let executable = macos_dir.join("os-notetaker-system-audio-recorder");
 
-    let status = std::process::Command::new("swiftc")
-        .arg("-framework")
-        .arg("Foundation")
-        .arg("-framework")
-        .arg("AVFoundation")
-        .arg("-framework")
-        .arg("CoreAudio")
-        .arg("-framework")
-        .arg("AudioToolbox")
-        .arg(&source)
-        .arg("-o")
-        .arg(&executable)
-        .status();
-    if !matches!(status, Ok(status) if status.success()) {
-        println!("cargo:warning=system audio helper could not be built; dual-source mode will report unavailable");
-        return;
+    let source_modified = std::fs::metadata(&source)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    let executable_current = executable.exists()
+        && source_modified
+            .and_then(|source_modified| {
+                std::fs::metadata(&executable)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+                    .map(|executable_modified| executable_modified >= source_modified)
+            })
+            .unwrap_or(false);
+    let mut should_sign = false;
+    if !executable_current {
+        let status = std::process::Command::new("swiftc")
+            .arg("-framework")
+            .arg("Foundation")
+            .arg("-framework")
+            .arg("AVFoundation")
+            .arg("-framework")
+            .arg("CoreAudio")
+            .arg("-framework")
+            .arg("AudioToolbox")
+            .arg(&source)
+            .arg("-o")
+            .arg(&executable)
+            .status();
+        if !matches!(status, Ok(status) if status.success()) {
+            println!("cargo:warning=system audio helper could not be built; dual-source mode will report unavailable");
+            return;
+        }
+        should_sign = true;
     }
 
     let plist = contents_dir.join("Info.plist");
-    std::fs::write(
-        plist,
-        r#"<?xml version="1.0" encoding="UTF-8"?>
+    let plist_contents = r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -78,15 +94,22 @@ fn build_system_audio_helper() {
   <string>OS Notetaker records system audio locally so generated notes can include meeting or media audio from your Mac.</string>
 </dict>
 </plist>
-"#,
-    )
-    .expect("system audio helper Info.plist should be written");
+"#;
+    let plist_current =
+        std::fs::read_to_string(&plist).is_ok_and(|current| current == plist_contents);
+    if !plist_current {
+        std::fs::write(plist, plist_contents)
+            .expect("system audio helper Info.plist should be written");
+        should_sign = true;
+    }
 
-    let _ = std::process::Command::new("codesign")
-        .arg("--force")
-        .arg("--deep")
-        .arg("--sign")
-        .arg("-")
-        .arg(&app_dir)
-        .status();
+    if should_sign {
+        let _ = std::process::Command::new("codesign")
+            .arg("--force")
+            .arg("--deep")
+            .arg("--sign")
+            .arg("-")
+            .arg(&app_dir)
+            .status();
+    }
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,92 @@
 fn main() {
+    build_system_audio_helper();
     tauri_build::build();
+}
+
+fn build_system_audio_helper() {
+    if std::env::var("CARGO_CFG_TARGET_OS").ok().as_deref() != Some("macos") {
+        return;
+    }
+    let manifest_dir = std::path::PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"),
+    );
+    let source = manifest_dir
+        .join("native")
+        .join("mac-system-audio-recorder")
+        .join("main.swift");
+    if !source.exists() {
+        return;
+    }
+    println!("cargo:rerun-if-changed={}", source.display());
+
+    let out_dir = manifest_dir.join("native").join("bin");
+    let app_dir = out_dir.join("OS Notetaker Audio Capture.app");
+    let contents_dir = app_dir.join("Contents");
+    let macos_dir = contents_dir.join("MacOS");
+    let _ = std::fs::remove_dir_all(&app_dir);
+    std::fs::create_dir_all(&macos_dir).expect("system audio helper app dir should be created");
+    let executable = macos_dir.join("os-notetaker-system-audio-recorder");
+
+    let status = std::process::Command::new("swiftc")
+        .arg("-framework")
+        .arg("Foundation")
+        .arg("-framework")
+        .arg("AVFoundation")
+        .arg("-framework")
+        .arg("CoreAudio")
+        .arg("-framework")
+        .arg("AudioToolbox")
+        .arg(&source)
+        .arg("-o")
+        .arg(&executable)
+        .status();
+    if !matches!(status, Ok(status) if status.success()) {
+        println!("cargo:warning=system audio helper could not be built; dual-source mode will report unavailable");
+        return;
+    }
+
+    let plist = contents_dir.join("Info.plist");
+    std::fs::write(
+        plist,
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>OS Notetaker Audio Capture</string>
+  <key>CFBundleExecutable</key>
+  <string>os-notetaker-system-audio-recorder</string>
+  <key>CFBundleIdentifier</key>
+  <string>network.opensoftware.os-notetaker.audio-capture</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>OS Notetaker Audio Capture</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.2</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>OS Notetaker records system audio locally so generated notes can include meeting or media audio from your Mac.</string>
+</dict>
+</plist>
+"#,
+    )
+    .expect("system audio helper Info.plist should be written");
+
+    let _ = std::process::Command::new("codesign")
+        .arg("--force")
+        .arg("--deep")
+        .arg("--sign")
+        .arg("-")
+        .arg(&app_dir)
+        .status();
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -47,6 +47,8 @@ fn build_system_audio_helper() {
             .arg("-framework")
             .arg("Foundation")
             .arg("-framework")
+            .arg("AppKit")
+            .arg("-framework")
             .arg("AVFoundation")
             .arg("-framework")
             .arg("CoreAudio")

--- a/src-tauri/migrations/002_source_modes.sql
+++ b/src-tauri/migrations/002_source_modes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS idx_audio_artifacts_session_source
+ON audio_artifacts (recording_session_id, source);
+
+CREATE INDEX IF NOT EXISTS idx_transcripts_session_source
+ON transcripts (recording_session_id, source);

--- a/src-tauri/native/mac-system-audio-recorder/main.swift
+++ b/src-tauri/native/mac-system-audio-recorder/main.swift
@@ -1,0 +1,293 @@
+import AVFoundation
+import AudioToolbox
+import CoreAudio
+import Darwin
+import Foundation
+
+extension String: @retroactive Error {}
+
+extension AudioObjectID {
+    static let system = AudioObjectID(kAudioObjectSystemObject)
+    static let unknown = kAudioObjectUnknown
+    var isValid: Bool { self != .unknown }
+
+    static func readDefaultSystemOutputDevice() throws -> AudioDeviceID {
+        try AudioObjectID.system.read(kAudioHardwarePropertyDefaultSystemOutputDevice, defaultValue: AudioDeviceID.unknown)
+    }
+
+    func readDeviceUID() throws -> String {
+        try readString(kAudioDevicePropertyDeviceUID)
+    }
+
+    func readAudioTapStreamBasicDescription() throws -> AudioStreamBasicDescription {
+        try read(kAudioTapPropertyFormat, defaultValue: AudioStreamBasicDescription())
+    }
+
+    func readString(_ selector: AudioObjectPropertySelector) throws -> String {
+        try read(AudioObjectPropertyAddress(mSelector: selector, mScope: kAudioObjectPropertyScopeGlobal, mElement: kAudioObjectPropertyElementMain), defaultValue: "" as CFString) as String
+    }
+
+    func read<T>(_ selector: AudioObjectPropertySelector, defaultValue: T) throws -> T {
+        try read(AudioObjectPropertyAddress(mSelector: selector, mScope: kAudioObjectPropertyScopeGlobal, mElement: kAudioObjectPropertyElementMain), defaultValue: defaultValue)
+    }
+
+    func read<T>(_ address: AudioObjectPropertyAddress, defaultValue: T) throws -> T {
+        var address = address
+        var dataSize: UInt32 = 0
+        var err = AudioObjectGetPropertyDataSize(self, &address, 0, nil, &dataSize)
+        guard err == noErr else { throw "Error reading data size for audio property: \(err)" }
+
+        var value = defaultValue
+        err = withUnsafeMutablePointer(to: &value) { pointer in
+            AudioObjectGetPropertyData(self, &address, 0, nil, &dataSize, pointer)
+        }
+        guard err == noErr else { throw "Error reading audio property: \(err)" }
+        return value
+    }
+}
+
+final class SystemAudioRecorder {
+    private let outputURL: URL?
+    private let queue = DispatchQueue(label: "network.opensoftware.os-notetaker.system-audio", qos: .userInitiated)
+    private let pauseLock = NSLock()
+
+    private var processTapID = AudioObjectID.unknown
+    private var aggregateDeviceID = AudioObjectID.unknown
+    private var deviceProcID: AudioDeviceIOProcID?
+    private var audioFile: AVAudioFile?
+    private var audioConverter: AVAudioConverter?
+    private var outputFormat: AVAudioFormat?
+    private var didStop = false
+    private var isPaused = false
+    private var lastLevelEmit = Date.distantPast
+
+    init(outputURL: URL?) {
+        self.outputURL = outputURL
+    }
+
+    func pause() {
+        pauseLock.lock()
+        isPaused = true
+        pauseLock.unlock()
+        emit(["event": "paused"])
+    }
+
+    func resume() {
+        pauseLock.lock()
+        isPaused = false
+        pauseLock.unlock()
+        emit(["event": "resumed"])
+    }
+
+    func start() throws {
+        if let outputURL {
+            try? FileManager.default.removeItem(at: outputURL)
+            try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        }
+
+        let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+        tapDescription.uuid = UUID()
+        tapDescription.muteBehavior = .unmuted
+        tapDescription.name = "OS Notetaker System Audio"
+
+        var tapID = AudioObjectID.unknown
+        var err = AudioHardwareCreateProcessTap(tapDescription, &tapID)
+        guard err == noErr else {
+            throw "System audio permission or tap creation failed with error \(err)"
+        }
+        processTapID = tapID
+
+        let systemOutputID = try AudioObjectID.readDefaultSystemOutputDevice()
+        let outputUID = try systemOutputID.readDeviceUID()
+        let aggregateUID = UUID().uuidString
+        let description: [String: Any] = [
+            kAudioAggregateDeviceNameKey: "OS Notetaker System Audio",
+            kAudioAggregateDeviceUIDKey: aggregateUID,
+            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
+            kAudioAggregateDeviceIsPrivateKey: true,
+            kAudioAggregateDeviceIsStackedKey: false,
+            kAudioAggregateDeviceTapAutoStartKey: true,
+            kAudioAggregateDeviceSubDeviceListKey: [
+                [kAudioSubDeviceUIDKey: outputUID]
+            ],
+            kAudioAggregateDeviceTapListKey: [
+                [
+                    kAudioSubTapDriftCompensationKey: true,
+                    kAudioSubTapUIDKey: tapDescription.uuid.uuidString
+                ]
+            ]
+        ]
+
+        err = AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateDeviceID)
+        guard err == noErr else { throw "Failed to create aggregate audio device: \(err)" }
+
+        var streamDescription = try tapID.readAudioTapStreamBasicDescription()
+        guard let inputFormat = AVAudioFormat(streamDescription: &streamDescription) else {
+            throw "Failed to create audio format for system tap."
+        }
+        guard let outputFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: inputFormat.sampleRate, channels: inputFormat.channelCount, interleaved: true) else {
+            throw "Failed to create output audio format."
+        }
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            throw "Failed to create audio converter."
+        }
+
+        self.outputFormat = outputFormat
+        audioConverter = converter
+        if let outputURL {
+            audioFile = try AVAudioFile(forWriting: outputURL, settings: outputFormat.settings, commonFormat: .pcmFormatInt16, interleaved: true)
+        }
+
+        err = AudioDeviceCreateIOProcIDWithBlock(&deviceProcID, aggregateDeviceID, queue) { [weak self] _, inputData, _, _, _ in
+            guard let self else { return }
+            self.pauseLock.lock()
+            let paused = self.isPaused
+            self.pauseLock.unlock()
+            guard !paused else { return }
+            guard let outputFormat = self.outputFormat, let converter = self.audioConverter else { return }
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, bufferListNoCopy: inputData, deallocator: nil) else { return }
+            do {
+                self.emitLevel(from: buffer)
+                let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * outputFormat.sampleRate / inputFormat.sampleRate))
+                guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: frameCapacity) else { return }
+                var didProvideInput = false
+                var conversionError: NSError?
+                let status = converter.convert(to: convertedBuffer, error: &conversionError) { _, inputStatus in
+                    if didProvideInput {
+                        inputStatus.pointee = .noDataNow
+                        return nil
+                    }
+                    didProvideInput = true
+                    inputStatus.pointee = .haveData
+                    return buffer
+                }
+                if let conversionError { throw conversionError }
+                if status == .haveData || status == .inputRanDry, convertedBuffer.frameLength > 0, let audioFile = self.audioFile {
+                    try audioFile.write(from: convertedBuffer)
+                }
+            } catch {
+                self.emit(["event": "error", "message": error.localizedDescription])
+            }
+        }
+        guard err == noErr else { throw "Failed to create audio IO callback: \(err)" }
+
+        err = AudioDeviceStart(aggregateDeviceID, deviceProcID)
+        guard err == noErr else { throw "Failed to start system audio capture: \(err)" }
+
+        emit(["event": "ready", "output": outputURL?.path ?? "check"])
+    }
+
+    func stop() {
+        guard !didStop else { return }
+        didStop = true
+        if aggregateDeviceID.isValid {
+            AudioDeviceStop(aggregateDeviceID, deviceProcID)
+            if let deviceProcID {
+                AudioDeviceDestroyIOProcID(aggregateDeviceID, deviceProcID)
+            }
+            AudioHardwareDestroyAggregateDevice(aggregateDeviceID)
+        }
+        if processTapID.isValid {
+            AudioHardwareDestroyProcessTap(processTapID)
+        }
+        audioFile = nil
+        audioConverter = nil
+        outputFormat = nil
+        emit(["event": "stopped", "output": outputURL?.path ?? "check"])
+    }
+
+    private func emitLevel(from buffer: AVAudioPCMBuffer) {
+        let now = Date()
+        guard now.timeIntervalSince(lastLevelEmit) >= 0.08 else { return }
+        lastLevelEmit = now
+        let frameLength = Int(buffer.frameLength)
+        let channelCount = Int(buffer.format.channelCount)
+        guard frameLength > 0, channelCount > 0, let channels = buffer.floatChannelData else {
+            emit(["event": "level", "level": "0"])
+            return
+        }
+        var sum: Float = 0
+        var count = 0
+        for channelIndex in 0..<channelCount {
+            let channel = channels[channelIndex]
+            for frameIndex in 0..<frameLength {
+                let sample = channel[frameIndex]
+                sum += sample * sample
+                count += 1
+            }
+        }
+        let rms = count > 0 ? sqrt(sum / Float(count)) : 0
+        emit(["event": "level", "level": String(min(1, Double(rms) * 4))])
+    }
+
+    private func emit(_ object: [String: String]) {
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        print(String(data: data, encoding: .utf8)!)
+        fflush(stdout)
+    }
+}
+
+func argumentValue(_ name: String, from arguments: [String]) -> String? {
+    guard let index = arguments.firstIndex(of: name), arguments.indices.contains(index + 1) else {
+        return nil
+    }
+    return arguments[index + 1]
+}
+
+guard #available(macOS 14.2, *) else {
+    let data = try! JSONSerialization.data(withJSONObject: ["event": "error", "message": "System audio recording requires macOS 14.2 or later."])
+    print(String(data: data, encoding: .utf8)!)
+    exit(2)
+}
+
+let checkOnly = CommandLine.arguments.contains("--check")
+let outputPath = argumentValue("--output", from: CommandLine.arguments)
+if !checkOnly && outputPath == nil {
+    let data = try! JSONSerialization.data(withJSONObject: ["event": "error", "message": "Usage: os-notetaker-system-audio-recorder --output /path/to/recording.wav"])
+    print(String(data: data, encoding: .utf8)!)
+    exit(2)
+}
+
+let recorder = SystemAudioRecorder(outputURL: outputPath.map { URL(fileURLWithPath: $0) })
+
+let terminateSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+let interruptSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+let pauseSource = DispatchSource.makeSignalSource(signal: SIGUSR1, queue: .main)
+let resumeSource = DispatchSource.makeSignalSource(signal: SIGUSR2, queue: .main)
+signal(SIGTERM, SIG_IGN)
+signal(SIGINT, SIG_IGN)
+signal(SIGUSR1, SIG_IGN)
+signal(SIGUSR2, SIG_IGN)
+
+terminateSource.setEventHandler {
+    recorder.stop()
+    exit(0)
+}
+interruptSource.setEventHandler {
+    recorder.stop()
+    exit(0)
+}
+pauseSource.setEventHandler {
+    recorder.pause()
+}
+resumeSource.setEventHandler {
+    recorder.resume()
+}
+terminateSource.resume()
+interruptSource.resume()
+pauseSource.resume()
+resumeSource.resume()
+
+do {
+    try recorder.start()
+    if checkOnly {
+        recorder.stop()
+        exit(0)
+    }
+} catch {
+    let data = try! JSONSerialization.data(withJSONObject: ["event": "error", "message": error.localizedDescription])
+    print(String(data: data, encoding: .utf8)!)
+    exit(1)
+}
+
+dispatchMain()

--- a/src-tauri/native/mac-system-audio-recorder/main.swift
+++ b/src-tauri/native/mac-system-audio-recorder/main.swift
@@ -50,6 +50,7 @@ final class SystemAudioRecorder {
     private let outputURL: URL?
     private let statusURL: URL?
     private let pidURL: URL?
+    private let logURL: URL?
     private let queue = DispatchQueue(label: "network.opensoftware.os-notetaker.system-audio", qos: .userInitiated)
     private let pauseLock = NSLock()
 
@@ -63,15 +64,17 @@ final class SystemAudioRecorder {
     private var isPaused = false
     private var lastLevelEmit = Date.distantPast
 
-    init(outputURL: URL?, statusURL: URL?, pidURL: URL?) {
+    init(outputURL: URL?, statusURL: URL?, pidURL: URL?, logURL: URL?) {
         self.outputURL = outputURL
         self.statusURL = statusURL
         self.pidURL = pidURL
+        self.logURL = logURL
     }
 
     func writePid() {
         guard let pidURL else { return }
         try? "\(getpid())".write(to: pidURL, atomically: true, encoding: .utf8)
+        log("wrote pid \(getpid()) to \(pidURL.path)")
     }
 
     func pause() {
@@ -89,6 +92,7 @@ final class SystemAudioRecorder {
     }
 
     func start() throws {
+        log("starting; output=\(outputURL?.path ?? "check") status=\(statusURL?.path ?? "none")")
         if let outputURL {
             try? FileManager.default.removeItem(at: outputURL)
             try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -102,12 +106,15 @@ final class SystemAudioRecorder {
         var tapID = AudioObjectID.unknown
         var err = AudioHardwareCreateProcessTap(tapDescription, &tapID)
         guard err == noErr else {
+            log("AudioHardwareCreateProcessTap failed err=\(err)")
             throw "System audio permission or tap creation failed with error \(err)"
         }
+        log("created process tap id=\(tapID)")
         processTapID = tapID
 
         let systemOutputID = try AudioObjectID.readDefaultSystemOutputDevice()
         let outputUID = try systemOutputID.readDeviceUID()
+        log("default output device id=\(systemOutputID) uid=\(outputUID)")
         let aggregateUID = UUID().uuidString
         let description: [String: Any] = [
             kAudioAggregateDeviceNameKey: "OS Notetaker System Audio",
@@ -128,7 +135,11 @@ final class SystemAudioRecorder {
         ]
 
         err = AudioHardwareCreateAggregateDevice(description as CFDictionary, &aggregateDeviceID)
-        guard err == noErr else { throw "Failed to create aggregate audio device: \(err)" }
+        guard err == noErr else {
+            log("AudioHardwareCreateAggregateDevice failed err=\(err)")
+            throw "Failed to create aggregate audio device: \(err)"
+        }
+        log("created aggregate device id=\(aggregateDeviceID)")
 
         var streamDescription = try tapID.readAudioTapStreamBasicDescription()
         guard let inputFormat = AVAudioFormat(streamDescription: &streamDescription) else {
@@ -178,10 +189,18 @@ final class SystemAudioRecorder {
                 self.emit(["event": "error", "message": error.localizedDescription])
             }
         }
-        guard err == noErr else { throw "Failed to create audio IO callback: \(err)" }
+        guard err == noErr else {
+            log("AudioDeviceCreateIOProcIDWithBlock failed err=\(err)")
+            throw "Failed to create audio IO callback: \(err)"
+        }
+        log("created IO callback")
 
         err = AudioDeviceStart(aggregateDeviceID, deviceProcID)
-        guard err == noErr else { throw "Failed to start system audio capture: \(err)" }
+        guard err == noErr else {
+            log("AudioDeviceStart failed err=\(err)")
+            throw "Failed to start system audio capture: \(err)"
+        }
+        log("audio device started")
 
         emit(["event": "ready", "output": outputURL?.path ?? "check"])
     }
@@ -202,6 +221,7 @@ final class SystemAudioRecorder {
         audioFile = nil
         audioConverter = nil
         outputFormat = nil
+        log("stopped")
         emit(["event": "stopped", "output": outputURL?.path ?? "check"])
     }
 
@@ -236,6 +256,10 @@ final class SystemAudioRecorder {
         guard let statusURL else { return }
         try? data.write(to: statusURL)
     }
+
+    private func log(_ message: String) {
+        writeLog(message, logURL: logURL)
+    }
 }
 
 func argumentValue(_ name: String, from arguments: [String]) -> String? {
@@ -254,8 +278,24 @@ func emitProcessStatus(_ object: [String: String], statusPath: String?) {
 }
 
 let statusPath = argumentValue("--status", from: CommandLine.arguments)
+let logPath = argumentValue("--log", from: CommandLine.arguments)
+
+func writeLog(_ message: String, logURL: URL?) {
+    guard let logURL else { return }
+    let line = "\(Date()) pid=\(getpid()) \(message)\n"
+    if FileManager.default.fileExists(atPath: logURL.path), let handle = try? FileHandle(forWritingTo: logURL) {
+        defer { try? handle.close() }
+        try? handle.seekToEnd()
+        try? handle.write(contentsOf: Data(line.utf8))
+    } else {
+        try? line.write(to: logURL, atomically: true, encoding: .utf8)
+    }
+}
+
+writeLog("launched args=\(CommandLine.arguments.joined(separator: " "))", logURL: logPath.map { URL(fileURLWithPath: $0) })
 
 guard #available(macOS 14.2, *) else {
+    writeLog("unsupported macOS version", logURL: logPath.map { URL(fileURLWithPath: $0) })
     emitProcessStatus(["event": "error", "message": "System audio recording requires macOS 14.2 or later."], statusPath: statusPath)
     exit(2)
 }
@@ -264,14 +304,17 @@ let checkOnly = CommandLine.arguments.contains("--check")
 let outputPath = argumentValue("--output", from: CommandLine.arguments)
 let pidPath = argumentValue("--pid", from: CommandLine.arguments)
 if !checkOnly && outputPath == nil {
+    writeLog("missing output argument", logURL: logPath.map { URL(fileURLWithPath: $0) })
     emitProcessStatus(["event": "error", "message": "Usage: os-notetaker-system-audio-recorder --output /path/to/recording.wav"], statusPath: statusPath)
     exit(2)
 }
 
+let helperLogURL = logPath.map { URL(fileURLWithPath: $0) }
 let recorder = SystemAudioRecorder(
     outputURL: outputPath.map { URL(fileURLWithPath: $0) },
     statusURL: statusPath.map { URL(fileURLWithPath: $0) },
-    pidURL: pidPath.map { URL(fileURLWithPath: $0) }
+    pidURL: pidPath.map { URL(fileURLWithPath: $0) },
+    logURL: helperLogURL
 )
 recorder.writePid()
 
@@ -310,6 +353,7 @@ do {
         exit(0)
     }
 } catch {
+    writeLog("start failed: \(error.localizedDescription)", logURL: helperLogURL)
     emitProcessStatus(["event": "error", "message": error.localizedDescription], statusPath: statusPath)
     exit(1)
 }

--- a/src-tauri/native/mac-system-audio-recorder/main.swift
+++ b/src-tauri/native/mac-system-audio-recorder/main.swift
@@ -48,6 +48,8 @@ extension AudioObjectID {
 
 final class SystemAudioRecorder {
     private let outputURL: URL?
+    private let statusURL: URL?
+    private let pidURL: URL?
     private let queue = DispatchQueue(label: "network.opensoftware.os-notetaker.system-audio", qos: .userInitiated)
     private let pauseLock = NSLock()
 
@@ -61,8 +63,15 @@ final class SystemAudioRecorder {
     private var isPaused = false
     private var lastLevelEmit = Date.distantPast
 
-    init(outputURL: URL?) {
+    init(outputURL: URL?, statusURL: URL?, pidURL: URL?) {
         self.outputURL = outputURL
+        self.statusURL = statusURL
+        self.pidURL = pidURL
+    }
+
+    func writePid() {
+        guard let pidURL else { return }
+        try? "\(getpid())".write(to: pidURL, atomically: true, encoding: .utf8)
     }
 
     func pause() {
@@ -224,6 +233,8 @@ final class SystemAudioRecorder {
         let data = try! JSONSerialization.data(withJSONObject: object)
         print(String(data: data, encoding: .utf8)!)
         fflush(stdout)
+        guard let statusURL else { return }
+        try? data.write(to: statusURL)
     }
 }
 
@@ -234,21 +245,35 @@ func argumentValue(_ name: String, from arguments: [String]) -> String? {
     return arguments[index + 1]
 }
 
-guard #available(macOS 14.2, *) else {
-    let data = try! JSONSerialization.data(withJSONObject: ["event": "error", "message": "System audio recording requires macOS 14.2 or later."])
+func emitProcessStatus(_ object: [String: String], statusPath: String?) {
+    let data = try! JSONSerialization.data(withJSONObject: object)
     print(String(data: data, encoding: .utf8)!)
+    fflush(stdout)
+    guard let statusPath else { return }
+    try? data.write(to: URL(fileURLWithPath: statusPath))
+}
+
+let statusPath = argumentValue("--status", from: CommandLine.arguments)
+
+guard #available(macOS 14.2, *) else {
+    emitProcessStatus(["event": "error", "message": "System audio recording requires macOS 14.2 or later."], statusPath: statusPath)
     exit(2)
 }
 
 let checkOnly = CommandLine.arguments.contains("--check")
 let outputPath = argumentValue("--output", from: CommandLine.arguments)
+let pidPath = argumentValue("--pid", from: CommandLine.arguments)
 if !checkOnly && outputPath == nil {
-    let data = try! JSONSerialization.data(withJSONObject: ["event": "error", "message": "Usage: os-notetaker-system-audio-recorder --output /path/to/recording.wav"])
-    print(String(data: data, encoding: .utf8)!)
+    emitProcessStatus(["event": "error", "message": "Usage: os-notetaker-system-audio-recorder --output /path/to/recording.wav"], statusPath: statusPath)
     exit(2)
 }
 
-let recorder = SystemAudioRecorder(outputURL: outputPath.map { URL(fileURLWithPath: $0) })
+let recorder = SystemAudioRecorder(
+    outputURL: outputPath.map { URL(fileURLWithPath: $0) },
+    statusURL: statusPath.map { URL(fileURLWithPath: $0) },
+    pidURL: pidPath.map { URL(fileURLWithPath: $0) }
+)
+recorder.writePid()
 
 let terminateSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
 let interruptSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
@@ -285,8 +310,7 @@ do {
         exit(0)
     }
 } catch {
-    let data = try! JSONSerialization.data(withJSONObject: ["event": "error", "message": error.localizedDescription])
-    print(String(data: data, encoding: .utf8)!)
+    emitProcessStatus(["event": "error", "message": error.localizedDescription], statusPath: statusPath)
     exit(1)
 }
 

--- a/src-tauri/native/mac-system-audio-recorder/main.swift
+++ b/src-tauri/native/mac-system-audio-recorder/main.swift
@@ -1,10 +1,15 @@
 import AVFoundation
+import AppKit
 import AudioToolbox
 import CoreAudio
 import Darwin
 import Foundation
 
 extension String: @retroactive Error {}
+
+extension String: @retroactive LocalizedError {
+    public var errorDescription: String? { self }
+}
 
 extension AudioObjectID {
     static let system = AudioObjectID(kAudioObjectSystemObject)
@@ -15,8 +20,31 @@ extension AudioObjectID {
         try AudioObjectID.system.read(kAudioHardwarePropertyDefaultSystemOutputDevice, defaultValue: AudioDeviceID.unknown)
     }
 
+    static func readAudioDevices() throws -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var dataSize: UInt32 = 0
+        var err = AudioObjectGetPropertyDataSize(AudioObjectID.system, &address, 0, nil, &dataSize)
+        guard err == noErr else { throw "Error reading audio device list size: \(err)" }
+        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        guard count > 0 else { return [] }
+        var devices = Array(repeating: AudioDeviceID.unknown, count: count)
+        err = devices.withUnsafeMutableBufferPointer { pointer in
+            AudioObjectGetPropertyData(AudioObjectID.system, &address, 0, nil, &dataSize, pointer.baseAddress!)
+        }
+        guard err == noErr else { throw "Error reading audio device list: \(err)" }
+        return devices.filter { $0 != AudioDeviceID.unknown }
+    }
+
     func readDeviceUID() throws -> String {
         try readString(kAudioDevicePropertyDeviceUID)
+    }
+
+    func readName() throws -> String {
+        try readString(kAudioObjectPropertyName)
     }
 
     func readAudioTapStreamBasicDescription() throws -> AudioStreamBasicDescription {
@@ -51,7 +79,6 @@ final class SystemAudioRecorder {
     private let statusURL: URL?
     private let pidURL: URL?
     private let logURL: URL?
-    private let queue = DispatchQueue(label: "network.opensoftware.os-notetaker.system-audio", qos: .userInitiated)
     private let pauseLock = NSLock()
 
     private var processTapID = AudioObjectID.unknown
@@ -59,10 +86,12 @@ final class SystemAudioRecorder {
     private var deviceProcID: AudioDeviceIOProcID?
     private var audioFile: AVAudioFile?
     private var audioConverter: AVAudioConverter?
+    private var inputFormat: AVAudioFormat?
     private var outputFormat: AVAudioFormat?
     private var didStop = false
     private var isPaused = false
     private var lastLevelEmit = Date.distantPast
+    private var maxLevel: Double = 0
 
     init(outputURL: URL?, statusURL: URL?, pidURL: URL?, logURL: URL?) {
         self.outputURL = outputURL
@@ -91,14 +120,20 @@ final class SystemAudioRecorder {
         emit(["event": "resumed"])
     }
 
-    func start() throws {
+    func start(checkOnly: Bool = false) throws {
         log("starting; output=\(outputURL?.path ?? "check") status=\(statusURL?.path ?? "none")")
+        try ensureSystemAudioPermission(logURL: logURL)
         if let outputURL {
             try? FileManager.default.removeItem(at: outputURL)
             try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         }
+        cleanupStaleAggregateDevices(named: "OS Notetaker System Audio")
 
-        let tapDescription = CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+        let systemOutputID = try AudioObjectID.readDefaultSystemOutputDevice()
+        let outputUID = try systemOutputID.readDeviceUID()
+        log("default output device id=\(systemOutputID) uid=\(outputUID)")
+
+        let tapDescription = CATapDescription(excludingProcesses: [], deviceUID: outputUID, stream: 0)
         tapDescription.uuid = UUID()
         tapDescription.muteBehavior = .unmuted
         tapDescription.name = "OS Notetaker System Audio"
@@ -112,9 +147,17 @@ final class SystemAudioRecorder {
         log("created process tap id=\(tapID)")
         processTapID = tapID
 
-        let systemOutputID = try AudioObjectID.readDefaultSystemOutputDevice()
-        let outputUID = try systemOutputID.readDeviceUID()
-        log("default output device id=\(systemOutputID) uid=\(outputUID)")
+        var streamDescription = try tapID.readAudioTapStreamBasicDescription()
+        guard let inputFormat = AVAudioFormat(streamDescription: &streamDescription) else {
+            throw "Failed to create audio format for system tap."
+        }
+        guard let outputFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: inputFormat.sampleRate, channels: inputFormat.channelCount, interleaved: true) else {
+            throw "Failed to create output audio format."
+        }
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            throw "Failed to create audio converter."
+        }
+
         let aggregateUID = UUID().uuidString
         let description: [String: Any] = [
             kAudioAggregateDeviceNameKey: "OS Notetaker System Audio",
@@ -140,57 +183,29 @@ final class SystemAudioRecorder {
             throw "Failed to create aggregate audio device: \(err)"
         }
         log("created aggregate device id=\(aggregateDeviceID)")
+        try waitForAggregateDeviceReady(aggregateDeviceID)
 
-        var streamDescription = try tapID.readAudioTapStreamBasicDescription()
-        guard let inputFormat = AVAudioFormat(streamDescription: &streamDescription) else {
-            throw "Failed to create audio format for system tap."
-        }
-        guard let outputFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: inputFormat.sampleRate, channels: inputFormat.channelCount, interleaved: true) else {
-            throw "Failed to create output audio format."
-        }
-        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
-            throw "Failed to create audio converter."
+        if checkOnly {
+            emit(["event": "authorized", "message": "System audio capture is authorized."])
+            return
         }
 
+        self.inputFormat = inputFormat
         self.outputFormat = outputFormat
         audioConverter = converter
         if let outputURL {
             audioFile = try AVAudioFile(forWriting: outputURL, settings: outputFormat.settings, commonFormat: .pcmFormatInt16, interleaved: true)
         }
 
-        err = AudioDeviceCreateIOProcIDWithBlock(&deviceProcID, aggregateDeviceID, queue) { [weak self] _, inputData, _, _, _ in
-            guard let self else { return }
-            self.pauseLock.lock()
-            let paused = self.isPaused
-            self.pauseLock.unlock()
-            guard !paused else { return }
-            guard let outputFormat = self.outputFormat, let converter = self.audioConverter else { return }
-            guard let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, bufferListNoCopy: inputData, deallocator: nil) else { return }
-            do {
-                self.emitLevel(from: buffer)
-                let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * outputFormat.sampleRate / inputFormat.sampleRate))
-                guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: frameCapacity) else { return }
-                var didProvideInput = false
-                var conversionError: NSError?
-                let status = converter.convert(to: convertedBuffer, error: &conversionError) { _, inputStatus in
-                    if didProvideInput {
-                        inputStatus.pointee = .noDataNow
-                        return nil
-                    }
-                    didProvideInput = true
-                    inputStatus.pointee = .haveData
-                    return buffer
-                }
-                if let conversionError { throw conversionError }
-                if status == .haveData || status == .inputRanDry, convertedBuffer.frameLength > 0, let audioFile = self.audioFile {
-                    try audioFile.write(from: convertedBuffer)
-                }
-            } catch {
-                self.emit(["event": "error", "message": error.localizedDescription])
-            }
-        }
+        log("creating IO callback")
+        err = AudioDeviceCreateIOProcID(
+            aggregateDeviceID,
+            systemAudioIOProc,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &deviceProcID
+        )
         guard err == noErr else {
-            log("AudioDeviceCreateIOProcIDWithBlock failed err=\(err)")
+            log("AudioDeviceCreateIOProcID failed err=\(err)")
             throw "Failed to create audio IO callback: \(err)"
         }
         log("created IO callback")
@@ -205,7 +220,7 @@ final class SystemAudioRecorder {
         emit(["event": "ready", "output": outputURL?.path ?? "check"])
     }
 
-    func stop() {
+    func stop(emitStopped: Bool = true) {
         guard !didStop else { return }
         didStop = true
         if aggregateDeviceID.isValid {
@@ -220,9 +235,12 @@ final class SystemAudioRecorder {
         }
         audioFile = nil
         audioConverter = nil
+        inputFormat = nil
         outputFormat = nil
-        log("stopped")
-        emit(["event": "stopped", "output": outputURL?.path ?? "check"])
+        log("stopped maxLevel=\(maxLevel)")
+        if emitStopped {
+            emit(["event": "stopped", "output": outputURL?.path ?? "check", "maxLevel": String(maxLevel)])
+        }
     }
 
     private func emitLevel(from buffer: AVAudioPCMBuffer) {
@@ -246,7 +264,9 @@ final class SystemAudioRecorder {
             }
         }
         let rms = count > 0 ? sqrt(sum / Float(count)) : 0
-        emit(["event": "level", "level": String(min(1, Double(rms) * 4))])
+        let level = min(1, Double(rms) * 4)
+        maxLevel = max(maxLevel, level)
+        emit(["event": "level", "level": String(level), "maxLevel": String(maxLevel)])
     }
 
     private func emit(_ object: [String: String]) {
@@ -260,6 +280,153 @@ final class SystemAudioRecorder {
     private func log(_ message: String) {
         writeLog(message, logURL: logURL)
     }
+
+    fileprivate func handleInputData(_ inputData: UnsafePointer<AudioBufferList>) {
+        pauseLock.lock()
+        let paused = isPaused
+        pauseLock.unlock()
+        guard !paused else { return }
+        guard let inputFormat, let outputFormat, let converter = audioConverter else { return }
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, bufferListNoCopy: inputData, deallocator: nil) else { return }
+        do {
+            emitLevel(from: buffer)
+            let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * outputFormat.sampleRate / inputFormat.sampleRate))
+            guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: frameCapacity) else { return }
+            var didProvideInput = false
+            var conversionError: NSError?
+            let status = converter.convert(to: convertedBuffer, error: &conversionError) { _, inputStatus in
+                if didProvideInput {
+                    inputStatus.pointee = .noDataNow
+                    return nil
+                }
+                didProvideInput = true
+                inputStatus.pointee = .haveData
+                return buffer
+            }
+            if let conversionError { throw conversionError }
+            if status == .haveData || status == .inputRanDry, convertedBuffer.frameLength > 0, let audioFile {
+                try audioFile.write(from: convertedBuffer)
+            }
+        } catch {
+            emit(["event": "error", "message": describeError(error)])
+        }
+    }
+
+    private func cleanupStaleAggregateDevices(named targetName: String) {
+        do {
+            for device in try AudioObjectID.readAudioDevices() {
+                guard (try? AudioObjectID(device).readName()) == targetName else { continue }
+                let err = AudioHardwareDestroyAggregateDevice(device)
+                log("destroy stale aggregate device id=\(device) err=\(err)")
+            }
+        } catch {
+            log("stale aggregate cleanup failed: \(describeError(error))")
+        }
+    }
+
+    private func waitForAggregateDeviceReady(_ deviceID: AudioObjectID) throws {
+        let deadline = Date().addingTimeInterval(3)
+        var lastError: Error?
+        while Date() < deadline {
+            do {
+                _ = try deviceID.readName()
+                log("aggregate device is readable")
+                return
+            } catch {
+                lastError = error
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+        }
+        throw "Aggregate audio device was not readable after creation: \(lastError.map(describeError) ?? "unknown error")"
+    }
+}
+
+private let systemAudioIOProc: AudioDeviceIOProc = { _, _, inputData, _, _, _, clientData in
+    guard let clientData else { return noErr }
+    let recorder = Unmanaged<SystemAudioRecorder>.fromOpaque(clientData).takeUnretainedValue()
+    recorder.handleInputData(inputData)
+    return noErr
+}
+
+private enum SystemAudioPermissionStatus {
+    case authorized
+    case denied
+    case unknown
+}
+
+private typealias TCCPreflightFunction = @convention(c) (CFString, CFDictionary?) -> Int32
+private typealias TCCRequestFunction = @convention(c) (CFString, CFDictionary?, @escaping (Bool) -> Void) -> Void
+
+private func ensureSystemAudioPermission(logURL: URL?) throws {
+    guard let preflight = loadTCCFunction("TCCAccessPreflight", as: TCCPreflightFunction.self, logURL: logURL) else {
+        writeLog("TCC preflight SPI is unavailable; continuing with CoreAudio permission behavior", logURL: logURL)
+        return
+    }
+
+    let status = systemAudioPermissionStatus(preflight("kTCCServiceAudioCapture" as CFString, nil))
+    writeLog("system audio permission preflight status=\(status)", logURL: logURL)
+    switch status {
+    case .authorized:
+        return
+    case .denied:
+        throw "System Audio Recording permission is denied. Enable OS Notetaker Audio Capture in System Settings > Privacy & Security > Screen & System Audio Recording."
+    case .unknown:
+        break
+    }
+
+    guard let request = loadTCCFunction("TCCAccessRequest", as: TCCRequestFunction.self, logURL: logURL) else {
+        throw "System Audio Recording permission has not been granted, and macOS did not expose a permission request API."
+    }
+
+    writeLog("requesting system audio permission", logURL: logURL)
+    NSApplication.shared.setActivationPolicy(.accessory)
+    NSApplication.shared.finishLaunching()
+    NSApplication.shared.activate(ignoringOtherApps: true)
+    var granted = false
+    var completed = false
+    request("kTCCServiceAudioCapture" as CFString, nil) { allowed in
+        granted = allowed
+        completed = true
+    }
+
+    let deadline = Date().addingTimeInterval(60)
+    while !completed && Date() < deadline {
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.1))
+    }
+
+    if !completed {
+        throw "Timed out waiting for System Audio Recording permission. Check the macOS permission prompt and try again."
+    }
+    writeLog("system audio permission request granted=\(granted)", logURL: logURL)
+    guard granted else {
+        throw "System Audio Recording permission was not granted. Enable OS Notetaker Audio Capture in System Settings > Privacy & Security > Screen & System Audio Recording."
+    }
+}
+
+private func systemAudioPermissionStatus(_ rawStatus: Int32) -> SystemAudioPermissionStatus {
+    if rawStatus == 0 { return .authorized }
+    if rawStatus == 1 { return .denied }
+    return .unknown
+}
+
+private func describeError(_ error: Error) -> String {
+    if let message = error as? String {
+        return message
+    }
+    return error.localizedDescription
+}
+
+private func loadTCCFunction<T>(_ name: String, as type: T.Type, logURL: URL?) -> T? {
+    let tccPath = "/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC"
+    guard let handle = dlopen(tccPath, RTLD_NOW) else {
+        writeLog("dlopen TCC failed for \(name)", logURL: logURL)
+        return nil
+    }
+    guard let symbol = dlsym(handle, name) else {
+        writeLog("dlsym TCC failed for \(name)", logURL: logURL)
+        return nil
+    }
+    return unsafeBitCast(symbol, to: type)
 }
 
 func argumentValue(_ name: String, from arguments: [String]) -> String? {
@@ -285,7 +452,7 @@ func writeLog(_ message: String, logURL: URL?) {
     let line = "\(Date()) pid=\(getpid()) \(message)\n"
     if FileManager.default.fileExists(atPath: logURL.path), let handle = try? FileHandle(forWritingTo: logURL) {
         defer { try? handle.close() }
-        try? handle.seekToEnd()
+        _ = try? handle.seekToEnd()
         try? handle.write(contentsOf: Data(line.utf8))
     } else {
         try? line.write(to: logURL, atomically: true, encoding: .utf8)
@@ -347,14 +514,15 @@ pauseSource.resume()
 resumeSource.resume()
 
 do {
-    try recorder.start()
+    try recorder.start(checkOnly: checkOnly)
     if checkOnly {
-        recorder.stop()
+        recorder.stop(emitStopped: false)
         exit(0)
     }
 } catch {
-    writeLog("start failed: \(error.localizedDescription)", logURL: helperLogURL)
-    emitProcessStatus(["event": "error", "message": error.localizedDescription], statusPath: statusPath)
+    let message = describeError(error)
+    writeLog("start failed: \(message)", logURL: helperLogURL)
+    emitProcessStatus(["event": "error", "message": message], statusPath: statusPath)
     exit(1)
 }
 

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,7 +1,9 @@
 use crate::{
     app_paths::AppPaths,
+    audio::system_macos::SystemAudioCapture,
     domain::types::{
-        AppError, AudioLevelDto, RecordingSessionDto, RecordingState, RecordingStatusDto,
+        AppError, AudioLevelDto, RecordingSessionDto, RecordingSource, RecordingSourceMode,
+        RecordingState, RecordingStatusDto, SourceState, SourceStatusDto,
     },
 };
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -27,8 +29,10 @@ static ACTIVE_RECORDING: LazyLock<Mutex<Option<ActiveRecording>>> =
 pub struct StartedRecording {
     pub session_id: String,
     pub note_id: String,
+    pub source_mode: RecordingSourceMode,
     pub partial_path: PathBuf,
     pub final_path: PathBuf,
+    pub sources: Vec<StartedSource>,
     pub device_label: Option<String>,
     pub status: RecordingStatusDto,
 }
@@ -36,9 +40,23 @@ pub struct StartedRecording {
 pub struct FinishedRecording {
     pub session_id: String,
     pub note_id: String,
+    pub source_mode: RecordingSourceMode,
     pub final_path: PathBuf,
+    pub sources: Vec<FinishedSource>,
     pub elapsed_ms: i64,
     pub recording: RecordingSessionDto,
+}
+
+pub struct StartedSource {
+    pub source: RecordingSource,
+    pub partial_path: PathBuf,
+    pub final_path: PathBuf,
+}
+
+pub struct FinishedSource {
+    pub source: RecordingSource,
+    pub final_path: PathBuf,
+    pub elapsed_ms: i64,
 }
 
 struct ActiveRecording {
@@ -46,6 +64,9 @@ struct ActiveRecording {
     note_id: String,
     partial_path: PathBuf,
     final_path: PathBuf,
+    source_mode: RecordingSourceMode,
+    system_final_path: Option<PathBuf>,
+    system_capture: Option<SystemAudioCapture>,
     started: Instant,
     active_since: Option<Instant>,
     accumulated_active: Duration,
@@ -83,7 +104,11 @@ pub fn microphone_permission_state() -> (String, Option<String>) {
     }
 }
 
-pub fn start_capture(paths: &AppPaths, note_id: String) -> Result<StartedRecording, AppError> {
+pub fn start_capture(
+    paths: &AppPaths,
+    note_id: String,
+    source_mode: RecordingSourceMode,
+) -> Result<StartedRecording, AppError> {
     let mut active = ACTIVE_RECORDING
         .lock()
         .map_err(|_| AppError::new("recording_lock_failed", "Recording state is unavailable."))?;
@@ -109,11 +134,15 @@ pub fn start_capture(paths: &AppPaths, note_id: String) -> Result<StartedRecordi
     let channels = config.channels();
 
     let session_id = Uuid::new_v4().to_string();
-    let note_dir = paths.recordings_dir.join(&note_id);
+    let note_dir = paths.recordings_dir.join(&note_id).join(&session_id);
     std::fs::create_dir_all(&note_dir)
         .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
-    let partial_path = note_dir.join(format!("{session_id}.partial.wav"));
-    let final_path = note_dir.join(format!("{session_id}.wav"));
+    let partial_path = note_dir.join("microphone.partial.wav");
+    let final_path = note_dir.join("microphone.wav");
+    let system_partial_path = (source_mode == RecordingSourceMode::MicrophonePlusSystem)
+        .then(|| note_dir.join("system.partial.wav"));
+    let system_final_path = (source_mode == RecordingSourceMode::MicrophonePlusSystem)
+        .then(|| note_dir.join("system.wav"));
     let writer = WavWriter::create(
         &partial_path,
         WavSpec {
@@ -186,8 +215,23 @@ pub fn start_capture(paths: &AppPaths, note_id: String) -> Result<StartedRecordi
         .play()
         .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
 
+    let system_capture = if let (Some(system_partial_path), Some(system_final_path)) =
+        (system_partial_path.clone(), system_final_path.clone())
+    {
+        match SystemAudioCapture::start(system_partial_path.clone(), system_final_path.clone()) {
+            Ok(capture) => Some(capture),
+            Err(error) => {
+                let _ = std::fs::remove_file(&partial_path);
+                return Err(error);
+            }
+        }
+    } else {
+        None
+    };
+
     let status = RecordingStatusDto {
         session_id: session_id.clone(),
+        source_mode,
         state: RecordingState::Recording,
         elapsed_ms: 0,
         level: AudioLevelDto {
@@ -197,6 +241,16 @@ pub fn start_capture(paths: &AppPaths, note_id: String) -> Result<StartedRecordi
         },
         silence_warning: false,
         bytes_written: 0,
+        sources: source_statuses(
+            source_mode,
+            RecordingState::Recording,
+            0,
+            AudioLevelDto::default(),
+            0,
+            system_capture.as_ref(),
+            false,
+        ),
+        warnings: Vec::new(),
     };
 
     *active = Some(ActiveRecording {
@@ -204,6 +258,9 @@ pub fn start_capture(paths: &AppPaths, note_id: String) -> Result<StartedRecordi
         note_id: note_id.clone(),
         partial_path: partial_path.clone(),
         final_path: final_path.clone(),
+        source_mode,
+        system_final_path: system_final_path.clone(),
+        system_capture,
         started: Instant::now(),
         active_since: Some(Instant::now()),
         accumulated_active: Duration::ZERO,
@@ -217,8 +274,10 @@ pub fn start_capture(paths: &AppPaths, note_id: String) -> Result<StartedRecordi
     Ok(StartedRecording {
         session_id,
         note_id,
+        source_mode,
         partial_path,
         final_path,
+        sources: started_sources(source_mode, &note_dir),
         device_label,
         status,
     })
@@ -233,6 +292,9 @@ pub fn pause_capture(session_id: &str) -> Result<RecordingStatusDto, AppError> {
         }
         recording.paused = true;
         recording.paused_flag.store(true, Ordering::Release);
+        if let Some(system) = recording.system_capture.as_mut() {
+            system.pause();
+        }
     }
     Ok(recording.status())
 }
@@ -244,6 +306,9 @@ pub fn resume_capture(session_id: &str) -> Result<RecordingStatusDto, AppError> 
         recording.active_since = Some(Instant::now());
         recording.paused = false;
         recording.paused_flag.store(false, Ordering::Release);
+        if let Some(system) = recording.system_capture.as_mut() {
+            system.resume();
+        }
     }
     Ok(recording.status())
 }
@@ -277,17 +342,23 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
     let recording_dto = RecordingSessionDto {
         id: recording.session_id.clone(),
         note_id: recording.note_id.clone(),
+        source_mode: recording.source_mode,
         state: status.state,
         started_at: crate::db::repositories::timestamp(),
         elapsed_ms: status.elapsed_ms,
         device_label: None,
         level: status.level,
+        sources: status.sources,
+        warnings: status.warnings,
     };
     let ActiveRecording {
         session_id,
         note_id,
         partial_path,
         final_path,
+        source_mode,
+        system_capture,
+        system_final_path,
         writer,
         paused_flag,
         _stream,
@@ -306,10 +377,25 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
     }
     std::fs::rename(&partial_path, &final_path)
         .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+    let mut sources = vec![FinishedSource {
+        source: RecordingSource::Microphone,
+        final_path: final_path.clone(),
+        elapsed_ms: recording_dto.elapsed_ms,
+    }];
+    if let Some(system_capture) = system_capture {
+        let system_path = system_capture.stop()?;
+        sources.push(FinishedSource {
+            source: RecordingSource::System,
+            final_path: system_final_path.unwrap_or(system_path.clone()),
+            elapsed_ms: recording_dto.elapsed_ms,
+        });
+    }
     Ok(FinishedRecording {
         session_id,
         note_id,
+        source_mode,
         final_path,
+        sources,
         elapsed_ms: recording_dto.elapsed_ms,
         recording: recording_dto,
     })
@@ -433,18 +519,96 @@ impl ActiveRecording {
         } else {
             (0.0, 0.0, Vec::new(), 0)
         };
+        let elapsed_ms = self.elapsed().as_millis() as i64;
+        let level = AudioLevelDto {
+            peak,
+            rms,
+            recent_peaks: recent_peaks.clone(),
+        };
         RecordingStatusDto {
             session_id: self.session_id.clone(),
+            source_mode: self.source_mode,
             state,
-            elapsed_ms: self.elapsed().as_millis() as i64,
-            level: AudioLevelDto {
-                peak,
-                rms,
-                recent_peaks,
-            },
+            elapsed_ms,
+            level: level.clone(),
             silence_warning: self.started.elapsed() >= Duration::from_secs(10)
                 && rms < DEFAULT_SILENCE_THRESHOLD,
             bytes_written,
+            sources: source_statuses(
+                self.source_mode,
+                state,
+                elapsed_ms,
+                level,
+                bytes_written,
+                self.system_capture.as_ref(),
+                self.started.elapsed() >= Duration::from_secs(10)
+                    && rms < DEFAULT_SILENCE_THRESHOLD,
+            ),
+            warnings: Vec::new(),
         }
     }
+}
+
+fn started_sources(
+    source_mode: RecordingSourceMode,
+    note_dir: &std::path::Path,
+) -> Vec<StartedSource> {
+    let mut sources = vec![StartedSource {
+        source: RecordingSource::Microphone,
+        partial_path: note_dir.join("microphone.partial.wav"),
+        final_path: note_dir.join("microphone.wav"),
+    }];
+    if source_mode == RecordingSourceMode::MicrophonePlusSystem {
+        sources.push(StartedSource {
+            source: RecordingSource::System,
+            partial_path: note_dir.join("system.partial.wav"),
+            final_path: note_dir.join("system.wav"),
+        });
+    }
+    sources
+}
+
+fn source_statuses(
+    source_mode: RecordingSourceMode,
+    state: RecordingState,
+    elapsed_ms: i64,
+    microphone_level: AudioLevelDto,
+    microphone_bytes: i64,
+    system_capture: Option<&SystemAudioCapture>,
+    microphone_silence_warning: bool,
+) -> Vec<SourceStatusDto> {
+    let source_state = match state {
+        RecordingState::Paused => SourceState::Paused,
+        RecordingState::Validating | RecordingState::Finalizing => SourceState::Finalizing,
+        RecordingState::Invalid => SourceState::Invalid,
+        RecordingState::Failed => SourceState::Failed,
+        RecordingState::Recoverable => SourceState::Recoverable,
+        _ => SourceState::Recording,
+    };
+    let mut sources = vec![SourceStatusDto {
+        source: RecordingSource::Microphone,
+        state: source_state,
+        elapsed_ms,
+        bytes_written: microphone_bytes,
+        level: microphone_level,
+        silence_warning: microphone_silence_warning,
+        path_finalized: false,
+        last_error: None,
+    }];
+    if source_mode == RecordingSourceMode::MicrophonePlusSystem {
+        let (level, bytes_written, last_error) = system_capture
+            .map(|capture| capture.status())
+            .unwrap_or_default();
+        sources.push(SourceStatusDto {
+            source: RecordingSource::System,
+            state: source_state,
+            elapsed_ms,
+            bytes_written,
+            level,
+            silence_warning: elapsed_ms >= 10_000 && bytes_written == 0,
+            path_finalized: false,
+            last_error,
+        });
+    }
+    sources
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -599,13 +599,14 @@ fn source_statuses(
         let (level, bytes_written, last_error) = system_capture
             .map(|capture| capture.status())
             .unwrap_or_default();
+        let system_silence_warning = elapsed_ms >= 10_000 && level.peak < DEFAULT_SILENCE_THRESHOLD;
         sources.push(SourceStatusDto {
             source: RecordingSource::System,
             state: source_state,
             elapsed_ms,
             bytes_written,
             level,
-            silence_warning: elapsed_ms >= 10_000 && bytes_written == 0,
+            silence_warning: system_silence_warning,
             path_finalized: false,
             last_error,
         });

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
 pub mod recovery;
+pub mod system_macos;
 pub mod validation;
 pub mod waveform;

--- a/src-tauri/src/audio/recovery.rs
+++ b/src-tauri/src/audio/recovery.rs
@@ -1,4 +1,6 @@
-use crate::domain::types::RecoverableRecordingDto;
+use crate::domain::types::{
+    RecordingSource, RecordingSourceMode, RecoverableRecordingDto, RecoverableSourceDto,
+};
 use sqlx::Row;
 use sqlx::SqlitePool;
 
@@ -6,7 +8,7 @@ pub async fn scan_recoverable_recordings(
     pool: &SqlitePool,
 ) -> Result<Vec<RecoverableRecordingDto>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, note_id, started_at, partial_path, final_path
+        "SELECT id, note_id, source_mode, started_at, partial_path, final_path
          FROM recording_sessions
          WHERE status IN ('recording', 'paused', 'finalizing', 'validating', 'transcribing', 'generating', 'failed', 'recoverable')",
     )
@@ -20,20 +22,59 @@ pub async fn scan_recoverable_recordings(
         let partial_bytes = file_size(partial_path.as_deref());
         let final_bytes = file_size(final_path.as_deref());
         let bytes_found = partial_bytes.max(final_bytes);
-        if bytes_found == 0 {
+        let sources = recoverable_sources(pool, row.get::<String, _>("id").as_str()).await?;
+        let source_bytes = sources
+            .iter()
+            .map(|source| source.bytes_found)
+            .max()
+            .unwrap_or_default();
+        if bytes_found == 0 && source_bytes == 0 {
             continue;
         }
         recoveries.push(RecoverableRecordingDto {
             session_id: row.get("id"),
             note_id: row.get("note_id"),
+            source_mode: RecordingSourceMode::from(row.get::<String, _>("source_mode").as_str()),
             started_at: row.get("started_at"),
             partial_path_present: partial_bytes > 0,
             final_path_present: final_bytes > 0,
-            bytes_found,
+            bytes_found: bytes_found.max(source_bytes),
+            sources,
         });
     }
 
     Ok(recoveries)
+}
+
+async fn recoverable_sources(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> Result<Vec<RecoverableSourceDto>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT source, partial_path, path, last_error
+         FROM audio_artifacts
+         WHERE recording_session_id = ?",
+    )
+    .bind(session_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let partial_path: Option<String> = row.get("partial_path");
+            let final_path: Option<String> = row.get("path");
+            let partial_bytes = file_size(partial_path.as_deref());
+            let final_bytes = file_size(final_path.as_deref());
+            let bytes_found = partial_bytes.max(final_bytes);
+            (bytes_found > 0).then(|| RecoverableSourceDto {
+                source: RecordingSource::from(row.get::<String, _>("source").as_str()),
+                partial_path_present: partial_bytes > 0,
+                final_path_present: final_bytes > 0,
+                bytes_found,
+                last_error: row.get("last_error"),
+            })
+        })
+        .collect())
 }
 
 fn file_size(path: Option<&str>) -> i64 {

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -1,0 +1,279 @@
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use std::{
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{mpsc, Arc, Mutex},
+    time::Duration,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct SystemAudioStats {
+    pub level: AudioLevelDto,
+    pub last_error: Option<String>,
+}
+
+pub struct SystemAudioCapture {
+    child: Child,
+    stats: Arc<Mutex<SystemAudioStats>>,
+    partial_path: PathBuf,
+    final_path: PathBuf,
+}
+
+impl SystemAudioCapture {
+    pub fn start(partial_path: PathBuf, final_path: PathBuf) -> Result<Self, AppError> {
+        let helper = helper_executable_path();
+        if !helper.exists() {
+            return Err(AppError::new(
+                "system_audio_unavailable",
+                "System audio helper is not built. Run pnpm tauri:dev again.",
+            ));
+        }
+        let mut child = Command::new(helper)
+            .arg("--output")
+            .arg(&partial_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            AppError::new(
+                "system_audio_unavailable",
+                "System audio helper stdout is unavailable.",
+            )
+        })?;
+        let stats = Arc::new(Mutex::new(SystemAudioStats::default()));
+        let stats_for_thread = Arc::clone(&stats);
+        let (ready_tx, ready_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines().map_while(Result::ok) {
+                let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+                    continue;
+                };
+                let event = value
+                    .get("event")
+                    .and_then(|event| event.as_str())
+                    .unwrap_or_default();
+                match event {
+                    "ready" => {
+                        let _ = ready_tx.send(Ok(()));
+                    }
+                    "error" => {
+                        let message = value
+                            .get("message")
+                            .and_then(|message| message.as_str())
+                            .unwrap_or("System audio capture failed.")
+                            .to_string();
+                        if let Ok(mut stats) = stats_for_thread.lock() {
+                            stats.last_error = Some(message.clone());
+                        }
+                        let _ = ready_tx.send(Err(message));
+                    }
+                    "level" => {
+                        let level = value
+                            .get("level")
+                            .and_then(|level| level.as_str())
+                            .and_then(|level| level.parse::<f32>().ok())
+                            .unwrap_or_default();
+                        if let Ok(mut stats) = stats_for_thread.lock() {
+                            stats.level = AudioLevelDto {
+                                peak: level,
+                                rms: level,
+                                recent_peaks: vec![level],
+                            };
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+        match ready_rx.recv_timeout(Duration::from_secs(8)) {
+            Ok(Ok(())) => Ok(Self {
+                child,
+                stats,
+                partial_path,
+                final_path,
+            }),
+            Ok(Err(message)) => {
+                let _ = child.kill();
+                Err(AppError::new("system_audio_permission_denied", message))
+            }
+            Err(_) => {
+                let _ = child.kill();
+                Err(AppError::new(
+                    "system_audio_unavailable",
+                    "System audio helper did not become ready.",
+                ))
+            }
+        }
+    }
+
+    pub fn pause(&mut self) {
+        send_signal(self.child.id(), "-USR1");
+    }
+
+    pub fn resume(&mut self) {
+        send_signal(self.child.id(), "-USR2");
+    }
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        let level = self
+            .stats
+            .lock()
+            .map(|stats| stats.level.clone())
+            .unwrap_or_default();
+        let error = self
+            .stats
+            .lock()
+            .ok()
+            .and_then(|stats| stats.last_error.clone());
+        let bytes = std::fs::metadata(&self.partial_path)
+            .or_else(|_| std::fs::metadata(&self.final_path))
+            .map(|metadata| metadata.len() as i64)
+            .unwrap_or_default();
+        (level, bytes, error)
+    }
+
+    pub fn stop(mut self) -> Result<PathBuf, AppError> {
+        send_signal(self.child.id(), "-TERM");
+        let _ = self.child.wait();
+        if self.partial_path.exists() {
+            std::fs::rename(&self.partial_path, &self.final_path)
+                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        }
+        Ok(self.final_path)
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    #[cfg(target_os = "macos")]
+    {
+        let capture_available =
+            macos_version_supports_system_audio() && helper_executable_path().exists();
+        return SourceReadinessDto {
+            source: RecordingSource::System,
+            required: true,
+            ready: capture_available,
+            permission_state: if capture_available {
+                "unknown".to_string()
+            } else {
+                "unsupported".to_string()
+            },
+            device_available: capture_available,
+            capture_available,
+            recovery_action: if capture_available {
+                Some("openSystemAudioSettings".to_string())
+            } else {
+                Some("upgradeMacos".to_string())
+            },
+            message: if capture_available {
+                None
+            } else {
+                Some(
+                    "System audio capture requires macOS 14.2 or later and a built capture helper."
+                        .to_string(),
+                )
+            },
+        };
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        SourceReadinessDto {
+            source: RecordingSource::System,
+            required: true,
+            ready: false,
+            permission_state: "unsupported".to_string(),
+            device_available: false,
+            capture_available: false,
+            recovery_action: None,
+            message: Some("System audio capture is only supported on macOS.".to_string()),
+        }
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    let helper = helper_executable_path();
+    if !helper.exists() {
+        return Err(AppError::new(
+            "system_audio_unavailable",
+            "System audio helper is not built. Run pnpm tauri:dev again.",
+        ));
+    }
+    let output = Command::new(helper)
+        .arg("--check")
+        .output()
+        .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let message = stdout
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find_map(|value| {
+            value
+                .get("message")
+                .and_then(|message| message.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "System audio permission check failed.".to_string());
+    Err(AppError::new("system_audio_permission_denied", message))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_version_supports_system_audio() -> bool {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output();
+    let Ok(output) = output else {
+        return false;
+    };
+    let version = String::from_utf8_lossy(&output.stdout);
+    let mut parts = version
+        .trim()
+        .split('.')
+        .filter_map(|part| part.parse::<u32>().ok());
+    let major = parts.next().unwrap_or(0);
+    let minor = parts.next().unwrap_or(0);
+    major > 14 || (major == 14 && minor >= 2)
+}
+
+pub fn helper_executable_path() -> PathBuf {
+    let dev_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("native")
+        .join("bin")
+        .join("OS Notetaker Audio Capture.app")
+        .join("Contents")
+        .join("MacOS")
+        .join("os-notetaker-system-audio-recorder");
+    if dev_path.exists() {
+        return dev_path;
+    }
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(contents_dir) = current_exe
+            .ancestors()
+            .find(|path| path.file_name().and_then(|name| name.to_str()) == Some("Contents"))
+        {
+            let resource_path = contents_dir
+                .join("Resources")
+                .join("native")
+                .join("bin")
+                .join("OS Notetaker Audio Capture.app")
+                .join("Contents")
+                .join("MacOS")
+                .join("os-notetaker-system-audio-recorder");
+            if resource_path.exists() {
+                return resource_path;
+            }
+        }
+    }
+    dev_path
+}
+
+fn send_signal(pid: u32, signal: &str) {
+    let _ = Command::new("kill")
+        .arg(signal)
+        .arg(pid.to_string())
+        .status();
+}

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -237,8 +237,9 @@ fn macos_version_supports_system_audio() -> bool {
 
 pub fn helper_app_path() -> PathBuf {
     let dev_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("native")
-        .join("bin")
+        .parent()
+        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")))
+        .join(".tauri-helper")
         .join("OS Notetaker Audio Capture.app");
     if dev_path.exists() {
         return dev_path;

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -19,6 +19,7 @@ pub struct SystemAudioCapture {
     final_path: PathBuf,
     status_path: PathBuf,
     pid_path: PathBuf,
+    log_path: PathBuf,
 }
 
 impl SystemAudioCapture {
@@ -32,9 +33,19 @@ impl SystemAudioCapture {
         }
         let status_path = partial_path.with_extension("status.json");
         let pid_path = partial_path.with_extension("pid");
+        let log_path = partial_path.with_extension("helper.log");
         let _ = std::fs::remove_file(&status_path);
         let _ = std::fs::remove_file(&pid_path);
-        Command::new("/usr/bin/open")
+        let _ = std::fs::remove_file(&log_path);
+        dev_log(format!(
+            "starting helper app={} output={} status={} pid={} log={}",
+            helper_app.display(),
+            partial_path.display(),
+            status_path.display(),
+            pid_path.display(),
+            log_path.display()
+        ));
+        let open_status = Command::new("/usr/bin/open")
             .arg("-n")
             .arg(&helper_app)
             .arg("--args")
@@ -44,11 +55,14 @@ impl SystemAudioCapture {
             .arg(&status_path)
             .arg("--pid")
             .arg(&pid_path)
+            .arg("--log")
+            .arg(&log_path)
             .status()
             .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
+        dev_log(format!("open returned status={open_status}"));
 
         let stats = Arc::new(Mutex::new(SystemAudioStats::default()));
-        let ready = wait_for_status(&status_path, Duration::from_secs(8))?;
+        let ready = wait_for_status(&status_path, Some(&log_path), Duration::from_secs(30))?;
         if ready.event == "error" {
             return Err(AppError::new(
                 "system_audio_permission_denied",
@@ -63,6 +77,7 @@ impl SystemAudioCapture {
                 "System audio helper PID was not written.",
             )
         })?;
+        dev_log(format!("helper ready event={} pid={pid}", ready.event));
         Ok(Self {
             pid,
             stats,
@@ -70,14 +85,17 @@ impl SystemAudioCapture {
             final_path,
             status_path,
             pid_path,
+            log_path,
         })
     }
 
     pub fn pause(&mut self) {
+        dev_log(format!("sending pause to helper pid={}", self.pid));
         send_signal(self.pid, "-USR1");
     }
 
     pub fn resume(&mut self) {
+        dev_log(format!("sending resume to helper pid={}", self.pid));
         send_signal(self.pid, "-USR2");
     }
 
@@ -115,8 +133,13 @@ impl SystemAudioCapture {
     }
 
     pub fn stop(self) -> Result<PathBuf, AppError> {
+        dev_log(format!("stopping helper pid={}", self.pid));
         send_signal(self.pid, "-TERM");
         if wait_for_stopped(&self.status_path, Duration::from_secs(5)).is_err() {
+            dev_log(format!(
+                "helper pid={} did not stop; sending kill",
+                self.pid
+            ));
             send_signal(self.pid, "-KILL");
             std::thread::sleep(Duration::from_millis(100));
         }
@@ -126,6 +149,7 @@ impl SystemAudioCapture {
         }
         let _ = std::fs::remove_file(&self.status_path);
         let _ = std::fs::remove_file(&self.pid_path);
+        let _ = std::fs::remove_file(&self.log_path);
         Ok(self.final_path)
     }
 }
@@ -187,6 +211,14 @@ pub fn helper_permission_check() -> Result<(), AppError> {
         std::env::temp_dir().join(format!("os-notetaker-audio-check-{}", uuid::Uuid::new_v4()));
     let status_path = temp.with_extension("json");
     let pid_path = temp.with_extension("pid");
+    let log_path = temp.with_extension("log");
+    dev_log(format!(
+        "checking helper permission app={} status={} pid={} log={}",
+        helper_app.display(),
+        status_path.display(),
+        pid_path.display(),
+        log_path.display()
+    ));
     let output = Command::new("/usr/bin/open")
         .arg("-W")
         .arg("-n")
@@ -197,11 +229,21 @@ pub fn helper_permission_check() -> Result<(), AppError> {
         .arg(&status_path)
         .arg("--pid")
         .arg(&pid_path)
+        .arg("--log")
+        .arg(&log_path)
         .output()
         .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
+    dev_log(format!("permission check open status={}", output.status));
     let status = read_status(&status_path).ok();
+    if let Some(status) = &status {
+        dev_log(format!("permission check helper event={}", status.event));
+    } else {
+        dev_log("permission check did not write status".to_string());
+        dump_helper_log(&log_path);
+    }
     let _ = std::fs::remove_file(&status_path);
     let _ = std::fs::remove_file(&pid_path);
+    let _ = std::fs::remove_file(&log_path);
     if output.status.success() {
         if let Some(status) = status {
             if status.event != "error" {
@@ -276,15 +318,32 @@ struct HelperStatus {
     message: Option<String>,
 }
 
-fn wait_for_status(path: &Path, timeout: Duration) -> Result<HelperStatus, AppError> {
+fn wait_for_status(
+    path: &Path,
+    log_path: Option<&Path>,
+    timeout: Duration,
+) -> Result<HelperStatus, AppError> {
     let started = Instant::now();
+    let mut last_event = String::new();
     loop {
         if let Ok(status) = read_status(path) {
-            if matches!(status.event.as_str(), "ready" | "error") {
+            if status.event != last_event {
+                dev_log(format!("helper status event={}", status.event));
+                last_event = status.event.clone();
+            }
+            if matches!(status.event.as_str(), "ready" | "level" | "error") {
                 return Ok(status);
             }
         }
         if started.elapsed() >= timeout {
+            dev_log(format!(
+                "helper readiness timed out after {:?}; status_exists={}",
+                timeout,
+                path.exists()
+            ));
+            if let Some(log_path) = log_path {
+                dump_helper_log(log_path);
+            }
             return Err(AppError::new(
                 "system_audio_unavailable",
                 "System audio helper did not become ready.",
@@ -339,3 +398,32 @@ fn read_status(path: &Path) -> Result<HelperStatus, std::io::Error> {
 fn read_pid(path: &Path) -> Option<u32> {
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
 }
+
+#[cfg(debug_assertions)]
+fn dev_log(message: String) {
+    eprintln!("[system-audio] {message}");
+}
+
+#[cfg(not(debug_assertions))]
+fn dev_log(_message: String) {}
+
+#[cfg(debug_assertions)]
+fn dump_helper_log(path: &Path) {
+    match std::fs::read_to_string(path) {
+        Ok(log) if !log.trim().is_empty() => {
+            eprintln!("[system-audio] helper log follows:");
+            for line in log.lines() {
+                eprintln!("[system-audio-helper] {line}");
+            }
+        }
+        Ok(_) => eprintln!("[system-audio] helper log is empty at {}", path.display()),
+        Err(error) => eprintln!(
+            "[system-audio] helper log unavailable at {}: {}",
+            path.display(),
+            error
+        ),
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn dump_helper_log(_path: &Path) {}

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -1,10 +1,9 @@
 use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
 use std::{
-    io::{BufRead, BufReader},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
-    sync::{mpsc, Arc, Mutex},
-    time::Duration,
+    process::Command,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 
 #[derive(Debug, Clone, Default)]
@@ -14,120 +13,100 @@ pub struct SystemAudioStats {
 }
 
 pub struct SystemAudioCapture {
-    child: Child,
+    pid: u32,
     stats: Arc<Mutex<SystemAudioStats>>,
     partial_path: PathBuf,
     final_path: PathBuf,
+    status_path: PathBuf,
+    pid_path: PathBuf,
 }
 
 impl SystemAudioCapture {
     pub fn start(partial_path: PathBuf, final_path: PathBuf) -> Result<Self, AppError> {
-        let helper = helper_executable_path();
-        if !helper.exists() {
+        let helper_app = helper_app_path();
+        if !helper_app.exists() {
             return Err(AppError::new(
                 "system_audio_unavailable",
                 "System audio helper is not built. Run pnpm tauri:dev again.",
             ));
         }
-        let mut child = Command::new(helper)
+        let status_path = partial_path.with_extension("status.json");
+        let pid_path = partial_path.with_extension("pid");
+        let _ = std::fs::remove_file(&status_path);
+        let _ = std::fs::remove_file(&pid_path);
+        Command::new("/usr/bin/open")
+            .arg("-n")
+            .arg(&helper_app)
+            .arg("--args")
             .arg("--output")
             .arg(&partial_path)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+            .arg("--status")
+            .arg(&status_path)
+            .arg("--pid")
+            .arg(&pid_path)
+            .status()
             .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
-        let stdout = child.stdout.take().ok_or_else(|| {
+
+        let stats = Arc::new(Mutex::new(SystemAudioStats::default()));
+        let ready = wait_for_status(&status_path, Duration::from_secs(8))?;
+        if ready.event == "error" {
+            return Err(AppError::new(
+                "system_audio_permission_denied",
+                ready
+                    .message
+                    .unwrap_or_else(|| "System audio capture failed.".to_string()),
+            ));
+        }
+        let pid = read_pid(&pid_path).ok_or_else(|| {
             AppError::new(
                 "system_audio_unavailable",
-                "System audio helper stdout is unavailable.",
+                "System audio helper PID was not written.",
             )
         })?;
-        let stats = Arc::new(Mutex::new(SystemAudioStats::default()));
-        let stats_for_thread = Arc::clone(&stats);
-        let (ready_tx, ready_rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines().map_while(Result::ok) {
-                let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
-                    continue;
-                };
-                let event = value
-                    .get("event")
-                    .and_then(|event| event.as_str())
-                    .unwrap_or_default();
-                match event {
-                    "ready" => {
-                        let _ = ready_tx.send(Ok(()));
-                    }
-                    "error" => {
-                        let message = value
-                            .get("message")
-                            .and_then(|message| message.as_str())
-                            .unwrap_or("System audio capture failed.")
-                            .to_string();
-                        if let Ok(mut stats) = stats_for_thread.lock() {
-                            stats.last_error = Some(message.clone());
-                        }
-                        let _ = ready_tx.send(Err(message));
-                    }
-                    "level" => {
-                        let level = value
-                            .get("level")
-                            .and_then(|level| level.as_str())
-                            .and_then(|level| level.parse::<f32>().ok())
-                            .unwrap_or_default();
-                        if let Ok(mut stats) = stats_for_thread.lock() {
-                            stats.level = AudioLevelDto {
-                                peak: level,
-                                rms: level,
-                                recent_peaks: vec![level],
-                            };
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        });
-        match ready_rx.recv_timeout(Duration::from_secs(8)) {
-            Ok(Ok(())) => Ok(Self {
-                child,
-                stats,
-                partial_path,
-                final_path,
-            }),
-            Ok(Err(message)) => {
-                let _ = child.kill();
-                Err(AppError::new("system_audio_permission_denied", message))
-            }
-            Err(_) => {
-                let _ = child.kill();
-                Err(AppError::new(
-                    "system_audio_unavailable",
-                    "System audio helper did not become ready.",
-                ))
-            }
-        }
+        Ok(Self {
+            pid,
+            stats,
+            partial_path,
+            final_path,
+            status_path,
+            pid_path,
+        })
     }
 
     pub fn pause(&mut self) {
-        send_signal(self.child.id(), "-USR1");
+        send_signal(self.pid, "-USR1");
     }
 
     pub fn resume(&mut self) {
-        send_signal(self.child.id(), "-USR2");
+        send_signal(self.pid, "-USR2");
     }
 
     pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
-        let level = self
+        if let Ok(status) = read_status(&self.status_path) {
+            if let Ok(mut stats) = self.stats.lock() {
+                if let Some(level) = status.level {
+                    stats.level = AudioLevelDto {
+                        peak: level,
+                        rms: level,
+                        recent_peaks: vec![level],
+                    };
+                }
+                if status.event == "error" {
+                    stats.last_error = Some(
+                        status
+                            .message
+                            .unwrap_or_else(|| "System audio capture failed.".to_string()),
+                    );
+                } else if status.message.is_some() {
+                    stats.last_error = status.message;
+                }
+            }
+        }
+        let (level, error) = self
             .stats
             .lock()
-            .map(|stats| stats.level.clone())
+            .map(|stats| (stats.level.clone(), stats.last_error.clone()))
             .unwrap_or_default();
-        let error = self
-            .stats
-            .lock()
-            .ok()
-            .and_then(|stats| stats.last_error.clone());
         let bytes = std::fs::metadata(&self.partial_path)
             .or_else(|_| std::fs::metadata(&self.final_path))
             .map(|metadata| metadata.len() as i64)
@@ -135,13 +114,18 @@ impl SystemAudioCapture {
         (level, bytes, error)
     }
 
-    pub fn stop(mut self) -> Result<PathBuf, AppError> {
-        send_signal(self.child.id(), "-TERM");
-        let _ = self.child.wait();
+    pub fn stop(self) -> Result<PathBuf, AppError> {
+        send_signal(self.pid, "-TERM");
+        if wait_for_stopped(&self.status_path, Duration::from_secs(5)).is_err() {
+            send_signal(self.pid, "-KILL");
+            std::thread::sleep(Duration::from_millis(100));
+        }
         if self.partial_path.exists() {
             std::fs::rename(&self.partial_path, &self.final_path)
                 .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
         }
+        let _ = std::fs::remove_file(&self.status_path);
+        let _ = std::fs::remove_file(&self.pid_path);
         Ok(self.final_path)
     }
 }
@@ -149,8 +133,7 @@ impl SystemAudioCapture {
 pub fn system_audio_readiness() -> SourceReadinessDto {
     #[cfg(target_os = "macos")]
     {
-        let capture_available =
-            macos_version_supports_system_audio() && helper_executable_path().exists();
+        let capture_available = macos_version_supports_system_audio() && helper_app_path().exists();
         return SourceReadinessDto {
             source: RecordingSource::System,
             required: true,
@@ -193,31 +176,44 @@ pub fn system_audio_readiness() -> SourceReadinessDto {
 }
 
 pub fn helper_permission_check() -> Result<(), AppError> {
-    let helper = helper_executable_path();
-    if !helper.exists() {
+    let helper_app = helper_app_path();
+    if !helper_app.exists() {
         return Err(AppError::new(
             "system_audio_unavailable",
             "System audio helper is not built. Run pnpm tauri:dev again.",
         ));
     }
-    let output = Command::new(helper)
+    let temp =
+        std::env::temp_dir().join(format!("os-notetaker-audio-check-{}", uuid::Uuid::new_v4()));
+    let status_path = temp.with_extension("json");
+    let pid_path = temp.with_extension("pid");
+    let output = Command::new("/usr/bin/open")
+        .arg("-W")
+        .arg("-n")
+        .arg(helper_app)
+        .arg("--args")
         .arg("--check")
+        .arg("--status")
+        .arg(&status_path)
+        .arg("--pid")
+        .arg(&pid_path)
         .output()
         .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
+    let status = read_status(&status_path).ok();
+    let _ = std::fs::remove_file(&status_path);
+    let _ = std::fs::remove_file(&pid_path);
     if output.status.success() {
-        return Ok(());
+        if let Some(status) = status {
+            if status.event != "error" {
+                return Ok(());
+            }
+            let message = status
+                .message
+                .unwrap_or_else(|| "System audio permission check failed.".to_string());
+            return Err(AppError::new("system_audio_permission_denied", message));
+        }
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let message = stdout
-        .lines()
-        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
-        .find_map(|value| {
-            value
-                .get("message")
-                .and_then(|message| message.as_str())
-                .map(str::to_string)
-        })
-        .unwrap_or_else(|| "System audio permission check failed.".to_string());
+    let message = "System audio permission check did not receive helper status.".to_string();
     Err(AppError::new("system_audio_permission_denied", message))
 }
 
@@ -239,14 +235,11 @@ fn macos_version_supports_system_audio() -> bool {
     major > 14 || (major == 14 && minor >= 2)
 }
 
-pub fn helper_executable_path() -> PathBuf {
+pub fn helper_app_path() -> PathBuf {
     let dev_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("native")
         .join("bin")
-        .join("OS Notetaker Audio Capture.app")
-        .join("Contents")
-        .join("MacOS")
-        .join("os-notetaker-system-audio-recorder");
+        .join("OS Notetaker Audio Capture.app");
     if dev_path.exists() {
         return dev_path;
     }
@@ -259,10 +252,7 @@ pub fn helper_executable_path() -> PathBuf {
                 .join("Resources")
                 .join("native")
                 .join("bin")
-                .join("OS Notetaker Audio Capture.app")
-                .join("Contents")
-                .join("MacOS")
-                .join("os-notetaker-system-audio-recorder");
+                .join("OS Notetaker Audio Capture.app");
             if resource_path.exists() {
                 return resource_path;
             }
@@ -276,4 +266,75 @@ fn send_signal(pid: u32, signal: &str) {
         .arg(signal)
         .arg(pid.to_string())
         .status();
+}
+
+#[derive(Debug)]
+struct HelperStatus {
+    event: String,
+    level: Option<f32>,
+    message: Option<String>,
+}
+
+fn wait_for_status(path: &Path, timeout: Duration) -> Result<HelperStatus, AppError> {
+    let started = Instant::now();
+    loop {
+        if let Ok(status) = read_status(path) {
+            if matches!(status.event.as_str(), "ready" | "error") {
+                return Ok(status);
+            }
+        }
+        if started.elapsed() >= timeout {
+            return Err(AppError::new(
+                "system_audio_unavailable",
+                "System audio helper did not become ready.",
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(80));
+    }
+}
+
+fn wait_for_stopped(path: &Path, timeout: Duration) -> Result<(), AppError> {
+    let started = Instant::now();
+    loop {
+        if read_status(path)
+            .map(|status| status.event == "stopped")
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+        if started.elapsed() >= timeout {
+            return Err(AppError::new(
+                "system_audio_unavailable",
+                "System audio helper did not stop cleanly.",
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(80));
+    }
+}
+
+fn read_status(path: &Path) -> Result<HelperStatus, std::io::Error> {
+    let data = std::fs::read_to_string(path)?;
+    let value = serde_json::from_str::<serde_json::Value>(&data)?;
+    let event = value
+        .get("event")
+        .and_then(|event| event.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let level = value
+        .get("level")
+        .and_then(|level| level.as_str())
+        .and_then(|level| level.parse::<f32>().ok());
+    let message = value
+        .get("message")
+        .and_then(|message| message.as_str())
+        .map(str::to_string);
+    Ok(HelperStatus {
+        event,
+        level,
+        message,
+    })
+}
+
+fn read_pid(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
 }

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -9,7 +9,9 @@ use std::{
 #[derive(Debug, Clone, Default)]
 pub struct SystemAudioStats {
     pub level: AudioLevelDto,
+    pub max_level: f32,
     pub last_error: Option<String>,
+    last_debug_log: Option<Instant>,
 }
 
 pub struct SystemAudioCapture {
@@ -31,6 +33,7 @@ impl SystemAudioCapture {
                 "System audio helper is not built. Run pnpm tauri:dev again.",
             ));
         }
+        terminate_existing_helpers();
         let status_path = partial_path.with_extension("status.json");
         let pid_path = partial_path.with_extension("pid");
         let log_path = partial_path.with_extension("helper.log");
@@ -62,7 +65,13 @@ impl SystemAudioCapture {
         dev_log(format!("open returned status={open_status}"));
 
         let stats = Arc::new(Mutex::new(SystemAudioStats::default()));
-        let ready = wait_for_status(&status_path, Some(&log_path), Duration::from_secs(30))?;
+        let ready = wait_for_status(
+            &status_path,
+            Some(&log_path),
+            Duration::from_secs(30),
+            &["ready", "level", "error"],
+            "System audio helper did not become ready. See the terminal helper log for the last CoreAudio step.",
+        )?;
         if ready.event == "error" {
             return Err(AppError::new(
                 "system_audio_permission_denied",
@@ -103,6 +112,7 @@ impl SystemAudioCapture {
         if let Ok(status) = read_status(&self.status_path) {
             if let Ok(mut stats) = self.stats.lock() {
                 if let Some(level) = status.level {
+                    stats.max_level = stats.max_level.max(status.max_level.unwrap_or(level));
                     stats.level = AudioLevelDto {
                         peak: level,
                         rms: level,
@@ -117,6 +127,17 @@ impl SystemAudioCapture {
                     );
                 } else if status.message.is_some() {
                     stats.last_error = status.message;
+                }
+                if stats
+                    .last_debug_log
+                    .map(|logged| logged.elapsed() >= Duration::from_secs(2))
+                    .unwrap_or(true)
+                {
+                    dev_log(format!(
+                        "capture status event={} level={:.5} max_level={:.5}",
+                        status.event, stats.level.peak, stats.max_level
+                    ));
+                    stats.last_debug_log = Some(Instant::now());
                 }
             }
         }
@@ -207,56 +228,78 @@ pub fn helper_permission_check() -> Result<(), AppError> {
             "System audio helper is not built. Run pnpm tauri:dev again.",
         ));
     }
+    terminate_existing_helpers();
     let temp =
         std::env::temp_dir().join(format!("os-notetaker-audio-check-{}", uuid::Uuid::new_v4()));
+    let output_path = temp.with_extension("wav");
     let status_path = temp.with_extension("json");
     let pid_path = temp.with_extension("pid");
     let log_path = temp.with_extension("log");
     dev_log(format!(
-        "checking helper permission app={} status={} pid={} log={}",
+        "probing helper capture app={} output={} status={} pid={} log={}",
         helper_app.display(),
+        output_path.display(),
         status_path.display(),
         pid_path.display(),
         log_path.display()
     ));
-    let output = Command::new("/usr/bin/open")
-        .arg("-W")
+    let open_status = Command::new("/usr/bin/open")
         .arg("-n")
-        .arg(helper_app)
+        .arg(&helper_app)
         .arg("--args")
-        .arg("--check")
+        .arg("--output")
+        .arg(&output_path)
         .arg("--status")
         .arg(&status_path)
         .arg("--pid")
         .arg(&pid_path)
         .arg("--log")
         .arg(&log_path)
-        .output()
+        .status()
         .map_err(|error| AppError::new("system_audio_unavailable", error.to_string()))?;
-    dev_log(format!("permission check open status={}", output.status));
-    let status = read_status(&status_path).ok();
-    if let Some(status) = &status {
-        dev_log(format!("permission check helper event={}", status.event));
-    } else {
-        dev_log("permission check did not write status".to_string());
-        dump_helper_log(&log_path);
+    dev_log(format!("capture probe open status={open_status}"));
+    let status = wait_for_status(
+        &status_path,
+        Some(&log_path),
+        Duration::from_secs(75),
+        &["ready", "level", "error"],
+        "System audio helper could not start a usable CoreAudio capture. Grant System Audio Recording permission if macOS prompts for it, then try again. The terminal helper log shows the last completed CoreAudio step.",
+    );
+    let helper_pid = read_pid(&pid_path);
+    if let Some(pid) = helper_pid {
+        send_signal(pid, "-TERM");
+        let _ = wait_for_stopped(&status_path, Duration::from_secs(3));
     }
+    let result = match status {
+        Ok(status) if status.event == "ready" || status.event == "level" => Ok(()),
+        Ok(status) if status.event == "error" => Err(AppError::new(
+            "system_audio_permission_denied",
+            status
+                .message
+                .unwrap_or_else(|| "System audio capture probe failed.".to_string()),
+        )),
+        Ok(status) => {
+            dump_helper_log(&log_path);
+            Err(AppError::new(
+                "system_audio_permission_denied",
+                format!(
+                    "System audio capture probe ended with unexpected event '{}'.",
+                    status.event
+                ),
+            ))
+        }
+        Err(error) => {
+            if let Some(pid) = helper_pid {
+                send_signal(pid, "-KILL");
+            }
+            Err(error)
+        }
+    };
+    let _ = std::fs::remove_file(&output_path);
     let _ = std::fs::remove_file(&status_path);
     let _ = std::fs::remove_file(&pid_path);
     let _ = std::fs::remove_file(&log_path);
-    if output.status.success() {
-        if let Some(status) = status {
-            if status.event != "error" {
-                return Ok(());
-            }
-            let message = status
-                .message
-                .unwrap_or_else(|| "System audio permission check failed.".to_string());
-            return Err(AppError::new("system_audio_permission_denied", message));
-        }
-    }
-    let message = "System audio permission check did not receive helper status.".to_string();
-    Err(AppError::new("system_audio_permission_denied", message))
+    result
 }
 
 #[cfg(target_os = "macos")]
@@ -311,10 +354,45 @@ fn send_signal(pid: u32, signal: &str) {
         .status();
 }
 
+fn terminate_existing_helpers() {
+    let helper_name = "os-notetaker-system-audio-recorder";
+    let Ok(output) = Command::new("pgrep").arg("-f").arg(helper_name).output() else {
+        return;
+    };
+    let pids: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .filter(|pid| *pid != std::process::id())
+        .collect();
+    if pids.is_empty() {
+        return;
+    }
+    dev_log(format!("terminating stale helper pids={pids:?}"));
+    for pid in &pids {
+        send_signal(*pid, "-TERM");
+    }
+    std::thread::sleep(Duration::from_millis(250));
+    for pid in pids {
+        if process_is_running(pid) {
+            send_signal(pid, "-KILL");
+        }
+    }
+}
+
+fn process_is_running(pid: u32) -> bool {
+    Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 #[derive(Debug)]
 struct HelperStatus {
     event: String,
     level: Option<f32>,
+    max_level: Option<f32>,
     message: Option<String>,
 }
 
@@ -322,6 +400,8 @@ fn wait_for_status(
     path: &Path,
     log_path: Option<&Path>,
     timeout: Duration,
+    terminal_events: &[&str],
+    timeout_message: &str,
 ) -> Result<HelperStatus, AppError> {
     let started = Instant::now();
     let mut last_event = String::new();
@@ -331,7 +411,7 @@ fn wait_for_status(
                 dev_log(format!("helper status event={}", status.event));
                 last_event = status.event.clone();
             }
-            if matches!(status.event.as_str(), "ready" | "level" | "error") {
+            if terminal_events.contains(&status.event.as_str()) {
                 return Ok(status);
             }
         }
@@ -346,7 +426,7 @@ fn wait_for_status(
             }
             return Err(AppError::new(
                 "system_audio_unavailable",
-                "System audio helper did not become ready.",
+                timeout_message,
             ));
         }
         std::thread::sleep(Duration::from_millis(80));
@@ -388,9 +468,14 @@ fn read_status(path: &Path) -> Result<HelperStatus, std::io::Error> {
         .get("message")
         .and_then(|message| message.as_str())
         .map(str::to_string);
+    let max_level = value
+        .get("maxLevel")
+        .and_then(|level| level.as_str())
+        .and_then(|level| level.parse::<f32>().ok());
     Ok(HelperStatus {
         event,
         level,
+        max_level,
         message,
     })
 }

--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -100,7 +100,7 @@ pub fn validate_audio_artifact(
         result.rms_amplitude = (sum_square / samples as f64).sqrt() as f32;
     }
     result.non_silent_signal = result.rms_amplitude >= config.silence_rms_threshold
-        || result.peak_amplitude >= config.silence_rms_threshold * 3.0;
+        && result.peak_amplitude >= config.silence_rms_threshold * 3.0;
     if !result.non_silent_signal {
         result.warnings.push("audio appears silent".to_string());
     }

--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -1,4 +1,4 @@
-use crate::domain::types::AudioValidationDto;
+use crate::domain::types::{AudioValidationDto, RecordingSource};
 use hound::WavReader;
 use sha2::{Digest, Sha256};
 use std::{fs::File, io::Read, path::Path};
@@ -67,10 +67,9 @@ pub fn validate_audio_artifact(
 
     result.readable_audio = true;
     let spec = reader.spec();
-    let channels = spec.channels.max(1) as i64;
     let sample_rate = spec.sample_rate.max(1) as i64;
     let sample_count = reader.duration() as i64;
-    result.actual_duration_ms = (sample_count * 1000) / (sample_rate * channels);
+    result.actual_duration_ms = (sample_count * 1000) / sample_rate;
     result.duration_within_tolerance =
         (result.actual_duration_ms - expected_duration_ms).abs() <= config.duration_tolerance_ms;
 
@@ -106,6 +105,18 @@ pub fn validate_audio_artifact(
     }
 
     Ok(result)
+}
+
+pub fn source_audio_passes_validation(
+    source: RecordingSource,
+    validation: &AudioValidationDto,
+) -> bool {
+    let has_usable_audio =
+        validation.non_zero_size && validation.readable_audio && validation.non_silent_signal;
+    match source {
+        RecordingSource::Microphone => has_usable_audio && validation.duration_within_tolerance,
+        RecordingSource::System => has_usable_audio,
+    }
 }
 
 pub fn checksum_file(path: &Path) -> Result<String, std::io::Error> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,13 +10,15 @@ use crate::{
     },
     db::{migrations::run_migrations, repositories::Repositories},
     domain::{
-        processing::{process_saved_audio, retry_from_saved_audio},
+        processing::{process_saved_audio, process_saved_source_audio, retry_from_saved_audio},
         types::{
-            AppError, AssignNoteToFolderRequest, BootstrapResponse, CreateFolderRequest,
-            CreateNoteRequest, FinishRecordingResponse, GetNoteRequest, ListNotesRequest,
-            ListNotesResponse, MicrophonePermissionResponse, NoteDto, RecordingSessionDto,
-            RecordingStatusDto, RemoveNoteFromFolderRequest, RetryProcessingRequest,
-            SessionRequest, StartRecordingRequest, UpdateNoteRequest,
+            AppError, AssignNoteToFolderRequest, BootstrapResponse,
+            CheckRecordingSourceReadinessRequest, CreateFolderRequest, CreateNoteRequest,
+            FinishRecordingResponse, GetNoteRequest, ListNotesRequest, ListNotesResponse,
+            MicrophonePermissionResponse, NoteDto, RecordingSessionDto, RecordingSource,
+            RecordingSourceMode, RecordingSourceReadinessDto, RecordingStatusDto,
+            RemoveNoteFromFolderRequest, RetryProcessingRequest, SessionRequest,
+            SourceReadinessDto, StartRecordingRequest, UpdateNoteRequest,
         },
     },
 };
@@ -143,30 +145,63 @@ pub async fn get_microphone_permission_state() -> Result<MicrophonePermissionRes
 }
 
 #[tauri::command]
+pub async fn check_recording_source_readiness(
+    request: CheckRecordingSourceReadinessRequest,
+) -> Result<RecordingSourceReadinessDto, AppError> {
+    Ok(recording_source_readiness(request.source_mode))
+}
+
+#[tauri::command]
 pub async fn start_recording(
     app: AppHandle,
     request: StartRecordingRequest,
 ) -> Result<RecordingSessionDto, AppError> {
     let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
-    let started = start_capture(&paths, request.note_id.clone())?;
+    let source_mode = request.source_mode.unwrap_or_default();
+    let readiness = recording_source_readiness(source_mode);
+    if !readiness.ready {
+        let message = readiness
+            .sources
+            .iter()
+            .find(|source| source.required && !source.ready)
+            .and_then(|source| source.message.clone())
+            .unwrap_or_else(|| "The selected recording sources are not ready.".to_string());
+        return Err(AppError::new("source_not_ready", message));
+    }
+    let started = start_capture(&paths, request.note_id.clone(), source_mode)?;
     repos
         .create_recording_session(
             &request.note_id,
             &started.session_id,
+            source_mode,
             &started.partial_path.to_string_lossy(),
             &started.final_path.to_string_lossy(),
             started.device_label.clone(),
         )
         .await?;
+    for source in &started.sources {
+        repos
+            .create_pending_source_artifact(
+                &request.note_id,
+                &started.session_id,
+                source.source.as_db(),
+                &source.partial_path.to_string_lossy(),
+                &source.final_path.to_string_lossy(),
+            )
+            .await?;
+    }
     Ok(RecordingSessionDto {
         id: started.session_id,
         note_id: request.note_id,
+        source_mode,
         state: started.status.state,
         started_at: crate::db::repositories::timestamp(),
         elapsed_ms: started.status.elapsed_ms,
         device_label: started.device_label,
         level: started.status.level,
+        sources: started.status.sources,
+        warnings: Vec::new(),
     })
 }
 
@@ -195,16 +230,106 @@ pub async fn finish_recording(
     repos
         .add_checkpoint(&finished.session_id, "done", None)
         .await?;
-    let validation = validate_audio_artifact(
-        &finished.final_path,
-        finished.elapsed_ms,
-        AudioValidationConfig::default(),
-    )
-    .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
-    let checksum = checksum_file(&finished.final_path).unwrap_or_default();
-    let file_size = std::fs::metadata(&finished.final_path)
-        .map(|metadata| metadata.len() as i64)
-        .unwrap_or_default();
+    let source_artifacts = repos
+        .source_artifacts_for_session(&finished.session_id)
+        .await?;
+    let mut source_validations = Vec::new();
+    let mut valid_sources = Vec::new();
+    let mut warnings = Vec::new();
+    let mut primary_validation = None;
+    let mut primary_checksum = String::new();
+    let mut primary_file_size = 0;
+    for source in &finished.sources {
+        let validation = validate_audio_artifact(
+            &source.final_path,
+            source.elapsed_ms,
+            AudioValidationConfig::default(),
+        )
+        .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
+        let checksum = checksum_file(&source.final_path).unwrap_or_default();
+        let file_size = std::fs::metadata(&source.final_path)
+            .map(|metadata| metadata.len() as i64)
+            .unwrap_or_default();
+        if source.source == RecordingSource::Microphone {
+            primary_validation = Some(validation.clone());
+            primary_checksum = checksum.clone();
+            primary_file_size = file_size;
+        }
+        let valid = validation.non_zero_size
+            && validation.readable_audio
+            && validation.duration_within_tolerance
+            && validation.non_silent_signal;
+        if let Some(artifact) = source_artifacts
+            .iter()
+            .find(|artifact| artifact.source == source.source.as_db())
+        {
+            repos
+                .finalize_source_artifact(
+                    &artifact.id,
+                    if valid { "valid" } else { "invalid" },
+                    validation.actual_duration_ms,
+                    file_size,
+                    &checksum,
+                    source.elapsed_ms,
+                    Some(serde_json::to_string(&validation).unwrap_or_default()),
+                    if valid {
+                        None
+                    } else {
+                        Some(validation.warnings.join("; "))
+                    },
+                )
+                .await?;
+            if valid {
+                valid_sources.push((
+                    artifact.id.clone(),
+                    source.source.as_db().to_string(),
+                    source.final_path.clone(),
+                ));
+            }
+        }
+        if !valid {
+            warnings.push(crate::domain::types::SourceWarningDto {
+                source: source.source,
+                code: "source_validation_failed".to_string(),
+                message: format!(
+                    "{} source did not pass validation: {}",
+                    source.source.as_db(),
+                    validation.warnings.join("; ")
+                ),
+            });
+        }
+        source_validations.push(crate::domain::types::SourceValidationDto {
+            source: source.source,
+            file_exists: validation.file_exists,
+            non_zero_size: validation.non_zero_size,
+            readable_audio: validation.readable_audio,
+            expected_duration_ms: validation.expected_duration_ms,
+            actual_duration_ms: Some(validation.actual_duration_ms),
+            duration_within_tolerance: validation.duration_within_tolerance,
+            non_silent_signal: validation.non_silent_signal,
+            peak_amplitude: Some(validation.peak_amplitude),
+            rms_amplitude: Some(validation.rms_amplitude),
+            warnings: validation.warnings.clone(),
+            error: if valid {
+                None
+            } else {
+                Some(validation.warnings.join("; "))
+            },
+        });
+    }
+    let validation =
+        primary_validation.unwrap_or_else(|| crate::domain::types::AudioValidationDto {
+            file_exists: false,
+            non_zero_size: false,
+            readable_audio: false,
+            expected_duration_ms: finished.elapsed_ms,
+            actual_duration_ms: 0,
+            duration_within_tolerance: false,
+            non_silent_signal: false,
+            peak_amplitude: 0.0,
+            rms_amplitude: 0.0,
+            warnings: vec!["No microphone validation was available.".to_string()],
+        });
     repos
         .update_recording_session(
             &finished.session_id,
@@ -214,9 +339,9 @@ pub async fn finish_recording(
                 "invalid"
             },
             finished.elapsed_ms,
-            Some(file_size),
+            Some(primary_file_size),
             Some(validation.actual_duration_ms),
-            Some(checksum.clone()),
+            Some(primary_checksum.clone()),
             Some(validation.peak_amplitude),
             Some(validation.rms_amplitude),
             Some(serde_json::to_string(&validation).unwrap_or_default()),
@@ -228,11 +353,7 @@ pub async fn finish_recording(
         )
         .await?;
 
-    if !(validation.non_zero_size
-        && validation.readable_audio
-        && validation.duration_within_tolerance
-        && validation.non_silent_signal)
-    {
+    if valid_sources.is_empty() {
         repos
             .set_note_status(
                 &finished.note_id,
@@ -244,38 +365,78 @@ pub async fn finish_recording(
             note: repos.get_note(&finished.note_id).await?,
             recording: finished.recording,
             validation,
+            validations: source_validations,
             processing_started: false,
+            warnings,
         });
     }
 
-    let artifact = repos
-        .create_audio_artifact(
-            &finished.note_id,
-            &finished.session_id,
-            &finished.final_path.to_string_lossy(),
-            validation.actual_duration_ms,
-            file_size,
-            &checksum,
-        )
-        .await?;
     repos
         .add_checkpoint(&finished.session_id, "validation", None)
         .await?;
     let title = repos.get_note(&finished.note_id).await?.title;
-    let note = process_saved_audio(
-        &repos,
-        &finished.note_id,
-        &artifact.id,
-        finished.final_path,
-        title,
-    )
-    .await?;
+    let note = if valid_sources.len() == 1
+        && finished.source_mode == RecordingSourceMode::MicrophoneOnly
+    {
+        let (artifact_id, _source, path) = valid_sources[0].clone();
+        process_saved_audio(&repos, &finished.note_id, &artifact_id, path, title).await?
+    } else {
+        process_saved_source_audio(
+            &repos,
+            &finished.note_id,
+            &finished.session_id,
+            finished.source_mode,
+            valid_sources,
+            title,
+        )
+        .await?
+    };
     Ok(FinishRecordingResponse {
         note,
         recording: finished.recording,
         validation,
+        validations: source_validations,
         processing_started: true,
+        warnings,
     })
+}
+
+fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSourceReadinessDto {
+    let (microphone_state, microphone_hint) = microphone_permission_state();
+    let microphone_ready = microphone_state == "granted";
+    let mut sources = vec![SourceReadinessDto {
+        source: RecordingSource::Microphone,
+        required: true,
+        ready: microphone_ready,
+        permission_state: microphone_state.clone(),
+        device_available: microphone_ready,
+        capture_available: microphone_ready,
+        recovery_action: microphone_hint
+            .as_ref()
+            .map(|_| "openMicrophoneSettings".to_string()),
+        message: microphone_hint,
+    }];
+    if source_mode == RecordingSourceMode::MicrophonePlusSystem {
+        let mut system = crate::audio::system_macos::system_audio_readiness();
+        if system.ready {
+            if let Err(error) = crate::audio::system_macos::helper_permission_check() {
+                system.ready = false;
+                system.permission_state = "denied".to_string();
+                system.capture_available = false;
+                system.message = Some(error.message);
+            }
+        }
+        sources.push(system);
+    }
+    let ready = sources
+        .iter()
+        .all(|source| !source.required || source.ready);
+    RecordingSourceReadinessDto {
+        source_mode,
+        ready,
+        checked_at: crate::db::repositories::timestamp(),
+        sources,
+    }
 }
 
 #[tauri::command]
@@ -303,12 +464,87 @@ pub async fn recover_recording(
         ));
     };
     if request.action == "discard" {
+        for artifact in repos
+            .source_artifact_paths_for_session(&request.session_id)
+            .await?
+        {
+            for path in [&artifact.partial_path, &artifact.final_path]
+                .into_iter()
+                .flatten()
+            {
+                let _ = std::fs::remove_file(path);
+            }
+        }
         for path in [&info.partial_path, &info.final_path].into_iter().flatten() {
             let _ = std::fs::remove_file(path);
         }
         return Ok(repos
             .mark_recording_discarded(&info.session_id, &info.note_id)
             .await?);
+    }
+    let source_paths = repos
+        .source_artifact_paths_for_session(&request.session_id)
+        .await?;
+    if !source_paths.is_empty() {
+        let mut valid_sources = Vec::new();
+        for artifact in source_paths {
+            let Some(path) = recovery_source_path(&artifact) else {
+                continue;
+            };
+            let validation = validate_audio_artifact(
+                &path,
+                artifact.expected_duration_ms.max(1),
+                AudioValidationConfig::default(),
+            )
+            .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
+            let checksum = checksum_file(&path).unwrap_or_default();
+            let file_size = std::fs::metadata(&path)
+                .map(|metadata| metadata.len() as i64)
+                .unwrap_or_default();
+            let valid = validation.non_zero_size
+                && validation.readable_audio
+                && validation.duration_within_tolerance
+                && validation.non_silent_signal;
+            repos
+                .finalize_source_artifact(
+                    &artifact.id,
+                    if valid { "valid" } else { "invalid" },
+                    validation.actual_duration_ms,
+                    file_size,
+                    &checksum,
+                    artifact.expected_duration_ms,
+                    Some(serde_json::to_string(&validation).unwrap_or_default()),
+                    if valid {
+                        None
+                    } else {
+                        Some(validation.warnings.join("; "))
+                    },
+                )
+                .await?;
+            if valid {
+                valid_sources.push((artifact.id, artifact.source, path));
+            }
+        }
+        if valid_sources.is_empty() {
+            repos
+                .set_note_status(
+                    &info.note_id,
+                    crate::domain::types::ProcessingStatus::Failed,
+                    Some("No recoverable source audio passed validation.".to_string()),
+                )
+                .await?;
+            return Ok(repos.get_note(&info.note_id).await?);
+        }
+        let title = repos.get_note(&info.note_id).await?.title;
+        return process_saved_source_audio(
+            &repos,
+            &info.note_id,
+            &info.session_id,
+            info.source_mode,
+            valid_sources,
+            title,
+        )
+        .await;
     }
     let path = recovery_audio_path(&info).ok_or_else(|| {
         AppError::new(
@@ -377,6 +613,18 @@ pub async fn recover_recording(
 }
 
 fn recovery_audio_path(info: &crate::db::repositories::RecordingRecoveryInfo) -> Option<PathBuf> {
+    for path in [&info.final_path, &info.partial_path].into_iter().flatten() {
+        if std::fs::metadata(path)
+            .map(|metadata| metadata.len() > 0)
+            .unwrap_or(false)
+        {
+            return Some(PathBuf::from(path));
+        }
+    }
+    None
+}
+
+fn recovery_source_path(info: &crate::db::repositories::SourceArtifactPath) -> Option<PathBuf> {
     for path in [&info.final_path, &info.partial_path].into_iter().flatten() {
         if std::fs::metadata(path)
             .map(|metadata| metadata.len() > 0)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6,7 +6,10 @@ use crate::{
             resume_capture, start_capture,
         },
         recovery::scan_recoverable_recordings,
-        validation::{checksum_file, validate_audio_artifact, AudioValidationConfig},
+        validation::{
+            checksum_file, source_audio_passes_validation, validate_audio_artifact,
+            AudioValidationConfig,
+        },
     },
     db::{migrations::run_migrations, repositories::Repositories},
     domain::{
@@ -255,10 +258,7 @@ pub async fn finish_recording(
             primary_checksum = checksum.clone();
             primary_file_size = file_size;
         }
-        let valid = validation.non_zero_size
-            && validation.readable_audio
-            && validation.duration_within_tolerance
-            && validation.non_silent_signal;
+        let valid = source_audio_passes_validation(source.source, &validation);
         if let Some(artifact) = source_artifacts
             .iter()
             .find(|artifact| artifact.source == source.source.as_db())
@@ -501,10 +501,8 @@ pub async fn recover_recording(
             let file_size = std::fs::metadata(&path)
                 .map(|metadata| metadata.len() as i64)
                 .unwrap_or_default();
-            let valid = validation.non_zero_size
-                && validation.readable_audio
-                && validation.duration_within_tolerance
-                && validation.non_silent_signal;
+            let source = RecordingSource::from(artifact.source.as_str());
+            let valid = source_audio_passes_validation(source, &validation);
             repos
                 .finalize_source_artifact(
                     &artifact.id,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -10,5 +10,83 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
                 .map_err(sqlx::migrate::MigrateError::Execute)?;
         }
     }
+    ensure_column(
+        _pool,
+        "recording_sessions",
+        "source_mode",
+        "TEXT NOT NULL DEFAULT 'microphone_only'",
+    )
+    .await?;
+    ensure_column(_pool, "recording_sessions", "permission_summary", "TEXT").await?;
+    ensure_column(
+        _pool,
+        "audio_artifacts",
+        "source",
+        "TEXT NOT NULL DEFAULT 'microphone'",
+    )
+    .await?;
+    ensure_column(_pool, "audio_artifacts", "partial_path", "TEXT").await?;
+    ensure_column(
+        _pool,
+        "audio_artifacts",
+        "status",
+        "TEXT NOT NULL DEFAULT 'valid'",
+    )
+    .await?;
+    ensure_column(
+        _pool,
+        "audio_artifacts",
+        "expected_duration_ms",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+    .await?;
+    ensure_column(_pool, "audio_artifacts", "validation_summary", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "last_error", "TEXT").await?;
+    ensure_column(_pool, "transcripts", "recording_session_id", "TEXT").await?;
+    ensure_column(_pool, "transcripts", "source_artifact_id", "TEXT").await?;
+    ensure_column(_pool, "transcripts", "source", "TEXT").await?;
+    ensure_column(
+        _pool,
+        "transcripts",
+        "source_mode",
+        "TEXT NOT NULL DEFAULT 'microphone_only'",
+    )
+    .await?;
+    ensure_column(_pool, "recording_checkpoints", "source", "TEXT").await?;
+    ensure_column(_pool, "recording_checkpoints", "source_artifact_id", "TEXT").await?;
+    for statement in include_str!("../../migrations/002_source_modes.sql").split(';') {
+        let statement = statement.trim();
+        if !statement.is_empty() {
+            sqlx::query(statement)
+                .execute(_pool)
+                .await
+                .map_err(sqlx::migrate::MigrateError::Execute)?;
+        }
+    }
+    Ok(())
+}
+
+async fn ensure_column(
+    pool: &SqlitePool,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> Result<(), sqlx::migrate::MigrateError> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let rows = sqlx::query(&pragma)
+        .fetch_all(pool)
+        .await
+        .map_err(sqlx::migrate::MigrateError::Execute)?;
+    let exists = rows.iter().any(|row| {
+        use sqlx::Row;
+        row.get::<String, _>("name") == column
+    });
+    if !exists {
+        let alter = format!("ALTER TABLE {table} ADD COLUMN {column} {definition}");
+        sqlx::query(&alter)
+            .execute(pool)
+            .await
+            .map_err(sqlx::migrate::MigrateError::Execute)?;
+    }
     Ok(())
 }

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1,6 +1,6 @@
 use crate::domain::types::{
     AudioArtifactDto, FolderDto, ListNotesResponse, NoteDto, NoteListItemDto, ProcessingStatus,
-    TranscriptDto,
+    RecordingSourceMode, TranscriptDto,
 };
 use chrono::{SecondsFormat, Utc};
 use sqlx::{Row, SqlitePool};
@@ -114,8 +114,10 @@ impl Repositories {
             generated_content: row.get("generated_content"),
             edited_content: row.get("edited_content"),
             transcript: self.latest_transcript(note_id).await?,
+            source_transcripts: self.source_transcripts(note_id).await?,
             recording: None,
             audio: self.latest_audio_artifact(note_id).await?,
+            audio_sources: self.latest_audio_sources(note_id).await?,
             active_tab: row.get("active_tab"),
             last_error: row.get("last_error"),
         })
@@ -293,16 +295,18 @@ impl Repositories {
         &self,
         note_id: &str,
         session_id: &str,
+        source_mode: RecordingSourceMode,
         partial_path: &str,
         final_path: &str,
         device_label: Option<String>,
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
-            "INSERT INTO recording_sessions (id, note_id, status, started_at, expected_elapsed_ms, device_label, permission_state, partial_path, final_path)
-             VALUES (?, ?, 'recording', ?, 0, ?, 'granted', ?, ?)",
+            "INSERT INTO recording_sessions (id, note_id, source_mode, status, started_at, expected_elapsed_ms, device_label, permission_state, partial_path, final_path)
+             VALUES (?, ?, ?, 'recording', ?, 0, ?, 'granted', ?, ?)",
         )
         .bind(session_id)
         .bind(note_id)
+        .bind(source_mode.as_db())
         .bind(timestamp())
         .bind(device_label)
         .bind(partial_path)
@@ -312,6 +316,17 @@ impl Repositories {
         self.set_note_status(note_id, ProcessingStatus::Recording, None)
             .await?;
         self.add_checkpoint(session_id, "start", None).await
+    }
+
+    pub async fn recording_session_source_mode(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<RecordingSourceMode>, sqlx::Error> {
+        let row = sqlx::query("SELECT source_mode FROM recording_sessions WHERE id = ?")
+            .bind(session_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|row| RecordingSourceMode::from(row.get::<String, _>("source_mode").as_str())))
     }
 
     pub async fn update_recording_session(
@@ -370,6 +385,147 @@ impl Repositories {
         Ok(())
     }
 
+    pub async fn add_source_checkpoint(
+        &self,
+        session_id: &str,
+        source_artifact_id: Option<&str>,
+        source: Option<&str>,
+        kind: &str,
+        details: Option<String>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO recording_checkpoints (id, recording_session_id, source_artifact_id, source, kind, created_at, details)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(session_id)
+        .bind(source_artifact_id)
+        .bind(source)
+        .bind(kind)
+        .bind(timestamp())
+        .bind(details)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn create_pending_source_artifact(
+        &self,
+        note_id: &str,
+        session_id: &str,
+        source: &str,
+        partial_path: &str,
+        final_path: &str,
+    ) -> Result<AudioArtifactDto, sqlx::Error> {
+        let artifact = AudioArtifactDto {
+            id: Uuid::new_v4().to_string(),
+            source: source.to_string(),
+            format: "wav".to_string(),
+            duration_ms: 0,
+            size_bytes: 0,
+            checksum: String::new(),
+            created_at: timestamp(),
+        };
+        sqlx::query(
+            "INSERT INTO audio_artifacts
+             (id, note_id, recording_session_id, source, partial_path, path, format, duration_ms, size_bytes, checksum, status, expected_duration_ms, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, 'wav', 0, 0, '', 'recording', 0, ?)",
+        )
+        .bind(&artifact.id)
+        .bind(note_id)
+        .bind(session_id)
+        .bind(source)
+        .bind(partial_path)
+        .bind(final_path)
+        .bind(&artifact.created_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(artifact)
+    }
+
+    pub async fn source_artifacts_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<AudioArtifactDto>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
+             FROM audio_artifacts
+             WHERE recording_session_id = ?
+             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| AudioArtifactDto {
+                id: row.get("id"),
+                source: row.get("source"),
+                format: row.get("format"),
+                duration_ms: row.get("duration_ms"),
+                size_bytes: row.get("size_bytes"),
+                checksum: row.get("checksum"),
+                created_at: row.get("created_at"),
+            })
+            .collect())
+    }
+
+    pub async fn source_artifact_paths_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<SourceArtifactPath>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, note_id, source, partial_path, path, expected_duration_ms
+             FROM audio_artifacts
+             WHERE recording_session_id = ?
+             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| SourceArtifactPath {
+                id: row.get("id"),
+                note_id: row.get("note_id"),
+                source: row.get("source"),
+                partial_path: row.get("partial_path"),
+                final_path: row.get("path"),
+                expected_duration_ms: row.get("expected_duration_ms"),
+            })
+            .collect())
+    }
+
+    pub async fn finalize_source_artifact(
+        &self,
+        artifact_id: &str,
+        status: &str,
+        duration_ms: i64,
+        size_bytes: i64,
+        checksum: &str,
+        expected_duration_ms: i64,
+        validation_summary: Option<String>,
+        last_error: Option<String>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE audio_artifacts
+             SET status = ?, duration_ms = ?, size_bytes = ?, checksum = ?, expected_duration_ms = ?,
+                 validation_summary = ?, last_error = ?
+             WHERE id = ?",
+        )
+        .bind(status)
+        .bind(duration_ms)
+        .bind(size_bytes)
+        .bind(checksum)
+        .bind(expected_duration_ms)
+        .bind(validation_summary)
+        .bind(last_error)
+        .bind(artifact_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn create_audio_artifact(
         &self,
         note_id: &str,
@@ -381,6 +537,7 @@ impl Repositories {
     ) -> Result<AudioArtifactDto, sqlx::Error> {
         let artifact = AudioArtifactDto {
             id: Uuid::new_v4().to_string(),
+            source: "microphone".to_string(),
             format: "wav".to_string(),
             duration_ms,
             size_bytes,
@@ -388,8 +545,8 @@ impl Repositories {
             created_at: timestamp(),
         };
         sqlx::query(
-            "INSERT INTO audio_artifacts (id, note_id, recording_session_id, path, format, duration_ms, size_bytes, checksum, created_at)
-             VALUES (?, ?, ?, ?, 'wav', ?, ?, ?, ?)",
+            "INSERT INTO audio_artifacts (id, note_id, recording_session_id, source, path, format, duration_ms, size_bytes, checksum, status, expected_duration_ms, created_at)
+             VALUES (?, ?, ?, 'microphone', ?, 'wav', ?, ?, ?, 'valid', ?, ?)",
         )
         .bind(&artifact.id)
         .bind(note_id)
@@ -398,6 +555,7 @@ impl Repositories {
         .bind(duration_ms)
         .bind(size_bytes)
         .bind(checksum)
+        .bind(duration_ms)
         .bind(&artifact.created_at)
         .execute(&self.pool)
         .await?;
@@ -409,7 +567,7 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Option<(String, String)>, sqlx::Error> {
         let row = sqlx::query(
-            "SELECT id, path FROM audio_artifacts WHERE note_id = ? ORDER BY created_at DESC LIMIT 1",
+            "SELECT id, path FROM audio_artifacts WHERE note_id = ? AND status = 'valid' ORDER BY created_at DESC LIMIT 1",
         )
         .bind(note_id)
         .fetch_optional(&self.pool)
@@ -422,9 +580,9 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Option<AudioArtifactDto>, sqlx::Error> {
         let row = sqlx::query(
-            "SELECT id, format, duration_ms, size_bytes, checksum, created_at
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
              FROM audio_artifacts
-             WHERE note_id = ?
+             WHERE note_id = ? AND status = 'valid'
              ORDER BY created_at DESC
              LIMIT 1",
         )
@@ -433,6 +591,7 @@ impl Repositories {
         .await?;
         Ok(row.map(|row| AudioArtifactDto {
             id: row.get("id"),
+            source: row.get("source"),
             format: row.get("format"),
             duration_ms: row.get("duration_ms"),
             size_bytes: row.get("size_bytes"),
@@ -441,9 +600,70 @@ impl Repositories {
         }))
     }
 
+    pub async fn latest_valid_audio_artifact_paths(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<(String, String, String)>, sqlx::Error> {
+        let session = sqlx::query(
+            "SELECT recording_session_id
+             FROM audio_artifacts
+             WHERE note_id = ? AND status = 'valid'
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )
+        .bind(note_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some(session) = session else {
+            return Ok(Vec::new());
+        };
+        let session_id: String = session.get("recording_session_id");
+        let rows = sqlx::query(
+            "SELECT id, source, path
+             FROM audio_artifacts
+             WHERE note_id = ? AND recording_session_id = ? AND status = 'valid'
+             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+        )
+        .bind(note_id)
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.get("id"), row.get("source"), row.get("path")))
+            .collect())
+    }
+
+    async fn latest_audio_sources(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<AudioArtifactDto>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
+             FROM audio_artifacts
+             WHERE note_id = ? AND status = 'valid'
+             ORDER BY created_at DESC",
+        )
+        .bind(note_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| AudioArtifactDto {
+                id: row.get("id"),
+                source: row.get("source"),
+                format: row.get("format"),
+                duration_ms: row.get("duration_ms"),
+                size_bytes: row.get("size_bytes"),
+                checksum: row.get("checksum"),
+                created_at: row.get("created_at"),
+            })
+            .collect())
+    }
+
     async fn latest_transcript(&self, note_id: &str) -> Result<Option<TranscriptDto>, sqlx::Error> {
         let row = sqlx::query(
-            "SELECT id, text, language, status, last_error
+            "SELECT id, text, source_mode, source, language, status, last_error
              FROM transcripts
              WHERE note_id = ?
              ORDER BY created_at DESC
@@ -455,10 +675,40 @@ impl Repositories {
         Ok(row.map(|row| TranscriptDto {
             id: row.get("id"),
             text: row.get("text"),
+            source_mode: Some(RecordingSourceMode::from(
+                row.get::<String, _>("source_mode").as_str(),
+            )),
+            source: row.get("source"),
             language: row.get("language"),
             status: row.get("status"),
             last_error: row.get("last_error"),
         }))
+    }
+
+    async fn source_transcripts(&self, note_id: &str) -> Result<Vec<TranscriptDto>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, text, source_mode, source, language, status, last_error
+             FROM transcripts
+             WHERE note_id = ?
+             ORDER BY created_at ASC",
+        )
+        .bind(note_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| TranscriptDto {
+                id: row.get("id"),
+                text: row.get("text"),
+                source_mode: Some(RecordingSourceMode::from(
+                    row.get::<String, _>("source_mode").as_str(),
+                )),
+                source: row.get("source"),
+                language: row.get("language"),
+                status: row.get("status"),
+                last_error: row.get("last_error"),
+            })
+            .collect())
     }
 
     pub async fn create_transcript(
@@ -472,18 +722,64 @@ impl Repositories {
         let transcript = TranscriptDto {
             id: Uuid::new_v4().to_string(),
             text: text.to_string(),
+            source_mode: Some(RecordingSourceMode::MicrophoneOnly),
+            source: Some("microphone".to_string()),
             language,
             status: "succeeded".to_string(),
             last_error: None,
         };
         let now = timestamp();
         sqlx::query(
-            "INSERT INTO transcripts (id, note_id, audio_artifact_id, text, language, provider, status, retry_count, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, 'succeeded', 0, ?, ?)",
+            "INSERT INTO transcripts (id, note_id, audio_artifact_id, source_artifact_id, source, source_mode, text, language, provider, status, retry_count, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'microphone', 'microphone_only', ?, ?, ?, 'succeeded', 0, ?, ?)",
         )
         .bind(&transcript.id)
         .bind(note_id)
         .bind(audio_artifact_id)
+        .bind(audio_artifact_id)
+        .bind(text)
+        .bind(&transcript.language)
+        .bind(provider)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+        Ok(transcript)
+    }
+
+    pub async fn create_source_transcript(
+        &self,
+        note_id: &str,
+        session_id: &str,
+        audio_artifact_id: &str,
+        source_mode: RecordingSourceMode,
+        source: &str,
+        text: &str,
+        language: Option<String>,
+        provider: &str,
+    ) -> Result<TranscriptDto, sqlx::Error> {
+        let transcript = TranscriptDto {
+            id: Uuid::new_v4().to_string(),
+            text: text.to_string(),
+            source_mode: Some(source_mode),
+            source: Some(source.to_string()),
+            language,
+            status: "succeeded".to_string(),
+            last_error: None,
+        };
+        let now = timestamp();
+        sqlx::query(
+            "INSERT INTO transcripts
+             (id, note_id, recording_session_id, audio_artifact_id, source_artifact_id, source, source_mode, text, language, provider, status, retry_count, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'succeeded', 0, ?, ?)",
+        )
+        .bind(&transcript.id)
+        .bind(note_id)
+        .bind(session_id)
+        .bind(audio_artifact_id)
+        .bind(audio_artifact_id)
+        .bind(source)
+        .bind(source_mode.as_db())
         .bind(text)
         .bind(&transcript.language)
         .bind(provider)
@@ -527,7 +823,7 @@ impl Repositories {
         session_id: &str,
     ) -> Result<Option<RecordingRecoveryInfo>, sqlx::Error> {
         let row = sqlx::query(
-            "SELECT id, note_id, partial_path, final_path, expected_elapsed_ms
+            "SELECT id, note_id, source_mode, partial_path, final_path, expected_elapsed_ms
              FROM recording_sessions
              WHERE id = ?",
         )
@@ -537,6 +833,7 @@ impl Repositories {
         Ok(row.map(|row| RecordingRecoveryInfo {
             session_id: row.get("id"),
             note_id: row.get("note_id"),
+            source_mode: RecordingSourceMode::from(row.get::<String, _>("source_mode").as_str()),
             partial_path: row.get("partial_path"),
             final_path: row.get("final_path"),
             expected_elapsed_ms: row.get("expected_elapsed_ms"),
@@ -589,9 +886,20 @@ fn append_note_content(existing: Option<String>, addition: String) -> String {
 pub struct RecordingRecoveryInfo {
     pub session_id: String,
     pub note_id: String,
+    pub source_mode: RecordingSourceMode,
     pub partial_path: Option<String>,
     pub final_path: Option<String>,
     pub expected_elapsed_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceArtifactPath {
+    pub id: String,
+    pub note_id: String,
+    pub source: String,
+    pub partial_path: Option<String>,
+    pub final_path: Option<String>,
+    pub expected_duration_ms: i64,
 }
 
 pub fn timestamp() -> String {

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::repositories::Repositories,
-    domain::types::{AppError, NoteDto, ProcessingStatus},
+    domain::types::{AppError, NoteDto, ProcessingStatus, RecordingSourceMode},
     providers::{
         generation::{generate_note_from_transcript, GenerationRequest},
         transcription::{transcribe_saved_audio, TranscriptionRequest},
@@ -9,6 +9,38 @@ use crate::{
 use std::path::PathBuf;
 
 pub const PROMPT_VERSION: &str = "notes-mvp-v1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceTranscriptInput {
+    pub source: String,
+    pub text: String,
+    pub valid: bool,
+    pub warning: Option<String>,
+}
+
+pub fn valid_sources_for_processing(
+    sources: Vec<SourceTranscriptInput>,
+) -> Vec<SourceTranscriptInput> {
+    sources
+        .into_iter()
+        .filter(|source| source.valid && !source.text.trim().is_empty())
+        .collect()
+}
+
+pub fn labeled_transcript_from_sources(sources: &[SourceTranscriptInput]) -> String {
+    sources
+        .iter()
+        .filter(|source| source.valid && !source.text.trim().is_empty())
+        .map(|source| {
+            let label = match source.source.as_str() {
+                "system" => "System audio",
+                _ => "Microphone",
+            };
+            format!("## {label}\n{}", source.text.trim())
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
 
 pub async fn process_saved_audio(
     repos: &Repositories,
@@ -88,23 +120,148 @@ pub async fn process_saved_audio(
         .await?)
 }
 
+pub async fn process_saved_source_audio(
+    repos: &Repositories,
+    note_id: &str,
+    session_id: &str,
+    source_mode: RecordingSourceMode,
+    sources: Vec<(String, String, PathBuf)>,
+    title: String,
+) -> Result<NoteDto, AppError> {
+    repos
+        .set_note_status(note_id, ProcessingStatus::Transcribing, None)
+        .await?;
+    let provider = crate::providers::configured_provider();
+    let mut transcript_inputs = Vec::new();
+    let mut first_transcript_id = None;
+    for (artifact_id, source, audio_path) in sources {
+        let transcript = match transcribe_saved_audio(TranscriptionRequest {
+            provider: provider.clone(),
+            audio_path,
+            title: title.clone(),
+        })
+        .await
+        {
+            Ok(transcript) => transcript,
+            Err(error) => {
+                transcript_inputs.push(SourceTranscriptInput {
+                    source,
+                    text: String::new(),
+                    valid: false,
+                    warning: Some(error.message),
+                });
+                continue;
+            }
+        };
+        let row = repos
+            .create_source_transcript(
+                note_id,
+                session_id,
+                &artifact_id,
+                source_mode,
+                &source,
+                &transcript.text,
+                transcript.language.clone(),
+                &transcript.provider,
+            )
+            .await?;
+        if first_transcript_id.is_none() {
+            first_transcript_id = Some(row.id);
+        }
+        transcript_inputs.push(SourceTranscriptInput {
+            source,
+            text: transcript.text,
+            valid: true,
+            warning: None,
+        });
+    }
+
+    let valid_sources = valid_sources_for_processing(transcript_inputs);
+    if valid_sources.is_empty() {
+        repos
+            .set_note_status(
+                note_id,
+                ProcessingStatus::Failed,
+                Some("No selected source produced a usable transcript.".to_string()),
+            )
+            .await?;
+        return Err(AppError::new(
+            "transcription_failed",
+            "No selected source produced a usable transcript.",
+        ));
+    }
+    let labeled_transcript = labeled_transcript_from_sources(&valid_sources);
+    repos
+        .set_note_status(note_id, ProcessingStatus::Generating, None)
+        .await?;
+    let generated = match generate_note_from_transcript(GenerationRequest {
+        provider,
+        title,
+        transcript: labeled_transcript,
+        language: None,
+    })
+    .await
+    {
+        Ok(generated) => generated,
+        Err(error) => {
+            repos
+                .set_note_status(
+                    note_id,
+                    ProcessingStatus::Failed,
+                    Some(error.message.clone()),
+                )
+                .await?;
+            return Err(error);
+        }
+    };
+    let transcript_id = first_transcript_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    repos
+        .create_generation_result(
+            note_id,
+            &transcript_id,
+            &generated.content,
+            generated.title_suggestion.clone(),
+            &generated.provider,
+            &generated.prompt_version,
+        )
+        .await?;
+    Ok(repos
+        .set_generated_note(note_id, generated.title_suggestion, generated.content)
+        .await?)
+}
+
 pub async fn retry_from_saved_audio(
     repos: &Repositories,
     note_id: &str,
 ) -> Result<NoteDto, AppError> {
-    let Some((audio_artifact_id, audio_path)) = repos.latest_audio_artifact_path(note_id).await?
-    else {
+    let sources = repos.latest_valid_audio_artifact_paths(note_id).await?;
+    if sources.is_empty() {
         return Err(AppError::new(
             "audio_artifact_missing",
             "No saved audio is available for retry.",
         ));
-    };
+    }
     let note = repos.get_note(note_id).await?;
-    process_saved_audio(
+    if sources.len() == 1 {
+        let (audio_artifact_id, _source, audio_path) = sources[0].clone();
+        return process_saved_audio(
+            repos,
+            note_id,
+            &audio_artifact_id,
+            PathBuf::from(audio_path),
+            note.title,
+        )
+        .await;
+    }
+    process_saved_source_audio(
         repos,
         note_id,
-        &audio_artifact_id,
-        PathBuf::from(audio_path),
+        "",
+        RecordingSourceMode::MicrophonePlusSystem,
+        sources
+            .into_iter()
+            .map(|(id, source, path)| (id, source, PathBuf::from(path)))
+            .collect(),
         note.title,
     )
     .await

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -78,8 +78,12 @@ pub struct NoteDto {
     pub generated_content: Option<String>,
     pub edited_content: Option<String>,
     pub transcript: Option<TranscriptDto>,
+    #[serde(default)]
+    pub source_transcripts: Vec<TranscriptDto>,
     pub recording: Option<RecordingSessionDto>,
     pub audio: Option<AudioArtifactDto>,
+    #[serde(default)]
+    pub audio_sources: Vec<AudioArtifactDto>,
     pub active_tab: Option<String>,
     pub last_error: Option<String>,
 }
@@ -137,6 +141,8 @@ pub struct RemoveNoteFromFolderRequest {
 #[serde(rename_all = "camelCase")]
 pub struct StartRecordingRequest {
     pub note_id: String,
+    #[serde(default)]
+    pub source_mode: Option<RecordingSourceMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,7 +157,11 @@ pub struct FinishRecordingResponse {
     pub note: NoteDto,
     pub recording: RecordingSessionDto,
     pub validation: AudioValidationDto,
+    #[serde(default)]
+    pub validations: Vec<SourceValidationDto>,
     pub processing_started: bool,
+    #[serde(default)]
+    pub warnings: Vec<SourceWarningDto>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -177,9 +187,39 @@ pub struct MicrophonePermissionResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct CheckRecordingSourceReadinessRequest {
+    pub source_mode: RecordingSourceMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingSourceReadinessDto {
+    pub source_mode: RecordingSourceMode,
+    pub ready: bool,
+    pub checked_at: String,
+    pub sources: Vec<SourceReadinessDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceReadinessDto {
+    pub source: RecordingSource,
+    pub required: bool,
+    pub ready: bool,
+    pub permission_state: String,
+    pub device_available: bool,
+    pub capture_available: bool,
+    pub recovery_action: Option<String>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TranscriptDto {
     pub id: String,
     pub text: String,
+    pub source_mode: Option<RecordingSourceMode>,
+    pub source: Option<String>,
     pub language: Option<String>,
     pub status: String,
     pub last_error: Option<String>,
@@ -190,33 +230,82 @@ pub struct TranscriptDto {
 pub struct RecordingSessionDto {
     pub id: String,
     pub note_id: String,
+    pub source_mode: RecordingSourceMode,
     pub state: RecordingState,
     pub started_at: String,
     pub elapsed_ms: i64,
     pub device_label: Option<String>,
     pub level: AudioLevelDto,
+    #[serde(default)]
+    pub sources: Vec<SourceStatusDto>,
+    #[serde(default)]
+    pub warnings: Vec<SourceWarningDto>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecordingStatusDto {
     pub session_id: String,
+    pub source_mode: RecordingSourceMode,
     pub state: RecordingState,
     pub elapsed_ms: i64,
     pub level: AudioLevelDto,
     pub silence_warning: bool,
     pub bytes_written: i64,
+    #[serde(default)]
+    pub sources: Vec<SourceStatusDto>,
+    #[serde(default)]
+    pub warnings: Vec<SourceWarningDto>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioArtifactDto {
     pub id: String,
+    pub source: String,
     pub format: String,
     pub duration_ms: i64,
     pub size_bytes: i64,
     pub checksum: String,
     pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceStatusDto {
+    pub source: RecordingSource,
+    pub state: SourceState,
+    pub elapsed_ms: i64,
+    pub bytes_written: i64,
+    pub level: AudioLevelDto,
+    pub silence_warning: bool,
+    pub path_finalized: bool,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceValidationDto {
+    pub source: RecordingSource,
+    pub file_exists: bool,
+    pub non_zero_size: bool,
+    pub readable_audio: bool,
+    pub expected_duration_ms: i64,
+    pub actual_duration_ms: Option<i64>,
+    pub duration_within_tolerance: bool,
+    pub non_silent_signal: bool,
+    pub peak_amplitude: Option<f32>,
+    pub rms_amplitude: Option<f32>,
+    pub warnings: Vec<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceWarningDto {
+    pub source: RecordingSource,
+    pub code: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -242,15 +331,38 @@ pub struct AudioLevelDto {
     pub recent_peaks: Vec<f32>,
 }
 
+impl Default for AudioLevelDto {
+    fn default() -> Self {
+        Self {
+            peak: 0.0,
+            rms: 0.0,
+            recent_peaks: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecoverableRecordingDto {
     pub session_id: String,
     pub note_id: String,
+    pub source_mode: RecordingSourceMode,
     pub started_at: String,
     pub partial_path_present: bool,
     pub final_path_present: bool,
     pub bytes_found: i64,
+    #[serde(default)]
+    pub sources: Vec<RecoverableSourceDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecoverableSourceDto {
+    pub source: RecordingSource,
+    pub partial_path_present: bool,
+    pub final_path_present: bool,
+    pub bytes_found: i64,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -298,15 +410,99 @@ impl From<&str> for ProcessingStatus {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub enum RecordingSourceMode {
+    MicrophoneOnly,
+    MicrophonePlusSystem,
+}
+
+impl Default for RecordingSourceMode {
+    fn default() -> Self {
+        Self::MicrophoneOnly
+    }
+}
+
+impl RecordingSourceMode {
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::MicrophoneOnly => "microphone_only",
+            Self::MicrophonePlusSystem => "microphone_plus_system",
+        }
+    }
+
+    pub fn required_sources(self) -> Vec<RecordingSource> {
+        match self {
+            Self::MicrophoneOnly => vec![RecordingSource::Microphone],
+            Self::MicrophonePlusSystem => {
+                vec![RecordingSource::Microphone, RecordingSource::System]
+            }
+        }
+    }
+}
+
+impl From<&str> for RecordingSourceMode {
+    fn from(value: &str) -> Self {
+        match value {
+            "microphone_plus_system" | "microphonePlusSystem" => Self::MicrophonePlusSystem,
+            _ => Self::MicrophoneOnly,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum RecordingSource {
+    Microphone,
+    System,
+}
+
+impl RecordingSource {
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::Microphone => "microphone",
+            Self::System => "system",
+        }
+    }
+}
+
+impl From<&str> for RecordingSource {
+    fn from(value: &str) -> Self {
+        match value {
+            "system" => Self::System,
+            _ => Self::Microphone,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub enum RecordingState {
     Idle,
     PermissionDenied,
+    Starting,
     Recording,
     Paused,
     Finalizing,
     Validating,
+    PartiallyValid,
     Invalid,
     Ready,
     Failed,
     Recoverable,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SourceState {
+    Pending,
+    PermissionDenied,
+    Unavailable,
+    Starting,
+    Recording,
+    Paused,
+    Finalizing,
+    Finalized,
+    Valid,
+    Invalid,
+    Recoverable,
+    Failed,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ pub fn run() {
             commands::assign_note_to_folder,
             commands::remove_note_from_folder,
             commands::get_microphone_permission_state,
+            commands::check_recording_source_readiness,
             commands::start_recording,
             commands::pause_recording,
             commands::resume_recording,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
   "bundle": {
     "active": true,
     "targets": ["app"],
+    "resources": ["native/bin/OS Notetaker Audio Capture.app"],
     "macOS": {
       "entitlements": "Entitlements.plist",
       "exceptionDomain": "",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,9 @@
   "bundle": {
     "active": true,
     "targets": ["app"],
-    "resources": ["native/bin/OS Notetaker Audio Capture.app"],
+    "resources": {
+      "../.tauri-helper/OS Notetaker Audio Capture.app": "native/bin/OS Notetaker Audio Capture.app"
+    },
     "macOS": {
       "entitlements": "Entitlements.plist",
       "exceptionDomain": "",

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -1,4 +1,7 @@
-use os_notetaker_lib::db::{migrations::run_migrations, repositories::Repositories};
+use os_notetaker_lib::{
+    db::{migrations::run_migrations, repositories::Repositories},
+    domain::types::RecordingSourceMode,
+};
 use sqlx::sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {
@@ -127,6 +130,7 @@ async fn get_note_returns_transcript_and_audio_metadata() {
         .create_recording_session(
             &note.id,
             session_id,
+            RecordingSourceMode::MicrophoneOnly,
             "/tmp/partial.wav",
             "/tmp/final.wav",
             None,

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -25,6 +25,22 @@ fn write_wav(path: &Path, amplitude: i16, duration_ms: u32) {
     writer.finalize().expect("wav finalize");
 }
 
+fn write_impulse_wav(path: &Path, impulse_amplitude: i16, duration_ms: u32) {
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec).expect("wav writer");
+    let samples = (spec.sample_rate as f32 * (duration_ms as f32 / 1000.0)) as usize;
+    for i in 0..samples {
+        let sample = if i == 20 { impulse_amplitude } else { 0 };
+        writer.write_sample(sample).expect("sample write");
+    }
+    writer.finalize().expect("wav finalize");
+}
+
 #[test]
 fn accepts_readable_non_silent_wav_with_expected_duration() {
     let dir = tempdir().expect("tempdir");
@@ -84,6 +100,25 @@ fn rejects_silent_audio() {
         .expect("validation should run");
 
     assert!(result.readable_audio);
+    assert!(!result.non_silent_signal);
+    assert!(result
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("silent")));
+}
+
+#[test]
+fn rejects_isolated_peak_without_sustained_signal() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("single-click.wav");
+    write_impulse_wav(&path, i16::MAX, 1_500);
+
+    let result = validate_audio_artifact(&path, 1_500, AudioValidationConfig::default())
+        .expect("validation should run");
+
+    assert!(result.readable_audio);
+    assert!(result.peak_amplitude > 0.9);
+    assert!(result.rms_amplitude < AudioValidationConfig::default().silence_rms_threshold);
     assert!(!result.non_silent_signal);
     assert!(result
         .warnings

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -1,5 +1,10 @@
 use hound::{SampleFormat, WavSpec, WavWriter};
-use os_notetaker_lib::audio::validation::{validate_audio_artifact, AudioValidationConfig};
+use os_notetaker_lib::{
+    audio::validation::{
+        source_audio_passes_validation, validate_audio_artifact, AudioValidationConfig,
+    },
+    domain::types::RecordingSource,
+};
 use std::path::Path;
 use tempfile::tempdir;
 
@@ -21,6 +26,23 @@ fn write_wav(path: &Path, amplitude: i16, duration_ms: u32) {
             -amplitude
         };
         writer.write_sample(sample).expect("sample write");
+    }
+    writer.finalize().expect("wav finalize");
+}
+
+fn write_stereo_wav(path: &Path, amplitude: i16, duration_ms: u32) {
+    let spec = WavSpec {
+        channels: 2,
+        sample_rate: 48_000,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec).expect("wav writer");
+    let frames = (spec.sample_rate as f32 * (duration_ms as f32 / 1000.0)) as usize;
+    for i in 0..frames {
+        let sample = if i % 2 == 0 { amplitude } else { -amplitude };
+        writer.write_sample(sample).expect("left sample write");
+        writer.write_sample(sample).expect("right sample write");
     }
     writer.finalize().expect("wav finalize");
 }
@@ -56,6 +78,41 @@ fn accepts_readable_non_silent_wav_with_expected_duration() {
     assert!(result.duration_within_tolerance);
     assert!(result.non_silent_signal);
     assert!(result.peak_amplitude > 0.1);
+}
+
+#[test]
+fn accepts_stereo_wav_with_expected_duration() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("stereo-system.wav");
+    write_stereo_wav(&path, 6_000, 2_000);
+
+    let result = validate_audio_artifact(&path, 2_000, AudioValidationConfig::default())
+        .expect("validation should run");
+
+    assert_eq!(result.actual_duration_ms, 2_000);
+    assert!(result.duration_within_tolerance);
+    assert!(result.non_silent_signal);
+}
+
+#[test]
+fn accepts_shorter_non_silent_system_audio() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("short-system.wav");
+    write_stereo_wav(&path, 6_000, 2_000);
+
+    let result = validate_audio_artifact(&path, 4_000, AudioValidationConfig::default())
+        .expect("validation should run");
+
+    assert!(!result.duration_within_tolerance);
+    assert!(result.non_silent_signal);
+    assert!(source_audio_passes_validation(
+        RecordingSource::System,
+        &result
+    ));
+    assert!(!source_audio_passes_validation(
+        RecordingSource::Microphone,
+        &result
+    ));
 }
 
 #[test]

--- a/src-tauri/tests/recovery.rs
+++ b/src-tauri/tests/recovery.rs
@@ -1,6 +1,7 @@
 use os_notetaker_lib::{
     audio::recovery::scan_recoverable_recordings,
     db::{migrations::run_migrations, repositories::Repositories},
+    domain::types::RecordingSourceMode,
 };
 use sqlx::sqlite::SqlitePoolOptions;
 use tempfile::tempdir;
@@ -26,6 +27,7 @@ async fn scan_surfaces_interrupted_recording_with_audio_bytes() {
         .create_recording_session(
             &note.id,
             "session-1",
+            RecordingSourceMode::MicrophoneOnly,
             &partial.to_string_lossy(),
             &dir.path().join("session.wav").to_string_lossy(),
             None,
@@ -53,6 +55,7 @@ async fn scan_ignores_missing_audio_bytes() {
         .create_recording_session(
             &note.id,
             "session-1",
+            RecordingSourceMode::MicrophoneOnly,
             &dir.path().join("missing.partial.wav").to_string_lossy(),
             &dir.path().join("missing.wav").to_string_lossy(),
             None,

--- a/src-tauri/tests/source_capture.rs
+++ b/src-tauri/tests/source_capture.rs
@@ -1,0 +1,17 @@
+use os_notetaker_lib::domain::types::{RecordingSource, RecordingSourceMode};
+
+#[test]
+fn dual_source_mode_requires_microphone_and_system_sources() {
+    assert_eq!(
+        RecordingSourceMode::MicrophonePlusSystem.required_sources(),
+        vec![RecordingSource::Microphone, RecordingSource::System]
+    );
+}
+
+#[test]
+fn microphone_only_mode_requires_only_microphone() {
+    assert_eq!(
+        RecordingSourceMode::MicrophoneOnly.required_sources(),
+        vec![RecordingSource::Microphone]
+    );
+}

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -1,0 +1,90 @@
+use os_notetaker_lib::{
+    db::{migrations::run_migrations, repositories::Repositories},
+    domain::types::RecordingSourceMode,
+};
+use sqlx::sqlite::SqlitePoolOptions;
+
+async fn test_repositories() -> Repositories {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite should open");
+    run_migrations(&pool).await.expect("migrations should run");
+    Repositories::new(pool)
+}
+
+#[tokio::test]
+async fn persists_source_mode_with_recording_session() {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note should exist");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            "/tmp/mic.partial.wav",
+            "/tmp/mic.wav",
+            Some("Built-in Microphone".to_string()),
+        )
+        .await
+        .expect("session should be created");
+
+    let session = repos
+        .recording_session_source_mode("session-1")
+        .await
+        .expect("query should succeed")
+        .expect("session should be found");
+
+    assert_eq!(session, RecordingSourceMode::MicrophonePlusSystem);
+}
+
+#[tokio::test]
+async fn stores_source_artifacts_independently() {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note should exist");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            "/tmp/mic.partial.wav",
+            "/tmp/mic.wav",
+            None,
+        )
+        .await
+        .expect("session should be created");
+    repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            "/tmp/mic.partial.wav",
+            "/tmp/mic.wav",
+        )
+        .await
+        .expect("microphone artifact should be created");
+    repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "system",
+            "/tmp/system.partial.wav",
+            "/tmp/system.wav",
+        )
+        .await
+        .expect("system artifact should be created");
+
+    let artifacts = repos
+        .source_artifacts_for_session("session-1")
+        .await
+        .expect("artifacts should load");
+
+    assert_eq!(artifacts.len(), 2);
+    assert!(artifacts
+        .iter()
+        .any(|artifact| artifact.source == "microphone"));
+    assert!(artifacts.iter().any(|artifact| artifact.source == "system"));
+}

--- a/src-tauri/tests/source_processing.rs
+++ b/src-tauri/tests/source_processing.rs
@@ -1,0 +1,47 @@
+use os_notetaker_lib::domain::processing::{
+    labeled_transcript_from_sources, valid_sources_for_processing, SourceTranscriptInput,
+};
+
+#[test]
+fn labeled_transcript_keeps_microphone_and_system_sections() {
+    let transcript = labeled_transcript_from_sources(&[
+        SourceTranscriptInput {
+            source: "microphone".to_string(),
+            text: "My action item is to follow up.".to_string(),
+            valid: true,
+            warning: None,
+        },
+        SourceTranscriptInput {
+            source: "system".to_string(),
+            text: "The deadline is Friday.".to_string(),
+            valid: true,
+            warning: None,
+        },
+    ]);
+
+    assert!(transcript.contains("## Microphone"));
+    assert!(transcript.contains("My action item is to follow up."));
+    assert!(transcript.contains("## System audio"));
+    assert!(transcript.contains("The deadline is Friday."));
+}
+
+#[test]
+fn processing_uses_only_valid_source_transcripts() {
+    let sources = valid_sources_for_processing(vec![
+        SourceTranscriptInput {
+            source: "microphone".to_string(),
+            text: "valid mic text".to_string(),
+            valid: true,
+            warning: None,
+        },
+        SourceTranscriptInput {
+            source: "system".to_string(),
+            text: "invalid system text".to_string(),
+            valid: false,
+            warning: Some("System audio was silent.".to_string()),
+        },
+    ]);
+
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].source, "microphone");
+}

--- a/src-tauri/tests/source_readiness.rs
+++ b/src-tauri/tests/source_readiness.rs
@@ -1,0 +1,11 @@
+use os_notetaker_lib::{
+    audio::system_macos::system_audio_readiness, domain::types::RecordingSource,
+};
+
+#[test]
+fn system_audio_readiness_reports_system_source() {
+    let readiness = system_audio_readiness();
+
+    assert_eq!(readiness.source, RecordingSource::System);
+    assert!(readiness.required);
+}

--- a/src-tauri/tests/source_recovery.rs
+++ b/src-tauri/tests/source_recovery.rs
@@ -1,0 +1,70 @@
+use os_notetaker_lib::{
+    audio::recovery::scan_recoverable_recordings,
+    db::{migrations::run_migrations, repositories::Repositories},
+    domain::types::RecordingSourceMode,
+};
+use sqlx::sqlite::SqlitePoolOptions;
+use tempfile::tempdir;
+
+async fn repos() -> Repositories {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("sqlite memory");
+    run_migrations(&pool).await.expect("migrations");
+    Repositories::new(pool)
+}
+
+#[tokio::test]
+async fn scan_surfaces_recoverable_sources() {
+    let repos = repos().await;
+    let dir = tempdir().expect("tempdir");
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            &dir.path().join("microphone.partial.wav").to_string_lossy(),
+            &dir.path().join("microphone.wav").to_string_lossy(),
+            None,
+        )
+        .await
+        .expect("session");
+    let mic_partial = dir.path().join("microphone.partial.wav");
+    let system_partial = dir.path().join("system.partial.wav");
+    std::fs::write(&mic_partial, b"mic bytes").expect("mic bytes");
+    std::fs::write(&system_partial, b"system bytes").expect("system bytes");
+    repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            &mic_partial.to_string_lossy(),
+            &dir.path().join("microphone.wav").to_string_lossy(),
+        )
+        .await
+        .expect("mic artifact");
+    repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "system",
+            &system_partial.to_string_lossy(),
+            &dir.path().join("system.wav").to_string_lossy(),
+        )
+        .await
+        .expect("system artifact");
+
+    let recoveries = scan_recoverable_recordings(&repos.pool)
+        .await
+        .expect("recoveries");
+
+    assert_eq!(recoveries.len(), 1);
+    assert_eq!(recoveries[0].sources.len(), 2);
+    assert!(recoveries[0]
+        .sources
+        .iter()
+        .any(|source| source.source.as_db() == "system"));
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from "../components/sidebar/Sidebar";
 import {
   assignNoteToFolder,
   bootstrapApp,
+  checkRecordingSourceReadiness,
   createFolder,
   createNote,
   finishRecording,
@@ -21,6 +22,10 @@ import {
   updateNote,
 } from "../lib/tauri";
 import type { NoteDto, RecordingStatusDto } from "../lib/tauri";
+import type {
+  RecordingSourceMode,
+  RecordingSourceReadinessDto,
+} from "../lib/tauri";
 import { createInitialState, notesReducer } from "./state/app-state";
 
 export function App() {
@@ -30,6 +35,10 @@ export function App() {
     createInitialState,
   );
   const [error, setError] = useState<string | null>(null);
+  const [sourceMode, setSourceMode] =
+    useState<RecordingSourceMode>("microphoneOnly");
+  const [sourceReadiness, setSourceReadiness] =
+    useState<RecordingSourceReadinessDto>();
   const selectedNote = state.selectedNote;
 
   useEffect(() => {
@@ -37,6 +46,12 @@ export function App() {
       .then((payload) => dispatch({ type: "bootstrapLoaded", payload }))
       .catch((err: unknown) => setError(messageFromError(err)));
   }, []);
+
+  useEffect(() => {
+    checkRecordingSourceReadiness(sourceMode)
+      .then(setSourceReadiness)
+      .catch((err: unknown) => setError(messageFromError(err)));
+  }, [sourceMode]);
 
   useEffect(() => {
     if (
@@ -124,7 +139,16 @@ export function App() {
   async function handleStartRecording() {
     if (!selectedNote) return;
     try {
-      const recording = await startRecording(selectedNote.id);
+      const readiness = await checkRecordingSourceReadiness(sourceMode);
+      setSourceReadiness(readiness);
+      if (!readiness.ready) {
+        setError(
+          readiness.sources.find((source) => source.required && !source.ready)
+            ?.message ?? "The selected recording sources are not ready.",
+        );
+        return;
+      }
+      const recording = await startRecording(selectedNote.id, sourceMode);
       dispatch({
         type: "recordingStatusChanged",
         status: recordingToStatus(recording),
@@ -193,10 +217,13 @@ export function App() {
               note={selectedNote}
               folders={state.folders}
               recordingStatus={state.recordingStatus}
+              sourceMode={sourceMode}
+              sourceReadiness={sourceReadiness}
               onTitleChange={(title) => void handleUpdateNote({ title })}
               onContentChange={(editedContent) =>
                 void handleUpdateNote({ editedContent })
               }
+              onSourceModeChange={setSourceMode}
               onTabChange={(activeTab) =>
                 void updateNote({ noteId: selectedNote.id, activeTab }).then(
                   (note) => dispatch({ type: "noteUpdated", note }),
@@ -253,17 +280,23 @@ export function App() {
 
 function recordingToStatus(recording: {
   id: string;
+  sourceMode?: RecordingStatusDto["sourceMode"];
   state: RecordingStatusDto["state"];
   elapsedMs: number;
   level: RecordingStatusDto["level"];
+  sources?: RecordingStatusDto["sources"];
+  warnings?: RecordingStatusDto["warnings"];
 }): RecordingStatusDto {
   return {
     sessionId: recording.id,
+    sourceMode: recording.sourceMode,
     state: recording.state,
     elapsedMs: recording.elapsedMs,
     level: recording.level,
     silenceWarning: false,
     bytesWritten: 0,
+    sources: recording.sources,
+    warnings: recording.warnings,
   };
 }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -39,6 +39,7 @@ export function App() {
     useState<RecordingSourceMode>("microphoneOnly");
   const [sourceReadiness, setSourceReadiness] =
     useState<RecordingSourceReadinessDto>();
+  const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
   const selectedNote = state.selectedNote;
 
   useEffect(() => {
@@ -48,9 +49,21 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+    setCheckingSourceReadiness(true);
     checkRecordingSourceReadiness(sourceMode)
-      .then(setSourceReadiness)
-      .catch((err: unknown) => setError(messageFromError(err)));
+      .then((readiness) => {
+        if (!cancelled) setSourceReadiness(readiness);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(messageFromError(err));
+      })
+      .finally(() => {
+        if (!cancelled) setCheckingSourceReadiness(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [sourceMode]);
 
   useEffect(() => {
@@ -139,6 +152,7 @@ export function App() {
   async function handleStartRecording() {
     if (!selectedNote) return;
     try {
+      setCheckingSourceReadiness(true);
       const readiness = await checkRecordingSourceReadiness(sourceMode);
       setSourceReadiness(readiness);
       if (!readiness.ready) {
@@ -155,6 +169,8 @@ export function App() {
       });
     } catch (err) {
       setError(messageFromError(err));
+    } finally {
+      setCheckingSourceReadiness(false);
     }
   }
 
@@ -205,7 +221,7 @@ export function App() {
               .catch((err: unknown) => setError(messageFromError(err)))
           }
         />
-        <div className="app-shell">
+        <div className="workspace-shell">
           <NotesList
             notes={state.notes}
             selectedNoteId={state.selectedNoteId}
@@ -219,6 +235,7 @@ export function App() {
               recordingStatus={state.recordingStatus}
               sourceMode={sourceMode}
               sourceReadiness={sourceReadiness}
+              checkingSourceReadiness={checkingSourceReadiness}
               onTitleChange={(title) => void handleUpdateNote({ title })}
               onContentChange={(editedContent) =>
                 void handleUpdateNote({ editedContent })

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -1,14 +1,24 @@
 import { Mic } from "lucide-react";
-import type { FolderDto, NoteDto, RecordingStatusDto } from "../../lib/tauri";
+import type {
+  FolderDto,
+  NoteDto,
+  RecordingSourceMode,
+  RecordingSourceReadinessDto,
+  RecordingStatusDto,
+} from "../../lib/tauri";
 import { RecorderBar } from "../recorder/RecorderBar";
+import { SourceModeControl } from "../recorder/SourceModeControl";
 import { FolderPicker } from "./FolderPicker";
 
 type NoteEditorProps = {
   note: NoteDto;
   folders: FolderDto[];
   recordingStatus?: RecordingStatusDto;
+  sourceMode: RecordingSourceMode;
+  sourceReadiness?: RecordingSourceReadinessDto;
   onTitleChange: (title: string) => void;
   onContentChange: (content: string) => void;
+  onSourceModeChange: (mode: RecordingSourceMode) => void;
   onStartRecording: () => void;
   onPauseRecording: (sessionId: string) => void;
   onResumeRecording: (sessionId: string) => void;
@@ -23,8 +33,11 @@ export function NoteEditor({
   note,
   folders,
   recordingStatus,
+  sourceMode,
+  sourceReadiness,
   onTitleChange,
   onContentChange,
+  onSourceModeChange,
   onStartRecording,
   onPauseRecording,
   onResumeRecording,
@@ -72,7 +85,21 @@ export function NoteEditor({
       />
       {activeTab === "transcription" ? (
         <section className="transcript-view">
-          {note.transcript?.text ? (
+          {note.sourceTranscripts?.length ? (
+            <div className="source-transcripts">
+              {note.sourceTranscripts.map((transcript) => (
+                <section key={transcript.id}>
+                  <h3>
+                    {transcript.source === "system"
+                      ? "System audio"
+                      : "Microphone"}
+                  </h3>
+                  <p>{transcript.text}</p>
+                  {transcript.lastError ? <p>{transcript.lastError}</p> : null}
+                </section>
+              ))}
+            </div>
+          ) : note.transcript?.text ? (
             <p>{note.transcript.text}</p>
           ) : (
             <div className="empty-state">
@@ -95,6 +122,12 @@ export function NoteEditor({
         />
       )}
       <div className="editor-footer">
+        <SourceModeControl
+          value={sourceMode}
+          disabled={!!recordingStatus}
+          readiness={sourceReadiness}
+          onChange={onSourceModeChange}
+        />
         {recordingStatus ? (
           <RecorderBar
             status={recordingStatus}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -16,6 +16,7 @@ type NoteEditorProps = {
   recordingStatus?: RecordingStatusDto;
   sourceMode: RecordingSourceMode;
   sourceReadiness?: RecordingSourceReadinessDto;
+  checkingSourceReadiness: boolean;
   onTitleChange: (title: string) => void;
   onContentChange: (content: string) => void;
   onSourceModeChange: (mode: RecordingSourceMode) => void;
@@ -35,6 +36,7 @@ export function NoteEditor({
   recordingStatus,
   sourceMode,
   sourceReadiness,
+  checkingSourceReadiness,
   onTitleChange,
   onContentChange,
   onSourceModeChange,
@@ -139,10 +141,16 @@ export function NoteEditor({
           <button
             type="button"
             className="record-button"
+            disabled={
+              checkingSourceReadiness ||
+              sourceReadiness?.sources.some(
+                (source) => source.required && !source.ready,
+              )
+            }
             onClick={onStartRecording}
           >
             <Mic size={18} />
-            Record
+            {checkingSourceReadiness ? "Checking..." : "Record"}
           </button>
         )}
       </div>

--- a/src/components/recorder/RecorderBar.tsx
+++ b/src/components/recorder/RecorderBar.tsx
@@ -17,6 +17,19 @@ export function RecorderBar({
   const paused = status.state === "paused";
   const controlsEnabled =
     status.state === "recording" || status.state === "paused";
+  const sources = status.sources?.length
+    ? status.sources
+    : [
+        {
+          source: "microphone" as const,
+          state: status.state,
+          elapsedMs: status.elapsedMs,
+          bytesWritten: status.bytesWritten,
+          level: status.level,
+          silenceWarning: status.silenceWarning,
+          pathFinalized: false,
+        },
+      ];
   const pauseLabel = paused
     ? "Resume"
     : status.state === "recording"
@@ -38,6 +51,20 @@ export function RecorderBar({
         <span className="elapsed">{formatElapsed(status.elapsedMs)}</span>
         <Waveform level={status.level} />
       </div>
+      {sources.length > 1 ? (
+        <div className="source-status-list" aria-label="Recording sources">
+          {sources.map((source) => (
+            <div className="source-status" key={source.source}>
+              <span>{labelForSource(source.source)}</span>
+              <Waveform level={source.level} />
+              <span>{source.bytesWritten} bytes</span>
+              {source.silenceWarning ? (
+                <span className="source-warning">Silent</span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
       <button
         type="button"
         className="done-button"
@@ -51,6 +78,11 @@ export function RecorderBar({
           Microphone input appears silent
         </p>
       ) : null}
+      {status.warnings?.map((warning) => (
+        <p className="recorder-warning" role="status" key={warning.code}>
+          {warning.message}
+        </p>
+      ))}
     </div>
   );
 }
@@ -60,4 +92,8 @@ export function formatElapsed(ms: number) {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function labelForSource(source: string) {
+  return source === "system" ? "System audio" : "Microphone";
 }

--- a/src/components/recorder/RecoveryBanner.tsx
+++ b/src/components/recorder/RecoveryBanner.tsx
@@ -22,6 +22,16 @@ export function RecoveryBanner({
           {recovery.bytesFound} bytes are available from an interrupted
           recording.
         </p>
+        {recovery.sources?.length ? (
+          <ul className="recovery-sources">
+            {recovery.sources.map((source) => (
+              <li key={source.source}>
+                {source.source === "system" ? "System audio" : "Microphone"}:{" "}
+                {source.bytesFound} bytes
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </div>
       <div className="recovery-actions">
         <button type="button" onClick={() => onValidate(recovery.sessionId)}>

--- a/src/components/recorder/SourceModeControl.tsx
+++ b/src/components/recorder/SourceModeControl.tsx
@@ -1,0 +1,69 @@
+import type {
+  RecordingSourceMode,
+  RecordingSourceReadinessDto,
+} from "../../lib/tauri";
+
+type SourceModeControlProps = {
+  value: RecordingSourceMode;
+  disabled: boolean;
+  readiness?: RecordingSourceReadinessDto;
+  onChange: (mode: RecordingSourceMode) => void;
+};
+
+const options: Array<{ value: RecordingSourceMode; label: string }> = [
+  { value: "microphoneOnly", label: "Microphone only" },
+  { value: "microphonePlusSystem", label: "Microphone + system audio" },
+];
+
+export function SourceModeControl({
+  value,
+  disabled,
+  readiness,
+  onChange,
+}: SourceModeControlProps) {
+  const failedSources =
+    readiness?.sources.filter((source) => source.required && !source.ready) ??
+    [];
+
+  return (
+    <div className="source-mode-control">
+      <div
+        className="source-mode-options"
+        role="radiogroup"
+        aria-label="Recording source"
+      >
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className="source-mode-option"
+            data-selected={value === option.value}
+          >
+            <input
+              type="radio"
+              name="recording-source-mode"
+              value={option.value}
+              checked={value === option.value}
+              disabled={disabled}
+              onChange={() => onChange(option.value)}
+            />
+            <span>{option.label}</span>
+          </label>
+        ))}
+      </div>
+      {failedSources.length > 0 ? (
+        <div className="source-readiness-warning" role="status">
+          {failedSources.map((source) => (
+            <p key={source.source}>
+              {source.message ??
+                `${labelForSource(source.source)} is not ready.`}
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function labelForSource(source: string) {
+  return source === "system" ? "System audio" : "Microphone";
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -31,6 +31,8 @@ export type NoteListItemDto = {
 export type TranscriptDto = {
   id: string;
   text: string;
+  sourceMode?: RecordingSourceMode;
+  source?: RecordingSource;
   language?: string;
   status: "pending" | "running" | "succeeded" | "failed";
   lastError?: string;
@@ -45,36 +47,79 @@ export type AudioLevelDto = {
 export type RecordingState =
   | "idle"
   | "permissionDenied"
+  | "starting"
   | "recording"
   | "paused"
   | "finalizing"
   | "validating"
+  | "partiallyValid"
   | "invalid"
   | "ready"
   | "failed"
   | "recoverable";
 
+export type RecordingSourceMode = "microphoneOnly" | "microphonePlusSystem";
+export type RecordingSource = "microphone" | "system";
+
+export type SourceState =
+  | "pending"
+  | "permissionDenied"
+  | "unavailable"
+  | "starting"
+  | "recording"
+  | "paused"
+  | "finalizing"
+  | "finalized"
+  | "valid"
+  | "invalid"
+  | "recoverable"
+  | "failed";
+
+export type SourceStatusDto = {
+  source: RecordingSource;
+  state: SourceState;
+  elapsedMs: number;
+  bytesWritten: number;
+  level: AudioLevelDto;
+  silenceWarning: boolean;
+  pathFinalized: boolean;
+  lastError?: string;
+};
+
+export type SourceWarningDto = {
+  source: RecordingSource;
+  code: string;
+  message: string;
+};
+
 export type RecordingStatusDto = {
   sessionId: string;
+  sourceMode?: RecordingSourceMode;
   state: RecordingState;
   elapsedMs: number;
   level: AudioLevelDto;
   silenceWarning: boolean;
   bytesWritten: number;
+  sources?: SourceStatusDto[];
+  warnings?: SourceWarningDto[];
 };
 
 export type RecordingSessionDto = {
   id: string;
   noteId: string;
+  sourceMode?: RecordingSourceMode;
   state: RecordingState;
   startedAt: string;
   elapsedMs: number;
   deviceLabel?: string;
   level: AudioLevelDto;
+  sources?: SourceStatusDto[];
+  warnings?: SourceWarningDto[];
 };
 
 export type AudioArtifactDto = {
   id: string;
+  source?: RecordingSource;
   format: "wav";
   durationMs: number;
   sizeBytes: number;
@@ -86,8 +131,10 @@ export type NoteDto = NoteListItemDto & {
   generatedContent?: string;
   editedContent?: string;
   transcript?: TranscriptDto;
+  sourceTranscripts?: TranscriptDto[];
   recording?: RecordingSessionDto;
   audio?: AudioArtifactDto;
+  audioSources?: AudioArtifactDto[];
   activeTab?: "notes" | "transcription";
   lastError?: string;
 };
@@ -95,10 +142,20 @@ export type NoteDto = NoteListItemDto & {
 export type RecoverableRecordingDto = {
   sessionId: string;
   noteId: string;
+  sourceMode?: RecordingSourceMode;
   startedAt: string;
   partialPathPresent: boolean;
   finalPathPresent: boolean;
   bytesFound: number;
+  sources?: RecoverableSourceDto[];
+};
+
+export type RecoverableSourceDto = {
+  source: RecordingSource;
+  partialPathPresent: boolean;
+  finalPathPresent: boolean;
+  bytesFound: number;
+  lastError?: string;
 };
 
 export type BootstrapResponse = {
@@ -121,16 +178,60 @@ export type AudioValidationDto = {
   warnings: string[];
 };
 
+export type SourceValidationDto = {
+  source: RecordingSource;
+  fileExists: boolean;
+  nonZeroSize: boolean;
+  readableAudio: boolean;
+  expectedDurationMs: number;
+  actualDurationMs?: number;
+  durationWithinTolerance: boolean;
+  nonSilentSignal: boolean;
+  peakAmplitude?: number;
+  rmsAmplitude?: number;
+  warnings: string[];
+  error?: string;
+};
+
 export type FinishRecordingResponse = {
   note: NoteDto;
   recording: RecordingSessionDto;
   validation: AudioValidationDto;
+  validations?: SourceValidationDto[];
   processingStarted: boolean;
+  warnings?: SourceWarningDto[];
 };
 
 export type ListNotesResponse = {
   items: NoteListItemDto[];
   nextCursor?: string;
+};
+
+export type SourceReadinessDto = {
+  source: RecordingSource;
+  required: boolean;
+  ready: boolean;
+  permissionState:
+    | "unknown"
+    | "granted"
+    | "denied"
+    | "restricted"
+    | "unsupported";
+  deviceAvailable: boolean;
+  captureAvailable: boolean;
+  recoveryAction?:
+    | "openMicrophoneSettings"
+    | "openSystemAudioSettings"
+    | "upgradeMacos"
+    | "restartApp";
+  message?: string;
+};
+
+export type RecordingSourceReadinessDto = {
+  sourceMode: RecordingSourceMode;
+  ready: boolean;
+  checkedAt?: string;
+  sources: SourceReadinessDto[];
 };
 
 export async function bootstrapApp() {
@@ -178,9 +279,23 @@ export async function updateNote(input: {
   return invoke<NoteDto>("update_note", { request: input });
 }
 
-export async function startRecording(noteId: string) {
+export async function checkRecordingSourceReadiness(
+  sourceMode: RecordingSourceMode,
+) {
+  return invoke<RecordingSourceReadinessDto>(
+    "check_recording_source_readiness",
+    {
+      request: { sourceMode },
+    },
+  );
+}
+
+export async function startRecording(
+  noteId: string,
+  sourceMode: RecordingSourceMode = "microphoneOnly",
+) {
   return invoke<RecordingSessionDto>("start_recording", {
-    request: { noteId },
+    request: { noteId, sourceMode },
   });
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -151,11 +151,96 @@ select {
   backdrop-filter: blur(22px) saturate(1.35);
 }
 
+.source-mode-control {
+  display: grid;
+  gap: 8px;
+  align-content: center;
+}
+
+.source-mode-options {
+  display: inline-grid;
+  grid-template-columns: repeat(2, minmax(150px, max-content));
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid rgba(31, 35, 42, 0.12);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.source-mode-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 8px;
+  color: #343b46;
+  font-size: 13px;
+  font-weight: 620;
+  cursor: pointer;
+}
+
+.source-mode-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.source-mode-option[data-selected="true"] {
+  color: #0f172a;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 5px 14px rgba(17, 24, 39, 0.08);
+}
+
+.source-mode-option:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.source-readiness-warning {
+  max-width: 420px;
+  color: #9a4d00;
+  font-size: 13px;
+  text-align: center;
+}
+
+.source-readiness-warning p {
+  margin: 0;
+}
+
 .recorder-meter {
   display: grid;
   grid-template-columns: 58px minmax(0, 1fr);
   gap: 12px;
   align-items: center;
+}
+
+.source-status-list {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.source-status {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr) 86px;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid rgba(31, 35, 42, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.48);
+  font-size: 12px;
+}
+
+.source-status .waveform {
+  min-height: 20px;
+}
+
+.source-status .waveform span {
+  min-height: 16px;
 }
 
 .elapsed {
@@ -283,9 +368,28 @@ select {
   line-height: 1.55;
 }
 
+.source-transcripts {
+  display: grid;
+  gap: 16px;
+}
+
+.source-transcripts h3 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  text-transform: uppercase;
+  color: #4b5563;
+}
+
+.source-transcripts p {
+  margin: 0;
+}
+
 .editor-footer {
   display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
   justify-content: center;
+  align-items: center;
   min-height: 64px;
 }
 
@@ -325,6 +429,16 @@ select {
 .recovery-banner p {
   margin: 4px 0 0;
   color: #7a4b18;
+}
+
+.recovery-sources {
+  display: flex;
+  gap: 10px;
+  margin: 8px 0 0;
+  padding: 0;
+  color: #7a4b18;
+  font-size: 13px;
+  list-style: none;
 }
 
 .recovery-actions {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -21,7 +21,8 @@
 body {
   margin: 0;
   min-width: 900px;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
 }
 
 button,
@@ -34,7 +35,8 @@ select {
 .app-shell {
   display: grid;
   grid-template-columns: 260px minmax(0, 1fr);
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .sidebar {
@@ -45,6 +47,8 @@ select {
   border-right: 1px solid rgba(40, 42, 48, 0.12);
   background: rgba(255, 255, 255, 0.62);
   backdrop-filter: blur(18px) saturate(1.35);
+  min-height: 0;
+  overflow: auto;
 }
 
 .sidebar h1 {
@@ -78,15 +82,19 @@ select {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
   padding: 32px;
+  overflow: hidden;
 }
 
-.app-shell {
+.workspace-shell {
   display: grid;
   grid-template-columns: 300px minmax(0, 1fr);
   gap: 24px;
   width: 100%;
-  min-height: calc(100vh - 64px);
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
 }
 
 .notes-list,
@@ -95,6 +103,8 @@ select {
   flex-direction: column;
   gap: 10px;
   min-width: 0;
+  min-height: 0;
+  overflow: auto;
 }
 
 .notes-empty {
@@ -280,16 +290,18 @@ select {
 
 .note-editor {
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
   gap: 18px;
   width: 100%;
-  min-height: calc(100vh - 64px);
+  min-height: 0;
+  overflow: hidden;
 }
 
 .editor-empty {
   display: grid;
   place-items: center;
   min-height: 100%;
+  overflow: hidden;
 }
 
 .note-title {
@@ -357,6 +369,7 @@ select {
 
 .note-body {
   resize: none;
+  overflow: auto;
   padding: 20px;
   line-height: 1.55;
   outline: none;

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -23,8 +23,10 @@ function note(overrides: Partial<NoteDto> = {}): NoteDto {
 
 const props = {
   folders: [],
+  sourceMode: "microphoneOnly" as const,
   onTitleChange: vi.fn(),
   onContentChange: vi.fn(),
+  onSourceModeChange: vi.fn(),
   onStartRecording: vi.fn(),
   onPauseRecording: vi.fn(),
   onResumeRecording: vi.fn(),
@@ -96,6 +98,7 @@ describe("NoteEditor", () => {
           lastError: "Transcription failed",
           audio: {
             id: "audio-1",
+            source: "microphone",
             format: "wav",
             durationMs: 1200,
             sizeBytes: 2048,

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -24,6 +24,7 @@ function note(overrides: Partial<NoteDto> = {}): NoteDto {
 const props = {
   folders: [],
   sourceMode: "microphoneOnly" as const,
+  checkingSourceReadiness: false,
   onTitleChange: vi.fn(),
   onContentChange: vi.fn(),
   onSourceModeChange: vi.fn(),

--- a/src/test/recorder-source-mode.test.tsx
+++ b/src/test/recorder-source-mode.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SourceModeControl } from "../components/recorder/SourceModeControl";
+
+describe("SourceModeControl", () => {
+  it("shows both required source mode labels", () => {
+    render(
+      <SourceModeControl
+        value="microphoneOnly"
+        disabled={false}
+        readiness={{ sourceMode: "microphoneOnly", ready: true, sources: [] }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Microphone only" }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "Microphone + system audio" }),
+    ).toBeInTheDocument();
+  });
+
+  it("requests readiness when the user changes mode", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SourceModeControl
+        value="microphoneOnly"
+        disabled={false}
+        readiness={{ sourceMode: "microphoneOnly", ready: true, sources: [] }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("radio", { name: "Microphone + system audio" }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith("microphonePlusSystem");
+  });
+
+  it("disables mode changes while recording is active", () => {
+    render(
+      <SourceModeControl
+        value="microphonePlusSystem"
+        disabled
+        readiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: true,
+          sources: [],
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Microphone only" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("radio", { name: "Microphone + system audio" }),
+    ).toBeDisabled();
+  });
+
+  it("shows source-specific readiness failures", () => {
+    render(
+      <SourceModeControl
+        value="microphonePlusSystem"
+        disabled={false}
+        readiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: false,
+          sources: [
+            {
+              source: "system",
+              required: true,
+              ready: false,
+              permissionState: "denied",
+              deviceAvailable: true,
+              captureAvailable: false,
+              recoveryAction: "openSystemAudioSettings",
+              message:
+                "Enable system audio capture in macOS Privacy & Security.",
+            },
+          ],
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Enable system audio capture in macOS Privacy & Security.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/test/recorder-source-status.test.tsx
+++ b/src/test/recorder-source-status.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RecorderBar } from "../components/recorder/RecorderBar";
+
+describe("RecorderBar source status", () => {
+  it("shows per-source evidence for dual-source recordings", () => {
+    render(
+      <RecorderBar
+        status={{
+          sessionId: "session-1",
+          state: "recording",
+          sourceMode: "microphonePlusSystem",
+          elapsedMs: 3_000,
+          level: { peak: 0.5, rms: 0.2, recentPeaks: [0.2, 0.5] },
+          silenceWarning: false,
+          bytesWritten: 4096,
+          warnings: [],
+          sources: [
+            {
+              source: "microphone",
+              state: "recording",
+              elapsedMs: 3_000,
+              bytesWritten: 2048,
+              level: { peak: 0.5, rms: 0.2, recentPeaks: [0.2, 0.5] },
+              silenceWarning: false,
+              pathFinalized: false,
+            },
+            {
+              source: "system",
+              state: "recording",
+              elapsedMs: 3_000,
+              bytesWritten: 2048,
+              level: { peak: 0.4, rms: 0.15, recentPeaks: [0.1, 0.4] },
+              silenceWarning: false,
+              pathFinalized: false,
+            },
+          ],
+        }}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Microphone")).toBeInTheDocument();
+    expect(screen.getByText("System audio")).toBeInTheDocument();
+    expect(screen.getAllByText("2048 bytes")).toHaveLength(2);
+  });
+});

--- a/src/test/recovery-source-mode.test.tsx
+++ b/src/test/recovery-source-mode.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RecoveryBanner } from "../components/recorder/RecoveryBanner";
+
+describe("RecoveryBanner source mode details", () => {
+  it("shows recoverable source bytes separately", () => {
+    render(
+      <RecoveryBanner
+        recoveries={[
+          {
+            sessionId: "session-1",
+            noteId: "note-1",
+            sourceMode: "microphonePlusSystem",
+            startedAt: "2026-05-19T10:00:00Z",
+            partialPathPresent: true,
+            finalPathPresent: false,
+            bytesFound: 4096,
+            sources: [
+              {
+                source: "microphone",
+                partialPathPresent: true,
+                finalPathPresent: false,
+                bytesFound: 2048,
+              },
+              {
+                source: "system",
+                partialPathPresent: true,
+                finalPathPresent: false,
+                bytesFound: 2048,
+              },
+            ],
+          },
+        ]}
+        onValidate={vi.fn()}
+        onDiscard={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Microphone: 2048 bytes")).toBeInTheDocument();
+    expect(screen.getByText("System audio: 2048 bytes")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Harden macOS system audio capture readiness with real helper probes, permission handling, stale-helper cleanup, and verbose development diagnostics.
- Fix source audio validation so system audio can pass when it contains non-silent local audio but is shorter than the microphone timeline.
- Keep microphone and system source artifacts/transcripts separate for dual-source processing.
- Fix the app layout so the notes list scrolls independently and recording controls stay visible in the editor.

## Root Cause

System audio was being treated like microphone audio during validation. The system tap may only write frames while local audio is actually present, so comparing its WAV duration to the full microphone recording duration incorrectly marked usable system audio as invalid. The UI also reused the root `app-shell` class for the inner workspace grid, causing the note list and editor to scroll together.

## Validation

- `pnpm test:rust`
- `pnpm test`
- `pnpm run lint`
- `pnpm tauri:build`
- `pnpm run build`
