### PR TITLE
Add macOS dictation with paste-only transcription flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-bun.lock
 dist/
 build/
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+bun.lock
 dist/
 build/
 *.log

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ The app data directory is resolved by Tauri at runtime. In development, inspect 
 - `recordings/{note_id}/{session_id}/microphone.wav`
 - `recordings/{note_id}/{session_id}/system.wav` when `Microphone + system audio` is selected
 
+## Dictation
+
+Dictation is paste-only: it does not create notes or store transcript records. Press the configured global shortcut from another app to start microphone dictation, press it again to stop, and OS Scribe transcribes the temporary m4a recording through the same Rust transcription provider used by note recording. On success, the helper temporarily places the transcript on the clipboard, activates the last focused external app, posts Cmd+V, and restores the previous clipboard when possible.
+
+The default shortcut is `Fn+Space`. If macOS cannot register it, the app falls back to `Ctrl+Opt+Space`. The Dictation settings page can save another shortcut with Cmd, Ctrl, Opt, or Shift plus one supported non-modifier key.
+
+Manual validation:
+
+1. Launch with `OPENAI_API_KEY` configured.
+2. Grant microphone and Accessibility permissions.
+3. Focus a text field in TextEdit, VS Code, or a browser.
+4. Press the configured shortcut to start dictation.
+5. Speak a short sentence.
+6. Press the configured shortcut again to stop.
+7. Confirm the HUD transitions through listening, transcribing, pasting, and success.
+8. Confirm the transcript appears in the original focused text field.
+9. Select a microphone in Dictation settings, restart, and confirm the selection persists.
+
 ## macOS Audio Permission Debugging
 
 The macOS bundle includes:
@@ -55,6 +73,8 @@ The macOS bundle includes:
 - `com.apple.security.device.audio-input` in `src-tauri/Entitlements.plist`
 
 The `Microphone only` mode is the default. The `Microphone + system audio` mode uses a small macOS helper built by `src-tauri/build.rs` into `.tauri-helper/` during `pnpm tauri:dev`, `pnpm test:rust`, or `pnpm tauri:build`. Generated helper binaries are ignored by git and kept outside `src-tauri` so Tauri dev does not restart on its own generated files.
+
+Dictation uses a separate macOS helper built into `.tauri-helper/OS Scribe Dictation Helper.app`. It needs microphone permission for capture and Accessibility permission to post the paste shortcut into the previously focused app.
 
 Local `pnpm tauri:build` output is ad-hoc signed unless a signing identity is configured. Before distribution, verify the signed bundle embeds the expected entitlements:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The app data directory is resolved by Tauri at runtime. In development, inspect 
 
 Dictation is paste-only: it does not create notes or store transcript records. Press the configured global shortcut from another app to start microphone dictation, press it again to stop, and OS Scribe transcribes the temporary m4a recording through the same Rust transcription provider used by note recording. On success, the helper temporarily places the transcript on the clipboard, activates the last focused external app, posts Cmd+V, and restores the previous clipboard when possible.
 
+Dictation requires real transcription. If `OPENAI_API_KEY` is not visible to the Tauri process, dictation reports a configuration error instead of pasting the local mock transcript used by offline note-recording tests. During development, put the key in `.env` or export it in the shell before running `pnpm tauri:dev`.
+
 The default shortcut is `Fn+Space`. If macOS cannot register it, the app falls back to `Ctrl+Opt+Space`. The Dictation settings page can save another shortcut with Cmd, Ctrl, Opt, or Shift plus one supported non-modifier key.
 
 Manual validation:

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,792 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "os-notetaker",
+      "dependencies": {
+        "@tauri-apps/api": "^2.9.0",
+        "@tiptap/extension-placeholder": "^3.23.5",
+        "@tiptap/react": "^3.23.5",
+        "@tiptap/starter-kit": "^3.23.5",
+        "central-icons": "npm:@central-icons-react/round-outlined-radius-3-stroke-2@1.1.233",
+        "central-icons-filled": "npm:@central-icons-react/round-filled-radius-3-stroke-2@1.1.241",
+        "framer-motion": "^12.39.0",
+        "lucide-react": "^0.468.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+      },
+      "devDependencies": {
+        "@tauri-apps/cli": "^2.9.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^25.0.1",
+        "prettier": "^3.4.2",
+        "typescript": "^5.6.3",
+        "vite": "^6.0.3",
+        "vitest": "^2.1.8",
+      },
+    },
+  },
+  "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "2.1.4", "@csstools/css-color-parser": "3.1.0", "@csstools/css-parser-algorithms": "3.0.5", "@csstools/css-tokenizer": "3.0.4", "lru-cache": "10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "7.28.5", "js-tokens": "4.0.0", "picocolors": "1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/generator": "7.29.1", "@babel/helper-compilation-targets": "7.28.6", "@babel/helper-module-transforms": "7.28.6", "@babel/helpers": "7.29.2", "@babel/parser": "7.29.3", "@babel/template": "7.28.6", "@babel/traverse": "7.29.0", "@babel/types": "7.29.0", "@jridgewell/remapping": "2.3.5", "convert-source-map": "2.0.0", "debug": "4.4.3", "gensync": "1.0.0-beta.2", "json5": "2.2.3", "semver": "6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "7.29.3", "@babel/types": "7.29.0", "@jridgewell/gen-mapping": "0.3.13", "@jridgewell/trace-mapping": "0.3.31", "jsesc": "3.1.0" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "7.29.3", "@babel/helper-validator-option": "7.27.1", "browserslist": "4.28.2", "lru-cache": "5.1.1", "semver": "6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "7.29.0", "@babel/types": "7.29.0" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "7.28.6", "@babel/helper-validator-identifier": "7.28.5", "@babel/traverse": "7.29.0" }, "peerDependencies": { "@babel/core": "7.29.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "7.28.6", "@babel/types": "7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "7.28.6" }, "peerDependencies": { "@babel/core": "7.29.0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "7.28.6" }, "peerDependencies": { "@babel/core": "7.29.0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/parser": "7.29.3", "@babel/types": "7.29.0" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/generator": "7.29.1", "@babel/helper-globals": "7.28.0", "@babel/parser": "7.29.3", "@babel/template": "7.28.6", "@babel/types": "7.29.0", "debug": "4.4.3" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "7.27.1", "@babel/helper-validator-identifier": "7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "3.0.5", "@csstools/css-tokenizer": "3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "5.1.0", "@csstools/css-calc": "2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "3.0.5", "@csstools/css-tokenizer": "3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "1.7.5", "@floating-ui/utils": "0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "1.5.5", "@jridgewell/trace-mapping": "0.3.31" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "0.3.13", "@jridgewell/trace-mapping": "0.3.31" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.4", "", { "os": "android", "cpu": "arm64" }, "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.4", "", { "os": "none", "cpu": "arm64" }, "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
+
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.2", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.2", "@tauri-apps/cli-darwin-x64": "2.11.2", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2", "@tauri-apps/cli-linux-arm64-gnu": "2.11.2", "@tauri-apps/cli-linux-arm64-musl": "2.11.2", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-musl": "2.11.2", "@tauri-apps/cli-win32-arm64-msvc": "2.11.2", "@tauri-apps/cli-win32-ia32-msvc": "2.11.2", "@tauri-apps/cli-win32-x64-msvc": "2.11.2" }, "bin": { "tauri": "tauri.js" } }, "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw=="],
+
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w=="],
+
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg=="],
+
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.2", "", { "os": "linux", "cpu": "arm" }, "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA=="],
+
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw=="],
+
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw=="],
+
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.2", "", { "os": "linux", "cpu": "none" }, "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ=="],
+
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw=="],
+
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw=="],
+
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA=="],
+
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA=="],
+
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
+
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/runtime": "7.29.2", "@types/aria-query": "5.0.4", "aria-query": "5.3.0", "dom-accessibility-api": "0.5.16", "lz-string": "1.5.0", "picocolors": "1.1.1", "pretty-format": "27.5.1" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "4.4.4", "aria-query": "5.3.2", "css.escape": "1.5.1", "dom-accessibility-api": "0.6.3", "picocolors": "1.1.1", "redent": "3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "7.29.2" }, "optionalDependencies": { "@types/react": "18.3.28", "@types/react-dom": "18.3.7" }, "peerDependencies": { "@testing-library/dom": "10.4.1", "react": "18.3.1", "react-dom": "18.3.1" } }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": "10.4.1" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
+    "@tiptap/core": ["@tiptap/core@3.23.5", "", { "peerDependencies": { "@tiptap/pm": "3.23.5" } }, "sha512-657Xqcgf1IYWLkAmRDJKNSGdoS1AHJEgK6zHWHFJERQGIqHnwC7Fz7nvWs/NQhQVBkclQd0ERRdTCZ3XwRc1+g=="],
+
+    "@tiptap/extension-blockquote": ["@tiptap/extension-blockquote@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-PBQRoGfSWfIY7HmGbS5PTHEBQl5nKbild5J5phPLFF+O3aOBQ0d49AC9cxbaou/6FRCtq6g4Uqse9rRTKJRM0w=="],
+
+    "@tiptap/extension-bold": ["@tiptap/extension-bold@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-DZsDCCf53fA9HmsFzfUHl5jLOwDYf+XzfP+QJjJ4cK23SsxDirameTjgnwi4l1EgEPLWunMZQjU+wHmh7vvX6Q=="],
+
+    "@tiptap/extension-bubble-menu": ["@tiptap/extension-bubble-menu@3.23.5", "", { "dependencies": { "@floating-ui/dom": "1.7.6" }, "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-otcGwyVO6OfxdDPnbooZxYGrb+6q5WYmS+g2V+XGGNRn5oJgyY5pW0dqELIUJ66dosIIXXPyw2XqBDpMMY2kyQ=="],
+
+    "@tiptap/extension-bullet-list": ["@tiptap/extension-bullet-list@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-o0bzZbFvOPhPX6+RAhIFPKMIN3jIenY6Ib3FJ6ZqxTdVcjuV2mIXUmJU0uV2BwKtz73GmKSRKRKia6KJ0ml8qA=="],
+
+    "@tiptap/extension-code": ["@tiptap/extension-code@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-NOJUD2Z0hrtBWnovXiiH1XtOjEQePOfIG3bNJgXSs1bWxPVhqp6KjVd8mUJNra974hxbml3tC97sL9QqjpAWFg=="],
+
+    "@tiptap/extension-code-block": ["@tiptap/extension-code-block@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-P2XH8WPM4UahavcWoQgAwNAKQCbF/JWi6ZqgsQmVBfAqQ3mf8gMxB7HnciMq1DlyI9EfjXoJH11yUqldF/6AaQ=="],
+
+    "@tiptap/extension-document": ["@tiptap/extension-document@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-Y7uPjEM1xIK4Spcdk/kp/vZ/Az3cEaglTCk6uHrWvNFVglEoGehNb6IQbQFZW0wjE19YoMIiLBLtG6V9dqrpBw=="],
+
+    "@tiptap/extension-dropcursor": ["@tiptap/extension-dropcursor@3.23.5", "", { "peerDependencies": { "@tiptap/extensions": "3.23.5" } }, "sha512-l72R798Q69D6f89Vp9xreoRnPcpK0LHPKLZIc6pvqBC2iOjx5wLKtW0uP1uqVWdQtvF5AUYBRNIGAQ5Gel9XEg=="],
+
+    "@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@3.23.5", "", { "peerDependencies": { "@floating-ui/dom": "1.7.6", "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-kP0bZKH/lxNogfvoIy/YJZ5gkty0OwqFVtQUwoc85vXYUfvy5Jh1VdO053tCE1iDzmvOITUpcb+MdWryP8dBxA=="],
+
+    "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.23.5", "", { "peerDependencies": { "@tiptap/extensions": "3.23.5" } }, "sha512-x9XlYG26TowX0Ly1w0ZV2D8qliyQy9fTmMY4suI6B/6o6m/sXHGTAJMmJqwP66sZKF6cMLU3HECumhtyQxPT2g=="],
+
+    "@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-j/BDBMOA1mA+RhCx622SRPBhpp2XWNFYz9asbg8T3yk8v9WI3Vjo6IDlfTp6fwsR2LGE7Pek3R0xDAjW6yVG3g=="],
+
+    "@tiptap/extension-heading": ["@tiptap/extension-heading@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-tFI+iYk34geacVOGqYgyoC8siQjdGn605XaYSZcGRFF8NY+HrGlLkQi2QRRCeLaUhxoctONmWc8USn3H5U7wLQ=="],
+
+    "@tiptap/extension-horizontal-rule": ["@tiptap/extension-horizontal-rule@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-9XkRYc4XE0stERZB3y8bsJd32Jw9UZfMwZXo1GLNYRHFr7dmhSGUj0IzgofqOVmLDcOMW6XcCk54TBYw6BCrWA=="],
+
+    "@tiptap/extension-italic": ["@tiptap/extension-italic@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-XjRSPr6j4mz+8O5j5KNfxVb+1fGNt0wr+js6MLxxGdU7M+PoDPdVY6fARbmBazv4ERlZ5PNS9m35Vo5xDjDfrg=="],
+
+    "@tiptap/extension-link": ["@tiptap/extension-link@3.23.5", "", { "dependencies": { "linkifyjs": "4.3.3" }, "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-FEI58NAPnauBbs4nw1dkgRyEhcWnure0vIlStfQoQGXxj3xSRvxKH2lOkz54fGzuzRJAoudyLU65HW6D7kc+8Q=="],
+
+    "@tiptap/extension-list": ["@tiptap/extension-list@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-nzZXpVwnyKwTj4TVyPyu1bCUFjJCsaXnhAthmvJDnX3RBtemNG9Ka07xGR2NIspzumSbQSMFtDxjmxv3W5dEtg=="],
+
+    "@tiptap/extension-list-item": ["@tiptap/extension-list-item@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-l7Hb4rfNIkO6JrNJYkdXap6QYXCz4XeeFmI1bfQgEiwPGs+RAn/+0cOdg7q+6MmtZFac5uSXV0PftPk6A0GsEA=="],
+
+    "@tiptap/extension-list-keymap": ["@tiptap/extension-list-keymap@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-Hz8jRA51VSiHezEkwqwaMYbTEYcR/5Aq3UgCgDlNPlE6k1OZrvRtV/4s3AOO0RRgzyVLKv7yv7KuOJN/OLGErw=="],
+
+    "@tiptap/extension-ordered-list": ["@tiptap/extension-ordered-list@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-qQeU71ij0cAAD9bbGqot5T5bpR3dysgQ+W67quRs6VDyusU89EYaJHKn/qWU6a1XOEQ4sL+5GNw52FYQVHUxbA=="],
+
+    "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-LtgMcR1rvWnZDtphFJ/LBltlC0+6HGA07k7vhy+U7P/zIg/V3Fb4RD6YDuAo0cPfBsLm8p1WYJV92WpAsGgtlg=="],
+
+    "@tiptap/extension-placeholder": ["@tiptap/extension-placeholder@3.23.5", "", { "peerDependencies": { "@tiptap/extensions": "3.23.5" } }, "sha512-B2snUujc6fb/16p8jSQCN4+mto7RlHKLm8quBTUWXksY8D82u/cxjUdmRQ7ueq7vsbRsA+WoJTrKEjJ8RQOpjw=="],
+
+    "@tiptap/extension-strike": ["@tiptap/extension-strike@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-PMB9lpQGOJGuRTIS9rBw8UZtHQwmsiJbWKjcBr5z20MluaJQ3ZCHFhDYG6ncIDRz+0ny4ZvoJ7cKGpI+NTvXMA=="],
+
+    "@tiptap/extension-text": ["@tiptap/extension-text@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-GLa+AaA2NC5XYRZad/Qq/oH5Pa95s+uA17J7+RCkF8j1RNREUBkYQ5CD5MT8kT+D3DHgU8MRyYdTd28I46HBDQ=="],
+
+    "@tiptap/extension-underline": ["@tiptap/extension-underline@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-fyxthzE6CNCi9a9OVAwXs1sSyJ7jlrzT3aP2KhYLQCsJABHaPJgJA7k52/CRuKqCW3WbxU1ULH9LGuGtBbhEyw=="],
+
+    "@tiptap/extensions": ["@tiptap/extensions@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-ROcdNPV+buzldEFKvD3o29P7H7zpAf2lnLfndO2LHSToWyHw4hlzVPCeAU8uAvhl/jyfeUoFLrBwxphMX/KG6A=="],
+
+    "@tiptap/pm": ["@tiptap/pm@3.23.5", "", { "dependencies": { "prosemirror-changeset": "2.4.1", "prosemirror-commands": "1.7.1", "prosemirror-dropcursor": "1.8.2", "prosemirror-gapcursor": "1.4.1", "prosemirror-history": "1.5.0", "prosemirror-keymap": "1.2.3", "prosemirror-model": "1.25.7", "prosemirror-schema-list": "1.5.1", "prosemirror-state": "1.4.4", "prosemirror-tables": "1.8.5", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8" } }, "sha512-9tgLdpTvNN0/fLP4RcNzbyQ0qjg9J2ahaFbQzgV5uvd+QMy8Xkg2IqKKnOoJJUAV3FDjGq3Yx0WrV2BGro9pfw=="],
+
+    "@tiptap/react": ["@tiptap/react@3.23.5", "", { "dependencies": { "@types/use-sync-external-store": "0.0.6", "fast-equals": "5.4.0", "use-sync-external-store": "1.6.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "3.23.5", "@tiptap/extension-floating-menu": "3.23.5" }, "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5", "@types/react": "18.3.28", "@types/react-dom": "18.3.7", "react": "18.3.1", "react-dom": "18.3.1" } }, "sha512-aEdKfJxoa6tCEV4FrnBqMQoUPwGcTWLaDzmP4fL1gR7E40rYDTiYNKoF1Ob+UimUpguAP6Emv1WlJa5oyI8FSw=="],
+
+    "@tiptap/starter-kit": ["@tiptap/starter-kit@3.23.5", "", { "dependencies": { "@tiptap/core": "3.23.5", "@tiptap/extension-blockquote": "3.23.5", "@tiptap/extension-bold": "3.23.5", "@tiptap/extension-bullet-list": "3.23.5", "@tiptap/extension-code": "3.23.5", "@tiptap/extension-code-block": "3.23.5", "@tiptap/extension-document": "3.23.5", "@tiptap/extension-dropcursor": "3.23.5", "@tiptap/extension-gapcursor": "3.23.5", "@tiptap/extension-hard-break": "3.23.5", "@tiptap/extension-heading": "3.23.5", "@tiptap/extension-horizontal-rule": "3.23.5", "@tiptap/extension-italic": "3.23.5", "@tiptap/extension-link": "3.23.5", "@tiptap/extension-list": "3.23.5", "@tiptap/extension-list-item": "3.23.5", "@tiptap/extension-list-keymap": "3.23.5", "@tiptap/extension-ordered-list": "3.23.5", "@tiptap/extension-paragraph": "3.23.5", "@tiptap/extension-strike": "3.23.5", "@tiptap/extension-text": "3.23.5", "@tiptap/extension-underline": "3.23.5", "@tiptap/extensions": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-ac0edQ1a1nYkNAzOgdqIBKGdrOlNQpPP9wGAG3Q9EgTq4+C4/EftJZZJmUn3KzaSOUv4cLEDo0z0jurJvZPkaw=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "7.29.3", "@babel/types": "7.29.0", "@types/babel__generator": "7.27.0", "@types/babel__template": "7.4.4", "@types/babel__traverse": "7.28.0" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "7.29.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "7.29.3", "@babel/types": "7.29.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "7.29.0" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
+
+    "@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "15.7.15", "csstype": "3.2.3" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
+
+    "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "18.3.28" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "7.29.0", "@babel/plugin-transform-react-jsx-self": "7.27.1", "@babel/plugin-transform-react-jsx-source": "7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "7.20.5", "react-refresh": "0.17.0" }, "peerDependencies": { "vite": "6.4.2" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "5.3.3", "tinyrainbow": "1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "3.0.3", "magic-string": "0.30.21" }, "optionalDependencies": { "vite": "5.4.21" } }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "0.30.21", "pathe": "1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "3.2.1", "tinyrainbow": "1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.31", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "2.10.31", "caniuse-lite": "1.0.30001793", "electron-to-chromium": "1.5.359", "node-releases": "2.0.44", "update-browserslist-db": "1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "1.3.0", "function-bind": "1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+
+    "central-icons": ["@central-icons-react/round-outlined-radius-3-stroke-2@1.1.233", "", { "peerDependencies": { "react": "18.3.1" } }, "sha512-uv79D/wxGWG4HPnUL0QPS436FEi84jxff8hXs+PUXb/cmfGOzEaEojv3GpQkXF9OCfH0DbVHOYJzIXJ5UVo/Hw=="],
+
+    "central-icons-filled": ["@central-icons-react/round-filled-radius-3-stroke-2@1.1.241", "", { "peerDependencies": { "react": "18.3.1" } }, "sha512-onigX/62UNm9o3gQwVghXAqJii9pbTVR2PnY7vT/OrU48vJxxgS3fMmkAxkkmxUIGY8MWbrvzQzigaYj7LKiSw=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "2.0.1", "check-error": "2.1.3", "deep-eql": "5.0.2", "loupe": "3.2.1", "pathval": "2.0.1" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "3.2.0", "rrweb-cssom": "0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "4.0.0", "whatwg-url": "14.2.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-errors": "1.3.0", "gopd": "1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.359", "", {}, "sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "1.3.0", "get-intrinsic": "1.3.0", "has-tostringtag": "1.0.2", "hasown": "2.0.3" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "1.0.9" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "optionalDependencies": { "picomatch": "4.0.4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "0.4.0", "combined-stream": "1.0.8", "es-set-tostringtag": "2.1.0", "hasown": "2.0.3", "mime-types": "2.1.35" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "framer-motion": ["framer-motion@12.39.0", "", { "dependencies": { "motion-dom": "12.39.0", "motion-utils": "12.39.0", "tslib": "2.8.1" }, "optionalDependencies": { "react": "18.3.1", "react-dom": "18.3.1" } }, "sha512-+vnLfzrv0MzjLzNl+nvNvR7jdg3q4cxxjz/YvzfifHl0TREtL00cs1RoMTxs+1PzLiEqZGV6gYsBY0oEAYZ24w=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-define-property": "1.0.1", "es-errors": "1.3.0", "es-object-atoms": "1.1.1", "function-bind": "1.1.2", "get-proto": "1.0.1", "gopd": "1.2.0", "has-symbols": "1.1.0", "hasown": "2.0.3", "math-intrinsics": "1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "1.0.1", "es-object-atoms": "1.1.1" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "1.1.0" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "7.1.4", "debug": "4.4.3" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "7.1.4", "debug": "4.4.3" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": "2.1.2" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "4.6.0", "data-urls": "5.0.0", "decimal.js": "10.6.0", "form-data": "4.0.5", "html-encoding-sniffer": "4.0.0", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "is-potential-custom-element-name": "1.0.1", "nwsapi": "2.2.23", "parse5": "7.3.0", "rrweb-cssom": "0.7.1", "saxes": "6.0.0", "symbol-tree": "3.2.4", "tough-cookie": "5.1.2", "w3c-xmlserializer": "5.0.0", "webidl-conversions": "7.0.0", "whatwg-encoding": "3.1.1", "whatwg-mimetype": "4.0.0", "whatwg-url": "14.2.0", "ws": "8.20.1", "xml-name-validator": "5.0.0" } }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "linkifyjs": ["linkifyjs@4.3.3", "", {}, "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "3.1.1" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@0.468.0", "", { "peerDependencies": { "react": "18.3.1" } }, "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
+    "motion-dom": ["motion-dom@12.39.0", "", { "dependencies": { "motion-utils": "12.39.0" } }, "sha512-Xn7aAcGDhco/JZTXOub64UmaYn73C6J1Po7Fk+8EvkJsNGTqfhon6UJY53vJKXW5v5Zl8HrYsVxv6oPXeGoGLQ=="],
+
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "node-releases": ["node-releases@2.0.44", "", {}, "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ=="],
+
+    "nwsapi": ["nwsapi@2.2.23", "", {}, "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ=="],
+
+    "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "6.0.1" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "3.3.12", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "5.0.1", "ansi-styles": "5.2.0", "react-is": "17.0.2" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "prosemirror-changeset": ["prosemirror-changeset@2.4.1", "", { "dependencies": { "prosemirror-transform": "1.12.0" } }, "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw=="],
+
+    "prosemirror-commands": ["prosemirror-commands@1.7.1", "", { "dependencies": { "prosemirror-model": "1.25.7", "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0" } }, "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w=="],
+
+    "prosemirror-dropcursor": ["prosemirror-dropcursor@1.8.2", "", { "dependencies": { "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8" } }, "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw=="],
+
+    "prosemirror-gapcursor": ["prosemirror-gapcursor@1.4.1", "", { "dependencies": { "prosemirror-keymap": "1.2.3", "prosemirror-model": "1.25.7", "prosemirror-state": "1.4.4", "prosemirror-view": "1.41.8" } }, "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw=="],
+
+    "prosemirror-history": ["prosemirror-history@1.5.0", "", { "dependencies": { "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8", "rope-sequence": "1.3.4" } }, "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg=="],
+
+    "prosemirror-keymap": ["prosemirror-keymap@1.2.3", "", { "dependencies": { "prosemirror-state": "1.4.4", "w3c-keyname": "2.2.8" } }, "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw=="],
+
+    "prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "2.1.1" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
+
+    "prosemirror-schema-list": ["prosemirror-schema-list@1.5.1", "", { "dependencies": { "prosemirror-model": "1.25.7", "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0" } }, "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q=="],
+
+    "prosemirror-state": ["prosemirror-state@1.4.4", "", { "dependencies": { "prosemirror-model": "1.25.7", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8" } }, "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw=="],
+
+    "prosemirror-tables": ["prosemirror-tables@1.8.5", "", { "dependencies": { "prosemirror-keymap": "1.2.3", "prosemirror-model": "1.25.7", "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8" } }, "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw=="],
+
+    "prosemirror-transform": ["prosemirror-transform@1.12.0", "", { "dependencies": { "prosemirror-model": "1.25.7" } }, "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w=="],
+
+    "prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "1.25.7", "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "1.4.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
+
+    "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "1.4.0", "scheduler": "0.23.2" }, "peerDependencies": { "react": "18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "4.0.0", "strip-indent": "3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "2.3.3" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
+
+    "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "1.4.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "1.0.1" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "6.5.0", "picomatch": "4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "6.1.86" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "3.2.0", "picocolors": "1.1.1" }, "peerDependencies": { "browserslist": "4.28.2" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "18.3.1" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "0.25.12", "fdir": "6.5.0", "picomatch": "4.0.4", "postcss": "8.5.15", "rollup": "4.60.4", "tinyglobby": "0.2.16" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "6.7.14", "debug": "4.4.3", "es-module-lexer": "1.7.0", "pathe": "1.1.2", "vite": "5.4.21" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "5.3.3", "debug": "4.4.3", "expect-type": "1.3.0", "magic-string": "0.30.21", "pathe": "1.1.2", "std-env": "3.10.0", "tinybench": "2.9.0", "tinyexec": "0.3.2", "tinypool": "1.1.1", "tinyrainbow": "1.2.0", "vite": "5.4.21", "vite-node": "2.1.9", "why-is-node-running": "2.3.0" }, "optionalDependencies": { "jsdom": "25.0.1" }, "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "5.1.1", "webidl-conversions": "7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.20.1", "", {}, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@vitest/mocker/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "0.21.5", "postcss": "8.5.15", "rollup": "4.60.4" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "estree-walker/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "vite-node/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "0.21.5", "postcss": "8.5.15", "rollup": "4.60.4" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitest/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "0.21.5", "postcss": "8.5.15", "rollup": "4.60.4" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "@vitest/mocker/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@vitest/mocker/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite-node/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite-node/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite-node/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite-node/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite-node/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite-node/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+  }
+}

--- a/hud.html
+++ b/hud.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OS Scribe Dictation</title>
+  </head>
+  <body>
+    <div id="hud" class="hud" data-state="idle">
+      <div class="hud-bars" aria-hidden="true">
+        <span class="hud-bar"></span>
+        <span class="hud-bar"></span>
+        <span class="hud-bar"></span>
+        <span class="hud-bar"></span>
+        <span class="hud-bar"></span>
+        <span class="hud-bar"></span>
+        <span class="hud-bar"></span>
+      </div>
+      <span class="hud-progress" aria-hidden="true"></span>
+      <span class="hud-success" aria-hidden="true"></span>
+      <span class="hud-error-mark" aria-hidden="true"></span>
+      <span id="hud-status" class="hud-status">Idle</span>
+      <p id="hud-transcript" class="hud-message"></p>
+    </div>
+    <script type="module" src="/src/hud.ts"></script>
+  </body>
+</html>

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }
-tauri = { version = "2.8.0", features = [] }
+tauri = { version = "2.8.0", features = ["macos-private-api"] }
 thiserror = "2.0"
 tokio = { version = "1.42", features = ["macros", "rt-multi-thread", "sync", "time"] }
 uuid = { version = "1.11", features = ["serde", "v4"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -6,6 +6,7 @@ fn main() {
     println!("cargo:rerun-if-changed=icons/128x128.png");
     println!("cargo:rerun-if-changed=icons/128x128@2x.png");
     build_system_audio_helper();
+    build_dictation_helper();
     tauri_build::build();
 }
 
@@ -49,7 +50,9 @@ fn build_system_audio_helper() {
             .unwrap_or(false);
     let mut should_sign = false;
     if !executable_current {
-        let status = std::process::Command::new("swiftc")
+        let mut command = std::process::Command::new("swiftc");
+        configure_swift_command(&mut command, &manifest_dir, "14.2");
+        let status = command
             .arg("-framework")
             .arg("Foundation")
             .arg("-framework")
@@ -119,5 +122,143 @@ fn build_system_audio_helper() {
             .arg("-")
             .arg(&app_dir)
             .status();
+    }
+}
+
+fn build_dictation_helper() {
+    if std::env::var("CARGO_CFG_TARGET_OS").ok().as_deref() != Some("macos") {
+        return;
+    }
+    let manifest_dir = std::path::PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"),
+    );
+    let source = manifest_dir
+        .join("native")
+        .join("mac-dictation-helper")
+        .join("main.swift");
+    if !source.exists() {
+        return;
+    }
+    println!("cargo:rerun-if-changed={}", source.display());
+
+    let helper_dir = manifest_dir
+        .parent()
+        .expect("src-tauri should have a repository parent")
+        .join(".tauri-helper");
+    let app_dir = helper_dir.join("OS Scribe Dictation Helper.app");
+    let contents_dir = app_dir.join("Contents");
+    let macos_dir = contents_dir.join("MacOS");
+    std::fs::create_dir_all(&macos_dir).expect("dictation helper app dir should be created");
+    let executable = macos_dir.join("os-scribe-dictation-helper");
+
+    let source_modified = std::fs::metadata(&source)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    let executable_current = executable.exists()
+        && source_modified
+            .and_then(|source_modified| {
+                std::fs::metadata(&executable)
+                    .and_then(|metadata| metadata.modified())
+                    .ok()
+                    .map(|executable_modified| executable_modified >= source_modified)
+            })
+            .unwrap_or(false);
+    let mut should_sign = false;
+    if !executable_current {
+        let mut command = std::process::Command::new("swiftc");
+        configure_swift_command(&mut command, &manifest_dir, "14.0");
+        let status = command
+            .arg("-framework")
+            .arg("Foundation")
+            .arg("-framework")
+            .arg("AppKit")
+            .arg("-framework")
+            .arg("AVFoundation")
+            .arg("-framework")
+            .arg("Carbon")
+            .arg("-framework")
+            .arg("CoreMedia")
+            .arg("-framework")
+            .arg("CoreGraphics")
+            .arg(&source)
+            .arg("-o")
+            .arg(&executable)
+            .status();
+        if !matches!(status, Ok(status) if status.success()) {
+            println!("cargo:warning=dictation helper could not be built; dictation will report unavailable");
+            return;
+        }
+        should_sign = true;
+    }
+
+    let plist = contents_dir.join("Info.plist");
+    let plist_contents = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>OS Scribe Dictation Helper</string>
+  <key>CFBundleExecutable</key>
+  <string>os-scribe-dictation-helper</string>
+  <key>CFBundleIdentifier</key>
+  <string>network.opensoftware.os-notetaker.dictation-helper</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>OS Scribe Dictation Helper</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSBackgroundOnly</key>
+  <true/>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>OS Scribe needs microphone access to turn your speech into text.</string>
+</dict>
+</plist>
+"#;
+    let plist_current =
+        std::fs::read_to_string(&plist).is_ok_and(|current| current == plist_contents);
+    if !plist_current {
+        std::fs::write(plist, plist_contents)
+            .expect("dictation helper Info.plist should be written");
+        should_sign = true;
+    }
+
+    if should_sign {
+        let _ = std::process::Command::new("codesign")
+            .arg("--force")
+            .arg("--deep")
+            .arg("--sign")
+            .arg("-")
+            .arg(&app_dir)
+            .status();
+    }
+}
+
+fn configure_swift_command(
+    command: &mut std::process::Command,
+    manifest_dir: &std::path::Path,
+    macos_version: &str,
+) {
+    if let Some(target) = swift_target(macos_version) {
+        command.arg("-target").arg(target);
+    }
+    let module_cache = manifest_dir.join("target").join("swift-module-cache");
+    std::fs::create_dir_all(&module_cache).expect("swift module cache dir should be created");
+    command.arg("-module-cache-path").arg(module_cache);
+}
+
+fn swift_target(macos_version: &str) -> Option<String> {
+    match std::env::var("HOST").ok()?.as_str() {
+        "aarch64-apple-darwin" => Some(format!("arm64-apple-macosx{macos_version}")),
+        "x86_64-apple-darwin" => Some(format!("x86_64-apple-macosx{macos_version}")),
+        _ => None,
     }
 }

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -2,6 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main",
   "description": "Main window access to scoped OS Notetaker commands.",
-  "windows": ["main"],
+  "windows": ["main", "hud"],
   "permissions": ["core:default", "core:window:allow-start-dragging"]
 }

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1,0 +1,806 @@
+import Foundation
+import AVFoundation
+import AppKit
+import Carbon
+import CoreMedia
+import CoreGraphics
+
+struct HelperEvent: Encodable {
+    let type: String
+    let payload: [String: String]
+}
+
+func emit(_ type: String, _ payload: [String: String] = [:]) {
+    let event = HelperEvent(type: type, payload: payload)
+    guard
+        let data = try? JSONEncoder().encode(event),
+        let line = String(data: data, encoding: .utf8)
+    else {
+        return
+    }
+    print(line)
+    fflush(stdout)
+}
+
+func emitJSON(_ type: String, _ payload: [String: Any] = [:]) {
+    let event: [String: Any] = [
+        "type": type,
+        "payload": payload,
+    ]
+    guard
+        JSONSerialization.isValidJSONObject(event),
+        let data = try? JSONSerialization.data(withJSONObject: event),
+        let line = String(data: data, encoding: .utf8)
+    else {
+        return
+    }
+    print(line)
+    fflush(stdout)
+}
+
+func boolStatus(_ value: Bool) -> String {
+    value ? "granted" : "missing"
+}
+
+func microphoneStatus() -> String {
+    switch AVCaptureDevice.authorizationStatus(for: .audio) {
+    case .authorized:
+        return "granted"
+    case .denied:
+        return "denied"
+    case .restricted:
+        return "restricted"
+    case .notDetermined:
+        return "not_determined"
+    @unknown default:
+        return "unknown"
+    }
+}
+
+func permissionPayload() -> [String: String] {
+    [
+        "microphone": microphoneStatus(),
+        "accessibility": boolStatus(AXIsProcessTrusted()),
+    ]
+}
+
+func helperBundleIdentifier() -> String {
+    Bundle.main.bundleIdentifier ?? "unknown"
+}
+
+func microphoneDevices() -> [[String: String]] {
+    audioInputDevices().map { device in
+        [
+            "id": device.uniqueID,
+            "name": device.localizedName,
+        ]
+    }
+}
+
+func audioInputDevices() -> [AVCaptureDevice] {
+    let deviceTypes: [AVCaptureDevice.DeviceType]
+    if #available(macOS 14.0, *) {
+        deviceTypes = [.microphone, .external]
+    } else {
+        deviceTypes = [.builtInMicrophone, .externalUnknown]
+    }
+    return AVCaptureDevice.DiscoverySession(
+        deviceTypes: deviceTypes,
+        mediaType: .audio,
+        position: .unspecified
+    ).devices
+}
+
+func microphoneDevice(for id: String?) -> AVCaptureDevice? {
+    guard let id, !id.isEmpty else {
+        return nil
+    }
+    return audioInputDevices().first { device in
+        device.uniqueID == id
+    }
+}
+
+func emitMicrophoneDevices(selectedID: String?) {
+    emitJSON("microphone_devices", [
+        "devices": microphoneDevices(),
+        "selectedID": selectedID ?? "",
+    ])
+}
+
+func runOnMain(_ work: @escaping () -> Void) {
+    if Thread.isMainThread {
+        work()
+    } else {
+        DispatchQueue.main.async(execute: work)
+    }
+}
+
+final class FocusTargetController {
+    static let shared = FocusTargetController()
+
+    private var lastExternalApp: NSRunningApplication?
+    private let ignoredBundleIdentifiers: Set<String> = [
+        "network.opensoftware.os-notetaker",
+        "network.opensoftware.os-notetaker.dictation-helper",
+    ]
+
+    private init() {}
+
+    func start() {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(applicationDidActivate(_:)),
+            name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
+
+        if let frontmostApplication = NSWorkspace.shared.frontmostApplication {
+            rememberIfExternal(frontmostApplication)
+        }
+    }
+
+    func activateLastExternalApp() -> Bool {
+        guard let app = lastExternalApp, !app.isTerminated else {
+            return false
+        }
+        return app.activate(options: [])
+    }
+
+    func targetDescription() -> String {
+        guard let app = lastExternalApp, !app.isTerminated else {
+            return "unknown"
+        }
+        return app.localizedName ?? app.bundleIdentifier ?? "\(app.processIdentifier)"
+    }
+
+    @objc private func applicationDidActivate(_ notification: Notification) {
+        guard
+            let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+        else {
+            return
+        }
+        rememberIfExternal(app)
+    }
+
+    private func rememberIfExternal(_ app: NSRunningApplication) {
+        let bundleIdentifier = app.bundleIdentifier ?? ""
+        let appName = app.localizedName ?? ""
+        guard !ignoredBundleIdentifiers.contains(bundleIdentifier) else {
+            return
+        }
+        guard !appName.localizedCaseInsensitiveContains("OS Scribe") else {
+            return
+        }
+        lastExternalApp = app
+        emit("focus_target", ["app": targetDescription()])
+    }
+}
+
+enum SelectedDeviceRecorderError: LocalizedError {
+    case cannotAddInput
+    case cannotAddOutput
+    case cannotCreateAudioInput
+    case cannotStartWriter
+    case cannotAppendAudio
+
+    var errorDescription: String? {
+        switch self {
+        case .cannotAddInput:
+            return "Could not use the selected microphone as a recording input."
+        case .cannotAddOutput:
+            return "Could not create audio output for the selected microphone."
+        case .cannotCreateAudioInput:
+            return "Could not create an audio track for the selected microphone."
+        case .cannotStartWriter:
+            return "Could not start writing audio from the selected microphone."
+        case .cannotAppendAudio:
+            return "Could not write audio from the selected microphone."
+        }
+    }
+}
+
+final class SelectedDeviceRecorder: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
+    private let session = AVCaptureSession()
+    private let output = AVCaptureAudioDataOutput()
+    private let queue = DispatchQueue(label: "network.opensoftware.os-notetaker.dictation-recorder")
+    private let writer: AVAssetWriter
+    private let writerInput: AVAssetWriterInput
+    private var didStartWriting = false
+    private var isStopping = false
+    private var finishHandler: ((Error?) -> Void)?
+    private let failureHandler: (Error) -> Void
+    private let levelHandler: (Float) -> Void
+
+    init(
+        device: AVCaptureDevice,
+        outputURL: URL,
+        onLevel: @escaping (Float) -> Void,
+        onFailure: @escaping (Error) -> Void
+    ) throws {
+        writer = try AVAssetWriter(outputURL: outputURL, fileType: .m4a)
+        writerInput = AVAssetWriterInput(
+            mediaType: .audio,
+            outputSettings: [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: 44_100,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderBitRateKey: 128_000,
+            ]
+        )
+        writerInput.expectsMediaDataInRealTime = true
+        failureHandler = onFailure
+        levelHandler = onLevel
+
+        super.init()
+
+        let input = try AVCaptureDeviceInput(device: device)
+        guard session.canAddInput(input) else {
+            throw SelectedDeviceRecorderError.cannotAddInput
+        }
+        session.addInput(input)
+
+        guard session.canAddOutput(output) else {
+            throw SelectedDeviceRecorderError.cannotAddOutput
+        }
+        output.setSampleBufferDelegate(self, queue: queue)
+        session.addOutput(output)
+
+        guard writer.canAdd(writerInput) else {
+            throw SelectedDeviceRecorderError.cannotCreateAudioInput
+        }
+        writer.add(writerInput)
+    }
+
+    func start() {
+        session.startRunning()
+    }
+
+    func stop(_ completion: @escaping (Error?) -> Void) {
+        queue.async { [weak self] in
+            guard let self else {
+                completion(nil)
+                return
+            }
+            guard !isStopping else {
+                completion(nil)
+                return
+            }
+            isStopping = true
+            finishHandler = completion
+            session.stopRunning()
+            output.setSampleBufferDelegate(nil, queue: nil)
+
+            guard didStartWriting else {
+                writer.cancelWriting()
+                completion(DictationError.missingRecording)
+                return
+            }
+
+            writerInput.markAsFinished()
+            writer.finishWriting { [weak self] in
+                guard let self else {
+                    completion(nil)
+                    return
+                }
+                let error = writer.status == .failed ? writer.error : nil
+                finishHandler = nil
+                completion(error)
+            }
+        }
+    }
+
+    func cancel() {
+        queue.sync {
+            isStopping = true
+            session.stopRunning()
+            output.setSampleBufferDelegate(nil, queue: nil)
+            writer.cancelWriting()
+        }
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard !isStopping else {
+            return
+        }
+        if !didStartWriting {
+            guard writer.startWriting() else {
+                fail(writer.error ?? SelectedDeviceRecorderError.cannotStartWriter)
+                return
+            }
+            writer.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+            didStartWriting = true
+        }
+
+        emitLevel(from: sampleBuffer)
+        guard writerInput.isReadyForMoreMediaData, writerInput.append(sampleBuffer) else {
+            fail(writer.error ?? SelectedDeviceRecorderError.cannotAppendAudio)
+            return
+        }
+    }
+
+    private func emitLevel(from sampleBuffer: CMSampleBuffer) {
+        guard
+            let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer)
+        else {
+            return
+        }
+        var length = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        guard CMBlockBufferGetDataPointer(
+            blockBuffer,
+            atOffset: 0,
+            lengthAtOffsetOut: nil,
+            totalLengthOut: &length,
+            dataPointerOut: &dataPointer
+        ) == noErr, let dataPointer, length > 1 else {
+            return
+        }
+        let sampleCount = length / MemoryLayout<Int16>.size
+        guard sampleCount > 0 else {
+            return
+        }
+        let samples = dataPointer.withMemoryRebound(to: Int16.self, capacity: sampleCount) { pointer in
+            UnsafeBufferPointer(start: pointer, count: sampleCount)
+        }
+        var peak: Float = 0
+        for sample in samples {
+            peak = max(peak, abs(Float(sample) / Float(Int16.max)))
+        }
+        levelHandler(peak)
+    }
+
+    private func fail(_ error: Error) {
+        guard !isStopping else {
+            return
+        }
+        isStopping = true
+        session.stopRunning()
+        output.setSampleBufferDelegate(nil, queue: nil)
+        writer.cancelWriting()
+        finishHandler = nil
+        failureHandler(error)
+    }
+}
+
+enum DictationError: LocalizedError {
+    case missingRecording
+    case missingTranscript
+
+    var errorDescription: String? {
+        switch self {
+        case .missingRecording:
+            return "No recorded audio was available to transcribe."
+        case .missingTranscript:
+            return "No transcript text was available to paste."
+        }
+    }
+
+    var code: String {
+        switch self {
+        case .missingRecording:
+            return "missing_recording"
+        case .missingTranscript:
+            return "empty_transcript"
+        }
+    }
+}
+
+final class DictationController {
+    private var audioRecorder: AVAudioRecorder?
+    private var selectedDeviceRecorder: SelectedDeviceRecorder?
+    private var recordingURL: URL?
+    private var meteringTimer: DispatchSourceTimer?
+    private var preferredMicrophoneID: String?
+    private var preferredMicrophoneName: String?
+    private var isListening = false
+    private var isFinalizing = false
+    private var maxObservedAudioLevel: Float = 0
+
+    var listening: Bool {
+        isListening || isFinalizing
+    }
+
+    func emitDiagnostics() {
+        emit("dictation_diagnostics", [
+            "bundleIdentifier": helperBundleIdentifier(),
+            "microphone": microphoneStatus(),
+            "accessibility": boolStatus(AXIsProcessTrusted()),
+        ])
+    }
+
+    func emitMicrophones() {
+        emitMicrophoneDevices(selectedID: preferredMicrophoneID)
+    }
+
+    func setMicrophone(id: String?, name: String?) {
+        preferredMicrophoneID = id?.isEmpty == true ? nil : id
+        preferredMicrophoneName = name?.isEmpty == true ? nil : name
+        emit("microphone_selected", [
+            "id": preferredMicrophoneID ?? "",
+            "name": preferredMicrophoneName ?? "Auto-detect",
+        ])
+        emitMicrophones()
+    }
+
+    func start() {
+        guard !listening else {
+            emit("error", ["code": "already_listening", "message": "Dictation is already listening."])
+            return
+        }
+
+        AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
+            guard microphoneAllowed else {
+                emit("error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
+                emit("permission_status", permissionPayload())
+                return
+            }
+            self?.startRecording()
+        }
+    }
+
+    func stop() {
+        guard isListening else {
+            emit("error", ["code": "not_listening", "message": "Dictation is not listening."])
+            return
+        }
+
+        isListening = false
+        isFinalizing = true
+        stopMetering()
+        emit("finalizing_transcript")
+
+        if let selectedDeviceRecorder {
+            selectedDeviceRecorder.stop { [weak self] error in
+                runOnMain {
+                    self?.selectedDeviceRecorder = nil
+                    if let error {
+                        self?.fail(error)
+                        return
+                    }
+                    self?.emitRecordingReady()
+                }
+            }
+            return
+        }
+
+        audioRecorder?.stop()
+        emitRecordingReady()
+    }
+
+    func paste(text: String) {
+        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            fail(DictationError.missingTranscript)
+            return
+        }
+
+        emit("final_transcript", ["text": text])
+        PasteboardInserter.paste(text)
+        resetRecordingState()
+    }
+
+    func discard() {
+        resetRecordingState()
+    }
+
+    func shutdown() {
+        resetRecordingState()
+        emit("shutdown_ack")
+        exit(0)
+    }
+
+    private func startRecording() {
+        resetRecordingState()
+
+        let nextRecordingURL = temporaryRecordingURL()
+        if let selectedDevice = microphoneDevice(for: preferredMicrophoneID) {
+            startSelectedDeviceRecording(device: selectedDevice, url: nextRecordingURL)
+            return
+        }
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+        ]
+
+        do {
+            let recorder = try AVAudioRecorder(url: nextRecordingURL, settings: settings)
+            recorder.isMeteringEnabled = true
+            recorder.prepareToRecord()
+
+            guard recorder.record() else {
+                emit("error", ["code": "audio_start_failed", "message": "Could not start microphone recording."])
+                resetRecordingState()
+                return
+            }
+
+            audioRecorder = recorder
+            recordingURL = nextRecordingURL
+            isListening = true
+            startMetering()
+            emit("listening_started", [
+                "recognitionMode": "openai_recording",
+                "microphone": preferredMicrophoneName ?? "Auto-detect",
+            ])
+        } catch {
+            resetRecordingState()
+            emit("error", ["code": "audio_start_failed", "message": error.localizedDescription])
+        }
+    }
+
+    private func startSelectedDeviceRecording(device: AVCaptureDevice, url: URL) {
+        do {
+            let recorder = try SelectedDeviceRecorder(
+                device: device,
+                outputURL: url,
+                onLevel: { [weak self] level in
+                    runOnMain {
+                        self?.observeAudioLevel(level)
+                    }
+                },
+                onFailure: { [weak self] error in
+                    runOnMain {
+                        self?.failSelectedDeviceRecording(error)
+                    }
+                }
+            )
+            selectedDeviceRecorder = recorder
+            recordingURL = url
+            isListening = true
+            recorder.start()
+            emit("listening_started", [
+                "recognitionMode": "openai_recording",
+                "microphone": device.localizedName,
+            ])
+        } catch {
+            resetRecordingState()
+            emit("error", ["code": "audio_start_failed", "message": error.localizedDescription])
+        }
+    }
+
+    private func failSelectedDeviceRecording(_ error: Error) {
+        guard selectedDeviceRecorder != nil else {
+            return
+        }
+        selectedDeviceRecorder = nil
+        fail(error)
+    }
+
+    private func emitRecordingReady() {
+        guard let recordingURL else {
+            fail(DictationError.missingRecording)
+            return
+        }
+
+        let fileSize = (try? FileManager.default.attributesOfItem(atPath: recordingURL.path)[.size] as? Int64) ?? 0
+        guard fileSize > 0 else {
+            fail(DictationError.missingRecording)
+            return
+        }
+
+        emit("recording_ready", [
+            "path": recordingURL.path,
+            "observedAudioLevel": String(format: "%.4f", maxObservedAudioLevel),
+        ])
+    }
+
+    private func temporaryRecordingURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("os-scribe-dictation-\(UUID().uuidString)")
+            .appendingPathExtension("m4a")
+    }
+
+    private func startMetering() {
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            self?.emitAudioRecorderLevel()
+        }
+        meteringTimer = timer
+        timer.resume()
+    }
+
+    private func emitAudioRecorderLevel() {
+        guard let audioRecorder, audioRecorder.isRecording else {
+            return
+        }
+
+        audioRecorder.updateMeters()
+        let averagePower = max(audioRecorder.averagePower(forChannel: 0), -80)
+        let level = Float(pow(10.0, Double(averagePower) / 20.0))
+        observeAudioLevel(level)
+    }
+
+    private func observeAudioLevel(_ level: Float) {
+        maxObservedAudioLevel = max(maxObservedAudioLevel, level)
+        emit("audio_level", ["level": String(format: "%.4f", level)])
+    }
+
+    private func stopMetering() {
+        meteringTimer?.cancel()
+        meteringTimer = nil
+    }
+
+    private func fail(_ error: Error) {
+        let code = (error as? DictationError)?.code ?? "dictation_failed"
+        emit("error", [
+            "code": code,
+            "message": error.localizedDescription,
+        ])
+        resetRecordingState()
+    }
+
+    private func cleanupRecordingFile() {
+        guard let recordingURL else {
+            return
+        }
+        try? FileManager.default.removeItem(at: recordingURL)
+    }
+
+    private func resetRecordingState() {
+        isListening = false
+        isFinalizing = false
+        maxObservedAudioLevel = 0
+        stopMetering()
+        audioRecorder?.stop()
+        audioRecorder = nil
+        selectedDeviceRecorder?.cancel()
+        selectedDeviceRecorder = nil
+        cleanupRecordingFile()
+        recordingURL = nil
+    }
+}
+
+struct PasteboardSnapshot {
+    let items: [[NSPasteboard.PasteboardType: Data]]
+}
+
+enum PasteboardInserter {
+    static func paste(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        let snapshot = capture(pasteboard)
+
+        pasteboard.clearContents()
+        guard pasteboard.setString(text, forType: .string) else {
+            emit("error", ["code": "pasteboard_write_failed", "message": "Could not write transcript to the clipboard."])
+            restore(snapshot, to: pasteboard)
+            return
+        }
+
+        let targetActivated = FocusTargetController.shared.activateLastExternalApp()
+        emit("paste_target", [
+            "app": FocusTargetController.shared.targetDescription(),
+            "activated": boolStatus(targetActivated),
+        ])
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            postPasteShortcut()
+            emit("paste_completed")
+        }
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.7) {
+            if pasteboard.string(forType: .string) == text {
+                restore(snapshot, to: pasteboard)
+            }
+        }
+    }
+
+    private static func capture(_ pasteboard: NSPasteboard) -> PasteboardSnapshot {
+        let items = pasteboard.pasteboardItems?.map { item in
+            item.types.reduce(into: [NSPasteboard.PasteboardType: Data]()) { result, type in
+                result[type] = item.data(forType: type)
+            }
+        } ?? []
+        return PasteboardSnapshot(items: items)
+    }
+
+    private static func restore(_ snapshot: PasteboardSnapshot, to pasteboard: NSPasteboard) {
+        pasteboard.clearContents()
+        guard !snapshot.items.isEmpty else {
+            return
+        }
+        let restoredItems = snapshot.items.map { storedItem in
+            let item = NSPasteboardItem()
+            for (type, data) in storedItem {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        pasteboard.writeObjects(restoredItems)
+    }
+
+    private static func postPasteShortcut() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: true)
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 9, keyDown: false)
+
+        keyDown?.flags = .maskCommand
+        keyUp?.flags = .maskCommand
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+    }
+}
+
+let dictation = DictationController()
+
+func handleCommandLine(_ line: String) {
+    guard let data = line.data(using: .utf8) else {
+        emit("error", ["code": "invalid_input", "message": "Command was not valid UTF-8."])
+        return
+    }
+
+    let command = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    let type = command?["type"] as? String
+
+    switch type {
+    case "ping":
+        emit("pong")
+        runOnMain {
+            dictation.emitDiagnostics()
+        }
+    case "get_permission_status":
+        emit("permission_status", permissionPayload())
+    case "list_microphones":
+        runOnMain {
+            dictation.emitMicrophones()
+        }
+    case "start_listening":
+        runOnMain {
+            dictation.start()
+        }
+    case "stop_and_paste":
+        runOnMain {
+            dictation.stop()
+        }
+    case "set_microphone":
+        let id = command?["id"] as? String
+        let name = command?["name"] as? String
+        runOnMain {
+            dictation.setMicrophone(id: id, name: name)
+        }
+    case "toggle_listening":
+        let shortcut = command?["shortcut"] as? String ?? "hotkey"
+        runOnMain {
+            if dictation.listening {
+                emit("hotkey_trigger", ["action": "stop", "shortcut": shortcut])
+                dictation.stop()
+            } else {
+                emit("hotkey_trigger", ["action": "start", "shortcut": shortcut])
+                dictation.start()
+            }
+        }
+    case "paste_text":
+        let text = command?["text"] as? String ?? ""
+        runOnMain {
+            dictation.paste(text: text)
+        }
+    case "discard_recording":
+        runOnMain {
+            dictation.discard()
+        }
+    case "shutdown":
+        runOnMain {
+            dictation.shutdown()
+        }
+    default:
+        emit("error", ["code": "unknown_command", "message": "Unknown helper command."])
+    }
+}
+
+emit("ready")
+FocusTargetController.shared.start()
+dictation.emitDiagnostics()
+
+Thread.detachNewThread {
+    while let line = readLine() {
+        handleCommandLine(line)
+    }
+}
+
+RunLoop.main.run()

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -13,8 +13,9 @@ use std::{
     ptr,
     sync::Mutex,
     thread,
+    time::Duration,
 };
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, PhysicalPosition, State};
 
 pub struct HelperProcess {
     child: Child,
@@ -229,6 +230,9 @@ impl DictationShortcutInput {
 }
 
 pub fn setup(app: &mut tauri::App) {
+    if let Err(error) = configure_hud_window(app.handle()) {
+        eprintln!("failed to configure dictation HUD: {error}");
+    }
     manage_settings(app.handle());
     app.manage(LastDictationEvent {
         event: Mutex::new(None),
@@ -639,6 +643,7 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
     }
 
     update_latest_event(app, event_type, Some(line.clone()));
+    update_hud_window(app, event_type, event.as_ref());
     let _ = app.emit("dictation-event", line);
 }
 
@@ -715,7 +720,24 @@ fn emit_dictation_event_value(app: &AppHandle, event: serde_json::Value) {
     let event_type = event.get("type").and_then(serde_json::Value::as_str);
     let line = event.to_string();
     update_latest_event(app, event_type, Some(line.clone()));
+    update_hud_window(app, event_type, Some(&event));
     let _ = app.emit("dictation-event", line);
+}
+
+fn update_hud_window(
+    app: &AppHandle,
+    event_type: Option<&str>,
+    event: Option<&serde_json::Value>,
+) {
+    match dictation_event_visibility(event_type) {
+        DictationEventVisibility::Show if should_show_hud_window_for_type(event_type) => {
+            show_hud_window(app)
+        }
+        DictationEventVisibility::Hide => {
+            schedule_hud_hide(app, hud_hide_delay_for_event(event_type, event))
+        }
+        DictationEventVisibility::Show | DictationEventVisibility::Ignore => {}
+    }
 }
 
 fn update_latest_event(app: &AppHandle, event_type: Option<&str>, line: Option<String>) {
@@ -749,6 +771,113 @@ fn dictation_event_visibility(event_type: Option<&str>) -> DictationEventVisibil
         Some("paste_completed" | "error" | "shutdown_ack") => DictationEventVisibility::Hide,
         _ => DictationEventVisibility::Ignore,
     }
+}
+
+fn should_show_hud_window_for_type(event_type: Option<&str>) -> bool {
+    !matches!(event_type, Some("audio_level"))
+}
+
+fn hud_hide_delay_for_event(
+    event_type: Option<&str>,
+    event: Option<&serde_json::Value>,
+) -> Duration {
+    match event_type {
+        Some("shutdown_ack") => Duration::ZERO,
+        Some("error") if event.is_some_and(is_silent_transcription_error) => {
+            Duration::from_millis(900)
+        }
+        Some("error") => Duration::from_millis(2200),
+        _ => Duration::from_millis(900),
+    }
+}
+
+fn is_silent_transcription_error(event: &serde_json::Value) -> bool {
+    let payload = event.get("payload");
+    let code = payload
+        .and_then(|payload| payload.get("code"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    let message = payload
+        .and_then(|payload| payload.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+
+    matches!(code, "no_speech" | "no_transcription" | "empty_transcript")
+        || message == "OpenAI did not return any transcript text."
+}
+
+fn show_hud_window(app: &AppHandle) {
+    if let Some(hud) = app.get_webview_window("hud") {
+        position_hud_window(&hud);
+        let _ = hud.show();
+    }
+}
+
+fn schedule_hud_hide(app: &AppHandle, delay: Duration) {
+    let app = app.clone();
+    thread::spawn(move || {
+        if !delay.is_zero() {
+            thread::sleep(delay);
+        }
+
+        if let Some(state) = app.try_state::<LastDictationEvent>() {
+            if state
+                .event
+                .lock()
+                .ok()
+                .and_then(|event| event.clone())
+                .is_some()
+            {
+                return;
+            }
+        }
+
+        if let Some(hud) = app.get_webview_window("hud") {
+            let _ = hud.hide();
+        }
+    });
+}
+
+fn position_hud_window(hud: &tauri::WebviewWindow) {
+    const HUD_BOTTOM_MARGIN: i32 = 12;
+
+    let monitor = hud
+        .cursor_position()
+        .ok()
+        .and_then(|cursor| hud.monitor_from_point(cursor.x, cursor.y).ok().flatten())
+        .or_else(|| hud.current_monitor().ok().flatten())
+        .or_else(|| hud.primary_monitor().ok().flatten());
+
+    let Some(monitor) = monitor else {
+        return;
+    };
+    let Ok(window_size) = hud.outer_size() else {
+        return;
+    };
+
+    let work_area = monitor.work_area();
+    let x = work_area.position.x
+        + ((work_area.size.width as i32).saturating_sub(window_size.width as i32) / 2);
+    let y = work_area.position.y + work_area.size.height as i32
+        - window_size.height as i32
+        - HUD_BOTTOM_MARGIN;
+
+    let _ = hud.set_position(PhysicalPosition::new(x, y));
+}
+
+fn configure_hud_window(app: &AppHandle) -> Result<(), String> {
+    if let Some(hud) = app.get_webview_window("hud") {
+        hud.set_always_on_top(true)
+            .map_err(|error| error.to_string())?;
+        hud.set_visible_on_all_workspaces(true)
+            .map_err(|error| error.to_string())?;
+        hud.set_focusable(false)
+            .map_err(|error| error.to_string())?;
+        hud.set_skip_taskbar(true)
+            .map_err(|error| error.to_string())?;
+        hud.set_shadow(false).map_err(|error| error.to_string())?;
+    }
+    Ok(())
 }
 
 fn hotkey_ready_event(shortcut: &DictationShortcutSetting) -> serde_json::Value {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1,0 +1,1074 @@
+use crate::domain::types::AppError;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{
+    ffi::c_void,
+    fs,
+    io::{BufRead, BufReader, Write},
+    path::PathBuf,
+    process::{Child, ChildStdin, Command, Stdio},
+    ptr,
+    sync::Mutex,
+    thread,
+};
+use tauri::{AppHandle, Emitter, Manager, State};
+
+pub struct HelperProcess {
+    child: Child,
+    stdin: ChildStdin,
+}
+
+pub struct HelperState {
+    process: Mutex<Option<HelperProcess>>,
+}
+
+pub struct LastDictationEvent {
+    event: Mutex<Option<String>>,
+}
+
+pub struct DictationSettingsState {
+    path: PathBuf,
+    settings: Mutex<DictationSettings>,
+}
+
+pub struct HotkeyStatus {
+    event: Mutex<serde_json::Value>,
+}
+
+#[cfg(target_os = "macos")]
+pub struct HotkeyManager {
+    hotkeys: Mutex<Option<carbon_hotkeys::CarbonHotkeys>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationSettings {
+    pub shortcut: DictationShortcutSetting,
+    pub microphone: DictationMicrophoneSetting,
+}
+
+impl Default for DictationSettings {
+    fn default() -> Self {
+        Self {
+            shortcut: DictationShortcutSetting::fn_space(),
+            microphone: DictationMicrophoneSetting::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationShortcutSetting {
+    pub key_code: u32,
+    pub code: String,
+    pub modifiers: DictationShortcutModifiers,
+    pub label: String,
+}
+
+impl<'de> Deserialize<'de> for DictationShortcutSetting {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct ShortcutSettingValue {
+            key_code: u32,
+            code: String,
+            modifiers: DictationShortcutModifiers,
+            label: String,
+        }
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if let Some(shortcut) = value.as_str() {
+            return DictationShortcutPreset::from_id(shortcut)
+                .map(DictationShortcutSetting::from)
+                .ok_or_else(|| serde::de::Error::custom("unknown shortcut preset"));
+        }
+
+        let shortcut: ShortcutSettingValue =
+            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            key_code: shortcut.key_code,
+            code: shortcut.code,
+            modifiers: shortcut.modifiers,
+            label: shortcut.label,
+        })
+    }
+}
+
+impl DictationShortcutSetting {
+    fn fn_space() -> Self {
+        DictationShortcutPreset::FnSpace.into()
+    }
+
+    fn control_option_space() -> Self {
+        DictationShortcutPreset::ControlOptionSpace.into()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationShortcutModifiers {
+    pub command: bool,
+    pub control: bool,
+    pub option: bool,
+    pub shift: bool,
+    pub function: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationShortcutInput {
+    pub code: String,
+    pub modifiers: DictationShortcutModifiers,
+    pub label: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DictationShortcutPreset {
+    FnSpace,
+    ControlOptionSpace,
+}
+
+impl DictationShortcutPreset {
+    fn from_id(id: &str) -> Option<Self> {
+        match id {
+            "fn_space" => Some(Self::FnSpace),
+            "control_option_space" => Some(Self::ControlOptionSpace),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::FnSpace => "Fn+Space",
+            Self::ControlOptionSpace => "Ctrl+Opt+Space",
+        }
+    }
+}
+
+impl From<DictationShortcutPreset> for DictationShortcutSetting {
+    fn from(shortcut: DictationShortcutPreset) -> Self {
+        match shortcut {
+            DictationShortcutPreset::FnSpace => Self {
+                key_code: 0x31,
+                code: "Space".to_string(),
+                modifiers: DictationShortcutModifiers {
+                    function: true,
+                    ..DictationShortcutModifiers::default()
+                },
+                label: shortcut.label().to_string(),
+            },
+            DictationShortcutPreset::ControlOptionSpace => Self {
+                key_code: 0x31,
+                code: "Space".to_string(),
+                modifiers: DictationShortcutModifiers {
+                    control: true,
+                    option: true,
+                    ..DictationShortcutModifiers::default()
+                },
+                label: shortcut.label().to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationMicrophoneSetting {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationSettingsResponse {
+    pub settings: DictationSettings,
+}
+
+impl DictationShortcutInput {
+    fn into_setting(self) -> Result<DictationShortcutSetting, AppError> {
+        if self.code.trim().is_empty() || self.label.trim().is_empty() {
+            return Err(AppError::new(
+                "dictation_shortcut_incomplete",
+                "Shortcut is incomplete.",
+            ));
+        }
+
+        let key_code = key_code_for_code(&self.code).ok_or_else(|| {
+            AppError::new(
+                "dictation_shortcut_unsupported",
+                "Shortcut key is not supported.",
+            )
+        })?;
+
+        let has_modifier = self.modifiers.command
+            || self.modifiers.control
+            || self.modifiers.option
+            || self.modifiers.shift
+            || self.modifiers.function;
+        if !has_modifier {
+            return Err(AppError::new(
+                "dictation_shortcut_modifier_required",
+                "Shortcut must include at least one modifier key.",
+            ));
+        }
+
+        Ok(DictationShortcutSetting {
+            key_code,
+            code: self.code,
+            modifiers: self.modifiers,
+            label: self.label,
+        })
+    }
+}
+
+pub fn setup(app: &mut tauri::App) {
+    manage_settings(app.handle());
+    app.manage(LastDictationEvent {
+        event: Mutex::new(None),
+    });
+
+    let helper = spawn_helper(app.handle()).ok();
+    app.manage(HelperState {
+        process: Mutex::new(helper),
+    });
+
+    {
+        let settings = app.state::<DictationSettingsState>();
+        let helper_state = app.state::<HelperState>();
+        let microphone = settings
+            .settings
+            .lock()
+            .ok()
+            .map(|settings| settings.microphone.clone());
+        if let Some(microphone) = microphone {
+            let _ = apply_microphone_setting(&helper_state, &microphone);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        app.manage(HotkeyManager {
+            hotkeys: Mutex::new(None),
+        });
+
+        let settings = app.state::<DictationSettingsState>();
+        let shortcut = settings
+            .settings
+            .lock()
+            .map(|settings| settings.shortcut.clone())
+            .unwrap_or_else(|_| DictationShortcutSetting::fn_space());
+        let hotkeys = carbon_hotkeys::register(app.handle(), shortcut.clone()).or_else(|error| {
+            if shortcut != DictationShortcutSetting::fn_space() {
+                return Err(error);
+            }
+
+            carbon_hotkeys::register(app.handle(), DictationShortcutSetting::control_option_space())
+                .map(|hotkeys| {
+                    if let Err(settings_error) = update_settings(&settings, |settings| {
+                        settings.shortcut = DictationShortcutSetting::control_option_space();
+                    }) {
+                        let message = format!(
+                            "Could not save fallback shortcut: {}",
+                            settings_error.message
+                        );
+                        eprintln!("{message}");
+                        let _ = app.emit(
+                            "dictation-event",
+                            hotkey_error_event(message).to_string(),
+                        );
+                    }
+                    hotkeys
+                })
+                .map_err(|fallback_error| format!("{error} {fallback_error}"))
+        });
+
+        let event = match hotkeys {
+            Ok(hotkeys) => {
+                let shortcut = hotkeys.shortcut().clone();
+                if let Some(manager) = app.try_state::<HotkeyManager>() {
+                    if let Ok(mut active_hotkeys) = manager.hotkeys.lock() {
+                        *active_hotkeys = Some(hotkeys);
+                    }
+                }
+                hotkey_ready_event(&shortcut)
+            }
+            Err(error) => hotkey_error_event(error),
+        };
+
+        app.manage(HotkeyStatus {
+            event: Mutex::new(event.clone()),
+        });
+        let _ = app.emit("dictation-event", event.to_string());
+    }
+}
+
+#[tauri::command]
+pub fn dictation_settings(
+    state: State<'_, DictationSettingsState>,
+) -> Result<DictationSettingsResponse, AppError> {
+    let settings = state
+        .settings
+        .lock()
+        .map_err(|_| AppError::new("dictation_settings_unavailable", "Settings lock failed."))?
+        .clone();
+    Ok(DictationSettingsResponse { settings })
+}
+
+#[tauri::command]
+#[cfg(target_os = "macos")]
+pub fn set_dictation_shortcut(
+    app: AppHandle,
+    state: State<'_, DictationSettingsState>,
+    hotkey_manager: State<'_, HotkeyManager>,
+    hotkey_status: State<'_, HotkeyStatus>,
+    shortcut: DictationShortcutInput,
+) -> Result<DictationSettings, AppError> {
+    let shortcut = shortcut.into_setting()?;
+    let current_settings = state
+        .settings
+        .lock()
+        .map_err(|_| AppError::new("dictation_settings_unavailable", "Settings lock failed."))?
+        .clone();
+
+    if current_settings.shortcut == shortcut {
+        set_hotkey_status(&hotkey_status, hotkey_ready_event(&shortcut));
+        return Ok(current_settings);
+    }
+
+    let next_hotkeys = carbon_hotkeys::register(&app, shortcut.clone()).map_err(|error| {
+        AppError::new("dictation_hotkey_registration_failed", error.to_string())
+    })?;
+    let settings = update_settings(&state, |settings| {
+        settings.shortcut = shortcut;
+    })?;
+
+    {
+        let mut active_hotkeys = hotkey_manager
+            .hotkeys
+            .lock()
+            .map_err(|_| AppError::new("dictation_hotkey_unavailable", "Hotkey lock failed."))?;
+        *active_hotkeys = Some(next_hotkeys);
+    }
+
+    set_hotkey_status(&hotkey_status, hotkey_ready_event(&settings.shortcut));
+    Ok(settings)
+}
+
+#[tauri::command]
+pub fn set_dictation_microphone(
+    state: State<'_, DictationSettingsState>,
+    helper_state: State<'_, HelperState>,
+    id: Option<String>,
+    name: Option<String>,
+) -> Result<DictationSettings, AppError> {
+    let settings = update_settings(&state, |settings| {
+        settings.microphone = DictationMicrophoneSetting { id, name };
+    })?;
+    apply_microphone_setting(&helper_state, &settings.microphone)?;
+    Ok(settings)
+}
+
+#[tauri::command]
+pub fn dictation_helper_command(
+    state: State<'_, HelperState>,
+    command: serde_json::Value,
+) -> Result<(), AppError> {
+    send_helper_command(&state, command)
+}
+
+#[tauri::command]
+pub fn dictation_hotkey_status(state: State<'_, HotkeyStatus>) -> serde_json::Value {
+    state
+        .event
+        .lock()
+        .map(|event| event.clone())
+        .unwrap_or_else(|_| hotkey_error_event("Hotkey status lock was poisoned.".to_string()))
+}
+
+#[tauri::command]
+pub fn latest_dictation_event(state: State<'_, LastDictationEvent>) -> Option<String> {
+    state.event.lock().ok().and_then(|event| event.clone())
+}
+
+pub fn stop_helper(app: &AppHandle) {
+    let state = app.state::<HelperState>();
+    let Ok(mut guard) = state.process.lock() else {
+        return;
+    };
+    let Some(mut process) = guard.take() else {
+        return;
+    };
+
+    let _ = process.stdin.write_all(b"{\"type\":\"shutdown\"}\n");
+    let _ = process.stdin.flush();
+    let _ = process.child.kill();
+    let _ = process.child.wait();
+}
+
+fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Result<(), AppError> {
+    let mut guard = state
+        .process
+        .lock()
+        .map_err(|_| AppError::new("dictation_helper_unavailable", "Helper lock failed."))?;
+    let process = guard.as_mut().ok_or_else(|| {
+        AppError::new(
+            "dictation_helper_unavailable",
+            "Dictation helper process is not running.",
+        )
+    })?;
+    let mut line = serde_json::to_string(&command)
+        .map_err(|error| AppError::new("dictation_helper_command_invalid", error.to_string()))?;
+    line.push('\n');
+    process
+        .stdin
+        .write_all(line.as_bytes())
+        .map_err(|error| AppError::new("dictation_helper_write_failed", error.to_string()))?;
+    process
+        .stdin
+        .flush()
+        .map_err(|error| AppError::new("dictation_helper_write_failed", error.to_string()))
+}
+
+fn apply_microphone_setting(
+    helper_state: &HelperState,
+    microphone: &DictationMicrophoneSetting,
+) -> Result<(), AppError> {
+    send_helper_command(
+        helper_state,
+        serde_json::json!({
+            "type": "set_microphone",
+            "id": microphone.id,
+            "name": microphone.name,
+        }),
+    )
+}
+
+fn settings_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|directory| directory.join("dictation-settings.json"))
+}
+
+fn manage_settings(app: &AppHandle) {
+    let path = settings_path(app).unwrap_or_else(|| PathBuf::from("dictation-settings.json"));
+    let settings = load_settings(app);
+    app.manage(DictationSettingsState {
+        path,
+        settings: Mutex::new(settings),
+    });
+}
+
+fn load_settings(app: &AppHandle) -> DictationSettings {
+    let Some(path) = settings_path(app) else {
+        return DictationSettings::default();
+    };
+
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|settings| serde_json::from_str::<DictationSettings>(&settings).ok())
+        .unwrap_or_default()
+}
+
+fn update_settings(
+    state: &DictationSettingsState,
+    update: impl FnOnce(&mut DictationSettings),
+) -> Result<DictationSettings, AppError> {
+    let mut settings = state
+        .settings
+        .lock()
+        .map_err(|_| AppError::new("dictation_settings_unavailable", "Settings lock failed."))?;
+    update(&mut settings);
+    save_settings(state, &settings)?;
+    Ok(settings.clone())
+}
+
+fn save_settings(
+    state: &DictationSettingsState,
+    settings: &DictationSettings,
+) -> Result<(), AppError> {
+    if let Some(parent) = state.path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| AppError::new("dictation_settings_save_failed", error.to_string()))?;
+    }
+
+    let serialized = serde_json::to_string_pretty(settings)
+        .map_err(|error| AppError::new("dictation_settings_save_failed", error.to_string()))?;
+    fs::write(&state.path, serialized)
+        .map_err(|error| AppError::new("dictation_settings_save_failed", error.to_string()))
+}
+
+fn helper_candidates(app: &AppHandle) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        let manifest_dir = PathBuf::from(manifest_dir);
+        if let Some(repo_dir) = manifest_dir.parent() {
+            paths.push(
+                repo_dir
+                    .join(".tauri-helper")
+                    .join("OS Scribe Dictation Helper.app")
+                    .join("Contents")
+                    .join("MacOS")
+                    .join("os-scribe-dictation-helper"),
+            );
+        }
+    }
+
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            paths.push(exe_dir.join("os-scribe-dictation-helper"));
+            paths.push(exe_dir.join("../Resources/os-scribe-dictation-helper"));
+        }
+    }
+
+    if let Ok(resource_dir) = app.path().resource_dir() {
+        paths.push(resource_dir.join("os-scribe-dictation-helper"));
+        paths.push(
+            resource_dir
+                .join("native")
+                .join("bin")
+                .join("OS Scribe Dictation Helper.app")
+                .join("Contents")
+                .join("MacOS")
+                .join("os-scribe-dictation-helper"),
+        );
+        paths.push(
+            resource_dir
+                .join("OS Scribe Dictation Helper.app")
+                .join("Contents")
+                .join("MacOS")
+                .join("os-scribe-dictation-helper"),
+        );
+    }
+
+    paths
+}
+
+fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
+    let helper_path = helper_candidates(app)
+        .into_iter()
+        .find(|path| path.exists())
+        .ok_or_else(|| {
+            AppError::new(
+                "dictation_helper_missing",
+                "Could not find bundled dictation helper binary.",
+            )
+        })?;
+
+    let mut child = Command::new(&helper_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            AppError::new(
+                "dictation_helper_start_failed",
+                format!("Failed to start helper at {}: {error}", helper_path.display()),
+            )
+        })?;
+
+    let stdin = child.stdin.take().ok_or_else(|| {
+        AppError::new("dictation_helper_start_failed", "Helper stdin was unavailable.")
+    })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        AppError::new(
+            "dictation_helper_start_failed",
+            "Helper stdout was unavailable.",
+        )
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        AppError::new(
+            "dictation_helper_start_failed",
+            "Helper stderr was unavailable.",
+        )
+    })?;
+
+    let output_app = app.clone();
+    thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            handle_helper_event_line(&output_app, line);
+        }
+    });
+
+    let error_app = app.clone();
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().map_while(Result::ok) {
+            let _ = error_app.emit("dictation-helper-stderr", line);
+        }
+    });
+
+    Ok(HelperProcess { child, stdin })
+}
+
+fn handle_helper_event_line(app: &AppHandle, line: String) {
+    let event = serde_json::from_str::<serde_json::Value>(&line).ok();
+    let event_type = event
+        .as_ref()
+        .and_then(|event| event.get("type"))
+        .and_then(serde_json::Value::as_str);
+
+    if let Some(state) = app.try_state::<LastDictationEvent>() {
+        if let Ok(mut event) = state.event.lock() {
+            match dictation_event_visibility(event_type) {
+                DictationEventVisibility::Show => *event = Some(line.clone()),
+                DictationEventVisibility::Hide => *event = None,
+                DictationEventVisibility::Ignore => {}
+            }
+        }
+    }
+
+    let _ = app.emit("dictation-event", line);
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DictationEventVisibility {
+    Show,
+    Hide,
+    Ignore,
+}
+
+fn dictation_event_visibility(event_type: Option<&str>) -> DictationEventVisibility {
+    match event_type {
+        Some(
+            "listening_started"
+            | "audio_level"
+            | "finalizing_transcript"
+            | "final_transcript"
+            | "paste_target",
+        ) => DictationEventVisibility::Show,
+        Some("paste_completed" | "error" | "shutdown_ack") => DictationEventVisibility::Hide,
+        _ => DictationEventVisibility::Ignore,
+    }
+}
+
+fn hotkey_ready_event(shortcut: &DictationShortcutSetting) -> serde_json::Value {
+    serde_json::json!({
+        "type": "hotkey_trigger_ready",
+        "payload": {
+            "shortcut": shortcut.label,
+            "shortcuts": shortcut.label,
+        },
+    })
+}
+
+fn hotkey_error_event(error: String) -> serde_json::Value {
+    serde_json::json!({
+        "type": "error",
+        "payload": {
+            "code": "hotkey_registration_failed",
+            "message": error,
+        },
+    })
+}
+
+fn set_hotkey_status(state: &HotkeyStatus, event: serde_json::Value) {
+    if let Ok(mut status) = state.event.lock() {
+        *status = event;
+    }
+}
+
+pub fn key_code_for_code(code: &str) -> Option<u32> {
+    Some(match code {
+        "KeyA" => 0x00,
+        "KeyS" => 0x01,
+        "KeyD" => 0x02,
+        "KeyF" => 0x03,
+        "KeyH" => 0x04,
+        "KeyG" => 0x05,
+        "KeyZ" => 0x06,
+        "KeyX" => 0x07,
+        "KeyC" => 0x08,
+        "KeyV" => 0x09,
+        "KeyB" => 0x0b,
+        "KeyQ" => 0x0c,
+        "KeyW" => 0x0d,
+        "KeyE" => 0x0e,
+        "KeyR" => 0x0f,
+        "KeyY" => 0x10,
+        "KeyT" => 0x11,
+        "Digit1" => 0x12,
+        "Digit2" => 0x13,
+        "Digit3" => 0x14,
+        "Digit4" => 0x15,
+        "Digit6" => 0x16,
+        "Digit5" => 0x17,
+        "Equal" => 0x18,
+        "Digit9" => 0x19,
+        "Digit7" => 0x1a,
+        "Minus" => 0x1b,
+        "Digit8" => 0x1c,
+        "Digit0" => 0x1d,
+        "BracketRight" => 0x1e,
+        "KeyO" => 0x1f,
+        "KeyU" => 0x20,
+        "BracketLeft" => 0x21,
+        "KeyI" => 0x22,
+        "KeyP" => 0x23,
+        "Enter" => 0x24,
+        "KeyL" => 0x25,
+        "KeyJ" => 0x26,
+        "Quote" => 0x27,
+        "KeyK" => 0x28,
+        "Semicolon" => 0x29,
+        "Backslash" => 0x2a,
+        "Comma" => 0x2b,
+        "Slash" => 0x2c,
+        "KeyN" => 0x2d,
+        "KeyM" => 0x2e,
+        "Period" => 0x2f,
+        "Tab" => 0x30,
+        "Space" => 0x31,
+        "Backquote" => 0x32,
+        "Backspace" => 0x33,
+        "Escape" => 0x35,
+        "F1" => 0x7a,
+        "ArrowLeft" => 0x7b,
+        "ArrowRight" => 0x7c,
+        "ArrowDown" => 0x7d,
+        "ArrowUp" => 0x7e,
+        _ => return None,
+    })
+}
+
+#[cfg(target_os = "macos")]
+mod carbon_hotkeys {
+    use super::*;
+
+    type OSStatus = i32;
+    type OSType = u32;
+    type EventHandlerCallRef = *mut c_void;
+    type EventRef = *mut c_void;
+    type EventHandlerRef = *mut c_void;
+    type EventHotKeyRef = *mut c_void;
+    type EventTargetRef = *mut c_void;
+    type EventHandlerUPP = extern "C" fn(EventHandlerCallRef, EventRef, *mut c_void) -> OSStatus;
+
+    const NO_ERR: OSStatus = 0;
+    const K_EVENT_CLASS_KEYBOARD: OSType = four_char_code(*b"keyb");
+    const K_EVENT_HOT_KEY_PRESSED: u32 = 5;
+    const K_EVENT_PARAM_DIRECT_OBJECT: OSType = four_char_code(*b"----");
+    const TYPE_EVENT_HOT_KEY_ID: OSType = four_char_code(*b"hkid");
+    const COMMAND_KEY: u32 = 1 << 8;
+    const SHIFT_KEY: u32 = 1 << 9;
+    const OPTION_KEY: u32 = 1 << 11;
+    const CONTROL_KEY: u32 = 1 << 12;
+    const FN_KEY: u32 = 1 << 17;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct EventTypeSpec {
+        event_class: OSType,
+        event_kind: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    struct EventHotKeyID {
+        signature: OSType,
+        id: u32,
+    }
+
+    #[link(name = "Carbon", kind = "framework")]
+    extern "C" {
+        fn GetApplicationEventTarget() -> EventTargetRef;
+        fn InstallEventHandler(
+            target: EventTargetRef,
+            handler: EventHandlerUPP,
+            num_types: u32,
+            list: *const EventTypeSpec,
+            user_data: *mut c_void,
+            out_ref: *mut EventHandlerRef,
+        ) -> OSStatus;
+        fn RemoveEventHandler(handler_ref: EventHandlerRef) -> OSStatus;
+        fn RegisterEventHotKey(
+            key_code: u32,
+            modifiers: u32,
+            hot_key_id: EventHotKeyID,
+            target: EventTargetRef,
+            options: u32,
+            out_ref: *mut EventHotKeyRef,
+        ) -> OSStatus;
+        fn UnregisterEventHotKey(hot_key_ref: EventHotKeyRef) -> OSStatus;
+        fn GetEventParameter(
+            event: EventRef,
+            name: OSType,
+            desired_type: OSType,
+            actual_type: *mut OSType,
+            buffer_size: usize,
+            actual_size: *mut usize,
+            out_data: *mut c_void,
+        ) -> OSStatus;
+    }
+
+    pub struct CarbonHotkeys {
+        handler_ref: EventHandlerRef,
+        hotkey_refs: Vec<EventHotKeyRef>,
+        shortcut: DictationShortcutSetting,
+        controller: *mut HotkeyController,
+    }
+
+    unsafe impl Send for CarbonHotkeys {}
+    unsafe impl Sync for CarbonHotkeys {}
+
+    struct HotkeyController {
+        app: AppHandle,
+        shortcut_label: String,
+    }
+
+    pub fn register(
+        app: &AppHandle,
+        shortcut: DictationShortcutSetting,
+    ) -> Result<CarbonHotkeys, String> {
+        let controller = Box::into_raw(Box::new(HotkeyController {
+            app: app.clone(),
+            shortcut_label: shortcut.label.clone(),
+        }));
+        let mut handler_ref = ptr::null_mut();
+        let event_type = EventTypeSpec {
+            event_class: K_EVENT_CLASS_KEYBOARD,
+            event_kind: K_EVENT_HOT_KEY_PRESSED,
+        };
+
+        let handler_status = unsafe {
+            InstallEventHandler(
+                GetApplicationEventTarget(),
+                hotkey_handler,
+                1,
+                &event_type,
+                controller.cast(),
+                &mut handler_ref,
+            )
+        };
+
+        if handler_status != NO_ERR {
+            unsafe {
+                drop(Box::from_raw(controller));
+            }
+            return Err(format!(
+                "Could not install Carbon hotkey handler (OSStatus {handler_status})."
+            ));
+        }
+
+        let mut hotkey_refs = Vec::new();
+        if let Err(error) = register_hotkey(&shortcut, &mut hotkey_refs) {
+            unsafe {
+                RemoveEventHandler(handler_ref);
+                drop(Box::from_raw(controller));
+            }
+            return Err(error);
+        }
+
+        Ok(CarbonHotkeys {
+            handler_ref,
+            hotkey_refs,
+            shortcut,
+            controller,
+        })
+    }
+
+    impl CarbonHotkeys {
+        pub fn shortcut(&self) -> &DictationShortcutSetting {
+            &self.shortcut
+        }
+    }
+
+    fn register_hotkey(
+        shortcut: &DictationShortcutSetting,
+        hotkey_refs: &mut Vec<EventHotKeyRef>,
+    ) -> Result<(), String> {
+        let mut hotkey_ref = ptr::null_mut();
+        let status = unsafe {
+            RegisterEventHotKey(
+                shortcut.key_code,
+                modifier_mask(&shortcut.modifiers),
+                EventHotKeyID {
+                    signature: four_char_code(*b"OSSD"),
+                    id: 1,
+                },
+                GetApplicationEventTarget(),
+                0,
+                &mut hotkey_ref,
+            )
+        };
+
+        if status != NO_ERR {
+            return Err(format!(
+                "Could not register {} (OSStatus {status}).",
+                shortcut.label
+            ));
+        }
+
+        hotkey_refs.push(hotkey_ref);
+        Ok(())
+    }
+
+    fn modifier_mask(modifiers: &DictationShortcutModifiers) -> u32 {
+        let mut mask = 0;
+        if modifiers.command {
+            mask |= COMMAND_KEY;
+        }
+        if modifiers.shift {
+            mask |= SHIFT_KEY;
+        }
+        if modifiers.option {
+            mask |= OPTION_KEY;
+        }
+        if modifiers.control {
+            mask |= CONTROL_KEY;
+        }
+        if modifiers.function {
+            mask |= FN_KEY;
+        }
+        mask
+    }
+
+    extern "C" fn hotkey_handler(
+        _next_handler: EventHandlerCallRef,
+        event: EventRef,
+        user_data: *mut c_void,
+    ) -> OSStatus {
+        if event.is_null() || user_data.is_null() {
+            return NO_ERR;
+        }
+
+        let controller = unsafe { &*(user_data.cast::<HotkeyController>()) };
+        if is_registered_hotkey_event(event) {
+            let state = controller.app.state::<HelperState>();
+            if let Err(error) = send_helper_command(
+                &state,
+                serde_json::json!({
+                    "type": "toggle_listening",
+                    "shortcut": controller.shortcut_label,
+                }),
+            ) {
+                let _ = controller.app.emit(
+                    "dictation-event",
+                    serde_json::json!({
+                        "type": "error",
+                        "payload": {
+                            "code": error.code,
+                            "message": error.message,
+                        },
+                    })
+                    .to_string(),
+                );
+            }
+        }
+
+        NO_ERR
+    }
+
+    fn is_registered_hotkey_event(event: EventRef) -> bool {
+        let mut hotkey_id = EventHotKeyID::default();
+        let status = unsafe {
+            GetEventParameter(
+                event,
+                K_EVENT_PARAM_DIRECT_OBJECT,
+                TYPE_EVENT_HOT_KEY_ID,
+                ptr::null_mut(),
+                std::mem::size_of::<EventHotKeyID>(),
+                ptr::null_mut(),
+                (&mut hotkey_id as *mut EventHotKeyID).cast(),
+            )
+        };
+
+        if status != NO_ERR {
+            return false;
+        }
+
+        hotkey_id.id == 1
+    }
+
+    impl Drop for CarbonHotkeys {
+        fn drop(&mut self) {
+            for hotkey_ref in self.hotkey_refs.drain(..) {
+                if !hotkey_ref.is_null() {
+                    unsafe {
+                        UnregisterEventHotKey(hotkey_ref);
+                    }
+                }
+            }
+
+            if !self.handler_ref.is_null() {
+                unsafe {
+                    RemoveEventHandler(self.handler_ref);
+                }
+            }
+
+            if !self.controller.is_null() {
+                unsafe {
+                    drop(Box::from_raw(self.controller));
+                }
+                self.controller = ptr::null_mut();
+            }
+        }
+    }
+
+    const fn four_char_code(value: [u8; 4]) -> OSType {
+        ((value[0] as OSType) << 24)
+            | ((value[1] as OSType) << 16)
+            | ((value[2] as OSType) << 8)
+            | (value[3] as OSType)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_settings_use_fn_space() {
+        let settings = DictationSettings::default();
+
+        assert_eq!(settings.shortcut.label, "Fn+Space");
+        assert_eq!(settings.shortcut.code, "Space");
+        assert!(settings.shortcut.modifiers.function);
+    }
+
+    #[test]
+    fn deserializes_shortcut_preset() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"shortcut":"control_option_space","microphone":{"id":null,"name":null}}"#,
+        )
+        .expect("preset should deserialize");
+
+        assert_eq!(settings.shortcut.label, "Ctrl+Opt+Space");
+        assert!(settings.shortcut.modifiers.control);
+        assert!(settings.shortcut.modifiers.option);
+    }
+
+    #[test]
+    fn shortcut_input_requires_modifier() {
+        let err = DictationShortcutInput {
+            code: "KeyT".to_string(),
+            modifiers: DictationShortcutModifiers::default(),
+            label: "T".to_string(),
+        }
+        .into_setting()
+        .expect_err("shortcut without modifiers should fail");
+
+        assert_eq!(err.code, "dictation_shortcut_modifier_required");
+    }
+
+    #[test]
+    fn shortcut_input_rejects_unsupported_key() {
+        let err = DictationShortcutInput {
+            code: "NumpadEnter".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+NumpadEnter".to_string(),
+        }
+        .into_setting()
+        .expect_err("unsupported key should fail");
+
+        assert_eq!(err.code, "dictation_shortcut_unsupported");
+    }
+}

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1,4 +1,8 @@
 use crate::domain::types::AppError;
+use crate::providers::{
+    configured_provider,
+    transcription::{transcribe_saved_audio, TranscriptionProviderResult, TranscriptionRequest},
+};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{
     ffi::c_void,
@@ -613,17 +617,117 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
         .and_then(|event| event.get("type"))
         .and_then(serde_json::Value::as_str);
 
+    if matches!(event_type, Some("recording_ready")) {
+        if let Some(event) = event.as_ref() {
+            match recording_path_from_event(event) {
+                Ok(audio_path) => {
+                    let app = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        transcribe_recording_ready(app, audio_path).await;
+                    });
+                }
+                Err(error) => {
+                    let state = app.state::<HelperState>();
+                    let _ = send_helper_command(
+                        &state,
+                        serde_json::json!({ "type": "discard_recording" }),
+                    );
+                    emit_dictation_event_value(app, app_error_event(error));
+                }
+            }
+        }
+    }
+
+    update_latest_event(app, event_type, Some(line.clone()));
+    let _ = app.emit("dictation-event", line);
+}
+
+async fn transcribe_recording_ready(app: AppHandle, audio_path: PathBuf) {
+    let result = transcribe_saved_audio(TranscriptionRequest {
+        provider: configured_provider(),
+        audio_path,
+        title: "Dictation".to_string(),
+        context: None,
+    })
+    .await;
+    let outcome = outcome_from_transcription_result(result);
+    let state = app.state::<HelperState>();
+    if let Err(error) = send_helper_command(&state, outcome.helper_command) {
+        emit_dictation_event_value(&app, app_error_event(error));
+        return;
+    }
+    if let Some(event) = outcome.event {
+        emit_dictation_event_value(&app, event);
+    }
+}
+
+fn recording_path_from_event(event: &serde_json::Value) -> Result<PathBuf, AppError> {
+    let path = event
+        .get("payload")
+        .and_then(|payload| payload.get("path"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| {
+            AppError::new(
+                "dictation_recording_path_missing",
+                "Dictation helper did not provide a recording path.",
+            )
+        })?;
+    Ok(PathBuf::from(path))
+}
+
+#[derive(Debug)]
+struct DictationTranscriptionOutcome {
+    helper_command: serde_json::Value,
+    event: Option<serde_json::Value>,
+}
+
+fn outcome_from_transcription_result(
+    result: Result<TranscriptionProviderResult, AppError>,
+) -> DictationTranscriptionOutcome {
+    match result {
+        Ok(transcript) => DictationTranscriptionOutcome {
+            helper_command: serde_json::json!({
+                "type": "paste_text",
+                "text": transcript.text,
+            }),
+            event: None,
+        },
+        Err(error) => DictationTranscriptionOutcome {
+            helper_command: serde_json::json!({ "type": "discard_recording" }),
+            event: Some(app_error_event(error)),
+        },
+    }
+}
+
+fn app_error_event(error: AppError) -> serde_json::Value {
+    serde_json::json!({
+        "type": "error",
+        "payload": {
+            "code": error.code,
+            "message": error.message,
+        },
+    })
+}
+
+fn emit_dictation_event_value(app: &AppHandle, event: serde_json::Value) {
+    let event_type = event.get("type").and_then(serde_json::Value::as_str);
+    let line = event.to_string();
+    update_latest_event(app, event_type, Some(line.clone()));
+    let _ = app.emit("dictation-event", line);
+}
+
+fn update_latest_event(app: &AppHandle, event_type: Option<&str>, line: Option<String>) {
     if let Some(state) = app.try_state::<LastDictationEvent>() {
         if let Ok(mut event) = state.event.lock() {
             match dictation_event_visibility(event_type) {
-                DictationEventVisibility::Show => *event = Some(line.clone()),
+                DictationEventVisibility::Show => *event = line,
                 DictationEventVisibility::Hide => *event = None,
                 DictationEventVisibility::Ignore => {}
             }
         }
     }
-
-    let _ = app.emit("dictation-event", line);
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1070,5 +1174,46 @@ mod tests {
         .expect_err("unsupported key should fail");
 
         assert_eq!(err.code, "dictation_shortcut_unsupported");
+    }
+
+    #[test]
+    fn successful_transcription_maps_to_paste_command() {
+        let outcome = outcome_from_transcription_result(Ok(TranscriptionProviderResult {
+            text: "Paste this transcript.".to_string(),
+            language: Some("en".to_string()),
+            provider: "mock".to_string(),
+        }));
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({
+                "type": "paste_text",
+                "text": "Paste this transcript.",
+            })
+        );
+        assert!(outcome.event.is_none());
+    }
+
+    #[test]
+    fn failed_transcription_maps_to_discard_and_error() {
+        let outcome = outcome_from_transcription_result(Err(AppError::new(
+            "transcription_failed",
+            "The provider failed.",
+        )));
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({ "type": "discard_recording" })
+        );
+        assert_eq!(
+            outcome.event,
+            Some(serde_json::json!({
+                "type": "error",
+                "payload": {
+                    "code": "transcription_failed",
+                    "message": "The provider failed.",
+                },
+            }))
+        );
     }
 }

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1,6 +1,6 @@
 use crate::domain::types::AppError;
 use crate::providers::{
-    configured_provider,
+    configured_provider, MOCK_PROVIDER,
     transcription::{transcribe_saved_audio, TranscriptionProviderResult, TranscriptionRequest},
 };
 use serde::{Deserialize, Deserializer, Serialize};
@@ -648,8 +648,20 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
 }
 
 async fn transcribe_recording_ready(app: AppHandle, audio_path: PathBuf) {
+    let provider = match dictation_transcription_provider(configured_provider()) {
+        Ok(provider) => provider,
+        Err(error) => {
+            let state = app.state::<HelperState>();
+            let _ = send_helper_command(
+                &state,
+                serde_json::json!({ "type": "discard_recording" }),
+            );
+            emit_dictation_event_value(&app, app_error_event(error));
+            return;
+        }
+    };
     let result = transcribe_saved_audio(TranscriptionRequest {
-        provider: configured_provider(),
+        provider,
         audio_path,
         title: "Dictation".to_string(),
         context: None,
@@ -664,6 +676,16 @@ async fn transcribe_recording_ready(app: AppHandle, audio_path: PathBuf) {
     if let Some(event) = outcome.event {
         emit_dictation_event_value(&app, event);
     }
+}
+
+fn dictation_transcription_provider(provider: String) -> Result<String, AppError> {
+    if provider == MOCK_PROVIDER {
+        return Err(AppError::new(
+            "dictation_provider_not_configured",
+            "Dictation requires real transcription. Set OPENAI_API_KEY in .env or in the shell that launches Tauri.",
+        ));
+    }
+    Ok(provider)
 }
 
 fn recording_path_from_event(event: &serde_json::Value) -> Result<PathBuf, AppError> {
@@ -1343,6 +1365,23 @@ mod tests {
                     "message": "The provider failed.",
                 },
             }))
+        );
+    }
+
+    #[test]
+    fn dictation_rejects_mock_provider() {
+        let err = dictation_transcription_provider(MOCK_PROVIDER.to_string())
+            .expect_err("dictation should not paste mock transcripts");
+
+        assert_eq!(err.code, "dictation_provider_not_configured");
+    }
+
+    #[test]
+    fn dictation_accepts_real_provider() {
+        assert_eq!(
+            dictation_transcription_provider(crate::providers::OPENAI_PROVIDER.to_string())
+                .expect("openai should be accepted"),
+            crate::providers::OPENAI_PROVIDER
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,11 +2,13 @@ pub mod app_paths;
 pub mod audio;
 pub mod commands;
 pub mod db;
+pub mod dictation;
 pub mod domain;
 pub mod providers;
 
 pub fn run() {
     providers::load_local_env();
+    let context = tauri::generate_context!();
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap_app,
@@ -28,8 +30,23 @@ pub fn run() {
             commands::get_recording_status,
             commands::finish_recording,
             commands::retry_processing,
-            commands::recover_recording
+            commands::recover_recording,
+            dictation::dictation_settings,
+            dictation::set_dictation_shortcut,
+            dictation::set_dictation_microphone,
+            dictation::dictation_helper_command,
+            dictation::dictation_hotkey_status,
+            dictation::latest_dictation_event
         ])
-        .run(tauri::generate_context!())
-        .expect("failed to run OS Notetaker");
+        .setup(|app| {
+            dictation::setup(app);
+            Ok(())
+        })
+        .build(context)
+        .expect("failed to build OS Notetaker")
+        .run(|app, event| {
+            if matches!(event, tauri::RunEvent::Exit) {
+                dictation::stop_helper(app);
+            }
+        });
 }

--- a/src-tauri/src/providers/transcription.rs
+++ b/src-tauri/src/providers/transcription.rs
@@ -1,7 +1,7 @@
 use crate::domain::types::AppError;
 use reqwest::multipart::{Form, Part};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub const DEFAULT_TRANSCRIPTION_PROVIDER: &str = "mock";
 const DEFAULT_OPENAI_TRANSCRIPTION_MODEL: &str = "gpt-4o-mini-transcribe";
@@ -86,7 +86,7 @@ async fn transcribe_with_openai(
         .unwrap_or_else(|| DEFAULT_OPENAI_TRANSCRIPTION_MODEL.to_string());
     let audio_part = Part::bytes(audio_bytes)
         .file_name(filename)
-        .mime_str("audio/wav")
+        .mime_str(transcription_audio_mime(&request.audio_path))
         .map_err(|error| AppError::new("provider_request_failed", error.to_string()))?;
     let supports_prompt = !model.contains("diarize");
     let mut form = Form::new()
@@ -137,6 +137,18 @@ async fn transcribe_with_openai(
         language: None,
         provider: crate::providers::OPENAI_PROVIDER.to_string(),
     })
+}
+
+pub fn transcription_audio_mime(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("m4a") | Some("mp4") => "audio/mp4",
+        _ => "audio/wav",
+    }
 }
 
 fn transcription_language_override() -> Option<String> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,8 @@
     ],
     "targets": ["app"],
     "resources": {
-      "../.tauri-helper/OS Notetaker Audio Capture.app": "native/bin/OS Notetaker Audio Capture.app"
+      "../.tauri-helper/OS Notetaker Audio Capture.app": "native/bin/OS Notetaker Audio Capture.app",
+      "../.tauri-helper/OS Scribe Dictation Helper.app": "native/bin/OS Scribe Dictation Helper.app"
     },
     "macOS": {
       "entitlements": "Entitlements.plist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,8 +10,10 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
+        "label": "main",
         "title": "OS Scribe",
         "width": 1180,
         "height": 780,
@@ -20,6 +22,23 @@
         "resizable": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true
+      },
+      {
+        "label": "hud",
+        "url": "/hud.html",
+        "title": "OS Scribe Dictation",
+        "width": 92,
+        "height": 29,
+        "resizable": false,
+        "decorations": false,
+        "transparent": true,
+        "backgroundColor": "#00000000",
+        "alwaysOnTop": true,
+        "visibleOnAllWorkspaces": true,
+        "focusable": false,
+        "skipTaskbar": true,
+        "shadow": false,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -6,7 +6,8 @@ use os_notetaker_lib::{
     providers::{
         generation::{generate_note_from_transcript, GenerationRequest},
         transcription::{
-            normalize_transcription_language, transcribe_saved_audio, TranscriptionRequest,
+            normalize_transcription_language, transcribe_saved_audio, transcription_audio_mime,
+            TranscriptionRequest,
         },
     },
 };
@@ -176,4 +177,11 @@ fn transcription_language_override_rejects_invalid_values() {
     assert_eq!(normalize_transcription_language(""), None);
     assert_eq!(normalize_transcription_language("spanish"), None);
     assert_eq!(normalize_transcription_language("es-ES"), None);
+}
+
+#[test]
+fn transcription_audio_mime_uses_file_extension() {
+    assert_eq!(transcription_audio_mime("recording.wav".as_ref()), "audio/wav");
+    assert_eq!(transcription_audio_mime("dictation.m4a".as_ref()), "audio/mp4");
+    assert_eq!(transcription_audio_mime("dictation.MP4".as_ref()), "audio/mp4");
 }

--- a/src/components/dictation/DictationSettings.tsx
+++ b/src/components/dictation/DictationSettings.tsx
@@ -78,10 +78,7 @@ const KEY_LABELS: Record<string, string> = {
 
 type ShortcutCaptureResult =
   | {
-      shortcut: Pick<
-        DictationShortcutSetting,
-        "code" | "modifiers" | "label"
-      >;
+      shortcut: Pick<DictationShortcutSetting, "code" | "modifiers" | "label">;
       error?: never;
     }
   | { shortcut?: never; error: string };
@@ -209,7 +206,9 @@ export function DictationSettings() {
       const next = await setDictationMicrophone(id, name);
       setSettings(next);
       setMicOpen(false);
-      setStatus(name ? `Microphone set to ${name}.` : "Microphone set to auto-detect.");
+      setStatus(
+        name ? `Microphone set to ${name}.` : "Microphone set to auto-detect.",
+      );
     } catch (error) {
       setStatus(messageFromError(error));
     }
@@ -320,7 +319,10 @@ export function DictationSettings() {
                             aria-selected={selected}
                             data-selected={selected}
                             onClick={() =>
-                              void selectMicrophone(option.id, option.id ? option.name : undefined)
+                              void selectMicrophone(
+                                option.id,
+                                option.id ? option.name : undefined,
+                              )
                             }
                           >
                             <span>{option.name}</span>
@@ -417,7 +419,9 @@ function keyLabel(code: string, key: string) {
   return key.length === 1 ? key.toUpperCase() : code;
 }
 
-function parseDictationEvent(payload: unknown): DictationHelperEvent | undefined {
+function parseDictationEvent(
+  payload: unknown,
+): DictationHelperEvent | undefined {
   try {
     if (typeof payload === "string") {
       return JSON.parse(payload) as DictationHelperEvent;

--- a/src/components/dictation/DictationSettings.tsx
+++ b/src/components/dictation/DictationSettings.tsx
@@ -159,7 +159,7 @@ export function DictationSettings() {
       if (event.repeat) return;
 
       const result = shortcutFromKeyboardEvent(event);
-      if (result.error) {
+      if ("error" in result) {
         setShortcutError(result.error);
         setStatus(result.error);
         return;

--- a/src/components/dictation/DictationSettings.tsx
+++ b/src/components/dictation/DictationSettings.tsx
@@ -247,7 +247,7 @@ export function DictationSettings() {
               <div className="settings-row-info">
                 <h3 className="settings-row-title">Dictate anywhere</h3>
                 <p className="settings-row-description">
-                  Hold this combination from anywhere on your Mac to start
+                  Press this combination from anywhere on your Mac to start
                   dictating.
                 </p>
                 {shortcutError ? (

--- a/src/components/dictation/DictationSettings.tsx
+++ b/src/components/dictation/DictationSettings.tsx
@@ -1,32 +1,133 @@
+import { listen } from "@tauri-apps/api/event";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { useEffect, useRef, useState } from "react";
+import {
+  dictationHelperCommand,
+  dictationHotkeyStatus,
+  dictationSettings,
+  setDictationMicrophone,
+  setDictationShortcut,
+} from "../../lib/tauri";
+import type {
+  DictationHelperEvent,
+  DictationMicrophoneDeviceDto,
+  DictationSettingsDto,
+  DictationShortcutModifiers,
+  DictationShortcutSetting,
+} from "../../lib/tauri";
 
-const MICROPHONE_OPTIONS = [
-  "Auto-detect",
-  "MacBook Pro Microphone",
-  "AirPods Pro",
-  "External USB Mic",
-] as const;
+const DEFAULT_SETTINGS: DictationSettingsDto = {
+  shortcut: {
+    code: "Space",
+    label: "Fn+Space",
+    modifiers: {
+      command: false,
+      control: false,
+      option: false,
+      shift: false,
+      function: true,
+    },
+  },
+  microphone: {},
+};
 
-type MicrophoneOption = (typeof MICROPHONE_OPTIONS)[number];
-
-const MODIFIER_KEYS = new Set([
-  "Meta",
-  "Shift",
-  "Alt",
-  "Control",
-  "OS",
-  "ContextMenu",
+const MODIFIER_CODES = new Set([
+  "AltLeft",
+  "AltRight",
+  "ControlLeft",
+  "ControlRight",
+  "MetaLeft",
+  "MetaRight",
+  "ShiftLeft",
+  "ShiftRight",
 ]);
 
+const KEY_LABELS: Record<string, string> = {
+  Backquote: "`",
+  Backslash: "\\",
+  Backspace: "Delete",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Comma: ",",
+  Digit0: "0",
+  Digit1: "1",
+  Digit2: "2",
+  Digit3: "3",
+  Digit4: "4",
+  Digit5: "5",
+  Digit6: "6",
+  Digit7: "7",
+  Digit8: "8",
+  Digit9: "9",
+  Enter: "Return",
+  Equal: "=",
+  Escape: "Esc",
+  Minus: "-",
+  Period: ".",
+  Quote: "'",
+  Semicolon: ";",
+  Slash: "/",
+  Space: "Space",
+  Tab: "Tab",
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+  ArrowUp: "Up",
+};
+
+type ShortcutCaptureResult =
+  | {
+      shortcut: Pick<
+        DictationShortcutSetting,
+        "code" | "modifiers" | "label"
+      >;
+      error?: never;
+    }
+  | { shortcut?: never; error: string };
+
 export function DictationSettings() {
-  const [shortcut, setShortcut] = useState<string[]>(["⇧", "T"]);
+  const [settings, setSettings] =
+    useState<DictationSettingsDto>(DEFAULT_SETTINGS);
+  const [microphones, setMicrophones] = useState<
+    DictationMicrophoneDeviceDto[]
+  >([]);
   const [capturing, setCapturing] = useState(false);
-  const [microphone, setMicrophone] =
-    useState<MicrophoneOption>("Auto-detect");
+  const [shortcutError, setShortcutError] = useState<string>();
+  const [status, setStatus] = useState<string>();
   const [micOpen, setMicOpen] = useState(false);
   const micWrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    async function boot() {
+      try {
+        const response = await dictationSettings();
+        if (cancelled) return;
+        setSettings(response.settings);
+        const hotkey = await dictationHotkeyStatus();
+        if (!cancelled) handleHelperEvent(hotkey);
+        await requestMicrophones();
+      } catch (error) {
+        if (!cancelled) setStatus(messageFromError(error));
+      }
+    }
+
+    void listen<string>("dictation-event", (event) => {
+      const helperEvent = parseDictationEvent(event.payload);
+      if (helperEvent) handleHelperEvent(helperEvent);
+    }).then((cleanup) => {
+      unlisten = cleanup;
+    });
+    void boot();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
 
   useEffect(() => {
     if (!micOpen) return;
@@ -49,26 +150,82 @@ export function DictationSettings() {
   useEffect(() => {
     if (!capturing) return;
     function onKey(event: KeyboardEvent) {
-      event.preventDefault();
       if (event.key === "Escape") {
         setCapturing(false);
+        setShortcutError(undefined);
         return;
       }
-      // Ignore standalone modifier presses — wait for the trailing key.
-      if (MODIFIER_KEYS.has(event.key)) return;
+      event.preventDefault();
+      if (event.repeat) return;
 
-      const parts: string[] = [];
-      if (event.metaKey) parts.push("⌘");
-      if (event.ctrlKey) parts.push("⌃");
-      if (event.altKey) parts.push("⌥");
-      if (event.shiftKey) parts.push("⇧");
-      parts.push(formatKey(event));
-      setShortcut(parts);
-      setCapturing(false);
+      const result = shortcutFromKeyboardEvent(event);
+      if (result.error) {
+        setShortcutError(result.error);
+        setStatus(result.error);
+        return;
+      }
+
+      setShortcutError(undefined);
+      void saveShortcut(result.shortcut);
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [capturing]);
+
+  async function requestMicrophones() {
+    try {
+      await dictationHelperCommand({ type: "list_microphones" });
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
+
+  function handleHelperEvent(helperEvent: DictationHelperEvent) {
+    if (helperEvent.type === "microphone_devices") {
+      setMicrophones(helperEvent.payload?.devices ?? []);
+      return;
+    }
+    if (helperEvent.type === "error") {
+      setStatus(helperEvent.payload?.message ?? "Dictation helper failed.");
+    }
+  }
+
+  async function saveShortcut(
+    shortcut: Pick<DictationShortcutSetting, "code" | "modifiers" | "label">,
+  ) {
+    try {
+      const next = await setDictationShortcut(shortcut);
+      setSettings(next);
+      setCapturing(false);
+      setStatus(`Shortcut set to ${next.shortcut.label}.`);
+    } catch (error) {
+      setShortcutError(messageFromError(error));
+      setStatus(messageFromError(error));
+    }
+  }
+
+  async function selectMicrophone(id?: string, name?: string) {
+    try {
+      const next = await setDictationMicrophone(id, name);
+      setSettings(next);
+      setMicOpen(false);
+      setStatus(name ? `Microphone set to ${name}.` : "Microphone set to auto-detect.");
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
+
+  const microphoneName = settings.microphone.name ?? "Auto-detect";
+  const microphoneOptions = [
+    { id: undefined, name: "Auto-detect" },
+    ...microphones,
+  ];
+  const selectedMicrophoneIndex = Math.max(
+    0,
+    microphoneOptions.findIndex(
+      (option) => (option.id ?? "") === (settings.microphone.id ?? ""),
+    ),
+  );
 
   return (
     <div className="settings-page">
@@ -78,6 +235,7 @@ export function DictationSettings() {
           Dictate from anywhere on your Mac. Scribe drops the transcript
           wherever your cursor is.
         </p>
+        {status ? <p className="settings-status">{status}</p> : null}
       </header>
 
       <section className="settings-group" aria-labelledby="shortcuts-heading">
@@ -93,13 +251,22 @@ export function DictationSettings() {
                   Hold this combination from anywhere on your Mac to start
                   dictating.
                 </p>
+                {shortcutError ? (
+                  <p className="settings-row-error">{shortcutError}</p>
+                ) : null}
               </div>
               <div className="settings-row-control">
-                <KeycapShortcut keys={shortcut} capturing={capturing} />
+                <KeycapShortcut
+                  label={settings.shortcut.label}
+                  capturing={capturing}
+                />
                 <button
                   type="button"
                   className="btn btn-secondary"
-                  onClick={() => setCapturing((value) => !value)}
+                  onClick={() => {
+                    setShortcutError(undefined);
+                    setCapturing((value) => !value);
+                  }}
                 >
                   {capturing ? "Cancel" : "Change"}
                 </button>
@@ -128,41 +295,35 @@ export function DictationSettings() {
                   className="select-trigger"
                   aria-haspopup="listbox"
                   aria-expanded={micOpen}
-                  onClick={() => setMicOpen((value) => !value)}
+                  onClick={() => {
+                    setMicOpen((value) => !value);
+                    void requestMicrophones();
+                  }}
                 >
-                  <span>{microphone}</span>
+                  <span>{microphoneName}</span>
                   <IconChevronDownSmall size={14} />
                 </button>
                 {micOpen ? (
                   <ul
                     className="select-popover"
                     role="listbox"
-                    style={{
-                      // Slide so the selected item's top sits at the
-                      // trigger top, accounting for the popover's 4px
-                      // (sp-1) inset padding.
-                      top: -(
-                        4 +
-                        Math.max(0, MICROPHONE_OPTIONS.indexOf(microphone)) *
-                          28
-                      ),
-                    }}
+                    style={{ top: -(4 + selectedMicrophoneIndex * 28) }}
                   >
-                    {MICROPHONE_OPTIONS.map((option) => {
-                      const selected = option === microphone;
+                    {microphoneOptions.map((option) => {
+                      const selected =
+                        (option.id ?? "") === (settings.microphone.id ?? "");
                       return (
-                        <li key={option}>
+                        <li key={option.id ?? "auto"}>
                           <button
                             type="button"
                             role="option"
                             aria-selected={selected}
                             data-selected={selected}
-                            onClick={() => {
-                              setMicrophone(option);
-                              setMicOpen(false);
-                            }}
+                            onClick={() =>
+                              void selectMicrophone(option.id, option.id ? option.name : undefined)
+                            }
                           >
-                            <span>{option}</span>
+                            <span>{option.name}</span>
                             <span className="select-check" aria-hidden>
                               {selected ? (
                                 <IconCheckmark1Small size={14} />
@@ -184,10 +345,10 @@ export function DictationSettings() {
 }
 
 function KeycapShortcut({
-  keys,
+  label,
   capturing,
 }: {
-  keys: string[];
+  label: string;
   capturing: boolean;
 }) {
   if (capturing) {
@@ -197,11 +358,9 @@ function KeycapShortcut({
       </span>
     );
   }
+  const keys = label.split("+").filter(Boolean);
   return (
-    <span
-      className="keycap-frame"
-      aria-label={`Shortcut ${keys.join(" ")}`}
-    >
+    <span className="keycap-frame" aria-label={`Shortcut ${label}`}>
       {keys.map((key, idx) => (
         <kbd key={`${key}-${idx}`} className="keycap">
           {key}
@@ -211,23 +370,70 @@ function KeycapShortcut({
   );
 }
 
-function formatKey(event: KeyboardEvent): string {
-  // Prefer event.code so Shift+T renders as "T", Option+T as "T" (not "†"),
-  // etc. Only fall back to event.key for non-letter/number keys.
-  const code = event.code;
-  if (code.startsWith("Key") && code.length === 4) return code.slice(3);
-  if (code.startsWith("Digit") && code.length === 6) return code.slice(5);
+export function shortcutFromKeyboardEvent(
+  event: Pick<
+    KeyboardEvent,
+    "code" | "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+  >,
+): ShortcutCaptureResult {
+  if (MODIFIER_CODES.has(event.code)) {
+    return { error: "Press one non-modifier key with your shortcut." };
+  }
+  if (!event.code) {
+    return { error: "That key is not supported for global shortcuts." };
+  }
 
-  const key = event.key;
-  if (key === " " || code === "Space") return "Space";
-  if (key === "ArrowUp") return "↑";
-  if (key === "ArrowDown") return "↓";
-  if (key === "ArrowLeft") return "←";
-  if (key === "ArrowRight") return "→";
-  if (key === "Enter") return "↩";
-  if (key === "Tab") return "⇥";
-  if (key === "Escape") return "⎋";
-  if (key === "Backspace") return "⌫";
-  if (key.length === 1) return key.toUpperCase();
-  return key;
+  const modifiers: DictationShortcutModifiers = {
+    command: event.metaKey,
+    control: event.ctrlKey,
+    option: event.altKey,
+    shift: event.shiftKey,
+    function: false,
+  };
+  const modifierLabels = [
+    modifiers.command && "Cmd",
+    modifiers.control && "Ctrl",
+    modifiers.option && "Opt",
+    modifiers.shift && "Shift",
+  ].filter(Boolean) as string[];
+
+  if (modifierLabels.length === 0) {
+    return { error: "Shortcut must include Cmd, Ctrl, Opt, or Shift." };
+  }
+
+  return {
+    shortcut: {
+      code: event.code,
+      modifiers,
+      label: [...modifierLabels, keyLabel(event.code, event.key)].join("+"),
+    },
+  };
+}
+
+function keyLabel(code: string, key: string) {
+  if (KEY_LABELS[code]) return KEY_LABELS[code];
+  if (code.startsWith("Key")) return code.slice(3);
+  if (code.startsWith("Digit")) return code.slice(5);
+  return key.length === 1 ? key.toUpperCase() : code;
+}
+
+function parseDictationEvent(payload: unknown): DictationHelperEvent | undefined {
+  try {
+    if (typeof payload === "string") {
+      return JSON.parse(payload) as DictationHelperEvent;
+    }
+    if (payload && typeof payload === "object") {
+      return payload as DictationHelperEvent;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function messageFromError(error: unknown) {
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
 }

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -25,11 +25,6 @@ let smoothedLevel = 0.2;
 
 const idleLevels = [0.22, 0.38, 0.58, 0.78, 0.48, 0.34, 0.2];
 const barWeights = [0.45, 0.64, 0.86, 1, 0.82, 0.58, 0.4];
-const silentErrorCodes = new Set([
-  "no_speech",
-  "no_transcription",
-  "empty_transcript",
-]);
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
@@ -136,22 +131,10 @@ async function handleDictationEventPayload(payload: unknown) {
   }
 
   if (dictationEvent.type === "error") {
-    const errorCode = dictationEvent.payload?.code || "";
     const errorMessage = dictationEvent.payload?.message || "";
-    const isEmptyTranscriptError =
-      silentErrorCodes.has(errorCode) ||
-      errorMessage === "OpenAI did not return any transcript text.";
-
-    if (isEmptyTranscriptError) {
-      setHud("silent-error", "No transcript returned");
-      await showHud();
-      hideSoon(900);
-      return;
-    }
-
-    setHud("error", "Needs attention", errorMessage || "Dictation failed.");
+    setHud("error", errorMessage || "Dictation failed.");
     await showHud();
-    hideSoon(2200);
+    hideSoon(900);
   }
 }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -1,0 +1,182 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import "./styles/hud.css";
+
+type DictationHudEvent = {
+  type: string;
+  payload?: {
+    app?: string;
+    code?: string;
+    message?: string;
+    level?: string;
+    [key: string]: unknown;
+  };
+};
+
+const appWindow = getCurrentWindow();
+const hud = document.querySelector<HTMLDivElement>("#hud");
+const bars = Array.from(document.querySelectorAll<HTMLElement>(".hud-bar"));
+const statusText = document.querySelector<HTMLElement>("#hud-status");
+const transcriptText = document.querySelector<HTMLElement>("#hud-transcript");
+
+let hideTimer: number | undefined;
+let smoothedLevel = 0.2;
+
+const idleLevels = [0.22, 0.38, 0.58, 0.78, 0.48, 0.34, 0.2];
+const barWeights = [0.45, 0.64, 0.86, 1, 0.82, 0.58, 0.4];
+const silentErrorCodes = new Set([
+  "no_speech",
+  "no_transcription",
+  "empty_transcript",
+]);
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function setHud(state: string, status: string, transcript = "") {
+  if (!hud || !statusText || !transcriptText) return;
+  hud.dataset.state = state;
+  statusText.textContent = status;
+  transcriptText.textContent = transcript;
+}
+
+function setBars(levels: number[]) {
+  bars.forEach((bar, index) => {
+    bar.style.setProperty("--level", String(levels[index] ?? 0.2));
+  });
+}
+
+function resetBars() {
+  smoothedLevel = 0.2;
+  setBars(idleLevels);
+}
+
+function renderAudioLevel(rawLevel: number) {
+  const normalizedLevel = clamp(Math.sqrt(rawLevel * 5), 0.08, 1);
+  smoothedLevel = smoothedLevel * 0.55 + normalizedLevel * 0.45;
+  const tick = Date.now() / 170;
+  setBars(
+    barWeights.map((weight, index) => {
+      const motion = Math.sin(tick + index * 0.84) * 0.055;
+      return clamp(0.08 + smoothedLevel * weight + motion, 0.12, 1);
+    }),
+  );
+}
+
+function clearHideTimer() {
+  if (hideTimer) {
+    window.clearTimeout(hideTimer);
+    hideTimer = undefined;
+  }
+}
+
+async function hideHud() {
+  clearHideTimer();
+  await appWindow.hide();
+}
+
+async function showHud() {
+  clearHideTimer();
+  await appWindow.show();
+}
+
+function hideSoon(delay = 1400) {
+  clearHideTimer();
+  hideTimer = window.setTimeout(() => {
+    void hideHud();
+  }, delay);
+}
+
+async function handleDictationEventPayload(payload: unknown) {
+  const dictationEvent = parseEvent(payload);
+  if (!dictationEvent) return;
+
+  if (dictationEvent.type === "listening_started") {
+    resetBars();
+    setHud("listening", "Listening");
+    await showHud();
+    return;
+  }
+
+  if (dictationEvent.type === "audio_level") {
+    const level = Number(dictationEvent.payload?.level || 0);
+    renderAudioLevel(level);
+    setHud("listening", "Listening");
+    return;
+  }
+
+  if (dictationEvent.type === "finalizing_transcript") {
+    setHud("transcribing", "Transcribing");
+    await showHud();
+    return;
+  }
+
+  if (dictationEvent.type === "final_transcript") {
+    setHud("pasting", "Pasting");
+    await showHud();
+    return;
+  }
+
+  if (dictationEvent.type === "paste_target") {
+    setHud(
+      "pasting",
+      `Pasting into ${dictationEvent.payload?.app || "previous app"}`,
+    );
+    await showHud();
+    return;
+  }
+
+  if (dictationEvent.type === "paste_completed") {
+    setHud("success", "Pasted");
+    await showHud();
+    hideSoon(900);
+    return;
+  }
+
+  if (dictationEvent.type === "error") {
+    const errorCode = dictationEvent.payload?.code || "";
+    const errorMessage = dictationEvent.payload?.message || "";
+    const isEmptyTranscriptError =
+      silentErrorCodes.has(errorCode) ||
+      errorMessage === "OpenAI did not return any transcript text.";
+
+    if (isEmptyTranscriptError) {
+      setHud("silent-error", "No transcript returned");
+      await showHud();
+      hideSoon(900);
+      return;
+    }
+
+    setHud("error", "Needs attention", errorMessage || "Dictation failed.");
+    await showHud();
+    hideSoon(2200);
+  }
+}
+
+function parseEvent(payload: unknown): DictationHudEvent | undefined {
+  try {
+    if (typeof payload === "string") {
+      return JSON.parse(payload) as DictationHudEvent;
+    }
+    if (payload && typeof payload === "object") {
+      return payload as DictationHudEvent;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+void listen("dictation-event", async (event) => {
+  await handleDictationEventPayload(event.payload);
+});
+
+void invoke<string | undefined>("latest_dictation_event")
+  .then((payload) => {
+    if (payload) {
+      return handleDictationEventPayload(payload);
+    }
+  })
+  .catch(() => {});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -64,6 +64,51 @@ export type RecordingState =
 export type RecordingSourceMode = "microphoneOnly" | "microphonePlusSystem";
 export type RecordingSource = "microphone" | "system";
 
+export type DictationShortcutModifiers = {
+  command: boolean;
+  control: boolean;
+  option: boolean;
+  shift: boolean;
+  function: boolean;
+};
+
+export type DictationShortcutSetting = {
+  keyCode?: number;
+  code: string;
+  modifiers: DictationShortcutModifiers;
+  label: string;
+};
+
+export type DictationMicrophoneSetting = {
+  id?: string;
+  name?: string;
+};
+
+export type DictationSettingsDto = {
+  shortcut: DictationShortcutSetting;
+  microphone: DictationMicrophoneSetting;
+};
+
+export type DictationSettingsResponse = {
+  settings: DictationSettingsDto;
+};
+
+export type DictationMicrophoneDeviceDto = {
+  id: string;
+  name: string;
+};
+
+export type DictationHelperEvent = {
+  type: string;
+  payload?: {
+    devices?: DictationMicrophoneDeviceDto[];
+    selectedID?: string;
+    message?: string;
+    code?: string;
+    [key: string]: unknown;
+  };
+};
+
 export type SourceState =
   | "pending"
   | "permissionDenied"
@@ -349,4 +394,34 @@ export async function recoverRecording(
   return invoke<NoteDto>("recover_recording", {
     request: { sessionId, action },
   });
+}
+
+export async function dictationSettings() {
+  return invoke<DictationSettingsResponse>("dictation_settings");
+}
+
+export async function setDictationShortcut(
+  shortcut: Pick<DictationShortcutSetting, "code" | "modifiers" | "label">,
+) {
+  return invoke<DictationSettingsDto>("set_dictation_shortcut", { shortcut });
+}
+
+export async function setDictationMicrophone(id?: string, name?: string) {
+  return invoke<DictationSettingsDto>("set_dictation_microphone", {
+    id,
+    name,
+  });
+}
+
+export async function dictationHelperCommand(command: Record<string, unknown>) {
+  return invoke<void>("dictation_helper_command", { command });
+}
+
+export async function dictationHotkeyStatus() {
+  return invoke<DictationHelperEvent>("dictation_hotkey_status");
+}
+
+export async function latestDictationEvent() {
+  const payload = await invoke<string | undefined>("latest_dictation_event");
+  return payload ? (JSON.parse(payload) as DictationHelperEvent) : undefined;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1641,9 +1641,7 @@ input:focus-visible,
   align-items: stretch;
   align-self: flex-end;
   justify-content: flex-end;
-  min-height: calc(
-    var(--record-idle-height) + (var(--record-shell-inset) * 2)
-  );
+  min-height: calc(var(--record-idle-height) + (var(--record-shell-inset) * 2));
   padding: var(--record-shell-padding);
   border: var(--record-shell-border) solid var(--border);
   border-radius: var(--r-xl);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1933,6 +1933,18 @@ input:focus-visible,
   line-height: 1.55;
 }
 
+.settings-status,
+.settings-row-error {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+}
+
+.settings-row-error {
+  color: var(--destructive);
+}
+
 /* Group label sits outside the card so multiple cards can sit under one
  * section, like macOS System Settings. */
 .settings-group {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -2,8 +2,13 @@
   color: #f7faf8;
   background: transparent;
   font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", sans-serif;
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -168,38 +168,21 @@ body {
 }
 
 .hud[data-state="success"],
-.hud[data-state="silent-error"] {
+.hud[data-state="silent-error"],
+.hud[data-state="error"] {
   min-width: 29px;
   padding-inline: 6px;
 }
 
 .hud[data-state="success"] .hud-success,
-.hud[data-state="silent-error"] .hud-error-mark {
+.hud[data-state="silent-error"] .hud-error-mark,
+.hud[data-state="error"] .hud-error-mark {
   display: block;
 }
 
 .hud[data-state="silent-error"],
 .hud[data-state="error"] {
   border-color: color-mix(in oklch, var(--hud-danger) 36%, var(--border));
-}
-
-.hud[data-state="error"] {
-  width: 120px;
-  min-height: 32px;
-  padding: 6px 8px;
-}
-
-.hud[data-state="error"] .hud-message {
-  display: block;
-  width: 100%;
-  max-height: 20px;
-  margin: 0;
-  overflow: hidden;
-  color: var(--hud-danger);
-  font-size: 0.41rem;
-  font-weight: 650;
-  line-height: 1.28;
-  text-align: center;
 }
 
 @keyframes hud-spin {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1,14 +1,9 @@
+@import "./tokens.css";
+
 :root {
-  color: #f7faf8;
+  color: var(--foreground);
   background: transparent;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
+  font-family: var(--font-sans);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -32,10 +27,11 @@ body {
 }
 
 .hud {
-  --hud-bg: rgba(15, 18, 20, 0.84);
-  --hud-border: rgba(255, 255, 255, 0.16);
-  --hud-accent: #dce86a;
-  --hud-danger: #ff8177;
+  --hud-bg: color-mix(in oklch, var(--popover) 92%, transparent);
+  --hud-border: color-mix(in oklch, var(--border) 80%, transparent);
+  --hud-bar: var(--foreground);
+  --hud-bar-soft: var(--muted-foreground);
+  --hud-danger: var(--destructive);
 
   display: grid;
   place-items: center;
@@ -45,7 +41,8 @@ body {
   border: 1px solid var(--hud-border);
   border-radius: 999px;
   background: var(--hud-bg);
-  box-shadow: 0 9px 19px rgba(0, 0, 0, 0.28);
+  color: var(--foreground);
+  box-shadow: var(--shadow-md);
   backdrop-filter: blur(9px) saturate(1.2);
 }
 
@@ -65,10 +62,10 @@ body {
   border-radius: 999px;
   background: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.96),
-    rgba(220, 232, 106, 0.88)
+    color-mix(in oklch, var(--hud-bar) 96%, transparent),
+    color-mix(in oklch, var(--hud-bar-soft) 86%, transparent)
   );
-  box-shadow: 0 0 9px rgba(220, 232, 106, 0.24);
+  box-shadow: 0 0 8px color-mix(in oklch, var(--foreground) 12%, transparent);
   transition:
     height 90ms ease-out,
     opacity 140ms ease-out,
@@ -85,8 +82,8 @@ body {
 .hud-progress {
   width: 17px;
   height: 17px;
-  border: 1.5px solid rgba(255, 255, 255, 0.22);
-  border-top-color: var(--hud-accent);
+  border: 1.5px solid color-mix(in oklch, var(--border) 72%, transparent);
+  border-top-color: var(--foreground);
   border-radius: 999px;
   animation: hud-spin 820ms linear infinite;
 }
@@ -95,9 +92,9 @@ body {
   position: relative;
   width: 17px;
   height: 17px;
-  border: 1px solid rgba(220, 232, 106, 0.9);
+  border: 1px solid color-mix(in oklch, var(--foreground) 76%, transparent);
   border-radius: 999px;
-  box-shadow: 0 0 11px rgba(220, 232, 106, 0.22);
+  box-shadow: 0 0 10px color-mix(in oklch, var(--foreground) 10%, transparent);
 }
 
 .hud-success::after {
@@ -107,7 +104,7 @@ body {
   left: 5px;
   width: 4.5px;
   height: 7.5px;
-  border: solid var(--hud-accent);
+  border: solid var(--foreground);
   border-width: 0 1.5px 1.5px 0;
   transform: rotate(45deg);
 }
@@ -116,9 +113,9 @@ body {
   position: relative;
   width: 17px;
   height: 17px;
-  border: 1px solid rgba(255, 129, 119, 0.9);
+  border: 1px solid color-mix(in oklch, var(--hud-danger) 78%, transparent);
   border-radius: 999px;
-  box-shadow: 0 0 11px rgba(255, 93, 82, 0.22);
+  box-shadow: 0 0 10px color-mix(in oklch, var(--hud-danger) 14%, transparent);
 }
 
 .hud-error-mark::before,
@@ -183,7 +180,7 @@ body {
 
 .hud[data-state="silent-error"],
 .hud[data-state="error"] {
-  border-color: rgba(255, 129, 119, 0.36);
+  border-color: color-mix(in oklch, var(--hud-danger) 36%, var(--border));
 }
 
 .hud[data-state="error"] {
@@ -198,7 +195,7 @@ body {
   max-height: 20px;
   margin: 0;
   overflow: hidden;
-  color: #ffe1de;
+  color: var(--hud-danger);
   font-size: 0.41rem;
   font-weight: 650;
   line-height: 1.28;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1,0 +1,215 @@
+:root {
+  color: #f7faf8;
+  background: transparent;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  display: grid;
+  place-items: center;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  overflow: hidden;
+  background: transparent;
+  pointer-events: none;
+  user-select: none;
+}
+
+.hud {
+  --hud-bg: rgba(15, 18, 20, 0.84);
+  --hud-border: rgba(255, 255, 255, 0.16);
+  --hud-accent: #dce86a;
+  --hud-danger: #ff8177;
+
+  display: grid;
+  place-items: center;
+  width: 88px;
+  height: 28px;
+  padding: 5px 8px;
+  border: 1px solid var(--hud-border);
+  border-radius: 999px;
+  background: var(--hud-bg);
+  box-shadow: 0 9px 19px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(9px) saturate(1.2);
+}
+
+.hud-bars {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 68px;
+  height: 17px;
+  gap: 3.5px;
+}
+
+.hud-bar {
+  width: 3.5px;
+  min-height: 4px;
+  height: calc(4px + (var(--level, 0.2) * 13px));
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.96),
+    rgba(220, 232, 106, 0.88)
+  );
+  box-shadow: 0 0 9px rgba(220, 232, 106, 0.24);
+  transition:
+    height 90ms ease-out,
+    opacity 140ms ease-out,
+    transform 140ms ease-out;
+}
+
+.hud-progress,
+.hud-success,
+.hud-error-mark,
+.hud-message {
+  display: none;
+}
+
+.hud-progress {
+  width: 17px;
+  height: 17px;
+  border: 1.5px solid rgba(255, 255, 255, 0.22);
+  border-top-color: var(--hud-accent);
+  border-radius: 999px;
+  animation: hud-spin 820ms linear infinite;
+}
+
+.hud-success {
+  position: relative;
+  width: 17px;
+  height: 17px;
+  border: 1px solid rgba(220, 232, 106, 0.9);
+  border-radius: 999px;
+  box-shadow: 0 0 11px rgba(220, 232, 106, 0.22);
+}
+
+.hud-success::after {
+  content: "";
+  position: absolute;
+  top: 3.5px;
+  left: 5px;
+  width: 4.5px;
+  height: 7.5px;
+  border: solid var(--hud-accent);
+  border-width: 0 1.5px 1.5px 0;
+  transform: rotate(45deg);
+}
+
+.hud-error-mark {
+  position: relative;
+  width: 17px;
+  height: 17px;
+  border: 1px solid rgba(255, 129, 119, 0.9);
+  border-radius: 999px;
+  box-shadow: 0 0 11px rgba(255, 93, 82, 0.22);
+}
+
+.hud-error-mark::before,
+.hud-error-mark::after {
+  content: "";
+  position: absolute;
+  top: 7.5px;
+  left: 4.5px;
+  width: 7px;
+  height: 1.5px;
+  border-radius: 999px;
+  background: var(--hud-danger);
+}
+
+.hud-error-mark::before {
+  transform: rotate(45deg);
+}
+
+.hud-error-mark::after {
+  transform: rotate(-45deg);
+}
+
+.hud-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hud[data-state="transcribing"] .hud-bars,
+.hud[data-state="pasting"] .hud-bars,
+.hud[data-state="success"] .hud-bars,
+.hud[data-state="silent-error"] .hud-bars,
+.hud[data-state="error"] .hud-bars {
+  display: none;
+}
+
+.hud[data-state="transcribing"] .hud-progress,
+.hud[data-state="pasting"] .hud-progress {
+  display: block;
+}
+
+.hud[data-state="pasting"] .hud-progress {
+  animation-duration: 620ms;
+}
+
+.hud[data-state="success"],
+.hud[data-state="silent-error"] {
+  min-width: 29px;
+  padding-inline: 6px;
+}
+
+.hud[data-state="success"] .hud-success,
+.hud[data-state="silent-error"] .hud-error-mark {
+  display: block;
+}
+
+.hud[data-state="silent-error"],
+.hud[data-state="error"] {
+  border-color: rgba(255, 129, 119, 0.36);
+}
+
+.hud[data-state="error"] {
+  width: 120px;
+  min-height: 32px;
+  padding: 6px 8px;
+}
+
+.hud[data-state="error"] .hud-message {
+  display: block;
+  width: 100%;
+  max-height: 20px;
+  margin: 0;
+  overflow: hidden;
+  color: #ffe1de;
+  font-size: 0.41rem;
+  font-weight: 650;
+  line-height: 1.28;
+  text-align: center;
+}
+
+@keyframes hud-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hud-bar,
+  .hud-progress {
+    transition: none;
+    animation: none;
+  }
+}

--- a/src/test/dictation-settings.test.tsx
+++ b/src/test/dictation-settings.test.tsx
@@ -100,13 +100,17 @@ describe("DictationSettings", () => {
     await user.click(await screen.findByRole("button", { name: "Change" }));
     fireEvent.keyDown(window, { code: "ShiftLeft", key: "Shift", shiftKey: true });
     expect(
-      await screen.findByText("Press one non-modifier key with your shortcut."),
-    ).toBeInTheDocument();
+      await screen.findAllByText(
+        "Press one non-modifier key with your shortcut.",
+      ),
+    ).toHaveLength(2);
 
     fireEvent.keyDown(window, { code: "KeyT", key: "t" });
     expect(
-      await screen.findByText("Shortcut must include Cmd, Ctrl, Opt, or Shift."),
-    ).toBeInTheDocument();
+      await screen.findAllByText(
+        "Shortcut must include Cmd, Ctrl, Opt, or Shift.",
+      ),
+    ).toHaveLength(2);
     expect(mocks.setDictationShortcut).not.toHaveBeenCalled();
   });
 

--- a/src/test/dictation-settings.test.tsx
+++ b/src/test/dictation-settings.test.tsx
@@ -11,9 +11,7 @@ const mocks = vi.hoisted(() => ({
   setDictationShortcut: vi.fn(),
   setDictationMicrophone: vi.fn(),
   listen: vi.fn(),
-  eventHandler: undefined as
-    | ((event: { payload: string }) => void)
-    | undefined,
+  eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -98,7 +96,11 @@ describe("DictationSettings", () => {
     render(<DictationSettings />);
 
     await user.click(await screen.findByRole("button", { name: "Change" }));
-    fireEvent.keyDown(window, { code: "ShiftLeft", key: "Shift", shiftKey: true });
+    fireEvent.keyDown(window, {
+      code: "ShiftLeft",
+      key: "Shift",
+      shiftKey: true,
+    });
     expect(
       await screen.findAllByText(
         "Press one non-modifier key with your shortcut.",
@@ -143,12 +145,11 @@ describe("DictationSettings", () => {
       }),
     });
 
-    await user.click(screen.getByRole("button", { name: /Auto-detect|USB Mic/ }));
+    await user.click(
+      screen.getByRole("button", { name: /Auto-detect|USB Mic/ }),
+    );
     await user.click(await screen.findByRole("option", { name: "USB Mic" }));
 
-    expect(mocks.setDictationMicrophone).toHaveBeenCalledWith(
-      "usb",
-      "USB Mic",
-    );
+    expect(mocks.setDictationMicrophone).toHaveBeenCalledWith("usb", "USB Mic");
   });
 });

--- a/src/test/dictation-settings.test.tsx
+++ b/src/test/dictation-settings.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DictationSettings } from "../components/dictation/DictationSettings";
+import type { DictationSettingsDto } from "../lib/tauri";
+
+const mocks = vi.hoisted(() => ({
+  dictationSettings: vi.fn(),
+  dictationHotkeyStatus: vi.fn(),
+  dictationHelperCommand: vi.fn(),
+  setDictationShortcut: vi.fn(),
+  setDictationMicrophone: vi.fn(),
+  listen: vi.fn(),
+  eventHandler: undefined as
+    | ((event: { payload: string }) => void)
+    | undefined,
+}));
+
+vi.mock("../lib/tauri", () => ({
+  dictationSettings: mocks.dictationSettings,
+  dictationHotkeyStatus: mocks.dictationHotkeyStatus,
+  dictationHelperCommand: mocks.dictationHelperCommand,
+  setDictationShortcut: mocks.setDictationShortcut,
+  setDictationMicrophone: mocks.setDictationMicrophone,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+const baseSettings: DictationSettingsDto = {
+  shortcut: {
+    code: "Space",
+    label: "Fn+Space",
+    modifiers: {
+      command: false,
+      control: false,
+      option: false,
+      shift: false,
+      function: true,
+    },
+  },
+  microphone: {},
+};
+
+describe("DictationSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.eventHandler = undefined;
+    mocks.dictationSettings.mockResolvedValue({ settings: baseSettings });
+    mocks.dictationHotkeyStatus.mockResolvedValue({
+      type: "hotkey_trigger_ready",
+      payload: { shortcut: "Fn+Space" },
+    });
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.setDictationShortcut.mockImplementation(async (shortcut) => ({
+      ...baseSettings,
+      shortcut,
+    }));
+    mocks.setDictationMicrophone.mockImplementation(async (id, name) => ({
+      ...baseSettings,
+      microphone: { id, name },
+    }));
+    mocks.listen.mockImplementation((_event, handler) => {
+      mocks.eventHandler = handler;
+      return Promise.resolve(vi.fn());
+    });
+  });
+
+  it("renders native shortcut and selected microphone settings", async () => {
+    mocks.dictationSettings.mockResolvedValue({
+      settings: {
+        shortcut: {
+          code: "Space",
+          label: "Ctrl+Opt+Space",
+          modifiers: {
+            command: false,
+            control: true,
+            option: true,
+            shift: false,
+            function: false,
+          },
+        },
+        microphone: { id: "airpods", name: "AirPods Pro" },
+      },
+    });
+
+    render(<DictationSettings />);
+
+    expect(
+      await screen.findByLabelText("Shortcut Ctrl+Opt+Space"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("AirPods Pro")).toBeInTheDocument();
+  });
+
+  it("rejects modifier-only and no-modifier shortcut captures", async () => {
+    const user = userEvent.setup();
+    render(<DictationSettings />);
+
+    await user.click(await screen.findByRole("button", { name: "Change" }));
+    fireEvent.keyDown(window, { code: "ShiftLeft", key: "Shift", shiftKey: true });
+    expect(
+      await screen.findByText("Press one non-modifier key with your shortcut."),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { code: "KeyT", key: "t" });
+    expect(
+      await screen.findByText("Shortcut must include Cmd, Ctrl, Opt, or Shift."),
+    ).toBeInTheDocument();
+    expect(mocks.setDictationShortcut).not.toHaveBeenCalled();
+  });
+
+  it("updates shortcut and microphone through native commands", async () => {
+    const user = userEvent.setup();
+    render(<DictationSettings />);
+
+    await user.click(await screen.findByRole("button", { name: "Change" }));
+    fireEvent.keyDown(window, { code: "KeyT", key: "t", ctrlKey: true });
+
+    await waitFor(() =>
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith({
+        code: "KeyT",
+        label: "Ctrl+T",
+        modifiers: {
+          command: false,
+          control: true,
+          option: false,
+          shift: false,
+          function: false,
+        },
+      }),
+    );
+
+    await waitFor(() => expect(mocks.listen).toHaveBeenCalled());
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "microphone_devices",
+        payload: { devices: [{ id: "usb", name: "USB Mic" }] },
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: /Auto-detect|USB Mic/ }));
+    await user.click(await screen.findByRole("option", { name: "USB Mic" }));
+
+    expect(mocks.setDictationMicrophone).toHaveBeenCalledWith(
+      "usb",
+      "USB Mic",
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
@@ -14,6 +15,12 @@ export default defineConfig({
     target: "es2022",
     minify: !process.env.TAURI_DEBUG,
     sourcemap: Boolean(process.env.TAURI_DEBUG),
+    rollupOptions: {
+      input: {
+        main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        hud: fileURLToPath(new URL("./hud.html", import.meta.url)),
+      },
+    },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- Add a macOS dictation helper for microphone capture, focus tracking, temporary recording, and pasteboard insertion.
- Route dictation recordings through the existing Rust transcription provider instead of transcribing in the helper.
- Add Dictation settings for global shortcut and microphone selection, plus a floating HUD window for dictation state.
- Preserve existing note recording/transcription behavior, including shared m4a MIME handling for OpenAI uploads.

## Testing
- `pnpm lint`
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm build`
- `pnpm tauri:build`