### PR TITLE
fix(ci): phala-deploy needs --cvm-id to update existing cvms

### DIFF
--- a/.github/actions/phala-deploy/action.yml
+++ b/.github/actions/phala-deploy/action.yml
@@ -6,7 +6,7 @@ description: >
 
 inputs:
   cvm-name:
-    description: Phala CVM name. Acts as the upsert key — same name updates in place.
+    description: Phala CVM name. The action probes `phala cvms get <name>` and branches between `phala deploy -n <name>` (create) and `phala deploy --cvm-id <name>` (update) since the CLI doesn't expose an upsert flag.
     required: true
   compose-file:
     description: Path to docker-compose.yml containing the literal placeholder ${SCRIBE_IMAGE}.
@@ -84,7 +84,25 @@ runs:
         RENDERED: ${{ steps.render.outputs.rendered }}
       run: |
         set -euo pipefail
-        phala deploy -c "$RENDERED" -n "$CVM_NAME" --wait
+        # List-based existence probe (not `phala cvms get`). `get` returns
+        # nonzero for "not found" but ALSO for auth/network errors and for
+        # stopped CVMs that don't show in `get` — all three would falsely
+        # route to the create path and reproduce ERR-01-004 with the real
+        # cause hidden. `list` returns the full set including stopped CVMs,
+        # and a list failure (auth/network) propagates visibly instead of
+        # masquerading as "doesn't exist".
+        if ! cvms_json=$(phala cvms list --json 2>&1); then
+          echo "::error::Could not list Phala CVMs (auth, network, or API issue):"
+          printf '%s\n' "$cvms_json" >&2
+          exit 1
+        fi
+        if printf '%s' "$cvms_json" | jq -e --arg name "$CVM_NAME" '.[] | select(.name == $name)' >/dev/null; then
+          echo "CVM $CVM_NAME exists; updating via --cvm-id."
+          phala deploy -c "$RENDERED" --cvm-id "$CVM_NAME" --wait
+        else
+          echo "CVM $CVM_NAME does not exist; creating via -n."
+          phala deploy -c "$RENDERED" -n "$CVM_NAME" --wait
+        fi
         url=$(phala cvms get "$CVM_NAME" --json | jq -r '.public_urls[0].app // empty')
         echo "deployed=true" >> "$GITHUB_OUTPUT"
         if [[ -n "$url" ]]; then

--- a/iac/phala/docker-compose.production.yml
+++ b/iac/phala/docker-compose.production.yml
@@ -6,6 +6,12 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
+    # Note: registry-auth env vars (DSTACK_DOCKER_REGISTRY,
+    # DSTACK_DOCKER_USERNAME, DSTACK_DOCKER_PASSWORD) are NOT declared
+    # here — dstack reads them from the CVM's sealed-env store at image-
+    # pull time, not from compose. Set them once per CVM via
+    # `phala envs encrypt + update`. Required only when the image is
+    # private; harmless to set when it's public.
     environment:
       RUST_LOG: scribe=warn,scribe_api=warn,scribe_services=warn,scribe_providers=warn,tower_http=warn
       SCRIBE__OS_ACCOUNTS__API_URL: ""

--- a/iac/phala/docker-compose.staging.yml
+++ b/iac/phala/docker-compose.staging.yml
@@ -6,6 +6,12 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
+    # Note: registry-auth env vars (DSTACK_DOCKER_REGISTRY,
+    # DSTACK_DOCKER_USERNAME, DSTACK_DOCKER_PASSWORD) are NOT declared
+    # here — dstack reads them from the CVM's sealed-env store at image-
+    # pull time, not from compose. Set them once per CVM via
+    # `phala envs encrypt + update`. Required only when the image is
+    # private; harmless to set when it's public.
     environment:
       RUST_LOG: scribe=info,scribe_api=info,scribe_services=info,scribe_providers=info,tower_http=info
       SCRIBE__OS_ACCOUNTS__API_URL: ""


### PR DESCRIPTION
## TL;DR

Hotfix for the broken \`build-scribe-api\` staging deploy on \`main\`: [run 26606769246](https://github.com/open-software-network/os-scribe/actions/runs/26606769246/job/78404058155) failed with **\`ERR-01-004: A CVM with name 'os-scribe-api-staging' already exists in this workspace\`**.

## Root cause

The composite action was running \`phala deploy -n <name>\` on every push, which is **strict create-only** — it errors when the name is taken rather than updating. Existing CVMs must be addressed via the \`--cvm-id\` flag (which accepts UUID, app_id, instance_id, *or* friendly name).

My earlier handoff document called CVM names "upsert keys" — that was wrong. The Phala CLI's \"the CLI detects existing CVMs by name\" language in the CI/CD docs only applies when you use \`--cvm-id\`, not \`-n\`. Two different flags with very different semantics.

## Fix

In \`.github/actions/phala-deploy/action.yml\`, probe with \`phala cvms get\` and branch:

\`\`\`bash
if phala cvms get \"\$CVM_NAME\" --json >/dev/null 2>&1; then
  phala deploy -c \"\$RENDERED\" --cvm-id \"\$CVM_NAME\" --wait   # update
else
  phala deploy -c \"\$RENDERED\" -n \"\$CVM_NAME\" --wait         # create
fi
\`\`\`

Same composite handles both first-deploy (when the CVM doesn't exist yet) and subsequent updates. No \`phala cvms upgrade\` step needed (that subcommand is deprecated — the cvms docs page explicitly points users to \`phala deploy\` as the replacement).

## Why this didn't surface during PR #34 / #35 review

- PR #34 (initial Phala swap) never reached a real deploy — Phala account wasn't bound yet.
- PR #35 (compose validation fix) was the **first successful deploy** — it created \`os-scribe-api-staging\` for the first time, so the \`-n\` flag worked.
- This push is the **second deploy attempt against an existing CVM** — the strict-create semantics surfaced for the first time.

So the bug was latent — it only manifests on the second deploy of any given CVM. Worth flagging because if this hadn't been caught at staging, the production path (\`promote-scribe-api.yml\`) would hit the same wall the next time anyone promotes (\`os-scribe-api-production\` was created on PR #35 too).

## Verification after merge

1. Push to \`main\` re-triggers \`build-scribe-api\`.
2. \`deploy-staging\` now probes \`phala cvms get os-scribe-api-staging\` → exists → \`phala deploy --cvm-id os-scribe-api-staging --wait\` → success.
3. Same fix applies to \`promote-scribe-api.yml\` since it uses the same composite — next production promote will update the existing \`os-scribe-api-production\` CVM rather than failing.

## Tangential observation

The staging CVM is currently stopped (env vars not sealed yet), but \`phala cvms get\` should still resolve a stopped CVM. If for some reason a stopped CVM is invisible to \`get\`, this PR would regress to the same error — flag if you see that and I'll switch the probe to \`phala cvms list --json | jq\` instead.