### PR TITLE
ci: record deployed image digest as a git tag (reproducibility anchor b)

### DIFF
--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -85,9 +85,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: staging
+    # contents: write lets the post-deploy step push the digest-record git tag
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/phala-deploy
+      - id: deploy
+        uses: ./.github/actions/phala-deploy
         with:
           cvm-name: os-scribe-api-staging
           compose-file: iac/phala/docker-compose.staging.yml
@@ -97,3 +101,23 @@ jobs:
           # The sha_short tag is unique per commit and pullable by that verifier.
           image-ref: ${{ env.IMAGE }}:${{ needs.build.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
+
+      # Anchor "b": record that commit <sha> deployed image digest <D> as an
+      # annotated git tag. Gives a verifier an in-repo, immutable link from the
+      # attested tag to a content digest, without trusting the registry's
+      # tag→digest mapping. (Pairs with reproducible builds: rebuild <sha> → D.)
+      - name: Record deployed digest
+        if: steps.deploy.outputs.deployed == 'true'
+        env:
+          DIGEST: ${{ needs.build.outputs.digest }}
+          IMG: ${{ env.IMAGE }}:${{ needs.build.outputs.sha_short }}
+          SHA_SHORT: ${{ needs.build.outputs.sha_short }}
+          FULL_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tag="deploy/staging/${SHA_SHORT}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$tag" -m "staging deploy: ${IMG} = ${DIGEST} (commit ${FULL_SHA})"
+          git push -f origin "refs/tags/${tag}"
+          echo "Recorded \`${tag}\` → \`${DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -51,6 +51,9 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write # push the digest-record git tag
+      packages: write # retag :production
     env:
       FROM_TAG: ${{ inputs.from-tag }}
     steps:
@@ -112,3 +115,19 @@ jobs:
           target="${{ env.IMAGE }}:production"
           docker buildx imagetools create --tag "$target" "${{ env.IMAGE }}@${{ steps.image.outputs.digest }}"
           echo "Retagged ${{ env.IMAGE }}@${{ steps.image.outputs.digest }} as $target"
+
+      # Anchor "b": in-repo immutable record that <sha> deployed digest <D>.
+      - name: Record deployed digest
+        if: steps.phala.outputs.deployed == 'true'
+        env:
+          DIGEST: ${{ steps.image.outputs.digest }}
+          IMG: ${{ env.IMAGE }}:${{ steps.image.outputs.sha_short }}
+          SHA_SHORT: ${{ steps.image.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          tag="deploy/production/${SHA_SHORT}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$tag" -m "production deploy: ${IMG} = ${DIGEST}"
+          git push -f origin "refs/tags/${tag}"
+          echo "Recorded \`${tag}\` → \`${DIGEST}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Anchor **(b)** from the reproducible-builds plan (#45). We deploy by tag (dstack can't verify digest refs — see #46), so the TEE attestation binds a *tag*, not a content digest. This adds an in-repo, immutable record tying that tag to the deployed content digest.

## What it does
After a successful deploy, push an annotated git tag:
- staging: `deploy/staging/<sha_short>` → `… = <digest> (commit <sha>)`
- production: `deploy/production/<sha_short>` → `… = <digest>`

A verifier then has a public, in-git link: **attested tag → recorded digest D**, and (once reproducible builds land) **rebuild commit → D** — closing most of the registry-trust gap without needing digest-in-compose.

## Implementation notes
- Uses the build's existing `digest` output / the promote `Resolve` step — no extra registry auth needed.
- Adds `contents: write` to the deploy jobs (production keeps `packages: write` for the `:production` retag).
- Annotated tags (`-fa`); idempotent on re-runs (reproducible ⇒ same sha → same digest).

## Limits (honest)
- This is an **audit/anchor improvement, not a security guarantee** — the attestation still references a tag, so it doesn't *prove* the enclave pulled D. The trustless version is anchor (c) (digest-in-compose), blocked upstream.
- Only meaningful once **reproducible builds** (Phase A #47 + Phase B) actually converge.

## Validation ⚠️
Can't run CI here. Needs a real deploy to confirm the tag push works under branch/tag protection and `GITHUB_TOKEN` `contents: write`. If tag protection blocks `deploy/*`, we'll adjust (or switch to a committed `deployments/*.json`).