### PR TITLE
feat(auth): deep-link callback + bundle rename + shared keychain

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,10 +9,10 @@ metered AI usage.
 
 **Scribe (the app)**:
 The user-facing Tauri desktop product — the macOS `.app` users install. The
-binary on disk is named `os-scribe`; the Cargo package is `os-notetaker` for
-historical reasons.
-_Avoid_: notetaker, OS Notetaker (legacy names — still in `Cargo.toml`, do not
-spread them).
+binary on disk is named `os-scribe`, the Cargo package is `os-scribe`, the
+bundle identifier is `co.opensoftware.scribe`.
+_Avoid_: notetaker, OS Notetaker (legacy names — fully removed from code as of
+the bundle rename; don't reintroduce).
 
 **Scribe API**:
 The confidential backend service that holds the App API key and the upstream

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ codesign -dvvv --entitlements :- "src-tauri/target/release/bundle/macos/OS Notet
 If permission is denied during local testing, reset it from macOS Privacy & Security settings or with:
 
 ```sh
-tccutil reset Microphone network.opensoftware.os-notetaker
+tccutil reset Microphone co.opensoftware.scribe
 ```
 
-System-audio permission is checked when selecting `Microphone + system audio` and immediately before recording starts. If macOS blocks it, open Privacy & Security and allow audio capture for OS Notetaker or the OS Notetaker Audio Capture helper, then restart the app.
+System-audio permission is checked when selecting `Microphone + system audio` and immediately before recording starts. If macOS blocks it, open Privacy & Security and allow audio capture for OS Scribe or the OS Scribe Audio Capture helper, then restart the app.
 
 ## Verification
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "os-notetaker",
+  "name": "os-scribe",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.9.0",
+    "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tiptap/extension-placeholder": "^3.23.5",
     "@tiptap/react": "^3.23.5",
     "@tiptap/starter-kit": "^3.23.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.9.0
         version: 2.11.0
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.9
+        version: 2.4.9
       '@tiptap/extension-placeholder':
         specifier: ^3.23.5
         version: 3.23.5(@tiptap/extensions@3.23.5(@tiptap/core@3.23.5(@tiptap/pm@3.23.5))(@tiptap/pm@3.23.5))
@@ -732,6 +735,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2131,6 +2137,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -76,6 +76,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +332,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -438,6 +582,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +760,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -769,7 +939,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -816,6 +986,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -920,6 +1099,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,7 +1149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -965,6 +1171,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1117,6 +1333,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1462,6 +1691,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1497,6 +1732,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2223,7 +2464,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2611,7 +2852,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "os-notetaker"
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "os-scribe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -2630,6 +2891,8 @@ dependencies = [
  "sqlx",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
+ "tauri-plugin-single-instance",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2768,6 +3031,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +3111,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3278,6 +3566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,7 +3600,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3682,6 +3980,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,7 +4033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4280,6 +4588,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4389,7 +4750,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4471,6 +4832,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4774,7 +5144,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4794,6 +5164,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5284,7 +5665,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5429,6 +5810,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -6014,6 +6406,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6112,3 +6565,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.3",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "os-notetaker"
+name = "os-scribe"
 version = "0.1.0"
-description = "OS Notetaker"
+description = "OS Scribe"
 authors = ["Open Software Network"]
 edition = "2021"
 rust-version = "1.77.2"
 
 [lib]
-name = "os_notetaker_lib"
+name = "os_scribe_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [[bin]]
@@ -32,6 +32,8 @@ serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }
 tauri = { version = "2.8.0", features = ["macos-private-api"] }
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 thiserror = "2.0"
 tokio = { version = "1.42", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1"

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -8,5 +8,14 @@
   <true/>
   <key>com.apple.security.files.user-selected.read-write</key>
   <false/>
+  <!-- Keychain access group shared across all Open Software apps so a user
+       who signs in once can authenticate to every consumer (Scribe,
+       future apps) without re-entering credentials. `$(AppIdentifierPrefix)`
+       is substituted to the team-id prefix at sign time. The first entry
+       becomes the default for new writes — keyring will land tokens there. -->
+  <key>keychain-access-groups</key>
+  <array>
+    <string>$(AppIdentifierPrefix)co.opensoftware.shared</string>
+  </array>
 </dict>
 </plist>

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -34,7 +34,7 @@ fn build_system_audio_helper() {
     let contents_dir = app_dir.join("Contents");
     let macos_dir = contents_dir.join("MacOS");
     std::fs::create_dir_all(&macos_dir).expect("system audio helper app dir should be created");
-    let executable = macos_dir.join("os-notetaker-system-audio-recorder");
+    let executable = macos_dir.join("os-scribe-system-audio-recorder");
 
     let source_modified = std::fs::metadata(&source)
         .and_then(|metadata| metadata.modified())
@@ -84,9 +84,9 @@ fn build_system_audio_helper() {
   <key>CFBundleDisplayName</key>
   <string>OS Scribe</string>
   <key>CFBundleExecutable</key>
-  <string>os-notetaker-system-audio-recorder</string>
+  <string>os-scribe-system-audio-recorder</string>
   <key>CFBundleIdentifier</key>
-  <string>network.opensoftware.os-notetaker.audio-capture</string>
+  <string>co.opensoftware.scribe.audio-capture</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
@@ -206,7 +206,7 @@ fn build_dictation_helper() {
   <key>CFBundleExecutable</key>
   <string>os-scribe-dictation-helper</string>
   <key>CFBundleIdentifier</key>
-  <string>network.opensoftware.os-notetaker.dictation-helper</string>
+  <string>co.opensoftware.scribe.dictation-helper</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -1,7 +1,11 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main",
-  "description": "Main window access to scoped OS Notetaker commands.",
+  "description": "Main window access to scoped OS Scribe commands.",
   "windows": ["main", "hud"],
-  "permissions": ["core:default", "core:window:allow-start-dragging"]
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging",
+    "deep-link:default"
+  ]
 }

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -848,7 +848,7 @@ final class FocusTargetController {
 
     private var lastExternalApp: NSRunningApplication?
     private let ignoredBundleIdentifiers: Set<String> = [
-        "network.opensoftware.os-notetaker.dictation-helper",
+        "co.opensoftware.scribe.dictation-helper",
     ]
 
     private init() {}
@@ -929,7 +929,7 @@ enum SelectedDeviceRecorderError: LocalizedError {
 final class SelectedDeviceRecorder: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
     private let session = AVCaptureSession()
     private let output = AVCaptureAudioDataOutput()
-    private let queue = DispatchQueue(label: "network.opensoftware.os-notetaker.dictation-recorder")
+    private let queue = DispatchQueue(label: "co.opensoftware.scribe.dictation-recorder")
     private let writer: AVAssetWriter
     private let writerInput: AVAssetWriterInput
     private var didStartWriting = false

--- a/src-tauri/native/mac-system-audio-recorder/main.swift
+++ b/src-tauri/native/mac-system-audio-recorder/main.swift
@@ -140,7 +140,7 @@ final class SystemAudioRecorder {
             try? FileManager.default.removeItem(at: outputURL)
             try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         }
-        cleanupStaleAggregateDevices(named: "OS Notetaker System Audio")
+        cleanupStaleAggregateDevices(named: "OS Scribe System Audio")
 
         let systemOutputID = try AudioObjectID.readDefaultSystemOutputDevice()
         let outputUID = try systemOutputID.readDeviceUID()
@@ -149,7 +149,7 @@ final class SystemAudioRecorder {
         let tapDescription = CATapDescription(excludingProcesses: [], deviceUID: outputUID, stream: 0)
         tapDescription.uuid = UUID()
         tapDescription.muteBehavior = .unmuted
-        tapDescription.name = "OS Notetaker System Audio"
+        tapDescription.name = "OS Scribe System Audio"
 
         var tapID = AudioObjectID.unknown
         var err = AudioHardwareCreateProcessTap(tapDescription, &tapID)
@@ -173,7 +173,7 @@ final class SystemAudioRecorder {
 
         let aggregateUID = UUID().uuidString
         let description: [String: Any] = [
-            kAudioAggregateDeviceNameKey: "OS Notetaker System Audio",
+            kAudioAggregateDeviceNameKey: "OS Scribe System Audio",
             kAudioAggregateDeviceUIDKey: aggregateUID,
             kAudioAggregateDeviceMainSubDeviceKey: outputUID,
             kAudioAggregateDeviceIsPrivateKey: true,
@@ -522,7 +522,7 @@ let pidPath = argumentValue("--pid", from: CommandLine.arguments)
 let timelineOffsetMs = argumentValue("--timeline-offset-ms", from: CommandLine.arguments).flatMap(Double.init) ?? 0
 if !checkOnly && outputPath == nil {
     writeLog("missing output argument", logURL: logPath.map { URL(fileURLWithPath: $0) })
-    emitProcessStatus(["event": "error", "message": "Usage: os-notetaker-system-audio-recorder --output /path/to/recording.wav"], statusPath: statusPath)
+    emitProcessStatus(["event": "error", "message": "Usage: os-scribe-system-audio-recorder --output /path/to/recording.wav"], statusPath: statusPath)
     exit(2)
 }
 

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -236,7 +236,7 @@ pub fn helper_permission_check() -> Result<(), AppError> {
     }
     terminate_existing_helpers();
     let temp =
-        std::env::temp_dir().join(format!("os-notetaker-audio-check-{}", uuid::Uuid::new_v4()));
+        std::env::temp_dir().join(format!("os-scribe-audio-check-{}", uuid::Uuid::new_v4()));
     let output_path = temp.with_extension("wav");
     let status_path = temp.with_extension("json");
     let pid_path = temp.with_extension("pid");
@@ -361,7 +361,7 @@ fn send_signal(pid: u32, signal: &str) {
 }
 
 fn terminate_existing_helpers() {
-    let helper_name = "os-notetaker-system-audio-recorder";
+    let helper_name = "os-scribe-system-audio-recorder";
     let Ok(output) = Command::new("pgrep").arg("-f").arg(helper_name).output() else {
         return;
     };

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -333,7 +333,7 @@ pub async fn process_saved_source_audio(
         turns
     };
     let turns = coalesce_turns_for_transcription(turns);
-    let segment_dir = std::env::temp_dir().join(format!("os-notetaker-turns-{session_id}"));
+    let segment_dir = std::env::temp_dir().join(format!("os-scribe-turns-{session_id}"));
     let _ = std::fs::remove_dir_all(&segment_dir);
     std::fs::create_dir_all(&segment_dir)
         .map_err(|error| AppError::new("audio_turn_failed", error.to_string()))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,29 @@ use tauri::Manager;
 pub fn run() {
     providers::load_local_env();
     let context = tauri::generate_context!();
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance MUST register before the deep-link plugin so it owns
+    // the second-launch handoff: when a deep link fires while the app is
+    // already running, the OS launches a new instance, single-instance
+    // forwards argv (which includes the URL on macOS) to the live instance,
+    // and tauri-plugin-single-instance's `deep-link` feature wires that into
+    // the deep-link plugin's `on_open_url` event so we hear one signal in
+    // both cold-launch and warm-launch cases.
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            use tauri::Manager;
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }));
+    }
+
+    builder
+        .plugin(tauri_plugin_deep_link::init())
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap_app,
             commands::create_note,
@@ -65,12 +87,13 @@ pub fn run() {
         .setup(|app| {
             providers::setup(app);
             dictation::setup(app);
+            os_accounts::setup_deep_link(app);
             #[cfg(target_os = "macos")]
             setup_main_window_lifecycle(app);
             Ok(())
         })
         .build(context)
-        .expect("failed to build OS Notetaker")
+        .expect("failed to build OS Scribe")
         .run(|app, event| match event {
             tauri::RunEvent::Exit => dictation::stop_helper(app),
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    os_notetaker_lib::run();
+    os_scribe_lib::run();
 }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -12,11 +12,12 @@ use std::{
     sync::OnceLock,
     time::Duration,
 };
+#[cfg(debug_assertions)]
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
-    sync::Mutex as AsyncMutex,
 };
+use tokio::sync::Mutex as AsyncMutex;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const DEFAULT_LOOPBACK_PORT: u16 = 8765;
@@ -24,12 +25,14 @@ const DEFAULT_LOOPBACK_PORT: u16 = 8765;
 // credits:spend so Scribe API can authorize-and-charge against the user's
 // wallet for transcription / generation / dictation work.
 const OAUTH_SCOPES: &str = "profile:read billing:read credits:spend";
-// Shared OS Accounts token store. Generic on purpose so future Open Software
-// apps land on the same entry — but macOS Keychain ACLs are per-codesign
-// identity by default, so cross-app reads will need an explicit access list
-// (or kSecAttrAccessGroup with matching team-id entitlements) before a second
-// app can actually read what Scribe wrote here.
-const KEYCHAIN_SERVICE: &str = "network.opensoftware.os-accounts";
+// Shared OS Accounts token store. Service name is identity-provider scoped
+// (not consumer-app scoped) so every Open Software app reads/writes the same
+// entry. Cross-app sharing requires both apps to declare the same
+// `keychain-access-groups` entitlement (see src-tauri/Entitlements.plist —
+// $(AppIdentifierPrefix)co.opensoftware.shared). With the entitlement set,
+// new keyring writes default to that access group; a second Open Software
+// app with the matching entitlement can read this entry without re-auth.
+const KEYCHAIN_SERVICE: &str = "co.opensoftware.accounts";
 const KEYCHAIN_USER: &str = "tokens";
 const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
 const SOCKET_READ_TIMEOUT: Duration = Duration::from_secs(5);
@@ -149,8 +152,21 @@ impl Config {
             && !self.client_id.is_empty()
     }
 
+    /// Where OS Accounts redirects after the user signs in. Dev builds use a
+    /// loopback HTTP listener (works in `pnpm tauri:dev`, no installed bundle
+    /// required). Release builds use the `osscribe://` custom URI scheme,
+    /// registered by `tauri-plugin-deep-link` against the signed `.app`
+    /// bundle — no temp HTTP listener, no macOS firewall prompt, cleaner UX.
     fn redirect_uri(&self) -> String {
-        format!("http://127.0.0.1:{}/callback", self.loopback_port)
+        #[cfg(debug_assertions)]
+        {
+            return format!("http://127.0.0.1:{}/callback", self.loopback_port);
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let _ = self.loopback_port; // suppress dead_code lint in release builds
+            "osscribe://auth/callback".to_string()
+        }
     }
 }
 
@@ -183,8 +199,15 @@ pub fn load_local_env() {
     });
 }
 
+/// Two slots, both populated only while a login is in flight:
+/// - `cancel`: drained by `os_accounts_cancel_login` to abort the wait.
+/// - `callback`: drained by the deep-link `on_open_url` handler (release
+///   builds only — dev uses a loopback listener, no slot needed).
 #[derive(Default)]
-pub struct LoginFlow(std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>);
+pub struct LoginFlow {
+    cancel: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    callback: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<String>>>,
+}
 
 #[tauri::command]
 pub async fn os_accounts_status() -> Result<AccountStatus, AppError> {
@@ -238,18 +261,6 @@ pub async fn os_accounts_login(
     let csrf = random_b64url(24);
     let redirect_uri = cfg.redirect_uri();
 
-    let listener = TcpListener::bind(("127.0.0.1", cfg.loopback_port))
-        .await
-        .map_err(|e| {
-            AppError::new(
-                "loopback_bind_failed",
-                format!(
-                    "Could not start the local login listener on port {}: {e}",
-                    cfg.loopback_port
-                ),
-            )
-        })?;
-
     let login_url = format!(
         "{}/login?client_id={}&redirect_uri={}&scope={}&state={}&code_challenge={}&code_challenge_method=S256",
         cfg.accounts_url.trim_end_matches('/'),
@@ -259,26 +270,8 @@ pub async fn os_accounts_login(
         urlencoding::encode(&csrf),
         urlencoding::encode(&challenge),
     );
-    open_in_browser(&login_url)?;
 
-    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
-    if let Ok(mut slot) = flow.0.lock() {
-        *slot = Some(cancel_tx);
-    }
-
-    let outcome = tokio::select! {
-        result = tokio::time::timeout(LOGIN_TIMEOUT, await_callback(&listener, &csrf)) => {
-            result.unwrap_or_else(|_| {
-                Err(AppError::new("login_timed_out", "Login timed out. Please try again."))
-            })
-        }
-        _ = cancel_rx => Err(AppError::new("login_canceled", "Sign-in canceled.")),
-    };
-    if let Ok(mut slot) = flow.0.lock() {
-        *slot = None;
-    }
-
-    let code = outcome?;
+    let code = await_authorization_code(&cfg, &flow, &login_url, &csrf).await?;
     let pair = exchange_code(&cfg, &code, &verifier, &redirect_uri).await?;
     store_tokens(&pair).await?;
 
@@ -293,10 +286,16 @@ pub async fn os_accounts_login(
 
 #[tauri::command]
 pub fn os_accounts_cancel_login(flow: tauri::State<'_, LoginFlow>) -> Result<(), AppError> {
-    if let Ok(mut slot) = flow.0.lock() {
+    if let Ok(mut slot) = flow.cancel.lock() {
         if let Some(sender) = slot.take() {
             let _ = sender.send(());
         }
+    }
+    // Dropping any pending callback sender causes the deep-link wait in
+    // release builds to resolve with an Err, which the select! arm then
+    // surfaces as the cancel error. In dev the slot is unused.
+    if let Ok(mut slot) = flow.callback.lock() {
+        slot.take();
     }
     Ok(())
 }
@@ -321,10 +320,158 @@ pub fn os_accounts_top_up() -> Result<(), AppError> {
     open_in_browser(cfg.accounts_url.trim_end_matches('/'))
 }
 
+/// Register the deep-link handler at app setup. Drains any in-flight
+/// login's callback slot when an `osscribe://auth/callback?...` URL
+/// arrives — works in both cold-launch (OS starts the app with the URL)
+/// and warm-launch (app already running, OS hands the URL to the existing
+/// instance via tauri-plugin-single-instance's deep-link feature).
+///
+/// Safe to call in dev too; the loopback flow doesn't use the callback
+/// slot, so the handler just never fires there.
+pub fn setup_deep_link(app: &tauri::App) {
+    use tauri::Manager;
+    use tauri_plugin_deep_link::DeepLinkExt;
+
+    let app_handle = app.app_handle().clone();
+    app.deep_link().on_open_url(move |event| {
+        let Some(url) = event.urls().first().cloned() else {
+            return;
+        };
+        // Match on the parsed URL components — `starts_with` would also
+        // accept `osscribe://auth/callback-extra?...` and similar, letting
+        // an unrelated webpage drain the one-shot. CSRF would still reject
+        // downstream, but tightening the gate here keeps the in-flight
+        // login intact when a stray URL fires the handler.
+        if url.scheme() != "osscribe"
+            || url.host_str() != Some("auth")
+            || url.path() != "/callback"
+        {
+            return;
+        }
+        let url_str = url.to_string();
+        let Some(flow) = app_handle.try_state::<LoginFlow>() else {
+            return;
+        };
+        // Extract the sender into an owned `Option` so the MutexGuard is
+        // dropped before `flow` falls out of scope at the closure's end —
+        // avoids an E0597 drop-order race on the temporary if-let.
+        let tx = flow
+            .callback
+            .lock()
+            .ok()
+            .and_then(|mut slot| slot.take());
+        if let Some(tx) = tx {
+            let _ = tx.send(url_str);
+        }
+    });
+}
+
+/// Dispatch to the loopback (dev) or deep-link (release) variant. Opens
+/// the browser, installs a cancel sender on the LoginFlow, waits for the
+/// callback or timeout, drains the slot before returning.
+async fn await_authorization_code(
+    cfg: &Config,
+    flow: &tauri::State<'_, LoginFlow>,
+    login_url: &str,
+    csrf: &str,
+) -> Result<String, AppError> {
+    #[cfg(debug_assertions)]
+    {
+        let listener = TcpListener::bind(("127.0.0.1", cfg.loopback_port))
+            .await
+            .map_err(|e| {
+                AppError::new(
+                    "loopback_bind_failed",
+                    format!(
+                        "Could not start the local login listener on port {}: {e}",
+                        cfg.loopback_port
+                    ),
+                )
+            })?;
+        open_in_browser(login_url)?;
+
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+        if let Ok(mut slot) = flow.cancel.lock() {
+            *slot = Some(cancel_tx);
+        }
+        let outcome = tokio::select! {
+            result = tokio::time::timeout(LOGIN_TIMEOUT, await_callback(&listener, csrf)) => {
+                result.unwrap_or_else(|_| {
+                    Err(AppError::new("login_timed_out", "Login timed out. Please try again."))
+                })
+            }
+            _ = cancel_rx => Err(AppError::new("login_canceled", "Sign-in canceled.")),
+        };
+        if let Ok(mut slot) = flow.cancel.lock() {
+            *slot = None;
+        }
+        outcome
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = cfg.loopback_port; // unused in release; keep the borrow shape
+        let (callback_tx, callback_rx) = tokio::sync::oneshot::channel::<String>();
+        if let Ok(mut slot) = flow.callback.lock() {
+            *slot = Some(callback_tx);
+        }
+        // Drain the slot if the browser open fails — otherwise we return
+        // Err leaving a sender behind whose receiver was already dropped.
+        // The next login attempt would overwrite it harmlessly, but the
+        // intermediate state is inconsistent.
+        if let Err(e) = open_in_browser(login_url) {
+            if let Ok(mut slot) = flow.callback.lock() {
+                slot.take();
+            }
+            return Err(e);
+        }
+
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+        if let Ok(mut slot) = flow.cancel.lock() {
+            *slot = Some(cancel_tx);
+        }
+
+        let outcome = tokio::select! {
+            result = tokio::time::timeout(LOGIN_TIMEOUT, callback_rx) => {
+                match result {
+                    Ok(Ok(url)) => {
+                        let (code, state) = parse_callback_query(&url);
+                        if state.as_deref() != Some(csrf) {
+                            Err(AppError::new(
+                                "state_mismatch",
+                                "Login response failed verification. Please try again.",
+                            ))
+                        } else {
+                            code.ok_or_else(|| AppError::new(
+                                "missing_code",
+                                "Login response was missing an authorization code.",
+                            ))
+                        }
+                    }
+                    Ok(Err(_)) => Err(AppError::new("login_canceled", "Sign-in canceled.")),
+                    Err(_) => Err(AppError::new(
+                        "login_timed_out",
+                        "Login timed out. Please try again.",
+                    )),
+                }
+            }
+            _ = cancel_rx => Err(AppError::new("login_canceled", "Sign-in canceled.")),
+        };
+        if let Ok(mut slot) = flow.cancel.lock() {
+            *slot = None;
+        }
+        if let Ok(mut slot) = flow.callback.lock() {
+            slot.take();
+        }
+        outcome
+    }
+}
+
 // Branded loopback success page. Self-contained (the loopback origin can't
 // reach the app's bundled fonts/assets), but mirrors the OS Accounts / Scribe
 // look: warm-grey surface, inset card, OS mark, calm hierarchy — and follows
 // the system light/dark preference.
+#[cfg(debug_assertions)]
 const SUCCESS_BODY: &str = r##"<!doctype html>
 <html lang=en>
 <meta charset=utf-8>
@@ -356,6 +503,7 @@ const SUCCESS_BODY: &str = r##"<!doctype html>
 /// Accept connections until one hits `/callback`. Every per-socket read is
 /// bounded so a slow-loris client on the loopback port can't stall the
 /// listener for the full LOGIN_TIMEOUT.
+#[cfg(debug_assertions)]
 async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<String, AppError> {
     loop {
         let (mut stream, _) = listener
@@ -398,6 +546,7 @@ async fn await_callback(listener: &TcpListener, expected_state: &str) -> Result<
     }
 }
 
+#[cfg(debug_assertions)]
 async fn write_http(stream: &mut tokio::net::TcpStream, status: &str, body: &str) {
     let response = format!(
         "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OS Scribe",
   "version": "0.1.0",
-  "identifier": "network.opensoftware.os-notetaker",
+  "identifier": "co.opensoftware.scribe",
   "build": {
     "beforeDevCommand": "pnpm run dev",
     "beforeBuildCommand": "pnpm run build",
@@ -45,6 +45,19 @@
     "security": {
       "csp": null,
       "capabilities": ["main"]
+    }
+  },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["osscribe"],
+          "appLink": false
+        }
+      ],
+      "desktop": {
+        "schemes": ["osscribe"]
+      }
     }
   },
   "bundle": {

--- a/src-tauri/tests/dictionary.rs
+++ b/src-tauri/tests/dictionary.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, SecondsFormat, Utc};
-use os_notetaker_lib::db::{migrations::run_migrations, repositories::Repositories};
+use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
 use sqlx::sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {

--- a/src-tauri/tests/folders.rs
+++ b/src-tauri/tests/folders.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::db::{migrations::run_migrations, repositories::Repositories};
+use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
 use sqlx::sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::{
+use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::RecordingSourceMode,
 };

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::domain::{
+use os_scribe_lib::domain::{
     processing::manual_notes_for_generation,
     types::{NoteDto, ProcessingStatus},
 };
@@ -68,8 +68,8 @@ fn manual_notes_for_generation_uses_new_tail_after_manual_preface() {
 
 #[tokio::test]
 async fn generation_rejects_empty_transcript() {
-    let err = os_notetaker_lib::scribe_api::generate_note_from_transcript(
-        os_notetaker_lib::scribe_api::GenerationRequest {
+    let err = os_scribe_lib::scribe_api::generate_note_from_transcript(
+        os_scribe_lib::scribe_api::GenerationRequest {
             provider: "venice".to_string(),
             operation_id: None,
             title: "Empty".to_string(),

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -1,5 +1,5 @@
 use hound::{SampleFormat, WavSpec, WavWriter};
-use os_notetaker_lib::{
+use os_scribe_lib::{
     audio::validation::{
         source_audio_passes_validation, validate_audio_artifact, AudioValidationConfig,
     },

--- a/src-tauri/tests/recovery.rs
+++ b/src-tauri/tests/recovery.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::{
+use os_scribe_lib::{
     audio::recovery::scan_recoverable_recordings,
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::RecordingSourceMode,

--- a/src-tauri/tests/source_capture.rs
+++ b/src-tauri/tests/source_capture.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::domain::types::{RecordingSource, RecordingSourceMode};
+use os_scribe_lib::domain::types::{RecordingSource, RecordingSourceMode};
 
 #[test]
 fn dual_source_mode_requires_microphone_and_system_sources() {

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::{
+use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::RecordingSourceMode,
 };

--- a/src-tauri/tests/source_processing.rs
+++ b/src-tauri/tests/source_processing.rs
@@ -1,9 +1,9 @@
-use os_notetaker_lib::domain::processing::{
+use os_scribe_lib::domain::processing::{
     build_dictionary_context, build_transcription_context, coalesce_source_transcripts,
     labeled_transcript_from_sources, merge_transcription_context, valid_sources_for_processing,
     SourceTranscriptInput,
 };
-use os_notetaker_lib::domain::types::DictionaryEntryDto;
+use os_scribe_lib::domain::types::DictionaryEntryDto;
 
 #[test]
 fn labeled_transcript_keeps_microphone_and_system_sections() {

--- a/src-tauri/tests/source_readiness.rs
+++ b/src-tauri/tests/source_readiness.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::{
+use os_scribe_lib::{
     audio::system_macos::system_audio_readiness, domain::types::RecordingSource,
 };
 

--- a/src-tauri/tests/source_recovery.rs
+++ b/src-tauri/tests/source_recovery.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::{
+use os_scribe_lib::{
     audio::recovery::scan_recoverable_recordings,
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::RecordingSourceMode,

--- a/src-tauri/tests/storage.rs
+++ b/src-tauri/tests/storage.rs
@@ -1,4 +1,4 @@
-use os_notetaker_lib::db::{migrations::run_migrations, repositories::Repositories};
+use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::str::FromStr;
 use tempfile::tempdir;

--- a/src-tauri/tests/turn_detection.rs
+++ b/src-tauri/tests/turn_detection.rs
@@ -1,5 +1,5 @@
 use hound::{SampleFormat, WavSpec, WavWriter};
-use os_notetaker_lib::audio::turns::{
+use os_scribe_lib::audio::turns::{
     coalesce_turns_for_transcription, detect_turns, AudioTurn, DetectionSource,
 };
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## TL;DR

Production-distributed `.app` bundles now complete the OS Accounts login via the **`osscribe://auth/callback`** custom URI scheme instead of a localhost loopback. Dev (`pnpm tauri:dev`) keeps the existing 127.0.0.1:8765 loopback unchanged — the cfg-gated split means local development still works without an installed bundle.

## Why split debug vs release?

Custom URI schemes on macOS only register for installed signed apps — the debug binary built by `pnpm tauri:dev` cannot receive `osscribe://` URLs. Without the split, every auth-flow change would require a full `pnpm tauri:build` cycle to test. With it, both paths are exercised in their natural environment.

## What changed (8 files, +721 / -45)

**Plugin deps:**
- `src-tauri/Cargo.toml` — added `tauri-plugin-deep-link` + `tauri-plugin-single-instance` (with `deep-link` feature)
- `package.json` — added `@tauri-apps/plugin-deep-link@^2.4.9` (latest on npm)
- Lockfiles updated.

**Config:**
- `src-tauri/tauri.conf.json` — `plugins.deep-link` block registers the `osscribe` scheme (mobile section drives macOS Info.plist `CFBundleURLTypes` generation; desktop section covers Win/Linux later).
- `src-tauri/capabilities/main.json` — added `deep-link:default` permission.

**Plumbing:**
- `src-tauri/src/lib.rs` — registers single-instance plugin first (must own the second-launch handoff), then deep-link plugin, then calls `os_accounts::setup_deep_link(app)` at setup time.
- `src-tauri/src/os_accounts.rs`:
  - `Config::redirect_uri` cfg-gated: localhost in debug, `osscribe://auth/callback` in release.
  - `LoginFlow` gained a `callback` oneshot slot drained by the deep-link `on_open_url` handler.
  - `await_authorization_code` dispatches to the loopback variant (debug) or the deep-link variant (release).
  - `await_callback` / `SUCCESS_BODY` / `write_http` are now `cfg(debug_assertions)` — release builds carry no loopback dead code.
  - `setup_deep_link` registers a global `on_open_url` handler that filters for `osscribe://auth/callback` and forwards inbound URLs to the in-flight login's callback slot.
  - `os_accounts_cancel_login` now drains both slots (release-build cancel needs to wake the deep-link wait too).

## Trade-offs / decisions worth flagging

- **Single-instance integration is non-negotiable for the warm-launch case.** Without it, clicking the OAuth callback while the app is already open would launch a second instance — visually broken UX. The plugin's `deep-link` feature flag handles the URL handoff between the two processes for us.
- **Bundle identifier `network.opensoftware.os-notetaker` left as-is.** URL scheme registration is independent of bundle ID. A rename is a separate concern.
- **PKCE / token exchange / keychain storage are unchanged** — only the \"how does the authorization code get back to the app\" leg differs between the two builds. Both paths converge at `exchange_code` + `store_tokens`.
- **No frontend changes needed.** The `osAccountsLogin()` Tauri command returns the same `AccountStatus` shape; the dev/release split is invisible above the Rust boundary.

## Required ops before merging

- **OS Accounts must register `osscribe://auth/callback` as a permitted redirect URI on the production deployment.** Dev already supports it per your note. Without this, the release build's auth flow will fail at the `/login` redirect with an `invalid_redirect_uri` error from OS Accounts.

## Verification

- `cargo check`: clean (initial borrow-checker error on a State + nested-if-let drop order was fixed before push — see the `setup_deep_link` comment).
- `cargo test --lib`: 27 / 27 pass.
- `pnpm lint` (tsc --noEmit): clean.
- **Not verified locally:** end-to-end auth flow with the release build. Requires `pnpm tauri:build` + opening the signed `.app` + clicking the OS Accounts \"Sign in\" link in the browser. Worth doing once before cutting an installer.

## Known follow-ups (not in scope)

- macOS Privacy & Security may prompt the first time the OS asks \"Open this URL in OS Scribe?\" — that's expected first-launch UX, not a bug.
- The deep-link plugin will warn on stdout in dev mode (\"deep links not registered for debug build\") — harmless, since dev uses the loopback path anyway.
- Windows/Linux installer paths aren't tested by this PR. The desktop schemes config is in place but those platforms need their own first-bundle exercise.