### PR TITLE
Harden release billing and deployment

### DIFF
--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -82,6 +82,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/phala-deploy
+        env:
+          SCRIBE__OS_ACCOUNTS__API_URL: ${{ secrets.SCRIBE_OS_ACCOUNTS_API_URL }}
+          SCRIBE__OS_ACCOUNTS__APP_API_KEY: ${{ secrets.SCRIBE_OS_ACCOUNTS_APP_API_KEY }}
+          SCRIBE__UPSTREAMS__OPENAI__API_KEY: ${{ secrets.SCRIBE_OPENAI_API_KEY }}
+          SCRIBE__UPSTREAMS__VENICE__API_KEY: ${{ secrets.SCRIBE_VENICE_API_KEY }}
         with:
           cvm-name: os-scribe-api-staging
           compose-file: iac/phala/docker-compose.staging.yml

--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -82,11 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/phala-deploy
-        env:
-          SCRIBE__OS_ACCOUNTS__API_URL: ${{ secrets.SCRIBE_OS_ACCOUNTS_API_URL }}
-          SCRIBE__OS_ACCOUNTS__APP_API_KEY: ${{ secrets.SCRIBE_OS_ACCOUNTS_APP_API_KEY }}
-          SCRIBE__UPSTREAMS__OPENAI__API_KEY: ${{ secrets.SCRIBE_OPENAI_API_KEY }}
-          SCRIBE__UPSTREAMS__VENICE__API_KEY: ${{ secrets.SCRIBE_VENICE_API_KEY }}
         with:
           cvm-name: os-scribe-api-staging
           compose-file: iac/phala/docker-compose.staging.yml

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -68,7 +68,40 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate signing and notarization secrets
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_SIGNING_IDENTITY \
+            APPLE_ID \
+            APPLE_PASSWORD \
+            APPLE_TEAM_ID
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::${name} is required to build a distributable signed and notarized DMG."
+              missing=1
+            fi
+          done
+          exit "$missing"
+
       - name: Build DMG
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm tauri build --bundles dmg
 
       - name: Upload DMG

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -96,6 +96,11 @@ jobs:
 
       - id: phala
         uses: ./.github/actions/phala-deploy
+        env:
+          SCRIBE__OS_ACCOUNTS__API_URL: ${{ secrets.SCRIBE_OS_ACCOUNTS_API_URL }}
+          SCRIBE__OS_ACCOUNTS__APP_API_KEY: ${{ secrets.SCRIBE_OS_ACCOUNTS_APP_API_KEY }}
+          SCRIBE__UPSTREAMS__OPENAI__API_KEY: ${{ secrets.SCRIBE_OPENAI_API_KEY }}
+          SCRIBE__UPSTREAMS__VENICE__API_KEY: ${{ secrets.SCRIBE_VENICE_API_KEY }}
         with:
           cvm-name: os-scribe-api-production
           compose-file: iac/phala/docker-compose.production.yml

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -96,11 +96,6 @@ jobs:
 
       - id: phala
         uses: ./.github/actions/phala-deploy
-        env:
-          SCRIBE__OS_ACCOUNTS__API_URL: ${{ secrets.SCRIBE_OS_ACCOUNTS_API_URL }}
-          SCRIBE__OS_ACCOUNTS__APP_API_KEY: ${{ secrets.SCRIBE_OS_ACCOUNTS_APP_API_KEY }}
-          SCRIBE__UPSTREAMS__OPENAI__API_KEY: ${{ secrets.SCRIBE_OPENAI_API_KEY }}
-          SCRIBE__UPSTREAMS__VENICE__API_KEY: ${{ secrets.SCRIBE_VENICE_API_KEY }}
         with:
           cvm-name: os-scribe-api-production
           compose-file: iac/phala/docker-compose.production.yml

--- a/README.md
+++ b/README.md
@@ -9,22 +9,28 @@ pnpm install
 pnpm tauri:dev
 ```
 
-Real transcription and note generation use Venice AI and require a Venice API key in the shell that launches Tauri:
-
-```sh
-export VENICE_API_KEY="..."
-pnpm tauri:dev
-```
-
-For local development, the Rust backend also loads `.env` from the repository root:
+The desktop app talks to Scribe API for transcription, dictation cleanup,
+model listing, and note generation. Provider API keys belong only in the
+Scribe API server env; never put OpenAI, Venice, or OS Accounts App API keys in
+the root desktop `.env`.
 
 ```sh
 cp .env.example .env
-# edit VENICE_API_KEY in .env
-pnpm tauri:dev
+# edit SCRIBE_API_URL and OS Accounts client settings when needed
 ```
 
-Restart `pnpm tauri:dev` after changing `.env`; the running Tauri process does not reload provider configuration.
+Run the local Scribe API separately when pointing the desktop app at
+`http://127.0.0.1:8080`:
+
+```sh
+cp scribe-api/.env.example scribe-api/.env
+# fill SCRIBE__OS_ACCOUNTS__APP_API_KEY, SCRIBE__UPSTREAMS__OPENAI__API_KEY,
+# and SCRIBE__UPSTREAMS__VENICE__API_KEY in scribe-api/.env
+(cd scribe-api && cargo run -- serve)
+```
+
+Restart `pnpm tauri:dev` after changing the root `.env`; the running Tauri
+process does not reload client configuration.
 
 Optional initial model defaults:
 
@@ -47,13 +53,16 @@ The app data directory is resolved by Tauri at runtime. In development, inspect 
 
 Dictation is paste-only: it does not create notes or store transcript records. Choose a dictation shortcut and an activation mode in Settings. Push-to-talk records while the shortcut is held and stops when it is released. Toggle starts or stops dictation each time the shortcut is pressed. OS Scribe transcribes the temporary m4a recording through the same Rust transcription provider used by note recording. On success, the helper temporarily places the transcript on the clipboard, activates the last focused external app, posts Cmd+V, and restores the previous clipboard when possible.
 
-Dictation requires Venice transcription. If `VENICE_API_KEY` is not visible to the Tauri process, dictation reports a configuration error. During development, put the key in `.env` or export it in the shell before running `pnpm tauri:dev`.
+Dictation requires a reachable Scribe API and a signed-in OS Accounts user.
+The selected transcription and cleanup models are executed server-side through
+Scribe API, so missing provider keys surface in the Scribe API logs rather than
+the desktop process.
 
 The default shortcut is bare `Fn`/Globe and the default activation mode is `Push-to-talk`. If macOS opens emoji, input-source, or system dictation UI when pressing Fn, set System Settings > Keyboard > "Press Fn key to" or "Press Globe key to" to `Do Nothing`. Settings records the shortcut you press, including bare `Fn`/Globe, `Fn+Space`, or another shortcut with Cmd, Ctrl, Opt, Shift, or Fn plus one supported non-modifier key. Push-to-talk for custom shortcuts depends on macOS exposing both key-down and key-up events for that shortcut.
 
 Manual validation:
 
-1. Launch with `VENICE_API_KEY` configured.
+1. Launch Scribe API with OS Accounts, OpenAI, and Venice env configured.
 2. Grant microphone and Accessibility permissions.
 3. Focus a text field in TextEdit, VS Code, or a browser.
 4. In Settings, press Change, record `Fn`/Globe, and choose `Push-to-talk`.

--- a/iac/phala/docker-compose.production.yml
+++ b/iac/phala/docker-compose.production.yml
@@ -6,19 +6,9 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
-    # Note: registry-auth env vars (DSTACK_DOCKER_REGISTRY,
-    # DSTACK_DOCKER_USERNAME, DSTACK_DOCKER_PASSWORD) are NOT declared
-    # here — dstack reads them from the CVM's sealed-env store at image-
-    # pull time, not from compose. Set them once per CVM via
-    # `phala envs encrypt + update`. Required only when the image is
-    # private; harmless to set when it's public.
-    #
-    # The Scribe and upstream secrets below must be supplied by the deploy
-    # environment. They intentionally fail compose rendering when unset so
-    # production cannot boot with empty auth/provider configuration.
+    # Registry auth and app/provider secrets are set directly on the Phala CVM
+    # via sealed env, not in GitHub Actions and not in this compose file.
+    # Keeping them out of `environment` avoids overriding sealed values with
+    # blanks during deploy.
     environment:
       RUST_LOG: scribe=warn,scribe_api=warn,scribe_services=warn,scribe_providers=warn,tower_http=warn
-      SCRIBE__OS_ACCOUNTS__API_URL: "${SCRIBE__OS_ACCOUNTS__API_URL:?set SCRIBE__OS_ACCOUNTS__API_URL}"
-      SCRIBE__OS_ACCOUNTS__APP_API_KEY: "${SCRIBE__OS_ACCOUNTS__APP_API_KEY:?set SCRIBE__OS_ACCOUNTS__APP_API_KEY}"
-      SCRIBE__UPSTREAMS__OPENAI__API_KEY: "${SCRIBE__UPSTREAMS__OPENAI__API_KEY:?set SCRIBE__UPSTREAMS__OPENAI__API_KEY}"
-      SCRIBE__UPSTREAMS__VENICE__API_KEY: "${SCRIBE__UPSTREAMS__VENICE__API_KEY:?set SCRIBE__UPSTREAMS__VENICE__API_KEY}"

--- a/iac/phala/docker-compose.production.yml
+++ b/iac/phala/docker-compose.production.yml
@@ -12,9 +12,13 @@ services:
     # pull time, not from compose. Set them once per CVM via
     # `phala envs encrypt + update`. Required only when the image is
     # private; harmless to set when it's public.
+    #
+    # The Scribe and upstream secrets below must be supplied by the deploy
+    # environment. They intentionally fail compose rendering when unset so
+    # production cannot boot with empty auth/provider configuration.
     environment:
       RUST_LOG: scribe=warn,scribe_api=warn,scribe_services=warn,scribe_providers=warn,tower_http=warn
-      SCRIBE__OS_ACCOUNTS__API_URL: ""
-      SCRIBE__OS_ACCOUNTS__APP_API_KEY: ""
-      SCRIBE__UPSTREAMS__OPENAI__API_KEY: ""
-      SCRIBE__UPSTREAMS__VENICE__API_KEY: ""
+      SCRIBE__OS_ACCOUNTS__API_URL: "${SCRIBE__OS_ACCOUNTS__API_URL:?set SCRIBE__OS_ACCOUNTS__API_URL}"
+      SCRIBE__OS_ACCOUNTS__APP_API_KEY: "${SCRIBE__OS_ACCOUNTS__APP_API_KEY:?set SCRIBE__OS_ACCOUNTS__APP_API_KEY}"
+      SCRIBE__UPSTREAMS__OPENAI__API_KEY: "${SCRIBE__UPSTREAMS__OPENAI__API_KEY:?set SCRIBE__UPSTREAMS__OPENAI__API_KEY}"
+      SCRIBE__UPSTREAMS__VENICE__API_KEY: "${SCRIBE__UPSTREAMS__VENICE__API_KEY:?set SCRIBE__UPSTREAMS__VENICE__API_KEY}"

--- a/iac/phala/docker-compose.staging.yml
+++ b/iac/phala/docker-compose.staging.yml
@@ -6,19 +6,9 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
-    # Note: registry-auth env vars (DSTACK_DOCKER_REGISTRY,
-    # DSTACK_DOCKER_USERNAME, DSTACK_DOCKER_PASSWORD) are NOT declared
-    # here — dstack reads them from the CVM's sealed-env store at image-
-    # pull time, not from compose. Set them once per CVM via
-    # `phala envs encrypt + update`. Required only when the image is
-    # private; harmless to set when it's public.
-    #
-    # The Scribe and upstream secrets below must be supplied by the deploy
-    # environment. They intentionally fail compose rendering when unset so
-    # staging cannot boot with empty auth/provider configuration.
+    # Registry auth and app/provider secrets are set directly on the Phala CVM
+    # via sealed env, not in GitHub Actions and not in this compose file.
+    # Keeping them out of `environment` avoids overriding sealed values with
+    # blanks during deploy.
     environment:
       RUST_LOG: scribe=info,scribe_api=info,scribe_services=info,scribe_providers=info,tower_http=info
-      SCRIBE__OS_ACCOUNTS__API_URL: "${SCRIBE__OS_ACCOUNTS__API_URL:?set SCRIBE__OS_ACCOUNTS__API_URL}"
-      SCRIBE__OS_ACCOUNTS__APP_API_KEY: "${SCRIBE__OS_ACCOUNTS__APP_API_KEY:?set SCRIBE__OS_ACCOUNTS__APP_API_KEY}"
-      SCRIBE__UPSTREAMS__OPENAI__API_KEY: "${SCRIBE__UPSTREAMS__OPENAI__API_KEY:?set SCRIBE__UPSTREAMS__OPENAI__API_KEY}"
-      SCRIBE__UPSTREAMS__VENICE__API_KEY: "${SCRIBE__UPSTREAMS__VENICE__API_KEY:?set SCRIBE__UPSTREAMS__VENICE__API_KEY}"

--- a/iac/phala/docker-compose.staging.yml
+++ b/iac/phala/docker-compose.staging.yml
@@ -12,9 +12,13 @@ services:
     # pull time, not from compose. Set them once per CVM via
     # `phala envs encrypt + update`. Required only when the image is
     # private; harmless to set when it's public.
+    #
+    # The Scribe and upstream secrets below must be supplied by the deploy
+    # environment. They intentionally fail compose rendering when unset so
+    # staging cannot boot with empty auth/provider configuration.
     environment:
       RUST_LOG: scribe=info,scribe_api=info,scribe_services=info,scribe_providers=info,tower_http=info
-      SCRIBE__OS_ACCOUNTS__API_URL: ""
-      SCRIBE__OS_ACCOUNTS__APP_API_KEY: ""
-      SCRIBE__UPSTREAMS__OPENAI__API_KEY: ""
-      SCRIBE__UPSTREAMS__VENICE__API_KEY: ""
+      SCRIBE__OS_ACCOUNTS__API_URL: "${SCRIBE__OS_ACCOUNTS__API_URL:?set SCRIBE__OS_ACCOUNTS__API_URL}"
+      SCRIBE__OS_ACCOUNTS__APP_API_KEY: "${SCRIBE__OS_ACCOUNTS__APP_API_KEY:?set SCRIBE__OS_ACCOUNTS__APP_API_KEY}"
+      SCRIBE__UPSTREAMS__OPENAI__API_KEY: "${SCRIBE__UPSTREAMS__OPENAI__API_KEY:?set SCRIBE__UPSTREAMS__OPENAI__API_KEY}"
+      SCRIBE__UPSTREAMS__VENICE__API_KEY: "${SCRIBE__UPSTREAMS__VENICE__API_KEY:?set SCRIBE__UPSTREAMS__VENICE__API_KEY}"

--- a/scribe-api/.env.example
+++ b/scribe-api/.env.example
@@ -7,6 +7,11 @@
 # field names stay literal (e.g. APP_API_KEY -> app_api_key).
 
 # --- OS Accounts ------------------------------------------------------------
+# OS Accounts API origin used for token verification and metering.
+# Local OS Accounts example: http://127.0.0.1:3000
+# Staging example: https://os-accounts-api-staging.up.railway.app
+SCRIBE__OS_ACCOUNTS__API_URL=http://127.0.0.1:3000
+
 # Per-app secret issued by the OS Accounts admin console. Server-side only —
 # never embed in the desktop binary or the root .env file.
 SCRIBE__OS_ACCOUNTS__APP_API_KEY=osk_REPLACE_ME
@@ -15,12 +20,10 @@ SCRIBE__OS_ACCOUNTS__APP_API_KEY=osk_REPLACE_ME
 # dictate). Skips per-request estimation entirely — the duration probe and
 # token pre-count are bypassed in favor of this single value. Trades a bigger
 # Hold for not needing to support every audio format the helper might produce.
-# Default: 20000.
-# SCRIBE__OS_ACCOUNTS__FLAT_ESTIMATE_CREDITS=20000
+# Default: 250.
+# SCRIBE__OS_ACCOUNTS__FLAT_ESTIMATE_CREDITS=250
 
-# --- Upstream providers (optional for local dev) ----------------------------
-# Required for /v1/notes/transcribe, /v1/dictate/transcribe etc. to actually
-# reach an upstream model. Without these, OS Accounts authorize succeeds but
-# the upstream step fails.
-# SCRIBE__UPSTREAMS__OPENAI__API_KEY=sk-...
-# SCRIBE__UPSTREAMS__VENICE__API_KEY=...
+# --- Upstream providers -----------------------------------------------------
+# Required when the configured pricing table exposes OpenAI/Venice models.
+SCRIBE__UPSTREAMS__OPENAI__API_KEY=sk_REPLACE_ME
+SCRIBE__UPSTREAMS__VENICE__API_KEY=VENICE_API_KEY_REPLACE_ME

--- a/scribe-api/crates/api/src/handlers/models.rs
+++ b/scribe-api/crates/api/src/handlers/models.rs
@@ -93,10 +93,10 @@ fn price_description(model: &ModelPriceConfig) -> String {
     match model.unit {
         scribe_config::PriceUnit::Seconds => format!(
             "{} per second audio",
-            model
-                .credits_per_million_seconds
-                .map(|credits| format_credits_as_usd_per_unit(credits, 1_000_000))
-                .unwrap_or_else(|| "$0.00".to_string())
+            model.credits_per_million_seconds.map_or_else(
+                || "$0.00".to_string(),
+                |credits| format_credits_as_usd_per_unit(credits, 1_000_000)
+            )
         ),
         scribe_config::PriceUnit::Tokens => format!(
             "{} input / {} output per 1M tokens",
@@ -107,14 +107,20 @@ fn price_description(model: &ModelPriceConfig) -> String {
 }
 
 fn format_credits_as_usd(credits: u64) -> String {
-    format!("${:.2}", credits as f64 / 1_000.0)
+    let cents = (u128::from(credits) + 5) / 10;
+    format!("${}.{:02}", cents / 100, cents % 100)
 }
 
 fn format_credits_as_usd_per_unit(credits: u64, units: u64) -> String {
-    let usd = credits as f64 / 1_000.0 / units as f64;
-    if usd >= 1.0 {
-        format!("${usd:.2}")
+    if units == 0 {
+        return "$0.00".to_string();
+    }
+    let micro_usd = (u128::from(credits) * 1_000 + (u128::from(units) / 2)) / u128::from(units);
+    if micro_usd >= 1_000_000 {
+        let cents = (micro_usd + 5_000) / 10_000;
+        format!("${}.{:02}", cents / 100, cents % 100)
     } else {
-        format!("${}", format!("{usd:.6}").trim_end_matches('0'))
+        let decimals = format!("{micro_usd:06}");
+        format!("$0.{}", decimals.trim_end_matches('0'))
     }
 }

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -36,11 +36,23 @@ pub fn router(state: ApiState) -> Router {
     Router::new()
         .route("/livez", get(handlers::health::livez))
         .route("/v1/models", get(handlers::models::list_models))
-        .route("/v1/notes/transcribe", post(handlers::notes::transcribe))
-        .route("/v1/notes/generate", post(handlers::notes::generate))
-        .route("/v1/dictate", post(handlers::dictate::transcribe))
-        .route("/v1/dictate/cleanup", post(handlers::dictate::cleanup))
-        .layer(DefaultBodyLimit::max(limits.max_audio_bytes))
+        .route(
+            "/v1/notes/transcribe",
+            post(handlers::notes::transcribe).layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
+        )
+        .route(
+            "/v1/notes/generate",
+            post(handlers::notes::generate).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
+        )
+        .route(
+            "/v1/dictate",
+            post(handlers::dictate::transcribe)
+                .layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
+        )
+        .route(
+            "/v1/dictate/cleanup",
+            post(handlers::dictate::cleanup).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
+        )
         .layer(timeout)
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::new())

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -38,7 +38,7 @@ async fn serve() -> anyhow::Result<()> {
     let address: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
     let http = default_client();
     let pricing = load_pricing(&config, http.clone()).await;
-    let app = build_router(&config, http, pricing);
+    let app = build_router(&config, &http, pricing);
     let listener = tokio::net::TcpListener::bind(address).await?;
     tracing::info!(%address, "scribe-api listening");
     axum::serve(listener, app).await?;
@@ -68,7 +68,7 @@ async fn load_pricing(
 
 fn build_router(
     config: &AppConfig,
-    http: reqwest::Client,
+    http: &reqwest::Client,
     pricing_config: BTreeMap<String, ModelPriceConfig>,
 ) -> axum::Router {
     let openai_model_ids = pricing_config

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -266,7 +266,7 @@ impl Default for AppConfig {
                 max_json_bytes: 524_288,
             },
             os_accounts: OsAccountsConfig {
-                api_url: "http://127.0.0.1:3000".to_string(),
+                api_url: String::new(),
                 app_api_key: String::new(),
                 iss: "os-accounts-dev".to_string(),
                 aud: "scribe-api-dev".to_string(),
@@ -297,6 +297,13 @@ impl Default for AppConfig {
 pub enum ConfigError {
     #[error(transparent)]
     Figment(#[from] Box<figment::Error>),
+    #[error("missing required config `{field}`")]
+    MissingRequired { field: &'static str },
+    #[error("invalid required config `{field}`: {reason}")]
+    InvalidRequired {
+        field: &'static str,
+        reason: &'static str,
+    },
     #[error("invalid pricing for model `{model}`: {reason}")]
     InvalidPricing { model: String, reason: String },
 }
@@ -314,6 +321,44 @@ pub fn load() -> Result<AppConfig, ConfigError> {
 }
 
 fn validate(config: &AppConfig) -> Result<(), ConfigError> {
+    validate_required_text("os_accounts.api_url", &config.os_accounts.api_url)?;
+    validate_required_secret(
+        "os_accounts.app_api_key",
+        &config.os_accounts.app_api_key,
+        "osk_REPLACE_ME",
+    )?;
+
+    let uses_openai = config
+        .pricing
+        .values()
+        .any(|pricing| pricing.provider == ModelProvider::Openai);
+    let uses_venice = config
+        .pricing
+        .values()
+        .any(|pricing| pricing.provider == ModelProvider::Venice);
+    if uses_openai {
+        validate_required_text(
+            "upstreams.openai.base_url",
+            &config.upstreams.openai.base_url,
+        )?;
+        validate_required_secret(
+            "upstreams.openai.api_key",
+            &config.upstreams.openai.api_key,
+            "sk_REPLACE_ME",
+        )?;
+    }
+    if uses_venice {
+        validate_required_text(
+            "upstreams.venice.base_url",
+            &config.upstreams.venice.base_url,
+        )?;
+        validate_required_secret(
+            "upstreams.venice.api_key",
+            &config.upstreams.venice.api_key,
+            "VENICE_API_KEY_REPLACE_ME",
+        )?;
+    }
+
     for (model_id, pricing) in &config.pricing {
         let expected_unit = match pricing.model_type {
             ModelType::Asr => PriceUnit::Seconds,
@@ -355,6 +400,28 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
+fn validate_required_text(field: &'static str, value: &str) -> Result<(), ConfigError> {
+    if value.trim().is_empty() {
+        return Err(ConfigError::MissingRequired { field });
+    }
+    Ok(())
+}
+
+fn validate_required_secret(
+    field: &'static str,
+    value: &str,
+    placeholder: &'static str,
+) -> Result<(), ConfigError> {
+    validate_required_text(field, value)?;
+    if value.trim() == placeholder {
+        return Err(ConfigError::InvalidRequired {
+            field,
+            reason: "placeholder value must be replaced",
+        });
+    }
+    Ok(())
+}
+
 fn validate_positive_rate(
     model_id: &str,
     value: Option<u64>,
@@ -374,6 +441,15 @@ mod tests {
     use super::{AppConfig, ModelPriceConfig, ModelProvider, ModelType, PriceUnit, validate};
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
+
+    fn valid_config() -> AppConfig {
+        let mut config = AppConfig::default();
+        config.os_accounts.api_url = "http://127.0.0.1:3000".to_string();
+        config.os_accounts.app_api_key = "osk_test".to_string();
+        config.upstreams.openai.api_key = "sk-test".to_string();
+        config.upstreams.venice.api_key = "venice-test".to_string();
+        config
+    }
 
     #[test]
     fn config_debug_redacts_secrets() {
@@ -414,7 +490,7 @@ mod tests {
         );
         let config = AppConfig {
             pricing,
-            ..AppConfig::default()
+            ..valid_config()
         };
 
         let result = validate(&config);
@@ -445,7 +521,7 @@ mod tests {
         );
         let config = AppConfig {
             pricing,
-            ..AppConfig::default()
+            ..valid_config()
         };
 
         let result = validate(&config);
@@ -454,7 +530,27 @@ mod tests {
     }
 
     #[test]
-    fn validate_passes_for_default() {
-        assert_eq!(validate(&AppConfig::default()).is_ok(), true);
+    fn validate_passes_for_complete_config() {
+        assert_eq!(validate(&valid_config()).is_ok(), true);
+    }
+
+    #[test]
+    fn validate_rejects_missing_os_accounts_key() {
+        let mut config = valid_config();
+        config.os_accounts.app_api_key = String::new();
+
+        let result = validate(&config);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_provider_placeholder_key() {
+        let mut config = valid_config();
+        config.upstreams.venice.api_key = "VENICE_API_KEY_REPLACE_ME".to_string();
+
+        let result = validate(&config);
+
+        assert!(result.is_err());
     }
 }

--- a/scribe-api/crates/providers/src/venice.rs
+++ b/scribe-api/crates/providers/src/venice.rs
@@ -542,9 +542,15 @@ fn credits_per_million_seconds(usd_per_second: f64) -> Option<u64> {
 }
 
 fn ceil_positive_u64(value: f64) -> Option<u64> {
-    if !value.is_finite() || value <= 0.0 || value > u64::MAX as f64 {
+    const MAX_EXACT_U64_AS_F64: f64 = 18_446_744_073_709_551_615.0;
+    if !value.is_finite() || value <= 0.0 || value > MAX_EXACT_U64_AS_F64 {
         return None;
     }
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "value is finite, positive, bounded, and explicitly rounded up"
+    )]
     Some(value.ceil() as u64)
 }
 
@@ -562,7 +568,7 @@ fn collect_capability_names(value: &serde_json::Value, prefix: &str, names: &mut
     };
     for (key, value) in map {
         let name = if prefix.is_empty() {
-            key.to_string()
+            key.clone()
         } else {
             format!("{prefix}.{key}")
         };

--- a/scribe-api/crates/services/src/charge_flow.rs
+++ b/scribe-api/crates/services/src/charge_flow.rs
@@ -86,54 +86,6 @@ pub(crate) async fn charge(params: ChargeParams<'_>) -> Result<Receipt, ServiceE
         .map_err(ServiceError::from)
 }
 
-pub(crate) struct AsyncAuthorizeAndChargeParams {
-    pub os_accounts: std::sync::Arc<dyn OsAccountsClient>,
-    pub user_id: UserId,
-    pub action: ActionSlug,
-    pub estimate: Credits,
-    pub hold_ttl_seconds: u64,
-    pub actual: Credits,
-    pub idempotency_key_parts: Vec<String>,
-}
-
-pub(crate) fn spawn_authorize_and_charge(params: AsyncAuthorizeAndChargeParams) {
-    tokio::spawn(async move {
-        let outcome = match authorize_or_deny(AuthorizeParams {
-            os_accounts: params.os_accounts.as_ref(),
-            user_id: params.user_id.clone(),
-            action: params.action,
-            estimate: params.estimate,
-            hold_ttl_seconds: params.hold_ttl_seconds,
-        })
-        .await
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                tracing::warn!(
-                    user_id = %params.user_id.0,
-                    action = params.action.as_str(),
-                    error = %error,
-                    "async metering authorize failed"
-                );
-                return;
-            }
-        };
-        settle_charge(AsyncChargeParams {
-            os_accounts: params.os_accounts,
-            user_id: params.user_id,
-            action: params.action,
-            model_id: None,
-            action_token: outcome.action_token.clone(),
-            credits: clamp_to_cap(params.actual, outcome.cap_credits),
-            idempotency_key: async_idempotency_key(
-                params.idempotency_key_parts,
-                &outcome.action_token,
-            ),
-        })
-        .await;
-    });
-}
-
 pub(crate) struct AsyncChargeParams {
     pub os_accounts: std::sync::Arc<dyn OsAccountsClient>,
     pub user_id: UserId,
@@ -179,11 +131,6 @@ async fn settle_charge(params: AsyncChargeParams) {
         idempotent_replay = receipt.idempotent_replay,
         "settled async metered request"
     );
-}
-
-fn async_idempotency_key(mut parts: Vec<String>, action_token: &str) -> String {
-    parts.push(action_token.to_string());
-    parts.join(":")
 }
 
 pub(crate) fn log_settled(action: ActionSlug, user_id: &UserId, model_id: &str, receipt: &Receipt) {

--- a/scribe-api/crates/services/src/dictate.rs
+++ b/scribe-api/crates/services/src/dictate.rs
@@ -1,7 +1,6 @@
 use crate::{
     charge_flow::{
-        AsyncAuthorizeAndChargeParams, AsyncChargeParams, AuthorizeParams, authorize_or_deny,
-        clamp_to_cap, spawn_authorize_and_charge, spawn_charge,
+        AsyncChargeParams, AuthorizeParams, authorize_or_deny, clamp_to_cap, spawn_charge,
     },
     error::ServiceError,
     pricing::PricingTable,
@@ -82,11 +81,9 @@ impl DictateService {
             })
             .await?;
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
-        // Include the action token so retries get a fresh key — see the
-        // matching comment in note_transcribe.rs.
         let idempotency_key = format!(
-            "dictate_transcribe:{}:{}:{}:{}",
-            params.user_id.0, params.session_id, params.utterance_id, authorization.action_token
+            "dictate_transcribe:{}:{}:{}",
+            params.user_id.0, params.session_id, params.utterance_id
         );
         let receipt = pending_receipt();
         spawn_charge(AsyncChargeParams {
@@ -108,6 +105,14 @@ impl DictateService {
         &self,
         params: DictateCleanupParams,
     ) -> Result<DictateCleanupOutput, ServiceError> {
+        let authorization = authorize_or_deny(AuthorizeParams {
+            os_accounts: self.os_accounts.as_ref(),
+            user_id: params.user_id.clone(),
+            action: ActionSlug::DictateCleanup,
+            estimate: Credits(self.flat_estimate_credits),
+            hold_ttl_seconds: self.cleanup_hold_ttl_seconds,
+        })
+        .await?;
         let cleaned = self
             .cleaner
             .cleanup(CleanupRequest {
@@ -122,19 +127,17 @@ impl DictateService {
             .pricing
             .price_token_usage(&params.model_id.0, cleaned.usage)?;
         let receipt = pending_receipt();
-        spawn_authorize_and_charge(AsyncAuthorizeAndChargeParams {
+        spawn_charge(AsyncChargeParams {
             os_accounts: self.os_accounts.clone(),
             user_id: params.user_id.clone(),
             action: ActionSlug::DictateCleanup,
-            estimate: Credits(self.flat_estimate_credits),
-            hold_ttl_seconds: self.cleanup_hold_ttl_seconds,
-            actual,
-            idempotency_key_parts: vec![
-                "dictate_cleanup".to_string(),
-                params.user_id.0.clone(),
-                params.session_id.clone(),
-                params.utterance_id.clone(),
-            ],
+            model_id: Some(params.model_id.0.clone()),
+            action_token: authorization.action_token,
+            credits: clamp_to_cap(actual, authorization.cap_credits),
+            idempotency_key: format!(
+                "dictate_cleanup:{}:{}:{}",
+                params.user_id.0, params.session_id, params.utterance_id
+            ),
         });
         Ok(DictateCleanupOutput { cleaned, receipt })
     }

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
                 RecordedCall::Charge {
                     action_token: "agt_test".to_string(),
                     credits: 40,
-                    idempotency_key: "note_generate:usr_123:note_1:v7:agt_test".to_string(),
+                    idempotency_key: "note_generate:usr_123:note_1:v7".to_string(),
                 },
             ]
         );
@@ -146,10 +146,7 @@ mod tests {
         let charge_call = wait_for_charge_idempotency_key(&os_accounts)
             .await
             .unwrap_or_default();
-        assert_eq!(
-            charge_call,
-            "dictate_cleanup:usr_123:session_1:utt_2:agt_test"
-        );
+        assert_eq!(charge_call, "dictate_cleanup:usr_123:session_1:utt_2");
     }
 
     #[tokio::test]
@@ -196,7 +193,7 @@ mod tests {
         );
         assert_eq!(
             wait_for_charge_idempotency_key(&os_accounts).await,
-            Some("dictate_transcribe:usr_123:session_1:utt_2:agt_test".to_string())
+            Some("dictate_transcribe:usr_123:session_1:utt_2".to_string())
         );
     }
 

--- a/scribe-api/crates/services/src/note_generate.rs
+++ b/scribe-api/crates/services/src/note_generate.rs
@@ -70,11 +70,9 @@ impl NoteGenerateService {
             .pricing
             .price_token_usage(&params.model_id.0, generated.usage)?;
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
-        // Include the action token so retries get a fresh key — see the
-        // matching comment in note_transcribe.rs.
         let idempotency_key = format!(
-            "note_generate:{}:{}:{}:{}",
-            params.user_id.0, params.note_id, params.prompt_version, authorization.action_token
+            "note_generate:{}:{}:{}",
+            params.user_id.0, params.note_id, params.prompt_version
         );
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -102,14 +102,7 @@ impl NoteTranscribeService {
             "note_transcribe: transcriber returned"
         );
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
-        // Include the per-authorize action token so retries (which mint a
-        // fresh token) get a fresh key. Without this, a retry collides with
-        // the previous attempt's key + different token and OS Accounts
-        // returns 4001 idempotency_key_collision.
-        let idempotency_key = format!(
-            "note_transcribe:{}:{}:{}",
-            params.user_id.0, params.note_id, authorization.action_token
-        );
+        let idempotency_key = format!("note_transcribe:{}:{}", params.user_id.0, params.note_id);
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
             action_token: authorization.action_token,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "OS Scribe"
 authors = ["Open Software Network"]
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.80.0"
 
 [lib]
 name = "os_scribe_lib"

--- a/src-tauri/capabilities/hud.json
+++ b/src-tauri/capabilities/hud.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "hud",
+  "description": "Dictation HUD access to only the Tauri APIs used by the overlay.",
+  "windows": ["hud"],
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+    "core:window:allow-hide",
+    "core:window:allow-show",
+    "core:window:allow-start-dragging"
+  ]
+}

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "main",
   "description": "Main window access to scoped OS Scribe commands.",
-  "windows": ["main", "hud"],
+  "windows": ["main"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -167,7 +167,7 @@ pub fn start_capture(
             &config.clone().into(),
             move |data: &[f32], _| {
                 write_input_data(
-                    data.iter().map(|sample| *sample),
+                    data.iter().copied(),
                     &writer_for_callback,
                     &stats_for_callback,
                     &paused_for_callback,

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -185,7 +185,7 @@ pub fn system_audio_readiness() -> SourceReadinessDto {
     #[cfg(target_os = "macos")]
     {
         let capture_available = macos_version_supports_system_audio() && helper_app_path().exists();
-        return SourceReadinessDto {
+        SourceReadinessDto {
             source: RecordingSource::System,
             required: true,
             ready: capture_available,
@@ -209,7 +209,7 @@ pub fn system_audio_readiness() -> SourceReadinessDto {
                         .to_string(),
                 )
             },
-        };
+        }
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -235,8 +235,7 @@ pub fn helper_permission_check() -> Result<(), AppError> {
         ));
     }
     terminate_existing_helpers();
-    let temp =
-        std::env::temp_dir().join(format!("os-scribe-audio-check-{}", uuid::Uuid::new_v4()));
+    let temp = std::env::temp_dir().join(format!("os-scribe-audio-check-{}", uuid::Uuid::new_v4()));
     let output_path = temp.with_extension("wav");
     let status_path = temp.with_extension("json");
     let pid_path = temp.with_extension("pid");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -166,10 +166,10 @@ pub async fn rename_folder(
             "Folder name is required.",
         ));
     }
-    Ok(repositories(&app)
+    repositories(&app)
         .await?
         .rename_folder(&request.folder_id, name, request.description.as_deref())
-        .await?)
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -833,6 +833,7 @@ impl Repositories {
         Ok(row.map(|row| RecordingSourceMode::from(row.get::<String, _>("source_mode").as_str())))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_recording_session(
         &self,
         session_id: &str,
@@ -1000,6 +1001,7 @@ impl Repositories {
             .collect())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn finalize_source_artifact(
         &self,
         artifact_id: &str,
@@ -1269,6 +1271,7 @@ impl Repositories {
         Ok(transcript)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_source_transcript(
         &self,
         note_id: &str,

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -630,10 +630,13 @@ fn cursor_position_via_cg() -> Option<(f64, f64)> {
     }
 
     #[link(name = "CoreGraphics", kind = "framework")]
-    #[link(name = "CoreFoundation", kind = "framework")]
     extern "C" {
         fn CGEventCreate(source: *const std::ffi::c_void) -> *mut std::ffi::c_void;
         fn CGEventGetLocation(event: *const std::ffi::c_void) -> CGPoint;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
         fn CFRelease(cf: *const std::ffi::c_void);
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -187,6 +187,7 @@ pub fn manual_notes_for_generation(note: &NoteDto) -> Option<String> {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn process_saved_audio(
     repos: &Repositories,
     note_id: &str,
@@ -287,6 +288,7 @@ pub async fn process_saved_audio(
         .await?)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn process_saved_source_audio(
     repos: &Repositories,
     note_id: &str,

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -488,17 +488,12 @@ impl From<&str> for ProcessingStatus {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum RecordingSourceMode {
+    #[default]
     MicrophoneOnly,
     MicrophonePlusSystem,
-}
-
-impl Default for RecordingSourceMode {
-    fn default() -> Self {
-        Self::MicrophoneOnly
-    }
 }
 
 impl RecordingSourceMode {

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -4,20 +4,17 @@
 //! Scribe API, which holds the App API key — never this binary.
 
 use crate::domain::types::AppError;
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{
-    sync::OnceLock,
-    time::Duration,
-};
+use std::{sync::OnceLock, time::Duration};
+use tokio::sync::Mutex as AsyncMutex;
 #[cfg(debug_assertions)]
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
 };
-use tokio::sync::Mutex as AsyncMutex;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const DEFAULT_LOOPBACK_PORT: u16 = 8765;
@@ -35,6 +32,7 @@ const OAUTH_SCOPES: &str = "profile:read billing:read credits:spend";
 const KEYCHAIN_SERVICE: &str = "co.opensoftware.accounts";
 const KEYCHAIN_USER: &str = "tokens";
 const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
+#[cfg(debug_assertions)]
 const SOCKET_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const ERR_TOKEN_EXPIRED: i64 = 3001;
@@ -147,9 +145,7 @@ impl Config {
     }
 
     fn configured(&self) -> bool {
-        !self.accounts_url.is_empty()
-            && !self.api_url.is_empty()
-            && !self.client_id.is_empty()
+        !self.accounts_url.is_empty() && !self.api_url.is_empty() && !self.client_id.is_empty()
     }
 
     /// Where OS Accounts redirects after the user signs in. Dev builds use a
@@ -160,7 +156,7 @@ impl Config {
     fn redirect_uri(&self) -> String {
         #[cfg(debug_assertions)]
         {
-            return format!("http://127.0.0.1:{}/callback", self.loopback_port);
+            format!("http://127.0.0.1:{}/callback", self.loopback_port)
         }
         #[cfg(not(debug_assertions))]
         {
@@ -342,9 +338,7 @@ pub fn setup_deep_link(app: &tauri::App) {
         // an unrelated webpage drain the one-shot. CSRF would still reject
         // downstream, but tightening the gate here keeps the in-flight
         // login intact when a stray URL fires the handler.
-        if url.scheme() != "osscribe"
-            || url.host_str() != Some("auth")
-            || url.path() != "/callback"
+        if url.scheme() != "osscribe" || url.host_str() != Some("auth") || url.path() != "/callback"
         {
             return;
         }
@@ -355,11 +349,7 @@ pub fn setup_deep_link(app: &tauri::App) {
         // Extract the sender into an owned `Option` so the MutexGuard is
         // dropped before `flow` falls out of scope at the closure's end —
         // avoids an E0597 drop-order race on the temporary if-let.
-        let tx = flow
-            .callback
-            .lock()
-            .ok()
-            .and_then(|mut slot| slot.take());
+        let tx = flow.callback.lock().ok().and_then(|mut slot| slot.take());
         if let Some(tx) = tx {
             let _ = tx.send(url_str);
         }
@@ -669,9 +659,7 @@ fn access_token_is_stale(jwt: &str) -> bool {
         return false;
     };
     use base64::Engine as _;
-    let Ok(decoded) =
-        base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload)
-    else {
+    let Ok(decoded) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload) else {
         return false;
     };
     let Ok(claims) = serde_json::from_slice::<serde_json::Value>(&decoded) else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,8 +43,8 @@
       }
     ],
     "security": {
-      "csp": null,
-      "capabilities": ["main"]
+      "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+      "capabilities": ["main", "hud"]
     }
   },
   "plugins": {

--- a/src-tauri/tests/source_readiness.rs
+++ b/src-tauri/tests/source_readiness.rs
@@ -1,6 +1,4 @@
-use os_scribe_lib::{
-    audio::system_macos::system_audio_readiness, domain::types::RecordingSource,
-};
+use os_scribe_lib::{audio::system_macos::system_audio_readiness, domain::types::RecordingSource};
 
 #[test]
 fn system_audio_readiness_reports_system_source() {

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -222,8 +222,7 @@ export function NoteEditor({
                   {processingText ??
                     (note.processingStatus === "failed"
                       ? "No transcript was produced."
-                      : (note.lastError ??
-                        "No transcript is available yet."))}
+                      : (note.lastError ?? "No transcript is available yet."))}
                 </p>
               </div>
             )}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -440,10 +440,7 @@ export function AppSettings({
         onRefresh={onAccountRefresh}
       />
 
-      <section
-        className="settings-group"
-        aria-labelledby="appearance-heading"
-      >
+      <section className="settings-group" aria-labelledby="appearance-heading">
         <h2 id="appearance-heading" className="settings-group-heading">
           Appearance
         </h2>

--- a/src/components/ui/InlineNotice.tsx
+++ b/src/components/ui/InlineNotice.tsx
@@ -38,9 +38,7 @@ export function InlineNotice({
         </span>
         <span className="inline-notice-body">{body}</span>
       </p>
-      {actions ? (
-        <div className="inline-notice-actions">{actions}</div>
-      ) : null}
+      {actions ? <div className="inline-notice-actions">{actions}</div> : null}
     </section>
   );
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -46,7 +46,10 @@ export function initTheme() {
 
 function resolveTheme(theme: ThemePreference): ResolvedTheme {
   if (theme === "light" || theme === "dark") return theme;
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
     return "light";
   }
   return window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -56,7 +59,10 @@ function resolveTheme(theme: ThemePreference): ResolvedTheme {
 
 function attachSystemListener() {
   if (systemListener) return;
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
     return;
   }
   systemMedia = window.matchMedia("(prefers-color-scheme: dark)");

--- a/src/test/recovery.test.tsx
+++ b/src/test/recovery.test.tsx
@@ -35,5 +35,4 @@ describe("NoteRecoveryPrompt", () => {
     expect(onRecover).toHaveBeenCalledWith("session-1");
     expect(onDiscard).toHaveBeenCalledWith("session-1");
   });
-
 });


### PR DESCRIPTION
## Summary
- make metering idempotency deterministic and gate dictation cleanup before provider work
- fail fast on missing Scribe API secrets at backend startup while keeping app/provider secrets managed directly by Phala sealed env
- add Tauri CSP/HUD capability split, DMG signing secret checks, and refresh public env docs
- fix Rust/Prettier issues surfaced during release review

## Verification
- pnpm lint
- pnpm test
- pnpm build
- pnpm format
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- cargo +1.95.0 test --manifest-path scribe-api/Cargo.toml --workspace --locked
- cargo +1.95.0 clippy --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- -D warnings
- cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
- cargo +1.95.0 fmt --manifest-path scribe-api/Cargo.toml --all -- --check
- pnpm tauri build --bundles app
- SCRIBE_IMAGE=test docker compose -f iac/phala/docker-compose.staging.yml config
- SCRIBE_IMAGE=test docker compose -f iac/phala/docker-compose.production.yml config