### PR TITLE
ci: deploy scribe-api to phala cloud (tee)

### DIFF
--- a/.github/actions/phala-deploy/action.yml
+++ b/.github/actions/phala-deploy/action.yml
@@ -1,0 +1,116 @@
+name: Phala Cloud deploy
+description: >
+  Substitute an image ref into a docker-compose file and deploy or update a
+  Phala Cloud CVM. Skips silently when api-key is empty so the workflow can
+  ship before the secret is bound.
+
+inputs:
+  cvm-name:
+    description: Phala CVM name. Acts as the upsert key — same name updates in place.
+    required: true
+  compose-file:
+    description: Path to docker-compose.yml containing the literal placeholder ${SCRIBE_IMAGE}.
+    required: true
+  image-ref:
+    description: Full GHCR image ref (tag or @sha256:digest) to substitute for ${SCRIBE_IMAGE}.
+    required: true
+  api-key:
+    description: Phala Cloud API key (PHALA_CLOUD_API_KEY).
+    required: false
+    default: ""
+  cli-version:
+    description: phala npm package version to install. Pinned for reproducibility.
+    required: false
+    default: "1.1.19"
+
+outputs:
+  cvm-url:
+    description: Public HTTPS URL of the deployed CVM on port 8080.
+    value: ${{ steps.deploy.outputs.cvm-url }}
+  deployed:
+    description: '"true" when a deploy ran, "false" when skipped.'
+    value: ${{ steps.deploy.outputs.deployed || 'false' }}
+
+runs:
+  using: composite
+  steps:
+    - name: Skip when Phala not configured
+      if: inputs.api-key == ''
+      shell: bash
+      env:
+        CVM_NAME: ${{ inputs.cvm-name }}
+      run: |
+        echo "::notice::api-key input empty; skipping Phala deploy for $CVM_NAME."
+
+    - name: Install Phala CLI
+      if: inputs.api-key != ''
+      shell: bash
+      env:
+        CLI_VERSION: ${{ inputs.cli-version }}
+      run: npm install -g "phala@${CLI_VERSION}"
+
+    - name: Render compose with pinned image
+      id: render
+      if: inputs.api-key != ''
+      shell: bash
+      env:
+        COMPOSE_FILE: ${{ inputs.compose-file }}
+        IMAGE_REF: ${{ inputs.image-ref }}
+      run: |
+        set -euo pipefail
+        if [[ ! -f "$COMPOSE_FILE" ]]; then
+          echo "::error::compose-file not found: $COMPOSE_FILE"
+          exit 1
+        fi
+        if ! grep -q '\${SCRIBE_IMAGE}' "$COMPOSE_FILE"; then
+          echo "::error::compose-file is missing the \${SCRIBE_IMAGE} placeholder."
+          exit 1
+        fi
+        rendered="${RUNNER_TEMP}/$(basename "$COMPOSE_FILE")"
+        sed "s|\${SCRIBE_IMAGE}|${IMAGE_REF}|g" "$COMPOSE_FILE" > "$rendered"
+        echo "Rendered compose for $IMAGE_REF:"
+        echo "----"
+        cat "$rendered"
+        echo "----"
+        echo "rendered=${rendered}" >> "$GITHUB_OUTPUT"
+
+    - name: Deploy CVM
+      id: deploy
+      if: inputs.api-key != ''
+      shell: bash
+      env:
+        PHALA_CLOUD_API_KEY: ${{ inputs.api-key }}
+        CVM_NAME: ${{ inputs.cvm-name }}
+        RENDERED: ${{ steps.render.outputs.rendered }}
+      run: |
+        set -euo pipefail
+        phala deploy -c "$RENDERED" -n "$CVM_NAME" --wait
+        url=$(phala cvms get "$CVM_NAME" --json | jq -r '.public_urls[0].app // empty')
+        echo "deployed=true" >> "$GITHUB_OUTPUT"
+        if [[ -n "$url" ]]; then
+          echo "cvm-url=${url}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Summary
+      if: always()
+      shell: bash
+      env:
+        CVM_NAME: ${{ inputs.cvm-name }}
+        IMAGE_REF: ${{ inputs.image-ref }}
+        CVM_URL: ${{ steps.deploy.outputs.cvm-url }}
+        DEPLOYED: ${{ steps.deploy.outputs.deployed }}
+      run: |
+        {
+          if [[ "$DEPLOYED" == "true" ]]; then
+            echo "### Phala Cloud deploy"
+            echo "- **CVM:** \`${CVM_NAME}\`"
+            echo "- **Image:** \`${IMAGE_REF}\`"
+            if [[ -n "$CVM_URL" ]]; then
+              echo "- **URL:** ${CVM_URL}"
+            fi
+            echo "- **Attestation:** \`phala cvms attestation ${CVM_NAME}\`"
+          else
+            echo "### Phala Cloud deploy skipped"
+            echo "PHALA_CLOUD_API_KEY not bound. Set it in the GitHub environment, then re-run."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "scribe-api/**"
+      - "iac/phala/docker-compose.staging.yml"
+      - ".github/actions/phala-deploy/**"
       - ".github/workflows/build-scribe-api.yml"
   workflow_dispatch:
 
@@ -16,34 +18,72 @@ concurrency:
   group: build-scribe-api-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository_owner }}/scribe-api
+
 jobs:
-  build-and-publish:
+  build:
+    name: Build & push
     runs-on: ubuntu-latest
+    outputs:
+      sha_short: ${{ steps.meta.outputs.sha_short }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Compute short SHA
-        id: sha
-        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Compute metadata
+        id: meta
+        run: |
+          sha_short=$(git rev-parse --short=7 HEAD)
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: scribe-api
           file: scribe-api/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/scribe-api:${{ steps.sha.outputs.short }}
-            ghcr.io/${{ github.repository_owner }}/scribe-api:staging
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ${{ env.IMAGE }}:${{ steps.meta.outputs.sha_short }}
+            ${{ env.IMAGE }}:staging
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha,scope=scribe-api
+          cache-to: type=gha,scope=scribe-api,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Summary
+        run: |
+          {
+            echo "### scribe-api image built"
+            echo "- **Tag:** \`${{ env.IMAGE }}:${{ steps.meta.outputs.sha_short }}\`"
+            echo "- **Digest:** \`${{ steps.build.outputs.digest }}\`"
+            echo "- **Commit:** ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-staging:
+    name: Deploy staging
+    needs: build
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/phala-deploy
+        with:
+          cvm-name: os-scribe-api-staging
+          compose-file: iac/phala/docker-compose.staging.yml
+          image-ref: ${{ env.IMAGE }}@${{ needs.build.outputs.digest }}
+          api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -3,14 +3,11 @@ name: promote-scribe-api
 on:
   workflow_dispatch:
     inputs:
-      source_tag:
-        description: "Existing tag in ghcr.io/<owner>/scribe-api to promote (e.g. a1b2c3d, staging)"
-        required: true
+      from-tag:
+        description: Source tag to promote. Use `staging` for normal release or a short SHA for rollback.
+        required: false
         default: staging
-      destination_tag:
-        description: "Destination tag to write (production | staging | rollback-<sha>)"
-        required: true
-        default: production
+        type: string
 
 permissions:
   contents: read
@@ -20,38 +17,95 @@ concurrency:
   group: promote-scribe-api
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/${{ github.repository_owner }}/scribe-api
+
 jobs:
-  promote:
+  verify:
+    name: Verify source image
     runs-on: ubuntu-latest
+    env:
+      FROM_TAG: ${{ inputs.from-tag }}
     steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify source manifest exists
-        env:
-          OWNER: ${{ github.repository_owner }}
-          SRC: ${{ inputs.source_tag }}
+      - name: Verify source image exists
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect "ghcr.io/${OWNER}/scribe-api:${SRC}"
+          image="${{ env.IMAGE }}:${FROM_TAG}"
+          if ! docker buildx imagetools inspect "$image" --raw > /dev/null 2>&1; then
+            echo "::error::Image $image was not found in GHCR. Build the staging image first, then rerun promotion."
+            exit 1
+          fi
+          echo "Found $image"
 
-      - name: Re-tag source as destination
-        env:
-          OWNER: ${{ github.repository_owner }}
-          SRC: ${{ inputs.source_tag }}
-          DEST: ${{ inputs.destination_tag }}
+  deploy:
+    name: Deploy to production
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      FROM_TAG: ${{ inputs.from-tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve digest and commit SHA
+        id: image
         run: |
           set -euo pipefail
-          docker buildx imagetools create \
-            "ghcr.io/${OWNER}/scribe-api:${SRC}" \
-            --tag "ghcr.io/${OWNER}/scribe-api:${DEST}"
+          source="${{ env.IMAGE }}:${FROM_TAG}"
 
-      - name: Confirm destination tag
-        env:
-          OWNER: ${{ github.repository_owner }}
-          DEST: ${{ inputs.destination_tag }}
-        run: docker buildx imagetools inspect "ghcr.io/${OWNER}/scribe-api:${DEST}"
+          digest=$(docker buildx imagetools inspect "$source" \
+            --format '{{ json .Manifest }}' | jq -r '.digest')
+          if [[ -z "$digest" || "$digest" == "null" ]]; then
+            echo "::error::Could not resolve manifest digest for $source."
+            exit 1
+          fi
+
+          rev=$(docker buildx imagetools inspect "$source" --format '{{json .Image}}' \
+            | jq -r 'first(.. | objects | select(.config?.Labels?["org.opencontainers.image.revision"] != null) | .config.Labels["org.opencontainers.image.revision"]) // empty')
+
+          if [[ -z "$rev" && "$FROM_TAG" =~ ^[0-9a-f]{7,40}$ ]]; then
+            rev="$FROM_TAG"
+          fi
+
+          if [[ -z "$rev" ]]; then
+            echo "::error::Could not resolve commit SHA for $source. Use an image built by this repository, or pass a SHA tag directly."
+            exit 1
+          fi
+
+          sha_short="${rev:0:7}"
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "Resolved $source → digest=${digest} sha=${sha_short}"
+
+      - id: phala
+        uses: ./.github/actions/phala-deploy
+        with:
+          cvm-name: os-scribe-api-production
+          compose-file: iac/phala/docker-compose.production.yml
+          image-ref: ${{ env.IMAGE }}@${{ steps.image.outputs.digest }}
+          api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
+
+      - name: Retag digest as :production
+        if: steps.phala.outputs.deployed == 'true'
+        run: |
+          set -euo pipefail
+          target="${{ env.IMAGE }}:production"
+          docker buildx imagetools create --tag "$target" "${{ env.IMAGE }}@${{ steps.image.outputs.digest }}"
+          echo "Retagged ${{ env.IMAGE }}@${{ steps.image.outputs.digest }} as $target"

--- a/iac/phala/docker-compose.production.yml
+++ b/iac/phala/docker-compose.production.yml
@@ -1,0 +1,14 @@
+services:
+  scribe-api:
+    image: ${SCRIBE_IMAGE}
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    environment:
+      RUST_LOG: scribe=warn,scribe_api=warn,scribe_services=warn,scribe_providers=warn,tower_http=warn
+      SCRIBE__OS_ACCOUNTS__API_URL:
+      SCRIBE__OS_ACCOUNTS__APP_API_KEY:
+      SCRIBE__UPSTREAMS__OPENAI__API_KEY:
+      SCRIBE__UPSTREAMS__VENICE__API_KEY:

--- a/iac/phala/docker-compose.staging.yml
+++ b/iac/phala/docker-compose.staging.yml
@@ -1,0 +1,14 @@
+services:
+  scribe-api:
+    image: ${SCRIBE_IMAGE}
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    environment:
+      RUST_LOG: scribe=info,scribe_api=info,scribe_services=info,scribe_providers=info,tower_http=info
+      SCRIBE__OS_ACCOUNTS__API_URL:
+      SCRIBE__OS_ACCOUNTS__APP_API_KEY:
+      SCRIBE__UPSTREAMS__OPENAI__API_KEY:
+      SCRIBE__UPSTREAMS__VENICE__API_KEY:

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -6,7 +6,9 @@ max_audio_bytes = 26214400
 max_json_bytes = 524288
 
 [os_accounts]
-api_url = "https://os-accounts-api-staging.up.railway.app"
+# api_url has no default — must come from SCRIBE__OS_ACCOUNTS__API_URL
+# per environment so a missing override fails loud against the dev
+# fallback in AppConfig::default rather than silently hitting staging.
 # iss is the canonical OS Accounts site URL used in the JWT's `iss` claim
 # — the same value on staging and prod. JWKS lives on the API origin, but
 # the issuer claim points at the canonical site. Confirmed by decoding a


### PR DESCRIPTION
## TL;DR

Replaces the Railway deploy pipeline with **Phala Cloud** — scribe-api now runs inside an Intel TDX confidential VM. Trust story:

- **Container runs in a TEE.** Phala (the platform operator) and Open Software (us) cannot read memory, disk, or logs.
- **Image hash is verifiable.** Users can fetch the CVM's remote attestation and confirm the running image matches what's built from this open-source repo.
- **Secrets stay sealed.** Three runtime secrets + one per-env URL are encrypted to the CVM's TEE pubkey via `phala envs encrypt` — only decryptable inside the enclave. Never in the repo.

Net diff: **-417 lines** of deploy infra (Railway GraphQL bash gone), replaced by ~280 lines of compose + composite action.

## What changed

| Removed | Added |
|---|---|
| `iac/apply-config.sh` (217 LOC Railway GraphQL) | `iac/phala/docker-compose.staging.yml` |
| `iac/railway-scribe-api.json` | `iac/phala/docker-compose.production.yml` |
| `.github/actions/railway-deploy/` | `.github/actions/phala-deploy/` |

Modified:
- `build-scribe-api.yml` — `deploy-staging` job calls the new composite. Image pinned by `@sha256:<digest>` (stronger than the previous tag pin). `paths:` filter updated.
- `promote-scribe-api.yml` — dropped `apply-config` input (compose lives in the repo, no separate apply step). Resolves the manifest digest, deploys to `os-scribe-api-production` CVM with the digest-pinned image, retags GHCR to `:production` as a stable rollback handle.

Unchanged (still load-bearing):
- GHCR push, OCI labels (`org.opencontainers.image.revision/created`), SBOM, provenance. The labels let `promote` recover the source commit SHA from the staging manifest.
- Immutable per-commit SHA tags + the `:staging` / `:production` mutable tags as rollback handles.

## Sealed env vars (the four figment overrides scribe-api requires)

| Env var | Maps to (`scribe-api/crates/config/src/lib.rs`) | Source |
|---|---|---|
| `SCRIBE__OS_ACCOUNTS__API_URL` | `os_accounts.api_url` | per-env OS Accounts API origin (no default in `config.toml`) |
| `SCRIBE__OS_ACCOUNTS__APP_API_KEY` | `os_accounts.app_api_key` | `osk_*` token, OS Accounts dashboard |
| `SCRIBE__UPSTREAMS__OPENAI__API_KEY` | `upstreams.openai.api_key` | OpenAI dashboard |
| `SCRIBE__UPSTREAMS__VENICE__API_KEY` | `upstreams.venice.api_key` | Venice dashboard |

**All four values differ per environment.** The staging CVM gets the staging OS Accounts API URL + the staging `osk_*` (already in Railway staging env vars today — copy from there). The production CVM gets the production OS Accounts API URL + a separate production `osk_*` minted from the production OS Accounts app. OpenAI / Venice keys may or may not differ depending on whether prod uses separate provider accounts.

The figment loader uses prefix `SCRIBE__` with `__` as the nesting separator (see `lib.rs:267`). `API_URL` is committed *nowhere* in the repo — `config.toml` has no default, so a forgotten production override falls through to the dev sentinel `127.0.0.1:3000` (loud failure) instead of silently hitting staging.

## Architectural decisions worth flagging

- **Compose uses a `${SCRIBE_IMAGE}` literal placeholder, not env interpolation.** The composite action does explicit `sed` substitution and `cat`s the rendered file to the workflow log, so the exact deployed manifest is always visible for audit.
- **Production runs at `RUST_LOG=warn`, staging at `info`.** The audit confirmed no logs contain audio bytes or transcript text — only lengths, user IDs (required for metering), durations, credit amounts. But the smaller the operator-visible log surface in prod, the easier the trust audit. One follow-up: `note_transcribe.rs:54` logs `filename` at info — usually neutral, but in theory could leak if the desktop client ever produced a meaningful filename. Not blocking this PR.
- **CVM names are upsert keys.** `os-scribe-api-staging` and `os-scribe-api-production`. Same name on next deploy → in-place update; new name → fresh CVM. Phala has no first-class env concept — the names are the only distinguisher.
- **Sealed env vars are mandatory, not optional.** Plaintext secrets in compose would leak via the open-source repo, defeating the whole story. Compose file declares env var *names* without values; Phala's sealed-env-var store provides the values at runtime.

## What's left / operator setup

| What | Where | How |
|---|---|---|
| `secrets.PHALA_CLOUD_API_KEY` | GitHub `staging` env | `cloud.phala.network` → username → API Tokens → Create. Bind in `Settings → Environments → staging → Secrets`. |
| `secrets.PHALA_CLOUD_API_KEY` | GitHub `production` env | Same token (or a separate scoped one), bind in `Settings → Environments → production → Secrets`. |
| Seal the four env vars above | each CVM, after first deploy | `phala envs encrypt -e .env.tee -i os-scribe-api-staging`<br>`phala envs update os-scribe-api-staging`<br>(repeat for production). `.env.tee` never committed. |
| Funded Phala account | `cloud.phala.network` | per-minute billing, no free tier. `tdx.small` is probably enough for a thin Rust HTTP proxy; resize if needed via `phala cvms resize`. |

The composite action **self-skips with `::notice::`** when `PHALA_CLOUD_API_KEY` is unset, so this PR can merge before the secret is bound — first push to `main` after merge will trigger the build but the deploy step will no-op visibly until secrets are in place.

## First end-to-end test

1. Bind `PHALA_CLOUD_API_KEY` in both environments.
2. Merge this PR. Push to `main` triggers `build-scribe-api`, which builds + pushes the image and then calls `phala-deploy` for staging.
3. First deploy creates the `os-scribe-api-staging` CVM. Read the public URL from the workflow summary.
4. **Critical first-time step:** `phala envs encrypt + update` to inject the four sealed env vars — the container will start but will fail at startup or first auth call until they're set.
5. Hit `https://<cvm-url>/livez` to verify.
6. `workflow_dispatch` of `promote-scribe-api` to test production. Same env-seal step needed for the production CVM on first run.

## Verifying the trust story (end user flow)

```bash
# 1. What image is running right now in production?
phala cvms get os-scribe-api-production --json | jq '.image'

# 2. Does that match what was built from this repo at <sha>?
# Cross-reference the GHCR manifest digest with the build workflow run.
docker buildx imagetools inspect ghcr.io/open-software-network/scribe-api:<sha> --format '{{ json .Manifest }}' | jq .digest

# 3. Get the attestation proving Phala is running that exact image in a real TDX enclave.
phala cvms attestation os-scribe-api-production
```

End user can verify (1) = (2) = (3.image_hash) → "the source on GitHub at commit `<sha>` is what's serving my requests, and physics prevents the operator from seeing my data."

## Follow-ups (not blocking this PR)

- **Image rename `scribe-api` → `os-scribe-api`** for naming consistency. Moot here since we're not deploying to Railway anymore.
- **CI attestation verification.** Add a step that fetches the post-deploy attestation and fails the workflow if the image hash doesn't match. Currently only surfaces the command for manual verification.
- **`filename` field at info-level logging** (`note_transcribe.rs:54`) — drop or hash for the prod trust story.
- **End-to-end privacy.** This PR ensures Phala + Open Software can't see user data. The audio still leaves the TEE when forwarded to OpenAI / Venice for STT. Migrating STT to Phala's Confidential AI is a separate, much bigger workstream.

## How operators should think about this

The promise to users is: *"We (Open Software) wrote this open-source code, you can read it, we built an image from it, you can verify the image hash, we deployed it to a TEE that prevents us from seeing your data, and the attestation proves all three are consistent."* That's a meaningful improvement over Railway's "trust us, we won't log your stuff."
