### PR TITLE
[codex] Fix dock reopen lifecycle

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,14 +73,19 @@ pub fn run() {
 #[cfg(target_os = "macos")]
 fn setup_main_window_lifecycle(app: &mut tauri::App) {
     if let Some(main_window) = app.get_webview_window("main") {
-        let window = main_window.clone();
-        main_window.on_window_event(move |event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                api.prevent_close();
-                let _ = window.hide();
-            }
-        });
+        register_main_window_lifecycle(&main_window);
     }
+}
+
+#[cfg(target_os = "macos")]
+fn register_main_window_lifecycle(window: &tauri::WebviewWindow) {
+    let close_window = window.clone();
+    window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_close();
+            let _ = close_window.hide();
+        }
+    });
 }
 
 #[cfg(target_os = "macos")]
@@ -105,6 +110,7 @@ fn show_main_window(app: &tauri::AppHandle) {
     if let Ok(window) =
         tauri::WebviewWindowBuilder::from_config(app, config).and_then(|builder| builder.build())
     {
+        register_main_window_lifecycle(&window);
         let _ = window.show();
         let _ = window.set_focus();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,9 @@ pub mod dictation;
 pub mod domain;
 pub mod providers;
 
+#[cfg(target_os = "macos")]
+use tauri::Manager;
+
 pub fn run() {
     providers::load_local_env();
     let context = tauri::generate_context!();
@@ -53,13 +56,56 @@ pub fn run() {
         .setup(|app| {
             providers::setup(app);
             dictation::setup(app);
+            #[cfg(target_os = "macos")]
+            setup_main_window_lifecycle(app);
             Ok(())
         })
         .build(context)
         .expect("failed to build OS Notetaker")
-        .run(|app, event| {
-            if matches!(event, tauri::RunEvent::Exit) {
-                dictation::stop_helper(app);
+        .run(|app, event| match event {
+            tauri::RunEvent::Exit => dictation::stop_helper(app),
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen { .. } => show_main_window(app),
+            _ => {}
+        });
+}
+
+#[cfg(target_os = "macos")]
+fn setup_main_window_lifecycle(app: &mut tauri::App) {
+    if let Some(main_window) = app.get_webview_window("main") {
+        let window = main_window.clone();
+        main_window.on_window_event(move |event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                let _ = window.hide();
             }
         });
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+        return;
+    }
+
+    let Some(config) = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|window| window.label == "main")
+    else {
+        return;
+    };
+
+    if let Ok(window) =
+        tauri::WebviewWindowBuilder::from_config(app, config).and_then(|builder| builder.build())
+    {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
 }


### PR DESCRIPTION
## Summary
Fixes macOS app lifecycle behavior so closing the main window with the X hides it instead of destroying it, allowing the running app to reopen from the dock. Handles Tauri's macOS reopen event by showing, unminimizing, and focusing the main window, with a config-based fallback if the window was destroyed. Real app exit still stops the dictation helper as before.

## Validation
Ran `cargo fmt --manifest-path src-tauri/Cargo.toml --check`, `git diff --check`, and `pnpm test:rust`.