### PR TITLE
[feat] split dictation shortcuts

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -145,7 +145,7 @@ func runOnMain(_ work: @escaping () -> Void) {
     }
 }
 
-struct ShortcutModifiers {
+struct ShortcutModifiers: Equatable, Hashable {
     let command: Bool
     let control: Bool
     let option: Bool
@@ -208,25 +208,29 @@ struct MonitoredShortcut {
     let code: String
     let label: String
     let modifiers: ShortcutModifiers
+    let pressCount: Int
 
     static let bareFn = MonitoredShortcut(
         keyCode: 0,
         code: "Fn",
         label: "Fn",
-        modifiers: ShortcutModifiers(function: true)
+        modifiers: ShortcutModifiers(function: true),
+        pressCount: 1
     )
 
-    init(keyCode: UInt16, code: String, label: String, modifiers: ShortcutModifiers) {
+    init(keyCode: UInt16, code: String, label: String, modifiers: ShortcutModifiers, pressCount: Int = 1) {
         self.keyCode = keyCode
         self.code = code
-        self.label = label
+        self.label = Self.displayLabel(label: label, pressCount: pressCount)
         self.modifiers = modifiers
+        self.pressCount = pressCount == 2 ? 2 : 1
     }
 
     init?(payload: [String: Any]) {
         let code = payload["code"] as? String ?? ""
         let label = payload["label"] as? String ?? ""
         let modifiersPayload = payload["modifiers"] as? [String: Any] ?? [:]
+        let rawPressCount = payload["pressCount"] as? Int ?? (payload["pressCount"] as? NSNumber)?.intValue ?? 1
         let keyCode: UInt16
 
         if let rawKeyCode = payload["keyCode"] as? UInt16 {
@@ -247,7 +251,8 @@ struct MonitoredShortcut {
 
         self.keyCode = keyCode
         self.code = code
-        self.label = label
+        self.pressCount = rawPressCount == 2 ? 2 : 1
+        self.label = Self.displayLabel(label: label, pressCount: self.pressCount)
         self.modifiers = ShortcutModifiers(payload: modifiersPayload)
     }
 
@@ -265,20 +270,71 @@ struct MonitoredShortcut {
             "keyCode": Int(keyCode),
             "code": code,
             "label": label,
+            "pressCount": pressCount,
             "modifiers": modifiers.payload,
         ]
+    }
+
+    private static func displayLabel(label: String, pressCount: Int) -> String {
+        guard pressCount == 2 else {
+            return label
+        }
+        let parts = label.split(separator: "+").map(String.init)
+        if parts.count.isMultiple(of: 2) && !parts.isEmpty {
+            let half = parts.count / 2
+            if Array(parts[0..<half]) == Array(parts[half..<parts.count]) {
+                return label
+            }
+        }
+        return "\(label)+\(label)"
+    }
+}
+
+enum ShortcutKind: String {
+    case pushToTalk = "push_to_talk"
+    case toggle
+}
+
+struct ShortcutIdentity: Equatable, Hashable {
+    let keyCode: UInt16
+    let code: String
+    let modifiers: ShortcutModifiers
+
+    init(_ shortcut: MonitoredShortcut) {
+        keyCode = shortcut.keyCode
+        code = shortcut.code
+        modifiers = shortcut.modifiers
     }
 }
 
 final class ShortcutKeyMonitor {
     static let shared = ShortcutKeyMonitor()
 
+    private static let holdThreshold: TimeInterval = 0.16
+    private static let doublePressWindow: TimeInterval = 0.34
+
     private var globalMonitor: Any?
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
-    private var shortcut = MonitoredShortcut.bareFn
-    private var shortcutIsDown = false
+    private var shortcuts: [ShortcutKind: MonitoredShortcut] = [
+        .pushToTalk: .bareFn,
+        .toggle: MonitoredShortcut(
+            keyCode: 0,
+            code: "Fn",
+            label: "Fn",
+            modifiers: ShortcutModifiers(function: true),
+            pressCount: 2
+        ),
+    ]
+    private var activeIdentity: ShortcutIdentity?
+    private var activePushIdentity: ShortcutIdentity?
+    private var pendingPushWork: DispatchWorkItem?
+    private var pendingPushIdentity: ShortcutIdentity?
+    private var pendingPushShortcut: MonitoredShortcut?
+    private var lastTapIdentity: ShortcutIdentity?
+    private var lastTapAt: Date?
     private var isCapturingShortcut = false
+    private var capturePressCount = 1
     private var pendingBareFnCapture: DispatchWorkItem?
 
     private init() {}
@@ -312,13 +368,16 @@ final class ShortcutKeyMonitor {
             return
         }
 
-        if shortcut.isBareFn {
-            observe(isDown: flags.contains(.maskSecondaryFn))
+        guard hasBareFnShortcut else {
             return
         }
 
-        if shortcutIsDown && !modifiersMatch(flags, shortcut.modifiers) {
-            observe(isDown: false)
+        let isDown = flags.contains(.maskSecondaryFn)
+        let identity = ShortcutIdentity(MonitoredShortcut.bareFn)
+        if isDown {
+            handlePhysicalDown(identity: identity)
+        } else {
+            handlePhysicalUp(identity: identity)
         }
     }
 
@@ -328,41 +387,41 @@ final class ShortcutKeyMonitor {
             return
         }
 
-        guard !shortcut.isBareFn else {
-            if type == .flagsChanged {
-                handle(flags: event.flags)
-            }
-            return
-        }
-
         switch type {
         case .keyDown:
-            guard keyCode(from: event) == shortcut.keyCode,
-                  modifiersMatch(event.flags, shortcut.modifiers)
-            else {
+            guard let identity = matchingIdentity(keyCode: keyCode(from: event), flags: event.flags) else {
                 return
             }
-            observe(isDown: true)
+            handlePhysicalDown(identity: identity)
         case .keyUp:
-            guard keyCode(from: event) == shortcut.keyCode else {
+            guard let identity = activeIdentity, keyCode(from: event) == identity.keyCode else {
                 return
             }
-            observe(isDown: false)
+            handlePhysicalUp(identity: identity)
         case .flagsChanged:
             handle(flags: event.flags)
+            if let identity = activeIdentity, !modifiersMatch(event.flags, identity.modifiers) {
+                handlePhysicalUp(identity: identity)
+            }
         default:
             break
         }
     }
 
-    func setShortcut(_ nextShortcut: MonitoredShortcut) {
-        shortcut = nextShortcut
-        shortcutIsDown = false
+    func setShortcut(_ nextShortcut: MonitoredShortcut, kind: ShortcutKind) {
+        shortcuts[kind] = nextShortcut
+        cancelPendingPush()
+        activeIdentity = nil
+        activePushIdentity = nil
+        lastTapIdentity = nil
+        lastTapAt = nil
     }
 
-    func startShortcutCapture() {
+    func startShortcutCapture(pressCount: Int = 1) {
         isCapturingShortcut = true
-        shortcutIsDown = false
+        capturePressCount = pressCount == 2 ? 2 : 1
+        cancelPendingPush()
+        activeIdentity = nil
         cancelPendingBareFnCapture()
         emit("shortcut_capture_started")
     }
@@ -411,30 +470,28 @@ final class ShortcutKeyMonitor {
             return
         }
 
-        if shortcut.isBareFn {
-            guard event.type == .flagsChanged else {
-                return
-            }
-            observe(isDown: event.modifierFlags.contains(.function))
-            return
-        }
-
         switch event.type {
         case .keyDown:
-            guard UInt16(event.keyCode) == shortcut.keyCode,
-                  modifiersMatch(event.modifierFlags, shortcut.modifiers)
-            else {
+            guard let identity = matchingIdentity(keyCode: UInt16(event.keyCode), flags: event.modifierFlags) else {
                 return
             }
-            observe(isDown: true)
+            handlePhysicalDown(identity: identity)
         case .keyUp:
-            guard UInt16(event.keyCode) == shortcut.keyCode else {
+            guard let identity = activeIdentity, UInt16(event.keyCode) == identity.keyCode else {
                 return
             }
-            observe(isDown: false)
+            handlePhysicalUp(identity: identity)
         case .flagsChanged:
-            if shortcutIsDown && !modifiersMatch(event.modifierFlags, shortcut.modifiers) {
-                observe(isDown: false)
+            if hasBareFnShortcut {
+                let identity = ShortcutIdentity(MonitoredShortcut.bareFn)
+                if event.modifierFlags.contains(.function) {
+                    handlePhysicalDown(identity: identity)
+                } else {
+                    handlePhysicalUp(identity: identity)
+                }
+            }
+            if let identity = activeIdentity, !modifiersMatch(event.modifierFlags, identity.modifiers) {
+                handlePhysicalUp(identity: identity)
             }
         default:
             break
@@ -499,7 +556,8 @@ final class ShortcutKeyMonitor {
                 keyCode: keyCode,
                 code: code,
                 label: (modifiers.labelParts + [label]).joined(separator: "+"),
-                modifiers: modifiers
+                modifiers: modifiers,
+                pressCount: capturePressCount
             )
         )
     }
@@ -510,7 +568,18 @@ final class ShortcutKeyMonitor {
         }
 
         let work = DispatchWorkItem { [weak self] in
-            self?.finishCapture(.bareFn)
+            guard let self else {
+                return
+            }
+            self.finishCapture(
+                MonitoredShortcut(
+                    keyCode: 0,
+                    code: "Fn",
+                    label: "Fn",
+                    modifiers: ShortcutModifiers(function: true),
+                    pressCount: self.capturePressCount
+                )
+            )
         }
         pendingBareFnCapture = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)
@@ -533,13 +602,120 @@ final class ShortcutKeyMonitor {
         pendingBareFnCapture = nil
     }
 
-    private func observe(isDown nextIsDown: Bool) {
-        guard nextIsDown != shortcutIsDown else {
+    private var hasBareFnShortcut: Bool {
+        shortcuts.values.contains { $0.isBareFn }
+    }
+
+    private var hasNonBareFnShortcut: Bool {
+        shortcuts.values.contains { !$0.isBareFn }
+    }
+
+    private func matchingIdentity(keyCode: UInt16, flags: CGEventFlags) -> ShortcutIdentity? {
+        for shortcut in shortcuts.values where !shortcut.isBareFn {
+            guard keyCode == shortcut.keyCode, modifiersMatch(flags, shortcut.modifiers) else {
+                continue
+            }
+            return ShortcutIdentity(shortcut)
+        }
+        return nil
+    }
+
+    private func matchingIdentity(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> ShortcutIdentity? {
+        for shortcut in shortcuts.values where !shortcut.isBareFn {
+            guard keyCode == shortcut.keyCode, modifiersMatch(flags, shortcut.modifiers) else {
+                continue
+            }
+            return ShortcutIdentity(shortcut)
+        }
+        return nil
+    }
+
+    private func shortcuts(matching identity: ShortcutIdentity) -> [(ShortcutKind, MonitoredShortcut)] {
+        shortcuts.compactMap { kind, shortcut in
+            ShortcutIdentity(shortcut) == identity ? (kind, shortcut) : nil
+        }
+    }
+
+    private func handlePhysicalDown(identity: ShortcutIdentity) {
+        guard activeIdentity != identity else {
+            return
+        }
+        activeIdentity = identity
+
+        let matches = shortcuts(matching: identity)
+        if let toggle = matches.first(where: { $0.0 == .toggle && $0.1.pressCount == 2 }) {
+            let now = Date()
+            if lastTapIdentity == identity,
+               let lastTapAt,
+               now.timeIntervalSince(lastTapAt) <= Self.doublePressWindow {
+                lastTapIdentity = nil
+                self.lastTapAt = nil
+                cancelPendingPush()
+                emitShortcut(.toggle, shortcut: toggle.1, isDown: true)
+                return
+            }
+        }
+
+        if let toggle = matches.first(where: { $0.0 == .toggle && $0.1.pressCount == 1 }) {
+            emitShortcut(.toggle, shortcut: toggle.1, isDown: true)
+        }
+
+        if let push = matches.first(where: { $0.0 == .pushToTalk && $0.1.pressCount == 1 }) {
+            schedulePushStart(identity: identity, shortcut: push.1)
+        }
+    }
+
+    private func handlePhysicalUp(identity: ShortcutIdentity) {
+        guard activeIdentity == identity else {
+            return
+        }
+        activeIdentity = nil
+
+        if activePushIdentity == identity, let push = shortcuts(matching: identity).first(where: { $0.0 == .pushToTalk }) {
+            activePushIdentity = nil
+            emitShortcut(.pushToTalk, shortcut: push.1, isDown: false)
             return
         }
 
-        shortcutIsDown = nextIsDown
-        emit(nextIsDown ? "shortcut_key_down" : "shortcut_key_up", [
+        cancelPendingPush()
+
+        if shortcuts(matching: identity).contains(where: { $0.0 == .toggle && $0.1.pressCount == 2 }) {
+            lastTapIdentity = identity
+            lastTapAt = Date()
+        }
+    }
+
+    private func schedulePushStart(identity: ShortcutIdentity, shortcut: MonitoredShortcut) {
+        cancelPendingPush()
+        pendingPushIdentity = identity
+        pendingPushShortcut = shortcut
+        let work = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.activeIdentity == identity,
+                  self.pendingPushIdentity == identity,
+                  let shortcut = self.pendingPushShortcut
+            else {
+                return
+            }
+            self.activePushIdentity = identity
+            self.pendingPushIdentity = nil
+            self.pendingPushShortcut = nil
+            self.emitShortcut(.pushToTalk, shortcut: shortcut, isDown: true)
+        }
+        pendingPushWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.holdThreshold, execute: work)
+    }
+
+    private func cancelPendingPush() {
+        pendingPushWork?.cancel()
+        pendingPushWork = nil
+        pendingPushIdentity = nil
+        pendingPushShortcut = nil
+    }
+
+    private func emitShortcut(_ kind: ShortcutKind, shortcut: MonitoredShortcut, isDown: Bool) {
+        emit(isDown ? "shortcut_key_down" : "shortcut_key_up", [
+            "kind": kind.rawValue,
             "shortcut": shortcut.label,
         ])
     }
@@ -1316,17 +1492,20 @@ func handleCommandLine(_ line: String) {
     case "set_shortcut":
         guard
             let payload = command?["shortcut"] as? [String: Any],
-            let shortcut = MonitoredShortcut(payload: payload)
+            let shortcut = MonitoredShortcut(payload: payload),
+            let rawKind = payload["kind"] as? String,
+            let kind = ShortcutKind(rawValue: rawKind)
         else {
             emit("error", ["code": "invalid_shortcut", "message": "Shortcut configuration was invalid."])
             return
         }
         runOnMain {
-            ShortcutKeyMonitor.shared.setShortcut(shortcut)
+            ShortcutKeyMonitor.shared.setShortcut(shortcut, kind: kind)
         }
     case "start_shortcut_capture":
+        let pressCount = command?["pressCount"] as? Int ?? (command?["pressCount"] as? NSNumber)?.intValue ?? 1
         runOnMain {
-            ShortcutKeyMonitor.shared.startShortcutCapture()
+            ShortcutKeyMonitor.shared.startShortcutCapture(pressCount: pressCount)
         }
     case "cancel_shortcut_capture":
         runOnMain {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -45,16 +45,16 @@ pub struct ShortcutActivationState {
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DictationSettings {
-    pub shortcut: DictationShortcutSetting,
-    pub activation_mode: DictationActivationMode,
+    pub push_to_talk_shortcut: DictationShortcutSetting,
+    pub toggle_shortcut: DictationShortcutSetting,
     pub microphone: DictationMicrophoneSetting,
 }
 
 impl Default for DictationSettings {
     fn default() -> Self {
         Self {
-            shortcut: DictationShortcutSetting::bare_fn(),
-            activation_mode: DictationActivationMode::default(),
+            push_to_talk_shortcut: DictationShortcutSetting::bare_fn(),
+            toggle_shortcut: DictationShortcutSetting::double_bare_fn(),
             microphone: DictationMicrophoneSetting::default(),
         }
     }
@@ -68,26 +68,36 @@ impl<'de> Deserialize<'de> for DictationSettings {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct SettingsValue {
-            shortcut: Option<DictationShortcutSetting>,
-            activation_mode: Option<DictationActivationMode>,
+            push_to_talk_shortcut: Option<DictationShortcutSetting>,
+            toggle_shortcut: Option<DictationShortcutSetting>,
             microphone: Option<DictationMicrophoneSetting>,
         }
 
         let value = serde_json::Value::deserialize(deserializer)?;
-        let has_activation_mode = value.get("activationMode").is_some();
-        let settings: SettingsValue =
-            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let microphone = value
+            .get("microphone")
+            .cloned()
+            .and_then(|microphone| serde_json::from_value(microphone).ok())
+            .unwrap_or_default();
+
+        if value.get("shortcut").is_some() || value.get("activationMode").is_some() {
+            return Ok(Self {
+                microphone,
+                ..Self::default()
+            });
+        }
+
+        let settings: SettingsValue = serde_json::from_value(value)
+            .map_err(serde::de::Error::custom)?;
 
         Ok(Self {
-            shortcut: if has_activation_mode {
-                settings
-                    .shortcut
-                    .unwrap_or_else(DictationShortcutSetting::bare_fn)
-            } else {
-                DictationShortcutSetting::bare_fn()
-            },
-            activation_mode: settings.activation_mode.unwrap_or_default(),
-            microphone: settings.microphone.unwrap_or_default(),
+            push_to_talk_shortcut: settings
+                .push_to_talk_shortcut
+                .unwrap_or_else(DictationShortcutSetting::bare_fn),
+            toggle_shortcut: settings
+                .toggle_shortcut
+                .unwrap_or_else(DictationShortcutSetting::double_bare_fn),
+            microphone: settings.microphone.unwrap_or(microphone),
         })
     }
 }
@@ -99,6 +109,7 @@ pub struct DictationShortcutSetting {
     pub code: String,
     pub modifiers: DictationShortcutModifiers,
     pub label: String,
+    pub press_count: u8,
 }
 
 impl<'de> Deserialize<'de> for DictationShortcutSetting {
@@ -113,6 +124,7 @@ impl<'de> Deserialize<'de> for DictationShortcutSetting {
             code: String,
             modifiers: DictationShortcutModifiers,
             label: String,
+            press_count: Option<u8>,
         }
 
         let value = serde_json::Value::deserialize(deserializer)?;
@@ -128,6 +140,8 @@ impl<'de> Deserialize<'de> for DictationShortcutSetting {
             code: shortcut.code,
             modifiers: shortcut.modifiers,
             label: shortcut.label,
+            press_count: normalize_press_count(shortcut.press_count.unwrap_or(1))
+                .map_err(serde::de::Error::custom)?,
         })
     }
 }
@@ -142,7 +156,28 @@ impl DictationShortcutSetting {
                 ..DictationShortcutModifiers::default()
             },
             label: "Fn".to_string(),
+            press_count: 1,
         }
+    }
+
+    fn double_bare_fn() -> Self {
+        Self {
+            key_code: 0,
+            code: "Fn".to_string(),
+            modifiers: DictationShortcutModifiers {
+                function: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Fn+Fn".to_string(),
+            press_count: 2,
+        }
+    }
+
+    fn same_trigger_as(&self, other: &Self) -> bool {
+        self.key_code == other.key_code
+            && self.code == other.code
+            && self.modifiers == other.modifiers
+            && self.press_count == other.press_count
     }
 }
 
@@ -162,12 +197,12 @@ pub struct DictationShortcutInput {
     pub code: String,
     pub modifiers: DictationShortcutModifiers,
     pub label: String,
+    pub press_count: Option<u8>,
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum DictationActivationMode {
-    #[default]
+pub enum DictationShortcutKind {
     PushToTalk,
     Toggle,
 }
@@ -187,7 +222,8 @@ pub struct DictationSettingsResponse {
 
 #[derive(Debug, Default)]
 struct ShortcutActivationController {
-    is_down: bool,
+    active_mode: Option<DictationShortcutKind>,
+    push_to_talk_is_down: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -207,42 +243,47 @@ impl ShortcutActivationController {
     fn handle_edge(
         &mut self,
         edge: ShortcutKeyEdge,
-        mode: DictationActivationMode,
+        kind: DictationShortcutKind,
     ) -> Option<DictationCommand> {
-        match (mode, edge) {
-            (DictationActivationMode::PushToTalk, ShortcutKeyEdge::Down) => {
-                if self.is_down {
-                    None
-                } else {
-                    self.is_down = true;
-                    Some(DictationCommand::StartListening)
+        match (kind, edge) {
+            (DictationShortcutKind::PushToTalk, ShortcutKeyEdge::Down) => {
+                if self.active_mode.is_some() || self.push_to_talk_is_down {
+                    return None;
                 }
+                self.active_mode = Some(DictationShortcutKind::PushToTalk);
+                self.push_to_talk_is_down = true;
+                Some(DictationCommand::StartListening)
             }
-            (DictationActivationMode::PushToTalk, ShortcutKeyEdge::Up) => {
-                if self.is_down {
-                    self.is_down = false;
+            (DictationShortcutKind::PushToTalk, ShortcutKeyEdge::Up) => {
+                if self.active_mode == Some(DictationShortcutKind::PushToTalk)
+                    && self.push_to_talk_is_down
+                {
+                    self.active_mode = None;
+                    self.push_to_talk_is_down = false;
                     Some(DictationCommand::StopAndPaste)
                 } else {
+                    self.push_to_talk_is_down = false;
                     None
                 }
             }
-            (DictationActivationMode::Toggle, ShortcutKeyEdge::Down) => {
-                if self.is_down {
-                    None
-                } else {
-                    self.is_down = true;
+            (DictationShortcutKind::Toggle, ShortcutKeyEdge::Down) => match self.active_mode {
+                Some(DictationShortcutKind::PushToTalk) => None,
+                Some(DictationShortcutKind::Toggle) => {
+                    self.active_mode = None;
                     Some(DictationCommand::ToggleListening)
                 }
-            }
-            (DictationActivationMode::Toggle, ShortcutKeyEdge::Up) => {
-                self.is_down = false;
-                None
-            }
+                None => {
+                    self.active_mode = Some(DictationShortcutKind::Toggle);
+                    Some(DictationCommand::ToggleListening)
+                }
+            },
+            (DictationShortcutKind::Toggle, ShortcutKeyEdge::Up) => None,
         }
     }
 
     fn reset(&mut self) {
-        self.is_down = false;
+        self.active_mode = None;
+        self.push_to_talk_is_down = false;
     }
 }
 
@@ -268,8 +309,20 @@ impl DictationShortcutInput {
             ));
         }
 
+        let press_count = normalize_press_count(self.press_count.unwrap_or(1)).map_err(|message| {
+            AppError::new("dictation_shortcut_press_count_invalid", message)
+        })?;
+
         if is_bare_fn_input(&self.code, &self.modifiers) {
-            return Ok(DictationShortcutSetting::bare_fn());
+            return Ok(DictationShortcutSetting {
+                press_count,
+                label: if press_count == 2 {
+                    "Fn+Fn".to_string()
+                } else {
+                    "Fn".to_string()
+                },
+                ..DictationShortcutSetting::bare_fn()
+            });
         }
 
         let key_code = key_code_for_code(&self.code).ok_or_else(|| {
@@ -296,7 +349,15 @@ impl DictationShortcutInput {
             code: self.code,
             modifiers: self.modifiers,
             label: self.label,
+            press_count,
         })
+    }
+}
+
+fn normalize_press_count(press_count: u8) -> Result<u8, String> {
+    match press_count {
+        1 | 2 => Ok(press_count),
+        _ => Err("Shortcut press count must be 1 or 2.".to_string()),
     }
 }
 
@@ -315,6 +376,7 @@ fn legacy_shortcut_setting(id: &str) -> Option<DictationShortcutSetting> {
                 ..DictationShortcutModifiers::default()
             },
             label: "Fn+Space".to_string(),
+            press_count: 1,
         }),
         "control_option_space" => Some(DictationShortcutSetting {
             key_code: 0x31,
@@ -325,15 +387,10 @@ fn legacy_shortcut_setting(id: &str) -> Option<DictationShortcutSetting> {
                 ..DictationShortcutModifiers::default()
             },
             label: "Ctrl+Opt+Space".to_string(),
+            press_count: 1,
         }),
         _ => None,
     }
-}
-
-fn is_bare_fn_shortcut(shortcut: &DictationShortcutSetting) -> bool {
-    shortcut.code.eq_ignore_ascii_case("Fn")
-        && shortcut.modifiers.function
-        && no_standard_modifiers(&shortcut.modifiers)
 }
 
 fn no_standard_modifiers(modifiers: &DictationShortcutModifiers) -> bool {
@@ -367,19 +424,19 @@ pub fn setup(app: &mut tauri::App) {
             .map(|settings| settings.clone());
         if let Some(settings) = settings {
             let _ = apply_microphone_setting(&helper_state, &settings.microphone);
-            let _ = apply_shortcut_setting(&helper_state, &settings.shortcut);
+            let _ = apply_shortcut_settings(&helper_state, &settings);
         }
     }
 
     #[cfg(target_os = "macos")]
     {
-        let shortcut = app
+        let settings = app
             .state::<DictationSettingsState>()
             .settings
             .lock()
-            .map(|settings| settings.shortcut.clone())
-            .unwrap_or_else(|_| DictationShortcutSetting::bare_fn());
-        let event = hotkey_ready_event(&shortcut);
+            .map(|settings| settings.clone())
+            .unwrap_or_default();
+        let event = hotkey_ready_event(&settings);
 
         app.manage(HotkeyStatus {
             event: Mutex::new(event.clone()),
@@ -407,6 +464,7 @@ pub fn set_dictation_shortcut(
     state: State<'_, DictationSettingsState>,
     helper_state: State<'_, HelperState>,
     hotkey_status: State<'_, HotkeyStatus>,
+    kind: DictationShortcutKind,
     shortcut: DictationShortcutInput,
 ) -> Result<DictationSettings, AppError> {
     let shortcut = shortcut.into_setting()?;
@@ -416,19 +474,29 @@ pub fn set_dictation_shortcut(
         .map_err(|_| AppError::new("dictation_settings_unavailable", "Settings lock failed."))?
         .clone();
 
-    if current_settings.shortcut == shortcut {
-        set_hotkey_status(&hotkey_status, hotkey_ready_event(&shortcut));
-        apply_shortcut_setting(&helper_state, &shortcut)?;
+    validate_shortcut_update(&current_settings, kind, &shortcut)?;
+
+    let current_shortcut = match kind {
+        DictationShortcutKind::PushToTalk => &current_settings.push_to_talk_shortcut,
+        DictationShortcutKind::Toggle => &current_settings.toggle_shortcut,
+    };
+
+    if current_shortcut == &shortcut {
+        set_hotkey_status(&hotkey_status, hotkey_ready_event(&current_settings));
+        apply_shortcut_settings(&helper_state, &current_settings)?;
         return Ok(current_settings);
     }
 
     let settings = update_settings(&state, |settings| {
-        settings.shortcut = shortcut;
+        match kind {
+            DictationShortcutKind::PushToTalk => settings.push_to_talk_shortcut = shortcut,
+            DictationShortcutKind::Toggle => settings.toggle_shortcut = shortcut,
+        }
     })?;
     reset_shortcut_activation(&app);
-    apply_shortcut_setting(&helper_state, &settings.shortcut)?;
+    apply_shortcut_settings(&helper_state, &settings)?;
 
-    set_hotkey_status(&hotkey_status, hotkey_ready_event(&settings.shortcut));
+    set_hotkey_status(&hotkey_status, hotkey_ready_event(&settings));
     Ok(settings)
 }
 
@@ -443,19 +511,6 @@ pub fn set_dictation_microphone(
         settings.microphone = DictationMicrophoneSetting { id, name };
     })?;
     apply_microphone_setting(&helper_state, &settings.microphone)?;
-    Ok(settings)
-}
-
-#[tauri::command]
-pub fn set_dictation_activation_mode(
-    app: AppHandle,
-    state: State<'_, DictationSettingsState>,
-    activation_mode: DictationActivationMode,
-) -> Result<DictationSettings, AppError> {
-    let settings = update_settings(&state, |settings| {
-        settings.activation_mode = activation_mode;
-    })?;
-    reset_shortcut_activation(&app);
     Ok(settings)
 }
 
@@ -536,6 +591,7 @@ fn apply_microphone_setting(
 
 fn apply_shortcut_setting(
     helper_state: &HelperState,
+    kind: DictationShortcutKind,
     shortcut: &DictationShortcutSetting,
 ) -> Result<(), AppError> {
     send_helper_command(
@@ -546,13 +602,55 @@ fn apply_shortcut_setting(
                 "keyCode": shortcut.key_code,
                 "code": shortcut.code,
                 "label": shortcut.label,
+                "kind": kind,
+                "pressCount": shortcut.press_count,
                 "modifiers": shortcut.modifiers,
             },
         }),
     )
 }
 
-fn handle_shortcut_key_event(app: &AppHandle, event_type: Option<&str>) {
+fn apply_shortcut_settings(
+    helper_state: &HelperState,
+    settings: &DictationSettings,
+) -> Result<(), AppError> {
+    apply_shortcut_setting(
+        helper_state,
+        DictationShortcutKind::PushToTalk,
+        &settings.push_to_talk_shortcut,
+    )?;
+    apply_shortcut_setting(
+        helper_state,
+        DictationShortcutKind::Toggle,
+        &settings.toggle_shortcut,
+    )
+}
+
+fn validate_shortcut_update(
+    settings: &DictationSettings,
+    kind: DictationShortcutKind,
+    shortcut: &DictationShortcutSetting,
+) -> Result<(), AppError> {
+    let other = match kind {
+        DictationShortcutKind::PushToTalk => &settings.toggle_shortcut,
+        DictationShortcutKind::Toggle => &settings.push_to_talk_shortcut,
+    };
+
+    if shortcut.same_trigger_as(other) {
+        return Err(AppError::new(
+            "dictation_shortcut_duplicate",
+            "Push-to-talk and toggle dictation shortcuts must be different.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn handle_shortcut_key_event(
+    app: &AppHandle,
+    event_type: Option<&str>,
+    event: Option<&serde_json::Value>,
+) {
     let Some(event_type) = event_type else {
         return;
     };
@@ -563,16 +661,15 @@ fn handle_shortcut_key_event(app: &AppHandle, event_type: Option<&str>) {
         _ => return,
     };
 
-    let Some(settings) = current_dictation_settings(app) else {
+    let Some(kind) = shortcut_kind_from_event(event) else {
         reset_shortcut_activation(app);
         return;
     };
 
-    if matches!(event_type, "fn_key_down" | "fn_key_up") && !is_bare_fn_shortcut(&settings.shortcut)
-    {
+    let Some(settings) = current_dictation_settings(app) else {
         reset_shortcut_activation(app);
         return;
-    }
+    };
 
     let command = app
         .try_state::<ShortcutActivationState>()
@@ -581,11 +678,28 @@ fn handle_shortcut_key_event(app: &AppHandle, event_type: Option<&str>) {
                 .controller
                 .lock()
                 .ok()
-                .and_then(|mut state| state.handle_edge(edge, settings.activation_mode))
+                .and_then(|mut state| state.handle_edge(edge, kind))
         });
 
+    let shortcut = match kind {
+        DictationShortcutKind::PushToTalk => settings.push_to_talk_shortcut,
+        DictationShortcutKind::Toggle => settings.toggle_shortcut,
+    };
+
     if let Some(command) = command {
-        send_dictation_command(app, command, &settings.shortcut.label);
+        send_dictation_command(app, command, &shortcut.label);
+    }
+}
+
+fn shortcut_kind_from_event(event: Option<&serde_json::Value>) -> Option<DictationShortcutKind> {
+    let kind = event?
+        .get("payload")
+        .and_then(|payload| payload.get("kind"))
+        .and_then(serde_json::Value::as_str)?;
+    match kind {
+        "push_to_talk" => Some(DictationShortcutKind::PushToTalk),
+        "toggle" => Some(DictationShortcutKind::Toggle),
+        _ => None,
     }
 }
 
@@ -792,7 +906,7 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
         .and_then(|event| event.get("type"))
         .and_then(serde_json::Value::as_str);
 
-    handle_shortcut_key_event(app, event_type);
+    handle_shortcut_key_event(app, event_type, event.as_ref());
 
     if matches!(event_type, Some("recording_ready")) {
         if let Some(event) = event.as_ref() {
@@ -1068,12 +1182,18 @@ fn configure_hud_window(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-fn hotkey_ready_event(shortcut: &DictationShortcutSetting) -> serde_json::Value {
+fn hotkey_ready_event(settings: &DictationSettings) -> serde_json::Value {
+    let shortcuts = format!(
+        "Push to talk: {}; Toggle: {}",
+        settings.push_to_talk_shortcut.label, settings.toggle_shortcut.label
+    );
     serde_json::json!({
         "type": "hotkey_trigger_ready",
         "payload": {
-            "shortcut": shortcut.label,
-            "shortcuts": shortcut.label,
+            "shortcut": settings.push_to_talk_shortcut.label,
+            "pushToTalkShortcut": settings.push_to_talk_shortcut.label,
+            "toggleShortcut": settings.toggle_shortcut.label,
+            "shortcuts": shortcuts,
         },
     })
 }
@@ -1162,57 +1282,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_settings_use_bare_fn() {
+    fn default_settings_use_fn_and_double_fn() {
         let settings = DictationSettings::default();
 
-        assert_eq!(settings.shortcut.label, "Fn");
-        assert_eq!(settings.shortcut.code, "Fn");
-        assert_eq!(settings.shortcut.key_code, 0);
-        assert!(settings.shortcut.modifiers.function);
-        assert_eq!(
-            settings.activation_mode,
-            DictationActivationMode::PushToTalk
-        );
+        assert_eq!(settings.push_to_talk_shortcut, DictationShortcutSetting::bare_fn());
+        assert_eq!(settings.toggle_shortcut, DictationShortcutSetting::double_bare_fn());
     }
 
     #[test]
-    fn deserializes_legacy_shortcut_string() {
+    fn legacy_settings_reset_to_defaults_and_preserve_microphone() {
         let settings: DictationSettings = serde_json::from_str(
-            r#"{"shortcut":"control_option_space","activationMode":"toggle","microphone":{"id":null,"name":null}}"#,
+            r#"{"shortcut":"control_option_space","activationMode":"toggle","microphone":{"id":"usb","name":"USB Mic"}}"#,
         )
         .expect("legacy shortcut should deserialize");
 
-        assert_eq!(settings.shortcut.label, "Ctrl+Opt+Space");
-        assert!(settings.shortcut.modifiers.control);
-        assert!(settings.shortcut.modifiers.option);
-        assert_eq!(settings.activation_mode, DictationActivationMode::Toggle);
-    }
-
-    #[test]
-    fn old_settings_without_activation_mode_migrate_to_fn_push_to_talk() {
-        let settings: DictationSettings = serde_json::from_str(
-            r#"{"shortcut":"control_option_space","microphone":{"id":"usb","name":"USB Mic"}}"#,
-        )
-        .expect("legacy settings should deserialize");
-
-        assert_eq!(settings.shortcut, DictationShortcutSetting::bare_fn());
-        assert_eq!(
-            settings.activation_mode,
-            DictationActivationMode::PushToTalk
-        );
+        assert_eq!(settings.push_to_talk_shortcut, DictationShortcutSetting::bare_fn());
+        assert_eq!(settings.toggle_shortcut, DictationShortcutSetting::double_bare_fn());
         assert_eq!(settings.microphone.id.as_deref(), Some("usb"));
         assert_eq!(settings.microphone.name.as_deref(), Some("USB Mic"));
     }
 
     #[test]
-    fn deserializes_legacy_bare_fn_shortcut_string() {
+    fn deserializes_new_shortcut_settings() {
         let settings: DictationSettings = serde_json::from_str(
-            r#"{"shortcut":"bare_fn","activationMode":"push_to_talk","microphone":{"id":null,"name":null}}"#,
+            r#"{"pushToTalkShortcut":{"keyCode":49,"code":"Space","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt+Space","pressCount":1},"toggleShortcut":{"keyCode":49,"code":"Space","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt+Space+Ctrl+Opt+Space","pressCount":2},"microphone":{"id":null,"name":null}}"#,
         )
-        .expect("legacy shortcut should deserialize");
+        .expect("new settings should deserialize");
 
-        assert_eq!(settings.shortcut, DictationShortcutSetting::bare_fn());
-        assert!(is_bare_fn_shortcut(&settings.shortcut));
+        assert_eq!(settings.push_to_talk_shortcut.press_count, 1);
+        assert_eq!(settings.toggle_shortcut.press_count, 2);
+        assert!(settings.push_to_talk_shortcut.same_trigger_as(&DictationShortcutSetting {
+            key_code: 0x31,
+            code: "Space".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                option: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+Opt+Space".to_string(),
+            press_count: 1,
+        }));
     }
 
     #[test]
@@ -1224,6 +1333,7 @@ mod tests {
                 ..DictationShortcutModifiers::default()
             },
             label: "Fn".to_string(),
+            press_count: None,
         }
         .into_setting()
         .expect("bare Fn should be accepted");
@@ -1232,11 +1342,29 @@ mod tests {
     }
 
     #[test]
+    fn shortcut_input_accepts_double_bare_fn() {
+        let shortcut = DictationShortcutInput {
+            code: "Fn".to_string(),
+            modifiers: DictationShortcutModifiers {
+                function: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Fn".to_string(),
+            press_count: Some(2),
+        }
+        .into_setting()
+        .expect("double bare Fn should be accepted");
+
+        assert_eq!(shortcut, DictationShortcutSetting::double_bare_fn());
+    }
+
+    #[test]
     fn shortcut_input_requires_modifier() {
         let err = DictationShortcutInput {
             code: "KeyT".to_string(),
             modifiers: DictationShortcutModifiers::default(),
             label: "T".to_string(),
+            press_count: Some(1),
         }
         .into_setting()
         .expect_err("shortcut without modifiers should fail");
@@ -1253,6 +1381,7 @@ mod tests {
                 ..DictationShortcutModifiers::default()
             },
             label: "Ctrl+NumpadEnter".to_string(),
+            press_count: Some(1),
         }
         .into_setting()
         .expect_err("unsupported key should fail");
@@ -1261,15 +1390,55 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_validation_distinguishes_press_count() {
+        let settings = DictationSettings {
+            push_to_talk_shortcut: DictationShortcutSetting {
+                key_code: 0x31,
+                code: "Space".to_string(),
+                modifiers: DictationShortcutModifiers {
+                    control: true,
+                    ..DictationShortcutModifiers::default()
+                },
+                label: "Ctrl+Space".to_string(),
+                press_count: 1,
+            },
+            toggle_shortcut: DictationShortcutSetting {
+                key_code: 0x31,
+                code: "Space".to_string(),
+                modifiers: DictationShortcutModifiers {
+                    control: true,
+                    ..DictationShortcutModifiers::default()
+                },
+                label: "Ctrl+Space+Ctrl+Space".to_string(),
+                press_count: 2,
+            },
+            microphone: DictationMicrophoneSetting::default(),
+        };
+
+        assert!(validate_shortcut_update(
+            &settings,
+            DictationShortcutKind::PushToTalk,
+            &settings.push_to_talk_shortcut
+        )
+        .is_ok());
+        assert!(validate_shortcut_update(
+            &settings,
+            DictationShortcutKind::PushToTalk,
+            &settings.toggle_shortcut
+        )
+        .is_err());
+    }
+
+    #[test]
     fn push_to_talk_starts_on_down_and_stops_on_up() {
         let mut controller = ShortcutActivationController::default();
 
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationActivationMode::PushToTalk),
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::PushToTalk),
             Some(DictationCommand::StartListening)
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationActivationMode::PushToTalk),
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk),
             Some(DictationCommand::StopAndPaste)
         );
     }
@@ -1279,33 +1448,33 @@ mod tests {
         let mut controller = ShortcutActivationController::default();
 
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationActivationMode::Toggle),
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle),
             Some(DictationCommand::ToggleListening)
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationActivationMode::Toggle),
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::Toggle),
             None
+        );
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle),
+            Some(DictationCommand::ToggleListening)
         );
     }
 
     #[test]
-    fn shortcut_activation_ignores_duplicate_edges() {
+    fn shortcut_activation_ignores_push_while_toggle_active() {
         let mut controller = ShortcutActivationController::default();
 
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationActivationMode::PushToTalk),
-            Some(DictationCommand::StartListening)
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle),
+            Some(DictationCommand::ToggleListening)
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationActivationMode::PushToTalk),
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::PushToTalk),
             None
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationActivationMode::PushToTalk),
-            Some(DictationCommand::StopAndPaste)
-        );
-        assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationActivationMode::PushToTalk),
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk),
             None
         );
     }

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -87,8 +87,8 @@ impl<'de> Deserialize<'de> for DictationSettings {
             });
         }
 
-        let settings: SettingsValue = serde_json::from_value(value)
-            .map_err(serde::de::Error::custom)?;
+        let settings: SettingsValue =
+            serde_json::from_value(value).map_err(serde::de::Error::custom)?;
 
         Ok(Self {
             push_to_talk_shortcut: settings
@@ -309,9 +309,8 @@ impl DictationShortcutInput {
             ));
         }
 
-        let press_count = normalize_press_count(self.press_count.unwrap_or(1)).map_err(|message| {
-            AppError::new("dictation_shortcut_press_count_invalid", message)
-        })?;
+        let press_count = normalize_press_count(self.press_count.unwrap_or(1))
+            .map_err(|message| AppError::new("dictation_shortcut_press_count_invalid", message))?;
 
         if is_bare_fn_input(&self.code, &self.modifiers) {
             return Ok(DictationShortcutSetting {
@@ -487,11 +486,9 @@ pub fn set_dictation_shortcut(
         return Ok(current_settings);
     }
 
-    let settings = update_settings(&state, |settings| {
-        match kind {
-            DictationShortcutKind::PushToTalk => settings.push_to_talk_shortcut = shortcut,
-            DictationShortcutKind::Toggle => settings.toggle_shortcut = shortcut,
-        }
+    let settings = update_settings(&state, |settings| match kind {
+        DictationShortcutKind::PushToTalk => settings.push_to_talk_shortcut = shortcut,
+        DictationShortcutKind::Toggle => settings.toggle_shortcut = shortcut,
     })?;
     reset_shortcut_activation(&app);
     apply_shortcut_settings(&helper_state, &settings)?;
@@ -1285,8 +1282,14 @@ mod tests {
     fn default_settings_use_fn_and_double_fn() {
         let settings = DictationSettings::default();
 
-        assert_eq!(settings.push_to_talk_shortcut, DictationShortcutSetting::bare_fn());
-        assert_eq!(settings.toggle_shortcut, DictationShortcutSetting::double_bare_fn());
+        assert_eq!(
+            settings.push_to_talk_shortcut,
+            DictationShortcutSetting::bare_fn()
+        );
+        assert_eq!(
+            settings.toggle_shortcut,
+            DictationShortcutSetting::double_bare_fn()
+        );
     }
 
     #[test]
@@ -1296,8 +1299,14 @@ mod tests {
         )
         .expect("legacy shortcut should deserialize");
 
-        assert_eq!(settings.push_to_talk_shortcut, DictationShortcutSetting::bare_fn());
-        assert_eq!(settings.toggle_shortcut, DictationShortcutSetting::double_bare_fn());
+        assert_eq!(
+            settings.push_to_talk_shortcut,
+            DictationShortcutSetting::bare_fn()
+        );
+        assert_eq!(
+            settings.toggle_shortcut,
+            DictationShortcutSetting::double_bare_fn()
+        );
         assert_eq!(settings.microphone.id.as_deref(), Some("usb"));
         assert_eq!(settings.microphone.name.as_deref(), Some("USB Mic"));
     }
@@ -1311,17 +1320,19 @@ mod tests {
 
         assert_eq!(settings.push_to_talk_shortcut.press_count, 1);
         assert_eq!(settings.toggle_shortcut.press_count, 2);
-        assert!(settings.push_to_talk_shortcut.same_trigger_as(&DictationShortcutSetting {
-            key_code: 0x31,
-            code: "Space".to_string(),
-            modifiers: DictationShortcutModifiers {
-                control: true,
-                option: true,
-                ..DictationShortcutModifiers::default()
-            },
-            label: "Ctrl+Opt+Space".to_string(),
-            press_count: 1,
-        }));
+        assert!(settings
+            .push_to_talk_shortcut
+            .same_trigger_as(&DictationShortcutSetting {
+                key_code: 0x31,
+                code: "Space".to_string(),
+                modifiers: DictationShortcutModifiers {
+                    control: true,
+                    option: true,
+                    ..DictationShortcutModifiers::default()
+                },
+                label: "Ctrl+Opt+Space".to_string(),
+                press_count: 1,
+            }));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,6 @@ pub fn run() {
             commands::recover_recording,
             dictation::dictation_settings,
             dictation::set_dictation_shortcut,
-            dictation::set_dictation_activation_mode,
             dictation::set_dictation_microphone,
             dictation::dictation_helper_command,
             dictation::dictation_hotkey_status,

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -10,15 +10,14 @@ import {
   listVeniceModels,
   openPrivacySettings,
   providerModelSettings,
-  setDictationActivationMode,
   setDictationMicrophone,
   setDictationShortcut,
   setVeniceModel,
 } from "../../lib/tauri";
 import type {
-  DictationActivationMode,
   DictationHelperEvent,
   DictationMicrophoneDeviceDto,
+  DictationShortcutKind,
   DictationSettingsDto,
   DictationShortcutModifiers,
   DictationShortcutSetting,
@@ -29,7 +28,6 @@ import type {
   VeniceModelDto,
 } from "../../lib/tauri";
 import { Dialog } from "../ui/Dialog";
-import { SegmentedControl } from "../ui/SegmentedControl";
 import { Switch } from "../ui/Switch";
 
 const EMPTY_MODIFIERS: DictationShortcutModifiers = {
@@ -41,22 +39,26 @@ const EMPTY_MODIFIERS: DictationShortcutModifiers = {
 };
 
 const DEFAULT_SETTINGS: DictationSettingsDto = {
-  shortcut: {
+  pushToTalkShortcut: {
     code: "Fn",
     label: "Fn",
+    pressCount: 1,
     modifiers: {
       ...EMPTY_MODIFIERS,
       function: true,
     },
   },
-  activationMode: "push_to_talk",
+  toggleShortcut: {
+    code: "Fn",
+    label: "Fn+Fn",
+    pressCount: 2,
+    modifiers: {
+      ...EMPTY_MODIFIERS,
+      function: true,
+    },
+  },
   microphone: {},
 };
-
-const ACTIVATION_MODE_OPTIONS = [
-  { value: "push_to_talk", label: "Push-to-talk" },
-  { value: "toggle", label: "Toggle" },
-] as const;
 
 const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
@@ -95,7 +97,9 @@ export function AppSettings({
     DictationMicrophoneDeviceDto[]
   >([]);
   const [permissions, setPermissions] = useState<DictationPermissionStatus>({});
-  const [capturingShortcut, setCapturingShortcut] = useState(false);
+  const [capturingShortcut, setCapturingShortcut] =
+    useState<DictationShortcutKind>();
+  const capturingShortcutRef = useRef<DictationShortcutKind>();
   const [shortcutError, setShortcutError] = useState<string>();
   const [status, setStatus] = useState<string>();
   const [micOpen, setMicOpen] = useState(false);
@@ -107,6 +111,10 @@ export function AppSettings({
     (source) => source.source === "system",
   );
   const systemBlocked = !!(systemReadiness && !systemReadiness.ready);
+
+  useEffect(() => {
+    capturingShortcutRef.current = capturingShortcut;
+  }, [capturingShortcut]);
 
   useEffect(() => {
     let cancelled = false;
@@ -236,8 +244,15 @@ export function AppSettings({
       return;
     }
     if (helperEvent.type === "shortcut_captured") {
+      const kind = capturingShortcutRef.current;
+      if (!kind) {
+        setShortcutError("Shortcut capture returned without an active target.");
+        setStatus("Shortcut capture returned without an active target.");
+        return;
+      }
       const shortcut = shortcutFromCapturePayload(
         helperEvent.payload?.shortcut,
+        pressCountForKind(kind),
       );
       if (!shortcut) {
         setShortcutError("Shortcut capture returned invalid data.");
@@ -245,7 +260,7 @@ export function AppSettings({
         return;
       }
       setShortcutError(undefined);
-      void saveShortcut(shortcut);
+      void saveShortcut(kind, shortcut);
       return;
     }
     if (helperEvent.type === "error") {
@@ -267,48 +282,45 @@ export function AppSettings({
   }
 
   async function saveShortcut(
-    shortcut: Pick<DictationShortcutSetting, "code" | "modifiers" | "label">,
+    kind: DictationShortcutKind,
+    shortcut: Pick<
+      DictationShortcutSetting,
+      "code" | "modifiers" | "label" | "pressCount"
+    >,
   ) {
     try {
-      const next = await setDictationShortcut(shortcut);
+      const next = await setDictationShortcut(kind, shortcut);
       setSettings(next);
-      setCapturingShortcut(false);
-      setStatus(`Shortcut set to ${next.shortcut.label}.`);
+      setCapturingShortcut(undefined);
+      setStatus(
+        `${shortcutKindLabel(kind)} set to ${shortcutForKind(next, kind).label}.`,
+      );
     } catch (error) {
       setShortcutError(messageFromError(error));
       setStatus(messageFromError(error));
     }
   }
 
-  async function startShortcutCapture() {
+  async function startShortcutCapture(kind: DictationShortcutKind) {
     setShortcutError(undefined);
-    setCapturingShortcut(true);
+    setCapturingShortcut(kind);
     try {
-      await dictationHelperCommand({ type: "start_shortcut_capture" });
+      await dictationHelperCommand({
+        type: "start_shortcut_capture",
+        pressCount: pressCountForKind(kind),
+      });
     } catch (error) {
-      setCapturingShortcut(false);
+      setCapturingShortcut(undefined);
       setShortcutError(messageFromError(error));
       setStatus(messageFromError(error));
     }
   }
 
   async function cancelShortcutCapture() {
-    setCapturingShortcut(false);
+    setCapturingShortcut(undefined);
     setShortcutError(undefined);
     try {
       await dictationHelperCommand({ type: "cancel_shortcut_capture" });
-    } catch (error) {
-      setStatus(messageFromError(error));
-    }
-  }
-
-  async function selectActivationMode(activationMode: DictationActivationMode) {
-    try {
-      const next = await setDictationActivationMode(activationMode);
-      setSettings(next);
-      setStatus(
-        `Activation mode set to ${activationModeLabel(next.activationMode)}.`,
-      );
     } catch (error) {
       setStatus(messageFromError(error));
     }
@@ -394,55 +406,31 @@ export function AppSettings({
         </h2>
         <div className="settings-card">
           <div className="settings-rows">
-            <div className="settings-row">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title">Shortcut</h3>
-                <p className="settings-row-description">
-                  Press Change, then press Fn/Globe or any supported modifier
-                  shortcut.
-                </p>
-                {shortcutError ? (
-                  <p className="settings-row-error">{shortcutError}</p>
-                ) : null}
-              </div>
-              <div className="settings-row-control">
-                <KeycapShortcut
-                  label={settings.shortcut.label}
-                  capturing={capturingShortcut}
-                />
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={() => {
-                    if (capturingShortcut) {
-                      void cancelShortcutCapture();
-                    } else {
-                      void startShortcutCapture();
-                    }
-                  }}
-                >
-                  {capturingShortcut ? "Cancel" : "Change"}
-                </button>
-              </div>
-            </div>
+            <ShortcutRow
+              title="Push to talk"
+              description="Hold this shortcut to dictate, then release to paste."
+              shortcut={settings.pushToTalkShortcut}
+              capturing={capturingShortcut === "push_to_talk"}
+              disabled={
+                !!capturingShortcut && capturingShortcut !== "push_to_talk"
+              }
+              error={
+                capturingShortcut === "push_to_talk" ? shortcutError : undefined
+              }
+              onChange={() => void startShortcutCapture("push_to_talk")}
+              onCancel={() => void cancelShortcutCapture()}
+            />
 
-            <div className="settings-row">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title">Activation mode</h3>
-                <p className="settings-row-description">
-                  Choose whether the shortcut records while held or toggles on
-                  each press.
-                </p>
-              </div>
-              <div className="settings-row-control">
-                <SegmentedControl
-                  value={settings.activationMode}
-                  options={ACTIVATION_MODE_OPTIONS}
-                  onValueChange={selectActivationMode}
-                  aria-label="Dictation activation mode"
-                />
-              </div>
-            </div>
+            <ShortcutRow
+              title="Toggle dictation"
+              description="Press this shortcut twice to start or stop dictation."
+              shortcut={settings.toggleShortcut}
+              capturing={capturingShortcut === "toggle"}
+              disabled={!!capturingShortcut && capturingShortcut !== "toggle"}
+              error={capturingShortcut === "toggle" ? shortcutError : undefined}
+              onChange={() => void startShortcutCapture("toggle")}
+              onCancel={() => void cancelShortcutCapture()}
+            />
           </div>
         </div>
       </section>
@@ -679,6 +667,47 @@ function ModelRow({
             <span className="model-summary-price">{pricingLabel(model)}</span>
           </span>
           <IconChevronDownSmall size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutRow({
+  title,
+  description,
+  shortcut,
+  capturing,
+  disabled,
+  error,
+  onChange,
+  onCancel,
+}: {
+  title: string;
+  description: string;
+  shortcut: DictationShortcutSetting;
+  capturing: boolean;
+  disabled: boolean;
+  error?: string;
+  onChange: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="settings-row">
+      <div className="settings-row-info">
+        <h3 className="settings-row-title">{title}</h3>
+        <p className="settings-row-description">{description}</p>
+        {error ? <p className="settings-row-error">{error}</p> : null}
+      </div>
+      <div className="settings-row-control">
+        <KeycapShortcut label={shortcut.label} capturing={capturing} />
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={disabled}
+          onClick={capturing ? onCancel : onChange}
+        >
+          {capturing ? "Cancel" : "Change"}
         </button>
       </div>
     </div>
@@ -1020,10 +1049,6 @@ function KeycapShortcut({
   );
 }
 
-function activationModeLabel(mode: DictationActivationMode) {
-  return mode === "toggle" ? "Toggle" : "Push-to-talk";
-}
-
 function parseDictationEvent(
   payload: unknown,
 ): DictationHelperEvent | undefined {
@@ -1042,11 +1067,21 @@ function parseDictationEvent(
 
 function shortcutFromCapturePayload(
   shortcut: unknown,
-): Pick<DictationShortcutSetting, "code" | "modifiers" | "label"> | undefined {
+  fallbackPressCount: 1 | 2,
+):
+  | Pick<
+      DictationShortcutSetting,
+      "code" | "modifiers" | "label" | "pressCount"
+    >
+  | undefined {
   if (!shortcut || typeof shortcut !== "object") return undefined;
 
   const value = shortcut as Partial<DictationShortcutSetting>;
   const modifiers = value.modifiers;
+  const pressCount =
+    value.pressCount === 1 || value.pressCount === 2
+      ? value.pressCount
+      : fallbackPressCount;
   if (
     typeof value.code !== "string" ||
     typeof value.label !== "string" ||
@@ -1062,9 +1097,37 @@ function shortcutFromCapturePayload(
 
   return {
     code: value.code,
-    label: value.label,
+    label:
+      pressCount === 2 && !isRepeatedShortcutLabel(value.label)
+        ? `${value.label}+${value.label}`
+        : value.label,
     modifiers,
+    pressCount,
   };
+}
+
+function pressCountForKind(kind: DictationShortcutKind): 1 | 2 {
+  return kind === "toggle" ? 2 : 1;
+}
+
+function shortcutKindLabel(kind: DictationShortcutKind) {
+  return kind === "toggle" ? "Toggle dictation" : "Push to talk";
+}
+
+function shortcutForKind(
+  settings: DictationSettingsDto,
+  kind: DictationShortcutKind,
+) {
+  return kind === "toggle"
+    ? settings.toggleShortcut
+    : settings.pushToTalkShortcut;
+}
+
+function isRepeatedShortcutLabel(label: string) {
+  const keys = label.split("+").filter(Boolean);
+  if (keys.length === 0 || keys.length % 2 !== 0) return false;
+  const half = keys.length / 2;
+  return keys.slice(0, half).join("+") === keys.slice(half).join("+");
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -78,9 +78,10 @@ export type DictationShortcutSetting = {
   code: string;
   modifiers: DictationShortcutModifiers;
   label: string;
+  pressCount: 1 | 2;
 };
 
-export type DictationActivationMode = "push_to_talk" | "toggle";
+export type DictationShortcutKind = "push_to_talk" | "toggle";
 
 export type DictationMicrophoneSetting = {
   id?: string;
@@ -88,8 +89,8 @@ export type DictationMicrophoneSetting = {
 };
 
 export type DictationSettingsDto = {
-  shortcut: DictationShortcutSetting;
-  activationMode: DictationActivationMode;
+  pushToTalkShortcut: DictationShortcutSetting;
+  toggleShortcut: DictationShortcutSetting;
   microphone: DictationMicrophoneSetting;
 };
 
@@ -470,16 +471,15 @@ export async function setVeniceModel(mode: ProviderModelMode, modelId: string) {
 }
 
 export async function setDictationShortcut(
-  shortcut: Pick<DictationShortcutSetting, "code" | "modifiers" | "label">,
+  kind: DictationShortcutKind,
+  shortcut: Pick<
+    DictationShortcutSetting,
+    "code" | "modifiers" | "label" | "pressCount"
+  >,
 ) {
-  return invoke<DictationSettingsDto>("set_dictation_shortcut", { shortcut });
-}
-
-export async function setDictationActivationMode(
-  activationMode: DictationActivationMode,
-) {
-  return invoke<DictationSettingsDto>("set_dictation_activation_mode", {
-    activationMode,
+  return invoke<DictationSettingsDto>("set_dictation_shortcut", {
+    kind,
+    shortcut,
   });
 }
 

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -12,7 +12,6 @@ const mocks = vi.hoisted(() => ({
   setVeniceModel: vi.fn(),
   openPrivacySettings: vi.fn(),
   setDictationShortcut: vi.fn(),
-  setDictationActivationMode: vi.fn(),
   setDictationMicrophone: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
@@ -26,7 +25,6 @@ vi.mock("../lib/tauri", () => ({
   setVeniceModel: mocks.setVeniceModel,
   openPrivacySettings: mocks.openPrivacySettings,
   setDictationShortcut: mocks.setDictationShortcut,
-  setDictationActivationMode: mocks.setDictationActivationMode,
   setDictationMicrophone: mocks.setDictationMicrophone,
 }));
 
@@ -35,9 +33,10 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 const baseSettings: DictationSettingsDto = {
-  shortcut: {
+  pushToTalkShortcut: {
     code: "Space",
     label: "Fn+Space",
+    pressCount: 1,
     modifiers: {
       command: false,
       control: false,
@@ -46,7 +45,18 @@ const baseSettings: DictationSettingsDto = {
       function: true,
     },
   },
-  activationMode: "push_to_talk",
+  toggleShortcut: {
+    code: "Space",
+    label: "Fn+Space+Fn+Space",
+    pressCount: 2,
+    modifiers: {
+      command: false,
+      control: false,
+      option: false,
+      shift: false,
+      function: true,
+    },
+  },
   microphone: {},
 };
 
@@ -126,16 +136,12 @@ describe("AppSettings", () => {
     }));
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
-    mocks.setDictationShortcut.mockImplementation(async (shortcut) => ({
+    mocks.setDictationShortcut.mockImplementation(async (kind, shortcut) => ({
       ...baseSettings,
-      shortcut,
+      ...(kind === "toggle"
+        ? { toggleShortcut: shortcut }
+        : { pushToTalkShortcut: shortcut }),
     }));
-    mocks.setDictationActivationMode.mockImplementation(
-      async (activationMode) => ({
-        ...baseSettings,
-        activationMode,
-      }),
-    );
     mocks.setDictationMicrophone.mockImplementation(async (id, name) => ({
       ...baseSettings,
       microphone: { id, name },
@@ -182,7 +188,7 @@ describe("AppSettings", () => {
     expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
   });
 
-  it("records dictation shortcut and activation mode in settings", async () => {
+  it("records push-to-talk and toggle dictation shortcuts in settings", async () => {
     const user = userEvent.setup();
     render(
       <AppSettings
@@ -192,10 +198,64 @@ describe("AppSettings", () => {
       />,
     );
 
-    await user.click(await screen.findByRole("button", { name: "Change" }));
+    expect(await screen.findByText("Push to talk")).toBeInTheDocument();
+    expect(screen.getByText("Toggle dictation")).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Dictation activation mode"),
+    ).not.toBeInTheDocument();
+
+    const changeButtons = await screen.findAllByRole("button", {
+      name: "Change",
+    });
+    await user.click(changeButtons[0]);
     await waitFor(() =>
       expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
         type: "start_shortcut_capture",
+        pressCount: 1,
+      }),
+    );
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "shortcut_captured",
+        payload: {
+          shortcut: {
+            code: "Fn",
+            label: "Fn",
+            modifiers: {
+              command: false,
+              control: false,
+              option: false,
+              shift: false,
+              function: true,
+            },
+            pressCount: 1,
+          },
+        },
+      }),
+    });
+
+    await waitFor(() =>
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith("push_to_talk", {
+        code: "Fn",
+        label: "Fn",
+        modifiers: {
+          command: false,
+          control: false,
+          option: false,
+          shift: false,
+          function: true,
+        },
+        pressCount: 1,
+      }),
+    );
+
+    await user.click(
+      (await screen.findAllByRole("button", { name: "Change" }))[1],
+    );
+    await waitFor(() =>
+      expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+        type: "start_shortcut_capture",
+        pressCount: 2,
       }),
     );
     mocks.eventHandler?.({
@@ -218,9 +278,9 @@ describe("AppSettings", () => {
     });
 
     await waitFor(() =>
-      expect(mocks.setDictationShortcut).toHaveBeenCalledWith({
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith("toggle", {
         code: "Fn",
-        label: "Fn",
+        label: "Fn+Fn",
         modifiers: {
           command: false,
           control: false,
@@ -228,16 +288,9 @@ describe("AppSettings", () => {
           shift: false,
           function: true,
         },
+        pressCount: 2,
       }),
     );
-
-    await user.click(screen.getByRole("button", { name: "Toggle" }));
-    await waitFor(() =>
-      expect(mocks.setDictationActivationMode).toHaveBeenCalledWith("toggle"),
-    );
-    expect(
-      await screen.findByText("Activation mode set to Toggle."),
-    ).toBeInTheDocument();
   });
 
   it("shows permission status and opens matching privacy panes", async () => {


### PR DESCRIPTION
## Summary
- split dictation into separate push-to-talk and toggle shortcut settings
- default push-to-talk to Fn and toggle dictation to Fn+Fn
- update the macOS helper to monitor both shortcuts independently
- replace the activation-mode selector with two shortcut choosers

## Tests
- pnpm test
- pnpm run lint
- pnpm test:rust
- pnpm run build