### PR TITLE
[feat] Folders workspace

### DIFF
--- a/src-tauri/migrations/001_init.sql
+++ b/src-tauri/migrations/001_init.sql
@@ -8,10 +8,6 @@ CREATE TABLE IF NOT EXISTS folders (
   deleted_at TEXT
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_folders_active_name
-ON folders (name)
-WHERE deleted_at IS NULL;
-
 CREATE TABLE IF NOT EXISTS notes (
   id TEXT PRIMARY KEY NOT NULL,
   title TEXT NOT NULL DEFAULT '',

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23,8 +23,9 @@ use crate::{
             DeleteFolderRequest, DeleteNoteRequest, FinishRecordingResponse, GetNoteRequest,
             ListNotesRequest, ListNotesResponse, MicrophonePermissionResponse, NoteDto,
             RecordingSessionDto, RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto,
-            RecordingStatusDto, RemoveNoteFromFolderRequest, RetryProcessingRequest,
-            SessionRequest, SourceReadinessDto, StartRecordingRequest, UpdateNoteRequest,
+            RecordingStatusDto, RemoveNoteFromFolderRequest, RenameFolderRequest,
+            RetryProcessingRequest, SessionRequest, SourceReadinessDto, StartRecordingRequest,
+            UpdateNoteRequest,
         },
     },
 };
@@ -129,7 +130,10 @@ pub async fn create_folder(
             "Folder name is required.",
         ));
     }
-    Ok(repositories(&app).await?.create_folder(name).await?)
+    Ok(repositories(&app)
+        .await?
+        .create_folder(name, request.description.as_deref())
+        .await?)
 }
 
 #[tauri::command]
@@ -146,6 +150,24 @@ pub async fn delete_folder(app: AppHandle, request: DeleteFolderRequest) -> Resu
         .delete_folder(&request.folder_id, request.delete_notes)
         .await?;
     Ok(())
+}
+
+#[tauri::command]
+pub async fn rename_folder(
+    app: AppHandle,
+    request: RenameFolderRequest,
+) -> Result<crate::domain::types::FolderDto, AppError> {
+    let name = request.name.trim();
+    if name.is_empty() {
+        return Err(AppError::new(
+            "folder_name_required",
+            "Folder name is required.",
+        ));
+    }
+    Ok(repositories(&app)
+        .await?
+        .rename_folder(&request.folder_id, name, request.description.as_deref())
+        .await?)
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -57,6 +57,10 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
     .await?;
     ensure_column(_pool, "recording_checkpoints", "source", "TEXT").await?;
     ensure_column(_pool, "recording_checkpoints", "source_artifact_id", "TEXT").await?;
+    ensure_column(_pool, "folders", "description", "TEXT").await?;
+    // Folder names don't need to be unique — each folder has a stable
+    // UUID, and the user may legitimately want two "Inbox"es etc.
+    drop_index_if_exists(_pool, "idx_folders_active_name").await?;
     for statement in include_str!("../../migrations/002_source_modes.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
@@ -107,4 +111,16 @@ async fn ensure_column(
 fn is_duplicate_column_error(error: &sqlx::Error, column: &str) -> bool {
     let message = error.to_string().to_lowercase();
     message.contains("duplicate column name") && message.contains(&column.to_lowercase())
+}
+
+async fn drop_index_if_exists(
+    pool: &SqlitePool,
+    index: &str,
+) -> Result<(), sqlx::migrate::MigrateError> {
+    let sql = format!("DROP INDEX IF EXISTS {index}");
+    sqlx::query(&sql)
+        .execute(pool)
+        .await
+        .map_err(sqlx::migrate::MigrateError::Execute)?;
+    Ok(())
 }

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -117,10 +117,14 @@ async fn drop_index_if_exists(
     pool: &SqlitePool,
     index: &str,
 ) -> Result<(), sqlx::migrate::MigrateError> {
-    let sql = format!("DROP INDEX IF EXISTS {index}");
+    let sql = format!("DROP INDEX IF EXISTS {}", quote_sqlite_identifier(index));
     sqlx::query(&sql)
         .execute(pool)
         .await
         .map_err(sqlx::migrate::MigrateError::Execute)?;
     Ok(())
+}
+
+fn quote_sqlite_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -18,40 +18,74 @@ impl Repositories {
 
     pub async fn list_folders(&self) -> Result<Vec<FolderDto>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT id, name, created_at, updated_at FROM folders WHERE deleted_at IS NULL ORDER BY lower(name) ASC",
+            "SELECT id, name, description, created_at, updated_at FROM folders WHERE deleted_at IS NULL ORDER BY lower(name) ASC",
         )
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows
-            .into_iter()
-            .map(|row| FolderDto {
-                id: row.get("id"),
-                name: row.get("name"),
-                created_at: row.get("created_at"),
-                updated_at: row.get("updated_at"),
-            })
-            .collect())
+        Ok(rows.into_iter().map(folder_from_row).collect())
     }
 
-    pub async fn create_folder(&self, name: impl AsRef<str>) -> Result<FolderDto, sqlx::Error> {
+    pub async fn create_folder(
+        &self,
+        name: impl AsRef<str>,
+        description: Option<&str>,
+    ) -> Result<FolderDto, sqlx::Error> {
         let now = timestamp();
+        let description = description
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
         let folder = FolderDto {
             id: Uuid::new_v4().to_string(),
             name: name.as_ref().trim().to_string(),
+            description: description.clone(),
             created_at: now.clone(),
             updated_at: now,
         };
 
-        sqlx::query("INSERT INTO folders (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)")
-            .bind(&folder.id)
-            .bind(&folder.name)
-            .bind(&folder.created_at)
-            .bind(&folder.updated_at)
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "INSERT INTO folders (id, name, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&folder.id)
+        .bind(&folder.name)
+        .bind(&folder.description)
+        .bind(&folder.created_at)
+        .bind(&folder.updated_at)
+        .execute(&self.pool)
+        .await?;
 
         Ok(folder)
+    }
+
+    pub async fn rename_folder(
+        &self,
+        folder_id: &str,
+        name: &str,
+        description: Option<&str>,
+    ) -> Result<FolderDto, sqlx::Error> {
+        let now = timestamp();
+        let trimmed = name.trim();
+        let description = description
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        sqlx::query(
+            "UPDATE folders SET name = ?, description = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
+        )
+        .bind(trimmed)
+        .bind(&description)
+        .bind(&now)
+        .bind(folder_id)
+        .execute(&self.pool)
+        .await?;
+
+        let row = sqlx::query(
+            "SELECT id, name, description, created_at, updated_at FROM folders WHERE id = ? AND deleted_at IS NULL",
+        )
+        .bind(folder_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(folder_from_row(row))
     }
 
     pub async fn create_note(&self, folder_id: Option<String>) -> Result<NoteDto, sqlx::Error> {
@@ -1440,6 +1474,26 @@ pub struct SourceArtifactPath {
 
 pub fn timestamp() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn folder_from_row(row: sqlx::sqlite::SqliteRow) -> FolderDto {
+    FolderDto {
+        id: row.get("id"),
+        name: row.get("name"),
+        description: row
+            .try_get::<Option<String>, _>("description")
+            .unwrap_or(None)
+            .and_then(|value| {
+                let trimmed = value.trim().to_string();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            }),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
 }
 
 fn preview_for(title: &str, content: &str) -> String {

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1,6 +1,6 @@
 use crate::domain::types::{
-    AudioArtifactDto, FolderDto, ListNotesResponse, NoteDto, NoteListItemDto, ProcessingStatus,
-    RecordingSourceMode, TranscriptDto,
+    AppError, AudioArtifactDto, FolderDto, ListNotesResponse, NoteDto, NoteListItemDto,
+    ProcessingStatus, RecordingSourceMode, TranscriptDto,
 };
 use chrono::{SecondsFormat, Utc};
 use sqlx::{Row, SqlitePool};
@@ -62,13 +62,13 @@ impl Repositories {
         folder_id: &str,
         name: &str,
         description: Option<&str>,
-    ) -> Result<FolderDto, sqlx::Error> {
+    ) -> Result<FolderDto, AppError> {
         let now = timestamp();
         let trimmed = name.trim();
         let description = description
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
-        sqlx::query(
+        let result = sqlx::query(
             "UPDATE folders SET name = ?, description = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
         )
         .bind(trimmed)
@@ -77,6 +77,12 @@ impl Repositories {
         .bind(folder_id)
         .execute(&self.pool)
         .await?;
+        if result.rows_affected() == 0 {
+            return Err(AppError::new(
+                "folder_not_found",
+                "Folder was not found or has already been deleted.",
+            ));
+        }
 
         let row = sqlx::query(
             "SELECT id, name, description, created_at, updated_at FROM folders WHERE id = ? AND deleted_at IS NULL",

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -47,6 +47,8 @@ pub struct ListNotesResponse {
 pub struct FolderDto {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -127,6 +129,8 @@ pub struct UpdateNoteRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CreateFolderRequest {
     pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -134,6 +138,15 @@ pub struct CreateFolderRequest {
 pub struct DeleteFolderRequest {
     pub folder_id: String,
     pub delete_notes: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenameFolderRequest {
+    pub folder_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run() {
             commands::create_folder,
             commands::list_folders,
             commands::delete_folder,
+            commands::rename_folder,
             commands::assign_note_to_folder,
             commands::remove_note_from_folder,
             commands::get_microphone_permission_state,

--- a/src-tauri/tests/folders.rs
+++ b/src-tauri/tests/folders.rs
@@ -12,20 +12,31 @@ async fn repos() -> Repositories {
 }
 
 #[tokio::test]
-async fn rejects_duplicate_active_folder_names() {
+async fn allows_duplicate_folder_names_with_distinct_ids() {
     let repos = repos().await;
-    repos.create_folder("Ideas").await.expect("first folder");
+    let first = repos
+        .create_folder("Ideas", None)
+        .await
+        .expect("first folder");
+    let second = repos
+        .create_folder("Ideas", None)
+        .await
+        .expect("second folder allowed");
 
-    let duplicate = repos.create_folder("Ideas").await;
-
-    assert!(duplicate.is_err());
+    assert_ne!(first.id, second.id);
+    let listed = repos.list_folders().await.expect("list");
+    let ideas: Vec<_> = listed
+        .into_iter()
+        .filter(|folder| folder.name == "Ideas")
+        .collect();
+    assert_eq!(ideas.len(), 2);
 }
 
 #[tokio::test]
 async fn assigning_and_removing_folder_keeps_note_in_all_notes() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");
-    let folder = repos.create_folder("Work").await.expect("folder");
+    let folder = repos.create_folder("Work", None).await.expect("folder");
 
     let assigned = repos
         .assign_note_to_folder(&note.id, &folder.id)
@@ -47,7 +58,7 @@ async fn assigning_and_removing_folder_keeps_note_in_all_notes() {
 #[tokio::test]
 async fn deleting_folder_without_notes_keeps_associated_notes() {
     let repos = repos().await;
-    let folder = repos.create_folder("Work").await.expect("folder");
+    let folder = repos.create_folder("Work", None).await.expect("folder");
     let note = repos
         .create_note(Some(folder.id.clone()))
         .await
@@ -70,7 +81,7 @@ async fn deleting_folder_without_notes_keeps_associated_notes() {
 #[tokio::test]
 async fn deleting_folder_with_notes_removes_associated_notes() {
     let repos = repos().await;
-    let folder = repos.create_folder("Work").await.expect("folder");
+    let folder = repos.create_folder("Work", None).await.expect("folder");
     repos
         .create_note(Some(folder.id.clone()))
         .await

--- a/src-tauri/tests/folders.rs
+++ b/src-tauri/tests/folders.rs
@@ -98,3 +98,18 @@ async fn deleting_folder_with_notes_removes_associated_notes() {
     let all_notes = repos.list_notes(None, 50, None).await.expect("all notes");
     assert!(all_notes.items.is_empty());
 }
+
+#[tokio::test]
+async fn renaming_missing_folder_returns_descriptive_error() {
+    let repos = repos().await;
+    let error = repos
+        .rename_folder("missing-folder", "Renamed", None)
+        .await
+        .expect_err("missing folder should fail");
+
+    assert_eq!(error.code, "folder_not_found");
+    assert_eq!(
+        error.message,
+        "Folder was not found or has already been deleted."
+    );
+}

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -37,7 +37,7 @@ async fn updates_title_body_and_active_tab() {
 #[tokio::test]
 async fn deleting_note_removes_it_from_all_note_lists() {
     let repos = repos().await;
-    let folder = repos.create_folder("Work").await.expect("folder");
+    let folder = repos.create_folder("Work", None).await.expect("folder");
     let note = repos
         .create_note(Some(folder.id.clone()))
         .await

--- a/src-tauri/tests/storage.rs
+++ b/src-tauri/tests/storage.rs
@@ -81,7 +81,7 @@ async fn creates_notes_in_reverse_chronological_order() {
 async fn creates_folders_and_assigns_notes_without_removing_all_notes_visibility() {
     let repos = test_repositories().await;
     let folder = repos
-        .create_folder("Field Notes")
+        .create_folder("Field Notes", None)
         .await
         .expect("folder should be created");
     let note = repos
@@ -120,7 +120,7 @@ async fn creates_folders_and_assigns_notes_without_removing_all_notes_visibility
 #[tokio::test]
 async fn deletes_note_and_removes_folder_assignment() {
     let repos = test_repositories().await;
-    let folder = repos.create_folder("Calls").await.expect("folder");
+    let folder = repos.create_folder("Calls", None).await.expect("folder");
     let note = repos
         .create_note(Some(folder.id.clone()))
         .await

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -402,7 +402,10 @@ export function App() {
                 onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
               />
             ) : selectedNote ? (
-              <>
+              <div
+                className="note-shell"
+                data-with-crumb={originFolderId ? "true" : undefined}
+              >
                 {originFolderId ? (
                   <NoteFromFolderCrumb
                     folder={state.folders.find(
@@ -489,7 +492,7 @@ export function App() {
                   })();
                 }}
               />
-              </>
+              </div>
             ) : (
               <section className="editor-empty">
                 <button

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,8 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useReducer, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { DictationSettings } from "../components/dictation/DictationSettings";
+import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
+import { NoteFromFolderCrumb } from "../components/folders/NoteFromFolderCrumb";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { RecoveryBanner } from "../components/recorder/RecoveryBanner";
 import { Sidebar, type SidebarView } from "../components/sidebar/Sidebar";
@@ -11,6 +13,7 @@ import {
   checkRecordingSourceReadiness,
   createFolder,
   createNote,
+  deleteFolder,
   deleteNote,
   finishRecording,
   getRecordingStatus,
@@ -19,6 +22,7 @@ import {
   pauseRecording,
   removeNoteFromFolder,
   recoverRecording,
+  renameFolder,
   resumeRecording,
   retryProcessing,
   startRecording,
@@ -41,6 +45,7 @@ export function App() {
   const [error, setError] = useState<string | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeView, setActiveView] = useState<SidebarView>("notes");
+  const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   const [sourceMode, setSourceMode] =
     useState<RecordingSourceMode>("microphonePlusSystem");
   const [sourceReadiness, setSourceReadiness] =
@@ -115,33 +120,68 @@ export function App() {
     return () => window.clearInterval(interval);
   }, [selectedNote?.id, selectedNote?.processingStatus]);
 
-  async function handleCreateNote() {
+  async function handleCreateNote(folderId?: string) {
     try {
-      const note = await createNote(state.selectedFolderId);
+      const note = await createNote(folderId ?? state.selectedFolderId);
       dispatch({ type: "noteLoaded", note });
+      setActiveView("notes");
     } catch (err) {
       setError(messageFromError(err));
     }
   }
 
-  async function handleSelectFolder(folderId?: string) {
+  function handleSelectFolder(folderId?: string) {
     dispatch({ type: "folderSelected", folderId });
+  }
+
+  async function handleCreateFolder(name: string, description?: string) {
     try {
-      const response = await listNotes(folderId);
-      dispatch({ type: "notesLoaded", notes: response.items });
+      const folder = await createFolder(name, description);
+      dispatch({ type: "folderCreated", folder });
+      return folder;
+    } catch (err) {
+      setError(messageFromError(err));
+      return undefined;
+    }
+  }
+
+  async function handleRenameFolder(
+    folderId: string,
+    name: string,
+    description?: string,
+  ) {
+    try {
+      const folder = await renameFolder(folderId, name, description);
+      dispatch({ type: "folderRenamed", folder });
     } catch (err) {
       setError(messageFromError(err));
     }
   }
 
-  async function handleCreateFolder() {
-    const name = window.prompt("Folder name");
-    if (!name?.trim()) return;
+  async function handleDeleteFolder(folderId: string) {
     try {
-      const folder = await createFolder(name);
-      dispatch({ type: "folderCreated", folder });
-      const response = await listNotes(folder.id);
-      dispatch({ type: "notesLoaded", notes: response.items });
+      // Deleting a folder strips its association from any notes but
+      // never deletes the notes themselves — they stay in your library.
+      await deleteFolder(folderId, false);
+      dispatch({ type: "folderDeleted", folderId });
+    } catch (err) {
+      setError(messageFromError(err));
+    }
+  }
+
+  async function handleAssignNoteToFolder(noteId: string, folderId: string) {
+    try {
+      const note = await assignNoteToFolder(noteId, folderId);
+      dispatch({ type: "noteUpdated", note });
+    } catch (err) {
+      setError(messageFromError(err));
+    }
+  }
+
+  async function handleRemoveNoteFromFolder(noteId: string, folderId: string) {
+    try {
+      const note = await removeNoteFromFolder(noteId, folderId);
+      dispatch({ type: "noteUpdated", note });
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -151,6 +191,7 @@ export function App() {
     try {
       const note = await getNote(noteId);
       dispatch({ type: "noteLoaded", note });
+      setOriginFolderId(undefined);
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -163,13 +204,24 @@ export function App() {
     }
     try {
       await deleteNote(noteId);
-      const response = await listNotes(state.selectedFolderId);
+      const response = await listNotes();
       dispatch({ type: "notesLoaded", notes: response.items });
       const nextNoteId = response.items[0]?.id;
       if (nextNoteId) {
         const note = await getNote(nextNoteId);
         dispatch({ type: "noteLoaded", note });
       }
+    } catch (err) {
+      setError(messageFromError(err));
+    }
+  }
+
+  async function handleSelectNoteFromFolder(noteId: string, folderId: string) {
+    try {
+      const note = await getNote(noteId);
+      dispatch({ type: "noteLoaded", note });
+      setOriginFolderId(folderId);
+      setActiveView("notes");
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -267,11 +319,22 @@ export function App() {
         selectedNoteId={state.selectedNoteId}
         selectedFolderId={state.selectedFolderId}
         activeView={activeView}
-        onChangeView={setActiveView}
-        onCreateFolder={() => void handleCreateFolder()}
+        onChangeView={(view) => {
+          setActiveView(view);
+          if (view === "folders") {
+            dispatch({ type: "folderSelected", folderId: undefined });
+          }
+          if (view !== "notes") {
+            setOriginFolderId(undefined);
+          }
+        }}
+        onCreateFolder={() => {
+          setActiveView("folders");
+          dispatch({ type: "folderSelected", folderId: undefined });
+        }}
         onCreateNote={() => void handleCreateNote()}
-        onSelectAll={() => void handleSelectFolder(undefined)}
-        onSelectFolder={(folderId) => void handleSelectFolder(folderId)}
+        onSelectAll={() => handleSelectFolder(undefined)}
+        onSelectFolder={(folderId) => handleSelectFolder(folderId)}
         onSelectNote={(noteId) => void handleSelectNote(noteId)}
         onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
         collapsed={sidebarCollapsed}
@@ -302,7 +365,65 @@ export function App() {
           <div className="workspace">
             {activeView === "dictation" ? (
               <DictationSettings />
+            ) : activeView === "folders" ? (
+              <FoldersWorkspace
+                folders={state.folders}
+                notes={state.notes}
+                selectedFolderId={state.selectedFolderId}
+                onSelectFolder={(folderId) =>
+                  dispatch({ type: "folderSelected", folderId })
+                }
+                onCreateFolder={(name, description) =>
+                  handleCreateFolder(name, description)
+                }
+                onRenameFolder={(folderId, name, description) =>
+                  void handleRenameFolder(folderId, name, description)
+                }
+                onDeleteFolder={(folderId) => void handleDeleteFolder(folderId)}
+                onCreateNote={(folderId) => void handleCreateNote(folderId)}
+                onSelectNote={(noteId) => {
+                  const folderId = state.selectedFolderId;
+                  if (folderId) {
+                    void handleSelectNoteFromFolder(noteId, folderId);
+                  } else {
+                    void handleSelectNote(noteId).then(() =>
+                      setActiveView("notes"),
+                    );
+                  }
+                }}
+                onAssignNoteToFolder={(noteId, folderId) =>
+                  assignNoteToFolder(noteId, folderId).then((note) => {
+                    dispatch({ type: "noteUpdated", note });
+                  })
+                }
+                onRemoveNoteFromFolder={(noteId, folderId) =>
+                  void handleRemoveNoteFromFolder(noteId, folderId)
+                }
+                onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
+              />
             ) : selectedNote ? (
+              <>
+                {originFolderId ? (
+                  <NoteFromFolderCrumb
+                    folder={state.folders.find(
+                      (folder) => folder.id === originFolderId,
+                    )}
+                    noteTitle={selectedNote.title.trim() || "New note"}
+                    onBackToFolders={() => {
+                      setActiveView("folders");
+                      dispatch({
+                        type: "folderSelected",
+                        folderId: undefined,
+                      });
+                      setOriginFolderId(undefined);
+                    }}
+                    onBackToFolder={(folderId) => {
+                      setActiveView("folders");
+                      dispatch({ type: "folderSelected", folderId });
+                      setOriginFolderId(undefined);
+                    }}
+                  />
+                ) : null}
               <NoteEditor
                 note={selectedNote}
                 folders={state.folders}
@@ -355,7 +476,20 @@ export function App() {
                     (note) => dispatch({ type: "noteUpdated", note }),
                   )
                 }
+                onCreateAndAssignFolder={(name) => {
+                  void (async () => {
+                    const folder = await handleCreateFolder(name);
+                    if (folder) {
+                      const note = await assignNoteToFolder(
+                        selectedNote.id,
+                        folder.id,
+                      );
+                      dispatch({ type: "noteUpdated", note });
+                    }
+                  })();
+                }}
               />
+              </>
             ) : (
               <section className="editor-empty">
                 <button

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -46,8 +46,9 @@ export function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeView, setActiveView] = useState<SidebarView>("notes");
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
-  const [sourceMode, setSourceMode] =
-    useState<RecordingSourceMode>("microphonePlusSystem");
+  const [sourceMode, setSourceMode] = useState<RecordingSourceMode>(
+    "microphonePlusSystem",
+  );
   const [sourceReadiness, setSourceReadiness] =
     useState<RecordingSourceReadinessDto>();
   const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
@@ -169,12 +170,21 @@ export function App() {
     }
   }
 
-  async function handleAssignNoteToFolder(noteId: string, folderId: string) {
+  async function handleAssignNoteToFolder(
+    noteId: string,
+    folderId: string,
+    options?: { rethrow?: boolean },
+  ) {
     try {
       const note = await assignNoteToFolder(noteId, folderId);
       dispatch({ type: "noteUpdated", note });
+      return note;
     } catch (err) {
       setError(messageFromError(err));
+      if (options?.rethrow) {
+        throw err;
+      }
+      return undefined;
     }
   }
 
@@ -392,8 +402,8 @@ export function App() {
                   }
                 }}
                 onAssignNoteToFolder={(noteId, folderId) =>
-                  assignNoteToFolder(noteId, folderId).then((note) => {
-                    dispatch({ type: "noteUpdated", note });
+                  handleAssignNoteToFolder(noteId, folderId, {
+                    rethrow: true,
                   })
                 }
                 onRemoveNoteFromFolder={(noteId, folderId) =>
@@ -427,71 +437,69 @@ export function App() {
                     }}
                   />
                 ) : null}
-              <NoteEditor
-                note={selectedNote}
-                folders={state.folders}
-                recordingStatus={state.recordingStatus}
-                sourceMode={sourceMode}
-                sourceReadiness={sourceReadiness}
-                checkingSourceReadiness={checkingSourceReadiness}
-                onTitleChange={(title) => void handleUpdateNote({ title })}
-                onContentChange={(sourceNoteId, editedContent) => {
-                  // Blur fired by an editor that was already torn
-                  // down on note-switch — ignore so we don't write
-                  // the old note's content into the new selectedNote.
-                  if (sourceNoteId !== selectedNote.id) return;
-                  void handleUpdateNote({ editedContent });
-                }}
-                onSourceModeChange={setSourceMode}
-                onTabChange={(activeTab) =>
-                  void updateNote({ noteId: selectedNote.id, activeTab }).then(
-                    (note) => dispatch({ type: "noteUpdated", note }),
-                  )
-                }
-                onStartRecording={() => void handleStartRecording()}
-                onPauseRecording={(sessionId) =>
-                  void pauseRecording(sessionId).then((status) =>
-                    dispatch({ type: "recordingStatusChanged", status }),
-                  )
-                }
-                onResumeRecording={(sessionId) =>
-                  void resumeRecording(sessionId).then((status) =>
-                    dispatch({ type: "recordingStatusChanged", status }),
-                  )
-                }
-                onFinishRecording={(sessionId) =>
-                  void handleFinishRecording(sessionId)
-                }
-                onRetry={() =>
-                  selectedNote
-                    ? void retryProcessing(selectedNote.id).then((note) =>
-                        dispatch({ type: "noteUpdated", note }),
-                      )
-                    : undefined
-                }
-                onAssignFolder={(folderId) =>
-                  void assignNoteToFolder(selectedNote.id, folderId).then(
-                    (note) => dispatch({ type: "noteUpdated", note }),
-                  )
-                }
-                onRemoveFolder={(folderId) =>
-                  void removeNoteFromFolder(selectedNote.id, folderId).then(
-                    (note) => dispatch({ type: "noteUpdated", note }),
-                  )
-                }
-                onCreateAndAssignFolder={(name) => {
-                  void (async () => {
-                    const folder = await handleCreateFolder(name);
-                    if (folder) {
-                      const note = await assignNoteToFolder(
-                        selectedNote.id,
-                        folder.id,
-                      );
-                      dispatch({ type: "noteUpdated", note });
-                    }
-                  })();
-                }}
-              />
+                <NoteEditor
+                  note={selectedNote}
+                  folders={state.folders}
+                  recordingStatus={state.recordingStatus}
+                  sourceMode={sourceMode}
+                  sourceReadiness={sourceReadiness}
+                  checkingSourceReadiness={checkingSourceReadiness}
+                  onTitleChange={(title) => void handleUpdateNote({ title })}
+                  onContentChange={(sourceNoteId, editedContent) => {
+                    // Blur fired by an editor that was already torn
+                    // down on note-switch — ignore so we don't write
+                    // the old note's content into the new selectedNote.
+                    if (sourceNoteId !== selectedNote.id) return;
+                    void handleUpdateNote({ editedContent });
+                  }}
+                  onSourceModeChange={setSourceMode}
+                  onTabChange={(activeTab) =>
+                    void updateNote({
+                      noteId: selectedNote.id,
+                      activeTab,
+                    }).then((note) => dispatch({ type: "noteUpdated", note }))
+                  }
+                  onStartRecording={() => void handleStartRecording()}
+                  onPauseRecording={(sessionId) =>
+                    void pauseRecording(sessionId).then((status) =>
+                      dispatch({ type: "recordingStatusChanged", status }),
+                    )
+                  }
+                  onResumeRecording={(sessionId) =>
+                    void resumeRecording(sessionId).then((status) =>
+                      dispatch({ type: "recordingStatusChanged", status }),
+                    )
+                  }
+                  onFinishRecording={(sessionId) =>
+                    void handleFinishRecording(sessionId)
+                  }
+                  onRetry={() =>
+                    selectedNote
+                      ? void retryProcessing(selectedNote.id).then((note) =>
+                          dispatch({ type: "noteUpdated", note }),
+                        )
+                      : undefined
+                  }
+                  onAssignFolder={(folderId) =>
+                    void handleAssignNoteToFolder(selectedNote.id, folderId)
+                  }
+                  onRemoveFolder={(folderId) =>
+                    void removeNoteFromFolder(selectedNote.id, folderId).then(
+                      (note) => dispatch({ type: "noteUpdated", note }),
+                    )
+                  }
+                  onCreateAndAssignFolder={(name) => {
+                    void (async () => {
+                      const folder = await handleCreateFolder(name);
+                      if (folder) {
+                        await handleAssignNoteToFolder(
+                          selectedNote.id,
+                          folder.id,
+                        );
+                      }
+                    })();
+                  }}
+                />
               </div>
             ) : (
               <section className="editor-empty">

--- a/src/app/state/app-state.ts
+++ b/src/app/state/app-state.ts
@@ -25,7 +25,10 @@ export type NotesAction =
   | { type: "recordingStatusChanged"; status: RecordingStatusDto }
   | { type: "recordingStatusCleared" }
   | { type: "folderCreated"; folder: FolderDto }
+  | { type: "folderRenamed"; folder: FolderDto }
+  | { type: "folderDeleted"; folderId: string }
   | { type: "folderSelected"; folderId?: string }
+  | { type: "foldersLoaded"; folders: FolderDto[] }
   | { type: "notesLoaded"; notes: NoteListItemDto[] }
   | { type: "recoveriesUpdated"; recoveries: RecoverableRecordingDto[] };
 
@@ -48,7 +51,7 @@ export function notesReducer(
         state.selectedNoteId ?? action.payload.notes[0]?.id;
       return {
         ...state,
-        folders: action.payload.folders,
+        folders: sortFolders(action.payload.folders),
         notes: action.payload.notes,
         activeRecoveries: action.payload.activeRecoveries,
         selectedNoteId,
@@ -82,8 +85,40 @@ export function notesReducer(
     case "folderCreated":
       return {
         ...state,
-        folders: [...state.folders, action.folder],
-        selectedFolderId: action.folder.id,
+        folders: sortFolders([...state.folders, action.folder]),
+      };
+    case "folderRenamed":
+      return {
+        ...state,
+        folders: sortFolders(
+          state.folders.map((folder) =>
+            folder.id === action.folder.id ? action.folder : folder,
+          ),
+        ),
+      };
+    case "folderDeleted":
+      return {
+        ...state,
+        folders: state.folders.filter((folder) => folder.id !== action.folderId),
+        selectedFolderId:
+          state.selectedFolderId === action.folderId
+            ? undefined
+            : state.selectedFolderId,
+        notes: state.notes.map((note) =>
+          note.folderIds.includes(action.folderId)
+            ? {
+                ...note,
+                folderIds: note.folderIds.filter(
+                  (id) => id !== action.folderId,
+                ),
+              }
+            : note,
+        ),
+      };
+    case "foldersLoaded":
+      return {
+        ...state,
+        folders: sortFolders(action.folders),
       };
     case "folderSelected":
       return {
@@ -117,6 +152,12 @@ function upsertNote(state: NotesState, note: NoteDto): NotesState {
       b.createdAt.localeCompare(a.createdAt),
     ),
   };
+}
+
+function sortFolders(folders: FolderDto[]): FolderDto[] {
+  return [...folders].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
 }
 
 function toListItem(note: NoteDto): NoteListItemDto {

--- a/src/components/folders/AddNotesToFolderDialog.tsx
+++ b/src/components/folders/AddNotesToFolderDialog.tsx
@@ -1,0 +1,162 @@
+import { IconCheckmark1 } from "central-icons-filled/IconCheckmark1";
+import { IconFileText } from "central-icons/IconFileText";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { useEffect, useMemo, useState } from "react";
+import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
+import { Dialog } from "../ui/Dialog";
+
+type AddNotesToFolderDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  folder: FolderDto;
+  notes: NoteListItemDto[];
+  /** Called once per note when the user commits the selection. */
+  onAdd: (noteId: string) => Promise<unknown> | void;
+};
+
+export function AddNotesToFolderDialog({
+  open,
+  onClose,
+  folder,
+  notes,
+  onAdd,
+}: AddNotesToFolderDialogProps) {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setSelected(new Set());
+    setSubmitting(false);
+  }, [open]);
+
+  const candidates = useMemo(() => {
+    const available = notes.filter(
+      (note) => !note.folderIds.includes(folder.id),
+    );
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return available;
+    return available.filter((note) =>
+      `${note.title} ${note.preview}`.toLowerCase().includes(normalized),
+    );
+  }, [notes, folder.id, query]);
+
+  function toggle(noteId: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(noteId)) next.delete(noteId);
+      else next.add(noteId);
+      return next;
+    });
+  }
+
+  async function handleSubmit() {
+    if (selected.size === 0 || submitting) return;
+    setSubmitting(true);
+    try {
+      // Commit serially so backend assigns are deterministic and the
+      // optimistic UI in the parent reducer applies in order.
+      for (const noteId of selected) {
+        await onAdd(noteId);
+      }
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const count = selected.size;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (submitting) return;
+        onClose();
+      }}
+      title={`Add notes to ${folder.name}`}
+      description="Pick the notes you want to move into this folder."
+      initialFocusSelector='input[name="add-notes-search"]'
+      footer={
+        <>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary-action primary-solid"
+            onClick={() => void handleSubmit()}
+            disabled={submitting || count === 0}
+          >
+            {submitting
+              ? "Adding…"
+              : count === 0
+                ? "Add notes"
+                : `Add ${count} ${count === 1 ? "note" : "notes"}`}
+          </button>
+        </>
+      }
+    >
+      <div className="add-notes-dialog">
+        <label className="add-notes-search">
+          <IconMagnifyingGlass size={14} />
+          <input
+            type="search"
+            name="add-notes-search"
+            placeholder="Search notes"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            autoComplete="off"
+          />
+        </label>
+        {candidates.length > 0 ? (
+          <ul className="add-notes-list" role="listbox" aria-multiselectable>
+            {candidates.map((note) => {
+              const isSelected = selected.has(note.id);
+              return (
+                <li key={note.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    className="add-notes-row"
+                    data-selected={isSelected}
+                    onClick={() => toggle(note.id)}
+                  >
+                    <span className="add-notes-icon" aria-hidden>
+                      <IconFileText size={14} />
+                    </span>
+                    <span className="add-notes-body">
+                      <span className="add-notes-title">
+                        {note.title.trim() || "New note"}
+                      </span>
+                      <span className="add-notes-preview">
+                        {note.preview.trim() ? note.preview : "No preview yet"}
+                      </span>
+                    </span>
+                    <span className="add-notes-check" aria-hidden>
+                      {isSelected ? <IconCheckmark1 size={12} /> : null}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="add-notes-empty">
+            {notes.some((note) => !note.folderIds.includes(folder.id))
+              ? "No notes match that search."
+              : "Every note already lives in this folder."}
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/folders/CreateFolderDialog.tsx
+++ b/src/components/folders/CreateFolderDialog.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { Dialog, DialogField } from "../ui/Dialog";
+
+type CreateFolderDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Optional seed name (e.g. when "Create new" is triggered from a search). */
+  defaultName?: string;
+  onCreate: (name: string, description?: string) => Promise<unknown> | void;
+};
+
+export function CreateFolderDialog({
+  open,
+  onClose,
+  defaultName,
+  onCreate,
+}: CreateFolderDialogProps) {
+  const [name, setName] = useState(defaultName ?? "");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(defaultName ?? "");
+    setDescription("");
+    setSubmitting(false);
+  }, [open, defaultName]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await onCreate(
+        trimmed,
+        description.trim() ? description.trim() : undefined,
+      );
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (submitting) return;
+        onClose();
+      }}
+      title="Create folder"
+      description="Group notes by project, client, or topic."
+      initialFocusSelector='input[name="folder-name"]'
+      footer={
+        <>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="create-folder-form"
+            className="primary-action primary-solid"
+            disabled={submitting || name.trim().length === 0}
+          >
+            {submitting ? "Creating…" : "Create folder"}
+          </button>
+        </>
+      }
+    >
+      <form
+        id="create-folder-form"
+        className="dialog-body"
+        onSubmit={handleSubmit}
+      >
+        <DialogField label="Name" htmlFor="folder-name">
+          <input
+            id="folder-name"
+            name="folder-name"
+            className="dialog-input"
+            placeholder="e.g. Customer interviews"
+            autoComplete="off"
+            value={name}
+            onChange={(event) => setName(event.currentTarget.value)}
+            maxLength={120}
+          />
+        </DialogField>
+        <DialogField label="Description" htmlFor="folder-description">
+          <textarea
+            id="folder-description"
+            name="folder-description"
+            className="dialog-textarea"
+            placeholder="What kind of notes belong here?"
+            value={description}
+            onChange={(event) => setDescription(event.currentTarget.value)}
+            rows={3}
+            maxLength={400}
+          />
+        </DialogField>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/folders/EditFolderDialog.tsx
+++ b/src/components/folders/EditFolderDialog.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react";
+import type { FolderDto } from "../../lib/tauri";
+import { Dialog, DialogField } from "../ui/Dialog";
+
+type EditFolderDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  folder: FolderDto;
+  onSave: (name: string, description?: string) => Promise<unknown> | void;
+};
+
+export function EditFolderDialog({
+  open,
+  onClose,
+  folder,
+  onSave,
+}: EditFolderDialogProps) {
+  const [name, setName] = useState(folder.name);
+  const [description, setDescription] = useState(folder.description ?? "");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(folder.name);
+    setDescription(folder.description ?? "");
+    setSubmitting(false);
+  }, [open, folder.name, folder.description]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSave(
+        trimmed,
+        description.trim() ? description.trim() : undefined,
+      );
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (submitting) return;
+        onClose();
+      }}
+      title="Edit folder"
+      description="Update the folder’s name or description."
+      initialFocusSelector='input[name="edit-folder-name"]'
+      footer={
+        <>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="edit-folder-form"
+            className="primary-action primary-solid"
+            disabled={submitting || name.trim().length === 0}
+          >
+            {submitting ? "Saving…" : "Save"}
+          </button>
+        </>
+      }
+    >
+      <form
+        id="edit-folder-form"
+        className="dialog-body"
+        onSubmit={handleSubmit}
+      >
+        <DialogField label="Name" htmlFor="edit-folder-name">
+          <input
+            id="edit-folder-name"
+            name="edit-folder-name"
+            className="dialog-input"
+            autoComplete="off"
+            value={name}
+            onChange={(event) => setName(event.currentTarget.value)}
+            maxLength={120}
+          />
+        </DialogField>
+        <DialogField label="Description" htmlFor="edit-folder-description">
+          <textarea
+            id="edit-folder-description"
+            name="edit-folder-description"
+            className="dialog-textarea"
+            placeholder="What kind of notes belong here?"
+            value={description}
+            onChange={(event) => setDescription(event.currentTarget.value)}
+            rows={3}
+            maxLength={400}
+          />
+        </DialogField>
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -904,8 +904,7 @@ function FolderEmptyState({
   return (
     <div className="folder-empty-surface" role="group">
       <p className="folder-empty-hint">
-        This folder is waiting for its first note. Capture a meeting,
-        a phone call, or a half-formed thought.
+        Capture a meeting, a phone call, or a half-formed thought
       </p>
       <div className="folder-empty-actions">
         {hasNotesElsewhere ? (

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -341,11 +341,16 @@ function FolderCard({
         <IconFolder1 size={13} />
       </div>
       <div className="folder-card-body">
-        <h3 className="folder-card-title">{folder.name}</h3>
-        {folder.description ? (
-          <p className="folder-card-meta">{folder.description}</p>
-        ) : null}
+        <div className="folder-card-text">
+          <h3 className="folder-card-title">{folder.name}</h3>
+          {folder.description ? (
+            <p className="folder-card-meta">{folder.description}</p>
+          ) : null}
+        </div>
         <p className="folder-card-footer">
+          <span className="folder-card-footer-icon" aria-hidden>
+            <IconFileText size={11} />
+          </span>
           <span>
             {folderNotes.length}{" "}
             {folderNotes.length === 1 ? "note" : "notes"}
@@ -899,7 +904,8 @@ function FolderEmptyState({
   return (
     <div className="folder-empty-surface" role="group">
       <p className="folder-empty-hint">
-        Nothing in this folder yet.
+        This folder is waiting for its first note. Capture a meeting,
+        a phone call, or a half-formed thought.
       </p>
       <div className="folder-empty-actions">
         {hasNotesElsewhere ? (

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -1,0 +1,985 @@
+import { IconCheckmark1 } from "central-icons-filled/IconCheckmark1";
+import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
+import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
+import { IconFileText } from "central-icons/IconFileText";
+import { IconFolder1 } from "central-icons/IconFolder1";
+import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
+import { IconFolderDelete } from "central-icons/IconFolderDelete";
+import { IconFolderOpen } from "central-icons/IconFolderOpen";
+import { IconPencil } from "central-icons/IconPencil";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { IconSortArrowUpDown } from "central-icons/IconSortArrowUpDown";
+import { IconTrashCan } from "central-icons/IconTrashCan";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
+import { AddNotesToFolderDialog } from "./AddNotesToFolderDialog";
+import { CreateFolderDialog } from "./CreateFolderDialog";
+import { EditFolderDialog } from "./EditFolderDialog";
+
+type FoldersWorkspaceProps = {
+  folders: FolderDto[];
+  notes: NoteListItemDto[];
+  selectedFolderId?: string;
+  onSelectFolder: (folderId?: string) => void;
+  onCreateFolder: (
+    name: string,
+    description?: string,
+  ) => Promise<FolderDto | undefined> | void;
+  onRenameFolder: (
+    folderId: string,
+    name: string,
+    description?: string,
+  ) => void;
+  onDeleteFolder: (folderId: string, deleteNotes: boolean) => void;
+  onCreateNote: (folderId?: string) => void;
+  onSelectNote: (noteId: string) => void;
+  onAssignNoteToFolder: (noteId: string, folderId: string) => Promise<unknown>;
+  onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
+  onDeleteNote: (noteId: string) => void;
+};
+
+export function FoldersWorkspace(props: FoldersWorkspaceProps) {
+  const { folders, selectedFolderId } = props;
+  const folder = useMemo(
+    () => folders.find((item) => item.id === selectedFolderId),
+    [folders, selectedFolderId],
+  );
+
+  if (selectedFolderId && folder) {
+    return <FolderDetail {...props} folder={folder} />;
+  }
+  return <FolderList {...props} />;
+}
+
+/* List view -------------------------------------------------------- */
+
+type SortKey = "updated" | "created" | "name" | "nameDesc";
+
+const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: "updated", label: "Recent" },
+  { value: "created", label: "Created" },
+  { value: "name", label: "A to Z" },
+  { value: "nameDesc", label: "Z to A" },
+];
+
+function FolderList({
+  folders,
+  notes,
+  onSelectFolder,
+  onCreateFolder,
+  onDeleteFolder,
+}: FoldersWorkspaceProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortKey>("updated");
+  const [menu, setMenu] = useState<MenuState | null>(null);
+
+  useEffect(() => {
+    if (!menu) return;
+    function close() {
+      setMenu(null);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") close();
+    }
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [menu]);
+
+  const sortedAndFiltered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const filtered = normalized
+      ? folders.filter((folder) =>
+          `${folder.name} ${folder.description ?? ""}`
+            .toLowerCase()
+            .includes(normalized),
+        )
+      : folders;
+    return [...filtered].sort((a, b) => {
+      switch (sort) {
+        case "name":
+          return a.name.localeCompare(b.name, undefined, {
+            sensitivity: "base",
+          });
+        case "nameDesc":
+          return b.name.localeCompare(a.name, undefined, {
+            sensitivity: "base",
+          });
+        case "created":
+          return b.createdAt.localeCompare(a.createdAt);
+        case "updated":
+        default:
+          return b.updatedAt.localeCompare(a.updatedAt);
+      }
+    });
+  }, [folders, query, sort]);
+
+  return (
+    <section className="folders-workspace" aria-label="Folders">
+      <header className="folders-header">
+        <div className="folders-heading">
+          <h1>Folders</h1>
+          <p className="folders-subtitle">
+            Group notes by project, client, or topic.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="primary-action primary-solid folders-create"
+          onClick={() => setCreateOpen(true)}
+        >
+          <IconFolderAddRight size={14} />
+          New folder
+        </button>
+      </header>
+
+      {folders.length > 0 ? (
+        <div className="folders-controls">
+          <label className="folders-search">
+            <IconMagnifyingGlass size={14} />
+            <input
+              type="search"
+              placeholder="Search"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+            />
+          </label>
+          <SortDropdown value={sort} onChange={setSort} />
+        </div>
+      ) : null}
+
+      {folders.length === 0 ? (
+        <div className="folders-empty">
+          <p>No folders yet.</p>
+          <button
+            type="button"
+            className="primary-action primary-solid"
+            onClick={() => setCreateOpen(true)}
+          >
+            <IconFolderAddRight size={14} />
+            Create your first folder
+          </button>
+        </div>
+      ) : sortedAndFiltered.length === 0 ? (
+        <div className="folders-empty">
+          <p>No folders match “{query.trim()}”.</p>
+        </div>
+      ) : (
+        <div className="folders-grid" role="list">
+          {sortedAndFiltered.map((folder) => (
+            <FolderCard
+              key={folder.id}
+              folder={folder}
+              notes={notes}
+              menuOpen={menu?.folderId === folder.id}
+              onOpen={() => onSelectFolder(folder.id)}
+              onOpenMenu={(anchor) => {
+                if (menu?.folderId === folder.id) {
+                  setMenu(null);
+                  return;
+                }
+                const rect = anchor.getBoundingClientRect();
+                setMenu({
+                  folderId: folder.id,
+                  right: window.innerWidth - rect.right,
+                  top: rect.bottom + 4,
+                });
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {menu ? (
+        <FolderCardMenu
+          right={menu.right}
+          top={menu.top}
+          folderId={menu.folderId}
+          folders={folders}
+          notes={notes}
+          onClose={() => setMenu(null)}
+          onOpen={(folderId) => {
+            onSelectFolder(folderId);
+            setMenu(null);
+          }}
+          onDelete={(folderId, deleteNotes) =>
+            onDeleteFolder(folderId, deleteNotes)
+          }
+        />
+      ) : null}
+
+      <CreateFolderDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreate={async (name, description) => {
+          await onCreateFolder(name, description);
+        }}
+      />
+    </section>
+  );
+}
+
+function SortDropdown({
+  value,
+  onChange,
+}: {
+  value: SortKey;
+  onChange: (value: SortKey) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(event: MouseEvent) {
+      if (!ref.current?.contains(event.target as Node)) setOpen(false);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("mousedown", onClick);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onClick);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const current = SORT_OPTIONS.find((option) => option.value === value);
+
+  return (
+    <div className="folders-sort" ref={ref}>
+      <button
+        type="button"
+        className="folders-sort-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <IconSortArrowUpDown size={13} />
+        <span>{current?.label ?? "Sort"}</span>
+        <IconChevronDownSmall size={12} />
+      </button>
+      {open ? (
+        <div className="folders-sort-menu" role="menu">
+          {SORT_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={option.value === value}
+              className="folders-sort-item"
+              onClick={() => {
+                onChange(option.value);
+                setOpen(false);
+              }}
+            >
+              <span className="folders-sort-check" aria-hidden>
+                {option.value === value ? <IconCheckmark1 size={11} /> : null}
+              </span>
+              {option.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type MenuState = { folderId: string; right: number; top: number };
+
+function FolderCard({
+  folder,
+  notes,
+  menuOpen,
+  onOpen,
+  onOpenMenu,
+}: {
+  folder: FolderDto;
+  notes: NoteListItemDto[];
+  menuOpen: boolean;
+  onOpen: () => void;
+  onOpenMenu: (anchor: HTMLElement) => void;
+}) {
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const folderNotes = notes.filter((note) =>
+    note.folderIds.includes(folder.id),
+  );
+  const lastUpdated = folderNotes[0]?.updatedAt ?? folder.updatedAt;
+
+  return (
+    <article
+      className="folder-card"
+      data-menu-open={menuOpen}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${folder.name}`}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        if (menuButtonRef.current) onOpenMenu(menuButtonRef.current);
+      }}
+    >
+      <div className="folder-card-icon" aria-hidden>
+        <IconFolder1 size={13} />
+      </div>
+      <div className="folder-card-body">
+        <h3 className="folder-card-title">{folder.name}</h3>
+        {folder.description ? (
+          <p className="folder-card-meta">{folder.description}</p>
+        ) : null}
+        <p className="folder-card-footer">
+          <span>
+            {folderNotes.length}{" "}
+            {folderNotes.length === 1 ? "note" : "notes"}
+          </span>
+          <span className="folder-card-footer-dot" aria-hidden>
+            ·
+          </span>
+          <span>Updated {formatRelative(lastUpdated)}</span>
+        </p>
+      </div>
+      <button
+        ref={menuButtonRef}
+        type="button"
+        className="folder-card-menu"
+        aria-label={`Actions for ${folder.name}`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onOpenMenu(event.currentTarget);
+        }}
+      >
+        <IconDotGrid1x3Horizontal size={14} />
+      </button>
+    </article>
+  );
+}
+
+function FolderCardMenu({
+  right,
+  top,
+  folderId,
+  folders,
+  onClose,
+  onOpen,
+  onDelete,
+}: {
+  right: number;
+  top: number;
+  folderId: string;
+  folders: FolderDto[];
+  notes: NoteListItemDto[];
+  onClose: () => void;
+  onOpen: (folderId: string) => void;
+  onDelete: (folderId: string, deleteNotes: boolean) => void;
+}) {
+  const folder = folders.find((item) => item.id === folderId);
+  if (!folder) return null;
+
+  return (
+    <div
+      className="context-menu"
+      style={{ right, top }}
+      role="menu"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <button type="button" role="menuitem" onClick={() => onOpen(folder.id)}>
+        <IconFolderOpen size={14} />
+        Open
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        className="destructive"
+        onClick={() => {
+          if (
+            window.confirm(
+              `Delete "${folder.name}"? Notes inside this folder will stay in your library.`,
+            )
+          ) {
+            onDelete(folder.id, false);
+          }
+          onClose();
+        }}
+      >
+        <IconTrashCan size={14} />
+        Delete
+      </button>
+    </div>
+  );
+}
+
+/* Detail view ------------------------------------------------------ */
+
+function FolderDetail({
+  folder,
+  notes,
+  onSelectFolder,
+  onRenameFolder,
+  onDeleteFolder,
+  onCreateNote,
+  onSelectNote,
+  onAssignNoteToFolder,
+  onRemoveNoteFromFolder,
+  onDeleteNote,
+}: FoldersWorkspaceProps & { folder: FolderDto }) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(folder.name);
+  const [menu, setMenu] = useState<{ right: number; top: number } | null>(
+    null,
+  );
+  const [addOpen, setAddOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const titleRef = useRef<HTMLInputElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (editingTitle && titleRef.current) {
+      titleRef.current.focus();
+      titleRef.current.select();
+    }
+  }, [editingTitle]);
+
+  useEffect(() => {
+    if (!editingTitle) setTitleDraft(folder.name);
+  }, [folder.name, editingTitle]);
+
+  useEffect(() => {
+    if (!menu) return;
+    function close() {
+      setMenu(null);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") close();
+    }
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [menu]);
+
+  const folderNotes = useMemo(
+    () =>
+      notes
+        .filter((note) => note.folderIds.includes(folder.id))
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    [notes, folder.id],
+  );
+
+  const lastUpdated = folderNotes[0]?.updatedAt ?? folder.updatedAt;
+
+  function commitRename() {
+    const next = titleDraft.trim();
+    setEditingTitle(false);
+    if (!next || next === folder.name) {
+      setTitleDraft(folder.name);
+      return;
+    }
+    onRenameFolder(folder.id, next, folder.description ?? undefined);
+  }
+
+  function openMenu(anchor: HTMLElement) {
+    const rect = anchor.getBoundingClientRect();
+    setMenu({
+      right: window.innerWidth - rect.right,
+      top: rect.bottom + 4,
+    });
+  }
+
+  return (
+    <section className="folder-detail" aria-label={folder.name}>
+      <div className="crumb-bar" data-tauri-drag-region>
+        <button
+          type="button"
+          className="crumb-link"
+          onClick={() => onSelectFolder(undefined)}
+        >
+          Folders
+        </button>
+        <span className="crumb-sep" aria-hidden>
+          /
+        </span>
+        <span className="crumb-current">{folder.name}</span>
+        <div className="crumb-actions">
+          <button
+            type="button"
+            className="ghost-icon-button"
+            aria-label={`Actions for ${folder.name}`}
+            aria-haspopup="menu"
+            aria-expanded={menu !== null}
+            onClick={(event) => {
+              event.stopPropagation();
+              if (menu) {
+                setMenu(null);
+                return;
+              }
+              openMenu(event.currentTarget);
+            }}
+          >
+            <IconDotGrid1x3Horizontal size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="folder-detail-content">
+        <header className="folder-detail-header">
+          {editingTitle ? (
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                commitRename();
+              }}
+            >
+              <input
+                ref={titleRef}
+                className="folder-detail-title-input"
+                value={titleDraft}
+                onChange={(event) =>
+                  setTitleDraft(event.currentTarget.value)
+                }
+                onBlur={commitRename}
+                onKeyDown={(event) => {
+                  if (event.key === "Escape") {
+                    event.preventDefault();
+                    setTitleDraft(folder.name);
+                    setEditingTitle(false);
+                  }
+                }}
+              />
+            </form>
+          ) : (
+            <h1
+              className="folder-detail-title"
+              tabIndex={0}
+              role="button"
+              aria-label="Rename folder"
+              onClick={() => setEditingTitle(true)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  setEditingTitle(true);
+                }
+              }}
+            >
+              {folder.name}
+            </h1>
+          )}
+          {folder.description ? (
+            <p className="folder-detail-description">{folder.description}</p>
+          ) : null}
+          <p className="folder-detail-meta">
+            <span className="folder-detail-meta-pill" aria-hidden>
+              <IconFolder1 size={12} />
+            </span>
+            <span className="folder-detail-meta-dot" aria-hidden>
+              ·
+            </span>
+            {folderNotes.length}{" "}
+            {folderNotes.length === 1 ? "note" : "notes"}
+            <span className="folder-detail-meta-dot" aria-hidden>
+              ·
+            </span>
+            Updated {formatDate(lastUpdated)}
+          </p>
+        </header>
+
+        {folderNotes.length > 0 ? (
+          <FolderNotesPanel
+            folder={folder}
+            notes={folderNotes}
+            hasNotesElsewhere={notes.some(
+              (note) => !note.folderIds.includes(folder.id),
+            )}
+            onSelectNote={onSelectNote}
+            onCreateNote={() => onCreateNote(folder.id)}
+            onAddExisting={() => setAddOpen(true)}
+            onRemoveNoteFromFolder={onRemoveNoteFromFolder}
+            onDeleteNote={onDeleteNote}
+          />
+        ) : (
+          <FolderEmptyState
+            onCreateNote={() => onCreateNote(folder.id)}
+            onAddExisting={() => setAddOpen(true)}
+            hasNotesElsewhere={notes.some(
+              (note) => !note.folderIds.includes(folder.id),
+            )}
+          />
+        )}
+      </div>
+
+      {menu ? (
+        <div
+          className="context-menu"
+          style={{ right: menu.right, top: menu.top }}
+          role="menu"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setMenu(null);
+              setEditOpen(true);
+            }}
+          >
+            <IconPencil size={14} />
+            Edit details
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="destructive"
+            onClick={() => {
+              setMenu(null);
+              if (
+                window.confirm(
+                  `Delete "${folder.name}"? Notes inside this folder will stay in your library.`,
+                )
+              ) {
+                onDeleteFolder(folder.id, false);
+              }
+            }}
+          >
+            <IconTrashCan size={14} />
+            Delete folder
+          </button>
+        </div>
+      ) : null}
+
+      <AddNotesToFolderDialog
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        folder={folder}
+        notes={notes}
+        onAdd={async (noteId) => {
+          await onAssignNoteToFolder(noteId, folder.id);
+        }}
+      />
+      <EditFolderDialog
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        folder={folder}
+        onSave={(name, description) =>
+          onRenameFolder(folder.id, name, description)
+        }
+      />
+    </section>
+  );
+}
+
+function FolderNotesPanel({
+  folder,
+  notes,
+  hasNotesElsewhere,
+  onSelectNote,
+  onCreateNote,
+  onAddExisting,
+  onRemoveNoteFromFolder,
+  onDeleteNote,
+}: {
+  folder: FolderDto;
+  notes: NoteListItemDto[];
+  hasNotesElsewhere: boolean;
+  onSelectNote: (noteId: string) => void;
+  onCreateNote: () => void;
+  onAddExisting: () => void;
+  onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
+  onDeleteNote: (noteId: string) => void;
+}) {
+  return (
+    <>
+      <FolderActions
+        onCreateNote={onCreateNote}
+        onAddExisting={onAddExisting}
+        hasNotesElsewhere={hasNotesElsewhere}
+      />
+      <ul className="folder-notes" role="list">
+        {notes.map((note) => (
+          <FolderNoteRow
+            key={note.id}
+            note={note}
+            folder={folder}
+            onSelect={() => onSelectNote(note.id)}
+            onRemoveFromFolder={() =>
+              onRemoveNoteFromFolder(note.id, folder.id)
+            }
+            onDelete={() => onDeleteNote(note.id)}
+          />
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function FolderActions({
+  onCreateNote,
+  onAddExisting,
+  hasNotesElsewhere,
+}: {
+  onCreateNote: () => void;
+  onAddExisting: () => void;
+  hasNotesElsewhere: boolean;
+}) {
+  return (
+    <div className="folder-actions-row">
+      {hasNotesElsewhere ? (
+        <button
+          type="button"
+          className="primary-action"
+          onClick={onAddExisting}
+        >
+          Add existing note
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className="primary-action primary-solid"
+        onClick={onCreateNote}
+      >
+        <IconPlusMedium size={13} />
+        New note
+      </button>
+    </div>
+  );
+}
+
+function FolderNoteRow({
+  note,
+  folder,
+  onSelect,
+  onRemoveFromFolder,
+  onDelete,
+}: {
+  note: NoteListItemDto;
+  folder: FolderDto;
+  onSelect: () => void;
+  onRemoveFromFolder: () => void;
+  onDelete: () => void;
+}) {
+  const [menu, setMenu] = useState<{ right: number; top: number } | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!menu) return;
+    function close() {
+      setMenu(null);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") close();
+    }
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [menu]);
+
+  return (
+    <li>
+      <div className="folder-note-row" data-menu-open={menu !== null}>
+        <button
+          type="button"
+          className="folder-note-main"
+          onClick={onSelect}
+        >
+          <span className="folder-note-icon" aria-hidden>
+            <IconFileText size={14} />
+          </span>
+          <span className="folder-note-body">
+            <span className="folder-note-title">
+              {note.title.trim() || "New note"}
+            </span>
+            <span className="folder-note-subtitle">
+              {note.preview.trim()
+                ? note.preview
+                : `Updated ${formatRelative(note.updatedAt)}`}
+            </span>
+          </span>
+        </button>
+        <span className="folder-note-time">
+          {formatNoteTime(note.updatedAt)}
+        </span>
+        <button
+          type="button"
+          className="folder-note-menu"
+          aria-label={`Actions for ${note.title.trim() || "this note"}`}
+          aria-haspopup="menu"
+          aria-expanded={menu !== null}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (menu) {
+              setMenu(null);
+              return;
+            }
+            const rect = event.currentTarget.getBoundingClientRect();
+            setMenu({
+              right: window.innerWidth - rect.right,
+              top: rect.bottom + 4,
+            });
+          }}
+        >
+          <IconDotGrid1x3Horizontal size={13} />
+        </button>
+        {menu ? (
+          <div
+            className="context-menu"
+            style={{ right: menu.right, top: menu.top }}
+            role="menu"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenu(null);
+                onRemoveFromFolder();
+              }}
+            >
+              <IconFolderDelete size={14} />
+              Remove from folder
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="destructive"
+              onClick={() => {
+                setMenu(null);
+                if (
+                  window.confirm(
+                    `Delete "${
+                      note.title.trim() || "New note"
+                    }"? This cannot be undone.`,
+                  )
+                ) {
+                  onDelete();
+                }
+              }}
+            >
+              <IconTrashCan size={14} />
+              Delete note
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function FolderEmptyState({
+  onCreateNote,
+  onAddExisting,
+  hasNotesElsewhere,
+}: {
+  onCreateNote: () => void;
+  onAddExisting: () => void;
+  hasNotesElsewhere: boolean;
+}) {
+  return (
+    <div className="folder-empty-surface" role="group">
+      <p className="folder-empty-hint">
+        Nothing in this folder yet.
+      </p>
+      <div className="folder-empty-actions">
+        {hasNotesElsewhere ? (
+          <button
+            type="button"
+            className="primary-action"
+            onClick={onAddExisting}
+          >
+            Add existing note
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="primary-action primary-solid"
+          onClick={onCreateNote}
+        >
+          <IconPlusMedium size={13} />
+          New note
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* Formatting helpers ----------------------------------------------- */
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diff = Date.now() - then;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return "just now";
+  if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`;
+  if (diff < 7 * day) return `${Math.floor(diff / day)}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const now = new Date();
+  const sameYear = date.getFullYear() === now.getFullYear();
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+}
+
+/** Right-aligned timestamp inside a folder's note row. Same-day shows
+ * just the time ("2:09 PM"). Within a week, the weekday ("Mon"). Older,
+ * the date ("May 22"). */
+function formatNoteTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) {
+    return date.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  const diffDays = Math.floor(
+    (now.getTime() - date.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (diffDays < 7) {
+    return date.toLocaleDateString(undefined, { weekday: "short" });
+  }
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/components/folders/NoteFromFolderCrumb.tsx
+++ b/src/components/folders/NoteFromFolderCrumb.tsx
@@ -1,0 +1,47 @@
+import type { FolderDto } from "../../lib/tauri";
+
+type Props = {
+  folder?: FolderDto;
+  noteTitle: string;
+  onBackToFolders: () => void;
+  onBackToFolder: (folderId: string) => void;
+};
+
+/**
+ * Sticky breadcrumb rendered above the note editor when the user
+ * landed on the note from a folder. Mirrors the folder-detail crumb
+ * bar so the in-folder context stays visible while the editor itself
+ * is the unchanged main-notes editor.
+ */
+export function NoteFromFolderCrumb({
+  folder,
+  noteTitle,
+  onBackToFolders,
+  onBackToFolder,
+}: Props) {
+  return (
+    <div className="crumb-bar" data-tauri-drag-region>
+      <button type="button" className="crumb-link" onClick={onBackToFolders}>
+        Folders
+      </button>
+      {folder ? (
+        <>
+          <span className="crumb-sep" aria-hidden>
+            /
+          </span>
+          <button
+            type="button"
+            className="crumb-link"
+            onClick={() => onBackToFolder(folder.id)}
+          >
+            {folder.name}
+          </button>
+        </>
+      ) : null}
+      <span className="crumb-sep" aria-hidden>
+        /
+      </span>
+      <span className="crumb-current">{noteTitle}</span>
+    </div>
+  );
+}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -215,7 +215,7 @@ export function NoteEditor({
               noteId={note.id}
               markdown={content}
               onChange={onContentChange}
-              emptyPlaceholder="Hit record to capture a conversation, or just start typing your thoughts here."
+              emptyPlaceholder="Hit record to capture a conversation, or just start typing your thoughts here"
             />
             {processingLock ? (
               <p

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -1,11 +1,13 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconClipboard } from "central-icons/IconClipboard";
 import { IconFolder1 } from "central-icons/IconFolder1";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconCheckmark1 } from "central-icons-filled/IconCheckmark1";
 import { IconChevronBottom } from "central-icons-filled/IconChevronBottom";
 import { IconMicrophone } from "central-icons-filled/IconMicrophone";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Switch } from "../ui/Switch";
 import type {
   FolderDto,
@@ -35,6 +37,7 @@ type NoteEditorProps = {
   onRetry: () => void;
   onAssignFolder: (folderId: string) => void;
   onRemoveFolder: (folderId: string) => void;
+  onCreateAndAssignFolder: (name: string) => void;
   onTabChange: (tab: "notes" | "transcription") => void;
 };
 
@@ -76,6 +79,7 @@ export function NoteEditor({
   onRetry,
   onAssignFolder,
   onRemoveFolder,
+  onCreateAndAssignFolder,
   onTabChange,
 }: NoteEditorProps) {
   const content = note.editedContent ?? note.generatedContent ?? "";
@@ -132,6 +136,7 @@ export function NoteEditor({
             folderIds={note.folderIds}
             onAssign={onAssignFolder}
             onRemove={onRemoveFolder}
+            onCreateAndAssign={onCreateAndAssignFolder}
           />
           {processing ? (
             <span className="note-overline-status">
@@ -210,7 +215,7 @@ export function NoteEditor({
               noteId={note.id}
               markdown={content}
               onChange={onContentChange}
-              emptyPlaceholder="Record or start writing..."
+              emptyPlaceholder="Hit record to capture a conversation, or just start typing your thoughts here."
             />
             {processingLock ? (
               <p
@@ -352,17 +357,22 @@ function FolderChip({
   folderIds,
   onAssign,
   onRemove,
+  onCreateAndAssign,
 }: {
   folders: FolderDto[];
   folderIds: string[];
   onAssign: (folderId: string) => void;
   onRemove: (folderId: string) => void;
+  onCreateAndAssign: (name: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const ref = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
+    setQuery("");
     function onClick(event: MouseEvent) {
       if (!ref.current?.contains(event.target as Node)) setOpen(false);
     }
@@ -371,6 +381,7 @@ function FolderChip({
     }
     window.addEventListener("mousedown", onClick);
     window.addEventListener("keydown", onKey);
+    requestAnimationFrame(() => searchRef.current?.focus());
     return () => {
       window.removeEventListener("mousedown", onClick);
       window.removeEventListener("keydown", onKey);
@@ -378,48 +389,102 @@ function FolderChip({
   }, [open]);
 
   const assigned = folders.filter((folder) => folderIds.includes(folder.id));
-  const label =
-    assigned.length > 0
-      ? assigned.map((folder) => folder.name).join(", ")
-      : "Add to folder";
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return folders;
+    return folders.filter((folder) =>
+      folder.name.toLowerCase().includes(normalized),
+    );
+  }, [folders, query]);
+
+  const trimmed = query.trim();
+  const exactMatch = folders.some(
+    (folder) => folder.name.toLowerCase() === trimmed.toLowerCase(),
+  );
+  const showCreate = trimmed.length > 0 && !exactMatch;
 
   return (
     <div className="folder-chip-wrap" ref={ref}>
       <button
         type="button"
-        className="folder-chip"
+        className="move-to-folder-trigger"
+        data-assigned={assigned.length > 0}
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
       >
         <IconFolder1 size={13} />
-        {label}
+        {assigned.length > 0
+          ? assigned.map((folder) => folder.name).join(", ")
+          : "Folder"}
       </button>
       {open ? (
-        <div className="folder-popover" role="menu">
-          {folders.length > 0 ? (
-            folders.map((folder) => {
-              const isAssigned = folderIds.includes(folder.id);
-              return (
-                <button
-                  key={folder.id}
-                  type="button"
-                  role="menuitemcheckbox"
-                  aria-checked={isAssigned}
-                  onClick={() =>
-                    isAssigned ? onRemove(folder.id) : onAssign(folder.id)
-                  }
-                >
-                  <span className="folder-popover-check">
-                    {isAssigned ? "✓" : ""}
-                  </span>
-                  {folder.name}
-                </button>
-              );
-            })
-          ) : (
-            <p className="folder-popover-empty">No folders yet</p>
-          )}
+        <div className="move-to-folder-popover" role="menu">
+          <div className="move-to-folder-search">
+            <IconMagnifyingGlass size={12} />
+            <input
+              ref={searchRef}
+              type="search"
+              placeholder="Search or create folder"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && showCreate) {
+                  event.preventDefault();
+                  onCreateAndAssign(trimmed);
+                  setOpen(false);
+                }
+              }}
+            />
+          </div>
+          {showCreate ? (
+            <>
+              <button
+                type="button"
+                className="move-to-folder-create"
+                onClick={() => {
+                  onCreateAndAssign(trimmed);
+                  setOpen(false);
+                }}
+              >
+                <IconPlusMedium size={12} />
+                <span className="move-to-folder-item-name">
+                  Create “{trimmed}”
+                </span>
+                <span aria-hidden />
+              </button>
+              <div className="move-to-folder-divider" aria-hidden />
+            </>
+          ) : null}
+          <div className="move-to-folder-list">
+            {filtered.length > 0 ? (
+              filtered.map((folder) => {
+                const isAssigned = folderIds.includes(folder.id);
+                return (
+                  <button
+                    key={folder.id}
+                    type="button"
+                    role="menuitemcheckbox"
+                    aria-checked={isAssigned}
+                    className="move-to-folder-item"
+                    onClick={() =>
+                      isAssigned ? onRemove(folder.id) : onAssign(folder.id)
+                    }
+                  >
+                    <IconFolder1 size={12} />
+                    <span className="move-to-folder-item-name">
+                      {folder.name}
+                    </span>
+                    <span className="move-to-folder-item-check" aria-hidden>
+                      {isAssigned ? "✓" : ""}
+                    </span>
+                  </button>
+                );
+              })
+            ) : trimmed.length === 0 ? (
+              <p className="move-to-folder-empty">No folders yet.</p>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/src/components/note-editor/NotePreview.tsx
+++ b/src/components/note-editor/NotePreview.tsx
@@ -37,7 +37,7 @@ export function NotePreview({
         Placeholder.configure({
           placeholder:
             emptyPlaceholder ??
-            "Hit record to capture a conversation, or just start typing your thoughts here.",
+            "Hit record to capture a conversation, or just start typing your thoughts here",
         }),
       ],
       content: initialHtml,

--- a/src/components/note-editor/NotePreview.tsx
+++ b/src/components/note-editor/NotePreview.tsx
@@ -35,7 +35,9 @@ export function NotePreview({
           },
         }),
         Placeholder.configure({
-          placeholder: emptyPlaceholder ?? "Record or start writing...",
+          placeholder:
+            emptyPlaceholder ??
+            "Hit record to capture a conversation, or just start typing your thoughts here.",
         }),
       ],
       content: initialHtml,

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { IconDotGrid1x3Vertical } from "central-icons/IconDotGrid1x3Vertical";
 import { IconFileText } from "central-icons/IconFileText";
+import { IconFolders } from "central-icons/IconFolders";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophoneSparkle } from "central-icons/IconMicrophoneSparkle";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
@@ -9,7 +10,7 @@ import { IconTrashCan } from "central-icons/IconTrashCan";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
 
-export type SidebarView = "notes" | "dictation";
+export type SidebarView = "notes" | "dictation" | "folders";
 
 type SidebarProps = {
   folders: FolderDto[];
@@ -35,6 +36,7 @@ type MenuState = {
 };
 
 export function Sidebar({
+  folders,
   notes,
   selectedNoteId,
   activeView,
@@ -163,6 +165,18 @@ export function Sidebar({
             <IconMicrophoneSparkle size={16} />
           </span>
           <span className="sidebar-nav-label">Dictation</span>
+        </button>
+        <button
+          type="button"
+          className="sidebar-nav-item"
+          data-active={activeView === "folders"}
+          aria-current={activeView === "folders" ? "page" : undefined}
+          onClick={() => onChangeView("folders")}
+        >
+          <span className="sidebar-nav-icon">
+            <IconFolders size={16} />
+          </span>
+          <span className="sidebar-nav-label">Folders</span>
         </button>
       </nav>
 

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -1,0 +1,175 @@
+import { IconCrossMedium } from "central-icons/IconCrossMedium";
+import {
+  type ReactNode,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+} from "react";
+import { createPortal } from "react-dom";
+
+type DialogProps = {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  description?: ReactNode;
+  /** Optional element rendered into the header beside the title (e.g. an icon). */
+  leading?: ReactNode;
+  /** Slot for the form / body content. */
+  children: ReactNode;
+  /** Slot for buttons; rendered right-aligned by default. */
+  footer?: ReactNode;
+  /** Disable closing on backdrop click (still closes on Esc). */
+  disableBackdropClose?: boolean;
+  /** Disables default focus management when the consumer wants to take over. */
+  initialFocusSelector?: string;
+  /** Optional width override. Defaults to the comfortable 460px form width. */
+  width?: number | string;
+  /** Optional class hook for unusual dialogs. */
+  className?: string;
+};
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Base dialog primitive. Renders into a portal with a blurred backdrop,
+ * a centered card, focus trap, and Esc-to-close — the substrate we share
+ * across folder create / rename / move and any future dialog.
+ */
+export function Dialog({
+  open,
+  onClose,
+  title,
+  description,
+  leading,
+  children,
+  footer,
+  disableBackdropClose = false,
+  initialFocusSelector,
+  width,
+  className,
+}: DialogProps) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  // Keep the latest onClose without making it a useEffect dependency.
+  // Re-running the keydown effect on every parent render would refocus
+  // `previousFocus` mid-typing and bounce focus out of the dialog.
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab" || !cardRef.current) return;
+      const focusables = Array.from(
+        cardRef.current.querySelectorAll<HTMLElement>(FOCUSABLE),
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+      previousFocusRef.current?.focus?.();
+    };
+  }, [open]);
+
+  useLayoutEffect(() => {
+    if (!open || !cardRef.current) return;
+    const target = initialFocusSelector
+      ? cardRef.current.querySelector<HTMLElement>(initialFocusSelector)
+      : cardRef.current.querySelector<HTMLElement>(FOCUSABLE);
+    target?.focus();
+  }, [open, initialFocusSelector]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="dialog-backdrop"
+      data-open="true"
+      onMouseDown={(event) => {
+        if (disableBackdropClose) return;
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+        className={`dialog-card${className ? ` ${className}` : ""}`}
+        style={width ? { width } : undefined}
+      >
+        <header className="dialog-header">
+          {leading ? <span className="dialog-leading">{leading}</span> : null}
+          <h2 id={titleId} className="dialog-title">
+            {title}
+          </h2>
+          <button
+            type="button"
+            className="dialog-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <IconCrossMedium size={14} />
+          </button>
+        </header>
+        {description ? (
+          <p id={descriptionId} className="dialog-description">
+            {description}
+          </p>
+        ) : null}
+        {children}
+        {footer ? <footer className="dialog-footer">{footer}</footer> : null}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export function DialogField({
+  label,
+  htmlFor,
+  hint,
+  children,
+}: {
+  label: ReactNode;
+  htmlFor?: string;
+  hint?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="dialog-field">
+      <label className="dialog-field-label" htmlFor={htmlFor}>
+        {label}
+      </label>
+      {children}
+      {hint ? <p className="dialog-field-hint">{hint}</p> : null}
+    </div>
+  );
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -13,6 +13,7 @@ export type ProcessingStatus =
 export type FolderDto = {
   id: string;
   name: string;
+  description?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -290,13 +291,25 @@ export async function createNote(folderId?: string) {
   return invoke<NoteDto>("create_note", { request: { folderId } });
 }
 
-export async function createFolder(name: string) {
-  return invoke<FolderDto>("create_folder", { request: { name } });
+export async function createFolder(name: string, description?: string) {
+  return invoke<FolderDto>("create_folder", {
+    request: { name, description },
+  });
 }
 
 export async function deleteFolder(folderId: string, deleteNotes: boolean) {
   return invoke<void>("delete_folder", {
     request: { folderId, deleteNotes },
+  });
+}
+
+export async function renameFolder(
+  folderId: string,
+  name: string,
+  description?: string,
+) {
+  return invoke<FolderDto>("rename_folder", {
+    request: { folderId, name, description },
   });
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -860,6 +860,30 @@ input:focus-visible,
   min-width: 0;
 }
 
+/* When a note is opened from a folder we render a sticky crumb bar
+ * above the same NoteEditor used everywhere else. Wrapping both in a
+ * flex column with min-height: 100% means the editor still gets a real
+ * height to grow into — its internal grid (auto / 1fr / auto) keeps
+ * the recorder pinned at the bottom and the header flush at the top. */
+.note-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  min-width: 0;
+}
+
+.note-shell > .note-editor {
+  flex: 1;
+  min-height: 0;
+}
+
+.note-shell[data-with-crumb="true"] > .note-editor {
+  /* The crumb bar already provides top breathing room; tighten the
+   * editor's own padding so the title sits where it would in the
+   * regular notes view, minus the crumb. */
+  padding-top: var(--sp-7);
+}
+
 .note-editor {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
@@ -2481,6 +2505,7 @@ input:focus-visible,
   grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: start;
   column-gap: var(--sp-3);
+  min-height: 96px;
   padding: var(--sp-4);
   border: 1px solid transparent;
   border-radius: var(--r-lg);
@@ -2519,15 +2544,23 @@ input:focus-visible,
   height: 13px;
 }
 
+/* Body is a flex column with `justify-content: space-between` so the
+ * footer always sits at the bottom regardless of whether a description
+ * is present. Card height stays predictable across the grid. */
 .folder-card-body {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  height: 100%;
 }
 
-.folder-card-body > .folder-card-footer {
-  margin-top: var(--sp-3);
+.folder-card-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .folder-card-title {
@@ -2550,9 +2583,8 @@ input:focus-visible,
   overflow: hidden;
 }
 
-/* Card footer — count + updated date sits below the description (or
- * directly under the title when there's no description) so the card
- * height stays compact and predictable. */
+/* Card footer — pinned to the bottom of the card via the body's
+ * space-between flex. Subtle file icon + count + updated date. */
 .folder-card-footer {
   margin: 0;
   display: inline-flex;
@@ -2560,6 +2592,15 @@ input:focus-visible,
   gap: var(--sp-2);
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
+}
+
+.folder-card-footer-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  color: var(--muted-foreground);
+  opacity: 0.85;
 }
 
 .folder-card-footer-dot {
@@ -2862,8 +2903,11 @@ input:focus-visible,
 
 .folder-empty-hint {
   margin: 0;
+  max-width: 360px;
   color: var(--muted-foreground);
   font-size: var(--fs-md);
+  text-align: center;
+  line-height: 1.5;
 }
 
 .folder-empty-actions {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -877,6 +877,7 @@ input:focus-visible,
   padding: var(--sp-10) 0 var(--sp-5);
 }
 
+
 .editor-header {
   display: grid;
   justify-items: start;
@@ -1275,15 +1276,16 @@ input:focus-visible,
 }
 
 /* Dull placeholder — visible enough to read with caret resting in an empty
- * editor, quiet enough to disappear next to real text. */
+ * editor, quiet enough to disappear next to real text. Body copy size so
+ * the prompt feels like an invitation, not a label. */
 .note-preview p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;
   height: 0;
-  color: color-mix(in oklch, var(--muted-foreground) 42%, transparent);
+  color: color-mix(in oklch, var(--muted-foreground) 60%, transparent);
   pointer-events: none;
+  font-size: var(--fs-lg);
   font-weight: 400;
-  white-space: nowrap;
 }
 
 .note-generating {
@@ -2199,4 +2201,1122 @@ input:focus-visible,
   place-items: center;
   width: 16px;
   color: var(--foreground);
+}
+
+/* Primary solid button (Granola / Claude style) -------------------- */
+
+.primary-action.primary-solid {
+  border-color: transparent;
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.primary-action.primary-solid:hover {
+  background: color-mix(in oklch, var(--primary) 92%, var(--foreground));
+  border-color: transparent;
+}
+
+.primary-action.primary-solid:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Ghost icon button — back-arrow style header chip ------------------ */
+
+.ghost-icon-button {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-md);
+  height: var(--control-md);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.ghost-icon-button:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.ghost-icon-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Shared sticky crumb bar (folder detail + note-from-folder editor) - */
+
+.crumb-bar {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: 40px;
+  margin: 0 calc(-1 * var(--sp-8));
+  padding: 0 var(--sp-4);
+  border-bottom: 1px solid
+    color-mix(in oklch, var(--border) 60%, transparent);
+  background: color-mix(in oklch, var(--card) 78%, transparent);
+  backdrop-filter: saturate(140%) blur(14px);
+  -webkit-backdrop-filter: saturate(140%) blur(14px);
+}
+
+.crumb-link {
+  height: var(--control-md);
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  cursor: pointer;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.crumb-link:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.crumb-sep {
+  color: var(--muted-foreground);
+  opacity: 0.5;
+  font-size: var(--fs-md);
+}
+
+.crumb-current {
+  color: var(--foreground);
+  font-weight: 500;
+  font-size: var(--fs-md);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 320px;
+}
+
+.crumb-actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+}
+
+/* Folders workspace ------------------------------------------------- */
+
+.folders-workspace {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--sp-10) 0 var(--sp-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-7);
+}
+
+.folders-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-6);
+}
+
+.folders-heading h1 {
+  margin: 0 0 var(--sp-2);
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: var(--fs-display);
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+
+.folders-subtitle {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+.folders-create {
+  flex-shrink: 0;
+}
+
+/* Folders controls row — short search left, sort right ---------- */
+
+.folders-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+}
+
+.folders-search {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--sp-2);
+  width: 260px;
+  max-width: 50%;
+  height: var(--control-lg);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--muted-foreground);
+  transition: border-color var(--t-fast) var(--ease-out);
+}
+
+.folders-search:focus-within {
+  border-color: var(--ring);
+}
+
+.folders-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-size: var(--fs-md);
+}
+
+.folders-search input::placeholder {
+  color: var(--muted-foreground);
+}
+
+/* Sort dropdown trigger ------------------------------------------- */
+
+.folders-sort {
+  position: relative;
+}
+
+.folders-sort-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--control-lg);
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.folders-sort-trigger:hover,
+.folders-sort-trigger[aria-expanded="true"] {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.folders-sort-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 40;
+  min-width: 140px;
+  padding: var(--sp-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--popover);
+  box-shadow: var(--shadow-lg);
+}
+
+.folders-sort-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--sp-2);
+  width: 100%;
+  min-height: 26px;
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--popover-foreground);
+  font-size: var(--fs-sm);
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.folders-sort-item:hover {
+  background: var(--muted);
+}
+
+.folders-sort-check {
+  display: inline-grid;
+  place-items: center;
+  color: var(--foreground);
+}
+
+.folders-grid {
+  display: grid;
+  gap: var(--sp-3);
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+/* Slim, click-anywhere card. The article itself is `role=button`, so
+ * every pixel inside the card padding routes to onOpen. The overflow
+ * menu is layered above with stopPropagation. */
+.folder-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  align-items: start;
+  column-gap: var(--sp-3);
+  padding: var(--sp-4);
+  border: 1px solid transparent;
+  border-radius: var(--r-lg);
+  background: color-mix(in oklch, var(--muted) 28%, transparent);
+  color: var(--card-foreground);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    border-color var(--t-fast) var(--ease-out);
+}
+
+.folder-card:hover,
+.folder-card[data-menu-open="true"] {
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
+}
+
+.folder-card:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Quiet folder icon — same subtle pill as the meta row. */
+.folder-card-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
+  color: var(--muted-foreground);
+}
+
+.folder-card-icon > svg {
+  width: 13px;
+  height: 13px;
+}
+
+.folder-card-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.folder-card-body > .folder-card-footer {
+  margin-top: var(--sp-3);
+}
+
+.folder-card-title {
+  margin: 0;
+  font-size: var(--fs-lg);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-card-meta {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Card footer — count + updated date sits below the description (or
+ * directly under the title when there's no description) so the card
+ * height stays compact and predictable. */
+.folder-card-footer {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.folder-card-footer-dot {
+  opacity: 0.5;
+}
+
+.folder-card-menu {
+  align-self: start;
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-sm);
+  height: var(--control-sm);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  opacity: 0;
+  transition:
+    opacity var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.folder-card:hover .folder-card-menu,
+.folder-card:focus-within .folder-card-menu,
+.folder-card[data-menu-open="true"] .folder-card-menu {
+  opacity: 1;
+}
+
+.folder-card-menu:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.folders-empty {
+  display: grid;
+  place-items: center;
+  gap: var(--sp-3);
+  min-height: 200px;
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+/* Folder detail ----------------------------------------------------- */
+
+.folder-detail {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+/* The detail content lives in a constrained column and centers under
+ * the sticky bar. Use the same max-width as the editor. */
+.folder-detail-content {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: var(--sp-8) 0 var(--sp-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-8);
+}
+
+/* Title + description hug each other (2px); meta sits well below. */
+.folder-detail-header {
+  display: flex;
+  flex-direction: column;
+}
+
+.folder-detail-header > h1,
+.folder-detail-header > form,
+.folder-detail-header > .folder-detail-description,
+.folder-detail-header > .folder-detail-meta {
+  margin: 0;
+}
+
+.folder-detail-header > .folder-detail-description {
+  margin-top: var(--sp-2);
+}
+
+.folder-detail-header > .folder-detail-meta {
+  margin-top: var(--sp-6);
+}
+
+/* Negative margin so the hover bg extends to the *left* of the text,
+ * but the text itself stays anchored at the column edge. Same trick
+ * for the inline edit input — the baseline doesn't shift. */
+.folder-detail-title {
+  margin: 0 calc(-1 * var(--sp-2));
+  padding: 2px var(--sp-2);
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: var(--fs-display);
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  cursor: text;
+  border-radius: var(--r-sm);
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.folder-detail-title:hover {
+  background: color-mix(in oklch, var(--muted) 30%, transparent);
+}
+
+.folder-detail-title:focus,
+.folder-detail-title:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
+.folder-detail-title-input {
+  display: block;
+  margin: 0 calc(-1 * var(--sp-2));
+  border: 0;
+  padding: 2px var(--sp-2);
+  outline: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: var(--fs-display);
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+  width: calc(100% + var(--sp-4));
+  border-radius: var(--r-sm);
+}
+
+.folder-detail-title-input:focus,
+.folder-detail-title-input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
+.folder-detail-description {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+/* Quiet meta row — folder icon in a soft pill, then count, then date. */
+.folder-detail-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.folder-detail-meta-pill {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
+  color: var(--muted-foreground);
+}
+
+.folder-detail-meta-dot {
+  opacity: 0.5;
+}
+
+/* Folder action row — primary New note + secondary Add existing. */
+.folder-actions-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+/* Notes list — rows ride on white by default, hover lifts a quiet
+ * gray bg and reveals the row overflow menu. Equal padding on all sides. */
+.folder-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Negative horizontal margin keeps the note's title aligned with the
+ * page text bounds at rest, while the hover background still extends
+ * past the column on each side for a roomier hit area. */
+.folder-note-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--sp-3);
+  margin: 0 calc(-1 * var(--sp-4));
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-md);
+  background: transparent;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.folder-note-row:hover,
+.folder-note-row[data-menu-open="true"] {
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.folder-note-main {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--sp-3);
+  border: 0;
+  padding: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.folder-note-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+}
+
+.folder-note-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.folder-note-title {
+  font-size: var(--fs-md);
+  font-weight: 500;
+  color: var(--foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-note-subtitle {
+  font-size: var(--fs-sm);
+  color: var(--muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-note-time {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.folder-note-menu {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-sm);
+  height: var(--control-sm);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  opacity: 0;
+  cursor: pointer;
+  transition:
+    opacity var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.folder-note-row:hover .folder-note-menu,
+.folder-note-row:focus-within .folder-note-menu,
+.folder-note-row[data-menu-open="true"] .folder-note-menu {
+  opacity: 1;
+}
+
+.folder-note-menu:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+/* Folder empty state — subtle gray surface, muted helper text above
+ * side-by-side primary + secondary actions. */
+.folder-empty-surface {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-5);
+  min-height: 280px;
+  padding: var(--sp-10) var(--sp-6);
+  border-radius: var(--r-lg);
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.folder-empty-hint {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+.folder-empty-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+/* Folder action row above the notes list — right-aligned. */
+.folder-actions-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--sp-3);
+}
+
+/* Add-existing-note dialog ----------------------------------------- */
+
+.add-notes-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  min-height: 320px;
+}
+
+.add-notes-search {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--control-lg);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--muted-foreground);
+  transition: border-color var(--t-fast) var(--ease-out);
+}
+
+.add-notes-search:focus-within {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.add-notes-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-size: var(--fs-md);
+}
+
+.add-notes-search input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.add-notes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.add-notes-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 18px;
+  align-items: center;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-3) var(--sp-4);
+  border: 0;
+  border-radius: var(--r-md);
+  background: var(--card);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.add-notes-row:hover,
+.add-notes-row[data-selected="true"] {
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.add-notes-check {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  color: var(--foreground);
+}
+
+.add-notes-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+}
+
+.add-notes-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.add-notes-title {
+  font-size: var(--fs-md);
+  font-weight: 500;
+  color: var(--foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.add-notes-preview {
+  font-size: var(--fs-sm);
+  color: var(--muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.add-notes-empty {
+  margin: 0;
+  padding: var(--sp-8) var(--sp-4);
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  text-align: center;
+}
+
+/* Dialog system ---------------------------------------------------- */
+
+.dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  place-items: center;
+  padding: var(--sp-8);
+  background: color-mix(in oklch, var(--foreground) 12%, transparent);
+  backdrop-filter: saturate(140%) blur(8px);
+  -webkit-backdrop-filter: saturate(140%) blur(8px);
+  animation: dialog-backdrop-in var(--t-med) var(--ease-out);
+}
+
+.dialog-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+  width: 460px;
+  max-width: 100%;
+  max-height: calc(100vh - var(--sp-12));
+  padding: var(--sp-6);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  background: var(--card);
+  color: var(--card-foreground);
+  box-shadow: var(--shadow-lg);
+  animation: dialog-card-in var(--t-med) var(--ease-spring);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.dialog-header .dialog-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.dialog-header .dialog-close {
+  flex: 0 0 auto;
+  margin-left: var(--sp-4);
+}
+
+.dialog-leading {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+}
+
+.dialog-title {
+  margin: 0;
+  font-size: var(--fs-xl);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dialog-close {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-md);
+  height: var(--control-md);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.dialog-close:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.dialog-description {
+  margin: calc(-1 * var(--sp-3)) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+/* Generous padding (+ negative outer margin) so the inputs' focus
+ * rings (3px outer box-shadow) can paint without being clipped by the
+ * dialog-card or by overflow on inner scrollers. */
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+  min-height: 0;
+  padding: var(--sp-1);
+  margin: calc(-1 * var(--sp-1));
+}
+
+.dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.dialog-field-label {
+  font-size: var(--fs-md);
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.dialog-field-hint {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.dialog-input,
+.dialog-textarea {
+  display: block;
+  width: 100%;
+  min-height: var(--control-lg);
+  padding: var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--fs-md);
+  transition:
+    border-color var(--t-fast) var(--ease-out),
+    box-shadow var(--t-fast) var(--ease-out);
+}
+
+.dialog-input:hover,
+.dialog-textarea:hover {
+  border-color: var(--ring);
+}
+
+.dialog-input:focus,
+.dialog-textarea:focus,
+.dialog-input:focus-visible,
+.dialog-textarea:focus-visible {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.dialog-textarea {
+  min-height: 96px;
+  resize: none;
+  line-height: 1.45;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-3);
+}
+
+@keyframes dialog-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialog-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* Move-to-folder popover (Claude pattern) -------------------------- */
+
+.move-to-folder-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  height: 22px;
+  margin: 0 calc(-1 * var(--sp-1));
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.move-to-folder-trigger:hover,
+.move-to-folder-trigger[aria-expanded="true"] {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.move-to-folder-trigger[data-assigned="true"] {
+  color: var(--foreground);
+}
+
+.move-to-folder-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 60;
+  width: 280px;
+  padding: var(--sp-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.move-to-folder-search {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--sp-2);
+  height: var(--control-md);
+  padding: 0 var(--sp-2);
+  border-radius: var(--r-sm);
+  color: var(--muted-foreground);
+}
+
+.move-to-folder-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-size: var(--fs-md);
+}
+
+.move-to-folder-search input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.move-to-folder-divider {
+  height: 1px;
+  margin: 2px var(--sp-1);
+  background: var(--border);
+}
+
+.move-to-folder-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.move-to-folder-item,
+.move-to-folder-create {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-2);
+  width: 100%;
+  min-height: 30px;
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--popover-foreground);
+  font-size: var(--fs-md);
+  text-align: left;
+  cursor: pointer;
+}
+
+.move-to-folder-item:hover,
+.move-to-folder-create:hover {
+  background: var(--muted);
+}
+
+.move-to-folder-item-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.move-to-folder-item-check {
+  color: var(--muted-foreground);
+}
+
+.move-to-folder-item[aria-checked="true"] .move-to-folder-item-check {
+  color: var(--foreground);
+}
+
+.move-to-folder-empty {
+  margin: 0;
+  padding: var(--sp-3) var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  text-align: center;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -901,7 +901,6 @@ input:focus-visible,
   padding: var(--sp-10) 0 var(--sp-5);
 }
 
-
 .editor-header {
   display: grid;
   justify-items: start;
@@ -2285,8 +2284,7 @@ input:focus-visible,
   height: 40px;
   margin: 0 calc(-1 * var(--sp-8));
   padding: 0 var(--sp-4);
-  border-bottom: 1px solid
-    color-mix(in oklch, var(--border) 60%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 60%, transparent);
   background: color-mix(in oklch, var(--card) 78%, transparent);
   backdrop-filter: saturate(140%) blur(14px);
   -webkit-backdrop-filter: saturate(140%) blur(14px);
@@ -2763,13 +2761,6 @@ input:focus-visible,
 
 .folder-detail-meta-dot {
   opacity: 0.5;
-}
-
-/* Folder action row — primary New note + secondary Add existing. */
-.folder-actions-row {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-3);
 }
 
 /* Notes list — rows ride on white by default, hover lifts a quiet

--- a/src/test/app-state.test.ts
+++ b/src/test/app-state.test.ts
@@ -89,6 +89,58 @@ describe("notesReducer", () => {
     expect(state.recordingStatus).toEqual(status);
   });
 
+  it("renames and deletes folders, keeping notes consistent", () => {
+    const initial = notesReducer(createInitialState(), {
+      type: "bootstrapLoaded",
+      payload: {
+        folders: [
+          { id: "folder-1", name: "Inbox", createdAt: now, updatedAt: now },
+          { id: "folder-2", name: "Archive", createdAt: now, updatedAt: now },
+        ],
+        notes: [
+          { ...note({ id: "note-1", title: "A" }), folderIds: ["folder-1"] },
+          {
+            ...note({ id: "note-2", title: "B" }),
+            folderIds: ["folder-1", "folder-2"],
+          },
+        ],
+        activeRecoveries: [],
+        providerConfigured: false,
+      },
+    });
+
+    expect(initial.folders.map((folder) => folder.name)).toEqual([
+      "Archive",
+      "Inbox",
+    ]);
+
+    const renamed = notesReducer(initial, {
+      type: "folderRenamed",
+      folder: {
+        id: "folder-1",
+        name: "Triage",
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+    expect(renamed.folders.map((folder) => folder.name)).toEqual([
+      "Archive",
+      "Triage",
+    ]);
+
+    const deleted = notesReducer(renamed, {
+      type: "folderDeleted",
+      folderId: "folder-1",
+    });
+    expect(deleted.folders.map((folder) => folder.id)).toEqual(["folder-2"]);
+    expect(
+      deleted.notes.find((item) => item.id === "note-2")?.folderIds,
+    ).toEqual(["folder-2"]);
+    expect(
+      deleted.notes.find((item) => item.id === "note-1")?.folderIds,
+    ).toEqual([]);
+  });
+
   it("clears recording status after finish processing starts", () => {
     const status: RecordingStatusDto = {
       sessionId: "session-1",

--- a/src/test/folder-chip.test.tsx
+++ b/src/test/folder-chip.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NoteEditor } from "../components/note-editor/NoteEditor";
+import type { FolderDto, NoteDto } from "../lib/tauri";
+
+const now = "2026-05-19T10:00:00Z";
+
+function note(): NoteDto {
+  return {
+    id: "note-1",
+    title: "Untitled",
+    preview: "",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    activeTab: "notes",
+  };
+}
+
+function baseProps(folders: FolderDto[]) {
+  return {
+    note: note(),
+    folders,
+    sourceMode: "microphonePlusSystem" as const,
+    checkingSourceReadiness: false,
+    onTitleChange: vi.fn(),
+    onContentChange: vi.fn(),
+    onSourceModeChange: vi.fn(),
+    onStartRecording: vi.fn(),
+    onPauseRecording: vi.fn(),
+    onResumeRecording: vi.fn(),
+    onFinishRecording: vi.fn(),
+    onRetry: vi.fn(),
+    onAssignFolder: vi.fn(),
+    onRemoveFolder: vi.fn(),
+    onCreateAndAssignFolder: vi.fn(),
+    onNavigateToFolders: vi.fn(),
+    onNavigateToFolder: vi.fn(),
+    onTabChange: vi.fn(),
+  };
+}
+
+describe("Folder chip — move-to-folder popover", () => {
+  it("shows 'Folder' label when nothing is assigned", () => {
+    render(<NoteEditor {...baseProps([])} />);
+    expect(
+      screen.getByRole("button", { name: /^Folder/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("filters folders by the search query", async () => {
+    const user = userEvent.setup();
+    render(
+      <NoteEditor
+        {...baseProps([
+          { id: "f1", name: "Ideas", createdAt: now, updatedAt: now },
+          { id: "f2", name: "Work", createdAt: now, updatedAt: now },
+        ])}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Folder/ }));
+    const input = screen.getByPlaceholderText("Search or create folder");
+    await user.type(input, "wor");
+
+    expect(screen.queryByText("Ideas")).toBeNull();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+  });
+
+  it("offers 'Create' when no existing folder matches", async () => {
+    const user = userEvent.setup();
+    const props = baseProps([
+      { id: "f1", name: "Ideas", createdAt: now, updatedAt: now },
+    ]);
+    render(<NoteEditor {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /^Folder/ }));
+    await user.type(
+      screen.getByPlaceholderText("Search or create folder"),
+      "Personal",
+    );
+
+    const create = screen.getByRole("button", { name: /Create.*Personal/ });
+    await user.click(create);
+    expect(props.onCreateAndAssignFolder).toHaveBeenCalledWith("Personal");
+  });
+});

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
+import { Sidebar } from "../components/sidebar/Sidebar";
+import type { FolderDto, NoteListItemDto } from "../lib/tauri";
+
+const now = "2026-05-19T10:00:00Z";
+
+const folders: FolderDto[] = [
+  { id: "folder-1", name: "Ideas", createdAt: now, updatedAt: now },
+  {
+    id: "folder-2",
+    name: "Work",
+    description: "Client projects in flight",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+const notes: NoteListItemDto[] = [
+  {
+    id: "note-1",
+    title: "Roadmap",
+    preview: "Q3 priorities",
+    processingStatus: "ready",
+    folderIds: ["folder-2"],
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: "note-2",
+    title: "Loose thought",
+    preview: "",
+    processingStatus: "draft",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+function baseProps() {
+  return {
+    folders,
+    notes,
+    selectedFolderId: undefined as string | undefined,
+    onSelectFolder: vi.fn(),
+    onCreateFolder: vi.fn(),
+    onRenameFolder: vi.fn(),
+    onDeleteFolder: vi.fn(),
+    onCreateNote: vi.fn(),
+    onSelectNote: vi.fn(),
+    onAssignNoteToFolder: vi.fn(async () => undefined),
+    onRemoveNoteFromFolder: vi.fn(),
+    onDeleteNote: vi.fn(),
+  };
+}
+
+describe("Sidebar — Folders nav item", () => {
+  it("activates the folders view when clicked", async () => {
+    const user = userEvent.setup();
+    const onChangeView = vi.fn();
+    render(
+      <Sidebar
+        folders={folders}
+        notes={notes}
+        selectedNoteId={undefined}
+        selectedFolderId={undefined}
+        activeView="notes"
+        onChangeView={onChangeView}
+        onCreateFolder={vi.fn()}
+        onCreateNote={vi.fn()}
+        onSelectAll={vi.fn()}
+        onSelectFolder={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Folders/ }));
+    expect(onChangeView).toHaveBeenCalledWith("folders");
+  });
+
+  it("does not render the folder count badge", () => {
+    render(
+      <Sidebar
+        folders={folders}
+        notes={notes}
+        selectedNoteId={undefined}
+        selectedFolderId={undefined}
+        activeView="notes"
+        onChangeView={vi.fn()}
+        onCreateFolder={vi.fn()}
+        onCreateNote={vi.fn()}
+        onSelectAll={vi.fn()}
+        onSelectFolder={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /Folders/ });
+    expect(button.textContent?.replace(/\s/g, "")).toBe("Folders");
+  });
+});
+
+describe("FoldersWorkspace — list view", () => {
+  it("renders folder cards with descriptions or note counts and no All notes", () => {
+    render(<FoldersWorkspace {...baseProps()} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Folders" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("All notes")).toBeNull();
+    expect(screen.getByText("Ideas")).toBeInTheDocument();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    const workCard = screen.getByText("Work").closest("article");
+    expect(workCard).not.toBeNull();
+    // Description preferred over note count when present.
+    expect(
+      within(workCard as HTMLElement).getByText("Client projects in flight"),
+    ).toBeInTheDocument();
+    const ideasCard = screen.getByText("Ideas").closest("article");
+    expect(
+      within(ideasCard as HTMLElement).getByText(/0 notes/),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the create dialog and submits name + description", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<FoldersWorkspace {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /New folder/ }));
+    expect(
+      screen.getByRole("dialog", { name: /Create folder/ }),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Name"), "Personal");
+    await user.type(screen.getByLabelText("Description"), "Side projects");
+    await user.click(screen.getByRole("button", { name: /Create folder/ }));
+
+    expect(props.onCreateFolder).toHaveBeenCalledWith(
+      "Personal",
+      "Side projects",
+    );
+  });
+
+  it("filters folders by search query", async () => {
+    const user = userEvent.setup();
+    render(<FoldersWorkspace {...baseProps()} />);
+
+    await user.type(screen.getByPlaceholderText("Search"), "work");
+    expect(screen.queryByText("Ideas")).toBeNull();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+  });
+
+  it("opens a folder when its card is clicked", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<FoldersWorkspace {...props} />);
+
+    const ideasCard = screen.getByText("Ideas").closest("article");
+    await user.click(within(ideasCard as HTMLElement).getByText("Ideas"));
+    expect(props.onSelectFolder).toHaveBeenCalledWith("folder-1");
+  });
+});
+
+describe("FoldersWorkspace — detail view", () => {
+  it("renders the folder via sticky header and surfaces description + meta", () => {
+    render(<FoldersWorkspace {...baseProps()} selectedFolderId="folder-2" />);
+
+    // Folder name shows in the breadcrumb and as the editable title.
+    expect(
+      screen.getByRole("button", { name: /Rename folder/ }),
+    ).toHaveTextContent("Work");
+    expect(screen.getByText("Client projects in flight")).toBeInTheDocument();
+    expect(screen.getByText("Roadmap")).toBeInTheDocument();
+  });
+
+  it("enters edit mode on a single click of the title", async () => {
+    const user = userEvent.setup();
+    render(<FoldersWorkspace {...baseProps()} selectedFolderId="folder-1" />);
+
+    await user.click(screen.getByRole("button", { name: /Rename folder/ }));
+    // The serif title is replaced by an input that auto-selects its value.
+    expect(document.activeElement).toBeInstanceOf(HTMLInputElement);
+    expect((document.activeElement as HTMLInputElement).value).toBe("Ideas");
+  });
+
+  it("returns to the list via the back button in the sticky bar", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<FoldersWorkspace {...props} selectedFolderId="folder-1" />);
+
+    await user.click(
+      screen.getByRole("button", { name: /^Folders$/ }),
+    );
+    expect(props.onSelectFolder).toHaveBeenCalledWith(undefined);
+  });
+
+  it("renders empty-state actions and triggers create-note", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<FoldersWorkspace {...props} selectedFolderId="folder-1" />);
+
+    // The empty surface is visual-only — no helper text — just the
+    // primary action and "Add existing note" when other notes exist.
+    await user.click(screen.getByRole("button", { name: /^New note$/ }));
+    expect(props.onCreateNote).toHaveBeenCalledWith("folder-1");
+  });
+
+  it("removes a note from the folder via its row overflow menu", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<FoldersWorkspace {...props} selectedFolderId="folder-2" />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Actions for Roadmap/ }),
+    );
+    await user.click(
+      screen.getByRole("menuitem", { name: /Remove from folder/ }),
+    );
+    expect(props.onRemoveNoteFromFolder).toHaveBeenCalledWith(
+      "note-1",
+      "folder-2",
+    );
+  });
+});

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -35,6 +35,9 @@ const props = {
   onRetry: vi.fn(),
   onAssignFolder: vi.fn(),
   onRemoveFolder: vi.fn(),
+  onCreateAndAssignFolder: vi.fn(),
+  onNavigateToFolders: vi.fn(),
+  onNavigateToFolder: vi.fn(),
   onTabChange: vi.fn(),
 };
 


### PR DESCRIPTION
## Summary

Introduces a **Folders** main-nav surface (below Dictation) with a Claude / Granola-inspired workspace for grouping notes.

- **Folder list page** — compact subtle cards (icon · title · description · `📄 N notes · Updated Xh ago` footer pinned to the bottom), 240px search field on the left, sort dropdown (Recent / Created / A → Z / Z → A) on the right, hover-revealed overflow with Open + Delete.
- **Folder detail page** — sticky blurred crumb bar (\`Folders / Name\`), single-click title rename, optional description, meta row (\`[subtle pill] · N notes · Updated date\`), right-aligned **New note** + **Add existing note** primary actions, Granola-style note rows (white default, hover gray, row overflow with **Remove from folder** + **Delete note**, actual timestamps on the right).
- **Note opened from a folder** — same sticky crumb bar (\`Folders / Folder / Note title\`) renders above the unmodified main note editor. A new \`.note-shell\` wrapper keeps the editor flexing to fill the workspace; recorder bar still sticks to the bottom.

## System primitives added
- \`src/components/ui/Dialog.tsx\` — base Dialog (blurred backdrop, focus trap, ESC/backdrop close, header flex layout with right-anchored close).
- \`CreateFolderDialog\`, \`EditFolderDialog\`, \`AddNotesToFolderDialog\` (multi-select, footer commit), and the **Move-to-folder** popover on the note editor (searchable + inline \"Create [name]\").

## Backend
- Optional \`description\` column on \`folders\` via idempotent \`ensure_column\` migration; threaded through DTO, commands, and TS client.
- \`UNIQUE\` index on \`folders.name\` removed — folders are identified by their UUID, duplicate names are intentionally allowed. Migration step \`drop_index_if_exists\` covers existing databases.
- \`delete_folder\` always preserves notes; the UI only ever passes \`deleteNotes=false\`. Deleting a folder just clears the \`note_folders\` associations.

## Test plan

- [ ] Open the Folders nav item; create a couple of folders via the dialog (name + description)
- [ ] Confirm duplicate folder names are now allowed and listed
- [ ] Open a folder, rename via title (single click), edit description via overflow \"Edit details\"
- [ ] Add a couple of existing notes via the multi-select dialog (footer commit)
- [ ] Click a note from inside a folder — confirm sticky crumb bar (\`Folders / Folder / Note\`) and that the editor lays out identically to the main notes view
- [ ] Use the note overline folder chip to move the note to a new folder via the search/create popover
- [ ] Use the row overflow on a folder note → \"Remove from folder\" and \"Delete note\"
- [ ] Delete a folder via the detail overflow → confirm notes survive in the global list

🤖 Generated with [Claude Code](https://claude.com/claude-code)