### PR TITLE
docs(readme): add phala trust center badge + privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ macOS-first Tauri MVP for local notes, reliable local audio recording, saved aud
 
 ## Privacy
 
-The `scribe-api` backend runs in an Intel TDX confidential VM on Phala Cloud. Neither Phala (the platform) nor Open Software (us) can read your audio, transcripts, or logs at runtime. The chain of trust is independently verifiable:
+The `scribe-api` backend runs in an Intel TDX confidential VM on Phala Cloud. Because the running image is attested, neither Phala (the platform) nor Open Software (us) can quietly change it to read your audio, transcripts, or logs at runtime without that change being visible in the verification chain below:
 
-- **Source** — this repository. The commit running in production is recoverable from the image's OCI `revision` label.
-- **Image** — built by [`build-scribe-api.yml`](.github/workflows/build-scribe-api.yml) and published to [`ghcr.io/open-software-network/scribe-api`](https://github.com/open-software-network/os-scribe/pkgs/container/scribe-api) with SBOM + provenance. Production deploys are pinned by `@sha256:<digest>`, not mutable tags.
-- **Attestation** — the [Phala Trust Center report](https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c) is a third-party-verifiable proof that the image hash above is what's actually running inside a real Intel TDX enclave.
+- **Source** — this repository. The exact commit running in production is stamped into the image's OCI `org.opencontainers.image.revision` label.
+- **Image** — built by [`build-scribe-api.yml`](.github/workflows/build-scribe-api.yml) and published to [`ghcr.io/open-software-network/scribe-api`](https://github.com/open-software-network/os-scribe/pkgs/container/scribe-api) as a plain single-arch image whose content digest is directly pullable. dstack cannot verify digest-pinned refs, so deploys pin an immutable per-commit tag (`:<sha>`); the digest each commit deploys is recorded in-repo as a signed `deploy/<env>/<sha>` git tag.
+- **Attestation** — the [Phala Trust Center report](https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c) is third-party-verifiable proof that the image digest above is what's actually running inside a real Intel TDX confidential VM.
 
-Audio still leaves the TEE when forwarded to OpenAI or Venice for transcription — those providers receive your audio under their own privacy policies. End-to-end private STT is a separate workstream.
+Together these bind the running image to a public commit: you can confirm the attested digest is the one our CI built and recorded for that commit. (Bit-for-bit *rebuild-from-source* reproducibility — so you can regenerate the digest yourself instead of trusting our CI — is in progress.)
+
+Audio still leaves the TEE when forwarded to OpenAI or Venice for transcription, under those providers' own privacy policies. This chain verifies the **code** running in the confidential VM, not what upstream providers do with audio. End-to-end private STT is a separate workstream.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 macOS-first Tauri MVP for local notes, reliable local audio recording, saved audio validation, batch transcription, and generated notes.
 
+[![Phala Trust Center — TEE verified](https://img.shields.io/badge/Phala%20Trust%20Center-TEE%20verified-success)](https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c)
+
+## Privacy
+
+The `scribe-api` backend runs in an Intel TDX confidential VM on Phala Cloud. Neither Phala (the platform) nor Open Software (us) can read your audio, transcripts, or logs at runtime. The chain of trust is independently verifiable:
+
+- **Source** — this repository. The commit running in production is recoverable from the image's OCI `revision` label.
+- **Image** — built by [`build-scribe-api.yml`](.github/workflows/build-scribe-api.yml) and published to [`ghcr.io/open-software-network/scribe-api`](https://github.com/open-software-network/os-scribe/pkgs/container/scribe-api) with SBOM + provenance. Production deploys are pinned by `@sha256:<digest>`, not mutable tags.
+- **Attestation** — the [Phala Trust Center report](https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c) is a third-party-verifiable proof that the image hash above is what's actually running inside a real Intel TDX enclave.
+
+Audio still leaves the TEE when forwarded to OpenAI or Venice for transcription — those providers receive your audio under their own privacy policies. End-to-end private STT is a separate workstream.
+
 ## Development
 
 ```sh


### PR DESCRIPTION
## What

Adds a Phala Trust Center badge + a **Privacy** section to the README, documenting the source → image → attestation chain of trust for the `scribe-api` backend running in an Intel TDX confidential VM on Phala Cloud.

## Status

- ✅ **Rebased on latest `main`** (was a merge; now linear, signed, README-only diff).
- ✅ **Production CVM deployed and serving** — `/livez` → 200. (Boot was blocked by a missing sealed `DSTACK_DOCKER_REGISTRY=ghcr.io`, which made the prelaunch log into `docker.io` with the GHCR PAT → 401. Fixed by re-sealing the full env set — `phala envs update` is full-replacement, not merge.)
- ✅ **README corrected to the real deploy mechanism.** This branch predated the #44/#46 deploy fixes, so the original text was wrong. Now:
  - no SBOM/provenance claim — we publish a plain, directly-pullable image;
  - deploy by **immutable per-commit tag** (dstack can't verify `@sha256:` refs), with the digest recorded as a signed `deploy/<env>/<sha>` git tag — *not* `@sha256:` in compose;
  - honest "bit-for-bit rebuild-from-source reproducibility is in progress" caveat (Phase B not yet shipped — claim stays at "verify the attested digest matches our CI build for commit X");
  - data-handling scope kept explicit: audio still leaves the TEE to OpenAI / Venice.
- ✅ **Addressed Copilot review:** reframed the absolute "can't read" claim as attestation-verifiable; full `org.opencontainers.image.revision` label key; "TDX enclave" → "confidential VM" (TDX is a CVM; enclave is SGX).

## ⚠️ Open before merge — attestation report is failing

The Trust Center verification for the prod app (`15f8d2fd…`) currently returns `status: "failed"` (task `01d67041…`, ran 2026-06-01 20:05, no error message exposed). The app itself is healthy, but the **public attestation the badge links to is failing verification**. The badge should not ship as "TEE verified" until that report passes — re-trigger / investigate the failed verification first (separate from this docs change).
