### PR TITLE
Add note folder move controls

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "minHeight": 620,
         "resizable": true,
         "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "hiddenTitle": true,
+        "dragDropEnabled": false
       },
       {
         "label": "hud",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -305,6 +305,7 @@ export function App() {
       dispatch({ type: "folderDeleted", folderId });
     } catch (err) {
       setError(messageFromError(err));
+      throw err;
     }
   }
 
@@ -572,7 +573,7 @@ export function App() {
                 onRenameFolder={(folderId, name, description) =>
                   void handleRenameFolder(folderId, name, description)
                 }
-                onDeleteFolder={(folderId) => void handleDeleteFolder(folderId)}
+                onDeleteFolder={(folderId) => handleDeleteFolder(folderId)}
                 onCreateNote={(folderId) => void handleCreateNote(folderId)}
                 onSelectNote={(noteId) => {
                   const folderId = state.selectedFolderId;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useReducer, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { DictionaryWorkspace } from "../components/dictionary/DictionaryWorkspace";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
+import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDialog";
 import { NoteFromFolderCrumb } from "../components/folders/NoteFromFolderCrumb";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { PermissionBanner } from "../components/permissions/PermissionBanner";
@@ -60,6 +61,7 @@ export function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeView, setActiveView] = useState<SidebarView>("notes");
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
+  const [moveDialogNoteId, setMoveDialogNoteId] = useState<string | null>(null);
   // User's intent for system audio. Defaults true ("record everything").
   // The actual sourceMode is derived below so that granting/revoking
   // permission in System Settings flips the toggle without losing intent.
@@ -306,30 +308,39 @@ export function App() {
     }
   }
 
-  async function handleAssignNoteToFolder(
-    noteId: string,
-    folderId: string,
-    options?: { rethrow?: boolean },
-  ) {
-    try {
-      const note = await assignNoteToFolder(noteId, folderId);
-      dispatch({ type: "noteUpdated", note });
-      return note;
-    } catch (err) {
-      setError(messageFromError(err));
-      if (options?.rethrow) {
-        throw err;
-      }
-      return undefined;
-    }
-  }
-
   async function handleRemoveNoteFromFolder(noteId: string, folderId: string) {
     try {
       const note = await removeNoteFromFolder(noteId, folderId);
       dispatch({ type: "noteUpdated", note });
     } catch (err) {
       setError(messageFromError(err));
+    }
+  }
+
+  // Single-folder semantics: a note belongs to at most one folder. Strip any
+  // existing folder assignments before adding the target. Legacy notes with
+  // multiple folders get normalized on the next move.
+  async function handleSetNoteFolder(
+    noteId: string,
+    folderId: string,
+    options?: { rethrow?: boolean },
+  ) {
+    const note = state.notes.find((n) => n.id === noteId);
+    if (!note) return;
+    if (note.folderIds.length === 1 && note.folderIds[0] === folderId) return;
+    try {
+      for (const existing of note.folderIds) {
+        if (existing === folderId) continue;
+        const updated = await removeNoteFromFolder(noteId, existing);
+        dispatch({ type: "noteUpdated", note: updated });
+      }
+      if (!note.folderIds.includes(folderId)) {
+        const updated = await assignNoteToFolder(noteId, folderId);
+        dispatch({ type: "noteUpdated", note: updated });
+      }
+    } catch (err) {
+      setError(messageFromError(err));
+      if (options?.rethrow) throw err;
     }
   }
 
@@ -522,6 +533,10 @@ export function App() {
         onSelectFolder={(folderId) => handleSelectFolder(folderId)}
         onSelectNote={(noteId) => void handleSelectNote(noteId)}
         onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
+        onOpenMoveDialog={(noteId) => setMoveDialogNoteId(noteId)}
+        onRemoveNoteFromFolder={(noteId, folderId) =>
+          void handleRemoveNoteFromFolder(noteId, folderId)
+        }
         recoverableNoteIds={recoverableNoteIds}
         collapsed={sidebarCollapsed}
         onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
@@ -570,13 +585,12 @@ export function App() {
                   }
                 }}
                 onAssignNoteToFolder={(noteId, folderId) =>
-                  handleAssignNoteToFolder(noteId, folderId, {
-                    rethrow: true,
-                  })
+                  handleSetNoteFolder(noteId, folderId, { rethrow: true })
                 }
                 onRemoveNoteFromFolder={(noteId, folderId) =>
                   void handleRemoveNoteFromFolder(noteId, folderId)
                 }
+                onOpenMoveDialog={(noteId) => setMoveDialogNoteId(noteId)}
                 onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
               />
             ) : selectedNote ? (
@@ -654,21 +668,16 @@ export function App() {
                       : undefined
                   }
                   onAssignFolder={(folderId) =>
-                    void handleAssignNoteToFolder(selectedNote.id, folderId)
+                    void handleSetNoteFolder(selectedNote.id, folderId)
                   }
                   onRemoveFolder={(folderId) =>
-                    void removeNoteFromFolder(selectedNote.id, folderId).then(
-                      (note) => dispatch({ type: "noteUpdated", note }),
-                    )
+                    void handleRemoveNoteFromFolder(selectedNote.id, folderId)
                   }
                   onCreateAndAssignFolder={(name) => {
                     void (async () => {
                       const folder = await handleCreateFolder(name);
                       if (folder) {
-                        await handleAssignNoteToFolder(
-                          selectedNote.id,
-                          folder.id,
-                        );
+                        await handleSetNoteFolder(selectedNote.id, folder.id);
                       }
                     })();
                   }}
@@ -688,6 +697,19 @@ export function App() {
           </div>
         </div>
       </section>
+      <MoveNoteToFolderDialog
+        open={moveDialogNoteId !== null}
+        onClose={() => setMoveDialogNoteId(null)}
+        note={
+          moveDialogNoteId
+            ? (state.notes.find((n) => n.id === moveDialogNoteId) ?? null)
+            : null
+        }
+        folders={state.folders}
+        onSetFolder={(noteId, folderId) =>
+          handleSetNoteFolder(noteId, folderId)
+        }
+      />
     </main>
   );
 }

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -40,7 +40,10 @@ type FoldersWorkspaceProps = {
     name: string,
     description?: string,
   ) => void;
-  onDeleteFolder: (folderId: string, deleteNotes: boolean) => void;
+  onDeleteFolder: (
+    folderId: string,
+    deleteNotes: boolean,
+  ) => Promise<unknown> | void;
   onCreateNote: (folderId?: string) => void;
   onSelectNote: (noteId: string) => void;
   onAssignNoteToFolder: (noteId: string, folderId: string) => Promise<unknown>;
@@ -193,7 +196,13 @@ function FolderList({
               onOpen={() => onSelectFolder(folder.id)}
               onDropNote={(noteId) => {
                 const note = notes.find((item) => item.id === noteId);
-                if (!note || note.folderIds.includes(folder.id)) return;
+                if (
+                  !note ||
+                  (note.folderIds.length === 1 &&
+                    note.folderIds[0] === folder.id)
+                ) {
+                  return;
+                }
                 void onAssignNoteToFolder(noteId, folder.id);
               }}
               onOpenMenu={(anchor) => {
@@ -233,7 +242,8 @@ function FolderList({
         open={deleteFolderTarget !== undefined}
         onClose={() => setDeleteId(null)}
         onConfirm={() => {
-          if (deleteFolderTarget) onDeleteFolder(deleteFolderTarget.id, false);
+          if (!deleteFolderTarget) return;
+          return onDeleteFolder(deleteFolderTarget.id, false);
         }}
         title={`Delete "${deleteFolderTarget?.name ?? ""}"?`}
         description="Notes inside this folder will stay in your library."
@@ -352,6 +362,21 @@ function FolderCard({
     return false;
   }
 
+  function resetDropState() {
+    dragDepth.current = 0;
+    setDropActive(false);
+  }
+
+  useEffect(() => {
+    if (!dropActive) return;
+    document.addEventListener("dragend", resetDropState);
+    document.addEventListener("drop", resetDropState);
+    return () => {
+      document.removeEventListener("dragend", resetDropState);
+      document.removeEventListener("drop", resetDropState);
+    };
+  }, [dropActive]);
+
   return (
     <article
       className="folder-card"
@@ -385,14 +410,13 @@ function FolderCard({
       onDragLeave={(event) => {
         if (!hasNoteData(event)) return;
         dragDepth.current = Math.max(0, dragDepth.current - 1);
-        if (dragDepth.current === 0) setDropActive(false);
+        if (dragDepth.current === 0) resetDropState();
       }}
       onDrop={(event) => {
         if (!hasNoteData(event)) return;
         event.preventDefault();
         const noteId = event.dataTransfer.getData(NOTE_DND_MIME);
-        dragDepth.current = 0;
-        setDropActive(false);
+        resetDropState();
         if (noteId) onDropNote(noteId);
       }}
     >

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -11,8 +11,17 @@ import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconSortArrowUpDown } from "central-icons/IconSortArrowUpDown";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  type DragEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { NOTE_DND_MIME } from "../../lib/dnd";
 import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { AddNotesToFolderDialog } from "./AddNotesToFolderDialog";
 import { CreateFolderDialog } from "./CreateFolderDialog";
 import { EditFolderDialog } from "./EditFolderDialog";
@@ -36,6 +45,7 @@ type FoldersWorkspaceProps = {
   onSelectNote: (noteId: string) => void;
   onAssignNoteToFolder: (noteId: string, folderId: string) => Promise<unknown>;
   onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
+  onOpenMoveDialog: (noteId: string) => void;
   onDeleteNote: (noteId: string) => void;
 };
 
@@ -69,11 +79,14 @@ function FolderList({
   onSelectFolder,
   onCreateFolder,
   onDeleteFolder,
+  onAssignNoteToFolder,
 }: FoldersWorkspaceProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<SortKey>("updated");
   const [menu, setMenu] = useState<MenuState | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const deleteFolderTarget = folders.find((f) => f.id === deleteId);
 
   useEffect(() => {
     if (!menu) return;
@@ -178,6 +191,11 @@ function FolderList({
               notes={notes}
               menuOpen={menu?.folderId === folder.id}
               onOpen={() => onSelectFolder(folder.id)}
+              onDropNote={(noteId) => {
+                const note = notes.find((item) => item.id === noteId);
+                if (!note || note.folderIds.includes(folder.id)) return;
+                void onAssignNoteToFolder(noteId, folder.id);
+              }}
               onOpenMenu={(anchor) => {
                 if (menu?.folderId === folder.id) {
                   setMenu(null);
@@ -207,11 +225,21 @@ function FolderList({
             onSelectFolder(folderId);
             setMenu(null);
           }}
-          onDelete={(folderId, deleteNotes) =>
-            onDeleteFolder(folderId, deleteNotes)
-          }
+          onRequestDelete={(folderId) => setDeleteId(folderId)}
         />
       ) : null}
+
+      <ConfirmDialog
+        open={deleteFolderTarget !== undefined}
+        onClose={() => setDeleteId(null)}
+        onConfirm={() => {
+          if (deleteFolderTarget) onDeleteFolder(deleteFolderTarget.id, false);
+        }}
+        title={`Delete "${deleteFolderTarget?.name ?? ""}"?`}
+        description="Notes inside this folder will stay in your library."
+        confirmLabel="Delete folder"
+        destructive
+      />
 
       <CreateFolderDialog
         open={createOpen}
@@ -299,23 +327,36 @@ function FolderCard({
   menuOpen,
   onOpen,
   onOpenMenu,
+  onDropNote,
 }: {
   folder: FolderDto;
   notes: NoteListItemDto[];
   menuOpen: boolean;
   onOpen: () => void;
   onOpenMenu: (anchor: HTMLElement) => void;
+  onDropNote: (noteId: string) => void;
 }) {
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dragDepth = useRef(0);
+  const [dropActive, setDropActive] = useState(false);
   const folderNotes = notes.filter((note) =>
     note.folderIds.includes(folder.id),
   );
   const lastUpdated = folderNotes[0]?.updatedAt ?? folder.updatedAt;
 
+  function hasNoteData(event: DragEvent<HTMLElement>) {
+    const types = event.dataTransfer.types;
+    for (let i = 0; i < types.length; i += 1) {
+      if (types[i] === NOTE_DND_MIME) return true;
+    }
+    return false;
+  }
+
   return (
     <article
       className="folder-card"
       data-menu-open={menuOpen}
+      data-drop-active={dropActive || undefined}
       role="button"
       tabIndex={0}
       aria-label={`Open ${folder.name}`}
@@ -329,6 +370,30 @@ function FolderCard({
       onContextMenu={(event) => {
         event.preventDefault();
         if (menuButtonRef.current) onOpenMenu(menuButtonRef.current);
+      }}
+      onDragEnter={(event) => {
+        if (!hasNoteData(event)) return;
+        event.preventDefault();
+        dragDepth.current += 1;
+        setDropActive(true);
+      }}
+      onDragOver={(event) => {
+        if (!hasNoteData(event)) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "link";
+      }}
+      onDragLeave={(event) => {
+        if (!hasNoteData(event)) return;
+        dragDepth.current = Math.max(0, dragDepth.current - 1);
+        if (dragDepth.current === 0) setDropActive(false);
+      }}
+      onDrop={(event) => {
+        if (!hasNoteData(event)) return;
+        event.preventDefault();
+        const noteId = event.dataTransfer.getData(NOTE_DND_MIME);
+        dragDepth.current = 0;
+        setDropActive(false);
+        if (noteId) onDropNote(noteId);
       }}
     >
       <div className="folder-card-icon" aria-hidden>
@@ -378,7 +443,7 @@ function FolderCardMenu({
   folders,
   onClose,
   onOpen,
-  onDelete,
+  onRequestDelete,
 }: {
   right: number;
   top: number;
@@ -387,7 +452,7 @@ function FolderCardMenu({
   notes: NoteListItemDto[];
   onClose: () => void;
   onOpen: (folderId: string) => void;
-  onDelete: (folderId: string, deleteNotes: boolean) => void;
+  onRequestDelete: (folderId: string) => void;
 }) {
   const folder = folders.find((item) => item.id === folderId);
   if (!folder) return null;
@@ -408,14 +473,8 @@ function FolderCardMenu({
         role="menuitem"
         className="destructive"
         onClick={() => {
-          if (
-            window.confirm(
-              `Delete "${folder.name}"? Notes inside this folder will stay in your library.`,
-            )
-          ) {
-            onDelete(folder.id, false);
-          }
           onClose();
+          onRequestDelete(folder.id);
         }}
       >
         <IconTrashCan size={14} />
@@ -429,6 +488,7 @@ function FolderCardMenu({
 
 function FolderDetail({
   folder,
+  folders,
   notes,
   onSelectFolder,
   onRenameFolder,
@@ -437,6 +497,7 @@ function FolderDetail({
   onSelectNote,
   onAssignNoteToFolder,
   onRemoveNoteFromFolder,
+  onOpenMoveDialog,
   onDeleteNote,
 }: FoldersWorkspaceProps & { folder: FolderDto }) {
   const [editingTitle, setEditingTitle] = useState(false);
@@ -444,6 +505,7 @@ function FolderDetail({
   const [menu, setMenu] = useState<{ right: number; top: number } | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const titleRef = useRef<HTMLInputElement | null>(null);
 
   useLayoutEffect(() => {
@@ -605,6 +667,7 @@ function FolderDetail({
             onSelectNote={onSelectNote}
             onCreateNote={() => onCreateNote(folder.id)}
             onAddExisting={() => setAddOpen(true)}
+            onOpenMoveDialog={onOpenMoveDialog}
             onRemoveNoteFromFolder={onRemoveNoteFromFolder}
             onDeleteNote={onDeleteNote}
           />
@@ -643,13 +706,7 @@ function FolderDetail({
             className="destructive"
             onClick={() => {
               setMenu(null);
-              if (
-                window.confirm(
-                  `Delete "${folder.name}"? Notes inside this folder will stay in your library.`,
-                )
-              ) {
-                onDeleteFolder(folder.id, false);
-              }
+              setDeleteOpen(true);
             }}
           >
             <IconTrashCan size={14} />
@@ -666,6 +723,15 @@ function FolderDetail({
         onAdd={async (noteId) => {
           await onAssignNoteToFolder(noteId, folder.id);
         }}
+      />
+      <ConfirmDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={() => onDeleteFolder(folder.id, false)}
+        title={`Delete "${folder.name}"?`}
+        description="Notes inside this folder will stay in your library."
+        confirmLabel="Delete folder"
+        destructive
       />
       <EditFolderDialog
         open={editOpen}
@@ -686,6 +752,7 @@ function FolderNotesPanel({
   onSelectNote,
   onCreateNote,
   onAddExisting,
+  onOpenMoveDialog,
   onRemoveNoteFromFolder,
   onDeleteNote,
 }: {
@@ -695,6 +762,7 @@ function FolderNotesPanel({
   onSelectNote: (noteId: string) => void;
   onCreateNote: () => void;
   onAddExisting: () => void;
+  onOpenMoveDialog: (noteId: string) => void;
   onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
   onDeleteNote: (noteId: string) => void;
 }) {
@@ -712,6 +780,7 @@ function FolderNotesPanel({
             note={note}
             folder={folder}
             onSelect={() => onSelectNote(note.id)}
+            onOpenMove={() => onOpenMoveDialog(note.id)}
             onRemoveFromFolder={() =>
               onRemoveNoteFromFolder(note.id, folder.id)
             }
@@ -757,14 +826,16 @@ function FolderActions({
 
 function FolderNoteRow({
   note,
-  folder,
+  folder: _folder,
   onSelect,
+  onOpenMove,
   onRemoveFromFolder,
   onDelete,
 }: {
   note: NoteListItemDto;
   folder: FolderDto;
   onSelect: () => void;
+  onOpenMove: () => void;
   onRemoveFromFolder: () => void;
   onDelete: () => void;
 }) {
@@ -841,12 +912,24 @@ function FolderNoteRow({
               role="menuitem"
               onClick={() => {
                 setMenu(null);
+                onOpenMove();
+              }}
+            >
+              <IconFolderAddRight size={14} />
+              Move to folder
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setMenu(null);
                 onRemoveFromFolder();
               }}
             >
               <IconFolderDelete size={14} />
               Remove from folder
             </button>
+            <div className="context-menu-separator" role="separator" />
             <button
               type="button"
               role="menuitem"

--- a/src/components/folders/MoveNoteToFolderDialog.tsx
+++ b/src/components/folders/MoveNoteToFolderDialog.tsx
@@ -1,0 +1,160 @@
+import { IconCheckmark1 } from "central-icons-filled/IconCheckmark1";
+import { IconFolder1 } from "central-icons/IconFolder1";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { useEffect, useMemo, useState } from "react";
+import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
+import { Dialog } from "../ui/Dialog";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  note: NoteListItemDto | null;
+  folders: FolderDto[];
+  onSetFolder: (noteId: string, folderId: string) => Promise<unknown> | void;
+};
+
+export function MoveNoteToFolderDialog({
+  open,
+  onClose,
+  note,
+  folders,
+  onSetFolder,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setSelectedId(null);
+    setSubmitting(false);
+  }, [open]);
+
+  const currentFolderId = note?.folderIds[0];
+  const currentFolder = folders.find((f) => f.id === currentFolderId);
+  const hasCurrent = Boolean(currentFolder);
+
+  const candidates = useMemo(() => {
+    const available = folders.filter((folder) => folder.id !== currentFolderId);
+    const normalized = query.trim().toLowerCase();
+    const filtered = normalized
+      ? available.filter((folder) =>
+          `${folder.name} ${folder.description ?? ""}`
+            .toLowerCase()
+            .includes(normalized),
+        )
+      : available;
+    return [...filtered].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+    );
+  }, [folders, currentFolderId, query]);
+
+  async function handleCommit() {
+    if (!note || !selectedId || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSetFolder(note.id, selectedId);
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title = hasCurrent ? "Move note" : "Add note to folder";
+  const description = hasCurrent
+    ? `This note is in "${currentFolder?.name}". Pick another folder to move it to.`
+    : "Pick a folder for this note.";
+  const commitLabel = hasCurrent ? "Move" : "Add";
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (submitting) return;
+        onClose();
+      }}
+      title={title}
+      description={description}
+      initialFocusSelector='input[name="move-note-search"]'
+      footer={
+        <>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary-action primary-solid"
+            onClick={() => void handleCommit()}
+            disabled={submitting || !selectedId}
+          >
+            {submitting ? `${commitLabel}ing…` : commitLabel}
+          </button>
+        </>
+      }
+    >
+      <div className="move-note-dialog">
+        <label className="add-notes-search">
+          <IconMagnifyingGlass size={14} />
+          <input
+            type="search"
+            name="move-note-search"
+            placeholder="Search folders"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            autoComplete="off"
+          />
+        </label>
+        {candidates.length > 0 ? (
+          <ul className="add-notes-list" role="listbox">
+            {candidates.map((folder) => {
+              const isSelected = folder.id === selectedId;
+              return (
+                <li key={folder.id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    className="add-notes-row"
+                    data-selected={isSelected}
+                    disabled={submitting}
+                    onClick={() => setSelectedId(folder.id)}
+                    onDoubleClick={() => void handleCommit()}
+                  >
+                    <span className="add-notes-icon" aria-hidden>
+                      <IconFolder1 size={14} />
+                    </span>
+                    <span className="add-notes-body">
+                      <span className="add-notes-title">{folder.name}</span>
+                      {folder.description ? (
+                        <span className="add-notes-preview">
+                          {folder.description}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="add-notes-check" aria-hidden>
+                      {isSelected ? <IconCheckmark1 size={12} /> : null}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="add-notes-empty">
+            {folders.length === 0
+              ? "No folders yet. Create one from the Folders view."
+              : query.trim()
+                ? "No folders match that search."
+                : "No other folders to move to."}
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -133,17 +133,14 @@ export function NoteEditor({
   // microphone itself isn't ready. handleStartRecording re-checks on
   // click and silently falls back to mic-only if system audio is denied.
   const recordDisabled = processingLock || !!recovery;
+  const updatedAtLabel = formatFullDate(note.updatedAt);
 
   return (
     <article className="note-editor">
       <header className="editor-header">
         <div className="note-overline">
-          <span className="note-overline-date">
-            {formatFullDate(note.updatedAt)}
-          </span>
-          <span className="note-overline-dot" aria-hidden>
-            ·
-          </span>
+          <span className="note-overline-date">{updatedAtLabel}</span>
+          <span className="note-overline-dot" aria-hidden="true" />
           <FolderChip
             folders={folders}
             folderIds={note.folderIds}
@@ -433,7 +430,8 @@ function FolderChip({
     };
   }, [open]);
 
-  const assigned = folders.filter((folder) => folderIds.includes(folder.id));
+  const currentFolderId = folderIds[0];
+  const currentFolder = folders.find((folder) => folder.id === currentFolderId);
   const filtered = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     if (!normalized) return folders;
@@ -453,20 +451,18 @@ function FolderChip({
       <button
         type="button"
         className="move-to-folder-trigger"
-        data-assigned={assigned.length > 0}
+        data-assigned={currentFolder !== undefined}
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
       >
-        <IconFolder1 size={13} />
-        {assigned.length > 0
-          ? assigned.map((folder) => folder.name).join(", ")
-          : "Folder"}
+        <IconFolder1 size={14} />
+        {currentFolder?.name ?? "Folder"}
       </button>
       {open ? (
         <div className="move-to-folder-popover" role="menu">
           <div className="move-to-folder-search">
-            <IconMagnifyingGlass size={12} />
+            <IconMagnifyingGlass size={13} />
             <input
               ref={searchRef}
               type="search"
@@ -492,7 +488,7 @@ function FolderChip({
                   setOpen(false);
                 }}
               >
-                <IconPlusMedium size={12} />
+                <IconPlusMedium size={14} />
                 <span className="move-to-folder-item-name">
                   Create “{trimmed}”
                 </span>
@@ -504,7 +500,7 @@ function FolderChip({
           <div className="move-to-folder-list">
             {filtered.length > 0 ? (
               filtered.map((folder) => {
-                const isAssigned = folderIds.includes(folder.id);
+                const isAssigned = folder.id === currentFolderId;
                 return (
                   <button
                     key={folder.id}
@@ -516,7 +512,7 @@ function FolderChip({
                       isAssigned ? onRemove(folder.id) : onAssign(folder.id)
                     }
                   >
-                    <IconFolder1 size={12} />
+                    <IconFolder1 size={14} />
                     <span className="move-to-folder-item-name">
                       {folder.name}
                     </span>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { IconBooks } from "central-icons/IconBooks";
 import { IconDotGrid1x3Vertical } from "central-icons/IconDotGrid1x3Vertical";
 import { IconFileText } from "central-icons/IconFileText";
+import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
+import { IconFolderDelete } from "central-icons/IconFolderDelete";
 import { IconFolders } from "central-icons/IconFolders";
 import { IconFontStyle } from "central-icons/IconFontStyle";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
@@ -9,7 +11,8 @@ import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { IconSidebarHiddenLeftWide } from "central-icons/IconSidebarHiddenLeftWide";
 import { IconSidebarSimpleLeftWide } from "central-icons/IconSidebarSimpleLeftWide";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
+import { NOTE_DND_MIME } from "../../lib/dnd";
 import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
 
 export type SidebarView =
@@ -32,6 +35,8 @@ type SidebarProps = {
   onSelectFolder: (folderId: string) => void;
   onSelectNote: (noteId: string) => void;
   onDeleteNote: (noteId: string) => void;
+  onOpenMoveDialog: (noteId: string) => void;
+  onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
   recoverableNoteIds?: ReadonlySet<string>;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
@@ -52,6 +57,8 @@ export function Sidebar({
   onCreateNote,
   onSelectNote,
   onDeleteNote,
+  onOpenMoveDialog,
+  onRemoveNoteFromFolder,
   recoverableNoteIds,
   collapsed = false,
   onToggleCollapsed,
@@ -266,25 +273,16 @@ export function Sidebar({
       </footer>
 
       {menu ? (
-        <div
-          className="context-menu"
-          style={{ right: menu.right, top: menu.top }}
-          role="menu"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <button
-            type="button"
-            role="menuitem"
-            className="destructive"
-            onClick={() => {
-              onDeleteNote(menu.noteId);
-              setMenu(null);
-            }}
-          >
-            <IconTrashCan size={14} />
-            Delete note
-          </button>
-        </div>
+        <NoteContextMenu
+          noteId={menu.noteId}
+          right={menu.right}
+          top={menu.top}
+          notes={notes}
+          onOpenMoveDialog={onOpenMoveDialog}
+          onRemoveNoteFromFolder={onRemoveNoteFromFolder}
+          onDeleteNote={onDeleteNote}
+          onClose={() => setMenu(null)}
+        />
       ) : null}
     </aside>
   );
@@ -305,19 +303,53 @@ function NoteRow({
 }) {
   const title = note.title.trim() || "New note";
   const menuRef = useRef<HTMLButtonElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  function handleDragStart(event: DragEvent<HTMLElement>) {
+    event.dataTransfer.effectAllowed = "link";
+    event.dataTransfer.setData(NOTE_DND_MIME, note.id);
+    event.dataTransfer.setData("text/plain", note.id);
+
+    const node = event.currentTarget;
+    const clone = node.cloneNode(true) as HTMLElement;
+    clone.classList.add("note-row-drag-image");
+    clone.removeAttribute("data-selected");
+    clone.removeAttribute("data-dragging");
+    clone.style.width = `${node.offsetWidth}px`;
+    document.body.appendChild(clone);
+    event.dataTransfer.setDragImage(clone, 16, 16);
+    window.setTimeout(() => clone.remove(), 0);
+
+    setDragging(true);
+  }
 
   return (
     <article
       className="note-row"
       data-selected={selected}
       data-recoverable={recoverable || undefined}
+      data-dragging={dragging || undefined}
+      draggable
+      onDragStart={handleDragStart}
+      onDragEnd={() => setDragging(false)}
       onContextMenu={(event) => {
         event.preventDefault();
         event.stopPropagation();
         if (menuRef.current) onOpenMenu(menuRef.current);
       }}
     >
-      <button type="button" className="note-row-main" onClick={onSelect}>
+      <div
+        className="note-row-main"
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelect();
+          }
+        }}
+      >
         <span className="note-row-icon">
           <IconFileText size={15} />
         </span>
@@ -331,12 +363,13 @@ function NoteRow({
             />
           ) : null}
         </span>
-      </button>
+      </div>
       <button
         ref={menuRef}
         type="button"
         className="note-row-menu"
         aria-label={`Actions for ${title}`}
+        draggable={false}
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -346,5 +379,76 @@ function NoteRow({
         <IconDotGrid1x3Vertical size={14} />
       </button>
     </article>
+  );
+}
+
+function NoteContextMenu({
+  noteId,
+  right,
+  top,
+  notes,
+  onOpenMoveDialog,
+  onRemoveNoteFromFolder,
+  onDeleteNote,
+  onClose,
+}: {
+  noteId: string;
+  right: number;
+  top: number;
+  notes: NoteListItemDto[];
+  onOpenMoveDialog: (noteId: string) => void;
+  onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
+  onDeleteNote: (noteId: string) => void;
+  onClose: () => void;
+}) {
+  const note = notes.find((item) => item.id === noteId);
+  const currentFolderId = note?.folderIds[0];
+  const hasFolder = Boolean(currentFolderId);
+
+  return (
+    <div
+      className="context-menu"
+      style={{ right, top }}
+      role="menu"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onOpenMoveDialog(noteId);
+          onClose();
+        }}
+      >
+        <IconFolderAddRight size={14} />
+        {hasFolder ? "Move to folder" : "Add to folder"}
+      </button>
+      {hasFolder && currentFolderId ? (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={() => {
+            onRemoveNoteFromFolder(noteId, currentFolderId);
+            onClose();
+          }}
+        >
+          <IconFolderDelete size={14} />
+          Remove from folder
+        </button>
+      ) : null}
+      <div className="context-menu-separator" role="separator" />
+      <button
+        type="button"
+        role="menuitem"
+        className="destructive"
+        onClick={() => {
+          onDeleteNote(noteId);
+          onClose();
+        }}
+      >
+        <IconTrashCan size={14} />
+        Delete note
+      </button>
+    </div>
   );
 }

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { Dialog } from "./Dialog";
 
 type ConfirmDialogProps = {
   open: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<unknown>;
   title: ReactNode;
   description?: ReactNode;
   confirmLabel?: string;
@@ -22,16 +23,38 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   destructive = false,
 }: ConfirmDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleConfirm() {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onConfirm();
+      onClose();
+    } catch {
+      // Keep the dialog open so callers can surface the error and retry.
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
     <Dialog
       open={open}
-      onClose={onClose}
+      onClose={() => {
+        if (!submitting) onClose();
+      }}
       title={title}
       description={description}
       width={420}
       footer={
         <>
-          <button type="button" className="primary-action" onClick={onClose}>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={onClose}
+            disabled={submitting}
+          >
             {cancelLabel}
           </button>
           <button
@@ -39,10 +62,8 @@ export function ConfirmDialog({
             className={`primary-action primary-solid${
               destructive ? " primary-destructive" : ""
             }`}
-            onClick={() => {
-              onConfirm();
-              onClose();
-            }}
+            onClick={() => void handleConfirm()}
+            disabled={submitting}
           >
             {confirmLabel}
           </button>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { Dialog } from "./Dialog";
+
+type ConfirmDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+};
+
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+      width={420}
+      footer={
+        <>
+          <button type="button" className="primary-action" onClick={onClose}>
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={`primary-action primary-solid${
+              destructive ? " primary-destructive" : ""
+            }`}
+            onClick={() => {
+              onConfirm();
+              onClose();
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </>
+      }
+    >
+      <div />
+    </Dialog>
+  );
+}

--- a/src/lib/dnd.ts
+++ b/src/lib/dnd.ts
@@ -1,0 +1,1 @@
+export const NOTE_DND_MIME = "application/x-scribe-note-id";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -519,7 +519,6 @@ input:focus-visible,
 .section-count {
   color: var(--muted-foreground);
   font-weight: 400;
-  font-variant-numeric: tabular-nums;
 }
 
 .section-add {
@@ -630,11 +629,33 @@ input:focus-visible,
   align-items: center;
   padding-right: var(--sp-1);
   border-radius: var(--r-md);
+  user-select: none;
+  -webkit-user-drag: element;
 }
 
 .note-row:hover,
 .note-row[data-selected="true"] {
   background: var(--sidebar-accent);
+}
+
+.note-row[data-dragging="true"] {
+  opacity: 0.4;
+}
+
+.note-row-drag-image {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+  pointer-events: none;
+  background: var(--popover);
+  border: 1px solid var(--focus-ring);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-lg);
+  opacity: 1;
+}
+
+.note-row-drag-image .note-row-menu {
+  display: none;
 }
 
 .note-row-main {
@@ -780,6 +801,12 @@ input:focus-visible,
 
 .context-menu .destructive:hover {
   background: var(--destructive-soft);
+}
+
+.context-menu-separator {
+  height: 1px;
+  margin: var(--sp-1) calc(var(--sp-1) * -1);
+  background: var(--border);
 }
 
 .sidebar-empty {
@@ -1074,18 +1101,21 @@ input:focus-visible,
 .note-overline {
   display: flex;
   align-items: center;
-  gap: var(--sp-3);
   font-size: var(--fs-sm);
   color: var(--muted-foreground);
 }
 
 .note-overline-date {
-  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .note-overline-dot {
-  color: var(--muted-foreground);
-  opacity: 0.5;
+  width: 2px;
+  height: 2px;
+  margin: 0 var(--sp-4);
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.45;
 }
 
 .folder-chip-wrap {
@@ -1349,7 +1379,6 @@ input:focus-visible,
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
   font-weight: 500;
-  font-variant-numeric: tabular-nums;
 }
 
 .source-transcripts p {
@@ -2922,6 +2951,17 @@ input:focus-visible,
   cursor: not-allowed;
 }
 
+.primary-action.primary-destructive {
+  border-color: transparent;
+  background: var(--destructive);
+  color: oklch(100% 0 none);
+}
+
+.primary-action.primary-destructive:hover {
+  background: color-mix(in oklch, var(--destructive) 92%, var(--foreground));
+  border-color: transparent;
+}
+
 /* Ghost icon button — back-arrow style header chip ------------------ */
 
 .ghost-icon-button {
@@ -3204,6 +3244,12 @@ input:focus-visible,
   outline-offset: 2px;
 }
 
+.folder-card[data-drop-active="true"] {
+  background: color-mix(in oklch, var(--muted) 80%, transparent);
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 1px var(--focus-ring) inset;
+}
+
 /* Quiet folder icon — same subtle pill as the meta row. */
 .folder-card-icon {
   display: inline-grid;
@@ -3347,7 +3393,6 @@ input:focus-visible,
   flex-direction: column;
 }
 
-.folder-detail-header > h1,
 .folder-detail-header > form,
 .folder-detail-header > .folder-detail-description,
 .folder-detail-header > .folder-detail-meta {
@@ -3523,7 +3568,6 @@ input:focus-visible,
 .folder-note-time {
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
-  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
@@ -3600,6 +3644,12 @@ input:focus-visible,
   flex-direction: column;
   gap: var(--sp-3);
   min-height: 320px;
+}
+
+.move-note-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
 }
 
 .add-notes-search {
@@ -3910,7 +3960,7 @@ input:focus-visible,
   align-items: center;
   gap: var(--sp-2);
   height: 22px;
-  margin: 0 calc(-1 * var(--sp-1));
+  margin: 0 calc(-1 * var(--sp-2));
   padding: 0 var(--sp-2);
   border: 0;
   border-radius: var(--r-sm);
@@ -3925,7 +3975,7 @@ input:focus-visible,
 
 .move-to-folder-trigger:hover,
 .move-to-folder-trigger[aria-expanded="true"] {
-  background: var(--muted);
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
   color: var(--foreground);
 }
 

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -1,8 +1,15 @@
-import { render, screen, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
 import { Sidebar } from "../components/sidebar/Sidebar";
+import { NOTE_DND_MIME } from "../lib/dnd";
 import type { FolderDto, NoteListItemDto } from "../lib/tauri";
 
 const now = "2026-05-19T10:00:00Z";
@@ -248,6 +255,92 @@ describe("FoldersWorkspace — list view", () => {
     const ideasCard = screen.getByText("Ideas").closest("article");
     await user.click(within(ideasCard as HTMLElement).getByText("Ideas"));
     expect(props.onSelectFolder).toHaveBeenCalledWith("folder-1");
+  });
+
+  it("normalizes legacy multi-folder notes when dropped on an assigned folder", () => {
+    const props = baseProps();
+    render(
+      <FoldersWorkspace
+        {...props}
+        notes={[{ ...notes[0], folderIds: ["folder-1", "folder-2"] }]}
+      />,
+    );
+
+    fireEvent.drop(screen.getByRole("button", { name: "Open Ideas" }), {
+      dataTransfer: {
+        types: [NOTE_DND_MIME],
+        getData: () => "note-1",
+      },
+    });
+
+    expect(props.onAssignNoteToFolder).toHaveBeenCalledWith(
+      "note-1",
+      "folder-1",
+    );
+  });
+
+  it("clears drop highlight when a drag is cancelled", async () => {
+    render(<FoldersWorkspace {...baseProps()} />);
+    const card = screen.getByRole("button", { name: "Open Ideas" });
+
+    fireEvent.dragEnter(card, {
+      dataTransfer: {
+        types: [NOTE_DND_MIME],
+      },
+    });
+    expect(card).toHaveAttribute("data-drop-active", "true");
+
+    fireEvent.dragEnd(document);
+
+    await waitFor(() => expect(card).not.toHaveAttribute("data-drop-active"));
+  });
+
+  it("keeps delete confirmation open until async delete resolves", async () => {
+    const user = userEvent.setup();
+    let resolveDelete: (() => void) | undefined;
+    const props = {
+      ...baseProps(),
+      onDeleteFolder: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDelete = resolve;
+          }),
+      ),
+    };
+    render(<FoldersWorkspace {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /Actions for Ideas/ }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete folder" }));
+
+    expect(
+      screen.getByRole("dialog", { name: /Delete "Ideas"/ }),
+    ).toBeInTheDocument();
+
+    resolveDelete?.();
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: /Delete "Ideas"/ }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps delete confirmation open when async delete fails", async () => {
+    const user = userEvent.setup();
+    const props = {
+      ...baseProps(),
+      onDeleteFolder: vi.fn(() => Promise.reject(new Error("Nope"))),
+    };
+    render(<FoldersWorkspace {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /Actions for Ideas/ }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete folder" }));
+
+    expect(
+      screen.getByRole("dialog", { name: /Delete "Ideas"/ }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -52,6 +52,7 @@ function baseProps() {
     onSelectNote: vi.fn(),
     onAssignNoteToFolder: vi.fn(async () => undefined),
     onRemoveNoteFromFolder: vi.fn(),
+    onOpenMoveDialog: vi.fn(),
     onDeleteNote: vi.fn(),
   };
 }
@@ -74,6 +75,8 @@ describe("Sidebar — Folders nav item", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 
@@ -96,6 +99,8 @@ describe("Sidebar — Folders nav item", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 
@@ -120,6 +125,8 @@ describe("Sidebar — Folders nav item", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 
@@ -144,6 +151,8 @@ describe("Sidebar — Folders nav item", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 
@@ -169,6 +178,8 @@ describe("Sidebar — Folders nav item", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -51,6 +51,8 @@ describe("folders UI", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={onSelectNote}
         onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 
@@ -81,6 +83,8 @@ describe("folders UI", () => {
         onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={onDeleteNote}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
       />,
     );
 


### PR DESCRIPTION
## Summary

This PR finishes the folder management pass around notes. It adds fast drag-and-drop assignment from the notes list to folder cards, replaces the fragile inline folder picker with a proper move/add dialog, and makes the UI treat notes as single-folder items going forward.

## What Changed

### Note-to-folder movement
- Added native drag support for sidebar note rows using a shared note drag MIME type.
- Made folder cards valid drop targets with a visible active-drop state.
- Disabled Tauri's window-level drag/drop interception so note drag/drop events reach the webview.
- Dragging a note onto a folder now uses the same single-folder move primitive as the rest of the UI.

### Single-folder semantics
- Added `handleSetNoteFolder`, which removes existing folder assignments before assigning the selected target folder.
- Kept the existing array-shaped `folderIds` data model intact, but normalized UI behavior to “one current folder”.
- Legacy notes with multiple folders are treated as using the first folder and normalize the next time they are moved.

### Move/add folder dialog
- Added `MoveNoteToFolderDialog`, modeled after the existing add-existing-note dialog pattern.
- The dialog supports search, folder selection, double-click commit, Cancel, and a disabled primary action until a target folder is selected.
- The copy switches between “Add note to folder” and “Move note” based on whether the note already has a folder.

### Kebab menu updates
- Updated note row menus in the sidebar to use flat actions:
  - Add to folder / Move to folder
  - Remove from folder when applicable
  - Delete note
- Updated folder-detail note row menus with the same move/remove/delete behavior.
- Removed the fragile nested folder picker menu path from note kebabs.

### Folder management fixes
- Wired folder deletion through a confirmation dialog.
- Folder deletion now removes the folder while keeping the notes in the library.
- Added a reusable `ConfirmDialog` wrapper for destructive confirmations.

### Metadata and visual polish
- Fixed note editor metadata spacing so the date, separator dot, and folder chip are separate pieces with balanced spacing.
- Removed `tabular-nums` from metadata labels where it caused optical right-side padding, while keeping it on the live recording timer where stable-width digits are useful.
- Tuned drag preview/source opacity and folder drop highlight styles.
- Preserved the newer microphone-blocked `InlineNotice` behavior from `main` while resolving the main merge.

## Reviewer Notes

- This intentionally commits the UI to single-folder behavior, even though the backend/data model still supports multiple `folderIds`.
- Drag/drop should be manually checked in the Tauri app because webview drag behavior depends on the `dragDropEnabled: false` config.
- The move dialog does not create folders directly; folder creation remains available from the folders view and the note editor metadata folder control.

## Validation

- `pnpm test`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec prettier --check src/components/note-editor/NoteEditor.tsx src/styles/app.css`

`pnpm run build` passes with the existing Vite large chunk warning.
