### PR TITLE
Fix scribe-api docker build (cargo-chef 0.1.77 + prompt files)

### DIFF
--- a/scribe-api/.dockerignore
+++ b/scribe-api/.dockerignore
@@ -2,3 +2,4 @@ target
 .git
 .github
 **/*.md
+!crates/services/src/prompts/*.md

--- a/scribe-api/Dockerfile
+++ b/scribe-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.95-bookworm AS chef
-RUN cargo install cargo-chef --locked --version 0.1.69
+RUN cargo install cargo-chef --locked --version 0.1.77
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
## Summary

Two regressions surfaced after the OS Accounts merge broke `build-scribe-api` ([failing run](https://github.com/open-software-network/os-scribe/actions/runs/26576039418/job/78295492216)):

- **cargo-chef 0.1.69 mis-generates `crates/app/Cargo.toml`** with an invalid `crate-type = ["bin"]` on the `[[bin]]` target — fixed upstream in newer releases. Bumped to 0.1.77 (latest stable, matches the version the `os-rust-backend` skill recommends).
- **`.dockerignore` excluded `**/*.md`** but `crates/services/src/prompts/{note_generate,dictate_cleanup}.md` are compile-time `include_str!()` inputs. Negated those paths so the prompts ship while READMEs etc. stay excluded.

## Test plan

- [x] `docker build --target builder` succeeds locally (cargo-chef cook no longer errors)
- [x] `docker build` (full multi-stage) succeeds — runtime image produced
- [x] `docker run --rm <image> --help` returns expected CLI usage
- [ ] CI `build-scribe-api` workflow goes green on this branch