### PR TITLE
feat(deploy): serve prod on scribe-api.opensoftware.co (dstack-ingress + Cloudflare)

### DIFF
--- a/scribe-api/deploy/docker-compose.production.yml
+++ b/scribe-api/deploy/docker-compose.production.yml
@@ -11,6 +11,12 @@ services:
   dstack-ingress:
     image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
     restart: unless-stopped
+    # Start after the app so the proxy isn't pointed at a cold backend on first
+    # boot. Plain start-ordering, not health-gated: the slim runtime image has no
+    # curl/wget for a healthcheck, and restart-policy + the proxy's own retry
+    # cover the brief window until scribe-api binds 8080.
+    depends_on:
+      - scribe-api
     ports:
       - "443:443"
     environment:

--- a/scribe-api/deploy/docker-compose.production.yml
+++ b/scribe-api/deploy/docker-compose.production.yml
@@ -1,15 +1,43 @@
 services:
+  # TLS terminator + custom-domain manager for scribe-api.opensoftware.co.
+  # Terminates HTTPS on 443, auto-provisions the Let's Encrypt cert and the
+  # Cloudflare DNS records (via CLOUDFLARE_API_TOKEN), and reverse-proxies to the
+  # app over the internal compose network (TARGET_ENDPOINT). SET_CAA pins cert
+  # issuance to the TEE's Let's Encrypt account for domain attestation — this
+  # works only because we use a SUBDOMAIN; Cloudflare overrides CAA at the apex.
+  # Digest-pinned per Phala guidance; public docker.io image, pulled anonymously
+  # (independent of the GHCR prelaunch login / DSTACK_DOCKER_REGISTRY).
+  # Docs: https://docs.phala.com/phala-cloud/networking/setup-custom-domain
+  dstack-ingress:
+    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
+    restart: unless-stopped
+    ports:
+      - "443:443"
+    environment:
+      - DOMAIN=scribe-api.opensoftware.co
+      - TARGET_ENDPOINT=http://scribe-api:8080
+      - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
+      - SET_CAA=true
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+      - CERTBOT_EMAIL=${CERTBOT_EMAIL}
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - cert-data:/etc/letsencrypt
+
   scribe-api:
     image: ${SCRIBE_IMAGE}
     restart: unless-stopped
-    ports:
-      - "8080:8080"
+    # No published ports: dstack-ingress is the sole external entry point
+    # (https://scribe-api.opensoftware.co). The ingress reaches the app over the
+    # internal compose network via TARGET_ENDPOINT=http://scribe-api:8080.
     volumes:
       - /var/run/dstack.sock:/var/run/dstack.sock
     # App secrets are encrypted per-CVM via Phala sealed env (`phala envs`) and
     # injected at boot by ${VAR} interpolation — reference each one, unquoted.
     # An empty `KEY: ""` clobbers the sealed value with a blank; omitting the ref
     # injects nothing — both leave the app seeing the config as missing.
+    # `phala envs update` is FULL REPLACEMENT: re-supply EVERY var each time
+    # (incl. the dstack-ingress CLOUDFLARE_API_TOKEN + CERTBOT_EMAIL below).
     # Docs: https://docs.phala.com/phala-cloud/phala-cloud-user-guides/create-cvm/set-secure-environment-variables
     # DSTACK_DOCKER_* (registry auth) is consumed by the prelaunch, not the app.
     environment:
@@ -18,3 +46,6 @@ services:
       - SCRIBE__OS_ACCOUNTS__APP_API_KEY=${SCRIBE__OS_ACCOUNTS__APP_API_KEY}
       - SCRIBE__UPSTREAMS__OPENAI__API_KEY=${SCRIBE__UPSTREAMS__OPENAI__API_KEY}
       - SCRIBE__UPSTREAMS__VENICE__API_KEY=${SCRIBE__UPSTREAMS__VENICE__API_KEY}
+
+volumes:
+  cert-data:


### PR DESCRIPTION
## What

Serve the **production** `scribe-api` on the custom domain **`scribe-api.opensoftware.co`** via a `dstack-ingress` sidecar. Staging is untouched.

## Change (production compose only)

- Add `dstack-ingress` (digest-pinned): terminates HTTPS on **443**, auto-manages the Cloudflare DNS records + a Let's Encrypt cert, and reverse-proxies to `http://scribe-api:8080` over the internal network.
- `SET_CAA=true` pins cert issuance to the TEE's Let's Encrypt account (domain attestation). Works because we use a **subdomain** — Cloudflare overrides CAA at the apex, which would otherwise break it.
- **Custom-domain-only:** removed `scribe-api`'s published `8080:8080` port. The old `<app-id>-8080.…phala.network` URL stops responding; the ingress is the sole external entry point.
- `cert-data` volume persists the cert across restarts.
- Ingress image is a public docker.io image (pulled anonymously) — unaffected by the GHCR prelaunch login.

## Required before deploy (ops)

`phala envs update` is **full replacement**, so production goes 7 → **9** sealed vars — re-supply all existing + the two new ones together:
- `CLOUDFLARE_API_TOKEN` — Cloudflare "Edit zone DNS" token scoped to `opensoftware.co`
- `CERTBOT_EMAIL` — `ops@opensoftware.co`

**Order:** seal env **before** running `promote-scribe-api` — the ingress reads `${CLOUDFLARE_API_TOKEN}` at boot; unsealed → no cert → ingress fails. First deploy takes 3–5 min (DNS + cert).

## Verify

```sh
curl -fsS https://scribe-api.opensoftware.co/livez       # 200
curl -fsS https://scribe-api.opensoftware.co/healthz      # version 0.2.0
dig @1.1.1.1 +short CAA scribe-api.opensoftware.co        # Let's Encrypt accounturi
curl -fsS https://scribe-api.opensoftware.co/evidences/   # domain attestation
```

## Follow-up (not in this PR)

Point the desktop app's production `SCRIBE_API_URL` at `https://scribe-api.opensoftware.co` (the `<app-id>-8080` URL is gone).
