### PR TITLE
fix(ci): phala deploy probe parses wrapped list json

### DIFF
--- a/.github/actions/phala-deploy/action.yml
+++ b/.github/actions/phala-deploy/action.yml
@@ -122,7 +122,15 @@ runs:
           echo "CVM $CVM_NAME does not exist; creating via -n."
           phala deploy -c "$RENDERED" -n "$CVM_NAME" --wait
         fi
-        url=$(phala cvms get "$CVM_NAME" --json | jq -r '.public_urls[0].app // empty')
+        # cvm-url is a summary nicety, never a gate. `phala cvms get --json` spreads
+        # its detail fields to the top level (no wrapper to unwrap), but the public-
+        # endpoint field is API-version dependent: `public_urls` (v2025-10-28) or
+        # `endpoints` (default) — both arrays of {app, instance}. Walk every nested
+        # object and take the first .app URL so either shape works, and let a get/jq
+        # failure leave the url empty rather than fail an already-successful deploy.
+        url=$(phala cvms get "$CVM_NAME" --json \
+          | jq -r 'first((.. | objects | .app? | select(type == "string" and startswith("http")))) // empty') \
+          || url=""
         echo "deployed=true" >> "$GITHUB_OUTPUT"
         if [[ -n "$url" ]]; then
           echo "cvm-url=${url}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/phala-deploy/action.yml
+++ b/.github/actions/phala-deploy/action.yml
@@ -6,7 +6,7 @@ description: >
 
 inputs:
   cvm-name:
-    description: Phala CVM name. The action probes `phala cvms get <name>` and branches between `phala deploy -n <name>` (create) and `phala deploy --cvm-id <name>` (update) since the CLI doesn't expose an upsert flag.
+    description: Phala CVM name. The action probes `phala cvms list --json` and branches between `phala deploy -n <name>` (create) and `phala deploy --cvm-id <name>` (update) since the CLI doesn't expose an upsert flag.
     required: true
   compose-file:
     description: Path to docker-compose.yml containing the literal placeholder ${SCRIBE_IMAGE}.
@@ -96,7 +96,26 @@ runs:
           printf '%s\n' "$cvms_json" >&2
           exit 1
         fi
-        if printf '%s' "$cvms_json" | jq -e --arg name "$CVM_NAME" '.[] | select(.name == $name)' >/dev/null; then
+        # `phala cvms list --json` is NOT a top-level array. The CLI wraps every
+        # --json payload as `{success: true, ...data}` and nests the CVMs under
+        # `.items[]` keyed by `cvmName` (not `name`):
+        #   {"success": true, "items": [{"cvmName": "...", "appId": "..."}], ...}
+        # The old `.[] | select(.name==...)` iterated the wrapper's values, hit the
+        # `success` boolean and errored ("Cannot index boolean"); because that jq
+        # ran inside an `if` condition, set -e could not catch it and the step fell
+        # through to create on an existing CVM (ERR-01-004). `any(.. | objects; ...)`
+        # walks every nested object so it survives the wrapper and matches cvmName
+        # (current) or name (older CLIs). Read the -e exit code directly: 0 found,
+        # 1 absent, >=2 a real parse/auth failure that must hard-fail, not create.
+        exists=$(printf '%s' "$cvms_json" | jq -e --arg name "$CVM_NAME" \
+          'any(.. | objects; (.cvmName? == $name) or (.name? == $name))' 2>&1) \
+          && jq_status=0 || jq_status=$?
+        if [[ "$jq_status" -ge 2 ]]; then
+          echo "::error::Could not parse 'phala cvms list --json' output:"
+          printf '%s\n' "$exists" >&2
+          exit 1
+        fi
+        if [[ "$jq_status" -eq 0 ]]; then
           echo "CVM $CVM_NAME exists; updating via --cvm-id."
           phala deploy -c "$RENDERED" --cvm-id "$CVM_NAME" --wait
         else


### PR DESCRIPTION
Two related fixes to the `phala-deploy` composite, both rooted in wrong assumptions about `phala cvms ... --json` output shapes (confirmed by reading the bundled source of the pinned `phala@1.1.19`, then verified against the live account).

## 1. List-probe fell through to create on existing CVMs (the deploy failure)

Staging deploy [run 26627103903](https://github.com/open-software-network/os-scribe/actions/runs/26627103903) failed with `ERR-01-004: A CVM with name 'os-scribe-api-staging' already exists` — the exact case PR #39's list-probe was meant to prevent.

```
jq: error (at <stdin>:20): Cannot index boolean with string "name"
CVM os-scribe-api-staging does not exist; creating via -n.
✗ Error [ERR-01-004]: ... already exists
```

The probe assumed `phala cvms list --json` is a top-level array. It isn't — the CLI wraps every `--json` payload as `{success: true, ...data}`, and the list nests CVMs under `.items[]` keyed by **`cvmName`** (not `name`):

```json
{ "success": true, "items": [ {"cvmName": "os-scribe-api-staging", "appId": "..."} ], "page": 1, ... }
```

So `.[] | select(.name == $name)` iterated the wrapper's values, hit the `success` boolean, and threw. Worse: that jq ran inside an `if` condition, so `set -e` couldn't catch it — the step silently took the **create** branch and hit the existing CVM with `-n`.

**Fix:** probe with `any(.. | objects; (.cvmName? == $name) or (.name? == $name))` (walks nested objects, survives the wrapper, matches current `cvmName` or legacy `name`) and read the `jq -e` exit code directly (`0` found, `1` absent, `>=2` parse/auth error → **hard-fail** with `::error::`, never silently create).

## 2. `cvm-url` extraction: version-dependent field + could fail a good deploy

`phala cvms get --json` *does* spread its detail fields to the top level (unlike `list`), so the wrapper isn't the issue here. The real problem is the public-endpoint field is **API-version dependent**: `public_urls` (schema for API `v2025-10-28`) vs `endpoints` (default schema) — both `[{app, instance}]`. The hardcoded `.public_urls[0].app` silently returned empty on the `endpoints` shape. Separately, `url=$(phala cvms get ... | jq ...)` under `set -e` meant a failed `get` would **fail an already-successful deploy**.

**Fix:** extract the first `.app` URL from any nested object (`first((.. | objects | .app? | select(type=="string" and startswith("http"))))`) so either schema works, and append `|| url=""` so a `get`/`jq` failure leaves the summary URL blank instead of failing the deploy.

## Verification

Reproduced the original `Cannot index boolean` error against a fixture matching the real list shape, then ran the **actual extracted step script** with a stubbed `phala` across all branches:

| Case | Result |
|---|---|
| staging present (the failing run's state) | `--cvm-id` (update), exit 0 |
| CVM absent | `-n` (create), exit 0 |
| non-JSON list output | `::error::` hard-fail, exit 1 |
| get returns `public_urls` (v2025-10-28) | `cvm-url` set |
| get returns `endpoints` (default) | `cvm-url` set (old code: empty) |
| empty endpoints | no `cvm-url`, exit 0 |
| `cvms get` fails | exit 0 (deploy not failed) |

YAML parses; `shellcheck` clean.

### Verified against the live account

Ran read-only probes against the real Phala workspace:

- `phala cvms list --json` → top-level keys `{items, page, pageSize, success, total, totalPages}`; item keys `{appId, cvmName, status, uptime}` — confirms the wrapper + `cvmName`.
- The new probe `any(.. | objects; .cvmName? == "os-scribe-api-staging")` returns **`true`** against live data.
- `phala cvms get os-scribe-api-staging --json` → `has_public_urls: false`, `has_endpoints: true`. The live API uses the **`endpoints`** schema, so the old `.public_urls[0].app` *was* returning empty in production. The new filter extracts the real port-8080 URL (`https://<app_id>-8080.dstack-pha-prod5.phala.network`) and ignores `gateway_app_url` and the empty `instance`.

Both filters remain shape/version-agnostic, so they also hold if Phala flips back to the `public_urls` schema.