### PR TITLE
Tween fixed recorder left during sidebar collapse/expand

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1874,6 +1874,15 @@ input:focus-visible,
   left: calc(var(--sp-3) + var(--sp-8));
 }
 
+/* The fixed recorder's `left` rides the card's left edge. During a smooth
+ * collapse/expand the sidebar grid tweens over --t-med, so match it here —
+ * otherwise the pill snaps to its collapsed offset at frame 0 while the
+ * sidebar is still in motion. While resizing (transition: none) the left
+ * tracks --sidebar-w-current live, so no transition there. */
+.app-shell[data-sidebar-transition="smooth"] .editor-footer {
+  transition: left var(--t-med) var(--ease-out);
+}
+
 .editor-footer > * {
   pointer-events: auto;
 }


### PR DESCRIPTION
## What

The recorder (`.editor-footer`) is `position: fixed` with a `left` override for the collapsed sidebar. That `left` switched synchronously via the CSS cascade the instant `data-sidebar="collapsed"` was applied, but the sidebar grid tweens over `--t-med` on a smooth collapse/expand. The result: the recorder snapped to its collapsed offset at frame 0 while the sidebar was still visually in motion — a visible jump.

This only manifested on the **drag-resize-release-into-collapse** path (which sets `data-sidebar-transition="smooth"`). The toggle button sets `"none"`, so a button collapse was already instant on both surfaces.

## Fix

Give `.editor-footer` the same `left` transition as the grid, gated on the identical `data-sidebar-transition="smooth"` flag, so the recorder rides the card's left edge in lockstep. During a live resize drag (`transition: none`) the `left` still tracks `--sidebar-w-current` instantly — no transition there.

CSS-only change.

## Context

This came out of a review of #59. A second flagged issue — the fixed recorder occluding the bottom of long notes — was investigated and found to be a false positive: the scroll surfaces (`.note-body`, `.note-body-stack`, `.transcript-view`) already carry 140px bottom padding, well clear of the ~88px recorder intrusion. No change made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)