### PR TITLE
Fix generated note append duplication

### DIFF
--- a/src-tauri/migrations/003_generation_blocks.sql
+++ b/src-tauri/migrations/003_generation_blocks.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS note_generation_blocks (
+  id TEXT PRIMARY KEY NOT NULL,
+  note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+  recording_session_id TEXT,
+  generation_result_id TEXT REFERENCES generation_results(id) ON DELETE SET NULL,
+  content TEXT NOT NULL,
+  title_suggestion TEXT,
+  sort_order INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_note_generation_blocks_session
+ON note_generation_blocks (note_id, recording_session_id)
+WHERE recording_session_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_note_generation_blocks_note_order
+ON note_generation_blocks (note_id, sort_order, created_at);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,10 @@ use crate::{
     },
     db::{migrations::run_migrations, repositories::Repositories},
     domain::{
-        processing::{process_saved_audio, process_saved_source_audio, retry_from_saved_audio},
+        processing::{
+            manual_notes_for_generation, process_saved_audio, process_saved_source_audio,
+            retry_from_saved_audio,
+        },
         types::{
             AppError, AssignNoteToFolderRequest, BootstrapResponse,
             CheckRecordingSourceReadinessRequest, CreateFolderRequest, CreateNoteRequest,
@@ -401,7 +404,7 @@ pub async fn finish_recording(
         )
         .await?;
     let note = repos.get_note(&finished.note_id).await?;
-    let manual_notes = note.edited_content.clone();
+    let manual_notes = manual_notes_for_generation(&note);
     let task_repos = repos.clone();
     let task_note_id = finished.note_id.clone();
     let task_session_id = finished.session_id.clone();
@@ -588,6 +591,7 @@ pub async fn recover_recording(
             return Ok(repos.get_note(&info.note_id).await?);
         }
         let note = repos.get_note(&info.note_id).await?;
+        let manual_notes = manual_notes_for_generation(&note);
         return process_saved_source_audio(
             &repos,
             &info.note_id,
@@ -595,7 +599,7 @@ pub async fn recover_recording(
             info.source_mode,
             valid_sources,
             note.title,
-            note.edited_content,
+            manual_notes,
         )
         .await;
     }
@@ -662,13 +666,14 @@ pub async fn recover_recording(
         )
         .await?;
     let note = repos.get_note(&info.note_id).await?;
+    let manual_notes = manual_notes_for_generation(&note);
     process_saved_audio(
         &repos,
         &info.note_id,
         &artifact.id,
         path,
         note.title,
-        note.edited_content,
+        manual_notes,
     )
     .await
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -420,6 +420,7 @@ pub async fn finish_recording(
             process_saved_audio(
                 &task_repos,
                 &task_note_id,
+                &task_session_id,
                 &artifact_id,
                 path,
                 title,
@@ -670,6 +671,7 @@ pub async fn recover_recording(
     process_saved_audio(
         &repos,
         &info.note_id,
+        &info.session_id,
         &artifact.id,
         path,
         note.title,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -404,6 +404,7 @@ pub async fn finish_recording(
         )
         .await?;
     let note = repos.get_note(&finished.note_id).await?;
+    let existing_generated_note = note.generated_content.clone();
     let manual_notes = manual_notes_for_generation(&note);
     let task_repos = repos.clone();
     let task_note_id = finished.note_id.clone();
@@ -424,6 +425,7 @@ pub async fn finish_recording(
                 &artifact_id,
                 path,
                 title,
+                existing_generated_note,
                 manual_notes,
             )
             .await
@@ -435,6 +437,7 @@ pub async fn finish_recording(
                 task_source_mode,
                 valid_sources,
                 title,
+                existing_generated_note,
                 manual_notes,
             )
             .await
@@ -592,6 +595,7 @@ pub async fn recover_recording(
             return Ok(repos.get_note(&info.note_id).await?);
         }
         let note = repos.get_note(&info.note_id).await?;
+        let existing_generated_note = note.generated_content.clone();
         let manual_notes = manual_notes_for_generation(&note);
         return process_saved_source_audio(
             &repos,
@@ -600,6 +604,7 @@ pub async fn recover_recording(
             info.source_mode,
             valid_sources,
             note.title,
+            existing_generated_note,
             manual_notes,
         )
         .await;
@@ -667,6 +672,7 @@ pub async fn recover_recording(
         )
         .await?;
     let note = repos.get_note(&info.note_id).await?;
+    let existing_generated_note = note.generated_content.clone();
     let manual_notes = manual_notes_for_generation(&note);
     process_saved_audio(
         &repos,
@@ -675,6 +681,7 @@ pub async fn recover_recording(
         &artifact.id,
         path,
         note.title,
+        existing_generated_note,
         manual_notes,
     )
     .await

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -66,6 +66,15 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
                 .map_err(sqlx::migrate::MigrateError::Execute)?;
         }
     }
+    for statement in include_str!("../../migrations/003_generation_blocks.sql").split(';') {
+        let statement = statement.trim();
+        if !statement.is_empty() {
+            sqlx::query(statement)
+                .execute(_pool)
+                .await
+                .map_err(sqlx::migrate::MigrateError::Execute)?;
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -351,13 +351,25 @@ impl Repositories {
         } else {
             current.title.clone()
         };
-        let content =
-            normalize_generated_addition(&title, current.generated_content.as_deref(), &content);
+        let manual_tail = manual_tail_for_append(
+            current.generated_content.as_deref(),
+            current.edited_content.as_deref(),
+        );
+        let content = normalize_generated_addition(
+            &title,
+            current.generated_content.as_deref(),
+            manual_tail.as_deref(),
+            &content,
+        );
         let next_generated_content =
             append_note_content(current.generated_content, content.clone());
         let next_edited_content = current.edited_content.map(|edited_content| {
-            let content =
-                normalize_generated_addition(&title, Some(edited_content.as_str()), &content);
+            let content = normalize_generated_addition(
+                &title,
+                Some(edited_content.as_str()),
+                manual_tail.as_deref(),
+                &content,
+            );
             append_note_content(Some(edited_content), content)
         });
         sqlx::query(
@@ -1026,9 +1038,15 @@ fn append_note_content(existing: Option<String>, addition: String) -> String {
     }
 }
 
-fn normalize_generated_addition(title: &str, existing: Option<&str>, content: &str) -> String {
+fn normalize_generated_addition(
+    title: &str,
+    existing: Option<&str>,
+    manual_tail: Option<&str>,
+    content: &str,
+) -> String {
     let content = content.trim();
-    let content = strip_duplicate_generated_heading(title, content);
+    let content = strip_manual_tail_echo(manual_tail, content);
+    let content = strip_duplicate_generated_heading(title, manual_tail, content);
     let Some(existing) = existing.map(str::trim).filter(|value| !value.is_empty()) else {
         return content.to_string();
     };
@@ -1041,26 +1059,70 @@ fn normalize_generated_addition(title: &str, existing: Option<&str>, content: &s
     }
 }
 
-fn strip_duplicate_generated_heading<'a>(title: &str, content: &'a str) -> &'a str {
+fn strip_manual_tail_echo<'a>(manual_tail: Option<&str>, content: &'a str) -> &'a str {
+    let Some(manual_tail) = manual_tail.map(str::trim).filter(|value| !value.is_empty()) else {
+        return content;
+    };
+    let Some(rest) = content.strip_prefix(manual_tail) else {
+        return content;
+    };
+    rest.strip_prefix(':').unwrap_or(rest).trim_start()
+}
+
+fn strip_duplicate_generated_heading<'a>(
+    title: &str,
+    manual_tail: Option<&str>,
+    content: &'a str,
+) -> &'a str {
     let Some((heading, rest)) = content.split_once('\n') else {
         return content;
     };
-    let Some(heading_text) = heading.strip_prefix("# ") else {
+    let Some(heading_text) = markdown_heading_text(heading) else {
         return content;
     };
-    if is_duplicate_generated_heading(title, heading_text) {
+    if is_duplicate_generated_heading(title, manual_tail, heading_text) {
         rest.trim_start()
     } else {
         content
     }
 }
 
-fn is_duplicate_generated_heading(title: &str, heading: &str) -> bool {
+fn markdown_heading_text(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let hash_count = trimmed
+        .chars()
+        .take_while(|character| *character == '#')
+        .count();
+    if hash_count == 0 || hash_count > 6 {
+        return None;
+    }
+
+    trimmed[hash_count..].strip_prefix(' ').map(str::trim)
+}
+
+fn is_duplicate_generated_heading(title: &str, manual_tail: Option<&str>, heading: &str) -> bool {
     let heading = heading.trim();
     let title = title.trim();
     heading.eq_ignore_ascii_case("New note")
         || heading.eq_ignore_ascii_case("Generated note")
         || (!title.is_empty() && heading.eq_ignore_ascii_case(title))
+        || manual_tail
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_some_and(|manual_tail| heading.eq_ignore_ascii_case(manual_tail))
+}
+
+fn manual_tail_for_append(generated: Option<&str>, edited: Option<&str>) -> Option<String> {
+    let generated = generated?.trim();
+    let edited = edited?.trim();
+    if generated.is_empty() || edited == generated {
+        return None;
+    }
+    edited
+        .strip_prefix(generated)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -351,14 +351,15 @@ impl Repositories {
         } else {
             current.title.clone()
         };
-        let appending_to_existing = current.generated_content.as_deref().is_some_and(has_text)
-            || current.edited_content.as_deref().is_some_and(has_text);
-        let content = normalize_generated_addition(&title, &content, appending_to_existing);
+        let content =
+            normalize_generated_addition(&title, current.generated_content.as_deref(), &content);
         let next_generated_content =
             append_note_content(current.generated_content, content.clone());
-        let next_edited_content = current
-            .edited_content
-            .map(|edited_content| append_note_content(Some(edited_content), content));
+        let next_edited_content = current.edited_content.map(|edited_content| {
+            let content =
+                normalize_generated_addition(&title, Some(edited_content.as_str()), &content);
+            append_note_content(Some(edited_content), content)
+        });
         sqlx::query(
             "UPDATE notes SET title = ?, generated_content = ?, edited_content = ?, active_tab = 'notes', processing_status = 'ready', last_error = NULL, updated_at = ? WHERE id = ?",
         )
@@ -1025,21 +1026,32 @@ fn append_note_content(existing: Option<String>, addition: String) -> String {
     }
 }
 
-fn normalize_generated_addition(title: &str, content: &str, appending_to_existing: bool) -> String {
+fn normalize_generated_addition(title: &str, existing: Option<&str>, content: &str) -> String {
     let content = content.trim();
-    if !appending_to_existing {
-        return content.to_string();
-    }
-    let Some((heading, rest)) = content.split_once('\n') else {
+    let content = strip_duplicate_generated_heading(title, content);
+    let Some(existing) = existing.map(str::trim).filter(|value| !value.is_empty()) else {
         return content.to_string();
     };
-    let Some(heading_text) = heading.strip_prefix("# ") else {
-        return content.to_string();
-    };
-    if is_duplicate_generated_heading(title, heading_text) {
+    if content == existing {
+        String::new()
+    } else if let Some(rest) = content.strip_prefix(existing) {
         rest.trim_start().to_string()
     } else {
         content.to_string()
+    }
+}
+
+fn strip_duplicate_generated_heading<'a>(title: &str, content: &'a str) -> &'a str {
+    let Some((heading, rest)) = content.split_once('\n') else {
+        return content;
+    };
+    let Some(heading_text) = heading.strip_prefix("# ") else {
+        return content;
+    };
+    if is_duplicate_generated_heading(title, heading_text) {
+        rest.trim_start()
+    } else {
+        content
     }
 }
 
@@ -1049,10 +1061,6 @@ fn is_duplicate_generated_heading(title: &str, heading: &str) -> bool {
     heading.eq_ignore_ascii_case("New note")
         || heading.eq_ignore_ascii_case("Generated note")
         || (!title.is_empty() && heading.eq_ignore_ascii_case(title))
-}
-
-fn has_text(value: &str) -> bool {
-    !value.trim().is_empty()
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -351,6 +351,9 @@ impl Repositories {
         } else {
             current.title.clone()
         };
+        let appending_to_existing = current.generated_content.as_deref().is_some_and(has_text)
+            || current.edited_content.as_deref().is_some_and(has_text);
+        let content = normalize_generated_addition(&title, &content, appending_to_existing);
         let next_generated_content =
             append_note_content(current.generated_content, content.clone());
         let next_edited_content = current
@@ -1020,6 +1023,36 @@ fn append_note_content(existing: Option<String>, addition: String) -> String {
     } else {
         format!("{existing}\n\n{addition}")
     }
+}
+
+fn normalize_generated_addition(title: &str, content: &str, appending_to_existing: bool) -> String {
+    let content = content.trim();
+    if !appending_to_existing {
+        return content.to_string();
+    }
+    let Some((heading, rest)) = content.split_once('\n') else {
+        return content.to_string();
+    };
+    let Some(heading_text) = heading.strip_prefix("# ") else {
+        return content.to_string();
+    };
+    if is_duplicate_generated_heading(title, heading_text) {
+        rest.trim_start().to_string()
+    } else {
+        content.to_string()
+    }
+}
+
+fn is_duplicate_generated_heading(title: &str, heading: &str) -> bool {
+    let heading = heading.trim();
+    let title = title.trim();
+    heading.eq_ignore_ascii_case("New note")
+        || heading.eq_ignore_ascii_case("Generated note")
+        || (!title.is_empty() && heading.eq_ignore_ascii_case(title))
+}
+
+fn has_text(value: &str) -> bool {
+    !value.trim().is_empty()
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -345,32 +345,87 @@ impl Repositories {
         title: Option<String>,
         content: String,
     ) -> Result<NoteDto, sqlx::Error> {
+        self.set_generated_note_for_session(note_id, None, None, title, content)
+            .await
+    }
+
+    pub async fn set_generated_note_for_session(
+        &self,
+        note_id: &str,
+        recording_session_id: Option<&str>,
+        generation_result_id: Option<&str>,
+        title: Option<String>,
+        content: String,
+    ) -> Result<NoteDto, sqlx::Error> {
         let current = self.get_note(note_id).await?;
         let title = if current.title.trim().is_empty() {
             title.unwrap_or_else(|| "New note".to_string())
         } else {
             current.title.clone()
         };
+        let recording_session_id = recording_session_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let existing_session_block = match recording_session_id {
+            Some(session_id) => self.generation_block_exists(note_id, session_id).await?,
+            None => false,
+        };
         let manual_tail = manual_tail_for_append(
             current.generated_content.as_deref(),
             current.edited_content.as_deref(),
         );
+        let existing_for_normalization = if existing_session_block {
+            None
+        } else {
+            current.generated_content.as_deref()
+        };
         let content = normalize_generated_addition(
             &title,
-            current.generated_content.as_deref(),
+            existing_for_normalization,
             manual_tail.as_deref(),
             &content,
         );
-        let next_generated_content =
-            append_note_content(current.generated_content, content.clone());
-        let next_edited_content = current.edited_content.map(|edited_content| {
-            let content = normalize_generated_addition(
-                &title,
-                Some(edited_content.as_str()),
-                manual_tail.as_deref(),
+        let next_generated_content = if let Some(session_id) = recording_session_id {
+            if self.generation_block_count(note_id).await? == 0 {
+                self.seed_legacy_generation_block(
+                    note_id,
+                    current.generated_content.as_deref(),
+                    Some(title.as_str()),
+                )
+                .await?;
+            }
+            self.upsert_generation_block(
+                note_id,
+                session_id,
+                generation_result_id,
+                Some(title.as_str()),
                 &content,
-            );
-            append_note_content(Some(edited_content), content)
+            )
+            .await?;
+            self.compose_generation_blocks(note_id)
+                .await?
+                .unwrap_or_default()
+        } else {
+            append_note_content(current.generated_content.clone(), content.clone())
+        };
+        let next_edited_content = current.edited_content.map(|edited_content| {
+            if existing_session_block {
+                if edited_content.trim()
+                    == current.generated_content.as_deref().unwrap_or("").trim()
+                {
+                    next_generated_content.clone()
+                } else {
+                    edited_content
+                }
+            } else {
+                let content = normalize_generated_addition(
+                    &title,
+                    Some(edited_content.as_str()),
+                    manual_tail.as_deref(),
+                    &content,
+                );
+                append_note_content(Some(edited_content), content)
+            }
         });
         sqlx::query(
             "UPDATE notes SET title = ?, generated_content = ?, edited_content = ?, active_tab = 'notes', processing_status = 'ready', last_error = NULL, updated_at = ? WHERE id = ?",
@@ -383,6 +438,146 @@ impl Repositories {
         .execute(&self.pool)
         .await?;
         self.get_note(note_id).await
+    }
+
+    async fn generation_block_exists(
+        &self,
+        note_id: &str,
+        recording_session_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT 1 FROM note_generation_blocks WHERE note_id = ? AND recording_session_id = ? LIMIT 1",
+        )
+        .bind(note_id)
+        .bind(recording_session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.is_some())
+    }
+
+    async fn generation_block_count(&self, note_id: &str) -> Result<i64, sqlx::Error> {
+        let row =
+            sqlx::query("SELECT COUNT(*) AS count FROM note_generation_blocks WHERE note_id = ?")
+                .bind(note_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.get("count"))
+    }
+
+    async fn seed_legacy_generation_block(
+        &self,
+        note_id: &str,
+        content: Option<&str>,
+        title_suggestion: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        let Some(content) = content.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(());
+        };
+        let now = timestamp();
+        sqlx::query(
+            "INSERT INTO note_generation_blocks
+             (id, note_id, recording_session_id, generation_result_id, content, title_suggestion, sort_order, created_at, updated_at)
+             VALUES (?, ?, NULL, NULL, ?, ?, 0, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(note_id)
+        .bind(content)
+        .bind(title_suggestion)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn upsert_generation_block(
+        &self,
+        note_id: &str,
+        recording_session_id: &str,
+        generation_result_id: Option<&str>,
+        title_suggestion: Option<&str>,
+        content: &str,
+    ) -> Result<(), sqlx::Error> {
+        let now = timestamp();
+        if let Some(row) = sqlx::query(
+            "SELECT id FROM note_generation_blocks WHERE note_id = ? AND recording_session_id = ? LIMIT 1",
+        )
+        .bind(note_id)
+        .bind(recording_session_id)
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            let id: String = row.get("id");
+            sqlx::query(
+                "UPDATE note_generation_blocks
+                 SET generation_result_id = ?, content = ?, title_suggestion = ?, updated_at = ?
+                 WHERE id = ?",
+            )
+            .bind(generation_result_id)
+            .bind(content)
+            .bind(title_suggestion)
+            .bind(&now)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+            return Ok(());
+        }
+
+        let sort_order = self.next_generation_block_sort_order(note_id).await?;
+        sqlx::query(
+            "INSERT INTO note_generation_blocks
+             (id, note_id, recording_session_id, generation_result_id, content, title_suggestion, sort_order, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(note_id)
+        .bind(recording_session_id)
+        .bind(generation_result_id)
+        .bind(content)
+        .bind(title_suggestion)
+        .bind(sort_order)
+        .bind(&now)
+        .bind(&now)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn next_generation_block_sort_order(&self, note_id: &str) -> Result<i64, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT COALESCE(MAX(sort_order), -1) + 1 AS next_order
+             FROM note_generation_blocks
+             WHERE note_id = ?",
+        )
+        .bind(note_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.get("next_order"))
+    }
+
+    async fn compose_generation_blocks(
+        &self,
+        note_id: &str,
+    ) -> Result<Option<String>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT content
+             FROM note_generation_blocks
+             WHERE note_id = ?
+             ORDER BY sort_order ASC, created_at ASC, rowid ASC",
+        )
+        .bind(note_id)
+        .fetch_all(&self.pool)
+        .await?;
+        if rows.is_empty() {
+            return Ok(None);
+        }
+        let content = rows
+            .into_iter()
+            .map(|row| row.get::<String, _>("content"))
+            .filter(|content| !content.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        Ok(Some(content))
     }
 
     pub async fn create_recording_session(
@@ -697,7 +892,7 @@ impl Repositories {
     pub async fn latest_valid_audio_artifact_paths(
         &self,
         note_id: &str,
-    ) -> Result<Vec<(String, String, String)>, sqlx::Error> {
+    ) -> Result<Vec<(String, String, String, String)>, sqlx::Error> {
         let session = sqlx::query(
             "SELECT recording_session_id
              FROM audio_artifacts
@@ -713,7 +908,7 @@ impl Repositories {
         };
         let session_id: String = session.get("recording_session_id");
         let rows = sqlx::query(
-            "SELECT id, source, path
+            "SELECT id, source, path, recording_session_id
              FROM audio_artifacts
              WHERE note_id = ? AND recording_session_id = ? AND status = 'valid'
              ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
@@ -724,7 +919,14 @@ impl Repositories {
         .await?;
         Ok(rows
             .into_iter()
-            .map(|row| (row.get("id"), row.get("source"), row.get("path")))
+            .map(|row| {
+                (
+                    row.get("id"),
+                    row.get("source"),
+                    row.get("path"),
+                    row.get("recording_session_id"),
+                )
+            })
             .collect())
     }
 
@@ -912,13 +1114,14 @@ impl Repositories {
         title_suggestion: Option<String>,
         provider: &str,
         prompt_version: &str,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<String, sqlx::Error> {
         let now = timestamp();
+        let id = Uuid::new_v4().to_string();
         sqlx::query(
             "INSERT INTO generation_results (id, note_id, transcript_id, content, title_suggestion, provider, prompt_version, status, retry_count, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, 'succeeded', 0, ?, ?)",
         )
-        .bind(Uuid::new_v4().to_string())
+        .bind(&id)
         .bind(note_id)
         .bind(transcript_id)
         .bind(content)
@@ -929,7 +1132,7 @@ impl Repositories {
         .bind(&now)
         .execute(&self.pool)
         .await?;
-        Ok(())
+        Ok(id)
     }
 
     pub async fn recording_recovery_info(
@@ -1045,18 +1248,25 @@ fn normalize_generated_addition(
     content: &str,
 ) -> String {
     let content = content.trim();
-    let content = strip_manual_tail_echo(manual_tail, content);
-    let content = strip_duplicate_generated_heading(title, manual_tail, content);
     let Some(existing) = existing.map(str::trim).filter(|value| !value.is_empty()) else {
-        return content.to_string();
+        return strip_generated_addition_prefixes(title, manual_tail, content).to_string();
     };
     if content == existing {
         String::new()
     } else if let Some(rest) = content.strip_prefix(existing) {
-        rest.trim_start().to_string()
+        strip_generated_addition_prefixes(title, manual_tail, rest.trim_start()).to_string()
     } else {
-        content.to_string()
+        strip_generated_addition_prefixes(title, manual_tail, content).to_string()
     }
+}
+
+fn strip_generated_addition_prefixes<'a>(
+    title: &str,
+    manual_tail: Option<&str>,
+    content: &'a str,
+) -> &'a str {
+    let content = strip_manual_tail_echo(manual_tail, content);
+    strip_duplicate_generated_heading(title, manual_tail, content)
 }
 
 fn strip_manual_tail_echo<'a>(manual_tail: Option<&str>, content: &'a str) -> &'a str {

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1265,8 +1265,18 @@ fn strip_generated_addition_prefixes<'a>(
     manual_tail: Option<&str>,
     content: &'a str,
 ) -> &'a str {
-    let content = strip_manual_tail_echo(manual_tail, content);
-    strip_duplicate_generated_heading(title, manual_tail, content)
+    let mut content = content;
+    loop {
+        let next = strip_duplicate_generated_heading(
+            title,
+            manual_tail,
+            strip_manual_tail_line_echo(manual_tail, strip_manual_tail_echo(manual_tail, content)),
+        );
+        if next == content {
+            return content;
+        }
+        content = next;
+    }
 }
 
 fn strip_manual_tail_echo<'a>(manual_tail: Option<&str>, content: &'a str) -> &'a str {
@@ -1277,6 +1287,40 @@ fn strip_manual_tail_echo<'a>(manual_tail: Option<&str>, content: &'a str) -> &'
         return content;
     };
     rest.strip_prefix(':').unwrap_or(rest).trim_start()
+}
+
+fn strip_manual_tail_line_echo<'a>(manual_tail: Option<&str>, content: &'a str) -> &'a str {
+    let Some(manual_tail) = manual_tail.map(str::trim).filter(|value| !value.is_empty()) else {
+        return content;
+    };
+    let Some((line, rest)) = content.split_once('\n') else {
+        return content;
+    };
+    if manual_echo_matches(line, manual_tail) {
+        rest.trim_start()
+    } else {
+        content
+    }
+}
+
+fn manual_echo_matches(line: &str, manual_tail: &str) -> bool {
+    let manual_tail = manual_echo_text(manual_tail);
+    let line = manual_echo_text(line);
+    !manual_tail.is_empty() && line.eq_ignore_ascii_case(&manual_tail)
+}
+
+fn manual_echo_text(value: &str) -> String {
+    let mut text = value.trim();
+    if let Some(heading) = markdown_heading_text(text) {
+        text = heading;
+    }
+    for prefix in ["- ", "* ", "+ "] {
+        if let Some(rest) = text.strip_prefix(prefix) {
+            text = rest.trim();
+            break;
+        }
+    }
+    text.trim_end_matches(':').trim().to_string()
 }
 
 fn strip_duplicate_generated_heading<'a>(
@@ -1314,6 +1358,7 @@ fn is_duplicate_generated_heading(title: &str, manual_tail: Option<&str>, headin
     let heading = heading.trim();
     let title = title.trim();
     heading.eq_ignore_ascii_case("New note")
+        || heading.eq_ignore_ascii_case("Note")
         || heading.eq_ignore_ascii_case("Generated note")
         || (!title.is_empty() && heading.eq_ignore_ascii_case(title))
         || manual_tail
@@ -1323,16 +1368,32 @@ fn is_duplicate_generated_heading(title: &str, manual_tail: Option<&str>, headin
 }
 
 fn manual_tail_for_append(generated: Option<&str>, edited: Option<&str>) -> Option<String> {
-    let generated = generated?.trim();
     let edited = edited?.trim();
-    if generated.is_empty() || edited == generated {
+    if edited.is_empty() {
         return None;
     }
-    edited
-        .strip_prefix(generated)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
+    let Some(generated) = generated.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Some(edited.to_string());
+    };
+    if edited == generated {
+        return None;
+    }
+    if let Some(rest) = edited.strip_prefix(generated) {
+        let rest = rest.trim();
+        return if rest.is_empty() {
+            None
+        } else {
+            Some(rest.to_string())
+        };
+    }
+    edited.find(generated).and_then(|index| {
+        let rest = edited[index + generated.len()..].trim();
+        if rest.is_empty() {
+            None
+        } else {
+            Some(rest.to_string())
+        }
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -145,6 +145,7 @@ pub fn manual_notes_for_generation(note: &NoteDto) -> Option<String> {
 pub async fn process_saved_audio(
     repos: &Repositories,
     note_id: &str,
+    session_id: &str,
     audio_artifact_id: &str,
     audio_path: PathBuf,
     title: String,
@@ -208,7 +209,7 @@ pub async fn process_saved_audio(
             return Err(error);
         }
     };
-    repos
+    let generation_result_id = repos
         .create_generation_result(
             note_id,
             &transcript_row.id,
@@ -219,7 +220,13 @@ pub async fn process_saved_audio(
         )
         .await?;
     Ok(repos
-        .set_generated_note(note_id, generated.title_suggestion, generated.content)
+        .set_generated_note_for_session(
+            note_id,
+            Some(session_id),
+            Some(&generation_result_id),
+            generated.title_suggestion,
+            generated.content,
+        )
         .await?)
 }
 
@@ -367,7 +374,7 @@ pub async fn process_saved_source_audio(
         }
     };
     let transcript_id = first_transcript_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    repos
+    let generation_result_id = repos
         .create_generation_result(
             note_id,
             &transcript_id,
@@ -378,7 +385,13 @@ pub async fn process_saved_source_audio(
         )
         .await?;
     Ok(repos
-        .set_generated_note(note_id, generated.title_suggestion, generated.content)
+        .set_generated_note_for_session(
+            note_id,
+            Some(session_id),
+            Some(&generation_result_id),
+            generated.title_suggestion,
+            generated.content,
+        )
         .await?)
 }
 
@@ -396,10 +409,11 @@ pub async fn retry_from_saved_audio(
     let note = repos.get_note(note_id).await?;
     let manual_notes = manual_notes_for_generation(&note);
     if sources.len() == 1 {
-        let (audio_artifact_id, _source, audio_path) = sources[0].clone();
+        let (audio_artifact_id, _source, audio_path, session_id) = sources[0].clone();
         return process_saved_audio(
             repos,
             note_id,
+            &session_id,
             &audio_artifact_id,
             PathBuf::from(audio_path),
             note.title,
@@ -407,14 +421,18 @@ pub async fn retry_from_saved_audio(
         )
         .await;
     }
+    let session_id = sources
+        .first()
+        .map(|(_id, _source, _path, session_id)| session_id.clone())
+        .unwrap_or_default();
     process_saved_source_audio(
         repos,
         note_id,
-        "",
+        &session_id,
         RecordingSourceMode::MicrophonePlusSystem,
         sources
             .into_iter()
-            .map(|(id, source, path)| (id, source, PathBuf::from(path)))
+            .map(|(id, source, path, _session_id)| (id, source, PathBuf::from(path)))
             .collect(),
         note.title,
         manual_notes,

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -121,6 +121,27 @@ pub fn build_transcription_context(previous: &[SourceTranscriptInput]) -> Option
     ))
 }
 
+pub fn manual_notes_for_generation(note: &NoteDto) -> Option<String> {
+    let edited = note.edited_content.as_deref()?.trim();
+    if edited.is_empty() {
+        return None;
+    }
+    let Some(generated) = note.generated_content.as_deref().map(str::trim) else {
+        return Some(edited.to_string());
+    };
+    if generated.is_empty() {
+        return Some(edited.to_string());
+    }
+    if edited == generated {
+        return None;
+    }
+    edited
+        .strip_prefix(generated)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
 pub async fn process_saved_audio(
     repos: &Repositories,
     note_id: &str,
@@ -373,6 +394,7 @@ pub async fn retry_from_saved_audio(
         ));
     }
     let note = repos.get_note(note_id).await?;
+    let manual_notes = manual_notes_for_generation(&note);
     if sources.len() == 1 {
         let (audio_artifact_id, _source, audio_path) = sources[0].clone();
         return process_saved_audio(
@@ -381,7 +403,7 @@ pub async fn retry_from_saved_audio(
             &audio_artifact_id,
             PathBuf::from(audio_path),
             note.title,
-            note.edited_content.clone(),
+            manual_notes,
         )
         .await;
     }
@@ -395,7 +417,7 @@ pub async fn retry_from_saved_audio(
             .map(|(id, source, path)| (id, source, PathBuf::from(path)))
             .collect(),
         note.title,
-        note.edited_content,
+        manual_notes,
     )
     .await
 }

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -135,11 +135,22 @@ pub fn manual_notes_for_generation(note: &NoteDto) -> Option<String> {
     if edited == generated {
         return None;
     }
-    edited
-        .strip_prefix(generated)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
+    if let Some(rest) = edited.strip_prefix(generated) {
+        let rest = rest.trim();
+        return if rest.is_empty() {
+            None
+        } else {
+            Some(rest.to_string())
+        };
+    }
+    edited.find(generated).and_then(|index| {
+        let rest = edited[index + generated.len()..].trim();
+        if rest.is_empty() {
+            None
+        } else {
+            Some(rest.to_string())
+        }
+    })
 }
 
 pub async fn process_saved_audio(

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use std::{future::Future, path::PathBuf, pin::Pin, sync::Arc};
 
-pub const PROMPT_VERSION: &str = "notes-mvp-v2";
+pub const PROMPT_VERSION: &str = "notes-mvp-v3";
 const TRANSCRIPT_COHERENCE_GAP_MS: i64 = 2_500;
 const TRANSCRIPTION_CONTEXT_MAX_CHARS: usize = 1_200;
 const TRANSCRIPTION_CONTEXT_MAX_TURNS: usize = 6;
@@ -160,6 +160,7 @@ pub async fn process_saved_audio(
     audio_artifact_id: &str,
     audio_path: PathBuf,
     title: String,
+    existing_generated_note: Option<String>,
     manual_notes: Option<String>,
 ) -> Result<NoteDto, AppError> {
     repos
@@ -202,6 +203,7 @@ pub async fn process_saved_audio(
     let generated = match generate_note_from_transcript(GenerationRequest {
         provider,
         title,
+        existing_generated_note,
         transcript: transcript.text,
         manual_notes,
         language: transcript.language,
@@ -248,6 +250,7 @@ pub async fn process_saved_source_audio(
     source_mode: RecordingSourceMode,
     sources: Vec<(String, String, PathBuf)>,
     title: String,
+    existing_generated_note: Option<String>,
     manual_notes: Option<String>,
 ) -> Result<NoteDto, AppError> {
     repos
@@ -366,6 +369,7 @@ pub async fn process_saved_source_audio(
     let generated = match generate_note_from_transcript(GenerationRequest {
         provider,
         title,
+        existing_generated_note,
         transcript: labeled_transcript,
         manual_notes,
         language: None,
@@ -428,6 +432,7 @@ pub async fn retry_from_saved_audio(
             &audio_artifact_id,
             PathBuf::from(audio_path),
             note.title,
+            note.generated_content,
             manual_notes,
         )
         .await;
@@ -446,6 +451,7 @@ pub async fn retry_from_saved_audio(
             .map(|(id, source, path, _session_id)| (id, source, PathBuf::from(path)))
             .collect(),
         note.title,
+        note.generated_content,
         manual_notes,
     )
     .await

--- a/src-tauri/src/providers/generation.rs
+++ b/src-tauri/src/providers/generation.rs
@@ -10,6 +10,7 @@ const OPENAI_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
 pub struct GenerationRequest {
     pub provider: String,
     pub title: String,
+    pub existing_generated_note: Option<String>,
     pub transcript: String,
     pub manual_notes: Option<String>,
     pub language: Option<String>,
@@ -40,7 +41,7 @@ pub async fn generate_note_from_transcript(
             content: format!(
                 "{}\n\n{}",
                 heading_for(&request.title),
-                generation_source_text(request.manual_notes.as_deref(), transcript)
+                mock_generation_source_text(request.manual_notes.as_deref(), transcript)
             ),
             title_suggestion: if request.title.trim().is_empty() {
                 Some("New note".to_string())
@@ -82,10 +83,14 @@ async fn generate_with_openai(
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_OPENAI_GENERATION_MODEL.to_string());
     let title_hint = request.title.trim();
-    let source_text = generation_source_text(request.manual_notes.as_deref(), transcript);
+    let source_text = generation_source_text(
+        request.existing_generated_note.as_deref(),
+        request.manual_notes.as_deref(),
+        transcript,
+    );
     let body = json!({
         "model": model,
-        "instructions": "You turn voice transcripts and user-written manual notes into concise markdown notes. Use only the manual notes and transcript. Treat manual notes as user-authored context and prioritize them when they clarify or correct the transcript. Do not invent facts, decisions, dates, or names. Preserve the speaker's language unless the source material is mixed-language. Return only the final note body in markdown.",
+        "instructions": "You write one incremental markdown note block from a newly captured transcript. Use only the new transcript plus optional new manual notes. Existing generated note content is context only: do not repeat, summarize, rewrite, or reformat it. Manual notes are context only unless they add facts; do not output manual note labels as headings, bullets, titles, or section names. Do not add wrapper headings such as Note, Generated note, Transcript, or Summary. Preserve the speaker's language unless the source material is mixed-language. Return only the new note block to append.",
         "input": format!(
             "Current title: {}\nDetected language: {}\n\n{}",
             if title_hint.is_empty() { "New note" } else { title_hint },
@@ -138,7 +143,37 @@ async fn generate_with_openai(
     })
 }
 
-fn generation_source_text(manual_notes: Option<&str>, transcript: &str) -> String {
+fn generation_source_text(
+    existing_generated_note: Option<&str>,
+    manual_notes: Option<&str>,
+    transcript: &str,
+) -> String {
+    let transcript = transcript.trim();
+    let existing_generated_note = existing_generated_note
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let manual_notes = manual_notes
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let mut sections = Vec::new();
+    if let Some(existing_generated_note) = existing_generated_note {
+        sections.push(format!(
+            "<existing_generated_note_context>\n{existing_generated_note}\n</existing_generated_note_context>"
+        ));
+    }
+    if let Some(manual_notes) = manual_notes {
+        sections.push(format!(
+            "<new_manual_notes_context>\n{manual_notes}\n</new_manual_notes_context>"
+        ));
+    }
+    sections.push(format!("<new_transcript>\n{transcript}\n</new_transcript>"));
+    sections.push(
+        "<output_contract>\nReturn only the new note block for the new transcript. Do not repeat existing note content. Do not output manual note labels. Do not add wrapper headings.\n</output_contract>".to_string(),
+    );
+    sections.join("\n\n")
+}
+
+fn mock_generation_source_text(manual_notes: Option<&str>, transcript: &str) -> String {
     let transcript = transcript.trim();
     let manual_notes = manual_notes
         .map(str::trim)
@@ -168,5 +203,25 @@ fn extract_response_text(value: &Value) -> Option<String> {
         None
     } else {
         Some(parts.join("\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generation_source_text;
+
+    #[test]
+    fn generation_source_text_separates_existing_manual_and_new_transcript() {
+        let input = generation_source_text(
+            Some("Existing generated note"),
+            Some("Test 2:"),
+            "New transcript text",
+        );
+
+        assert!(input.contains("<existing_generated_note_context>\nExisting generated note"));
+        assert!(input.contains("<new_manual_notes_context>\nTest 2:"));
+        assert!(input.contains("<new_transcript>\nNew transcript text"));
+        assert!(input.contains("Do not repeat existing note content"));
+        assert!(input.contains("Do not output manual note labels"));
     }
 }

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -130,6 +130,34 @@ async fn generated_note_strips_placeholder_heading_when_appending() {
 }
 
 #[tokio::test]
+async fn generated_note_strips_existing_note_prefix_when_appending() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .set_generated_note(
+            &note.id,
+            Some("Generated title".to_string()),
+            "Hola hola\n\nSegundo test".to_string(),
+        )
+        .await
+        .expect("first generated note");
+
+    let updated = repos
+        .set_generated_note(
+            &note.id,
+            None,
+            "Hola hola\n\nSegundo test\n\nTres, tres, dos, uno.".to_string(),
+        )
+        .await
+        .expect("second generated note");
+
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("Hola hola\n\nSegundo test\n\nTres, tres, dos, uno.")
+    );
+}
+
+#[tokio::test]
 async fn generated_note_appends_to_existing_edited_content() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -158,6 +158,48 @@ async fn generated_note_strips_existing_note_prefix_when_appending() {
 }
 
 #[tokio::test]
+async fn generated_note_strips_manual_note_echo_when_appending() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .set_generated_note(
+            &note.id,
+            Some("Generated title".to_string()),
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"".to_string(),
+        )
+        .await
+        .expect("first generated note");
+    repos
+        .update_note(
+            &note.id,
+            None,
+            Some(
+                "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\nTest 2".to_string(),
+            ),
+            Some("notes".to_string()),
+        )
+        .await
+        .expect("manual note");
+
+    let updated = repos
+        .set_generated_note(
+            &note.id,
+            None,
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\nTest 2:\n\n## Test 2\n\n- Transcript: \"Tres, dos, uno, hola hola.\""
+                .to_string(),
+        )
+        .await
+        .expect("second generated note");
+
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some(
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\nTest 2\n\n- Transcript: \"Tres, dos, uno, hola hola.\""
+        )
+    );
+}
+
+#[tokio::test]
 async fn generated_note_appends_to_existing_edited_content() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -106,6 +106,30 @@ async fn generated_note_appends_to_existing_generated_content() {
 }
 
 #[tokio::test]
+async fn generated_note_strips_placeholder_heading_when_appending() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .set_generated_note(
+            &note.id,
+            Some("Generated title".to_string()),
+            "First recording".to_string(),
+        )
+        .await
+        .expect("first generated note");
+
+    let updated = repos
+        .set_generated_note(&note.id, None, "# New note\n\nSecond recording".to_string())
+        .await
+        .expect("second generated note");
+
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("First recording\n\nSecond recording")
+    );
+}
+
+#[tokio::test]
 async fn generated_note_appends_to_existing_edited_content() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -200,6 +200,124 @@ async fn generated_note_strips_manual_note_echo_when_appending() {
 }
 
 #[tokio::test]
+async fn generated_note_replaces_existing_session_block() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+
+    repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "First transcript result".to_string(),
+        )
+        .await
+        .expect("first generated block");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            None,
+            "Retried transcript result".to_string(),
+        )
+        .await
+        .expect("retried generated block");
+
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("Retried transcript result")
+    );
+}
+
+#[tokio::test]
+async fn generated_note_composes_distinct_session_blocks_in_order() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+
+    repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "First transcript result".to_string(),
+        )
+        .await
+        .expect("first generated block");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-2"),
+            None,
+            None,
+            "First transcript result\n\nSecond transcript result".to_string(),
+        )
+        .await
+        .expect("second generated block");
+
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("First transcript result\n\nSecond transcript result")
+    );
+}
+
+#[tokio::test]
+async fn generated_session_block_strips_manual_note_echo_before_composing() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"".to_string(),
+        )
+        .await
+        .expect("first generated block");
+    repos
+        .update_note(
+            &note.id,
+            None,
+            Some(
+                "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\nTest 2".to_string(),
+            ),
+            Some("notes".to_string()),
+        )
+        .await
+        .expect("manual note");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-2"),
+            None,
+            None,
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\nTest 2:\n\n## Test 2\n\n- Transcript: \"Tres, dos, uno, hola hola.\""
+                .to_string(),
+        )
+        .await
+        .expect("second generated block");
+
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some(
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\n- Transcript: \"Tres, dos, uno, hola hola.\""
+        )
+    );
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some(
+            "## Transcript (verbatim)\n\n- \"Un, dos, tres, hola hola.\"\n\nTest 2\n\n- Transcript: \"Tres, dos, uno, hola hola.\""
+        )
+    );
+}
+
+#[tokio::test]
 async fn generated_note_appends_to_existing_edited_content() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -318,6 +318,84 @@ async fn generated_session_block_strips_manual_note_echo_before_composing() {
 }
 
 #[tokio::test]
+async fn first_generated_session_block_strips_initial_manual_note_echo() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .update_note(
+            &note.id,
+            None,
+            Some("Test 1:".to_string()),
+            Some("notes".to_string()),
+        )
+        .await
+        .expect("manual note");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "Test 1:\n\n- Test 1\n- \"Test uno, probando probando, un dos tres.\"".to_string(),
+        )
+        .await
+        .expect("first generated block");
+
+    assert_eq!(
+        updated.generated_content.as_deref(),
+        Some("- \"Test uno, probando probando, un dos tres.\"")
+    );
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some("Test 1:\n\n- \"Test uno, probando probando, un dos tres.\"")
+    );
+}
+
+#[tokio::test]
+async fn generated_session_block_strips_generic_note_heading_after_manual_echo() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-1"),
+            None,
+            Some("Generated title".to_string()),
+            "- \"Test uno, probando probando, un dos tres.\"".to_string(),
+        )
+        .await
+        .expect("first generated block");
+    repos
+        .update_note(
+            &note.id,
+            None,
+            Some("- \"Test uno, probando probando, un dos tres.\"\n\nTest 2:".to_string()),
+            Some("notes".to_string()),
+        )
+        .await
+        .expect("manual note");
+
+    let updated = repos
+        .set_generated_note_for_session(
+            &note.id,
+            Some("session-2"),
+            None,
+            None,
+            "Test 2:\n\n## Note\n\n- Test: \"probando, probando, tres, dos, uno\"".to_string(),
+        )
+        .await
+        .expect("second generated block");
+
+    assert_eq!(
+        updated.edited_content.as_deref(),
+        Some(
+            "- \"Test uno, probando probando, un dos tres.\"\n\nTest 2:\n\n- Test: \"probando, probando, tres, dos, uno\""
+        )
+    );
+}
+
+#[tokio::test]
 async fn generated_note_appends_to_existing_edited_content() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -1,10 +1,42 @@
-use os_notetaker_lib::providers::{
-    generation::{generate_note_from_transcript, GenerationRequest},
-    transcription::{
-        normalize_transcription_language, transcribe_saved_audio, TranscriptionRequest,
+use os_notetaker_lib::{
+    domain::{
+        processing::manual_notes_for_generation,
+        types::{NoteDto, ProcessingStatus},
+    },
+    providers::{
+        generation::{generate_note_from_transcript, GenerationRequest},
+        transcription::{
+            normalize_transcription_language, transcribe_saved_audio, TranscriptionRequest,
+        },
     },
 };
 use tempfile::NamedTempFile;
+
+const NOW: &str = "2026-05-21T10:00:00Z";
+
+fn note(overrides: impl FnOnce(&mut NoteDto)) -> NoteDto {
+    let mut note = NoteDto {
+        id: "note-1".to_string(),
+        title: "Note".to_string(),
+        preview: String::new(),
+        processing_status: ProcessingStatus::Ready,
+        folder_ids: Vec::new(),
+        created_at: NOW.to_string(),
+        updated_at: NOW.to_string(),
+        duration_ms: None,
+        generated_content: None,
+        edited_content: None,
+        transcript: None,
+        source_transcripts: Vec::new(),
+        recording: None,
+        audio: None,
+        audio_sources: Vec::new(),
+        active_tab: Some("notes".to_string()),
+        last_error: None,
+    };
+    overrides(&mut note);
+    note
+}
 
 #[tokio::test]
 async fn mock_transcription_returns_retryable_transcript_from_saved_audio() {
@@ -70,6 +102,30 @@ async fn generation_combines_manual_notes_with_transcript() {
     assert!(generated.content.contains("Ask Marta"));
     assert!(generated.content.contains("Transcript"));
     assert!(generated.content.contains("launch deadline"));
+}
+
+#[test]
+fn manual_notes_for_generation_uses_only_new_text_after_generated_note() {
+    let note = note(|note| {
+        note.generated_content = Some("First generated note".to_string());
+        note.edited_content =
+            Some("First generated note\n\nManual note for the next recording".to_string());
+    });
+
+    assert_eq!(
+        manual_notes_for_generation(&note).as_deref(),
+        Some("Manual note for the next recording")
+    );
+}
+
+#[test]
+fn manual_notes_for_generation_ignores_existing_edited_note_body() {
+    let note = note(|note| {
+        note.generated_content = Some("First generated note".to_string());
+        note.edited_content = Some("Edited version of the first generated note".to_string());
+    });
+
+    assert_eq!(manual_notes_for_generation(&note), None);
 }
 
 #[tokio::test]

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -128,6 +128,19 @@ fn manual_notes_for_generation_ignores_existing_edited_note_body() {
     assert_eq!(manual_notes_for_generation(&note), None);
 }
 
+#[test]
+fn manual_notes_for_generation_uses_new_tail_after_manual_preface() {
+    let note = note(|note| {
+        note.generated_content = Some("- Generated transcript note".to_string());
+        note.edited_content = Some("Test 1:\n\n- Generated transcript note\n\nTest 2".to_string());
+    });
+
+    assert_eq!(
+        manual_notes_for_generation(&note).as_deref(),
+        Some("Test 2")
+    );
+}
+
 #[tokio::test]
 async fn generation_rejects_empty_transcript() {
     let err = generate_note_from_transcript(GenerationRequest {

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -75,6 +75,7 @@ async fn generation_uses_transcript_without_inventing_extra_sections() {
     let generated = generate_note_from_transcript(GenerationRequest {
         provider: "mock".to_string(),
         title: "Launch notes".to_string(),
+        existing_generated_note: None,
         transcript: "We decided to ship the Tauri notes MVP after validation.".to_string(),
         manual_notes: None,
         language: Some("en".to_string()),
@@ -83,7 +84,7 @@ async fn generation_uses_transcript_without_inventing_extra_sections() {
     .expect("mock generation should succeed");
 
     assert!(generated.content.contains("We decided to ship"));
-    assert_eq!(generated.prompt_version, "notes-mvp-v2");
+    assert_eq!(generated.prompt_version, "notes-mvp-v3");
 }
 
 #[tokio::test]
@@ -91,6 +92,7 @@ async fn generation_combines_manual_notes_with_transcript() {
     let generated = generate_note_from_transcript(GenerationRequest {
         provider: "mock".to_string(),
         title: "Meeting notes".to_string(),
+        existing_generated_note: Some("Existing generated note".to_string()),
         transcript: "System: The launch deadline is Friday.".to_string(),
         manual_notes: Some("Ask Marta about the release checklist.".to_string()),
         language: Some("en".to_string()),
@@ -146,6 +148,7 @@ async fn generation_rejects_empty_transcript() {
     let err = generate_note_from_transcript(GenerationRequest {
         provider: "mock".to_string(),
         title: "Empty".to_string(),
+        existing_generated_note: None,
         transcript: "   ".to_string(),
         manual_notes: None,
         language: None,


### PR DESCRIPTION
## Summary

- Compose generated note content from session-scoped blocks so retries replace the right recording output instead of appending duplicates.
- Keep previous generated content, new manual notes, and the new transcript separated in the generation request.
- Harden append normalization for manual note labels and wrapper headings returned by generation.

## Root cause

Appending another recording to an existing note treated prior generated text and new manual notes as one ambiguous body. That allowed generation output to repeat earlier note content or turn short manual labels into headings.

## Validation

- pnpm test
- pnpm test:rust
- pnpm run lint
- pnpm run format
- pnpm run build
- pnpm tauri:build
