### PR TITLE
Add sidebar notes overview

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,13 @@
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useEffect, useMemo, useReducer, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { DictionaryWorkspace } from "../components/dictionary/DictionaryWorkspace";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
 import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDialog";
 import { NoteFromFolderCrumb } from "../components/folders/NoteFromFolderCrumb";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
+import { NotesList } from "../components/notes-list/NotesList";
 import { PermissionBanner } from "../components/permissions/PermissionBanner";
 import { AppSettings } from "../components/settings/AppSettings";
 import { Sidebar, type SidebarView } from "../components/sidebar/Sidebar";
@@ -259,15 +260,32 @@ export function App() {
     return () => window.clearInterval(interval);
   }, [selectedNote?.id, selectedNote?.processingStatus]);
 
-  async function handleCreateNote(folderId?: string) {
-    try {
-      const note = await createNote(folderId ?? state.selectedFolderId);
-      dispatch({ type: "noteLoaded", note });
-      setActiveView("notes");
-    } catch (err) {
-      setError(messageFromError(err));
+  const handleCreateNote = useCallback(
+    async (folderId?: string | null) => {
+      try {
+        const targetFolderId =
+          folderId === null ? undefined : (folderId ?? state.selectedFolderId);
+        const note = await createNote(targetFolderId);
+        dispatch({ type: "noteLoaded", note });
+        setActiveView("notes");
+      } catch (err) {
+        setError(messageFromError(err));
+      }
+    },
+    [state.selectedFolderId],
+  );
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!isCreateNoteShortcut(event)) return;
+      if (document.querySelector('[role="dialog"]')) return;
+      event.preventDefault();
+      void handleCreateNote(null);
     }
-  }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleCreateNote]);
 
   function handleSelectFolder(folderId?: string) {
     dispatch({ type: "folderSelected", folderId });
@@ -529,7 +547,7 @@ export function App() {
           setActiveView("folders");
           dispatch({ type: "folderSelected", folderId: undefined });
         }}
-        onCreateNote={() => void handleCreateNote()}
+        onCreateNote={() => void handleCreateNote(null)}
         onSelectAll={() => handleSelectFolder(undefined)}
         onSelectFolder={(folderId) => handleSelectFolder(folderId)}
         onSelectNote={(noteId) => void handleSelectNote(noteId)}
@@ -559,6 +577,17 @@ export function App() {
               <StylesWorkspace />
             ) : activeView === "dictionary" ? (
               <DictionaryWorkspace />
+            ) : activeView === "all-notes" ? (
+              <NotesList
+                notes={state.notes}
+                selectedNoteId={state.selectedNoteId}
+                onSelectNote={(noteId) =>
+                  void handleSelectNote(noteId).then(() =>
+                    setActiveView("notes"),
+                  )
+                }
+                onCreateNote={() => void handleCreateNote(null)}
+              />
             ) : activeView === "folders" ? (
               <FoldersWorkspace
                 folders={state.folders}
@@ -689,7 +718,7 @@ export function App() {
                 <button
                   type="button"
                   className="primary-action"
-                  onClick={() => void handleCreateNote()}
+                  onClick={() => void handleCreateNote(null)}
                 >
                   New note
                 </button>
@@ -727,6 +756,16 @@ function handleTitlebarPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
 
 function isDeniedPermission(state?: string) {
   return state === "denied" || state === "restricted";
+}
+
+function isCreateNoteShortcut(event: KeyboardEvent) {
+  return (
+    event.key.toLowerCase() === "n" &&
+    event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
 }
 
 function parseDictationEvent(

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -1,3 +1,7 @@
+import { IconFileText } from "central-icons/IconFileText";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { useMemo, useState } from "react";
 import type { NoteListItemDto } from "../../lib/tauri";
 
 type NotesListProps = {
@@ -13,39 +17,113 @@ export function NotesList({
   onSelectNote,
   onCreateNote,
 }: NotesListProps) {
-  if (notes.length === 0) {
-    return (
-      <section className="notes-empty">
-        <p>No notes yet</p>
-        <button type="button" className="primary-action" onClick={onCreateNote}>
-          New note
-        </button>
-      </section>
+  const [query, setQuery] = useState("");
+  const filteredNotes = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const sorted = [...notes].sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
     );
-  }
+    if (!normalized) return sorted;
+    return sorted.filter((note) => {
+      return `${note.title} ${note.preview}`.toLowerCase().includes(normalized);
+    });
+  }, [notes, query]);
 
   return (
-    <section className="notes-list" aria-label="Notes">
-      <button type="button" className="primary-action" onClick={onCreateNote}>
-        New note
-      </button>
-      {notes.map((note) => {
-        const title = note.title.trim() || "New note";
-        const preview =
-          note.preview.trim() || statusLabel(note.processingStatus);
-        return (
+    <section className="all-notes-workspace" aria-label="Notes">
+      <header className="folders-header">
+        <div className="folders-heading">
+          <h1>Notes</h1>
+          <p className="folders-subtitle">
+            {notes.length} {notes.length === 1 ? "note" : "notes"} across your
+            workspace.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="primary-action primary-solid folders-create"
+          onClick={onCreateNote}
+        >
+          <IconPlusMedium size={13} />
+          New note
+        </button>
+      </header>
+
+      {notes.length > 0 ? (
+        <div className="folders-controls">
+          <label className="folders-search">
+            <IconMagnifyingGlass size={14} />
+            <input
+              type="search"
+              placeholder="Search"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+            />
+          </label>
+        </div>
+      ) : null}
+
+      {notes.length === 0 ? (
+        <div className="folders-empty">
+          <p>No notes yet.</p>
           <button
-            key={note.id}
             type="button"
-            className={selectedNoteId === note.id ? "selected" : undefined}
-            onClick={() => onSelectNote(note.id)}
+            className="primary-action primary-solid"
+            onClick={onCreateNote}
           >
-            <span>{title}</span>
-            <small>{preview}</small>
+            <IconPlusMedium size={13} />
+            Create your first note
           </button>
-        );
-      })}
+        </div>
+      ) : filteredNotes.length === 0 ? (
+        <div className="folders-empty">
+          <p>No notes match “{query.trim()}”.</p>
+        </div>
+      ) : (
+        <ul className="folder-notes all-notes-list" role="list">
+          {filteredNotes.map((note) => (
+            <AllNoteRow
+              key={note.id}
+              note={note}
+              selected={selectedNoteId === note.id}
+              onSelect={() => onSelectNote(note.id)}
+            />
+          ))}
+        </ul>
+      )}
     </section>
+  );
+}
+
+function AllNoteRow({
+  note,
+  selected,
+  onSelect,
+}: {
+  note: NoteListItemDto;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const title = note.title.trim() || "New note";
+  const preview = note.preview.trim() || statusLabel(note.processingStatus);
+
+  return (
+    <li>
+      <div className="folder-note-row all-notes-row" data-selected={selected}>
+        <button type="button" className="folder-note-main" onClick={onSelect}>
+          <span className="folder-note-icon" aria-hidden>
+            <IconFileText size={14} />
+          </span>
+          <span className="folder-note-body">
+            <span className="folder-note-title">{title}</span>
+            <span className="folder-note-subtitle">{preview}</span>
+          </span>
+        </button>
+        <span className="folder-note-time">
+          {formatNoteTime(note.updatedAt)}
+        </span>
+      </div>
+    </li>
   );
 }
 
@@ -68,4 +146,30 @@ function statusLabel(status: NoteListItemDto["processingStatus"]) {
     default:
       return "Draft";
   }
+}
+
+function formatNoteTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  if (diffMs < 0) return "Future";
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) {
+    return date.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000));
+  if (diffDays < 7) {
+    return date.toLocaleDateString(undefined, { weekday: "short" });
+  }
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
 
 export type SidebarView =
   | "notes"
+  | "all-notes"
   | "settings"
   | "folders"
   | "dictionary"
@@ -150,7 +151,7 @@ export function Sidebar({
         <button
           type="button"
           className="icon-button sidebar-search-collapsed"
-          aria-label="Jump to"
+          aria-label="Search"
           onClick={onToggleCollapsed}
         >
           <IconMagnifyingGlass size={16} />
@@ -161,15 +162,28 @@ export function Sidebar({
           <input
             value={query}
             onChange={(event) => setQuery(event.currentTarget.value)}
-            placeholder="Jump to…"
+            placeholder="Search"
           />
-          <kbd className="sidebar-search-kbd" aria-hidden>
-            ⌘K
-          </kbd>
         </label>
       )}
 
       <nav className="sidebar-nav" aria-label="Primary">
+        <button
+          type="button"
+          className="sidebar-nav-item"
+          onClick={() => {
+            onChangeView("notes");
+            onCreateNote();
+          }}
+        >
+          <span className="sidebar-nav-icon">
+            <IconPlusMedium size={15} />
+          </span>
+          <span className="sidebar-nav-label">New note</span>
+          <kbd className="sidebar-search-kbd sidebar-nav-shortcut" aria-hidden>
+            ⌘N
+          </kbd>
+        </button>
         <button
           type="button"
           className="sidebar-nav-item"
@@ -213,20 +227,20 @@ export function Sidebar({
         aria-label="Notes"
         data-active={activeView === "notes"}
       >
-        <div className="section-title">
-          <span className="section-title-label">
-            Notes <span className="section-count">{filteredNotes.length}</span>
-          </span>
+        <div className="section-title section-title-with-action">
           <button
             type="button"
-            className="icon-button section-add"
-            aria-label="New note"
-            onClick={() => {
-              onChangeView("notes");
-              onCreateNote();
-            }}
+            className="section-title-label section-title-open"
+            onClick={() => onChangeView("all-notes")}
           >
-            <IconPlusMedium size={14} />
+            Notes <span className="section-count">{notes.length}</span>
+          </button>
+          <button
+            type="button"
+            className="section-view-all"
+            onClick={() => onChangeView("all-notes")}
+          >
+            View all
           </button>
         </div>
         <div className="notes-nav-wrap">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -338,7 +338,7 @@ input:focus-visible,
  * kbd hint on the right uses muted/60 bg + mono-ish font. */
 .sidebar-search {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) auto;
+  grid-template-columns: 14px minmax(0, 1fr);
   align-items: center;
   gap: var(--sp-2);
   height: 32px;
@@ -418,7 +418,7 @@ input:focus-visible,
 
 .sidebar-nav-item {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
+  grid-template-columns: 18px minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--sp-3);
   width: 100%;
@@ -465,6 +465,10 @@ input:focus-visible,
   display: none;
 }
 
+.sidebar[data-collapsed="true"] .sidebar-nav-shortcut {
+  display: none;
+}
+
 .sidebar[data-collapsed="true"] .sidebar-nav-item {
   width: 38px;
   height: 38px;
@@ -505,7 +509,7 @@ input:focus-visible,
   gap: var(--sp-2);
   padding: 0 var(--sp-2);
   min-height: var(--control-md);
-  color: var(--foreground);
+  color: var(--muted-foreground);
   font-size: var(--fs-md);
   font-weight: 500;
 }
@@ -516,18 +520,61 @@ input:focus-visible,
   gap: var(--sp-2);
 }
 
+.section-title-with-action {
+  border-radius: var(--r-md);
+}
+
+.section-title-open {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease-out);
+}
+
+.section-title-with-action:hover .section-title-open,
+.section-title-with-action:focus-within .section-title-open {
+  color: var(--foreground);
+}
+
+.section-view-all {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.section-title-with-action:hover .section-view-all,
+.section-title-with-action:focus-within .section-view-all {
+  opacity: 1;
+}
+
+.section-title-with-action:hover .section-view-all:hover {
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
+  color: var(--foreground);
+}
+
 .section-count {
   color: var(--muted-foreground);
   font-weight: 400;
 }
 
-.section-add {
-  width: var(--control-sm);
-  height: var(--control-sm);
-}
-
 .sidebar[data-collapsed="true"] .section-title-label,
-.sidebar[data-collapsed="true"] .section-add,
 .sidebar[data-collapsed="true"] .section-title,
 .sidebar[data-collapsed="true"] .notes-nav-wrap {
   /* Collapsed rail = focus mode: hide the note list entirely so only the
@@ -3068,6 +3115,16 @@ input:focus-visible,
   gap: var(--sp-7);
 }
 
+.all-notes-workspace {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: var(--sp-10) 0 var(--sp-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-7);
+}
+
 .folders-header {
   display: flex;
   align-items: flex-start;
@@ -3515,7 +3572,8 @@ input:focus-visible,
 }
 
 .folder-note-row:hover,
-.folder-note-row[data-menu-open="true"] {
+.folder-note-row[data-menu-open="true"],
+.folder-note-row[data-selected="true"] {
   background: color-mix(in oklch, var(--muted) 35%, transparent);
 }
 
@@ -3570,6 +3628,14 @@ input:focus-visible,
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
   white-space: nowrap;
+}
+
+.all-notes-list {
+  gap: 2px;
+}
+
+.all-notes-row {
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .folder-note-menu {

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1,0 +1,141 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "../app/App";
+import type { BootstrapResponse, NoteDto } from "../lib/tauri";
+
+const mocks = vi.hoisted(() => ({
+  listen: vi.fn(),
+  getCurrentWindow: vi.fn(),
+  bootstrapApp: vi.fn(),
+  createNote: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFolder: vi.fn(),
+  renameFolder: vi.fn(),
+  assignNoteToFolder: vi.fn(),
+  removeNoteFromFolder: vi.fn(),
+  listNotes: vi.fn(),
+  getNote: vi.fn(),
+  deleteNote: vi.fn(),
+  updateNote: vi.fn(),
+  checkRecordingSourceReadiness: vi.fn(),
+  openPrivacySettings: vi.fn(),
+  startRecording: vi.fn(),
+  pauseRecording: vi.fn(),
+  resumeRecording: vi.fn(),
+  getRecordingStatus: vi.fn(),
+  finishRecording: vi.fn(),
+  retryProcessing: vi.fn(),
+  recoverRecording: vi.fn(),
+  dictationHelperCommand: vi.fn(),
+  playRecordingSound: vi.fn(),
+  preloadRecordingSounds: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: mocks.getCurrentWindow,
+}));
+
+vi.mock("../lib/recording-sounds", () => ({
+  playRecordingSound: mocks.playRecordingSound,
+  preloadRecordingSounds: mocks.preloadRecordingSounds,
+}));
+
+vi.mock("../lib/tauri", () => ({
+  bootstrapApp: mocks.bootstrapApp,
+  createNote: mocks.createNote,
+  createFolder: mocks.createFolder,
+  deleteFolder: mocks.deleteFolder,
+  renameFolder: mocks.renameFolder,
+  assignNoteToFolder: mocks.assignNoteToFolder,
+  removeNoteFromFolder: mocks.removeNoteFromFolder,
+  listNotes: mocks.listNotes,
+  getNote: mocks.getNote,
+  deleteNote: mocks.deleteNote,
+  updateNote: mocks.updateNote,
+  checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
+  openPrivacySettings: mocks.openPrivacySettings,
+  startRecording: mocks.startRecording,
+  pauseRecording: mocks.pauseRecording,
+  resumeRecording: mocks.resumeRecording,
+  getRecordingStatus: mocks.getRecordingStatus,
+  finishRecording: mocks.finishRecording,
+  retryProcessing: mocks.retryProcessing,
+  recoverRecording: mocks.recoverRecording,
+  dictationHelperCommand: mocks.dictationHelperCommand,
+}));
+
+const now = "2026-05-19T10:00:00Z";
+
+function note(overrides: Partial<NoteDto> = {}): NoteDto {
+  return {
+    id: "note-1",
+    title: "First note",
+    preview: "Preview",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    generatedContent: "Existing note",
+    activeTab: "notes",
+    ...overrides,
+  };
+}
+
+describe("App shortcuts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const first = note();
+    const created = note({
+      id: "note-2",
+      title: "",
+      preview: "",
+      processingStatus: "draft",
+      generatedContent: "",
+      editedContent: "",
+    });
+    const payload: BootstrapResponse = {
+      folders: [],
+      notes: [first],
+      activeRecoveries: [],
+      providerConfigured: true,
+    };
+
+    mocks.listen.mockResolvedValue(vi.fn());
+    mocks.getCurrentWindow.mockReturnValue({
+      startDragging: vi.fn().mockResolvedValue(undefined),
+    });
+    mocks.bootstrapApp.mockResolvedValue(payload);
+    mocks.getNote.mockResolvedValue(first);
+    mocks.createNote.mockResolvedValue(created);
+    mocks.checkRecordingSourceReadiness.mockResolvedValue({
+      sources: [
+        { source: "microphone", ready: true },
+        { source: "system", ready: true },
+      ],
+    });
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.updateNote.mockImplementation(async (input) => ({
+      ...first,
+      ...input,
+    }));
+  });
+
+  it("creates a loose note with Command-N but ignores bare n", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    fireEvent.keyDown(window, { key: "n" });
+    expect(mocks.createNote).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(window, { key: "n", metaKey: true });
+
+    await waitFor(() =>
+      expect(mocks.createNote).toHaveBeenCalledWith(undefined),
+    );
+  });
+});

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -37,6 +37,7 @@ describe("folders UI", () => {
   it("renders notes in the sidebar and filters them", async () => {
     const user = userEvent.setup();
     const onSelectNote = vi.fn();
+    const onCreateNote = vi.fn();
     render(
       <Sidebar
         folders={folders}
@@ -46,7 +47,7 @@ describe("folders UI", () => {
         activeView="notes"
         onChangeView={vi.fn()}
         onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
+        onCreateNote={onCreateNote}
         onSelectAll={vi.fn()}
         onSelectFolder={vi.fn()}
         onSelectNote={onSelectNote}
@@ -59,11 +60,42 @@ describe("folders UI", () => {
     expect(screen.getByText("Scribe")).toBeInTheDocument();
     expect(screen.getByText("Second")).toBeInTheDocument();
 
-    await user.type(screen.getByPlaceholderText("Jump to…"), "second");
+    await user.type(screen.getByPlaceholderText("Search"), "second");
     await user.click(screen.getAllByRole("button", { name: /Second/ })[0]);
 
-    expect(screen.queryByText("New note")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "New note" }));
+
     expect(onSelectNote).toHaveBeenCalledWith("note-2");
+    expect(onCreateNote).toHaveBeenCalled();
+  });
+
+  it("opens the all-notes view from the Notes header actions", async () => {
+    const user = userEvent.setup();
+    const onChangeView = vi.fn();
+    render(
+      <Sidebar
+        folders={folders}
+        notes={notes}
+        selectedNoteId="note-2"
+        selectedFolderId={undefined}
+        activeView="notes"
+        onChangeView={onChangeView}
+        onCreateFolder={vi.fn()}
+        onCreateNote={vi.fn()}
+        onSelectAll={vi.fn()}
+        onSelectFolder={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Notes/ }));
+    await user.click(screen.getByRole("button", { name: "View all" }));
+
+    expect(onChangeView).toHaveBeenCalledWith("all-notes");
+    expect(onChangeView).toHaveBeenCalledTimes(2);
   });
 
   it("opens note actions from right click and deletes", async () => {
@@ -94,21 +126,44 @@ describe("folders UI", () => {
     expect(onDeleteNote).toHaveBeenCalledWith("note-2");
   });
 
-  it("shows notes with placeholders and empty folder action", () => {
+  it("shows notes with placeholders and selects notes", async () => {
+    const user = userEvent.setup();
+    const onSelectNote = vi.fn();
     const { container } = render(
       <NotesList
         notes={notes}
         selectedNoteId="note-2"
+        onSelectNote={onSelectNote}
+        onCreateNote={vi.fn()}
+      />,
+    );
+    const list = within(
+      container.querySelector(".all-notes-list") as HTMLElement,
+    );
+
+    expect(list.getByRole("button", { name: /Second/ })).toBeInTheDocument();
+    expect(screen.queryByText("Ideas")).not.toBeInTheDocument();
+
+    await user.click(list.getByRole("button", { name: /Second/ }));
+    expect(onSelectNote).toHaveBeenCalledWith("note-2");
+  });
+
+  it("labels future-dated notes explicitly", () => {
+    render(
+      <NotesList
+        notes={[
+          {
+            ...notes[0],
+            id: "future-note",
+            updatedAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+          },
+        ]}
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
       />,
     );
-    const list = within(container.querySelector(".notes-list") as HTMLElement);
 
-    expect(list.getByRole("button", { name: /Second/ })).toBeInTheDocument();
-    expect(
-      list.getAllByRole("button", { name: /New note/ }).length,
-    ).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Future")).toBeInTheDocument();
   });
 
   it("shows empty state with create action", () => {
@@ -116,9 +171,9 @@ describe("folders UI", () => {
       <NotesList notes={[]} onSelectNote={vi.fn()} onCreateNote={vi.fn()} />,
     );
 
-    expect(screen.getByText("No notes yet")).toBeInTheDocument();
+    expect(screen.getByText("No notes yet.")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "New note" }),
+      screen.getByRole("button", { name: "Create your first note" }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
This PR reworks the Notes area in the sidebar into a clearer navigation model and adds a dedicated full notes overview page.

## What Changed
- Adds `New note` as the first primary sidebar action so creating a note is always available at the top of the nav.
- Adds a visible `⌘N` keycap to `New note` and wires `Command-N` to create a new loose note. Bare `n` intentionally does nothing so normal typing in the writing surface stays safe.
- Changes the sidebar note filter copy from `Jump to…` to `Search` and removes the misleading `⌘K` hint because there is not a command palette yet.
- Turns the existing Notes section header into the entry point for the full notes view: hovering or focusing the row reveals a subtle `View all` action, while clicking either `Notes` or `View all` opens the overview.
- Keeps the Notes header visually quiet by default; it no longer pins active styling after navigating to the overview, so it reads like a page transition rather than a selected sidebar item.

## Full Notes View
- Replaces the old simple notes list with a real all-notes page.
- Matches the folder detail notes-list pattern: file icon, title, preview/status, right-aligned updated time, hover row background, and click-through into the note editor.
- Keeps the overview narrower at `760px`, matching the folder detail content width instead of the wider folder grid page.
- Includes search over note title and preview.
- Deliberately does not show folder metadata in this view, keeping the row structure consistent with folder note rows.

## Behavior Notes
- New notes created from the top sidebar action or `⌘N` are loose notes, not implicitly assigned to the currently selected folder.
- Empty draft notes are preserved when navigating away. This PR does not auto-delete blank notes.
- The branch has been rebased onto latest `origin/main` after PR #28, so the recent folder-card/footer changes remain in the base and are not overwritten here.

## Validation
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`