### PR TITLE
Fix folder card footer wrapping at narrow widths

### DIFF
--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -437,9 +437,6 @@ function FolderCard({
           <span>
             {folderNotes.length} {folderNotes.length === 1 ? "note" : "notes"}
           </span>
-          <span className="folder-card-footer-dot" aria-hidden>
-            ·
-          </span>
           <span>Updated {formatRelative(lastUpdated)}</span>
         </p>
       </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3209,7 +3209,7 @@ input:focus-visible,
 .folders-grid {
   display: grid;
   gap: var(--sp-3);
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
 /* Slim, click-anywhere card. The article itself is `role=button`, so
@@ -3309,11 +3309,16 @@ input:focus-visible,
  * space-between flex. Subtle file icon + count + updated date. */
 .folder-card-footer {
   margin: 0;
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--sp-2);
+  gap: 2px var(--sp-2);
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
+}
+
+.folder-card-footer > span {
+  white-space: nowrap;
 }
 
 .folder-card-footer-icon {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3312,7 +3312,7 @@ input:focus-visible,
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 2px var(--sp-2);
+  gap: var(--sp-1) var(--sp-3);
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
 }
@@ -3328,10 +3328,6 @@ input:focus-visible,
   height: 14px;
   color: var(--muted-foreground);
   opacity: 0.85;
-}
-
-.folder-card-footer-dot {
-  opacity: 0.5;
 }
 
 .folder-card-menu {


### PR DESCRIPTION
## Summary
- Bumped `.folders-grid` min track from 220px to 260px so the meta footer fits on one line at common card widths.
- Switched `.folder-card-footer` to wrappable flex with `white-space: nowrap` on children, so tight cards wrap whole tokens ("Updated 9h ago") instead of breaking mid-phrase.

## Test plan
- [ ] Open Folders, resize window narrow → wide; confirm footer never splits "2 / notes" or "Updated 9h / ago".

🤖 Generated with [Claude Code](https://claude.com/claude-code)