### PR TITLE
build: deterministic scribe-api image (reproducible builds — Phase A)

### DIFF
--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -35,8 +35,11 @@ jobs:
       - name: Compute metadata
         id: meta
         run: |
-          sha_short=$(git rev-parse --short=7 HEAD)
-          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+          # Reproducibility: derive timestamps from the commit, not build time,
+          # so a rebuild of the same commit yields the same image bytes.
+          echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
+          echo "created=$(git log -1 --pretty=%cI)" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -49,17 +52,20 @@ jobs:
       - name: Build and push
         id: build
         uses: docker/build-push-action@v6
+        env:
+          # Normalizes layer/file timestamps to the commit time (with
+          # rewrite-timestamp below) so the image digest is reproducible.
+          SOURCE_DATE_EPOCH: ${{ steps.meta.outputs.epoch }}
         with:
           context: scribe-api
           file: scribe-api/Dockerfile
-          push: true
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.meta.outputs.sha_short }}
-            ${{ env.IMAGE }}:staging
+          # `outputs` (not push:+tags:) so we can pass rewrite-timestamp, which
+          # applies SOURCE_DATE_EPOCH to layer timestamps. Pushes both tags.
+          outputs: type=image,"name=${{ env.IMAGE }}:${{ steps.meta.outputs.sha_short }},${{ env.IMAGE }}:staging",push=true,rewrite-timestamp=true
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
           cache-from: type=gha,scope=scribe-api
           cache-to: type=gha,scope=scribe-api,mode=max
           # No provenance/SBOM attestations: they make build.outputs.digest an OCI

--- a/scribe-api/Dockerfile
+++ b/scribe-api/Dockerfile
@@ -1,4 +1,6 @@
-FROM rust:1.95-bookworm AS chef
+# Base images pinned by digest for reproducible builds. Bump deliberately;
+# resolve a new digest with `docker buildx imagetools inspect <image:tag>`.
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS chef
 RUN cargo install cargo-chef --locked --version 0.1.77
 WORKDIR /app
 
@@ -7,16 +9,20 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+# Deterministic codegen: remap absolute build paths out of the binary and
+# disable incremental artifacts. (strip + codegen-units=1 live in Cargo.toml.)
+ENV CARGO_INCREMENTAL=0 \
+    RUSTFLAGS="--remap-path-prefix=/app=. --remap-path-prefix=/usr/local/cargo=/cargo"
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin scribe
 
-FROM debian:bookworm-slim AS runtime
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin scribe
+FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS runtime
+# CA bundle copied from the pinned builder base instead of apt-installed:
+# removes the only build-time network fetch and its version drift.
+RUN useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin scribe
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 WORKDIR /app
 COPY --from=builder /app/target/release/scribe /usr/local/bin/scribe
 COPY config.toml /app/config.toml


### PR DESCRIPTION
Phase A of the reproducible-builds plan (#45): make the `scribe-api` image bytes a deterministic function of the source, so anyone can rebuild a commit and get the same digest to check against the TEE attestation.

## Changes
- **Pin base images by digest** — `rust:1.95-bookworm@sha256:6258907…`, `debian:bookworm-slim@sha256:0104b33…` (resolved from Docker Hub; bump deliberately).
- **Strip absolute build paths** — `RUSTFLAGS=--remap-path-prefix=/app=. --remap-path-prefix=/usr/local/cargo=/cargo` + `CARGO_INCREMENTAL=0` in the builder stage.
- **CA bundle by copy, not apt** — `COPY --from=builder /etc/ssl/certs/ca-certificates.crt …` removes the only build-time network fetch and its version drift.
- **Commit-derived timestamps** — `SOURCE_DATE_EPOCH` (= `git log -1 %ct`) + buildkit `rewrite-timestamp=true`, and the `created` label now uses `git log -1 %cI` instead of `github.event.head_commit.timestamp` (which is push-only and non-deterministic on `workflow_dispatch`).

Already in the repo (not touched): `rust-toolchain.toml` (`1.95.0`), and `[profile.release]` with `codegen-units = 1` + `strip = true`.

## Risk / validation ⚠️
I can't run Docker/CI locally, so this **needs a CI build to validate**:
1. It still **compiles** (Dockerfile changes — esp. the `outputs:` form replacing `push:`/`tags:`, and the cert COPY path).
2. It actually **reproduces** — that's Phase B (a double-build + `diffoci` job), not proven here.

The `outputs: type=image,…,rewrite-timestamp=true` line is the most likely to need tweaking; it follows Docker's documented reproducible-build recipe. `build.outputs.digest` is still emitted (deploy is by tag, so it's informational).

## Not in scope
- Phase B (verify script + double-build CI guard) — follow-up.
- Digest-in-compose / prelaunch (anchor "c") — separate investigation.