### PR TITLE
fix(ci): build a pullable plain-image digest for the TEE (drop provenance/SBOM)

### DIFF
--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -62,8 +62,14 @@ jobs:
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha,scope=scribe-api
           cache-to: type=gha,scope=scribe-api,mode=max
-          provenance: true
-          sbom: true
+          # No provenance/SBOM attestations: they make build.outputs.digest an OCI
+          # *index* (image + attestation manifests) that dstack cannot pull by
+          # digest at CVM image-pull time. Disabling them yields a plain single-arch
+          # image manifest whose digest is pullable AND is what the TEE attestation
+          # binds — and it keeps the door open to reproducible (rebuild-and-verify)
+          # digests, the trust model we actually want. We consume neither attestation.
+          provenance: false
+          sbom: false
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Problem

After PR #42 fixed the deploy probe, the staging CVM failed at dstack's image-pull with a misleading `GHCR pull access denied`. The credentials were fine (a local `docker login` + pull succeeded); the real cause is the **reference form**.

The build runs with `provenance: true` + `sbom: true`, so `build.outputs.digest` is the digest of an **OCI image *index*** — `[linux/amd64 image] + [SLSA provenance] + [SBOM]` attestation manifests. The composite deploys by that index digest (`IMAGE@${digest}`). dstack can't resolve a runnable image from an attestation-bearing index *by digest*, and surfaces it as "access denied." (Pulling by **tag** works because tag→index→normal platform selection — which is the manual cloud workaround currently keeping staging alive, and which the next `main` push would clobber.)

## Fix

`provenance: false` + `sbom: false`. The single-arch build then pushes a **plain image manifest**, so `build.outputs.digest` is the image content digest — pullable by dstack, immutable, and the thing the TEE attestation binds (dstack measures the compose, which pins this digest).

No image-ref changes needed: staging already deploys `build.outputs.digest`, and `promote-scribe-api.yml` resolves `imagetools inspect .Manifest.digest`, which for a plain image is the image digest. Both now pin a pullable content digest.

## Why drop the attestations

We consume neither: no provenance-verification gate, no SBOM scanner. They only created the unpullable index. The verifiability goal is **"rebuild this image from public source and check its hash against the TEE attestation"** (reproducible builds — a *stronger*, trustless guarantee than CI-signed provenance), and a plain reproducible image digest is exactly what that needs. Re-adding either is a one-line flag if a compliance need appears later.

## Verification

- YAML parses; build step now `provenance=false sbom=false`.
- After merge: staging deploy should pull by digest and the CVM should boot. Will confirm on the triggered run.

Follow-up (separate): make the build deterministic so the digest is reproducible from git, delivering the README trust claim in #36. Scoped separately.