### PR TITLE
Polish settings, HUD, and AI model picker

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1,8 +1,13 @@
 import { listen } from "@tauri-apps/api/event";
-import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
-import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
+import { IconAnonymous } from "central-icons/IconAnonymous";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
+import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
+import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
+import { IconFire1 } from "central-icons/IconFire1";
+import { IconGhost2 } from "central-icons/IconGhost2";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import {
   dictationHelperCommand,
   dictationSettings,
@@ -28,6 +33,7 @@ import type {
 import { Dialog } from "../ui/Dialog";
 import { Switch } from "../ui/Switch";
 import { APP_COMMIT_HASH, APP_VERSION } from "../../app/build-info";
+import { ProviderLogo } from "./ProviderLogo";
 
 const EMPTY_MODIFIERS: DictationShortcutModifiers = {
   command: false,
@@ -366,7 +372,6 @@ export function AppSettings({
         <p className="settings-description">
           Manage audio, dictation, and AI models for notes.
         </p>
-        {status ? <p className="settings-status">{status}</p> : null}
       </header>
 
       <section className="settings-group" aria-labelledby="dictation-heading">
@@ -512,9 +517,6 @@ export function AppSettings({
         search={modelSearch}
         onSearchChange={setModelSearch}
         onClose={() => setPickerMode(undefined)}
-        onRefresh={() =>
-          pickerMode ? void requestVeniceModels(pickerMode) : undefined
-        }
         onSelect={(modelId) => {
           if (!pickerMode) return;
           void selectVeniceModel(pickerMode, modelId);
@@ -523,24 +525,9 @@ export function AppSettings({
       />
 
       <section className="settings-group" aria-labelledby="models-heading">
-        <div className="settings-group-header">
-          <h2 id="models-heading" className="settings-group-heading">
-            AI models
-          </h2>
-          <button
-            type="button"
-            className="btn btn-ghost settings-group-action"
-            onClick={() =>
-              void Promise.all([
-                requestVeniceModels("transcription"),
-                requestVeniceModels("generation"),
-              ])
-            }
-          >
-            <IconArrowRotateClockwise size={14} />
-            Refresh
-          </button>
-        </div>
+        <h2 id="models-heading" className="settings-group-heading">
+          AI models
+        </h2>
         <div className="settings-card">
           <div className="settings-rows">
             <ModelRow
@@ -567,24 +554,29 @@ export function AppSettings({
         </h2>
         <div className="settings-card">
           <div className="settings-rows">
-            <div className="settings-row">
+            <div className="settings-row settings-row-meta">
               <div className="settings-row-info">
-                <h3 className="settings-row-title">Release version</h3>
+                <h3 className="settings-row-title settings-meta-label">
+                  Release version
+                </h3>
               </div>
               <div className="settings-row-control">
-                <span className="settings-version-text">{APP_VERSION}</span>
+                <span className="settings-meta-value">{APP_VERSION}</span>
               </div>
             </div>
 
-            <div className="settings-row">
+            <div className="settings-row settings-row-meta">
               <div className="settings-row-info">
-                <h3 className="settings-row-title">Commit</h3>
+                <h3 className="settings-row-title settings-meta-label">
+                  Commit
+                </h3>
               </div>
               <div className="settings-row-control">
-                <span className="settings-version-text">{APP_COMMIT_HASH}</span>
+                <span className="settings-meta-value settings-meta-value-mono">
+                  {APP_COMMIT_HASH}
+                </span>
               </div>
             </div>
-
           </div>
         </div>
       </section>
@@ -619,19 +611,85 @@ function ModelRow({
           onClick={onOpen}
           aria-label={`Change ${title.toLowerCase()} model`}
         >
-          <span className="model-summary-main">
-            <span className="model-summary-name">{model.name}</span>
-            <span className="model-summary-id">{model.id}</span>
+          <span className="model-summary-logo" aria-hidden>
+            <ProviderLogo
+              provider={model.provider}
+              id={model.id}
+              name={model.name}
+            />
           </span>
-          <span className="model-summary-meta">
-            <ModelBadges model={model} compact />
-            <span className="model-summary-price">{pricingLabel(model)}</span>
-          </span>
+          <span className="model-summary-name">{model.name}</span>
           <IconChevronDownSmall size={14} />
+          <span className="model-summary-meta">
+            <ModelMeta model={model} />
+          </span>
         </button>
       </div>
     </div>
   );
+}
+
+function ModelMeta({ model }: { model: VeniceModelDto }) {
+  const flags = traitFlags(model);
+  const context = contextLabel(model);
+  const items: ReactNode[] = [
+    <span className="model-meta-price">{pricingLabel(model)}</span>,
+  ];
+  if (context) items.push(<span>{context}</span>);
+  if (flags.private) {
+    items.push(
+      <span className="model-trait-icon" title="Private">
+        <IconGhost2 size={14} />
+        <span>Private</span>
+      </span>,
+    );
+  }
+  if (flags.anon) {
+    items.push(
+      <span className="model-trait-icon" title="Anonymous">
+        <IconAnonymous size={14} />
+        <span>Anon</span>
+      </span>,
+    );
+  }
+  if (flags.uncensored) {
+    items.push(
+      <span className="model-trait-icon" title="Uncensored">
+        <IconFire1 size={14} />
+        <span>Uncensored</span>
+      </span>,
+    );
+  }
+  return (
+    <span className="model-meta-items">
+      {items.map((item, index) => (
+        <span className="model-meta-item" key={index}>
+          {index > 0 ? (
+            <span className="model-meta-sep" aria-hidden>
+              ·
+            </span>
+          ) : null}
+          {item}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function traitFlags(model: VeniceModelDto) {
+  const privacy = (model.privacy ?? "").toLowerCase();
+  const traits = model.traits.map((trait) => trait.toLowerCase());
+  return {
+    private: privacy === "private",
+    anon:
+      privacy.includes("anonymous") ||
+      privacy.includes("anonymized") ||
+      traits.some(
+        (trait) =>
+          trait.includes("anonymous") || trait.includes("anonymized"),
+      ),
+    uncensored: traits.some((trait) => trait.includes("uncensored")),
+  };
 }
 
 function ShortcutRow({
@@ -683,7 +741,6 @@ function ModelPickerDialog({
   search,
   onSearchChange,
   onClose,
-  onRefresh,
   onSelect,
 }: {
   open: boolean;
@@ -693,7 +750,6 @@ function ModelPickerDialog({
   search: string;
   onSearchChange: (value: string) => void;
   onClose: () => void;
-  onRefresh: () => void;
   onSelect: (modelId: string) => void;
 }) {
   const filteredOptions = useMemo(() => {
@@ -718,22 +774,17 @@ function ModelPickerDialog({
       width={760}
       className="model-picker-dialog"
       initialFocusSelector=".model-picker-search"
-      footer={
-        <button type="button" className="btn btn-ghost" onClick={onRefresh}>
-          <IconArrowRotateClockwise size={14} />
-          Refresh
-        </button>
-      }
     >
-      <div className="model-picker-toolbar">
+      <label className="model-picker-search">
+        <IconMagnifyingGlass size={15} />
         <input
-          className="model-picker-search"
+          className="model-picker-search-input"
           value={search}
           onChange={(event) => onSearchChange(event.currentTarget.value)}
           placeholder="Search models"
           aria-label="Search models"
         />
-      </div>
+      </label>
       <div className="model-picker-list" role="listbox" aria-label={title}>
         {filteredOptions.map((model) => {
           const selected = model.id === value;
@@ -747,30 +798,22 @@ function ModelPickerDialog({
               data-selected={selected}
               onClick={() => onSelect(model.id)}
             >
-              <span className="model-picker-option-header">
-                <span className="model-picker-title-group">
-                  <span className="model-picker-name">{model.name}</span>
-                  <span className="model-picker-id">{model.id}</span>
-                </span>
-                <span className="model-picker-selected" aria-hidden>
-                  {selected ? <IconCheckmark1Small size={15} /> : null}
-                </span>
+              <span className="model-picker-logo" aria-hidden>
+                <ProviderLogo
+                  provider={model.provider}
+                  id={model.id}
+                  name={model.name}
+                />
               </span>
-              {model.description ? (
-                <span className="model-picker-description">
-                  {model.description}
-                </span>
-              ) : null}
-              {(() => {
-                const context = contextLabel(model);
-                return (
-                  <span className="model-picker-facts">
-                    <span>{pricingLabel(model)}</span>
-                    {context ? <span>{context}</span> : null}
-                  </span>
-                );
-              })()}
-              <ModelBadges model={model} />
+              <span className="model-picker-name" title={model.description}>
+                {model.name}
+              </span>
+              <span className="model-picker-selected" aria-hidden>
+                {selected ? <IconCheckmark2Small size={14} /> : null}
+              </span>
+              <span className="model-picker-meta">
+                <ModelMeta model={model} />
+              </span>
             </button>
           );
         })}
@@ -790,80 +833,6 @@ function selectedModel(options: VeniceModelDto[], value: string) {
       capabilities: [],
     }
   );
-}
-
-function ModelBadges({
-  model,
-  compact = false,
-}: {
-  model: VeniceModelDto;
-  compact?: boolean;
-}) {
-  const badges = modelBadges(model);
-  const visible = compact ? badges.slice(0, 2) : badges.slice(0, 6);
-  if (visible.length === 0) {
-    return compact ? null : (
-      <span className="model-badge" data-kind="neutral">
-        Standard
-      </span>
-    );
-  }
-  return (
-    <span className="model-badges">
-      {visible.map((badge) => (
-        <span
-          key={`${badge.kind}-${badge.label}`}
-          className="model-badge"
-          data-kind={badge.kind}
-        >
-          {badge.label}
-        </span>
-      ))}
-    </span>
-  );
-}
-
-function modelBadges(model: VeniceModelDto) {
-  const badges: Array<{ label: string; kind: string }> = [];
-  if (model.privacy) {
-    badges.push({
-      label: privacyLabel(model.privacy),
-      kind: model.privacy.toLowerCase().includes("private")
-        ? "private"
-        : "privacy",
-    });
-  }
-  for (const trait of model.traits) {
-    const normalized = trait.toLowerCase();
-    if (normalized.includes("uncensored")) {
-      badges.push({ label: "Uncensored", kind: "uncensored" });
-    } else if (
-      normalized.includes("anonymous") ||
-      normalized.includes("anonymized")
-    ) {
-      badges.push({ label: "Anon", kind: "anon" });
-    }
-  }
-  return uniqueBadges(badges);
-}
-
-function uniqueBadges(badges: Array<{ label: string; kind: string }>) {
-  const seen = new Set<string>();
-  return badges.filter((badge) => {
-    const key = `${badge.kind}:${badge.label}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-}
-
-function privacyLabel(value: string) {
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "private") return "Private";
-  if (normalized.includes("anonymous") || normalized.includes("anonymized")) {
-    return "Anon";
-  }
-  return titleCase(value);
 }
 
 function pricingLabel(model: VeniceModelDto) {
@@ -926,14 +895,6 @@ function contextLabel(model: VeniceModelDto) {
 
 function trimNumber(value: number) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
-}
-
-function titleCase(value: string) {
-  return value
-    .split(/[\s_-]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 function modelOptions(models: VeniceModelDto[], selectedModel: string) {

--- a/src/components/settings/ProviderLogo.tsx
+++ b/src/components/settings/ProviderLogo.tsx
@@ -1,0 +1,250 @@
+import { IconAnthropic } from "central-icons/IconAnthropic";
+import { IconClaudeai } from "central-icons/IconClaudeai";
+import { IconDeepseek } from "central-icons/IconDeepseek";
+import { IconGemini } from "central-icons/IconGemini";
+import { IconGrok } from "central-icons/IconGrok";
+import { IconMetaAi } from "central-icons/IconMetaAi";
+import { IconMistral } from "central-icons/IconMistral";
+import { IconNvidia } from "central-icons/IconNvidia";
+import { IconOllama } from "central-icons/IconOllama";
+import { IconOpenai } from "central-icons/IconOpenai";
+import { IconPerplexity } from "central-icons/IconPerplexity";
+
+type ProviderLogoProps = {
+  provider: string;
+  id: string;
+  name?: string;
+  size?: number;
+};
+
+export function ProviderLogo({
+  provider,
+  id,
+  name = "",
+  size = 18,
+}: ProviderLogoProps) {
+  const kind = classifyProvider(provider, id, name);
+  switch (kind) {
+    case "openai":
+      return <IconOpenai size={size} aria-label="OpenAI" />;
+    case "anthropic":
+      return <IconClaudeai size={size} aria-label="Claude" />;
+    case "google":
+      return <IconGemini size={size} aria-label="Gemini" />;
+    case "meta":
+      return <IconMetaAi size={size} aria-label="Meta" />;
+    case "mistral":
+      return <IconMistral size={size} aria-label="Mistral" />;
+    case "deepseek":
+      return <IconDeepseek size={size} aria-label="DeepSeek" />;
+    case "perplexity":
+      return <IconPerplexity size={size} aria-label="Perplexity" />;
+    case "ollama":
+      return <IconOllama size={size} aria-label="Ollama" />;
+    case "xai":
+      return <IconGrok size={size} aria-label="Grok" />;
+    case "nvidia":
+      return <IconNvidia size={size} aria-label="NVIDIA" />;
+    case "elevenlabs":
+      return <ElevenLabsMark size={size} />;
+    case "venice":
+      return <VeniceMark size={size} />;
+    case "fal":
+      return <FalMark size={size} />;
+    default:
+      return <Monogram label={initials(name || id || provider)} size={size} />;
+  }
+}
+
+// Anthropic gets two aliases — IconAnthropic and IconClaudeai. We prefer the
+// product mark (Claude) because that's the visible product name.
+export { IconAnthropic };
+
+type ProviderKind =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "meta"
+  | "mistral"
+  | "deepseek"
+  | "perplexity"
+  | "ollama"
+  | "xai"
+  | "nvidia"
+  | "elevenlabs"
+  | "venice"
+  | "fal"
+  | "unknown";
+
+function classifyProvider(
+  provider: string,
+  id: string,
+  name: string,
+): ProviderKind {
+  // Model family takes precedence over hosting platform (e.g. Venice-hosted
+  // GPT-4o still reads as OpenAI). Hosting providers (venice, fal) only win
+  // when nothing more specific matched.
+  const normalizedProvider = provider.toLowerCase();
+  const haystack = `${normalizedProvider} ${id} ${name}`.toLowerCase();
+
+  if (
+    normalizedProvider === "openai" ||
+    haystack.includes("gpt-") ||
+    haystack.includes("whisper-1") ||
+    haystack.includes("o1-") ||
+    haystack.includes("o3-") ||
+    haystack.includes("o4-")
+  ) {
+    return "openai";
+  }
+  if (
+    normalizedProvider === "anthropic" ||
+    haystack.includes("claude") ||
+    haystack.includes("anthropic")
+  ) {
+    return "anthropic";
+  }
+  if (haystack.includes("gemini") || haystack.includes("google")) {
+    return "google";
+  }
+  if (haystack.includes("llama") || haystack.includes("meta-")) return "meta";
+  if (haystack.includes("mistral") || haystack.includes("mixtral")) {
+    return "mistral";
+  }
+  if (haystack.includes("deepseek")) return "deepseek";
+  if (haystack.includes("perplexity") || haystack.includes("pplx")) {
+    return "perplexity";
+  }
+  if (haystack.includes("ollama")) return "ollama";
+  if (
+    normalizedProvider === "xai" ||
+    haystack.includes("grok") ||
+    haystack.includes("xai/")
+  ) {
+    return "xai";
+  }
+  if (haystack.includes("nvidia") || haystack.includes("parakeet")) {
+    return "nvidia";
+  }
+  if (haystack.includes("eleven")) return "elevenlabs";
+
+  // Whisper Large V3 / V3 ships through Fal — checked after OpenAI's
+  // whisper-1 so the legacy model still maps correctly.
+  if (
+    haystack.includes("whisper-large") ||
+    haystack.includes("whisper-v3") ||
+    haystack.includes("fal-ai") ||
+    haystack.includes("fal/") ||
+    haystack.startsWith("fal ")
+  ) {
+    return "fal";
+  }
+  if (haystack.includes("openai")) return "openai";
+  if (haystack.includes("venice")) return "venice";
+
+  return "unknown";
+}
+
+function initials(source: string) {
+  const cleaned = source
+    .replace(/[/_\-]+/g, " ")
+    .replace(/[^A-Za-z0-9 ]/g, " ")
+    .trim();
+  if (!cleaned) return "";
+  const words = cleaned.split(/\s+/);
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+function Monogram({ label, size }: { label: string; size: number }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.55),
+        fontWeight: 600,
+        lineHeight: 1,
+        letterSpacing: "-0.02em",
+      }}
+    >
+      {label || "?"}
+    </span>
+  );
+}
+
+// Visual weight calibration. Custom SVGs fill their viewBox unevenly, so at
+// equal pixel size their marks read larger or smaller than central-icons.
+// These factors approximate the central-icons baseline (~85% viewBox fill).
+const FAL_SCALE = 0.78;
+const VENICE_SCALE = 0.86;
+const ELEVENLABS_SCALE = 1.05;
+
+function ElevenLabsMark({ size }: { size: number }) {
+  const s = Math.round(size * ELEVENLABS_SCALE);
+  return (
+    <svg
+      width={s}
+      height={s}
+      viewBox="0 0 876 876"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="ElevenLabs"
+    >
+      <path d="M468 292H528V584H468V292Z" fill="currentColor" />
+      <path d="M348 292H408V584H348V292Z" fill="currentColor" />
+    </svg>
+  );
+}
+
+function FalMark({ size }: { size: number }) {
+  const s = Math.round(size * FAL_SCALE);
+  return (
+    <svg
+      width={s}
+      height={s}
+      viewBox="0 0 170 171"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Fal"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M109.571 0.690002C112.515 0.690002 114.874 3.08348 115.155 6.01352C117.665 32.149 138.466 52.948 164.603 55.458C167.534 55.7394 169.927 58.0985 169.927 61.042V110.255C169.927 113.198 167.534 115.557 164.603 115.839C138.466 118.349 117.665 139.148 115.155 165.283C114.874 168.213 112.515 170.607 109.571 170.607H60.3553C57.4116 170.607 55.0524 168.213 54.7709 165.283C52.2608 139.148 31.4601 118.349 5.32289 115.839C2.39266 115.557 -0.000976562 113.198 -0.000976562 110.255V61.042C-0.000976562 58.0985 2.39267 55.7394 5.3229 55.458C31.4601 52.948 52.2608 32.149 54.7709 6.01351C55.0524 3.08348 57.4116 0.690002 60.3553 0.690002H109.571ZM34.1182 85.5045C34.1182 113.776 57.0124 136.694 85.2539 136.694C113.495 136.694 136.39 113.776 136.39 85.5045C136.39 57.2332 113.495 34.3147 85.2539 34.3147C57.0124 34.3147 34.1182 57.2332 34.1182 85.5045Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function VeniceMark({ size }: { size: number }) {
+  const s = Math.round(size * VENICE_SCALE);
+  return (
+    <svg
+      width={s}
+      height={s}
+      viewBox="0 0 326 366"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Venice"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M105.481 245.984C99.4744 241.518 92.2244 237.777 84.2074 235.504C76.1903 233.231 67.406 232.427 58.8167 233.38C50.2272 234.332 41.8327 237.042 34.5086 241.017C27.1847 244.991 20.931 250.231 16.0487 255.905C11.1531 261.567 6.88803 268.522 4.0314 276.35C1.17477 284.178 -0.273403 292.879 0.0448796 301.515C0.36299 310.152 2.44756 318.723 5.87231 326.319C9.29724 333.916 14.0625 340.538 19.3617 345.825C24.6482 351.124 31.2704 355.889 38.867 359.314C46.4637 362.739 55.0349 364.823 63.671 365.142C72.3073 365.46 81.0085 364.012 88.8366 361.155C96.6647 358.298 103.62 354.033 109.282 349.138C114.956 344.256 120.195 338.002 124.17 330.678C128.144 323.354 130.854 314.959 131.807 306.37C132.76 297.781 131.956 288.996 129.683 280.979C127.41 272.962 123.668 265.712 119.203 259.705L133.953 244.954L144.69 255.691H150.789L158.149 248.331V242.233L147.412 231.496L163 215.908L178.588 231.496L167.851 242.233V248.331L175.211 255.691H181.31L192.047 244.954L206.797 259.705C202.332 265.712 198.59 272.962 196.317 280.979C194.044 288.996 193.24 297.781 194.193 306.37C195.146 314.959 197.856 323.354 201.83 330.678C205.805 338.002 211.044 344.256 216.718 349.138C222.38 354.033 229.335 358.298 237.163 361.155C244.991 364.012 253.693 365.46 262.329 365.142C270.965 364.823 279.536 362.739 287.133 359.314C294.73 355.889 301.352 351.124 306.638 345.825C311.937 340.538 316.703 333.916 320.128 326.319C323.552 318.723 325.637 310.152 325.955 301.515C326.273 292.879 324.825 284.178 321.969 276.35C319.112 268.522 314.847 261.567 309.951 255.905C305.069 250.231 298.815 244.991 291.491 241.017C284.167 237.042 275.773 234.332 267.183 233.38C258.594 232.427 249.81 233.231 241.793 235.504C233.776 237.777 226.526 241.518 220.519 245.984L206.042 231.484L216.773 220.753V214.655L209.151 207.032H203.052L192.315 217.769L176.721 202.186L258.473 120.434L291.567 153.528V119.095H326L292.907 86.0012L326 52.9077V46.8095L318.377 39.1865H312.279L163 188.465L13.7212 39.1865H7.62295L0 46.8095V52.9077L33.0934 86.0012L0 119.095H34.4331V153.528L67.5263 120.434L149.279 202.186L133.685 217.769L122.948 207.032H116.849L109.226 214.655V220.753L119.958 231.484L105.481 245.984ZM238.144 321.715C234.778 328.62 235.477 338.188 239.811 344.531C243.793 351.1 252.216 355.693 259.895 355.484C267.574 355.693 275.997 351.1 279.979 344.531C284.313 338.188 285.012 328.62 281.646 321.715L282.484 320.812C289.389 324.196 298.971 323.511 305.324 319.178C311.904 315.2 316.508 306.768 316.297 299.081C316.508 291.395 311.904 282.963 305.324 278.984C298.971 274.652 289.389 273.966 282.484 277.351L281.646 276.448C285.012 269.543 284.313 259.974 279.979 253.632C275.997 247.063 267.574 242.469 259.895 242.679C252.216 242.469 243.793 247.063 239.811 253.632C235.477 259.974 234.778 269.543 238.144 276.448L237.306 277.351C230.401 273.966 220.818 274.652 214.466 278.984C207.886 282.963 203.282 291.395 203.492 299.081C203.282 306.768 207.886 315.2 214.466 319.178C220.818 323.511 230.401 324.196 237.306 320.812L238.144 321.715ZM86.1857 344.531C90.52 338.188 91.2191 328.62 87.8528 321.715L88.6913 320.812C95.5956 324.196 105.178 323.511 111.531 319.178C118.11 315.2 122.715 306.768 122.504 299.081C122.715 291.395 118.11 282.963 111.531 278.984C105.178 274.652 95.5956 273.966 88.6913 277.351L87.8528 276.448C91.2191 269.543 90.52 259.974 86.1857 253.632C82.2037 247.063 73.7808 242.469 66.1018 242.679C58.423 242.469 50.0001 247.063 46.0181 253.632C41.6839 259.974 40.9847 269.543 44.351 276.448L43.5126 277.351C36.6082 273.966 27.0255 274.652 20.6731 278.984C14.0932 282.963 9.48904 291.395 9.69934 299.081C9.48904 306.768 14.0932 315.2 20.6731 319.178C27.0255 323.511 36.6082 324.196 43.5126 320.812L44.351 321.715C40.9847 328.62 41.6839 338.188 46.0181 344.531C50.0001 351.1 58.423 355.693 66.1018 355.484C73.7808 355.693 82.2037 351.1 86.1857 344.531Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M162.891 39.1864L202.078 0L221.482 19.4047V84.8147L167.742 138.555H158.04L104.3 84.8147V19.4047L123.705 0L162.891 39.1864ZM123.705 13.7213L158.04 48.0567V111.112L123.705 76.7773V13.7213ZM167.744 48.0567L202.079 13.7213V76.7773L167.744 111.112V48.0567Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import { IconFolders } from "central-icons/IconFolders";
 import { IconFontStyle } from "central-icons/IconFontStyle";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
-import { IconSettingsGear1 } from "central-icons/IconSettingsGear1";
+import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { IconSidebarHiddenLeftWide } from "central-icons/IconSidebarHiddenLeftWide";
 import { IconSidebarSimpleLeftWide } from "central-icons/IconSidebarSimpleLeftWide";
 import { IconTrashCan } from "central-icons/IconTrashCan";
@@ -259,7 +259,7 @@ export function Sidebar({
           onClick={() => onChangeView("settings")}
         >
           <span className="sidebar-nav-icon">
-            <IconSettingsGear1 size={16} />
+            <IconSettingsGear4 size={16} />
           </span>
           <span className="sidebar-nav-label">Settings</span>
         </button>

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -45,8 +45,8 @@ const BAR_WEIGHTS = [0.64, 0.86, 0.7, 0.84, 0.58];
 const BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1];
 const LEVEL_HISTORY_LENGTH = 8;
 const LIVE_LEVEL_MIX = 0.7;
-const ATTACK_ALPHA = 0.44;
-const RELEASE_ALPHA = 0.48;
+const ATTACK_ALPHA = 0.7;
+const RELEASE_ALPHA = 0.55;
 const IDLE_SNAP_DELTA = 0.004;
 
 const levelHistory: number[] = new Array(LEVEL_HISTORY_LENGTH).fill(IDLE_LEVEL);
@@ -313,10 +313,11 @@ async function handleDictationEventPayload(payload: unknown) {
     // Rust pre-classifies via payload.silent so the HUD has one source of
     // truth for what counts as a "Nothing recorded" case.
     if (dictationEvent.payload?.silent === true) {
-      setHud("silent-error", "Nothing recorded");
-    } else {
-      setHud("error", "Error");
+      // Silent (nothing recorded) shouldn't look like a failure — just dismiss.
+      void hideHud();
+      return;
     }
+    setHud("error", "Error");
     await showHud();
     // Hold long enough for the shake to finish and the message to read.
     hideSoon(1800);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2312,7 +2312,11 @@ input:focus-visible,
 .settings-group {
   display: grid;
   gap: var(--sp-2);
-  margin-bottom: var(--sp-6);
+  margin-bottom: var(--sp-10);
+}
+
+.settings-group:last-of-type {
+  margin-bottom: 0;
 }
 
 .settings-group-header {
@@ -2320,15 +2324,20 @@ input:focus-visible,
   align-items: center;
   justify-content: space-between;
   gap: var(--sp-3);
-  padding: 0 var(--sp-1);
+  padding: 0 var(--sp-3);
 }
 
 .settings-group-heading {
   margin: 0;
+  padding-left: var(--sp-3);
   color: color-mix(in oklch, var(--foreground) 65%, var(--muted-foreground));
   font-size: var(--fs-md);
   font-weight: 500;
   letter-spacing: 0;
+}
+
+.settings-group-header .settings-group-heading {
+  padding-left: 0;
 }
 
 /* Granola-style settings card — quiet rounded container, no heavy chrome. */
@@ -2394,6 +2403,22 @@ input:focus-visible,
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: var(--fs-md);
+}
+
+/* About / metadata rows — label is the muted side, value carries the
+ * body weight. Inverts the usual title-bright / description-muted rhythm. */
+.settings-meta-label {
+  color: var(--muted-foreground);
+  font-weight: 400;
+}
+
+.settings-meta-value {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+}
+
+.settings-meta-value-mono {
+  font-family: var(--font-mono);
 }
 
 .settings-permission-control {
@@ -2670,13 +2695,19 @@ input:focus-visible,
   color: var(--foreground);
 }
 
+/* Trigger button mirrors a picker row: stacked name/meta with a subtle
+ * border so it reads as the "current selection" card. */
 .model-summary-button {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 14px;
-  gap: var(--sp-2);
+  grid-template-columns: 28px minmax(0, 1fr) 14px;
+  grid-template-areas:
+    "logo name chev"
+    "logo meta chev";
+  row-gap: 2px;
+  column-gap: var(--sp-3);
   width: 100%;
   min-width: 300px;
-  padding: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   background: transparent;
@@ -2684,33 +2715,40 @@ input:focus-visible,
   text-align: left;
   cursor: pointer;
   transition:
-    border-color var(--t-fast) var(--ease-out),
-    background-color var(--t-fast) var(--ease-out);
+    background-color var(--t-fast) var(--ease-out),
+    border-color var(--t-fast) var(--ease-out);
 }
 
 .model-summary-button:hover {
-  border-color: color-mix(in oklch, var(--foreground) 25%, transparent);
-  background: color-mix(in oklch, var(--muted) 28%, transparent);
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.model-summary-button[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--foreground) 22%, transparent);
 }
 
 .model-summary-button > svg {
-  grid-row: 1 / span 2;
-  grid-column: 2;
+  grid-area: chev;
   align-self: center;
+  justify-self: center;
   color: var(--muted-foreground);
 }
 
-.model-summary-main,
-.model-summary-meta {
-  min-width: 0;
-}
-
-.model-summary-main {
-  display: grid;
-  gap: 1px;
+.model-summary-logo {
+  grid-area: logo;
+  display: inline-grid;
+  place-items: center;
+  align-self: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
+  color: var(--foreground);
 }
 
 .model-summary-name {
+  grid-area: name;
+  align-self: end;
   overflow: hidden;
   color: var(--foreground);
   font-size: var(--fs-md);
@@ -2719,103 +2757,100 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-.model-summary-id {
-  overflow: hidden;
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: var(--fs-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .model-summary-meta {
+  grid-area: meta;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--sp-2);
-  overflow: hidden;
-}
-
-.model-summary-price {
-  overflow: hidden;
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
-  text-overflow: ellipsis;
+}
+
+.model-meta-items,
+.model-meta-item {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.model-meta-items {
+  flex-wrap: wrap;
+  gap: 0 var(--sp-2);
+}
+
+.model-meta-price {
+  color: var(--muted-foreground);
   white-space: nowrap;
 }
 
-.model-badges {
+.model-meta-sep {
   display: inline-flex;
-  align-items: center;
-  gap: var(--sp-1);
-  min-width: 0;
+  margin-right: var(--sp-2);
+  color: color-mix(in oklch, var(--muted-foreground) 50%, transparent);
 }
 
-.model-badge {
+/* Tag-style chip wrapping each trait icon + label. Squared-off corners
+ * match the keycap / kbd chips used elsewhere in the app. */
+.model-trait-icon {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  min-width: 0;
-  height: 20px;
-  padding: 0 var(--sp-2);
-  border-radius: var(--r-pill);
-  background: var(--muted);
+  gap: 4px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: var(--r-xs);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
   color: var(--muted-foreground);
-  font-size: var(--fs-sm);
-  font-weight: 500;
   line-height: 1;
-  white-space: nowrap;
-}
-
-.model-badge[data-kind="private"] {
-  background: color-mix(in oklch, oklch(0.58 0.08 285) 18%, transparent);
-  color: oklch(0.42 0.12 285);
-}
-
-.model-badge[data-kind="anon"],
-.model-badge[data-kind="privacy"] {
-  background: color-mix(in oklch, oklch(0.58 0.08 220) 16%, transparent);
-  color: oklch(0.42 0.12 220);
-}
-
-.model-badge[data-kind="uncensored"] {
-  background: color-mix(in oklch, oklch(0.62 0.14 45) 16%, transparent);
-  color: oklch(0.46 0.14 45);
+  font-size: var(--fs-sm);
 }
 
 .model-picker-dialog {
   gap: var(--sp-4);
 }
 
-.model-picker-toolbar {
+.model-picker-search {
   display: flex;
   align-items: center;
-}
-
-.model-picker-search {
-  width: 100%;
+  gap: var(--sp-2);
   height: var(--control-xl);
   padding: 0 var(--sp-3);
-  border: 1px solid var(--border);
+  border: 0;
   border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--muted-foreground);
+  box-shadow:
+    inset 0 1px 0 0 oklch(100% 0 none / 60%),
+    0 1px 2px 0 oklch(0% 0 none / 4%),
+    0 0 0 1px oklch(0% 0 none / 6%);
+  transition: box-shadow var(--t-fast) var(--ease-out);
+}
+
+.model-picker-search:focus-within {
+  box-shadow:
+    0 0 0 1px var(--ring),
+    0 0 0 4px var(--focus-ring);
+}
+
+.model-picker-search input,
+.model-picker-search-input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
   background: transparent;
   color: var(--foreground);
   font: inherit;
   font-size: var(--fs-md);
-  transition:
-    border-color var(--t-fast) var(--ease-out),
-    box-shadow var(--t-fast) var(--ease-out);
+  outline: 0;
 }
 
-.model-picker-search:focus,
-.model-picker-search:focus-visible {
-  outline: none;
-  border-color: var(--ring);
-  box-shadow: 0 0 0 3px var(--focus-ring);
+.model-picker-search input:focus-visible,
+.model-picker-search-input:focus-visible {
+  outline: 0;
 }
 
 .model-picker-list {
   display: grid;
-  gap: var(--sp-3);
+  gap: var(--sp-2);
   max-height: min(520px, calc(100vh - 260px));
   min-height: 0;
   overflow-y: auto;
@@ -2824,86 +2859,80 @@ input:focus-visible,
 }
 
 .model-picker-option {
+  /* Check spans both rows so it sits vertically centered against the
+   * logo + name + meta stack. Transparent border reserves space so the
+   * selected state's visible border doesn't reflow other rows. */
   display: grid;
-  gap: var(--sp-2);
+  grid-template-columns: 28px minmax(0, 1fr) 22px;
+  grid-template-areas:
+    "logo name  check"
+    "logo meta  check";
+  row-gap: 2px;
+  column-gap: var(--sp-3);
   width: 100%;
-  padding: var(--sp-4);
-  border: 1px solid var(--border);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid transparent;
   border-radius: var(--r-md);
   background: transparent;
   color: var(--foreground);
   text-align: left;
   cursor: pointer;
   transition:
-    border-color var(--t-fast) var(--ease-out),
     background-color var(--t-fast) var(--ease-out),
-    box-shadow var(--t-fast) var(--ease-out);
+    border-color var(--t-fast) var(--ease-out);
 }
 
 .model-picker-option:hover {
-  border-color: color-mix(in oklch, var(--foreground) 22%, transparent);
-  background: color-mix(in oklch, var(--muted) 30%, transparent);
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
 }
 
+/* Selected gets the system surface-subtle wash. Hover stacks darker so
+ * both states remain distinguishable. */
 .model-picker-option[data-selected="true"] {
-  border-color: color-mix(in oklch, var(--foreground) 28%, transparent);
-  background: color-mix(in oklch, var(--muted) 38%, transparent);
-  box-shadow: var(--shadow-sm);
+  background: var(--surface-subtle);
 }
 
-.model-picker-option-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 18px;
-  align-items: start;
-  gap: var(--sp-3);
+.model-picker-option[data-selected="true"]:hover {
+  background: color-mix(in oklch, var(--muted) 80%, transparent);
 }
 
-.model-picker-title-group {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
+.model-picker-logo {
+  grid-area: logo;
+  display: inline-grid;
+  place-items: center;
+  align-self: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
+  color: var(--foreground);
 }
 
 .model-picker-name {
+  grid-area: name;
   overflow: hidden;
-  font-size: var(--fs-lg);
-  font-weight: 600;
+  font-size: var(--fs-md);
+  font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.model-picker-id {
-  overflow: hidden;
+.model-picker-meta {
+  grid-area: meta;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   color: var(--muted-foreground);
-  font-family: var(--font-mono);
   font-size: var(--fs-sm);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .model-picker-selected {
+  grid-area: check;
   display: inline-grid;
   place-items: center;
-  color: var(--foreground);
-}
-
-.model-picker-description {
-  display: -webkit-box;
-  overflow: hidden;
+  align-self: stretch;
+  width: 22px;
   color: var(--muted-foreground);
-  font-size: var(--fs-md);
-  line-height: 1.4;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
-.model-picker-facts {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--sp-2) var(--sp-4);
-  color: var(--foreground);
-  font-size: var(--fs-sm);
-  font-weight: 500;
 }
 
 /* Primary solid button (Granola / Claude style) -------------------- */

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -51,9 +51,11 @@ body {
   --hud-bar: var(--foreground);
   --hud-handle: color-mix(in oklch, var(--foreground) 58%, transparent);
   --hud-stop-bg: color-mix(in oklch, var(--foreground) 5%, transparent);
-  --hud-stop-bg-hover: var(--accent);
+  /* Pin hover to a foreground-tinted overlay so the highlight reads the
+   * same regardless of OS color scheme — --accent here would leak the
+   * light-mode (near-white) value into the always-dark HUD. */
+  --hud-stop-bg-hover: color-mix(in oklch, var(--foreground) 16%, transparent);
   --hud-danger: var(--destructive);
-  --hud-warning: var(--warm-strong);
   --hud-alert: var(--hud-danger);
 
   display: flex;
@@ -159,7 +161,7 @@ body {
   border-radius: 999px;
   background: var(--hud-bar);
   transform: translateY(50%);
-  transition: height 80ms ease-out;
+  transition: height 40ms linear;
 }
 
 .hud-braille,
@@ -292,30 +294,18 @@ body {
 }
 
 /* State machine ------------------------------------------------------- */
-.hud[data-state="silent-error"] .hud-handle,
 .hud[data-state="error"] .hud-handle {
   display: none;
 }
 
-/* Text-only shaking pill shared by both error states. Tint differs:
- * warm for "Nothing recorded", red for hard errors. */
-.hud[data-state="silent-error"],
-.hud[data-state="error"] {
-  gap: var(--sp-2);
-  padding-inline: var(--sp-3) var(--sp-4);
-  animation: hud-shake 380ms var(--ease-out);
-}
-
-.hud[data-state="silent-error"] {
-  --hud-alert: var(--hud-warning);
-  border-color: color-mix(in oklch, var(--hud-warning) 28%, var(--border));
-  background: color-mix(in oklch, var(--popover) 78%, var(--hud-warning) 22%);
-}
-
+/* Text-only shaking pill for hard errors. */
 .hud[data-state="error"] {
   --hud-alert: var(--hud-danger);
+  gap: var(--sp-2);
+  padding-inline: var(--sp-3) var(--sp-4);
   border-color: color-mix(in oklch, var(--hud-danger) 28%, var(--border));
   background: color-mix(in oklch, var(--popover) 78%, var(--hud-danger) 22%);
+  animation: hud-shake 380ms var(--ease-out);
 }
 
 .hud[data-state="transcribing"] .hud-viz,
@@ -325,14 +315,12 @@ body {
   width: 88px;
 }
 
-.hud[data-state="silent-error"] .hud-viz,
 .hud[data-state="error"] .hud-viz {
   display: none;
 }
 
 .hud[data-state="transcribing"] .hud-bars,
 .hud[data-state="pasting"] .hud-bars,
-.hud[data-state="silent-error"] .hud-bars,
 .hud[data-state="error"] .hud-bars {
   display: none;
 }
@@ -342,7 +330,6 @@ body {
   display: flex;
 }
 
-.hud[data-state="silent-error"] .hud-error-text,
 .hud[data-state="error"] .hud-error-text {
   display: block;
 }
@@ -350,7 +337,6 @@ body {
 /* Stop button only matters while we're still capturing audio. */
 .hud[data-state="transcribing"] .hud-stop,
 .hud[data-state="pasting"] .hud-stop,
-.hud[data-state="silent-error"] .hud-stop,
 .hud[data-state="error"] .hud-stop {
   display: none;
 }
@@ -410,7 +396,6 @@ body {
     transition: none;
   }
 
-  .hud[data-state="silent-error"],
   .hud[data-state="error"] {
     animation: none;
   }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -143,7 +143,7 @@ describe("AppSettings", () => {
                 privacy: "private",
                 pricing: { input: { usd: 0.2 }, output: { usd: 0.8 } },
                 contextTokens: 65536,
-                traits: ["uncensored"],
+                traits: ["anonymized", "uncensored"],
                 capabilities: [],
               },
             ],
@@ -338,7 +338,6 @@ describe("AppSettings", () => {
         name: "Change transcription model",
       }),
     );
-    expect((await screen.findAllByText("Private")).length).toBeGreaterThan(0);
     expect(
       await screen.findByRole("option", { name: /Parakeet/ }),
     ).toBeInTheDocument();
@@ -356,11 +355,7 @@ describe("AppSettings", () => {
         name: "Change note generation model",
       }),
     );
-    expect((await screen.findAllByText("Uncensored")).length).toBeGreaterThan(
-      0,
-    );
-    expect(screen.queryByText("Tools")).not.toBeInTheDocument();
-    expect(screen.queryByText("Reasoning")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Anon").length).toBeGreaterThan(0);
     await user.click(
       await screen.findByRole("option", { name: /Venice Uncensored/ }),
     );

--- a/src/test/provider-logo.test.tsx
+++ b/src/test/provider-logo.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProviderLogo } from "../components/settings/ProviderLogo";
+
+describe("ProviderLogo", () => {
+  it("does not classify broad Anthropic family words as Claude", () => {
+    render(<ProviderLogo provider="venice" id="poetry-haiku" name="Haiku" />);
+
+    expect(screen.queryByLabelText("Claude")).not.toBeInTheDocument();
+  });
+
+  it("classifies xAI providers as Grok", () => {
+    render(<ProviderLogo provider="xai" id="grok-4" name="Grok 4" />);
+
+    expect(screen.getByLabelText("Grok")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- **Settings page** — indented group headings, IconSettingsGear4 in sidebar, dropped the inline status line, more spacing between groups, About row hierarchy flipped (muted label · foreground value).
- **AI model picker + trigger** — stacked card pattern shared between the trigger button and picker rows (logo chip · name · meta with dot separators). Selected uses `--surface-subtle` fill, 14px muted `IconCheckmark2Small` vertically centered. New `ProviderLogo` component covers OpenAI / Anthropic / Gemini / Meta / Mistral / DeepSeek / Perplexity / Ollama / xAI / NVIDIA plus inline ElevenLabs / Fal / Venice SVGs, with 2-letter monogram fallback and per-mark size calibration. Trait pills (Ghost · Anonymous · Fire) wrapped in squared `--r-xs` chips matching the keycap/kbd pattern.
- **HUD** — bars react faster (`ATTACK_ALPHA` 0.44→0.7, height transition 80ms→40ms linear). Silent "Nothing recorded" now exits via the regular fade instead of shaking; only hard errors keep the shake. `--hud-stop-bg-hover` pinned to a foreground tint so the overlay reads identically in light and dark OS modes.

## Test plan
- [x] `pnpm run lint` (tsc --noEmit) clean
- [x] `pnpm test` — 52/52 passing
- [ ] Visual: open Settings → AI models → verify trigger card, picker rows, hover/selected, provider logos, search focus state
- [ ] Visual: trigger dictation in light and dark mode, confirm HUD bar response and stop-button hover match
- [ ] Visual: cause a silent "nothing recorded" event, confirm HUD fades out (no shake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)