### PR TITLE
[codex] Polish markdown preview and billing settings

### DIFF
--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -26,7 +26,7 @@ export function AccountSettings({
       <header className="settings-header">
         <h1 className="settings-title">Account</h1>
         <p className="settings-description">
-          Sign in with Open Software to use your shared identity and balance
+          Sign in with OpenSoftware to use your shared identity and balance
           across the network.
         </p>
       </header>
@@ -49,19 +49,21 @@ export function AccountSettingsSection({
 }: Props) {
   const [refreshing, setRefreshing] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [status, setStatus] = useState<string>();
+  const [accountStatus, setAccountStatus] = useState<string>();
+  const [billingStatus, setBillingStatus] = useState<string>();
+  const [spins, setSpins] = useState(0);
 
   async function handleSignIn() {
     setBusy(true);
-    setStatus("Opening your browser to sign in…");
+    setAccountStatus("Opening your browser to sign in…");
     try {
       const next = await osAccountsLogin();
       onAccountChanged(next);
-      setStatus(
+      setAccountStatus(
         next.signedIn ? `Signed in as ${displayName(next)}.` : undefined,
       );
     } catch (error) {
-      setStatus(messageFromError(error));
+      setAccountStatus(messageFromError(error));
     } finally {
       setBusy(false);
     }
@@ -73,7 +75,7 @@ export function AccountSettingsSection({
     try {
       await osAccountsCancelLogin();
     } catch (error) {
-      setStatus(messageFromError(error));
+      setAccountStatus(messageFromError(error));
     }
   }
 
@@ -82,9 +84,10 @@ export function AccountSettingsSection({
     try {
       await osAccountsLogout();
       onAccountChanged({ signedIn: false, configured: account.configured });
-      setStatus("Signed out.");
+      setAccountStatus("Signed out.");
+      setBillingStatus(undefined);
     } catch (error) {
-      setStatus(messageFromError(error));
+      setAccountStatus(messageFromError(error));
     } finally {
       setBusy(false);
     }
@@ -93,115 +96,139 @@ export function AccountSettingsSection({
   async function handleTopUp() {
     try {
       await osAccountsTopUp();
-      setStatus("Opened OS Accounts. Your balance updates after checkout.");
+      setBillingStatus(
+        "Opened OS Accounts. Your balance updates after checkout.",
+      );
     } catch (error) {
-      setStatus(messageFromError(error));
+      setBillingStatus(messageFromError(error));
     }
   }
 
   async function handleRefresh() {
     setRefreshing(true);
+    setSpins((turns) => turns + 1);
     try {
       await onRefresh();
+      setBillingStatus(undefined);
+    } catch (error) {
+      setBillingStatus(messageFromError(error));
     } finally {
       setRefreshing(false);
     }
   }
 
   return (
-    <section className="settings-group" aria-labelledby="account-heading">
-      <h2 id="account-heading" className="settings-group-heading">
-        Account
-      </h2>
-      {status ? <p className="settings-status">{status}</p> : null}
-      <div className="settings-card">
-        <div className="settings-rows">
-          <div className="settings-row">
-            <div className="settings-row-info">
-              <h3 className="settings-row-title">
-                {loading
-                  ? "Checking sign-in…"
-                  : account.signedIn
-                    ? displayName(account)
-                    : "Not signed in"}
-              </h3>
-              <p className="settings-row-description">
-                {account.signedIn
-                  ? (account.user?.email ??
-                    `@${account.user?.handle ?? "account"}`)
-                  : account.configured
-                    ? "Your login and balance are managed by Open Software."
-                    : "Open Software sign-in is not configured for this build."}
-              </p>
-            </div>
-            <div className="settings-row-control">
-              {account.signedIn ? (
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  disabled={busy}
-                  onClick={() => void handleSignOut()}
-                >
-                  Sign out
-                </button>
-              ) : busy ? (
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={() => void handleCancel()}
-                >
-                  Cancel
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  disabled={loading || !account.configured}
-                  onClick={() => void handleSignIn()}
-                >
-                  Sign in with Open Software
-                </button>
-              )}
-            </div>
-          </div>
-
-          {account.signedIn ? (
+    <>
+      <section className="settings-group" aria-labelledby="account-heading">
+        <h2 id="account-heading" className="settings-group-heading">
+          Account
+        </h2>
+        {accountStatus ? (
+          <p className="settings-status">{accountStatus}</p>
+        ) : null}
+        <div className="settings-card">
+          <div className="settings-rows">
             <div className="settings-row">
               <div className="settings-row-info">
                 <h3 className="settings-row-title">
-                  {formatUsd(account.balance?.usdMillis)}
+                  {loading
+                    ? "Checking sign-in…"
+                    : account.signedIn
+                      ? displayName(account)
+                      : "Not signed in"}
                 </h3>
                 <p className="settings-row-description">
-                  Available balance. Open Software updates this after checkout.
+                  {account.signedIn
+                    ? (account.user?.email ??
+                      `@${account.user?.handle ?? "account"}`)
+                    : account.configured
+                      ? "Your login and balance are managed by OpenSoftware."
+                      : "OpenSoftware sign-in is not configured for this build."}
                 </p>
               </div>
               <div className="settings-row-control">
-                <button
-                  type="button"
-                  className="btn btn-ghost"
-                  aria-label="Refresh balance"
-                  title="Refresh balance"
-                  disabled={refreshing}
-                  onClick={() => void handleRefresh()}
-                >
-                  <IconArrowRotateClockwise
-                    size={14}
-                    data-spinning={refreshing ? "true" : undefined}
-                  />
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={() => void handleTopUp()}
-                >
-                  Add funds
-                </button>
+                {account.signedIn ? (
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    disabled={busy}
+                    onClick={() => void handleSignOut()}
+                  >
+                    Sign out
+                  </button>
+                ) : busy ? (
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => void handleCancel()}
+                  >
+                    Cancel
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    disabled={loading || !account.configured}
+                    onClick={() => void handleSignIn()}
+                  >
+                    Sign in with OpenSoftware
+                  </button>
+                )}
               </div>
             </div>
-          ) : null}
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      {account.signedIn ? (
+        <section className="settings-group" aria-labelledby="billing-heading">
+          <h2 id="billing-heading" className="settings-group-heading">
+            Billing
+          </h2>
+          <p className="settings-group-description">
+            Managed by OpenSoftware. Your balance updates after checkout.
+          </p>
+          {billingStatus ? (
+            <p className="settings-status">{billingStatus}</p>
+          ) : null}
+          <div className="settings-card">
+            <div className="settings-rows">
+              <div className="settings-row">
+                <div className="settings-row-info">
+                  <p className="balance-amount">
+                    {formatUsd(account.balance?.usdMillis)}
+                  </p>
+                  <p className="settings-row-description">Available balance</p>
+                </div>
+                <div className="settings-row-control">
+                  <button
+                    type="button"
+                    className="icon-button"
+                    aria-label="Refresh balance"
+                    title="Refresh balance"
+                    disabled={refreshing}
+                    onClick={() => void handleRefresh()}
+                  >
+                    <IconArrowRotateClockwise
+                      size={14}
+                      className="balance-refresh-icon"
+                      style={{ transform: `rotate(${spins * 360}deg)` }}
+                    />
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => void handleTopUp()}
+                  >
+                    Add funds
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </>
   );
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1347,7 +1347,7 @@ input:focus-visible,
   position: relative;
   padding: var(--sp-2) 0 0;
   font-size: var(--fs-lg);
-  line-height: 1.7;
+  line-height: 1.5;
   color: var(--foreground);
 }
 
@@ -1371,7 +1371,7 @@ input:focus-visible,
 }
 
 .note-preview p {
-  margin: 0 0 var(--sp-4);
+  margin: 0 0 var(--sp-3);
   color: var(--foreground);
 }
 
@@ -2419,6 +2419,24 @@ input:focus-visible,
 
 .settings-meta-value-mono {
   font-family: var(--font-mono);
+}
+
+.balance-amount {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--fs-2xl);
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.balance-refresh-icon {
+  transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .balance-refresh-icon {
+    transition: none;
+  }
 }
 
 .settings-permission-control {
@@ -4363,8 +4381,16 @@ input:focus-visible,
   display: grid;
   place-items: center;
   padding: var(--sp-8);
-  --welcome-bg-start: color-mix(in oklch, var(--background) 78%, var(--warm-soft));
-  --welcome-bg-end: color-mix(in oklch, var(--background) 92%, var(--warm-soft));
+  --welcome-bg-start: color-mix(
+    in oklch,
+    var(--background) 78%,
+    var(--warm-soft)
+  );
+  --welcome-bg-end: color-mix(
+    in oklch,
+    var(--background) 92%,
+    var(--warm-soft)
+  );
   background: linear-gradient(
     180deg,
     var(--welcome-bg-start) 0%,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -117,7 +117,7 @@
    * macOS-blue glow next to the rest of the palette. */
   --focus-ring: oklch(60% 0.03 84.59 / 22%);
   /* Warm-gray text selection — neutral to the warm palette, never blue. */
-  --selection: oklch(86% 0.0015 84.59);
+  --selection: oklch(93% 0.0015 84.59);
   --selection-foreground: var(--foreground);
 
   /* Scrim behind modal dialogs. In light mode this layers a translucent
@@ -190,7 +190,7 @@
   /* Selection keeps the foreground white (no contrast flip) and lays a
    * translucent warm-grey wash on top, matching the light-mode pattern
    * where the text color stays put through the highlight. */
-  --selection: oklch(0.52 0.015 84.59 / 55%);
+  --selection: oklch(0.52 0.015 84.59 / 38%);
   --selection-foreground: var(--foreground);
 
   --shadow-sm: 0 1px 2px oklch(0% 0 none / 30%);


### PR DESCRIPTION
## Summary

- Tighten generated-note markdown preview spacing and soften text-selection colors.
- Split signed-in account billing details into a dedicated settings section.
- Make balance refresh use a single eased icon turn per refresh, with reduced-motion support.

## Validation

- `pnpm run lint`
- `pnpm test`
- `pnpm exec prettier --check src/components/account/AccountSettings.tsx src/styles/app.css src/styles/tokens.css`

## Notes

- The branch was rebased onto the latest `origin/main` before pushing.
- Repo-wide `pnpm run format` still reports pre-existing formatting issues in files outside this PR scope: `src/components/note-editor/NoteEditor.tsx`, `src/components/settings/AppSettings.tsx`, `src/components/ui/InlineNotice.tsx`, `src/lib/theme.ts`, and `src/test/recovery.test.tsx`. The touched files pass scoped Prettier.