### PR TITLE
Unify recorder & dictation HUD waveforms onto a shared meter

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -252,6 +252,9 @@ export function App() {
       return;
     }
     const sessionId = state.recordingStatus.sessionId;
+    // ~10Hz so the waveform has enough fresh peaks to interpolate smoothly.
+    // The HUD is event-driven; this is the polled equivalent for the recorder.
+    // (Audio is sampled every ~5–10ms in Rust; 250ms left the bars starved.)
     const interval = window.setInterval(() => {
       getRecordingStatus(sessionId)
         .then((status) => dispatch({ type: "recordingStatusChanged", status }))
@@ -260,7 +263,7 @@ export function App() {
             setError(messageFromError(err));
           }
         });
-    }, 250);
+    }, 100);
     return () => window.clearInterval(interval);
   }, [state.recordingStatus?.sessionId, state.recordingStatus?.state]);
 

--- a/src/components/recorder/Waveform.tsx
+++ b/src/components/recorder/Waveform.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useRef } from "react";
 import type { AudioLevelDto } from "../../lib/tauri";
-import { BAR_COUNT, clamp, createBarMeter, IDLE_LEVEL } from "../../lib/audio-meter";
+import {
+  clamp,
+  createBarMeter,
+  IDLE_LEVEL,
+  RECORDER_BAR_COUNT,
+  RECORDER_BAR_HISTORY_OFFSETS,
+  RECORDER_BAR_WEIGHTS,
+} from "../../lib/audio-meter";
 
 type WaveformProps = {
   level: AudioLevelDto;
@@ -19,8 +26,15 @@ const KNEE = 6;
 
 export function Waveform({ level }: WaveformProps) {
   const refs = useRef<Array<HTMLSpanElement | null>>([]);
-  // Shared with the dictation HUD so both waveforms move identically.
-  const meterRef = useRef(createBarMeter());
+  // Shares the dictation HUD's synthesis + ballistics, with the recorder's own
+  // taller 7-bar layout.
+  const meterRef = useRef(
+    createBarMeter(
+      RECORDER_BAR_COUNT,
+      RECORDER_BAR_WEIGHTS,
+      RECORDER_BAR_HISTORY_OFFSETS,
+    ),
+  );
 
   // Feed each new sample's shaped peak into the meter; the rAF loop animates
   // the bars toward it (fast attack, smooth release, snap-to-zero on silence).
@@ -38,7 +52,7 @@ export function Waveform({ level }: WaveformProps) {
     let raf = 0;
     const tick = () => {
       meter.step();
-      for (let i = 0; i < BAR_COUNT; i++) {
+      for (let i = 0; i < RECORDER_BAR_COUNT; i++) {
         const el = refs.current[i];
         if (el) el.style.setProperty("--level", meter.displayed[i].toFixed(3));
       }
@@ -50,7 +64,7 @@ export function Waveform({ level }: WaveformProps) {
 
   return (
     <div className="waveform" aria-label="Microphone activity">
-      {Array.from({ length: BAR_COUNT }, (_, index) => (
+      {Array.from({ length: RECORDER_BAR_COUNT }, (_, index) => (
         <span
           key={index}
           style={{ ["--level" as string]: IDLE_LEVEL }}

--- a/src/components/recorder/Waveform.tsx
+++ b/src/components/recorder/Waveform.tsx
@@ -1,30 +1,59 @@
 import { useEffect, useRef } from "react";
 import type { AudioLevelDto } from "../../lib/tauri";
+import { BAR_COUNT, clamp, createBarMeter, IDLE_LEVEL } from "../../lib/audio-meter";
 
 type WaveformProps = {
   level: AudioLevelDto;
 };
 
-const BAR_COUNT = 8;
-const FLOOR = 0.06;
-const GAIN = 11;
+// Below this the input reads as silence — a soft downward expander that keeps
+// room/ambient hiss pinned to zero (bars collapse to the base dot). Whispers
+// sit just above it. Raise if ambient creeps in; lower if whispers don't show.
+const NOISE_FLOOR = 0.004;
+// Sub-1 power that lifts quiet input (whispers) toward visibility before the
+// knee. Lower = more low-end lift.
+const LOW_LIFT = 0.6;
+// Soft-knee steepness — loud speech approaches the ceiling asymptotically
+// instead of slamming flat. Higher reaches the ceiling sooner.
+const KNEE = 6;
 
 export function Waveform({ level }: WaveformProps) {
   const refs = useRef<Array<HTMLSpanElement | null>>([]);
-  const targets = computeTargetPeaks(level);
+  // Shared with the dictation HUD so both waveforms move identically.
+  const meterRef = useRef(createBarMeter());
+
+  // Feed each new sample's shaped peak into the meter; the rAF loop animates
+  // the bars toward it (fast attack, smooth release, snap-to-zero on silence).
+  const raw =
+    level.recentPeaks.length > 0
+      ? level.recentPeaks[level.recentPeaks.length - 1]
+      : level.peak;
+  const shaped = visualPeakScale(raw);
+  useEffect(() => {
+    meterRef.current.pushLevel(shaped);
+  }, [shaped]);
 
   useEffect(() => {
-    for (let i = 0; i < BAR_COUNT; i++) {
-      const el = refs.current[i];
-      if (el) el.style.setProperty("--bar-fill", targets[i].toFixed(3));
-    }
-  });
+    const meter = meterRef.current;
+    let raf = 0;
+    const tick = () => {
+      meter.step();
+      for (let i = 0; i < BAR_COUNT; i++) {
+        const el = refs.current[i];
+        if (el) el.style.setProperty("--level", meter.displayed[i].toFixed(3));
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
 
   return (
     <div className="waveform" aria-label="Microphone activity">
       {Array.from({ length: BAR_COUNT }, (_, index) => (
         <span
           key={index}
+          style={{ ["--level" as string]: IDLE_LEVEL }}
           ref={(el) => {
             refs.current[index] = el;
           }}
@@ -34,29 +63,16 @@ export function Waveform({ level }: WaveformProps) {
   );
 }
 
-function computeTargetPeaks(level: AudioLevelDto) {
-  const source =
-    level.recentPeaks.length > 0
-      ? level.recentPeaks.slice(-BAR_COUNT)
-      : [level.rms, level.peak, level.rms];
-  return Array.from({ length: BAR_COUNT }, (_, index) => {
-    const sourceIndex = Math.floor((index / BAR_COUNT) * source.length);
-    const peak = source[sourceIndex] ?? level.rms;
-    const neighbor = source[sourceIndex - 1] ?? peak;
-    const next = source[sourceIndex + 1] ?? peak;
-    const rolloff = 0.78 + Math.sin(index * 0.85) * 0.12;
-    const blended = Math.max(
-      0,
-      (neighbor * 0.22 + peak * 0.56 + next * 0.22) * rolloff,
-    );
-    return visualPeakScale(blended);
-  });
-}
-
 export function visualPeakScale(peak: number) {
-  const normalized = Math.max(0, Math.min(1, peak));
-  if (normalized <= 0.002) {
-    return FLOOR;
+  const normalized = clamp(peak, 0, 1);
+  // Downward expander: anything at/below the noise floor reads as silence so
+  // the bars can collapse to zero (the base dot) instead of shimmering.
+  const gated = (normalized - NOISE_FLOOR) / (1 - NOISE_FLOOR);
+  if (gated <= 0) {
+    return 0;
   }
-  return Math.min(1, Math.max(FLOOR, Math.sqrt(normalized * GAIN)));
+  // Lift whispers with a sub-1 power, then soft-knee the top so loud speech
+  // approaches the ceiling without ever slamming flat against it.
+  const shaped = 1 - Math.exp(-KNEE * Math.pow(gated, LOW_LIFT));
+  return clamp(shaped, 0, 1);
 }

--- a/src/components/recorder/Waveform.tsx
+++ b/src/components/recorder/Waveform.tsx
@@ -36,16 +36,17 @@ export function Waveform({ level }: WaveformProps) {
     ),
   );
 
-  // Feed each new sample's shaped peak into the meter; the rAF loop animates
-  // the bars toward it (fast attack, smooth release, snap-to-zero on silence).
-  const raw =
-    level.recentPeaks.length > 0
-      ? level.recentPeaks[level.recentPeaks.length - 1]
-      : level.peak;
-  const shaped = visualPeakScale(raw);
+  // Feed a sample into the meter on every poll (keyed on the level prop, not the
+  // shaped value — silence collapses to a constant 0, and we still want the
+  // history ring to advance each poll). The rAF loop animates the bars toward
+  // it (fast attack, smooth release, snap-to-zero on silence).
   useEffect(() => {
-    meterRef.current.pushLevel(shaped);
-  }, [shaped]);
+    const raw =
+      level.recentPeaks.length > 0
+        ? level.recentPeaks[level.recentPeaks.length - 1]
+        : level.peak;
+    meterRef.current.pushLevel(visualPeakScale(raw));
+  }, [level]);
 
   useEffect(() => {
     const meter = meterRef.current;

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { spinners } from "unicode-animations";
+import { clamp, createBarMeter, IDLE_LEVEL } from "./lib/audio-meter";
 import "./styles/hud.css";
 
 type DictationHudEvent = {
@@ -35,52 +36,20 @@ const brailleWave = spinners.waverows;
 // Matches the .hud[data-state="exiting"] transition in hud.css.
 const EXIT_TRANSITION_MS = 160;
 
-// Zero idle plus the CSS 3px base height makes silence read as a dot row.
-const IDLE_LEVEL = 0;
-
-// Per-bar weight + history offset so each bar samples slightly different
-// recent audio. Blending newest level with a nearby recent sample keeps the
-// shape coherent without making every bar move identically.
-const BAR_WEIGHTS = [0.64, 0.86, 0.7, 0.84, 0.58];
-const BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1];
-const LEVEL_HISTORY_LENGTH = 8;
-const LIVE_LEVEL_MIX = 0.7;
-const ATTACK_ALPHA = 0.7;
-const RELEASE_ALPHA = 0.55;
-const IDLE_SNAP_DELTA = 0.004;
-
-const levelHistory: number[] = new Array(LEVEL_HISTORY_LENGTH).fill(IDLE_LEVEL);
-const displayedLevels: number[] = new Array(bars.length).fill(IDLE_LEVEL);
-const targetLevels: number[] = new Array(bars.length).fill(IDLE_LEVEL);
-let levelHead = 0;
+// Bar synthesis + ballistics live in the shared meter so the recorder waveform
+// moves identically. The meter holds the level history and the displayed bars.
+const meter = createBarMeter();
 
 let rafHandle: number | undefined;
 let lastAudioLevelAt = 0;
 const IDLE_RAF_TIMEOUT_MS = 260;
-const AUDIO_NOISE_GATE = 0.012;
+// Lowered so a whisper crosses into the "voice" regime instead of being capped
+// at the ambient ceiling — quiet speech now reads on the bars. Raise back toward
+// 0.012 if room ambient starts lighting them up.
+const AUDIO_NOISE_GATE = 0.008;
 const AUDIO_VISUAL_GAIN = 16;
 const AMBIENT_VISUAL_GAIN = 4;
 const AMBIENT_MAX_LEVEL = 0.11;
-
-function clamp(value: number, min: number, max: number) {
-  return Math.min(max, Math.max(min, value));
-}
-
-function setTargetLevels(level: number) {
-  levelHead = (levelHead + 1) % LEVEL_HISTORY_LENGTH;
-  levelHistory[levelHead] = level;
-
-  for (let i = 0; i < bars.length; i++) {
-    const weight = BAR_WEIGHTS[i] ?? 0.5;
-    const offset = BAR_HISTORY_OFFSETS[i] ?? 0;
-    const historyIndex =
-      (levelHead - offset + LEVEL_HISTORY_LENGTH) % LEVEL_HISTORY_LENGTH;
-    const blendedLevel =
-      levelHistory[levelHead] * LIVE_LEVEL_MIX +
-      levelHistory[historyIndex] * (1 - LIVE_LEVEL_MIX);
-    targetLevels[i] = clamp(IDLE_LEVEL + blendedLevel * weight, IDLE_LEVEL, 1);
-  }
-}
 
 function setHud(state: string, status: string) {
   if (!hud || !statusText) return;
@@ -115,24 +84,9 @@ function setHud(state: string, status: string) {
 function startBarLoop() {
   if (rafHandle !== undefined) return;
   const tick = () => {
-    let stillAnimating = false;
+    const stillAnimating = meter.step();
     for (let i = 0; i < bars.length; i++) {
-      const diff = targetLevels[i] - displayedLevels[i];
-      const alpha = diff > 0 ? ATTACK_ALPHA : RELEASE_ALPHA;
-      displayedLevels[i] = clamp(displayedLevels[i] + diff * alpha, 0, 1);
-
-      if (
-        targetLevels[i] === IDLE_LEVEL &&
-        Math.abs(displayedLevels[i] - IDLE_LEVEL) < IDLE_SNAP_DELTA
-      ) {
-        displayedLevels[i] = IDLE_LEVEL;
-      }
-
-      if (Math.abs(targetLevels[i] - displayedLevels[i]) > 0.004) {
-        stillAnimating = true;
-      }
-
-      bars[i].style.setProperty("--level", displayedLevels[i].toFixed(3));
+      bars[i].style.setProperty("--level", meter.displayed[i].toFixed(3));
     }
     const sinceAudio = performance.now() - lastAudioLevelAt;
     if (stillAnimating || sinceAudio < IDLE_RAF_TIMEOUT_MS) {
@@ -145,15 +99,10 @@ function startBarLoop() {
 }
 
 function resetBars() {
-  for (let i = 0; i < LEVEL_HISTORY_LENGTH; i++) {
-    levelHistory[i] = IDLE_LEVEL;
-  }
+  meter.reset();
   for (let i = 0; i < bars.length; i++) {
-    targetLevels[i] = IDLE_LEVEL;
-    displayedLevels[i] = IDLE_LEVEL;
     bars[i].style.setProperty("--level", IDLE_LEVEL.toFixed(3));
   }
-  levelHead = 0;
   lastAudioLevelAt = performance.now();
 }
 
@@ -168,7 +117,7 @@ function renderAudioLevel(rawLevel: number) {
           1,
         );
   lastAudioLevelAt = performance.now();
-  setTargetLevels(shaped);
+  meter.pushLevel(shaped);
   startBarLoop();
 }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -2,7 +2,13 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { spinners } from "unicode-animations";
-import { clamp, createBarMeter, IDLE_LEVEL } from "./lib/audio-meter";
+import {
+  clamp,
+  createBarMeter,
+  HUD_BAR_HISTORY_OFFSETS,
+  HUD_BAR_WEIGHTS,
+  IDLE_LEVEL,
+} from "./lib/audio-meter";
 import "./styles/hud.css";
 
 type DictationHudEvent = {
@@ -38,7 +44,12 @@ const EXIT_TRANSITION_MS = 160;
 
 // Bar synthesis + ballistics live in the shared meter so the recorder waveform
 // moves identically. The meter holds the level history and the displayed bars.
-const meter = createBarMeter();
+// Sized to the actual bar count so meter.displayed always matches bars.length.
+const meter = createBarMeter(
+  bars.length,
+  HUD_BAR_WEIGHTS,
+  HUD_BAR_HISTORY_OFFSETS,
+);
 
 let rafHandle: number | undefined;
 let lastAudioLevelAt = 0;

--- a/src/lib/audio-meter.ts
+++ b/src/lib/audio-meter.ts
@@ -1,0 +1,86 @@
+// Shared waveform meter: bar synthesis + envelope ballistics used by BOTH the
+// dictation HUD (hud.ts) and the note recorder (recorder/Waveform.tsx) so the
+// two waveforms move and look identically. The HUD is the canonical design;
+// the recorder is brought over to match it.
+//
+// Inputs are already-shaped 0..1 levels (each surface shapes its own raw audio
+// before pushing — the HUD from the helper's level, the recorder from peaks).
+
+export const BAR_COUNT = 5;
+// Per-bar weight + history offset so each bar samples slightly different recent
+// audio — keeps the shape coherent without every bar moving identically.
+export const BAR_WEIGHTS = [0.64, 0.86, 0.7, 0.84, 0.58];
+export const BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1];
+export const LEVEL_HISTORY_LENGTH = 8;
+export const LIVE_LEVEL_MIX = 0.7;
+export const IDLE_LEVEL = 0;
+
+// Ballistics, applied per rAF frame (~60fps). Fast attack on the way up, a
+// smooth release on the way down, and a quicker collapse to zero once the input
+// goes silent so the tail snaps back instead of lingering.
+export const ATTACK_ALPHA = 0.7;
+export const RELEASE_ALPHA = 0.7;
+export const SILENCE_RELEASE_ALPHA = 0.9;
+export const IDLE_SNAP_DELTA = 0.004;
+
+export function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+// Stateful meter: push shaped 0..1 levels in, step the displayed bars toward
+// their targets once per frame. Both surfaces drive this from their own rAF.
+export function createBarMeter() {
+  const history = new Array<number>(LEVEL_HISTORY_LENGTH).fill(IDLE_LEVEL);
+  const targets = new Array<number>(BAR_COUNT).fill(IDLE_LEVEL);
+  const displayed = new Array<number>(BAR_COUNT).fill(IDLE_LEVEL);
+  let head = 0;
+
+  function pushLevel(level: number) {
+    head = (head + 1) % LEVEL_HISTORY_LENGTH;
+    history[head] = level;
+    for (let i = 0; i < BAR_COUNT; i++) {
+      const weight = BAR_WEIGHTS[i] ?? 0.5;
+      const offset = BAR_HISTORY_OFFSETS[i] ?? 0;
+      const historyIndex =
+        (head - offset + LEVEL_HISTORY_LENGTH) % LEVEL_HISTORY_LENGTH;
+      const blended =
+        history[head] * LIVE_LEVEL_MIX +
+        history[historyIndex] * (1 - LIVE_LEVEL_MIX);
+      targets[i] = clamp(IDLE_LEVEL + blended * weight, IDLE_LEVEL, 1);
+    }
+  }
+
+  // Advance the displayed bars one frame toward their targets. Returns true
+  // while anything is still moving.
+  function step() {
+    let animating = false;
+    for (let i = 0; i < BAR_COUNT; i++) {
+      const diff = targets[i] - displayed[i];
+      const goingSilent = targets[i] <= IDLE_LEVEL + IDLE_SNAP_DELTA;
+      const alpha =
+        diff > 0
+          ? ATTACK_ALPHA
+          : goingSilent
+            ? SILENCE_RELEASE_ALPHA
+            : RELEASE_ALPHA;
+      let next = clamp(displayed[i] + diff * alpha, 0, 1);
+      if (goingSilent && Math.abs(next - IDLE_LEVEL) < IDLE_SNAP_DELTA) {
+        next = IDLE_LEVEL;
+      }
+      displayed[i] = next;
+      if (Math.abs(targets[i] - displayed[i]) > IDLE_SNAP_DELTA) {
+        animating = true;
+      }
+    }
+    return animating;
+  }
+
+  function reset() {
+    history.fill(IDLE_LEVEL);
+    targets.fill(IDLE_LEVEL);
+    displayed.fill(IDLE_LEVEL);
+    head = 0;
+  }
+
+  return { targets, displayed, pushLevel, step, reset };
+}

--- a/src/lib/audio-meter.ts
+++ b/src/lib/audio-meter.ts
@@ -1,26 +1,38 @@
 // Shared waveform meter: bar synthesis + envelope ballistics used by BOTH the
 // dictation HUD (hud.ts) and the note recorder (recorder/Waveform.tsx) so the
-// two waveforms move and look identically. The HUD is the canonical design;
-// the recorder is brought over to match it.
+// two waveforms share one design language. Bar count/weights are per-surface
+// (the HUD is a compact 5-bar pill; the recorder is a taller 7-bar meter), but
+// the motion is identical.
 //
 // Inputs are already-shaped 0..1 levels (each surface shapes its own raw audio
 // before pushing — the HUD from the helper's level, the recorder from peaks).
 
-export const BAR_COUNT = 5;
-// Per-bar weight + history offset so each bar samples slightly different recent
-// audio — keeps the shape coherent without every bar moving identically.
-export const BAR_WEIGHTS = [0.64, 0.86, 0.7, 0.84, 0.58];
-export const BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1];
+// HUD: compact 5 bars. Hand-tuned organic weights + history offsets so each bar
+// samples slightly different recent audio (coherent shape, not a uniform block).
+export const HUD_BAR_COUNT = 5;
+export const HUD_BAR_WEIGHTS = [0.64, 0.86, 0.7, 0.84, 0.58];
+export const HUD_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1];
+
+// Recorder: 7 bars, symmetric with a taller center, to fill its wider/taller
+// meter area.
+export const RECORDER_BAR_COUNT = 7;
+export const RECORDER_BAR_WEIGHTS = [0.6, 0.84, 0.72, 0.9, 0.72, 0.84, 0.6];
+export const RECORDER_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1, 0, 1];
+
 export const LEVEL_HISTORY_LENGTH = 8;
 export const LIVE_LEVEL_MIX = 0.7;
 export const IDLE_LEVEL = 0;
 
 // Ballistics, applied per rAF frame (~60fps). Fast attack on the way up, a
-// smooth release on the way down, and a quicker collapse to zero once the input
-// goes silent so the tail snaps back instead of lingering.
+// quick release on the way down, and an even quicker collapse once the input
+// drops into the "quiet" zone so the tail snaps back instead of lingering.
 export const ATTACK_ALPHA = 0.7;
-export const RELEASE_ALPHA = 0.7;
-export const SILENCE_RELEASE_ALPHA = 0.9;
+export const RELEASE_ALPHA = 0.78;
+export const SILENCE_RELEASE_ALPHA = 0.92;
+// Targets at/below this are treated as "going silent" → fast release. Set above
+// zero so the snap-back kicks in as soon as you stop talking, not only once the
+// level reaches dead silence.
+export const SILENCE_TARGET = 0.08;
 export const IDLE_SNAP_DELTA = 0.004;
 
 export function clamp(value: number, min: number, max: number) {
@@ -29,18 +41,22 @@ export function clamp(value: number, min: number, max: number) {
 
 // Stateful meter: push shaped 0..1 levels in, step the displayed bars toward
 // their targets once per frame. Both surfaces drive this from their own rAF.
-export function createBarMeter() {
+export function createBarMeter(
+  barCount = HUD_BAR_COUNT,
+  weights: number[] = HUD_BAR_WEIGHTS,
+  historyOffsets: number[] = HUD_BAR_HISTORY_OFFSETS,
+) {
   const history = new Array<number>(LEVEL_HISTORY_LENGTH).fill(IDLE_LEVEL);
-  const targets = new Array<number>(BAR_COUNT).fill(IDLE_LEVEL);
-  const displayed = new Array<number>(BAR_COUNT).fill(IDLE_LEVEL);
+  const targets = new Array<number>(barCount).fill(IDLE_LEVEL);
+  const displayed = new Array<number>(barCount).fill(IDLE_LEVEL);
   let head = 0;
 
   function pushLevel(level: number) {
     head = (head + 1) % LEVEL_HISTORY_LENGTH;
     history[head] = level;
-    for (let i = 0; i < BAR_COUNT; i++) {
-      const weight = BAR_WEIGHTS[i] ?? 0.5;
-      const offset = BAR_HISTORY_OFFSETS[i] ?? 0;
+    for (let i = 0; i < barCount; i++) {
+      const weight = weights[i] ?? 0.5;
+      const offset = historyOffsets[i] ?? 0;
       const historyIndex =
         (head - offset + LEVEL_HISTORY_LENGTH) % LEVEL_HISTORY_LENGTH;
       const blended =
@@ -54,9 +70,9 @@ export function createBarMeter() {
   // while anything is still moving.
   function step() {
     let animating = false;
-    for (let i = 0; i < BAR_COUNT; i++) {
+    for (let i = 0; i < barCount; i++) {
       const diff = targets[i] - displayed[i];
-      const goingSilent = targets[i] <= IDLE_LEVEL + IDLE_SNAP_DELTA;
+      const goingSilent = targets[i] <= SILENCE_TARGET;
       const alpha =
         diff > 0
           ? ATTACK_ALPHA
@@ -64,7 +80,10 @@ export function createBarMeter() {
             ? SILENCE_RELEASE_ALPHA
             : RELEASE_ALPHA;
       let next = clamp(displayed[i] + diff * alpha, 0, 1);
-      if (goingSilent && Math.abs(next - IDLE_LEVEL) < IDLE_SNAP_DELTA) {
+      if (
+        targets[i] <= IDLE_LEVEL + IDLE_SNAP_DELTA &&
+        Math.abs(next - IDLE_LEVEL) < IDLE_SNAP_DELTA
+      ) {
         next = IDLE_LEVEL;
       }
       displayed[i] = next;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1984,7 +1984,9 @@ input:focus-visible,
   align-items: center;
   justify-content: center;
   min-width: 0;
-  height: 22px;
+  /* Taller than the HUD pill — the recorder bar is 40px, so the waveform fills
+   * more of that vertical space. */
+  height: 30px;
   padding: 0 2px;
 }
 
@@ -1992,7 +1994,7 @@ input:focus-visible,
   position: relative;
   flex: 0 0 auto;
   width: 3px;
-  height: 22px;
+  height: 30px;
   opacity: 0.85;
 }
 
@@ -2002,10 +2004,10 @@ input:focus-visible,
   left: 0;
   bottom: 50%;
   width: 100%;
-  /* Headroom: cap growth below the 22px box so loud peaks don't crowd the
-   * top/bottom edges. The shared meter drives --level per frame; the 40ms
-   * transition just smooths sub-frame steps. */
-  height: calc(3px + var(--level, 0) * 15px);
+  /* Grows toward the 30px box with a little headroom at the edges. The shared
+   * meter drives --level per frame; the 40ms transition smooths sub-frame
+   * steps. */
+  height: calc(3px + var(--level, 0) * 24px);
   border-radius: 999px;
   background: var(--foreground);
   transform: translateY(50%);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1975,28 +1975,41 @@ input:focus-visible,
 
 /* Waveform ---------------------------------------------------------- */
 
+/* Mirrors the dictation HUD bars (.hud-bar) so the recorder waveform reads as
+ * the same component — same geometry, center-anchored growth, and ballistics
+ * (driven by the shared meter in src/lib/audio-meter.ts). */
 .waveform {
   display: flex;
-  gap: 2px;
+  gap: 3px;
   align-items: center;
   justify-content: center;
   min-width: 0;
-  height: 24px;
+  height: 22px;
   padding: 0 2px;
 }
 
 .waveform span {
-  display: block;
+  position: relative;
   flex: 0 0 auto;
   width: 3px;
-  /* Animate height directly so the rounded ends stay perfect circles —
-   * scaleY would squash the border-radius into a lozenge at low values. */
-  height: max(3px, calc(20px * var(--bar-fill, 0.15)));
+  height: 22px;
+  opacity: 0.85;
+}
+
+.waveform span::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 50%;
+  width: 100%;
+  /* Headroom: cap growth below the 22px box so loud peaks don't crowd the
+   * top/bottom edges. The shared meter drives --level per frame; the 40ms
+   * transition just smooths sub-frame steps. */
+  height: calc(3px + var(--level, 0) * 15px);
   border-radius: 999px;
   background: var(--foreground);
-  opacity: 0.85;
-  transition: height 200ms cubic-bezier(0.22, 1, 0.36, 1);
-  will-change: height;
+  transform: translateY(50%);
+  transition: height 40ms linear;
 }
 
 .recorder-bar[data-state="paused"] .waveform span {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -157,7 +157,9 @@ body {
   left: 0;
   bottom: 50%;
   width: 100%;
-  height: calc(3px + var(--level, 0) * 19px);
+  /* Headroom: cap the growth below the 22px box so loud peaks don't crowd the
+   * top/bottom edges of the pill. */
+  height: calc(3px + var(--level, 0) * 15px);
   border-radius: 999px;
   background: var(--hud-bar);
   transform: translateY(50%);

--- a/src/test/recorder.test.tsx
+++ b/src/test/recorder.test.tsx
@@ -95,9 +95,16 @@ describe("RecorderBar", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("amplifies normal speech peaks for visible meter movement", () => {
-    expect(visualPeakScale(0.02)).toBeGreaterThanOrEqual(0.4);
+  it("keeps quiet speech visible while leaving loud speech headroom", () => {
+    // Near-silence settles to the floor.
     expect(visualPeakScale(0.001)).toBeLessThanOrEqual(0.1);
-    expect(visualPeakScale(0.9)).toBe(1);
+    // Quiet speech is still clearly visible.
+    expect(visualPeakScale(0.02)).toBeGreaterThanOrEqual(0.2);
+    // Loud speech reads high but never pegs the ceiling — there's room above it.
+    const loud = visualPeakScale(0.15);
+    expect(loud).toBeGreaterThan(0.75);
+    expect(loud).toBeLessThan(0.95);
+    // A genuine peak still reaches (effectively) full height.
+    expect(visualPeakScale(0.9)).toBeGreaterThanOrEqual(0.99);
   });
 });


### PR DESCRIPTION
Unifies the note recorder and the dictation HUD onto one shared waveform engine (`src/lib/audio-meter.ts`) so they share the same bar synthesis and envelope ballistics — fast attack, smooth release, and a quick snap-back to zero once input drops into the quiet zone. The recorder gets 7 taller bars to fill its larger meter while the HUD stays a compact 5-bar pill, both center-anchored and rounded. Adds whisper visibility (lower noise gate plus low-end lift) and height headroom so loud peaks no longer crowd the edges. Recorder level polling moves from 250ms to 100ms so the bars have enough fresh peaks to interpolate smoothly (the polled equivalent of the HUD's pushed events). All 76 tests pass and typecheck is clean.