### PR TITLE
fix(ci): deploy Phala CVM by per-commit tag (dstack can't parse digest refs)

### DIFF
--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -91,5 +91,9 @@ jobs:
         with:
           cvm-name: os-scribe-api-staging
           compose-file: iac/phala/docker-compose.staging.yml
-          image-ref: ${{ env.IMAGE }}@${{ needs.build.outputs.digest }}
+          # Pin by per-commit tag, not @digest: dstack's GHCR prelaunch verify
+          # parses image refs as repo:tag and mangles repo@sha256:digest (cuts at
+          # the ':' in sha256:), so any digest ref 404s and the CVM never boots.
+          # The sha_short tag is unique per commit and pullable by that verifier.
+          image-ref: ${{ env.IMAGE }}:${{ needs.build.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -99,7 +99,10 @@ jobs:
         with:
           cvm-name: os-scribe-api-production
           compose-file: iac/phala/docker-compose.production.yml
-          image-ref: ${{ env.IMAGE }}@${{ steps.image.outputs.digest }}
+          # Pin by per-commit tag, not @digest: dstack's GHCR prelaunch verify
+          # mangles repo@sha256:digest refs (cuts at the ':' in sha256:) → 404 →
+          # CVM never boots. The sha_short tag is resolved above and pullable.
+          image-ref: ${{ env.IMAGE }}:${{ steps.image.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
 
       - name: Retag digest as :production


### PR DESCRIPTION
## Root cause (the real one)

The staging CVM kept failing to boot — first "GHCR pull access denied", then HTTP 404 after #44 — and `--wait` timed out with `status=stopped`. CVM logs showed the credentials are fine:

```
Docker login successful: ghcr.io
Verifying GHCR pull access: ...@sha256:f9321731...
ERROR: GHCR pull access denied ...@sha256:f9321731... (HTTP 404)
```

The failure is in **dstack's stock prelaunch verify** ([`Dstack-TEE/dstack-examples` `prelaunch.sh`](https://github.com/Dstack-TEE/dstack-examples/blob/main/phala-cloud-prelaunch-script/prelaunch.sh), lines 158-170):

```sh
repo="${img#ghcr.io/}"; repo="${repo%%:*}"   # cuts at FIRST ':'
tag="${img##*:}"                              # after LAST ':'
curl ... "https://ghcr.io/v2/${repo}/manifests/${tag}"
```

For `…/scribe-api@sha256:f9321731…` this yields `repo=…/scribe-api@sha256` and `tag=f9321731…` → malformed manifest URL → **404** → `exit 1` → CVM never boots. It only handles `repo:tag`, never `repo@sha256:digest`. (The `Accept` header is fine; this is pure ref-parsing.) Both prior failures were this same bug — auth, image, and #44 were never wrong.

## Fix

Deploy by the per-commit **tag** `:${sha_short}` (which dstack's verify parses correctly) instead of `@${digest}`, for both staging and production. This is exactly the manual cloud workaround that was keeping staging alive, made durable.

- `build-scribe-api.yml`: `IMAGE:${{ needs.build.outputs.sha_short }}`
- `promote-scribe-api.yml`: `IMAGE:${{ steps.image.outputs.sha_short }}` (already resolves sha_short)

## TEE-proof note

Pinning a content digest in the compose would be the cleaner attestation anchor, but it's blocked by the upstream bug above. The `sha_short` tag is unique per commit and we control the registry, so the chain still holds via one extra hop (attested tag → registry digest → reproducible build of that commit). Reclaiming digest-in-compose requires a patched prelaunch script (or an upstream dstack fix) — tracked in the reproducible-builds plan (#45). Worth reporting upstream to Phala/dstack regardless.

## Verification

- Both workflows parse; image-refs now use `:sha_short`.
- After merge: staging deploy should pull by tag and the CVM should boot. Will confirm on the triggered run.