### PR TITLE
Restyle Transcription tab + dark-mode login logo

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -4,6 +4,8 @@ import { IconFolder1 } from "central-icons/IconFolder1";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophoneOff } from "central-icons/IconMicrophoneOff";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { IconMicrophone as IconMicrophoneLine } from "central-icons/IconMicrophone";
+import { IconVolumeFull } from "central-icons/IconVolumeFull";
 import { IconCheckmark1 } from "central-icons-filled/IconCheckmark1";
 import { IconChevronBottom } from "central-icons-filled/IconChevronBottom";
 import { IconMicrophone } from "central-icons-filled/IconMicrophone";
@@ -17,6 +19,7 @@ import type {
   RecordingSourceReadinessDto,
   RecordingStatusDto,
   RecoverableRecordingDto,
+  TranscriptDto,
 } from "../../lib/tauri";
 import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
@@ -65,6 +68,20 @@ function sourceLabel(source?: string) {
   return source === "system" ? "System" : "Microphone";
 }
 
+/** Normalise a turn's source to one of the two filterable buckets — an
+ * absent source is treated as microphone, matching sourceLabel. */
+function sourceKey(source?: string): "microphone" | "system" {
+  return source === "system" ? "system" : "microphone";
+}
+
+type SourceFilter = "all" | "microphone" | "system";
+
+const SOURCE_FILTERS = [
+  { value: "all", label: "All" },
+  { value: "microphone", label: "Microphone" },
+  { value: "system", label: "System" },
+] as const;
+
 function formatTurnTime(startMs?: number, endMs?: number) {
   if (startMs === undefined || endMs === undefined || endMs <= startMs) {
     return null;
@@ -109,6 +126,32 @@ export function NoteEditor({
   const sourceTranscripts = visibleSourceTranscripts(note);
   const recordingForNote = recordingStatus;
   const [optionsOpen, setOptionsOpen] = useState(false);
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  // The source filter is ephemeral view state — reset it when navigating
+  // to a different note so it never leaks across transcripts.
+  useEffect(() => {
+    setSourceFilter("all");
+  }, [note.id]);
+
+  // The filter only earns its place when both sources are present — a
+  // mic-only voice memo has nothing to switch between. Built on the
+  // already-pruned visible list so silent/error-only lanes don't count.
+  const hasBothSources = useMemo(() => {
+    let mic = false;
+    let system = false;
+    for (const turn of sourceTranscripts) {
+      if (sourceKey(turn.source) === "system") system = true;
+      else mic = true;
+      if (mic && system) return true;
+    }
+    return false;
+  }, [sourceTranscripts]);
+  const visibleTurns = useMemo(() => {
+    if (!hasBothSources || sourceFilter === "all") return sourceTranscripts;
+    return sourceTranscripts.filter(
+      (turn) => sourceKey(turn.source) === sourceFilter,
+    );
+  }, [sourceTranscripts, hasBothSources, sourceFilter]);
   const systemOn = sourceMode === "microphonePlusSystem";
   const systemSource = sourceReadiness?.sources.find(
     (source) => source.source === "system",
@@ -192,31 +235,29 @@ export function NoteEditor({
           <div className="transcript-view">
             {transcriptToText(note) ? (
               <div className="transcript-toolbar">
-                <CopyTranscriptButton text={transcriptToText(note)} />
+                {hasBothSources ? (
+                  <SegmentedControl
+                    className="transcript-source-filter"
+                    aria-label="Filter transcript by source"
+                    value={sourceFilter}
+                    options={SOURCE_FILTERS}
+                    onValueChange={setSourceFilter}
+                  />
+                ) : null}
+                <CopyTranscriptButton
+                  text={
+                    visibleTurns.length
+                      ? turnsToText(visibleTurns)
+                      : transcriptToText(note)
+                  }
+                />
               </div>
             ) : null}
-            {sourceTranscripts.length ? (
+            {visibleTurns.length ? (
               <div className="source-transcripts">
-                {sourceTranscripts.map((transcript) => {
-                  const turnTime = formatTurnTime(
-                    transcript.startMs,
-                    transcript.endMs,
-                  );
-                  return (
-                    <section className="transcript-turn" key={transcript.id}>
-                      <div className="transcript-turn-meta">
-                        <span>{sourceLabel(transcript.source)}</span>
-                        {turnTime ? <time>{turnTime}</time> : null}
-                      </div>
-                      <p>{transcript.text}</p>
-                      {transcript.lastError ? (
-                        <p className="source-transcript-error">
-                          {userFacingFailureMessage(transcript.lastError)}
-                        </p>
-                      ) : null}
-                    </section>
-                  );
-                })}
+                {visibleTurns.map((transcript) => (
+                  <TranscriptTurn key={transcript.id} transcript={transcript} />
+                ))}
               </div>
             ) : note.transcript?.text ? (
               <p>{note.transcript.text}</p>
@@ -569,17 +610,21 @@ function processingMessage(status: NoteDto["processingStatus"]): string | null {
   }
 }
 
+function turnsToText(turns: TranscriptDto[]): string {
+  return turns
+    .filter((turn) => turn.text.trim())
+    .map((turn) => {
+      const meta = formatTurnTime(turn.startMs, turn.endMs)
+        ? `${sourceLabel(turn.source)} ${formatTurnTime(turn.startMs, turn.endMs)}`
+        : sourceLabel(turn.source);
+      return `${meta}\n${turn.text}`;
+    })
+    .join("\n\n");
+}
+
 function transcriptToText(note: NoteDto): string {
   if (note.sourceTranscripts?.length) {
-    return note.sourceTranscripts
-      .filter((turn) => turn.text.trim())
-      .map((turn) => {
-        const meta = formatTurnTime(turn.startMs, turn.endMs)
-          ? `${sourceLabel(turn.source)} ${formatTurnTime(turn.startMs, turn.endMs)}`
-          : sourceLabel(turn.source);
-        return `${meta}\n${turn.text}`;
-      })
-      .join("\n\n");
+    return turnsToText(note.sourceTranscripts);
   }
   return note.transcript?.text ?? "";
 }
@@ -591,6 +636,114 @@ function visibleSourceTranscripts(
     if (turn.text.trim()) return true;
     return note.processingStatus !== "failed" && !!turn.lastError;
   });
+}
+
+/** A single conversation turn in the Transcription tab. Mirrors the dictation
+ * history row language: a source glyph, a light meta line, and the transcript
+ * text — copy reveals on hover, long turns clamp to a "Show more" toggle. */
+function TranscriptTurn({ transcript }: { transcript: TranscriptDto }) {
+  const textRef = useRef<HTMLParagraphElement>(null);
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [clamped, setClamped] = useState(false);
+
+  const isSystem = transcript.source === "system";
+  const turnTime = formatTurnTime(transcript.startMs, transcript.endMs);
+  const hasText = transcript.text.trim().length > 0;
+  // Every turn is copyable — a turn where nothing was said still carries
+  // its error ("No speech detected…"), which is worth being able to grab.
+  // The error is run through userFacingFailureMessage so raw provider codes
+  // never reach the clipboard (or the card below).
+  const errorMessage = userFacingFailureMessage(transcript.lastError) ?? "";
+  const copyValue = hasText ? transcript.text : errorMessage;
+  const canCopy = copyValue.trim().length > 0;
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1600);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  // Measure whether the collapsed text overflows its line clamp so the
+  // "Show more" toggle only appears when there's hidden content.
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el || expanded) return;
+    const measure = () => setClamped(el.scrollHeight - el.clientHeight > 1);
+    measure();
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [transcript.text, expanded]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(copyValue);
+      setCopied(true);
+    } catch {
+      // Clipboard can fail in restricted contexts; stay silent.
+    }
+  }
+
+  return (
+    <article
+      className="transcript-turn"
+      data-source={isSystem ? "system" : "microphone"}
+    >
+      <span className="transcript-turn-icon" aria-hidden>
+        {isSystem ? (
+          <IconVolumeFull size={14} />
+        ) : (
+          <IconMicrophoneLine size={14} />
+        )}
+      </span>
+      <div className="transcript-turn-body">
+        <div className="transcript-turn-meta">
+          <span className="transcript-turn-source">
+            {sourceLabel(transcript.source)}
+          </span>
+          {turnTime ? <time>{turnTime}</time> : null}
+        </div>
+        {hasText ? (
+          <p
+            ref={textRef}
+            className="transcript-turn-text"
+            data-expanded={expanded || undefined}
+          >
+            {transcript.text}
+          </p>
+        ) : null}
+        {clamped || expanded ? (
+          <button
+            type="button"
+            className="transcript-turn-more"
+            onClick={() => setExpanded((value) => !value)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        ) : null}
+        {errorMessage ? (
+          <p className="source-transcript-error">{errorMessage}</p>
+        ) : null}
+      </div>
+      {canCopy ? (
+        <button
+          type="button"
+          className="transcript-turn-copy"
+          data-copied={copied || undefined}
+          aria-label={copied ? "Copied" : "Copy turn"}
+          title={copied ? "Copied" : "Copy"}
+          onClick={() => void handleCopy()}
+        >
+          {copied ? <IconCheckmark1 size={14} /> : <IconClipboard size={14} />}
+        </button>
+      ) : null}
+    </article>
+  );
 }
 
 function CopyTranscriptButton({ text }: { text: string }) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1233,25 +1233,49 @@ input:focus-visible,
 }
 
 .transcript-view {
+  /* The scroll box is clipped to its own edges, so a turn's hover bleed
+   * (margin: 0 -sp-4) would be shorn flat against the right edge. Borrow
+   * the .main-panel-body trick: pad the scroller by sp-4 and pull it back
+   * out by the same amount with a negative margin (width:auto keeps the
+   * content column at content-max). The bleed now lands inside the
+   * padding — fully rounded — while the content still aligns with the
+   * editor header above. */
+  width: auto;
   overflow: auto;
-  padding: var(--sp-2) 0 140px;
+  margin-inline: calc(-1 * var(--sp-4));
+  padding: var(--sp-2) var(--sp-4) 140px;
   font-size: var(--fs-lg);
   line-height: 1.6;
 }
 
-/* Sits above the first transcript card and shares its max-width so
- * the copy action right-aligns with the card edge. */
+/* Sits above the first transcript turn and shares its max-width so the
+ * filter/Copy align with the turn content (and the editor header). Copy
+ * hugs the right by default; the source filter (when present) takes the
+ * left, splitting the bar via :has() so we don't need a layout
+ * placeholder. */
 .transcript-toolbar {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   width: 100%;
   max-width: var(--content-max);
   margin-bottom: var(--sp-2);
 }
 
-.transcript-toolbar::before {
-  content: "";
+.transcript-toolbar:has(.transcript-source-filter) {
+  justify-content: space-between;
+}
+
+/* A quieter, smaller cut of the segmented control so the source filter
+ * reads as a sub-filter rather than echoing the Notes/Transcription tabs
+ * sitting just above it. */
+.transcript-source-filter {
+  height: 28px;
+}
+
+.transcript-source-filter button {
+  padding: 0 var(--sp-3);
+  font-size: var(--fs-sm);
 }
 
 /* "Copy entire transcript" pill — mirrors the muted-chip language
@@ -1287,48 +1311,142 @@ input:focus-visible,
   margin: 0;
 }
 
+/* Conversation turns read top-to-bottom as one transcript, so they shed
+ * the heavy card chrome in favour of the lighter dictation-row language:
+ * a source glyph, a quiet meta line, and hover-revealed per-turn copy. */
 .source-transcripts {
   display: grid;
-  gap: var(--sp-6);
-}
-
-.source-transcripts section {
-  display: grid;
-  gap: var(--sp-3);
+  gap: 2px;
   max-width: var(--content-max);
-  padding: var(--sp-5) var(--sp-6);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: var(--card);
 }
 
-/* Squircle chips for source / timestamp metadata — modest radius
- * keeps them reading as metadata blocks rather than pills, the muted
- * fill lets them sit quietly against the white card. */
+/* Content aligns at the column edge (icon ↔ filter ↔ header); the hover
+ * background bleeds sp-4 past it on each side and lands in the scroller's
+ * matching padding, exactly like the dictation rows. */
+.transcript-turn {
+  position: relative;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--sp-3);
+  margin: 0 calc(-1 * var(--sp-4));
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-md);
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.transcript-turn:hover,
+.transcript-turn:focus-within {
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.transcript-turn-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin-top: 1px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+}
+
+.transcript-turn-body {
+  display: grid;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
 .transcript-turn-meta {
   display: flex;
   flex-wrap: wrap;
+  align-items: baseline;
   gap: var(--sp-2);
-  align-items: center;
 }
 
-.transcript-turn-meta > span,
+.transcript-turn-source {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--foreground);
+}
+
 .transcript-turn-meta > time {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px var(--sp-2);
-  border-radius: var(--r-sm);
-  background: var(--surface-subtle);
+  font-size: var(--fs-sm);
   color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.transcript-turn-text {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+/* Clamp long turns until expanded; the measured "Show more" toggle below
+ * lifts the clamp in place rather than opening a dialog. */
+.transcript-turn-text:not([data-expanded]) {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 8;
+  overflow: hidden;
+}
+
+.transcript-turn-more {
+  justify-self: start;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font: inherit;
   font-size: var(--fs-sm);
   font-weight: 500;
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease-out);
 }
 
-.source-transcripts p {
-  margin: 0;
+.transcript-turn-more:hover {
+  color: var(--foreground);
+}
+
+.transcript-turn-copy {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-sm);
+  height: var(--control-sm);
+  margin-top: 1px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  opacity: 0;
+  cursor: pointer;
+  transition:
+    opacity var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.transcript-turn:hover .transcript-turn-copy,
+.transcript-turn:focus-within .transcript-turn-copy,
+.transcript-turn-copy:focus-visible,
+.transcript-turn-copy[data-copied] {
+  opacity: 1;
+}
+
+.transcript-turn-copy:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.transcript-turn-copy[data-copied] {
+  color: var(--warm-strong);
 }
 
 .source-transcript-error {
+  margin: 0;
   color: color-mix(in oklch, var(--destructive) 70%, var(--foreground));
   font-size: var(--fs-sm);
 }
@@ -4835,7 +4953,9 @@ input:focus-visible,
   align-self: center;
   border-radius: var(--r-xl);
   background: linear-gradient(135deg, #dbc1a3 0%, #9d7355 100%);
-  color: var(--primary-foreground);
+  /* Mark sits on the fixed tan gradient in both themes, so keep it white
+     rather than inheriting --primary-foreground (which inverts in dark). */
+  color: #fff;
   line-height: 0;
   margin-bottom: var(--sp-2);
 }

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -111,8 +111,14 @@ describe("NoteEditor", () => {
       />,
     );
 
-    expect(screen.getByText("System")).toBeInTheDocument();
-    expect(screen.getByText("Microphone")).toBeInTheDocument();
+    // Scope to the turn labels — the source filter (shown when both
+    // sources are present) also renders "System"/"Microphone" options.
+    expect(
+      screen.getByText("System", { selector: ".transcript-turn-source" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Microphone", { selector: ".transcript-turn-source" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("0:01-0:03")).toBeInTheDocument();
     expect(screen.getByText("System playback text")).toBeInTheDocument();
     expect(screen.getByText("Microphone response")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Two UI changes to the note editor and login:

**Login** — keep the Scribe mark white in dark mode. It sits on the fixed tan gradient but inherited `--primary-foreground`, which inverts to charcoal in dark, leaving the glyph nearly invisible.

**Transcription tab** — replace the heavy bordered transcript cards with the dictation-row language: a source glyph, a quiet meta line (bold source + tabular turn time), and the transcript text. Per-turn copy reveals on hover; long turns clamp to a "Show more" toggle.

- **Source filter** (All / Microphone / System) via the shared `SegmentedControl`, shown only when a note actually has both sources. Copy reflects the filtered view.
- **Per-turn copy on every box**, including error-only turns — those copy their (user-facing) error string.
- **Hover** background bleeds `sp-4` like the dictation rows, landing in the scroller's matching padding so it rounds fully instead of clipping; content stays aligned with the editor header by default.
- Both source icons are neutral (no warm tint — it read as an alarm color and clashed with the destructive-red error text in the same view).

Rebased on top of #52, integrating its work: errors run through `userFacingFailureMessage`, the filter is built on `visibleSourceTranscripts` (so pruned silent/error-only lanes don't count toward "both sources"), and `turnsToText` skips empty turns.

## Test plan
- `npm run lint` (tsc) — clean
- `npx vitest run` — 82 passed (updated the source-label assertion in `note-editor.test.tsx`, since the filter now also renders "System"/"Microphone")
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)