### PR TITLE
feat(api): add /readyz + /healthz endpoints; bump to 0.2.0

### DIFF
--- a/scribe-api/Cargo.lock
+++ b/scribe-api/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scribe"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "scribe-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "scribe-config",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "scribe-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "figment",
  "pretty_assertions",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "scribe-domain"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "scribe-providers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "scribe-services"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "pretty_assertions",

--- a/scribe-api/Cargo.toml
+++ b/scribe-api/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.95"
 license = "UNLICENSED"

--- a/scribe-api/crates/api/src/handlers/health.rs
+++ b/scribe-api/crates/api/src/handlers/health.rs
@@ -1,5 +1,34 @@
-use axum::http::StatusCode;
+use axum::{Json, http::StatusCode};
+use serde::Serialize;
 
+use crate::envelope::ApiResponse;
+
+/// Liveness probe — the process is up. Polled by the Phala/dstack prelaunch and
+/// load balancers; must stay dependency-free so it answers even mid-startup.
 pub(crate) async fn livez() -> StatusCode {
     StatusCode::OK
+}
+
+/// Readiness probe — the service is ready to accept traffic.
+pub(crate) async fn readyz() -> StatusCode {
+    StatusCode::OK
+}
+
+/// Service identity + build version, returned in the standard response envelope.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthDto {
+    pub status: &'static str,
+    pub service: &'static str,
+    pub version: &'static str,
+}
+
+/// Health summary: reports the running service name and compiled-in version so
+/// callers can confirm which build is live.
+pub(crate) async fn healthz() -> Json<ApiResponse<HealthDto>> {
+    Json(ApiResponse::ok(HealthDto {
+        status: "healthy",
+        service: env!("CARGO_PKG_NAME"),
+        version: env!("CARGO_PKG_VERSION"),
+    }))
 }

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -23,6 +23,7 @@ pub use error::ApiError;
 pub use handlers::dictate::{
     DictateCleanupRequest, DictateCleanupResponse, DictateTranscribeResponse,
 };
+pub use handlers::health::HealthDto;
 pub use handlers::models::ModelDto;
 pub use handlers::notes::{GenerateRequest, GenerateResponse, TranscribeResponse};
 pub use state::{ApiLimits, ApiState, ApiStateParams};
@@ -35,6 +36,8 @@ pub fn router(state: ApiState) -> Router {
     );
     Router::new()
         .route("/livez", get(handlers::health::livez))
+        .route("/readyz", get(handlers::health::readyz))
+        .route("/healthz", get(handlers::health::healthz))
         .route("/v1/models", get(handlers::models::list_models))
         .route(
             "/v1/notes/transcribe",


### PR DESCRIPTION
## What

Two unauthenticated health endpoints on `scribe-api`, plus a release version bump:

- `GET /readyz` — readiness probe (200), alongside the existing `/livez`.
- `GET /healthz` — service identity + compiled-in version in the standard envelope:
  ```json
  {"data":{"status":"healthy","service":"scribe-api","version":"0.2.0"},"success":true}
  ```
- Workspace version `0.1.0` → `0.2.0`, so this is a genuinely new release and `/healthz` reports it.

## Why

We need a real new image version to redeploy production cleanly (fresh build → new digest → clean `phala deploy` → fresh TDX attestation), and a `/healthz` that surfaces the running version is useful operationally and on-theme for the verifiability work. Kept separate from the docs PR (#36) so provenance stays clean.

## Verification

- `cargo check` + `cargo clippy -- -D warnings` clean.
- Booted the binary locally with dummy config and hit the routes:
  - `/readyz` → 200
  - `/healthz` → the JSON above (HTTP 200)
  - `/livez` → 200 (unchanged)

## Release flow after merge

1. Merge → `build-scribe-api` builds + pushes `:staging` and `:<sha>` (v0.2.0 image).
2. Run `promote-scribe-api` → clean `phala deploy --cvm-id` to production → new version live, fresh attestation, Trust Center re-verifies.
