### PR TITLE
Retune dictation HUD + recorder waveform (Wispr-style) + tuning playground

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -30,6 +30,8 @@
           <span class="hud-bar"></span>
           <span class="hud-bar"></span>
           <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
         </div>
         <span id="hud-braille" class="hud-braille" aria-hidden="true"></span>
         <span class="hud-error-mark" aria-hidden="true"></span>

--- a/playground/waveform-playground.html
+++ b/playground/waveform-playground.html
@@ -1,0 +1,938 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Waveform ballistics playground</title>
+    <style>
+      :root {
+        --bg: #0d0f12;
+        --panel: #16191e;
+        --panel-2: #1c2027;
+        --line: #2a2f37;
+        --fg: #e7ebf0;
+        --muted: #98a2b3;
+        --accent: #6ea8fe;
+        --good: #7ee0a8;
+        --warn: #f4b860;
+        --bar: #e7ebf0;
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        -webkit-font-smoothing: antialiased;
+      }
+      header {
+        padding: 20px 24px 12px;
+        border-bottom: 1px solid var(--line);
+        position: sticky;
+        top: 0;
+        background: linear-gradient(var(--bg), color-mix(in oklch, var(--bg) 86%, transparent));
+        backdrop-filter: blur(6px);
+        z-index: 5;
+      }
+      h1 { font-size: 16px; margin: 0 0 4px; letter-spacing: 0.2px; }
+      header p { margin: 0; color: var(--muted); font-size: 13px; max-width: 70ch; }
+      .wrap {
+        display: grid;
+        grid-template-columns: 380px 1fr;
+        gap: 0;
+        min-height: calc(100vh - 70px);
+      }
+      .controls {
+        border-right: 1px solid var(--line);
+        padding: 16px 18px 60px;
+        overflow-y: auto;
+        max-height: calc(100vh - 70px);
+        position: sticky;
+        top: 70px;
+      }
+      .stage {
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 22px;
+      }
+
+      /* ---- Bar stage ---- */
+      .surface {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 16px;
+        padding: 20px 22px;
+      }
+      .surface h2 {
+        font-size: 12px;
+        text-transform: none;
+        margin: 0 0 2px;
+        color: var(--fg);
+        font-weight: 600;
+      }
+      .surface .sub { color: var(--muted); font-size: 12px; margin: 0 0 16px; }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 14px;
+        background: #0a0c0f;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 14px 22px;
+      }
+      .bars { display: flex; align-items: center; justify-content: center; }
+      .bar { position: relative; flex: 0 0 auto; }
+      .bar > i {
+        content: "";
+        position: absolute;
+        left: 0;
+        bottom: 50%;
+        width: 100%;
+        border-radius: 999px;
+        background: var(--bar);
+        transform: translateY(50%);
+        display: block;
+        height: 3px;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 28px;
+        flex-wrap: wrap;
+      }
+      .row .label { font-size: 12px; color: var(--muted); width: 120px; }
+      .col { display: flex; flex-direction: column; gap: 16px; }
+
+      /* ---- Controls ---- */
+      .group {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 12px 14px 14px;
+        margin-bottom: 14px;
+        background: var(--panel);
+      }
+      .group > h3 {
+        margin: 0 0 10px;
+        font-size: 12px;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .group > h3 .tag {
+        font-size: 10px;
+        color: var(--muted);
+        font-weight: 500;
+      }
+      .knob { margin: 11px 0; }
+      .knob .top {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-size: 12px;
+        margin-bottom: 5px;
+      }
+      .knob .top .name { color: var(--fg); }
+      .knob .top .val {
+        font-variant-numeric: tabular-nums;
+        color: var(--accent);
+        font-size: 12px;
+      }
+      .knob .top .def {
+        color: var(--muted);
+        font-size: 11px;
+        margin-left: 6px;
+      }
+      .knob input[type="range"] { width: 100%; accent-color: var(--accent); }
+      .knob .hint { font-size: 11px; color: var(--muted); margin-top: 3px; line-height: 1.35; }
+
+      button, select {
+        font: inherit;
+        font-size: 13px;
+        color: var(--fg);
+        background: var(--panel-2);
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        padding: 8px 12px;
+        cursor: pointer;
+      }
+      button:hover { border-color: var(--accent); }
+      button.primary { background: var(--accent); color: #0a0c0f; border-color: var(--accent); font-weight: 600; }
+      .btnrow { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+
+      .meters {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 6px 18px;
+        font-size: 12px;
+        font-variant-numeric: tabular-nums;
+      }
+      .meters .m { display: flex; justify-content: space-between; }
+      .meters .m span:first-child { color: var(--muted); }
+
+      canvas { display: block; width: 100%; height: 90px; border-radius: 10px; background: #0a0c0f; border: 1px solid var(--line); }
+      .legend { display: flex; gap: 16px; font-size: 11px; color: var(--muted); margin-top: 6px; }
+      .legend i { display: inline-block; width: 10px; height: 3px; border-radius: 2px; vertical-align: middle; margin-right: 5px; }
+
+      details summary { cursor: pointer; font-size: 12px; color: var(--muted); margin-bottom: 10px; }
+      code { background: #0a0c0f; padding: 1px 5px; border-radius: 5px; font-size: 11px; }
+      .pre {
+        white-space: pre;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 11px;
+        background: #0a0c0f;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 12px;
+        overflow-x: auto;
+        color: var(--good);
+      }
+      .status { font-size: 12px; color: var(--warn); margin-left: 8px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Waveform ballistics playground</h1>
+      <p>
+        Live-tune the dictation HUD waveform. The <b>top row</b> runs your slider
+        values; the <b>bottom row</b> runs the shipping defaults on the exact same
+        audio, so you can A/B the snap-back directly. Click <b>Start mic</b>, or use
+        <b>Spike</b> / <b>Burst loop</b> to fire a loud→silent transient and watch the
+        tail collapse.
+      </p>
+    </header>
+
+    <div class="wrap">
+      <aside class="controls">
+        <div class="btnrow">
+          <button id="mic" class="primary">Start mic</button>
+          <button id="spike">Spike</button>
+          <button id="burst">Burst loop</button>
+          <button id="reset">Reset to defaults</button>
+        </div>
+        <div class="btnrow">
+          <select id="surface">
+            <option value="hud">HUD — 5 bars (dictation)</option>
+            <option value="recorder">Recorder — 7 bars</option>
+          </select>
+          <select id="source">
+            <option value="rms">Raw = RMS (HUD-like)</option>
+            <option value="peak">Raw = peak (recorder-like)</option>
+          </select>
+          <span id="status" class="status"></span>
+        </div>
+
+        <div class="group">
+          <h3>Bars &amp; shape <span class="tag">geometry</span></h3>
+          <div id="barsCtl"></div>
+        </div>
+
+        <div class="group">
+          <h3>Idle wave <span class="tag">carrier · "shimmer across"</span></h3>
+          <div id="waveCtl"></div>
+        </div>
+
+        <div class="group">
+          <h3>Speaking spread <span class="tag">wave travels across</span></h3>
+          <div id="spreadCtl"></div>
+          <div class="knob">
+            <div class="top"><span class="name">Spread origin</span></div>
+            <select id="sl-PROP_MODE" style="width: 100%">
+              <option value="across">left → right sweep</option>
+              <option value="center">center → out ripple</option>
+            </select>
+            <div class="hint">Where the speaking wave enters the row. "center → out" can still read jumpy in the middle; "left → right" sweeps cleanly across.</div>
+          </div>
+        </div>
+
+        <div class="group">
+          <h3>Ballistics <span class="tag">audio-meter.ts · step()</span></h3>
+          <div id="ballistics"></div>
+        </div>
+
+        <div class="group">
+          <h3>Render smoothing <span class="tag">the second layer</span></h3>
+          <div id="render"></div>
+        </div>
+
+        <div class="group" id="shapingHud">
+          <h3>Shaping — HUD <span class="tag">hud.ts · renderAudioLevel()</span></h3>
+          <div id="shapeHud"></div>
+        </div>
+
+        <div class="group" id="shapingRec" style="display:none">
+          <h3>Shaping — recorder <span class="tag">visualPeakScale()</span></h3>
+          <div id="shapeRec"></div>
+        </div>
+
+        <details>
+          <summary>Export current values</summary>
+          <div class="pre" id="export"></div>
+        </details>
+      </aside>
+
+      <main class="stage">
+        <div class="surface">
+          <h2>Your tuning</h2>
+          <p class="sub">live slider values</p>
+          <div class="col">
+            <div class="row">
+              <span class="label">Waveform</span>
+              <div class="pill"><div class="bars" id="barsA"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="surface">
+          <h2>Original HUD</h2>
+          <p class="sub">untouched — 5 bars, 3px, 40ms, no wave · same audio</p>
+          <div class="col">
+            <div class="row">
+              <span class="label">Waveform</span>
+              <div class="pill"><div class="bars" id="barsB"></div></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="surface">
+          <h2>Signal scope</h2>
+          <p class="sub">last ~3s</p>
+          <canvas id="scope" width="900" height="90"></canvas>
+          <div class="legend">
+            <span><i style="background:#6ea8fe"></i>shaped level (in)</span>
+            <span><i style="background:#e7ebf0"></i>your displayed (mid bar)</span>
+            <span><i style="background:#7ee0a8"></i>default displayed (mid bar)</span>
+          </div>
+          <div class="meters" style="margin-top:14px">
+            <div class="m"><span>raw rms</span><span id="mRms">0.000</span></div>
+            <div class="m"><span>raw peak</span><span id="mPeak">0.000</span></div>
+            <div class="m"><span>shaped (yours)</span><span id="mShaped">0.000</span></div>
+            <div class="m"><span>target mid</span><span id="mTarget">0.000</span></div>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script>
+      // ===================================================================
+      // Faithful port of the shipping waveform engine.
+      //   ballistics: src/lib/audio-meter.ts (createBarMeter / step / pushLevel)
+      //   HUD shaping: src/hud.ts renderAudioLevel()
+      //   recorder shaping: src/components/recorder/Waveform.tsx visualPeakScale()
+      // Slider values feed meter A; meter B is locked to DEFAULTS for A/B.
+      // ===================================================================
+      const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+      const SURFACES = {
+        hud: {
+          count: 5, // ORIGINAL (bottom row). Top row count comes from BAR_COUNT.
+          weights: [0.64, 0.86, 0.7, 0.84, 0.58],
+          offsets: [1, 0, 1, 0, 1],
+          boxH: 22, // px box height
+          growth: 15, // px: height = 3 + level*growth
+          barW: 3, // original geometry (bottom row)
+          gap: 3,
+          tunedBarW: 2, // tuned thin bars (top row)
+          tunedGap: 2.5,
+        },
+        recorder: {
+          count: 7,
+          weights: [0.6, 0.84, 0.72, 0.9, 0.72, 0.84, 0.6],
+          offsets: [1, 0, 1, 0, 1, 0, 1],
+          boxH: 30,
+          growth: 24,
+          barW: 3,
+          gap: 3,
+          tunedBarW: 3,
+          tunedGap: 3,
+        },
+      };
+
+      // Shipping defaults — DO NOT mutate; meter B + "reset" read from here.
+      const DEFAULTS = {
+        // ballistics
+        ATTACK_ALPHA: 0.7,
+        RELEASE_ALPHA: 0.78,
+        SILENCE_RELEASE_ALPHA: 0.92,
+        SILENCE_TARGET: 0.08,
+        IDLE_SNAP_DELTA: 0.004,
+        LIVE_LEVEL_MIX: 0.7,
+        // render
+        PUSH_HZ: 25, // app pushes audio_level ~25Hz; rAF steps at 60Hz
+        CSS_MS: 40, // hud.css transition: height 40ms linear
+        // HUD shaping
+        AUDIO_NOISE_GATE: 0.008,
+        AUDIO_VISUAL_GAIN: 16,
+        AMBIENT_VISUAL_GAIN: 4,
+        AMBIENT_MAX_LEVEL: 0.11,
+        // recorder shaping
+        NOISE_FLOOR: 0.004,
+        LOW_LIFT: 0.6,
+        KNEE: 6,
+        // bars & shape (geometry) — prod HUD is 5 bars, organic weights; the
+        // generator below makes a clean symmetric "lens" from count + emphasis.
+        BAR_COUNT: 5,
+        CENTER_EMPHASIS: 0.3,
+        // whisper floor — minimum shown when ANY voice is detected. Prod = 0.
+        WHISPER_FLOOR: 0,
+        // idle "carrier" wave — a slow sine travelling across the bars at a base
+        // level, present even in silence, to signify active listening / time.
+        // Layered UNDER the audio response (recedes as bars get loud).
+        IDLE_AMP: 0, // base height of the wave (0 = off / shipping)
+        IDLE_SPEED: 0.5, // cycles per second
+        IDLE_SPREAD: 0.9, // radians of phase per bar = the "across" wavelength
+        // speaking-wave propagation: each bar reads the audio envelope delayed by
+        // its distance × PROP_DELAY (pushes), so a loud moment travels across the
+        // row instead of all centre bars spiking at once. 0 = original (no travel).
+        PROP_DELAY: 0,
+        PROP_MODE: "across", // "across" = left→right sweep, "center" = ripple out
+        SPATIAL: 0, // 0..1 neighbour blend — smooths the wave across bars
+      };
+      // Longer ring so the per-bar propagation delays have history to read from.
+      const LEVEL_HISTORY_LENGTH = 32;
+      const IDLE_LEVEL = 0;
+
+      // Andrew's tuned set — now mirrors what shipped to the real HUD
+      // (src/hud.ts, src/lib/audio-meter.ts) so the top A/B row matches the app:
+      //   • Whisper≈yell compression: AUDIO_VISUAL_GAIN 16→28, WHISPER_FLOOR 0→0.2.
+      //   • Idle carrier "shimmer across" at IDLE_AMP 0.05.
+      //   • Ambient floor damped hard (AMBIENT_VISUAL_GAIN 4→3, AMBIENT_MAX_LEVEL
+      //     0.11→0.03, AUDIO_NOISE_GATE 0.008→0.01) so a quiet room rests the bars
+      //     near zero and the carrier reads against a flat floor instead of being
+      //     buried in ambient jitter — the fix for "shimmer wasn't clear in-app",
+      //     where the mic is always live (the silent playground idle hid this).
+      // CSS_MS sharpened 40→24 so the low-mix shimmer reads crisp; whisper floor
+      // is voice-gated (see pushTick). The bottom A/B row still runs DEFAULTS
+      // (prod), so every one of these shows as "← changed".
+      const TUNED = {
+        BAR_COUNT: 7,
+        CENTER_EMPHASIS: 0.28,
+        WHISPER_FLOOR: 0.2,
+        LIVE_LEVEL_MIX: 0.35,
+        CSS_MS: 24,
+        // compress speaking so a whisper fills the pill nearly as much as a yell
+        AUDIO_VISUAL_GAIN: 28,
+        // damp the ambient floor so the idle carrier reads against a flat baseline
+        AUDIO_NOISE_GATE: 0.01,
+        AMBIENT_VISUAL_GAIN: 3,
+        AMBIENT_MAX_LEVEL: 0.03,
+        // always-on travelling carrier wave (the "shimmer across" at base level)
+        IDLE_AMP: 0.05,
+        IDLE_SPEED: 0.45,
+        IDLE_SPREAD: 0.9,
+        // speaking wave spreads across the row instead of spiking in the middle
+        PROP_DELAY: 0.7,
+        PROP_MODE: "across",
+        SPATIAL: 0.3,
+      };
+
+      // live params (meter A) start from defaults, overlaid with the tuned set
+      const P = { ...DEFAULTS, ...TUNED };
+
+      // Generate a clean symmetric "lens" envelope from count + emphasis: edges
+      // sit low, the center rides high (stays elevated while speaking), and the
+      // [1,0,1,0,...] history offsets give the traveling shimmer.
+      function genWeights(count, emphasis) {
+        const w = [], off = [];
+        const mid = (count - 1) / 2;
+        const edge = 0.55, center = 0.6 + emphasis;
+        for (let i = 0; i < count; i++) {
+          const d = mid === 0 ? 0 : Math.abs(i - mid) / mid; // 0 center .. 1 edge
+          const env = 0.5 * (1 + Math.cos(d * Math.PI)); // raised cosine 1 .. 0
+          w.push(+(edge + (center - edge) * env).toFixed(3));
+          off.push(i % 2 === 0 ? 1 : 0);
+        }
+        return { weights: w, offsets: off };
+      }
+      function makeSurfaceA() {
+        const count = Math.round(P.BAR_COUNT);
+        const { weights, offsets } = genWeights(count, P.CENTER_EMPHASIS);
+        return {
+          count,
+          weights,
+          offsets,
+          boxH: surface.boxH,
+          growth: surface.growth,
+          barW: surface.tunedBarW,
+          gap: surface.tunedGap,
+        };
+      }
+
+      // ---- shaping (mirrors the two real surfaces) ----
+      function shapeHud(rawLevel, p) {
+        return rawLevel <= p.AUDIO_NOISE_GATE
+          ? clamp(Math.sqrt(rawLevel * p.AMBIENT_VISUAL_GAIN), 0, p.AMBIENT_MAX_LEVEL)
+          : clamp(
+              p.AMBIENT_MAX_LEVEL +
+                Math.sqrt((rawLevel - p.AUDIO_NOISE_GATE) * p.AUDIO_VISUAL_GAIN),
+              0,
+              1,
+            );
+      }
+      function shapeRecorder(peak, p) {
+        const normalized = clamp(peak, 0, 1);
+        const gated = (normalized - p.NOISE_FLOOR) / (1 - p.NOISE_FLOOR);
+        if (gated <= 0) return 0;
+        const shaped = 1 - Math.exp(-p.KNEE * Math.pow(gated, p.LOW_LIFT));
+        return clamp(shaped, 0, 1);
+      }
+
+      // ---- meter (port of createBarMeter, reads alphas live from `p`) ----
+      function createBarMeter(surface, p) {
+        const { count, weights, offsets } = surface;
+        const history = new Array(LEVEL_HISTORY_LENGTH).fill(IDLE_LEVEL);
+        const targets = new Array(count).fill(IDLE_LEVEL);
+        const displayed = new Array(count).fill(IDLE_LEVEL);
+        let head = 0;
+        const len = LEVEL_HISTORY_LENGTH;
+        // Read the envelope `d` pushes back, interpolating between the two
+        // nearest samples so a fractional propagation delay reads smoothly.
+        function sampleAt(d) {
+          d = clamp(d, 0, len - 1);
+          const base = Math.floor(d);
+          const frac = d - base;
+          const i0 = (((head - base) % len) + len) % len;
+          const i1 = (((head - base - 1) % len) + len) % len;
+          return history[i0] * (1 - frac) + history[i1] * frac;
+        }
+        function pushLevel(level) {
+          head = (head + 1) % len;
+          history[head] = level;
+          const mix = p.LIVE_LEVEL_MIX;
+          const mid = (count - 1) / 2;
+          const raw = new Array(count);
+          for (let i = 0; i < count; i++) {
+            let sample;
+            if (p.PROP_DELAY > 0) {
+              // Spatial delay per bar → the speaking envelope travels across.
+              const dist = p.PROP_MODE === "center" ? Math.abs(i - mid) : i;
+              const delayed = sampleAt(dist * p.PROP_DELAY);
+              sample = history[head] * mix + delayed * (1 - mix);
+            } else {
+              // Original path: a fixed [1,0,1,0,…] one-push offset shimmer.
+              const offset = offsets[i] ?? 0;
+              const hi = (((head - offset) % len) + len) % len;
+              sample = history[head] * mix + history[hi] * (1 - mix);
+            }
+            raw[i] = (weights[i] ?? 0.5) * sample;
+          }
+          // Spatial smoothing: blend each bar toward its neighbours so the wave
+          // spreads smoothly across the row instead of spiking on single bars.
+          const s = p.SPATIAL || 0;
+          for (let i = 0; i < count; i++) {
+            let v = raw[i];
+            if (s > 0) {
+              const l = raw[i - 1] ?? raw[i];
+              const r = raw[i + 1] ?? raw[i];
+              v = raw[i] * (1 - s) + ((l + r) / 2) * s;
+            }
+            targets[i] = clamp(v, 0, 1);
+          }
+        }
+        function step() {
+          let animating = false;
+          for (let i = 0; i < count; i++) {
+            const diff = targets[i] - displayed[i];
+            const goingSilent = targets[i] <= p.SILENCE_TARGET;
+            const alpha =
+              diff > 0
+                ? p.ATTACK_ALPHA
+                : goingSilent
+                  ? p.SILENCE_RELEASE_ALPHA
+                  : p.RELEASE_ALPHA;
+            let next = clamp(displayed[i] + diff * alpha, 0, 1);
+            if (
+              targets[i] <= IDLE_LEVEL + p.IDLE_SNAP_DELTA &&
+              Math.abs(next - IDLE_LEVEL) < p.IDLE_SNAP_DELTA
+            ) {
+              next = IDLE_LEVEL;
+            }
+            displayed[i] = next;
+            if (Math.abs(targets[i] - displayed[i]) > p.IDLE_SNAP_DELTA)
+              animating = true;
+          }
+          return animating;
+        }
+        function reset() {
+          history.fill(IDLE_LEVEL);
+          targets.fill(IDLE_LEVEL);
+          displayed.fill(IDLE_LEVEL);
+          head = 0;
+        }
+        return { targets, displayed, pushLevel, step, reset, count };
+      }
+
+      // ===================================================================
+      // DOM bars
+      // ===================================================================
+      let surface = SURFACES.hud; // base preset: geometry + prod bars for meter B
+      let surfaceA = makeSurfaceA(); // your custom bars for meter A
+      let meterA = createBarMeter(surfaceA, P);
+      let meterB = createBarMeter(surface, DEFAULTS);
+
+      function buildBars(containerId, surf) {
+        const c = document.getElementById(containerId);
+        c.innerHTML = "";
+        c.style.gap = surf.gap + "px";
+        c.style.height = surf.boxH + "px";
+        const fills = [];
+        for (let i = 0; i < surf.count; i++) {
+          const bar = document.createElement("div");
+          bar.className = "bar";
+          bar.style.width = surf.barW + "px";
+          bar.style.height = surf.boxH + "px";
+          const fill = document.createElement("i");
+          bar.appendChild(fill);
+          c.appendChild(bar);
+          fills.push(fill);
+        }
+        return fills;
+      }
+      let fillsA = buildBars("barsA", surfaceA);
+      let fillsB = buildBars("barsB", surface);
+
+      function applyTransition() {
+        // meter A uses the slider's CSS_MS; meter B uses the shipping 40ms.
+        for (const f of fillsA) f.style.transition = `height ${P.CSS_MS}ms linear`;
+        for (const f of fillsB) f.style.transition = `height ${DEFAULTS.CSS_MS}ms linear`;
+      }
+      // Paint the bars, layering the audio-driven displayed level with the
+      // always-on travelling carrier wave. The wave recedes as a bar gets loud
+      // (× (1 - lvl)) so it reads as a baseline shimmer, not noise on top.
+      function paint(fills, meter, p, now) {
+        const t = now / 1000;
+        for (let i = 0; i < meter.count; i++) {
+          let lvl = meter.displayed[i];
+          if (p.IDLE_AMP > 0) {
+            const ripple =
+              p.IDLE_AMP *
+              0.5 *
+              (1 + Math.sin(2 * Math.PI * p.IDLE_SPEED * t - i * p.IDLE_SPREAD));
+            lvl = clamp(lvl + ripple * (1 - lvl), 0, 1);
+          }
+          fills[i].style.height = (3 + lvl * surface.growth).toFixed(2) + "px";
+        }
+      }
+
+      function rebuildSurface() {
+        surfaceA = makeSurfaceA();
+        meterA = createBarMeter(surfaceA, P);
+        meterB = createBarMeter(surface, DEFAULTS);
+        fillsA = buildBars("barsA", surfaceA);
+        fillsB = buildBars("barsB", surface);
+        applyTransition();
+      }
+      // Rebuild only meter A's bars (count / emphasis changed) — leaves the
+      // shipping-default row alone for A/B.
+      function rebuildAGeometry() {
+        surfaceA = makeSurfaceA();
+        meterA = createBarMeter(surfaceA, P);
+        fillsA = buildBars("barsA", surfaceA);
+        applyTransition();
+      }
+
+      // ===================================================================
+      // Audio input
+      // ===================================================================
+      let audioCtx = null;
+      let analyser = null;
+      let timeData = null;
+      let micOn = false;
+      let injected = null; // {level, until} synthetic override
+
+      async function toggleMic() {
+        if (micOn) {
+          micOn = false;
+          document.getElementById("mic").textContent = "Start mic";
+          document.getElementById("status").textContent = "";
+          return;
+        }
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            audio: { echoCancellation: false, noiseSuppression: false, autoGainControl: false },
+          });
+          audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+          await audioCtx.resume();
+          const src = audioCtx.createMediaStreamSource(stream);
+          analyser = audioCtx.createAnalyser();
+          analyser.fftSize = 1024;
+          timeData = new Float32Array(analyser.fftSize);
+          src.connect(analyser);
+          micOn = true;
+          document.getElementById("mic").textContent = "Stop mic";
+          document.getElementById("status").textContent = "mic live";
+        } catch (e) {
+          document.getElementById("status").textContent = "mic blocked: " + e.message;
+        }
+      }
+
+      function readRaw() {
+        // synthetic injection wins (Spike / Burst) so you can test without talking
+        const now = performance.now();
+        if (injected && now < injected.until) {
+          return { rms: injected.level, peak: injected.level };
+        }
+        if (!analyser) return { rms: 0, peak: 0 };
+        analyser.getFloatTimeDomainData(timeData);
+        let sum = 0,
+          peak = 0;
+        for (let i = 0; i < timeData.length; i++) {
+          const s = timeData[i];
+          sum += s * s;
+          const a = Math.abs(s);
+          if (a > peak) peak = a;
+        }
+        return { rms: Math.sqrt(sum / timeData.length), peak };
+      }
+
+      // ===================================================================
+      // Loops:  push at PUSH_HZ (like the app's ~25Hz audio_level),
+      //         step + paint on rAF (60Hz), exactly like hud.ts.
+      // ===================================================================
+      let lastPush = 0;
+      let lastShaped = 0,
+        lastRms = 0,
+        lastPeak = 0;
+      let sourceMode = "rms";
+
+      function pushTick(now) {
+        const interval = 1000 / P.PUSH_HZ;
+        if (now - lastPush < interval) return;
+        lastPush = now;
+        const { rms, peak } = readRaw();
+        lastRms = rms;
+        lastPeak = peak;
+        const raw = sourceMode === "peak" ? peak : rms;
+        // meter A uses your shaping params; meter B uses defaults — same raw.
+        const surfShape = surfaceKey === "recorder" ? shapeRecorder : shapeHud;
+        let shapedA = surfShape(raw, P);
+        // Whisper floor: lift quiet *speech* off the baseline so it still reads.
+        // Voice-gated — only fires above the noise gate, so ambient room hiss and
+        // silence still collapse the bars to zero (no idle shimmer in calm tabs).
+        const voiceGate =
+          surfaceKey === "recorder" ? P.NOISE_FLOOR : P.AUDIO_NOISE_GATE;
+        if (raw > voiceGate && shapedA > 0.0001 && P.WHISPER_FLOOR > 0) {
+          shapedA = P.WHISPER_FLOOR + (1 - P.WHISPER_FLOOR) * shapedA;
+        }
+        const shapedB = surfShape(raw, DEFAULTS);
+        lastShaped = shapedA;
+        meterA.pushLevel(shapedA);
+        meterB.pushLevel(shapedB);
+      }
+
+      // scope history
+      const SCOPE_N = 360;
+      const histShaped = new Array(SCOPE_N).fill(0);
+      const histA = new Array(SCOPE_N).fill(0);
+      const histB = new Array(SCOPE_N).fill(0);
+      let scopeAcc = 0;
+      const scope = document.getElementById("scope");
+      const sctx = scope.getContext("2d");
+
+      function drawScope() {
+        const w = scope.width,
+          h = scope.height;
+        sctx.clearRect(0, 0, w, h);
+        const line = (arr, color) => {
+          sctx.beginPath();
+          sctx.strokeStyle = color;
+          sctx.lineWidth = 1.5;
+          for (let i = 0; i < SCOPE_N; i++) {
+            const x = (i / (SCOPE_N - 1)) * w;
+            const y = h - arr[i] * (h - 6) - 3;
+            i === 0 ? sctx.moveTo(x, y) : sctx.lineTo(x, y);
+          }
+          sctx.stroke();
+        };
+        line(histShaped, "#6ea8fe");
+        line(histB, "#7ee0a8");
+        line(histA, "#e7ebf0");
+      }
+
+      let surfaceKey = "hud";
+
+      function frame(now) {
+        pushTick(now);
+        meterA.step();
+        meterB.step();
+        paint(fillsA, meterA, P, now);
+        paint(fillsB, meterB, DEFAULTS, now);
+
+        // scope + readouts (downsample to ~ every other frame)
+        if (++scopeAcc % 2 === 0) {
+          const mid = (m) => m.displayed[Math.floor(m.count / 2)];
+          histShaped.push(lastShaped); histShaped.shift();
+          histA.push(mid(meterA)); histA.shift();
+          histB.push(mid(meterB)); histB.shift();
+          drawScope();
+          document.getElementById("mRms").textContent = lastRms.toFixed(3);
+          document.getElementById("mPeak").textContent = lastPeak.toFixed(3);
+          document.getElementById("mShaped").textContent = lastShaped.toFixed(3);
+          document.getElementById("mTarget").textContent =
+            meterA.targets[Math.floor(meterA.count / 2)].toFixed(3);
+        }
+        requestAnimationFrame(frame);
+      }
+      requestAnimationFrame(frame);
+
+      // ===================================================================
+      // Controls
+      // ===================================================================
+      const SLIDERS = {
+        wave: [
+          ["IDLE_AMP", "Idle amplitude", 0, 0.3, 0.01, "Height of the always-on carrier wave at the baseline — the 'shimmer across' you want. Recedes as bars get loud. 0 = off (shipping)."],
+          ["IDLE_SPEED", "Idle speed", 0.05, 2, 0.05, "How fast the wave travels across the bars (cycles/sec). ~0.4 reads as a calm breathing time-signifier; faster feels busier."],
+          ["IDLE_SPREAD", "Idle spread", 0, 2, 0.05, "Phase shift per bar = wavelength across the row. Higher = a tight wave clearly travelling left→right; 0 = all bars pulse in unison (no travel)."],
+        ],
+        spread: [
+          ["PROP_DELAY", "Propagation", 0, 1.5, 0.05, "How much the speaking envelope is delayed per bar of distance — i.e. how fast it travels across. 0 = all bars react together (the 'jumpy in the middle' you have now); higher = a smooth wave that spreads across the row."],
+          ["SPATIAL", "Spatial smoothing", 0, 1, 0.05, "Blend each bar toward its neighbours so the wave is smooth across the row instead of spiking on individual bars."],
+        ],
+        bars: [
+          ["BAR_COUNT", "Bar count", 3, 13, 1, "How many bars. Prod HUD = 5, recorder = 7. The pill you screenshotted reads ~10–11. Weights auto-generate as a symmetric lens."],
+          ["CENTER_EMPHASIS", "Center emphasis", 0, 0.4, 0.02, "How much taller the middle bars sit vs the edges — the lens/envelope shape. The center stays elevated while you speak."],
+          ["WHISPER_FLOOR", "Whisper floor", 0, 0.4, 0.01, "Minimum level shown whenever ANY voice is detected, so whispers still light the bars. Prod = 0. Try 0.1–0.18."],
+        ],
+        ballistics: [
+          ["ATTACK_ALPHA", "Attack", 0, 1, 0.01, "Rise speed per frame toward a louder target. 1 = instant snap up."],
+          ["RELEASE_ALPHA", "Release", 0, 1, 0.01, "Fall speed per frame for normal (above-silence) drops. Higher = snappier tail. The main snap-back knob."],
+          ["SILENCE_RELEASE_ALPHA", "Silence release", 0, 1, 0.01, "Fall speed once the target is below the silence threshold."],
+          ["SILENCE_TARGET", "Silence threshold", 0, 0.4, 0.005, "Target at/below this uses the fast 'silence release'. Raise it so the snap-back kicks in while still quiet, not only at dead silence."],
+          ["IDLE_SNAP_DELTA", "Idle snap", 0, 0.03, 0.001, "Dead zone — bars snap to 0 within this distance."],
+          ["LIVE_LEVEL_MIX", "Live/history mix", 0, 1, 0.05, "Blend of current sample vs a slightly older one. Lower = more smear/lag, higher = more reactive."],
+        ],
+        render: [
+          ["PUSH_HZ", "Push rate (Hz)", 10, 60, 1, "How often a new level is fed in. The app runs ~25Hz; rAF still paints at 60. Lower rates feel steppier."],
+          ["CSS_MS", "CSS transition (ms)", 0, 80, 1, "The SECOND smoothing layer — a linear height tween on top of the ballistics. 0 = let ballistics alone drive it (crispest). This is the prime suspect for mushy snap-back."],
+        ],
+        shapeHud: [
+          ["AUDIO_NOISE_GATE", "Noise gate", 0, 0.05, 0.001, "Below this, input is treated as ambient (quiet zone)."],
+          ["AUDIO_VISUAL_GAIN", "Voice gain", 1, 40, 0.5, "Amplification of speech above the gate."],
+          ["AMBIENT_VISUAL_GAIN", "Ambient gain", 1, 20, 0.5, "Amplification of the quiet/ambient zone."],
+          ["AMBIENT_MAX_LEVEL", "Ambient ceiling", 0, 0.4, 0.01, "Cap on how tall ambient noise can drive the bars."],
+        ],
+        shapeRec: [
+          ["NOISE_FLOOR", "Noise floor", 0, 0.05, 0.001, "Soft expander gate — at/below this reads as silence."],
+          ["LOW_LIFT", "Low lift", 0.2, 1, 0.02, "Sub-1 power lifting whispers. Lower lifts quiet input more."],
+          ["KNEE", "Knee", 1, 16, 0.5, "Soft-knee steepness for loud speech approaching the ceiling."],
+        ],
+      };
+
+      function makeKnob(key, name, min, max, stepv, hint) {
+        const wrap = document.createElement("div");
+        wrap.className = "knob";
+        wrap.innerHTML = `
+          <div class="top">
+            <span class="name">${name}</span>
+            <span><span class="val" id="val-${key}"></span><span class="def">def ${DEFAULTS[key]}</span></span>
+          </div>
+          <input type="range" id="sl-${key}" min="${min}" max="${max}" step="${stepv}" value="${P[key]}" />
+          <div class="hint">${hint}</div>`;
+        const sl = wrap.querySelector("input");
+        const val = wrap.querySelector(".val");
+        val.textContent = (+P[key]).toString();
+        sl.addEventListener("input", () => {
+          P[key] = parseFloat(sl.value);
+          val.textContent = sl.value;
+          if (key === "CSS_MS") applyTransition();
+          if (key === "BAR_COUNT" || key === "CENTER_EMPHASIS") rebuildAGeometry();
+          updateExport();
+        });
+        return wrap;
+      }
+      function mount(containerId, defs) {
+        const c = document.getElementById(containerId);
+        c.innerHTML = "";
+        for (const d of defs) c.appendChild(makeKnob(...d));
+      }
+      mount("barsCtl", SLIDERS.bars);
+      mount("waveCtl", SLIDERS.wave);
+      mount("spreadCtl", SLIDERS.spread);
+      mount("ballistics", SLIDERS.ballistics);
+
+      // Spread-origin select (string param, so it's outside the slider system).
+      const propModeSel = document.getElementById("sl-PROP_MODE");
+      propModeSel.value = P.PROP_MODE;
+      propModeSel.addEventListener("change", () => {
+        P.PROP_MODE = propModeSel.value;
+        updateExport();
+      });
+      mount("render", SLIDERS.render);
+      mount("shapeHud", SLIDERS.shapeHud);
+      mount("shapeRec", SLIDERS.shapeRec);
+      applyTransition();
+
+      function updateExport() {
+        const lines = Object.keys(DEFAULTS)
+          .map((k) => {
+            const changed = P[k] !== DEFAULTS[k];
+            return `${k.padEnd(22)} ${String(P[k]).padStart(6)}${changed ? "   ← changed (was " + DEFAULTS[k] + ")" : ""}`;
+          })
+          .join("\n");
+        document.getElementById("export").textContent =
+          lines + "\n\nweights (yours)        [" + makeSurfaceA().weights.join(", ") + "]";
+      }
+      updateExport();
+
+      // surface / source / buttons
+      document.getElementById("surface").addEventListener("change", (e) => {
+        surfaceKey = e.target.value;
+        surface = SURFACES[surfaceKey];
+        document.getElementById("shapingHud").style.display =
+          surfaceKey === "hud" ? "" : "none";
+        document.getElementById("shapingRec").style.display =
+          surfaceKey === "recorder" ? "" : "none";
+        // sensible default raw source per surface
+        sourceMode = surfaceKey === "recorder" ? "peak" : "rms";
+        document.getElementById("source").value = sourceMode;
+        // sync the bar-count slider to the new preset's prod count
+        P.BAR_COUNT = surface.count;
+        const slc = document.getElementById("sl-BAR_COUNT");
+        if (slc) {
+          slc.value = surface.count;
+          document.getElementById("val-BAR_COUNT").textContent = surface.count;
+        }
+        rebuildSurface();
+        updateExport();
+      });
+      document.getElementById("source").addEventListener("change", (e) => {
+        sourceMode = e.target.value;
+      });
+      document.getElementById("mic").addEventListener("click", toggleMic);
+      document.getElementById("spike").addEventListener("click", () => {
+        injected = { level: 0.95, until: performance.now() + 120 };
+      });
+      let burstTimer = null;
+      document.getElementById("burst").addEventListener("click", (e) => {
+        if (burstTimer) {
+          clearInterval(burstTimer);
+          burstTimer = null;
+          injected = null;
+          e.target.textContent = "Burst loop";
+          return;
+        }
+        e.target.textContent = "Stop burst";
+        const fire = () => {
+          injected = { level: 0.85, until: performance.now() + 180 };
+        };
+        fire();
+        burstTimer = setInterval(fire, 900);
+      });
+      document.getElementById("reset").addEventListener("click", () => {
+        Object.assign(P, DEFAULTS);
+        for (const key of Object.keys(DEFAULTS)) {
+          const sl = document.getElementById("sl-" + key);
+          const val = document.getElementById("val-" + key);
+          if (sl) sl.value = DEFAULTS[key];
+          if (val) val.textContent = DEFAULTS[key];
+        }
+        rebuildAGeometry();
+        applyTransition();
+        updateExport();
+      });
+    </script>
+  </body>
+</html>

--- a/playground/waveform-playground.html
+++ b/playground/waveform-playground.html
@@ -215,7 +215,7 @@
         </div>
         <div class="btnrow">
           <select id="surface">
-            <option value="hud">HUD — 5 bars (dictation)</option>
+            <option value="hud">HUD — 7 bars (dictation)</option>
             <option value="recorder">Recorder — 7 bars</option>
           </select>
           <select id="source">

--- a/src/components/recorder/RecorderBar.tsx
+++ b/src/components/recorder/RecorderBar.tsx
@@ -49,7 +49,10 @@ export function RecorderBar({
       </button>
       <div className="recorder-meter">
         <span className="elapsed">{formatElapsed(status.elapsedMs)}</span>
-        <Waveform level={meterLevel} />
+        <Waveform
+          level={meterLevel}
+          active={status.state === "recording"}
+        />
       </div>
       <button
         type="button"

--- a/src/components/recorder/Waveform.tsx
+++ b/src/components/recorder/Waveform.tsx
@@ -8,13 +8,18 @@ import {
   clamp,
   createBarMeter,
   IDLE_LEVEL,
+  LIVE_WAVE_OPTIONS,
   RECORDER_BAR_COUNT,
   RECORDER_BAR_HISTORY_OFFSETS,
   RECORDER_BAR_WEIGHTS,
+  withIdleCarrier,
 } from "../../lib/audio-meter";
 
 type WaveformProps = {
   level: AudioLevelDto;
+  // Whether recording is live. The idle carrier shimmer only travels while
+  // active; when paused the bars settle and hold (CSS also dims them).
+  active?: boolean;
 };
 
 // Below this the input reads as silence — a soft downward expander that keeps
@@ -28,17 +33,21 @@ const LOW_LIFT = 0.6;
 // instead of slamming flat. Higher reaches the ceiling sooner.
 const KNEE = 6;
 
-export function Waveform({ level }: WaveformProps) {
+export function Waveform({ level, active = true }: WaveformProps) {
   const refs = useRef<Array<HTMLSpanElement | null>>([]);
-  // Shares the dictation HUD's synthesis + ballistics, with the recorder's own
-  // taller 7-bar layout.
+  // Shares the dictation HUD's synthesis + ballistics AND its travelling-wave
+  // motion, with the recorder's own taller 7-bar layout and peak-based shaping.
   const meterRef = useRef(
     createBarMeter(
       RECORDER_BAR_COUNT,
       RECORDER_BAR_WEIGHTS,
       RECORDER_BAR_HISTORY_OFFSETS,
+      LIVE_WAVE_OPTIONS,
     ),
   );
+  // Read the latest `active` from inside the rAF loop without re-subscribing it.
+  const activeRef = useRef(active);
+  activeRef.current = active;
 
   // Feed a sample into the meter on every poll (keyed on the level prop, not the
   // shaped value — silence collapses to a constant 0, and we still want the
@@ -55,11 +64,15 @@ export function Waveform({ level }: WaveformProps) {
   useEffect(() => {
     const meter = meterRef.current;
     let raf = 0;
-    const tick = () => {
+    const tick = (now: number) => {
       meter.step();
       for (let i = 0; i < RECORDER_BAR_COUNT; i++) {
         const el = refs.current[i];
-        if (el) el.style.setProperty("--level", meter.displayed[i].toFixed(3));
+        if (!el) continue;
+        const value = activeRef.current
+          ? withIdleCarrier(meter.displayed[i], i, now)
+          : meter.displayed[i];
+        el.style.setProperty("--level", value.toFixed(3));
       }
       raf = requestAnimationFrame(tick);
     };

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -49,18 +49,47 @@ const meter = createBarMeter(
   bars.length,
   HUD_BAR_WEIGHTS,
   HUD_BAR_HISTORY_OFFSETS,
+  {
+    // Tuned 2026-06-04 to match Wispr Flow (see playground/waveform-playground.html):
+    // a smearier blend plus a speaking wave that sweeps left→right across the
+    // row and is smoothed between neighbours, instead of center bars spiking.
+    liveLevelMix: 0.35,
+    propDelay: 0.7,
+    propMode: "across",
+    spatial: 0.3,
+  },
 );
 
 let rafHandle: number | undefined;
 let lastAudioLevelAt = 0;
 const IDLE_RAF_TIMEOUT_MS = 260;
-// Lowered so a whisper crosses into the "voice" regime instead of being capped
-// at the ambient ceiling — quiet speech now reads on the bars. Raise back toward
-// 0.012 if room ambient starts lighting them up.
-const AUDIO_NOISE_GATE = 0.008;
-const AUDIO_VISUAL_GAIN = 16;
-const AMBIENT_VISUAL_GAIN = 4;
-const AMBIENT_MAX_LEVEL = 0.11;
+// Nudged 0.008→0.01 (2026-06-04) so quiet room ambient stays in the (now
+// heavily damped) ambient regime — real speech still clears it into the voice
+// path + whisper floor, but room tone no longer crosses over and lights bars.
+const AUDIO_NOISE_GATE = 0.01;
+// Raised 16→28 (2026-06-04) so the sqrt curve saturates at a much quieter input
+// — a whisper now fills the bars nearly as much as a shout (Wispr-Flow-style
+// compression, where bar height reads "voice present" more than "how loud").
+const AUDIO_VISUAL_GAIN = 28;
+// Ambient floor damped hard (gain 4→3, ceiling 0.11→0.03) so a quiet room rests
+// the bars near zero — the carrier wave, not room tone, is the idle "we're
+// listening" signal. The old 0.11 ceiling pegged the baseline and buried the
+// shimmer in ambient jitter, since the real HUD always has a live mic (unlike
+// the silent playground idle where the carrier was tuned).
+const AMBIENT_VISUAL_GAIN = 3;
+const AMBIENT_MAX_LEVEL = 0.03;
+
+// Whisper floor: once voice clears the gate, lift it off the baseline so even
+// quiet speech reads tall. Voice-gated (see renderAudioLevel) — ambient/silence
+// stays below the gate and still collapses the bars to zero.
+const HUD_WHISPER_FLOOR = 0.2;
+// Always-on carrier wave: a slow sine travelling across the bars at a low
+// baseline while listening, so the pill shimmers as an active-listening / time
+// signifier. Layered UNDER the audio response so it recedes as bars get loud.
+// Nudged 0.04→0.05 to sit clearly above the damped ambient floor (0.03).
+const HUD_IDLE_AMP = 0.05;
+const HUD_IDLE_SPEED = 0.45;
+const HUD_IDLE_SPREAD = 0.9;
 
 function setHud(state: string, status: string) {
   if (!hud || !statusText) return;
@@ -94,13 +123,29 @@ function setHud(state: string, status: string) {
 
 function startBarLoop() {
   if (rafHandle !== undefined) return;
-  const tick = () => {
+  const tick = (now: number) => {
     const stillAnimating = meter.step();
+    const t = now / 1000;
     for (let i = 0; i < bars.length; i++) {
-      bars[i].style.setProperty("--level", meter.displayed[i].toFixed(3));
+      let level = meter.displayed[i];
+      if (HUD_IDLE_AMP > 0) {
+        // Carrier rides under the audio (× (1 - level)) so it reads as a
+        // baseline shimmer, not noise on top of a loud bar.
+        const ripple =
+          HUD_IDLE_AMP *
+          0.5 *
+          (1 +
+            Math.sin(2 * Math.PI * HUD_IDLE_SPEED * t - i * HUD_IDLE_SPREAD));
+        level = clamp(level + ripple * (1 - level), 0, 1);
+      }
+      bars[i].style.setProperty("--level", level.toFixed(3));
     }
     const sinceAudio = performance.now() - lastAudioLevelAt;
-    if (stillAnimating || sinceAudio < IDLE_RAF_TIMEOUT_MS) {
+    // Keep painting while bars move or audio is recent — and, once the carrier
+    // wave is on, for as long as we're listening so the shimmer never freezes.
+    const keepShimmering =
+      HUD_IDLE_AMP > 0 && hud?.dataset.state === "listening";
+    if (stillAnimating || sinceAudio < IDLE_RAF_TIMEOUT_MS || keepShimmering) {
       rafHandle = window.requestAnimationFrame(tick);
     } else {
       rafHandle = undefined;
@@ -118,7 +163,7 @@ function resetBars() {
 }
 
 function renderAudioLevel(rawLevel: number) {
-  const shaped =
+  let shaped =
     rawLevel <= AUDIO_NOISE_GATE
       ? clamp(Math.sqrt(rawLevel * AMBIENT_VISUAL_GAIN), 0, AMBIENT_MAX_LEVEL)
       : clamp(
@@ -127,6 +172,12 @@ function renderAudioLevel(rawLevel: number) {
           0,
           1,
         );
+  // Voice-gated whisper floor — only lifts once real voice clears the gate, so
+  // ambient room hiss stays pinned to zero (bars collapse) while any actual
+  // speech, however quiet, reads tall.
+  if (rawLevel > AUDIO_NOISE_GATE && shaped > 0.0001 && HUD_WHISPER_FLOOR > 0) {
+    shaped = HUD_WHISPER_FLOOR + (1 - HUD_WHISPER_FLOOR) * shaped;
+  }
   lastAudioLevelAt = performance.now();
   meter.pushLevel(shaped);
   startBarLoop();

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -56,8 +56,15 @@ const meter = createBarMeter(
 );
 
 let rafHandle: number | undefined;
+let shimmerTimer: number | undefined;
 let lastAudioLevelAt = 0;
 const IDLE_RAF_TIMEOUT_MS = 260;
+// Once the bars have settled and no fresh audio is arriving, the only thing
+// left to animate is the slow idle carrier. Pace it at ~30fps via a timer
+// instead of painting every rAF, so a long listening session doesn't pin the
+// CPU at 60fps compositing — the carrier (a 0.45Hz sine) reads smooth either
+// way. Full rAF resumes the moment audio or bar motion returns.
+const SHIMMER_FRAME_MS = 33;
 // Nudged 0.008→0.01 (2026-06-04) so quiet room ambient stays in the (now
 // heavily damped) ambient regime — real speech still clears it into the voice
 // path + whisper floor, but room tone no longer crosses over and lights bars.
@@ -113,21 +120,34 @@ function setHud(state: string, status: string) {
 
 function startBarLoop() {
   if (rafHandle !== undefined) return;
+  // Audio arriving mid-shimmer cancels the throttled tick so we snap back to
+  // full-rate rAF immediately instead of waiting out the timer.
+  if (shimmerTimer !== undefined) {
+    window.clearTimeout(shimmerTimer);
+    shimmerTimer = undefined;
+  }
   const tick = (now: number) => {
+    rafHandle = undefined;
     const stillAnimating = meter.step();
     for (let i = 0; i < bars.length; i++) {
       const level = withIdleCarrier(meter.displayed[i], i, now);
       bars[i].style.setProperty("--level", level.toFixed(3));
     }
     const sinceAudio = performance.now() - lastAudioLevelAt;
-    // Keep painting while bars move or audio is recent — and, once the carrier
-    // wave is on, for as long as we're listening so the shimmer never freezes.
+    const reactive = stillAnimating || sinceAudio < IDLE_RAF_TIMEOUT_MS;
+    // Once the carrier wave is on, keep animating for as long as we're listening
+    // so the shimmer never freezes.
     const keepShimmering =
       IDLE_CARRIER_AMP > 0 && hud?.dataset.state === "listening";
-    if (stillAnimating || sinceAudio < IDLE_RAF_TIMEOUT_MS || keepShimmering) {
+    if (reactive) {
+      // Bars moving or audio recent → paint every frame for responsiveness.
       rafHandle = window.requestAnimationFrame(tick);
-    } else {
-      rafHandle = undefined;
+    } else if (keepShimmering) {
+      // Idle but listening → throttle the carrier so the CPU can idle between ticks.
+      shimmerTimer = window.setTimeout(() => {
+        shimmerTimer = undefined;
+        rafHandle = window.requestAnimationFrame(tick);
+      }, SHIMMER_FRAME_MS);
     }
   };
   rafHandle = window.requestAnimationFrame(tick);

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -7,7 +7,10 @@ import {
   createBarMeter,
   HUD_BAR_HISTORY_OFFSETS,
   HUD_BAR_WEIGHTS,
+  IDLE_CARRIER_AMP,
   IDLE_LEVEL,
+  LIVE_WAVE_OPTIONS,
+  withIdleCarrier,
 } from "./lib/audio-meter";
 import "./styles/hud.css";
 
@@ -49,15 +52,7 @@ const meter = createBarMeter(
   bars.length,
   HUD_BAR_WEIGHTS,
   HUD_BAR_HISTORY_OFFSETS,
-  {
-    // Tuned 2026-06-04 to match Wispr Flow (see playground/waveform-playground.html):
-    // a smearier blend plus a speaking wave that sweeps left→right across the
-    // row and is smoothed between neighbours, instead of center bars spiking.
-    liveLevelMix: 0.35,
-    propDelay: 0.7,
-    propMode: "across",
-    spatial: 0.3,
-  },
+  LIVE_WAVE_OPTIONS,
 );
 
 let rafHandle: number | undefined;
@@ -83,13 +78,8 @@ const AMBIENT_MAX_LEVEL = 0.03;
 // quiet speech reads tall. Voice-gated (see renderAudioLevel) — ambient/silence
 // stays below the gate and still collapses the bars to zero.
 const HUD_WHISPER_FLOOR = 0.2;
-// Always-on carrier wave: a slow sine travelling across the bars at a low
-// baseline while listening, so the pill shimmers as an active-listening / time
-// signifier. Layered UNDER the audio response so it recedes as bars get loud.
-// Nudged 0.04→0.05 to sit clearly above the damped ambient floor (0.03).
-const HUD_IDLE_AMP = 0.05;
-const HUD_IDLE_SPEED = 0.45;
-const HUD_IDLE_SPREAD = 0.9;
+// The always-on idle carrier wave lives in the shared meter (IDLE_CARRIER_*) so
+// the HUD and recorder shimmer identically.
 
 function setHud(state: string, status: string) {
   if (!hud || !statusText) return;
@@ -125,26 +115,15 @@ function startBarLoop() {
   if (rafHandle !== undefined) return;
   const tick = (now: number) => {
     const stillAnimating = meter.step();
-    const t = now / 1000;
     for (let i = 0; i < bars.length; i++) {
-      let level = meter.displayed[i];
-      if (HUD_IDLE_AMP > 0) {
-        // Carrier rides under the audio (× (1 - level)) so it reads as a
-        // baseline shimmer, not noise on top of a loud bar.
-        const ripple =
-          HUD_IDLE_AMP *
-          0.5 *
-          (1 +
-            Math.sin(2 * Math.PI * HUD_IDLE_SPEED * t - i * HUD_IDLE_SPREAD));
-        level = clamp(level + ripple * (1 - level), 0, 1);
-      }
+      const level = withIdleCarrier(meter.displayed[i], i, now);
       bars[i].style.setProperty("--level", level.toFixed(3));
     }
     const sinceAudio = performance.now() - lastAudioLevelAt;
     // Keep painting while bars move or audio is recent — and, once the carrier
     // wave is on, for as long as we're listening so the shimmer never freezes.
     const keepShimmering =
-      HUD_IDLE_AMP > 0 && hud?.dataset.state === "listening";
+      IDLE_CARRIER_AMP > 0 && hud?.dataset.state === "listening";
     if (stillAnimating || sinceAudio < IDLE_RAF_TIMEOUT_MS || keepShimmering) {
       rafHandle = window.requestAnimationFrame(tick);
     } else {

--- a/src/lib/audio-meter.ts
+++ b/src/lib/audio-meter.ts
@@ -1,17 +1,18 @@
 // Shared waveform meter: bar synthesis + envelope ballistics used by BOTH the
 // dictation HUD (hud.ts) and the note recorder (recorder/Waveform.tsx) so the
 // two waveforms share one design language. Bar count/weights are per-surface
-// (the HUD is a compact 5-bar pill; the recorder is a taller 7-bar meter), but
-// the motion is identical.
+// (both are now 7-bar symmetric "lens" rows), and the per-meter options below
+// let the HUD layer on its travelling-wave motion without touching the recorder.
 //
 // Inputs are already-shaped 0..1 levels (each surface shapes its own raw audio
 // before pushing — the HUD from the helper's level, the recorder from peaks).
 
-// HUD: compact 5 bars. Hand-tuned organic weights + history offsets so each bar
-// samples slightly different recent audio (coherent shape, not a uniform block).
-export const HUD_BAR_COUNT = 5;
-export const HUD_BAR_WEIGHTS = [0.64, 0.86, 0.7, 0.84, 0.58];
-export const HUD_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1];
+// HUD: 7 bars, a symmetric lens (low edges, tall center) tuned 2026-06-04 to
+// match Wispr Flow's waveform. The center stays elevated while speaking; the
+// HUD drives motion via the travelling-wave options rather than these offsets.
+export const HUD_BAR_COUNT = 7;
+export const HUD_BAR_WEIGHTS = [0.55, 0.633, 0.797, 0.88, 0.797, 0.633, 0.55];
+export const HUD_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1, 0, 1];
 
 // Recorder: 7 bars, symmetric with a taller center, to fill its wider/taller
 // meter area.
@@ -19,9 +20,29 @@ export const RECORDER_BAR_COUNT = 7;
 export const RECORDER_BAR_WEIGHTS = [0.6, 0.84, 0.72, 0.9, 0.72, 0.84, 0.6];
 export const RECORDER_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1, 0, 1];
 
-export const LEVEL_HISTORY_LENGTH = 8;
+// Long enough that the HUD's per-bar propagation delays (a loud moment travels
+// across the row over several pushes) have history to read back from. The
+// recorder only reads the freshest one/two samples, so the extra length is free.
+export const LEVEL_HISTORY_LENGTH = 32;
 export const LIVE_LEVEL_MIX = 0.7;
 export const IDLE_LEVEL = 0;
+
+export type BarMeterOptions = {
+  // Blend of the freshest sample vs a slightly older one. Lower = more
+  // smear/lag (smoother), higher = more reactive. Default = LIVE_LEVEL_MIX.
+  liveLevelMix?: number;
+  // >0 makes the speaking envelope travel across the row: each bar reads the
+  // history delayed by its distance × propDelay (in pushes), so a loud moment
+  // sweeps across instead of every center bar spiking at once. 0 = the original
+  // fixed [1,0,1,0,…] one-push offset shimmer (what the recorder uses).
+  propDelay?: number;
+  // Where the travelling wave originates: "across" = left→right sweep,
+  // "center" = ripple outward from the middle.
+  propMode?: "across" | "center";
+  // 0..1 neighbour blend that smooths the wave across bars instead of letting
+  // single bars spike. 0 = off.
+  spatial?: number;
+};
 
 // Ballistics, applied per rAF frame (~60fps). Fast attack on the way up, a
 // quick release on the way down, and an even quicker collapse once the input
@@ -45,24 +66,62 @@ export function createBarMeter(
   barCount = HUD_BAR_COUNT,
   weights: number[] = HUD_BAR_WEIGHTS,
   historyOffsets: number[] = HUD_BAR_HISTORY_OFFSETS,
+  options: BarMeterOptions = {},
 ) {
+  const liveLevelMix = options.liveLevelMix ?? LIVE_LEVEL_MIX;
+  const propDelay = options.propDelay ?? 0;
+  const propMode = options.propMode ?? "across";
+  const spatial = options.spatial ?? 0;
+
   const history = new Array<number>(LEVEL_HISTORY_LENGTH).fill(IDLE_LEVEL);
   const targets = new Array<number>(barCount).fill(IDLE_LEVEL);
   const displayed = new Array<number>(barCount).fill(IDLE_LEVEL);
   let head = 0;
+  const len = LEVEL_HISTORY_LENGTH;
+  const mid = (barCount - 1) / 2;
+
+  // Read the envelope `d` pushes back, interpolating between the two nearest
+  // ring samples so a fractional propagation delay reads smoothly.
+  function sampleAt(d: number) {
+    d = clamp(d, 0, len - 1);
+    const base = Math.floor(d);
+    const frac = d - base;
+    const i0 = (((head - base) % len) + len) % len;
+    const i1 = (((head - base - 1) % len) + len) % len;
+    return history[i0] * (1 - frac) + history[i1] * frac;
+  }
 
   function pushLevel(level: number) {
-    head = (head + 1) % LEVEL_HISTORY_LENGTH;
+    head = (head + 1) % len;
     history[head] = level;
+    const raw = new Array<number>(barCount);
     for (let i = 0; i < barCount; i++) {
-      const weight = weights[i] ?? 0.5;
-      const offset = historyOffsets[i] ?? 0;
-      const historyIndex =
-        (head - offset + LEVEL_HISTORY_LENGTH) % LEVEL_HISTORY_LENGTH;
-      const blended =
-        history[head] * LIVE_LEVEL_MIX +
-        history[historyIndex] * (1 - LIVE_LEVEL_MIX);
-      targets[i] = clamp(IDLE_LEVEL + blended * weight, IDLE_LEVEL, 1);
+      let sample: number;
+      if (propDelay > 0) {
+        // Spatial delay per bar → the speaking envelope travels across the row.
+        const dist = propMode === "center" ? Math.abs(i - mid) : i;
+        const delayed = sampleAt(dist * propDelay);
+        sample = history[head] * liveLevelMix + delayed * (1 - liveLevelMix);
+      } else {
+        // Original path: a fixed [1,0,1,0,…] one-push offset shimmer.
+        const offset = historyOffsets[i] ?? 0;
+        const historyIndex = (((head - offset) % len) + len) % len;
+        sample =
+          history[head] * liveLevelMix +
+          history[historyIndex] * (1 - liveLevelMix);
+      }
+      raw[i] = (weights[i] ?? 0.5) * sample;
+    }
+    // Spatial smoothing: blend each bar toward its neighbours so the wave
+    // spreads smoothly across the row instead of spiking on single bars.
+    for (let i = 0; i < barCount; i++) {
+      let value = raw[i];
+      if (spatial > 0) {
+        const left = raw[i - 1] ?? raw[i];
+        const right = raw[i + 1] ?? raw[i];
+        value = raw[i] * (1 - spatial) + ((left + right) / 2) * spatial;
+      }
+      targets[i] = clamp(IDLE_LEVEL + value, IDLE_LEVEL, 1);
     }
   }
 

--- a/src/lib/audio-meter.ts
+++ b/src/lib/audio-meter.ts
@@ -7,18 +7,22 @@
 // Inputs are already-shaped 0..1 levels (each surface shapes its own raw audio
 // before pushing — the HUD from the helper's level, the recorder from peaks).
 
-// HUD: 7 bars, a symmetric lens (low edges, tall center) tuned 2026-06-04 to
-// match Wispr Flow's waveform. The center stays elevated while speaking; the
-// HUD drives motion via the travelling-wave options rather than these offsets.
-export const HUD_BAR_COUNT = 7;
-export const HUD_BAR_WEIGHTS = [0.55, 0.633, 0.797, 0.88, 0.797, 0.633, 0.55];
-export const HUD_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1, 0, 1];
+// 7-bar symmetric "lens": low edges, tall center (raised cosine between),
+// tuned 2026-06-04 to match Wispr Flow. Shared by BOTH surfaces so the
+// dictation HUD and the note recorder read as one waveform family — only their
+// pixel geometry and raw-audio shaping differ. The center stays elevated while
+// speaking; motion comes from the travelling-wave options below, not the
+// offsets (which only matter on the legacy propDelay=0 path).
+export const LENS_BAR_WEIGHTS = [0.55, 0.633, 0.797, 0.88, 0.797, 0.633, 0.55];
+export const LENS_HISTORY_OFFSETS = [1, 0, 1, 0, 1, 0, 1];
 
-// Recorder: 7 bars, symmetric with a taller center, to fill its wider/taller
-// meter area.
+export const HUD_BAR_COUNT = 7;
+export const HUD_BAR_WEIGHTS = LENS_BAR_WEIGHTS;
+export const HUD_BAR_HISTORY_OFFSETS = LENS_HISTORY_OFFSETS;
+
 export const RECORDER_BAR_COUNT = 7;
-export const RECORDER_BAR_WEIGHTS = [0.6, 0.84, 0.72, 0.9, 0.72, 0.84, 0.6];
-export const RECORDER_BAR_HISTORY_OFFSETS = [1, 0, 1, 0, 1, 0, 1];
+export const RECORDER_BAR_WEIGHTS = LENS_BAR_WEIGHTS;
+export const RECORDER_BAR_HISTORY_OFFSETS = LENS_HISTORY_OFFSETS;
 
 // Long enough that the HUD's per-bar propagation delays (a loud moment travels
 // across the row over several pushes) have history to read back from. The
@@ -34,7 +38,7 @@ export type BarMeterOptions = {
   // >0 makes the speaking envelope travel across the row: each bar reads the
   // history delayed by its distance × propDelay (in pushes), so a loud moment
   // sweeps across instead of every center bar spiking at once. 0 = the original
-  // fixed [1,0,1,0,…] one-push offset shimmer (what the recorder uses).
+  // fixed [1,0,1,0,…] one-push offset shimmer.
   propDelay?: number;
   // Where the travelling wave originates: "across" = left→right sweep,
   // "center" = ripple outward from the middle.
@@ -43,6 +47,41 @@ export type BarMeterOptions = {
   // single bars spike. 0 = off.
   spatial?: number;
 };
+
+// The travelling-wave motion shared by both live surfaces (HUD + recorder): a
+// smearier blend plus a speaking envelope that sweeps left→right across the row,
+// smoothed between neighbours, instead of center bars spiking. Pass to
+// createBarMeter so both surfaces move identically.
+export const LIVE_WAVE_OPTIONS: BarMeterOptions = {
+  liveLevelMix: 0.35,
+  propDelay: 0.7,
+  propMode: "across",
+  spatial: 0.3,
+};
+
+// Idle carrier wave — a slow sine travelling across the bars at a low baseline
+// so a live listening/recording surface shimmers as an "active" / time-passing
+// signifier. Layered UNDER the audio response (recedes as a bar gets loud).
+// Shared so the HUD and recorder shimmer identically.
+export const IDLE_CARRIER_AMP = 0.05;
+export const IDLE_CARRIER_SPEED = 0.45; // cycles per second
+export const IDLE_CARRIER_SPREAD = 0.9; // radians of phase per bar
+
+// Blend the carrier ripple into a displayed `level` for bar `index` at `timeMs`
+// (a monotonic clock, e.g. an rAF timestamp). Returns `level` unchanged when the
+// carrier is disabled (amp 0).
+export function withIdleCarrier(level: number, index: number, timeMs: number) {
+  if (IDLE_CARRIER_AMP <= 0) return level;
+  const t = timeMs / 1000;
+  const ripple =
+    IDLE_CARRIER_AMP *
+    0.5 *
+    (1 +
+      Math.sin(
+        2 * Math.PI * IDLE_CARRIER_SPEED * t - index * IDLE_CARRIER_SPREAD,
+      ));
+  return clamp(level + ripple * (1 - level), 0, 1);
+}
 
 // Ballistics, applied per rAF frame (~60fps). Fast attack on the way up, a
 // quick release on the way down, and an even quicker collapse once the input

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2327,13 +2327,13 @@ input:focus-visible,
   bottom: 50%;
   width: 100%;
   /* Grows toward the 30px box with a little headroom at the edges. The shared
-   * meter drives --level per frame; the 40ms transition smooths sub-frame
-   * steps. */
+   * meter drives --level per frame; the 24ms transition smooths sub-frame steps
+   * (sharpened from 40ms to match the HUD so the carrier shimmer reads crisp). */
   height: calc(3px + var(--level, 0) * 24px);
   border-radius: 999px;
   background: var(--foreground);
   transform: translateY(50%);
-  transition: height 40ms linear;
+  transition: height 24ms linear;
 }
 
 .recorder-bar[data-state="paused"] .waveform span {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -138,16 +138,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 3px;
+  gap: 2.5px;
   height: 22px;
 }
 
 /* The bar boxes stay a fixed size; only their absolutely-positioned inner
  * fills change height. That keeps the waveform fully rounded without forcing
- * flex layout work on every audio-level event. */
+ * flex layout work on every audio-level event. 7 thin bars (2026-06-04) read
+ * as a finer, Wispr-Flow-like waveform than the original 5 × 3px. */
 .hud-bar {
   position: relative;
-  width: 3px;
+  width: 2px;
   height: 22px;
 }
 
@@ -163,7 +164,9 @@ body {
   border-radius: 999px;
   background: var(--hud-bar);
   transform: translateY(50%);
-  transition: height 40ms linear;
+  /* Sharpened 40→24ms (2026-06-04) so the low-mix shimmer reads crisp rather
+   * than smeared on top of the ballistics. */
+  transition: height 24ms linear;
 }
 
 .hud-braille,


### PR DESCRIPTION
Retunes the dictation HUD waveform to feel like Wispr Flow — finer bars, whisper-friendly compression, a subtle always-on shimmer — then carries the same motion across to the **note recorder** so the two read as one waveform family. Also adds the standalone playground the values were tuned in.

## Shared waveform engine (`src/lib/audio-meter.ts`)
- Unified 7-bar **lens** weights (`LENS_BAR_WEIGHTS`) used by both surfaces.
- `createBarMeter` gained an options bag (`liveLevelMix` / `propDelay` / `propMode` / `spatial`); `LIVE_WAVE_OPTIONS` packages the travelling-wave motion both surfaces share. A loud moment now sweeps left→right across the row (smoothed between neighbours) instead of spiking the center bars.
- The idle **carrier wave** lives here too (`IDLE_CARRIER_*` + `withIdleCarrier()`), so the HUD and recorder shimmer identically.
- `LEVEL_HISTORY_LENGTH` 8→32 to give the propagation delays history to read from.

## HUD (`src/hud.ts`, `src/styles/hud.css`, `hud.html`)
- 7 thin bars (2px / 2.5px gap), replacing 5 × 3px.
- **Whisper ≈ shout compression** — `AUDIO_VISUAL_GAIN` 16→28 plus a voice-gated whisper floor (0.2).
- Carrier kept alive by the rAF loop while listening so the shimmer never freezes.
- **Damped ambient floor** (gate 0.008→0.01, gain 4→3, ceiling 0.11→0.03) so a quiet room rests the bars near zero and the carrier reads against a flat baseline — the real HUD always has a live mic, and the old 0.11 ceiling pegged/jittered the baseline and buried the shimmer.
- Bar transition sharpened 40→24ms.

## Recorder (`src/components/recorder/*`, `src/styles/app.css`)
- Shares `LIVE_WAVE_OPTIONS` + the carrier (gated on a new `active` prop — a paused recording settles and dims instead of shimmering).
- Bar transition sharpened 40→24ms.
- **Keeps its own peak shaping** (`visualPeakScale`): its dynamic-range/headroom curve is intentional and locked by `recorder.test.tsx`, per the codebase's "motion identical, each surface shapes its own audio" split. So the recorder shares motion + carrier but not the HUD's hard compression. Easy to add later if we want it.

## Playground (`playground/waveform-playground.html`)
Standalone, dependency-free dev tool that live-tunes the waveform and A/Bs slider values against prod defaults on the same audio. Kept in-tree for future waveform work; no build wiring.

## Testing
- `tsc --noEmit` clean, `prettier --check` clean.
- All 88 vitest tests pass, including `recorder.test.tsx` (shaping curve unchanged).
- HUD verified live in `tauri:dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)