### PR TITLE
fix(ci): phala compose env vars need "" not null

### DIFF
--- a/iac/phala/docker-compose.production.yml
+++ b/iac/phala/docker-compose.production.yml
@@ -8,7 +8,7 @@ services:
       - /var/run/dstack.sock:/var/run/dstack.sock
     environment:
       RUST_LOG: scribe=warn,scribe_api=warn,scribe_services=warn,scribe_providers=warn,tower_http=warn
-      SCRIBE__OS_ACCOUNTS__API_URL:
-      SCRIBE__OS_ACCOUNTS__APP_API_KEY:
-      SCRIBE__UPSTREAMS__OPENAI__API_KEY:
-      SCRIBE__UPSTREAMS__VENICE__API_KEY:
+      SCRIBE__OS_ACCOUNTS__API_URL: ""
+      SCRIBE__OS_ACCOUNTS__APP_API_KEY: ""
+      SCRIBE__UPSTREAMS__OPENAI__API_KEY: ""
+      SCRIBE__UPSTREAMS__VENICE__API_KEY: ""

--- a/iac/phala/docker-compose.staging.yml
+++ b/iac/phala/docker-compose.staging.yml
@@ -8,7 +8,7 @@ services:
       - /var/run/dstack.sock:/var/run/dstack.sock
     environment:
       RUST_LOG: scribe=info,scribe_api=info,scribe_services=info,scribe_providers=info,tower_http=info
-      SCRIBE__OS_ACCOUNTS__API_URL:
-      SCRIBE__OS_ACCOUNTS__APP_API_KEY:
-      SCRIBE__UPSTREAMS__OPENAI__API_KEY:
-      SCRIBE__UPSTREAMS__VENICE__API_KEY:
+      SCRIBE__OS_ACCOUNTS__API_URL: ""
+      SCRIBE__OS_ACCOUNTS__APP_API_KEY: ""
+      SCRIBE__UPSTREAMS__OPENAI__API_KEY: ""
+      SCRIBE__UPSTREAMS__VENICE__API_KEY: ""


### PR DESCRIPTION
## TL;DR

Hotfix for the broken \`build-scribe-api\` run on \`main\` after PR #34 merged: [run 26582254019](https://github.com/open-software-network/os-scribe/actions/runs/26582254019/job/78319337944) failed with **"Invalid docker-compose.yaml file"** from \`phala deploy\`.

## Root cause

Env vars declared as bare \`KEY:\` (map form, no value) — which YAML parses as **null** — are rejected by Phala's compose schema. Confirmed against Phala's own [\`Phala-Network/phala-cloud\` template repo](https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt): every working template uses **map-form env vars with explicit values** (e.g. \`KEY: \"value\"\` or \`KEY: \${VAR:-default}\`), never null/bare.

## Fix

Switch every sealed-env slot from \`KEY:\` to \`KEY: \"\"\` in both staging and production compose files. Empty-string default; sealed envs from \`phala envs update\` override at container runtime.

Validated locally with \`docker compose -f <file> config\` — env values normalize to \`KEY: \"\"\` (empty string) instead of \`KEY: null\`. The diff from the failing rendered compose is structurally meaningful even though it looks cosmetic.

## What's NOT changing

- Composite action logic, build job, promote workflow — all still correct
- Config crate / Rust code — figment reads empty-string env vars the same way as unset; downstream runtime behavior is identical to the operator's pre-seal state
- Operator setup: still \`phala envs encrypt + update\` to inject the four real values per CVM

## Verification path after merge

1. Push to \`main\` re-triggers \`build-scribe-api\`.
2. Build job rebuilds + pushes the image (same as before).
3. \`deploy-staging\` job calls \`phala-deploy\` → \`phala deploy --wait\` against the new compose → CVM should now provision (no more "Invalid docker-compose.yaml file").
4. \`os-scribe-api-staging\` CVM appears. Run \`phala envs encrypt + update\` once to inject the four sealed values. App becomes functional.

## Why this slipped through the original PR

The original PR was reviewed by Copilot + Greptile but neither flagged the null env value as a Phala-specific issue — both treated the compose as valid generic Docker Compose (which it technically was — \`docker compose config\` parses it cleanly, just normalizes to null). Phala's stricter validator is the surfacing-point. Lesson: compose patterns must match Phala's templates, not generic Docker examples.