### PR TITLE
Hide recorder when microphone is blocked

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -243,7 +243,7 @@ export function NoteEditor({
       </section>
 
       <div className="editor-footer">
-        {!recordingForNote && !processingLock && micDenied ? (
+        {micDenied && !recordingForNote ? (
           <section className="record-mic-blocked" role="alert">
             <p className="record-mic-blocked-message">
               <span className="record-mic-blocked-eyebrow">
@@ -251,7 +251,8 @@ export function NoteEditor({
                 Microphone access is blocked
               </span>
               <span className="record-mic-blocked-body">
-                Enable it in System Settings to record notes.
+                Enable it in System Settings to record audio. You can still
+                write notes here.
               </span>
             </p>
             <div className="record-mic-blocked-actions">
@@ -264,16 +265,15 @@ export function NoteEditor({
               </button>
             </div>
           </section>
-        ) : null}
+        ) : (
         <div
           className="record-shell"
           data-state={shellState}
-          data-mic-blocked={micDenied || undefined}
           data-options-open={
-            !recordingForNote && !processingLock && optionsOpen && !micDenied
+            !recordingForNote && !processingLock && optionsOpen
           }
         >
-          {!recordingForNote && !processingLock && !micDenied ? (
+          {!recordingForNote && !processingLock ? (
             <div
               className="record-options-panel"
               data-open={optionsOpen}
@@ -384,7 +384,6 @@ export function NoteEditor({
                       aria-label="Recording options"
                       aria-expanded={optionsOpen}
                       data-rotated={optionsOpen}
-                      disabled={micDenied}
                       onClick={() => setOptionsOpen((value) => !value)}
                     >
                       <IconChevronBottom size={16} />
@@ -395,6 +394,7 @@ export function NoteEditor({
             </AnimatePresence>
           </div>
         </div>
+        )}
       </div>
     </article>
   );

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -18,6 +18,7 @@ import type {
   RecordingStatusDto,
   RecoverableRecordingDto,
 } from "../../lib/tauri";
+import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
@@ -244,27 +245,23 @@ export function NoteEditor({
 
       <div className="editor-footer">
         {micDenied && !recordingForNote ? (
-          <section className="record-mic-blocked" role="alert">
-            <p className="record-mic-blocked-message">
-              <span className="record-mic-blocked-eyebrow">
-                <IconMicrophoneOff size={14} aria-hidden />
-                Microphone access is blocked
-              </span>
-              <span className="record-mic-blocked-body">
-                Enable it in System Settings to record audio. You can still
-                write notes here.
-              </span>
-            </p>
-            <div className="record-mic-blocked-actions">
+          <InlineNotice
+            className="record-mic-blocked"
+            role="alert"
+            aria-label="Microphone access required"
+            icon={<IconMicrophoneOff size={14} aria-hidden />}
+            eyebrow="Microphone access is blocked"
+            body="Enable it in System Settings to record audio. You can still write notes here."
+            actions={
               <button
                 type="button"
-                className="btn btn-ghost record-mic-blocked-enable"
+                className="btn btn-secondary"
                 onClick={onEnableMicrophone}
               >
                 Enable
               </button>
-            </div>
-          </section>
+            }
+          />
         ) : (
         <div
           className="record-shell"

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -132,7 +132,7 @@ export function NoteEditor({
   // System audio is optional — the record button only blocks when the
   // microphone itself isn't ready. handleStartRecording re-checks on
   // click and silently falls back to mic-only if system audio is denied.
-  const recordDisabled = processingLock || !!recovery || micDenied;
+  const recordDisabled = processingLock || !!recovery;
 
   return (
     <article className="note-editor">
@@ -263,134 +263,134 @@ export function NoteEditor({
             }
           />
         ) : (
-        <div
-          className="record-shell"
-          data-state={shellState}
-          data-options-open={
-            !recordingForNote && !processingLock && optionsOpen
-          }
-        >
-          {!recordingForNote && !processingLock ? (
-            <div
-              className="record-options-panel"
-              data-open={optionsOpen}
-              aria-hidden={!optionsOpen}
-            >
-              <div className="record-options-panel-inner">
-                {systemUnsupported ? (
-                  <p className="record-options-unsupported">
-                    System audio requires macOS 14.2 or later.
-                  </p>
-                ) : (
-                  <div
-                    className="record-options-row"
-                    data-locked={systemDenied || undefined}
-                  >
-                    <Switch
-                      checked={systemOn}
-                      disabled={systemDenied}
-                      aria-labelledby="record-options-system"
-                      onCheckedChange={(next) =>
-                        onSourceModeChange(
-                          next ? "microphonePlusSystem" : "microphoneOnly",
-                        )
-                      }
-                    />
-                    <span
-                      id="record-options-system"
-                      className="record-options-label"
+          <div
+            className="record-shell"
+            data-state={shellState}
+            data-options-open={
+              !recordingForNote && !processingLock && optionsOpen
+            }
+          >
+            {!recordingForNote && !processingLock ? (
+              <div
+                className="record-options-panel"
+                data-open={optionsOpen}
+                aria-hidden={!optionsOpen}
+              >
+                <div className="record-options-panel-inner">
+                  {systemUnsupported ? (
+                    <p className="record-options-unsupported">
+                      System audio requires macOS 14.2 or later.
+                    </p>
+                  ) : (
+                    <div
+                      className="record-options-row"
+                      data-locked={systemDenied || undefined}
                     >
-                      Capture system audio
-                    </span>
-                    {systemDenied ? (
+                      <Switch
+                        checked={systemOn}
+                        disabled={systemDenied}
+                        aria-labelledby="record-options-system"
+                        onCheckedChange={(next) =>
+                          onSourceModeChange(
+                            next ? "microphonePlusSystem" : "microphoneOnly",
+                          )
+                        }
+                      />
+                      <span
+                        id="record-options-system"
+                        className="record-options-label"
+                      >
+                        Capture system audio
+                      </span>
+                      {systemDenied ? (
+                        <button
+                          type="button"
+                          className="btn btn-ghost record-options-enable"
+                          onClick={onEnableSystemAudio}
+                        >
+                          Enable
+                        </button>
+                      ) : null}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : null}
+            <div className="record-stage">
+              <AnimatePresence initial={false}>
+                {recordingForNote ? (
+                  <motion.div
+                    key="recorder"
+                    className="record-state record-state-recorder"
+                    initial={{ opacity: 0 }}
+                    animate={{
+                      opacity: 1,
+                      transition: {
+                        duration: 0.22,
+                        delay: 0.14,
+                        ease: [0.22, 1, 0.36, 1],
+                      },
+                    }}
+                    exit={{
+                      opacity: 0,
+                      transition: { duration: 0.12, ease: [0.22, 1, 0.36, 1] },
+                    }}
+                  >
+                    <RecorderBar
+                      status={recordingForNote}
+                      onPause={onPauseRecording}
+                      onResume={onResumeRecording}
+                      onDone={onFinishRecording}
+                    />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="idle"
+                    className="record-state record-state-idle"
+                    initial={{ opacity: 0 }}
+                    animate={{
+                      opacity: 1,
+                      // Symmetric to the recorder enter — delay the reveal
+                      // so the idle pill resolves as the shell finishes
+                      // collapsing back, not while it's still wide.
+                      transition: {
+                        duration: 0.22,
+                        delay: 0.12,
+                        ease: [0.22, 1, 0.36, 1],
+                      },
+                    }}
+                    exit={{
+                      opacity: 0,
+                      transition: { duration: 0.12, ease: [0.22, 1, 0.36, 1] },
+                    }}
+                  >
+                    <div className="record-idle">
                       <button
                         type="button"
-                        className="btn btn-ghost record-options-enable"
-                        onClick={onEnableSystemAudio}
+                        className="record-button"
+                        aria-label="Record"
+                        title="Record"
+                        disabled={recordDisabled}
+                        onClick={onStartRecording}
                       >
-                        Enable
+                        <IconMicrophone size={20} />
                       </button>
-                    ) : null}
-                  </div>
+                      <button
+                        type="button"
+                        className="record-options-trigger"
+                        aria-label="Recording options"
+                        aria-expanded={optionsOpen}
+                        data-rotated={optionsOpen}
+                        onClick={() => setOptionsOpen((value) => !value)}
+                      >
+                        <IconChevronBottom size={16} />
+                      </button>
+                    </div>
+                  </motion.div>
                 )}
-              </div>
+              </AnimatePresence>
             </div>
-          ) : null}
-          <div className="record-stage">
-            <AnimatePresence initial={false}>
-              {recordingForNote ? (
-                <motion.div
-                  key="recorder"
-                  className="record-state record-state-recorder"
-                  initial={{ opacity: 0 }}
-                  animate={{
-                    opacity: 1,
-                    transition: {
-                      duration: 0.22,
-                      delay: 0.14,
-                      ease: [0.22, 1, 0.36, 1],
-                    },
-                  }}
-                  exit={{
-                    opacity: 0,
-                    transition: { duration: 0.12, ease: [0.22, 1, 0.36, 1] },
-                  }}
-                >
-                  <RecorderBar
-                    status={recordingForNote}
-                    onPause={onPauseRecording}
-                    onResume={onResumeRecording}
-                    onDone={onFinishRecording}
-                  />
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="idle"
-                  className="record-state record-state-idle"
-                  initial={{ opacity: 0 }}
-                  animate={{
-                    opacity: 1,
-                    // Symmetric to the recorder enter — delay the reveal
-                    // so the idle pill resolves as the shell finishes
-                    // collapsing back, not while it's still wide.
-                    transition: {
-                      duration: 0.22,
-                      delay: 0.12,
-                      ease: [0.22, 1, 0.36, 1],
-                    },
-                  }}
-                  exit={{
-                    opacity: 0,
-                    transition: { duration: 0.12, ease: [0.22, 1, 0.36, 1] },
-                  }}
-                >
-                  <div className="record-idle">
-                    <button
-                      type="button"
-                      className="record-button"
-                      aria-label="Record"
-                      title="Record"
-                      disabled={recordDisabled}
-                      onClick={onStartRecording}
-                    >
-                      <IconMicrophone size={20} />
-                    </button>
-                    <button
-                      type="button"
-                      className="record-options-trigger"
-                      aria-label="Recording options"
-                      aria-expanded={optionsOpen}
-                      data-rotated={optionsOpen}
-                      onClick={() => setOptionsOpen((value) => !value)}
-                    >
-                      <IconChevronBottom size={16} />
-                    </button>
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
           </div>
-        </div>
         )}
       </div>
     </article>

--- a/src/components/recorder/NoteRecoveryPrompt.tsx
+++ b/src/components/recorder/NoteRecoveryPrompt.tsx
@@ -1,4 +1,5 @@
 import { IconRecord } from "central-icons/IconRecord";
+import { InlineNotice } from "../ui/InlineNotice";
 import type { RecoverableRecordingDto } from "../../lib/tauri";
 
 type NoteRecoveryPromptProps = {
@@ -15,38 +16,33 @@ export function NoteRecoveryPrompt({
   disabled,
 }: NoteRecoveryPromptProps) {
   return (
-    <section
+    <InlineNotice
       className="note-recovery-prompt"
       aria-label="Recoverable recording"
-    >
-      <p className="note-recovery-prompt-message">
-        <span className="note-recovery-prompt-eyebrow">
-          <IconRecord size={14} aria-hidden />
-          Interrupted recording
-        </span>
-        <span className="note-recovery-prompt-body">
-          We saved {formatBytes(recovery.bytesFound)} before this note stopped.
-        </span>
-      </p>
-      <div className="note-recovery-prompt-actions">
-        <button
-          type="button"
-          className="btn btn-ghost"
-          disabled={disabled}
-          onClick={() => onDiscard(recovery.sessionId)}
-        >
-          Discard
-        </button>
-        <button
-          type="button"
-          className="btn btn-secondary"
-          disabled={disabled}
-          onClick={() => onRecover(recovery.sessionId)}
-        >
-          Recover
-        </button>
-      </div>
-    </section>
+      icon={<IconRecord size={14} aria-hidden />}
+      eyebrow="Interrupted recording"
+      body={`We saved ${formatBytes(recovery.bytesFound)} before this note stopped.`}
+      actions={
+        <>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            disabled={disabled}
+            onClick={() => onDiscard(recovery.sessionId)}
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={disabled}
+            onClick={() => onRecover(recovery.sessionId)}
+          >
+            Recover
+          </button>
+        </>
+      }
+    />
   );
 }
 

--- a/src/components/ui/InlineNotice.tsx
+++ b/src/components/ui/InlineNotice.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+export type InlineNoticeTone = "warning" | "destructive";
+
+type InlineNoticeProps = {
+  eyebrow: ReactNode;
+  body: ReactNode;
+  actions?: ReactNode;
+  icon?: ReactNode;
+  tone?: InlineNoticeTone;
+  role?: "status" | "alert";
+  className?: string;
+  "aria-label"?: string;
+};
+
+export function InlineNotice({
+  eyebrow,
+  body,
+  actions,
+  icon,
+  tone = "warning",
+  role = "status",
+  className,
+  "aria-label": ariaLabel,
+}: InlineNoticeProps) {
+  const classes = ["inline-notice", className].filter(Boolean).join(" ");
+  return (
+    <section
+      className={classes}
+      data-tone={tone}
+      role={role}
+      aria-label={ariaLabel}
+    >
+      <p className="inline-notice-message">
+        <span className="inline-notice-eyebrow">
+          {icon}
+          {eyebrow}
+        </span>
+        <span className="inline-notice-body">{body}</span>
+      </p>
+      {actions ? (
+        <div className="inline-notice-actions">{actions}</div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1730,61 +1730,11 @@ input:focus-visible,
  * chevron popover when microphone access is denied. Mirrors the
  * .record-options-row shape so it feels like part of the same family
  * of inline status surfaces. */
-/* Persistent banner that sits above the recorder when microphone access
- * is blocked. flex-basis 100% with width 100% forces the editor-footer
- * to wrap so the recorder lands on its own row beneath. Mirrors the
- * shape of .note-recovery-prompt so the two banners feel like part of
- * the same family. */
+/* Inline notice layout slot for the editor footer — forces the notice
+ * onto its own row so the recorder shell (if rendered) sits below. */
 .record-mic-blocked {
   flex: 0 0 100%;
   width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-5);
-  padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-5);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-md);
-  background: var(--card);
-  color: var(--foreground);
-}
-
-.record-mic-blocked-message {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--sp-2) var(--sp-3);
-  margin: 0;
-  min-width: 0;
-  font-size: var(--fs-md);
-}
-
-.record-mic-blocked-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-  color: var(--destructive);
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.record-mic-blocked-body {
-  color: var(--muted-foreground);
-}
-
-.record-mic-blocked-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
-  flex-shrink: 0;
-}
-
-.record-mic-blocked-enable {
-  color: var(--destructive);
-}
-
-.record-mic-blocked-enable:hover {
-  background: color-mix(in oklch, var(--destructive) 10%, transparent);
 }
 
 /* Blur + fade + slide reveal. Row resolves out of a soft blur as the
@@ -2170,18 +2120,24 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
-.note-recovery-prompt {
+/* Inline notice — shared shape used by NoteRecoveryPrompt and the
+ * mic-blocked banner. Tone-aware via the [data-tone] attribute so the
+ * eyebrow color reflects the severity without changing the surrounding
+ * surface. Layout slot overrides (spacing, flex-basis) live on a
+ * consumer class passed through via the InlineNotice `className` prop. */
+.inline-notice {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--sp-5);
-  margin: 0 0 var(--sp-5);
   padding: var(--sp-3) var(--sp-3) var(--sp-3) var(--sp-5);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--foreground);
 }
 
-.note-recovery-prompt-message {
+.inline-notice-message {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -2191,24 +2147,37 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
-.note-recovery-prompt-eyebrow {
+.inline-notice-eyebrow {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-2);
-  color: var(--warm-strong);
   font-weight: 500;
   white-space: nowrap;
 }
 
-.note-recovery-prompt-body {
+.inline-notice[data-tone="warning"] .inline-notice-eyebrow {
+  color: var(--warm-strong);
+}
+
+.inline-notice[data-tone="destructive"] .inline-notice-eyebrow {
+  color: var(--destructive);
+}
+
+.inline-notice-body {
   color: var(--muted-foreground);
 }
 
-.note-recovery-prompt-actions {
+.inline-notice-actions {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);
   flex-shrink: 0;
+}
+
+/* Layout slot for the recovery prompt — sits in editor-content with
+ * spacing below it before the editor body begins. */
+.note-recovery-prompt {
+  margin: 0 0 var(--sp-5);
 }
 
 .editor-empty,


### PR DESCRIPTION
## Summary

Follow-up to #23. Replaces the "disabled recorder + banner above" pattern with a clean swap:

- When microphone access is denied, the recorder shell isn't rendered at all — only the mic-blocked banner appears in the footer.
- The note remains fully usable as a text editor.
- Active recordings stay visible if permission is revoked mid-session (edge case, but avoids the recorder disappearing mid-record).
- Banner copy updated to make it explicit that text notes still work: "Enable it in System Settings to record audio. You can still write notes here."

## Why

The previous "disabled record button with banner above it" approach created a half-on/half-off state that read as "broken UI" rather than "intentional gating." Hiding the affordance entirely is more honest: no mic → no recorder, with a clear path to enable.

## Test plan

- [ ] Deny mic → record button + chevron disappear, only the banner remains in the footer. Text editor still works.
- [ ] Grant mic in System Settings → tab back → recorder reappears via the focus listener probe.
- [ ] If recording is in progress and mic gets revoked, the recorder shell stays visible (it's keyed off `recordingForNote`) so the user can still stop the take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)