### PR TITLE
feat: macos in-app auto-updates

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -1,22 +1,48 @@
-name: production-desktop-dmg
+name: production-desktop-release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version to release (for example 0.2.0)"
+        required: true
+        type: string
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
-  group: production-desktop-dmg-${{ github.ref }}
-  cancel-in-progress: true
+  group: production-desktop-release
+  cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build production macOS DMG
+  release:
+    name: Release production macOS app
     runs-on: macos-latest
     environment: production
     steps:
+      # Mint a short-lived token from the release GitHub App, scoped to BOTH the
+      # private source repo (to push the version-bump commit to main) and the
+      # public releases repo (tauri-action publishes there). One App is the sole
+      # release identity — org-owned, no personal PAT — and is the ruleset bypass
+      # actor for when main is protected (docs/adr/0001 + infra runbook).
+      - name: Mint release token (GitHub App)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: open-software-network
+          repositories: os-scribe,os-scribe-releases
+
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # Persist the App token so the later `git push origin main` (the
+          # version-bump commit) is authenticated as the App, not GITHUB_TOKEN.
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -32,6 +58,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -55,7 +83,7 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Validate production DMG secrets
+      - name: Validate release secrets
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -63,6 +91,10 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           PRODUCTION_OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
           PRODUCTION_OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
           PRODUCTION_OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
@@ -77,46 +109,111 @@ jobs:
             APPLE_API_ISSUER \
             APPLE_API_KEY \
             APPLE_API_KEY_P8 \
+            TAURI_SIGNING_PRIVATE_KEY \
+            RELEASE_APP_ID \
+            RELEASE_APP_PRIVATE_KEY \
             PRODUCTION_OS_ACCOUNTS_URL \
             PRODUCTION_OS_ACCOUNTS_API_URL \
             PRODUCTION_OS_ACCOUNTS_CLIENT_ID \
             PRODUCTION_SCRIBE_API_URL
           do
             if [ -z "${!name:-}" ]; then
-              echo "::error::${name} is required to build a production distributable signed and notarized DMG."
+              echo "::error::${name} is required for a production auto-update release."
               missing=1
             fi
           done
           exit "$missing"
 
-      - name: Build production DMG
+      - name: Validate release version input
         env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          re='^[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "$VERSION_INPUT" =~ $re ]]; then
+            echo "::error::Version must be semver X.Y.Z (digits only), got: $VERSION_INPUT"
+            exit 1
+          fi
+          # Stash the validated value. Every downstream step uses $VERSION (run:)
+          # or env.VERSION (with:), never the raw ${{ inputs.version }} — so the
+          # workflow_dispatch input can't reach a shell or action arg unsanitised
+          # (command/arg injection). The bash =~ match is anchored against the
+          # whole string, so an embedded newline fails the gate too.
+          echo "VERSION=$VERSION_INPUT" >> "$GITHUB_ENV"
+
+      - name: Bump release version
+        run: |
+          set -euo pipefail
+          pnpm version:bump "$VERSION"
+          cargo generate-lockfile --manifest-path src-tauri/Cargo.toml
+
+      - name: Run release checks
+        run: |
+          set -euo pipefail
+          pnpm lint
+          pnpm test
+          pnpm test:rust
+
+      - name: Write Apple API key
+        id: apple-api-key
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          chmod 600 "$key_path"
+          echo "path=$key_path" >> "$GITHUB_OUTPUT"
+
+      - name: Build, sign, notarize, and publish updater release
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_PATH: ${{ steps.apple-api-key.outputs.path }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
           OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
           OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
           SCRIBE_API_URL: ${{ secrets.PRODUCTION_SCRIBE_API_URL }}
-        run: pnpm tauri:build:signed-dmg
-
-      - name: Upload DMG
-        uses: actions/upload-artifact@v4
         with:
-          name: os-scribe-production-dmg-${{ github.sha }}
-          path: src-tauri/target/release/bundle/dmg/*.dmg
-          if-no-files-found: error
+          owner: open-software-network
+          repo: os-scribe-releases
+          tagName: v${{ env.VERSION }}
+          releaseName: OS Scribe v${{ env.VERSION }}
+          releaseBody: "Stable OS Scribe release v${{ env.VERSION }}."
+          releaseCommitish: main
+          generateReleaseNotes: true
+          args: --bundles app,dmg --target aarch64-apple-darwin
+          uploadUpdaterJson: true
+          uploadUpdaterSignatures: true
+
+      # Push the version bump to main only AFTER the release is published, so a
+      # build/notarize failure never leaves an orphan `release:` commit on main
+      # with no matching release. The push is authenticated as the release App
+      # (token persisted by checkout above), so when main gets a ruleset, add
+      # this App to the bypass actors and the push keeps working
+      # (docs/adr/0001 + infra runbook).
+      - name: Commit release version
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json pnpm-lock.yaml src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+          git commit -m "release: v$VERSION"
+          git push origin main
 
       - name: Summary
         run: |
           {
-            echo "### Production macOS DMG"
-            echo "This artifact is built against the production OS Accounts and Scribe API environment."
-            for dmg in src-tauri/target/release/bundle/dmg/*.dmg; do
-              [ -e "$dmg" ] || continue
-              echo "- \`$dmg\`"
-            done
+            echo "### Production macOS release"
+            echo "- Version: \`$VERSION\`"
+            echo "- Release repo: \`open-software-network/os-scribe-releases\`"
+            echo "- Update manifest: \`https://github.com/open-software-network/os-scribe-releases/releases/latest/download/latest.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -129,9 +129,11 @@ jobs:
           VERSION_INPUT: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          re='^[0-9]+\.[0-9]+\.[0-9]+$'
+          # Reject leading zeros so this gate matches bump-version.mjs's VERSION_RE
+          # exactly — invalid inputs fail here, not later with a murkier error.
+          re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
           if [[ ! "$VERSION_INPUT" =~ $re ]]; then
-            echo "::error::Version must be semver X.Y.Z (digits only), got: $VERSION_INPUT"
+            echo "::error::Version must be semver X.Y.Z (no leading zeros), got: $VERSION_INPUT"
             exit 1
           fi
           # Stash the validated value. Every downstream step uses $VERSION (run:)
@@ -189,7 +191,10 @@ jobs:
           releaseName: OS Scribe v${{ env.VERSION }}
           releaseBody: "Stable OS Scribe release v${{ env.VERSION }}."
           releaseCommitish: main
-          generateReleaseNotes: true
+          # Plain notes only: the in-app update dialog renders latest.json's
+          # `notes` as plain text, so GitHub's auto-generated markdown would show
+          # raw (## headings, @-mentions). Keep notes = the plain releaseBody.
+          generateReleaseNotes: false
           args: --bundles app,dmg --target aarch64-apple-darwin
           uploadUpdaterJson: true
           uploadUpdaterSignatures: true
@@ -207,6 +212,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json pnpm-lock.yaml src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
           git commit -m "release: v$VERSION"
+          # Rebase onto anything that landed on main during the (~15 min) build so
+          # the push isn't rejected non-fast-forward after the release is live.
+          git pull --rebase origin main
           git push origin main
 
       - name: Summary

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Thumbs.db
 .pnpm-store/
 .pre-flight-reviews/
 keys/
+.tmp/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,7 +43,8 @@ phrase, releases, and expects cleaned-up text inserted into the foreground
 app within a few hundred milliseconds. Distinct from **note transcription**
 (long-form, recorded session, async). Dictation goes through Scribe API in
 v1, so the binary holds no upstream provider key, but the request shape and
-charge timing are tuned for low latency (see ADR-0001 if/when written).
+charge timing are tuned for low latency (a dictation ADR may capture this
+if/when written).
 _Avoid_: speech-to-text (too generic; covers both dictation and note
 transcription).
 

--- a/docs/adr/0001-auto-updates-via-tauri-updater.md
+++ b/docs/adr/0001-auto-updates-via-tauri-updater.md
@@ -1,0 +1,47 @@
+# Auto-updates via Tauri updater, hosted on a separate public releases repo
+
+OS Scribe ships in-app auto-updates using `tauri-plugin-updater` (single stable
+track). Because the source repo is private and the Tauri updater fetches its
+manifest over an **unauthenticated** GET, the signed + notarized artifacts and
+`latest.json` are published to a **separate public repo**
+(`open-software-network/os-scribe-releases`) rather than the private source
+repo's releases. When the source repo eventually goes public, the updater
+`endpoints` URL repoints to it and the releases repo is retired.
+
+## Status
+
+accepted
+
+## Considered options
+
+- **GitHub Releases on the private source repo** — rejected. Private release
+  assets (including `latest.json`) return 404 to the updater's unauthenticated
+  GET. The only workaround is embedding a repo-read token in the binary, which
+  hands clone access to the private source to anyone holding the `.app`.
+- **Railway storage bucket** — rejected. Railway buckets are private-only ("public
+  buckets are currently not supported"); presigned URLs expire and cannot be
+  baked into the app as a permanent endpoint, so the bucket would need a separate
+  public proxy service in front — *more* infra than the alternative, for a
+  temporary need. Scribe API runs in a Phala TEE and is the wrong place to serve
+  static files.
+- **Cloudflare R2 public bucket** — viable (native public URLs, optional custom
+  domain). Kept as the upgrade path if a permanent, GitHub-independent update
+  domain is later wanted.
+- **Separate public releases repo** — chosen. Zero new infra, reuses
+  `gh release create` / `tauri-action`, and is a one-line endpoint change away
+  from the eventual public-source-repo end state.
+
+## Consequences
+
+- The updater `endpoints` URL is **baked into every shipped build and is
+  permanent for that build**. The chosen host must outlive the last install
+  pointing at it; repointing requires a new release, and old installs keep
+  polling the old URL until they update.
+- Updater integrity uses a **separate Ed25519 signing key** (distinct from the
+  Apple Developer ID cert). Losing its private key permanently breaks
+  auto-update for all installs and forces a manual reinstall — back it up.
+- Builds are **`aarch64`-only** for now; Intel Macs find no matching `platforms`
+  entry in `latest.json` and silently will not auto-update.
+- The shipped `0.1.0` predates the updater and cannot auto-update. The first
+  updater-capable build is `0.2.0`; existing internal users do one manual
+  reinstall, automatic thereafter.

--- a/docs/adr/0001-auto-updates-via-tauri-updater.md
+++ b/docs/adr/0001-auto-updates-via-tauri-updater.md
@@ -42,6 +42,5 @@ accepted
   auto-update for all installs and forces a manual reinstall — back it up.
 - Builds are **`aarch64`-only** for now; Intel Macs find no matching `platforms`
   entry in `latest.json` and silently will not auto-update.
-- The shipped `0.1.0` predates the updater and cannot auto-update. The first
-  updater-capable build is `0.2.0`; existing internal users do one manual
-  reinstall, automatic thereafter.
+- Builds that predate the updater cannot auto-update; the first updater-capable
+  build must be installed manually once, automatic for every release thereafter.

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -1,369 +1,122 @@
 # Releasing OS Scribe for macOS
 
-End-to-end runbook for cutting a signed, notarized `.app` + `.dmg` that
-end users can download, drag to `/Applications`, and launch without
-Gatekeeper warnings. Covers the nested helper apps (Swift sources at
-`src-tauri/native/mac-system-audio-recorder` and `mac-dictation-helper`,
-bundled into the distribution as `OS Scribe.app` and `OS Scribe
-Dictation Helper.app`) and the `osscribe://` URL scheme registration.
+OS Scribe ships signed, notarized macOS builds with in-app auto-updates through
+`tauri-plugin-updater`. The source repo stays private; update artifacts,
+signatures, the DMG, and `latest.json` are published to the public
+`open-software-network/os-scribe-releases` repo.
 
-If something here is wrong or missing, fix it in the same PR as the
-release — runbooks rot if they're not maintained against reality.
+The first updater-capable release is `0.2.0`. Users on `0.1.0` must manually
+install that build once; later releases update in place.
 
-## Prerequisites (one-time setup)
+## One-time prerequisites
 
-### 1. Apple Developer Program enrollment
+Create or confirm these before cutting the first updater release:
 
-- Active **Apple Developer Program** account ($99/year, organization tier
-  recommended for shared signing across team members).
-- Note your **Team ID** (10-character alphanumeric) from
-  https://developer.apple.com/account → Membership.
+- Public GitHub repo: `open-software-network/os-scribe-releases`.
+- Release GitHub App (org-owned) installed on the public releases repo with
+  `contents:write`, exposed as `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.
+  The workflow mints a short-lived, repo-scoped token from it at run time
+  (replaces the old `RELEASES_REPO_TOKEN` PAT). The same App can later be added
+  as a ruleset bypass actor when `main` is protected.
+- Apple signing secrets: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`,
+  `APPLE_SIGNING_IDENTITY`.
+- Apple notarization API secrets: `APPLE_API_ISSUER`, `APPLE_API_KEY`,
+  `APPLE_API_KEY_P8`.
+- Updater signing secrets: `TAURI_SIGNING_PRIVATE_KEY` and, when the key is
+  password-protected, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.
+- Production runtime secrets: `PRODUCTION_OS_ACCOUNTS_URL`,
+  `PRODUCTION_OS_ACCOUNTS_API_URL`, `PRODUCTION_OS_ACCOUNTS_CLIENT_ID`, and
+  `PRODUCTION_SCRIBE_API_URL`.
 
-### 2. Developer ID Application certificate
+The updater keypair is separate from the Apple Developer ID certificate. The
+public key is embedded in `src-tauri/tauri.conf.json`; the private key must live
+only in CI secrets and the team password manager. Losing the private key
+permanently breaks auto-update for all builds signed with its public key.
 
-For distribution *outside* the Mac App Store (DMG download), you need a
-**Developer ID Application** certificate. Not the same as "Apple
-Distribution" (App Store only) or "Apple Development" (local builds only).
-
-Create via Xcode (preferred) or Apple Developer portal:
-
-```
-Xcode → Settings → Accounts → your Apple ID → Manage Certificates →
-"+" → "Developer ID Application"
-```
-
-Export it to `.p12` for use in CI:
-
-```
-Keychain Access → login keychain → Certificates → right-click the
-Developer ID Application cert → Export → Personal Information
-Exchange (.p12) → set a strong password.
-```
-
-The `.p12` password becomes `APPLE_CERTIFICATE_PASSWORD` in env.
-
-### 3. App-specific password for notarization
-
-Apple requires a separate password for `notarytool`:
-
-1. https://appleid.apple.com → Sign-In and Security → App-Specific
-   Passwords → Generate (label it "OS Scribe notarization").
-2. Save the password — you only see it once.
-
-This becomes `APPLE_PASSWORD` in env. **Do not** use your Apple ID
-account password.
-
-### 4. Environment variables
-
-Set these in your shell (or CI secrets) before any signed build:
+Generate a keypair with:
 
 ```sh
-# Identity: the common name of your Developer ID Application cert.
-# Find with: security find-identity -v -p codesigning
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Open Software Network (XXXXXXXXXX)"
-
-# Notarization credentials.
-export APPLE_ID="ops@opensoftware.network"
-export APPLE_PASSWORD="<app-specific password from step 3>"
-export APPLE_TEAM_ID="XXXXXXXXXX"
-
-# Optional: if signing in CI (no keychain available), provide the
-# certificate as base64. Tauri imports it into a temporary keychain.
-# Convert with: base64 -i Certificate.p12 | pbcopy
-# export APPLE_CERTIFICATE="<base64 .p12 contents>"
-# export APPLE_CERTIFICATE_PASSWORD="<the .p12 password from step 2>"
+pnpm tauri signer generate --write-keys keys/os-scribe-updater.key
 ```
 
-Tauri's `tauri build` reads these env vars and signs + notarizes
-automatically when present. No tauri.conf.json change needed.
+Do not commit `keys/`. Copy the private key contents into
+`TAURI_SIGNING_PRIVATE_KEY`, copy the password into
+`TAURI_SIGNING_PRIVATE_KEY_PASSWORD` if one was used, back both up, and embed
+the `.pub` contents as the updater `pubkey`.
 
-## Per-release checklist
+## Cutting a production release
 
-### 1. Confirm clean main + green CI
+Use the manual workflow:
 
-```sh
-git checkout main
-git pull
-git status                                # working tree must be clean
-gh run list --workflow=build-scribe-api --limit 3   # recent ci green
+```text
+GitHub Actions -> production-desktop-release -> Run workflow -> version X.Y.Z
 ```
 
-### 2. Bump versions in three places
+The workflow performs the release steps in order:
 
-Tauri reads three separate version fields; keep them aligned to avoid
-about-page / bundle-version mismatches.
+1. Checks out `main`.
+2. Validates required secrets.
+3. Validates the requested version is plain semver and greater than the current
+   version.
+4. Bumps `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and
+   `package.json`, refreshes `src-tauri/Cargo.lock`, commits
+   `release: vX.Y.Z`, and pushes to `main`.
+5. Runs `pnpm lint`, `pnpm test`, and `pnpm test:rust`.
+6. Builds the `aarch64-apple-darwin` app and DMG with `tauri-action`.
+7. Signs with the Apple Developer ID cert, notarizes with Apple API key
+   credentials, signs updater artifacts with the Ed25519 updater key, and
+   publishes the release assets plus `latest.json` to
+   `open-software-network/os-scribe-releases`.
+
+The app polls:
+
+```text
+https://github.com/open-software-network/os-scribe-releases/releases/latest/download/latest.json
+```
+
+That endpoint is baked into shipped builds. Keep it alive until every install
+that points at it has aged out or updated.
+
+## Local fallback build
+
+`scripts/build-signed-dmg.sh` remains as a fallback until a CI-built,
+updater-delivered build passes Gatekeeper assessment and relaunches cleanly.
+Use it only if the `tauri-action` path is blocked:
 
 ```sh
-# Pick a version per semver. Examples below use 0.2.0.
+pnpm tauri:build:signed-dmg
+```
+
+Do not delete the fallback script until the first production updater release has
+been installed over a previous updater-capable build and relaunched successfully.
+
+## First updater release validation
+
+After the workflow publishes a release, download the DMG from
+`open-software-network/os-scribe-releases`, install the app into
+`/Applications`, and run:
+
+```sh
 VERSION="0.2.0"
+APP="/Applications/OS Scribe.app"
+DMG="$HOME/Downloads/OS Scribe_${VERSION}_aarch64.dmg"
 
-# 1/3 — frontend / Tauri config (drives Info.plist CFBundleShortVersionString).
-# Edit src-tauri/tauri.conf.json: "version": "0.2.0"
-
-# 2/3 — Rust crate (drives the binary).
-# Edit src-tauri/Cargo.toml: version = "0.2.0"
-
-# 3/3 — npm package (cosmetic but kept in sync).
-# Edit package.json: "version": "0.2.0"
-```
-
-No manual `cargo update` needed — `pnpm tauri:build` invokes `cargo
-build`, which refreshes `Cargo.lock` only when the version bump
-requires it. Running `cargo update -p os-scribe` here would pull
-newer compatible patch versions of dependencies as a side effect,
-which is the wrong thing to do mid-release.
-
-### 3. Update CHANGELOG (if you keep one)
-
-Convention: append a `## v0.2.0 — YYYY-MM-DD` section. Skip if no
-CHANGELOG exists; the git log + PR titles are the source of truth.
-
-### 4. Verify clean local checks pass
-
-```sh
-pnpm lint                                 # tsc --noEmit
-pnpm test                                 # vitest
-pnpm test:rust                            # cargo test (--lib + integration)
-```
-
-Don't skip — `pnpm tauri:build` will still produce a binary even with
-broken types or failing tests; you want both gates here.
-
-### 5. Build the signed + notarized bundle
-
-```sh
-# Source the env from step 4 of Prerequisites first, then:
-pnpm tauri:build
-```
-
-This runs `tauri build --bundles app,dmg` (already configured in
-`package.json`). With the env vars set:
-
-1. `cargo build --release` compiles the Rust binary.
-2. `build.rs` builds the Swift helper apps from
-   `src-tauri/native/mac-system-audio-recorder` and `mac-dictation-helper`
-   into `.tauri-helper/OS Scribe.app` and `.tauri-helper/OS Scribe
-   Dictation Helper.app` (the `.app` names — not the source dir names —
-   are what land in the final bundle).
-3. Tauri bundles `OS Scribe.app` with both helper `.app`s nested in
-   `Contents/Resources/native/bin/`.
-4. **Code signing** runs `codesign --deep --options runtime` across the
-   bundle, signing nested executables first, then the outer app.
-5. **Notarization** uploads the signed bundle to Apple via
-   `notarytool submit --wait`. Returns when Apple's automated scan
-   completes (5–15 minutes typically).
-6. **Stapling** attaches the notarization ticket to the bundle so it
-   verifies offline.
-7. The DMG is built around the stapled `.app` and stapled separately.
-
-Output (the DMG filename embeds the version + host architecture —
-`aarch64` on Apple Silicon, `x86_64` on Intel — so the exact name
-varies):
-
-```
-src-tauri/target/release/bundle/macos/OS Scribe.app
-src-tauri/target/release/bundle/dmg/OS Scribe_${VERSION}_<arch>.dmg
-```
-
-### 6. Verify the build before distributing
-
-These checks catch ~95% of "user sees Gatekeeper warning" issues:
-
-```sh
-ARCH=$(uname -m | sed 's/arm64/aarch64/')   # arm64 → aarch64, x86_64 stays
-APP="src-tauri/target/release/bundle/macos/OS Scribe.app"
-DMG="src-tauri/target/release/bundle/dmg/OS Scribe_${VERSION}_${ARCH}.dmg"
-
-# 1. Signature is intact and matches your Developer ID.
 codesign --verify --deep --strict --verbose=2 "$APP"
-
-# 2. Gatekeeper will accept it (Apple's actual install-time check).
 spctl --assess --type execute --verbose "$APP"
 spctl --assess --type install --verbose "$DMG"
-
-# 3. Notarization ticket is stapled (works offline).
 xcrun stapler validate "$APP"
 xcrun stapler validate "$DMG"
-
-# 4. The deep-link URL scheme is registered in Info.plist.
 plutil -extract CFBundleURLTypes xml1 -o - "$APP/Contents/Info.plist"
-# Expect to see <string>osscribe</string> inside CFBundleURLSchemes.
-
-# 5. Entitlements are what you expect (especially helpers).
-codesign -d --entitlements :- "$APP"
-codesign -d --entitlements :- "$APP/Contents/Resources/native/bin/OS Scribe.app"
-codesign -d --entitlements :- "$APP/Contents/Resources/native/bin/OS Scribe Dictation Helper.app"
 ```
 
-If any check fails, **do not distribute**. Common fixes in the
-Troubleshooting section below.
+Confirm `osscribe` appears in `CFBundleURLSchemes`.
 
-### 7. Smoke-test the DMG manually
+For the first updater-to-updater validation, install an older updater-capable
+build, run **OS Scribe -> Check for updates…**, confirm the prompt shows the
+new version and release notes, install, and verify the app relaunches without
+Gatekeeper warnings. Also confirm microphone and Accessibility permissions are
+still granted after relaunch.
 
-Drag the `.app` out of the DMG into `/Applications` (don't double-launch
-from the DMG; that's not how end users will run it). Then:
-
-```sh
-# Force Launch Services to re-index — useful if you're testing
-# multiple builds in a row and want a fresh URL-handler registration.
-/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister \
-  -R -f /Applications/OS\ Scribe.app
-
-# Confirm the URL handler is registered.
-/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister \
-  -dump | grep -i osscribe
-```
-
-You should see your bundle ID claiming the `osscribe` scheme.
-
-Then in a browser address bar:
-
-```
-osscribe://auth/callback?code=test&state=test
-```
-
-macOS should prompt "Open in OS Scribe?" the first time, then forward
-the URL to the running app. If the app is closed, it should launch and
-receive the URL. Either way, the auth flow should resolve (or fail
-gracefully with `state_mismatch` since this is a synthetic URL).
-
-### 8. Tag and publish
-
-```sh
-git tag -a "v$VERSION" -m "release: v$VERSION"
-git push origin "v$VERSION"
-
-# Create a GitHub release with the DMG attached.
-gh release create "v$VERSION" \
-  "$DMG" \
-  --title "OS Scribe v$VERSION" \
-  --notes-file RELEASE-NOTES.md   # or --generate-notes
-```
-
-### 9. Update the install link on the marketing site / README
-
-Point any "Download for macOS" link at the new release's DMG asset URL:
-
-```
-https://github.com/open-software-network/os-scribe/releases/download/v$VERSION/OS%20Scribe_${VERSION}_aarch64.dmg
-```
-
-## How URL scheme registration actually works
-
-You don't register `osscribe://` "during installation" in any active
-sense — there's no install script. Instead:
-
-1. `tauri-plugin-deep-link`'s config in `tauri.conf.json` causes
-   `tauri build` to inject `CFBundleURLTypes` into `Info.plist` at
-   build time.
-2. When the user drags the `.app` to `/Applications` (or anywhere else),
-   macOS's **Launch Services** indexes the bundle. The first index can
-   happen as early as the user hovering the `.app` in Finder; it
-   definitely happens on first launch.
-3. Launch Services reads `CFBundleURLTypes` and registers the bundle as
-   the handler for `osscribe://`.
-4. Any subsequent `osscribe://...` URL — whether clicked in a browser,
-   typed in Spotlight, or `open`ed from Terminal — routes to your app.
-5. If two apps register the same scheme, the most recently launched
-   wins. Not a concern for `osscribe://` (it's specific to us).
-
-So the installer responsibility is: **produce a valid `.app` with the
-right `Info.plist`, and trust Launch Services to do the rest.** The
-verification commands in step 6 + step 7 confirm this worked.
-
-### Updating an existing install
-
-If a user already has v0.1.0 installed and you ship v0.2.0 with the
-URL scheme added, dragging the new `.app` over the old one in
-`/Applications` doesn't always trigger Launch Services to re-index. Two
-mitigations:
-
-- **First-launch fix**: every macOS user opens the app at least once
-  after upgrading. That always triggers re-indexing.
-- **Force re-index**: if you need it sooner (e.g., the auth flow runs
-  before first interactive launch in some scenarios), tell users to
-  run the `lsregister -R -f /Applications/OS\ Scribe.app` command from
-  step 7. We don't bake this into an installer because there's no
-  installer — it's a manual drag.
-
-## Distribution channels
-
-| Channel | What to ship | Notes |
-|---|---|---|
-| GitHub Releases (recommended) | the `.dmg` from step 5 | Free, versioned, signed URL. |
-| Marketing site direct download | a pinned link to the GH release asset | Re-point on each release. Don't host the DMG yourself unless you need to control bandwidth — Cloudflare in front of GH releases is usually fine. |
-| Homebrew Cask | a cask formula pointing at the GH release | Optional. Adds discoverability. Casks require notarized DMGs (we have that). |
-| Mac App Store | **not from this runbook** | Different cert (Apple Distribution), sandbox tighter, custom URL schemes are second-class. Not recommended for this app. |
-
-## Troubleshooting
-
-### "Could not be verified" / "damaged" Gatekeeper warning
-
-- **Cause**: not notarized, not stapled, or signed with the wrong cert.
-- **Check**: `spctl --assess --type install --verbose "$DMG"`. The
-  output should include `accepted` and `source=Notarized Developer ID`.
-- **Fix**: re-run `pnpm tauri:build` with the right env vars; confirm
-  `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` are set.
-
-### Notarization fails with "binary not signed with hardened runtime"
-
-- **Cause**: a nested helper binary wasn't signed with `--options runtime`.
-- **Check**: `codesign -d --verbose=4 "$APP/Contents/Resources/native/bin/OS Scribe.app/Contents/MacOS/<helper>"`.
-  Look for `flags=0x10000(runtime)`.
-- **Fix**: usually a Tauri / build.rs issue. The `--deep` codesign pass
-  should handle it; if it didn't, manually sign the helper first:
-  ```sh
-  codesign --force --options runtime --sign "$APPLE_SIGNING_IDENTITY" \
-    "$APP/Contents/Resources/native/bin/OS Scribe.app/Contents/MacOS/<helper>"
-  ```
-
-### URL scheme not firing after install
-
-- **First check**: `lsregister -dump | grep osscribe`. If your bundle
-  ID isn't listed, Launch Services didn't index. Run the force
-  re-index from step 7.
-- **Second check**: `plutil -extract CFBundleURLTypes xml1 -o - "$APP/Contents/Info.plist"`.
-  If empty, the deep-link plugin didn't inject the entry — confirm
-  `tauri.conf.json` has a `plugins.deep-link` block and rebuild.
-  Note: tauri-plugin-deep-link reads the `mobile` array (not
-  `desktop`) to drive macOS `CFBundleURLTypes` injection at build
-  time — the `desktop` block is for the runtime scheme registration
-  on Windows/Linux. Both should be set; the macOS build step only
-  cares about `mobile`.
-
-### Sandbox blocks something at runtime
-
-Current `Entitlements.plist` intentionally avoids App Sandbox for the
-Developer ID build, but it must include `com.apple.security.device.audio-input`
-for signed microphone capture. If a future feature needs another capability,
-add the entitlement to `Entitlements.plist` *before* signing — hardened runtime
-behavior is based on what's signed in, not what's in the source file at runtime.
-
-### Helper app loses Accessibility permission after update
-
-macOS treats each codesigned binary as a separate identity. If you
-re-sign a helper app with a different cert (e.g., during a team transfer),
-the user's previously-granted Accessibility permission is revoked and
-must be re-granted in System Settings → Privacy & Security → Accessibility.
-Reset for testing with:
-
-```sh
-# The dictation helper is the bundle that actually requests
-# Accessibility (it posts the paste shortcut into the focused app),
-# so reset its bundle id — not the main app's.
-tccutil reset Accessibility co.opensoftware.scribe.dictation-helper
-```
-
-## CI automation (future work — not in scope yet)
-
-A `release-macos.yml` GitHub Actions workflow could run the steps
-above unattended on every tag push. Requires:
-
-- `APPLE_CERTIFICATE` (base64), `APPLE_CERTIFICATE_PASSWORD`,
-  `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`,
-  `APPLE_SIGNING_IDENTITY` bound as repo secrets.
-- A `macos-14` runner (Apple Silicon).
-- `tauri-action@v0` does the sign + notarize + release-attach in one
-  step. Worth the ~15min build time once you do >1 release per month.
-
-Open an issue when this gets prioritized.
+If any signing, notarization, updater signature, Gatekeeper, or relaunch check
+fails, do not promote the release. Keep the fallback build path until the CI
+path is proven with a real updater-delivered relaunch.

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -5,8 +5,10 @@ OS Scribe ships signed, notarized macOS builds with in-app auto-updates through
 signatures, the DMG, and `latest.json` are published to the public
 `open-software-network/os-scribe-releases` repo.
 
-The first updater-capable release is `0.2.0`. Users on `0.1.0` must manually
-install that build once; later releases update in place.
+The first updater-capable build must be installed manually once — earlier builds
+ship without the updater, so they can't pull it in — and every release after that
+updates in place. Choose the release version per semver when you run the release
+workflow; don't hard-code a specific number in this runbook.
 
 ## One-time prerequisites
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-scribe",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.4",
@@ -14,12 +14,15 @@
     "test": "vitest run",
     "test:ui": "vitest run",
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml",
+    "version:bump": "node scripts/bump-version.mjs",
     "lint": "tsc --noEmit",
     "format": "prettier --check \"src/**/*.{ts,tsx,css}\" \"src-tauri/tauri.conf.json\" \"package.json\" \"tsconfig.json\" \"vite.config.ts\" \"index.html\" \"README.md\""
   },
   "dependencies": {
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@tiptap/extension-placeholder": "^3.23.5",
     "@tiptap/react": "^3.23.5",
     "@tiptap/starter-kit": "^3.23.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@tauri-apps/plugin-deep-link':
         specifier: ^2.4.9
         version: 2.4.9
+      '@tauri-apps/plugin-process':
+        specifier: ^2.3.1
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.10.1
+        version: 2.10.1
       '@tiptap/extension-placeholder':
         specifier: ^3.23.5
         version: 3.23.5(@tiptap/extensions@3.23.5(@tiptap/core@3.23.5(@tiptap/pm@3.23.5))(@tiptap/pm@3.23.5))
@@ -738,6 +744,12 @@ packages:
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2139,6 +2151,14 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
   '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,141 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function parseSemver(version) {
+  const match = VERSION_RE.exec(version);
+  if (!match) return undefined;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+export function compareSemver(left, right) {
+  const a = parseSemver(left);
+  const b = parseSemver(right);
+  if (!a || !b) throw new Error("Cannot compare invalid semver values.");
+  for (const key of ["major", "minor", "patch"]) {
+    if (a[key] > b[key]) return 1;
+    if (a[key] < b[key]) return -1;
+  }
+  return 0;
+}
+
+export function validateRequestedVersion(currentVersion, requestedVersion) {
+  if (!parseSemver(requestedVersion)) {
+    return {
+      ok: false,
+      reason: `Requested version "${requestedVersion}" is not valid semver (expected X.Y.Z).`,
+    };
+  }
+  if (!parseSemver(currentVersion)) {
+    return {
+      ok: false,
+      reason: `Current version "${currentVersion}" is not valid semver.`,
+    };
+  }
+  if (compareSemver(requestedVersion, currentVersion) <= 0) {
+    return {
+      ok: false,
+      reason: `Requested version ${requestedVersion} must be greater than current version ${currentVersion}.`,
+    };
+  }
+  return { ok: true };
+}
+
+export function bumpVersionContents(files, requestedVersion) {
+  return {
+    tauriConf: replaceJsonVersion(files.tauriConf, requestedVersion),
+    cargoToml: replaceCargoPackageVersion(files.cargoToml, requestedVersion),
+    packageJson: replaceJsonVersion(files.packageJson, requestedVersion),
+  };
+}
+
+export function currentVersionFromTauriConf(contents) {
+  return JSON.parse(contents).version;
+}
+
+export function currentVersionFromPackageJson(contents) {
+  return JSON.parse(contents).version;
+}
+
+export function currentVersionFromCargoToml(contents) {
+  const match = /^version\s*=\s*"([^"]+)"/m.exec(contents);
+  if (!match) throw new Error("Could not find package version in Cargo.toml.");
+  return match[1];
+}
+
+// The three version-bearing files must already agree before a bump — otherwise
+// the "strictly greater than current" gate would trust whichever file we read
+// and silently carry a pre-existing drift into the release.
+export function readCurrentVersion(files) {
+  const tauri = currentVersionFromTauriConf(files.tauriConf);
+  const cargo = currentVersionFromCargoToml(files.cargoToml);
+  const pkg = currentVersionFromPackageJson(files.packageJson);
+  if (tauri !== cargo || tauri !== pkg) {
+    return {
+      ok: false,
+      reason: `Version drift before bump (tauri.conf.json=${tauri}, Cargo.toml=${cargo}, package.json=${pkg}); reconcile the three files first.`,
+    };
+  }
+  return { ok: true, version: tauri };
+}
+
+function replaceJsonVersion(contents, requestedVersion) {
+  const parsed = JSON.parse(contents);
+  parsed.version = requestedVersion;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+function replaceCargoPackageVersion(contents, requestedVersion) {
+  const next = contents.replace(
+    /^version\s*=\s*"[^"]+"/m,
+    `version = "${requestedVersion}"`,
+  );
+  if (next === contents) {
+    throw new Error("Could not find package version in Cargo.toml.");
+  }
+  return next;
+}
+
+async function main() {
+  const requestedVersion = process.argv[2];
+  if (!requestedVersion) {
+    throw new Error("Usage: node scripts/bump-version.mjs <version>");
+  }
+
+  const root = process.cwd();
+  const paths = {
+    tauriConf: resolve(root, "src-tauri/tauri.conf.json"),
+    cargoToml: resolve(root, "src-tauri/Cargo.toml"),
+    packageJson: resolve(root, "package.json"),
+  };
+  const files = {
+    tauriConf: await readFile(paths.tauriConf, "utf8"),
+    cargoToml: await readFile(paths.cargoToml, "utf8"),
+    packageJson: await readFile(paths.packageJson, "utf8"),
+  };
+  const current = readCurrentVersion(files);
+  if (!current.ok) {
+    throw new Error(current.reason);
+  }
+  const validation = validateRequestedVersion(current.version, requestedVersion);
+  if (!validation.ok) {
+    throw new Error(validation.reason);
+  }
+  const next = bumpVersionContents(files, requestedVersion);
+  await writeFile(paths.tauriConf, next.tauriConf);
+  await writeFile(paths.cargoToml, next.cargoToml);
+  await writeFile(paths.packageJson, next.packageJson);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -63,10 +63,29 @@ export function currentVersionFromPackageJson(contents) {
   return JSON.parse(contents).version;
 }
 
+// Index of the `version = "..."` line inside the [package] table specifically,
+// so a [workspace]/[dependencies] table's own version is never matched. The bare
+// /^version/m first-match was fragile to table ordering.
+function packageVersionLineIndex(lines) {
+  let inPackage = false;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("[")) {
+      inPackage = trimmed === "[package]";
+      continue;
+    }
+    if (inPackage && /^\s*version\s*=\s*"[^"]*"/.test(lines[i])) return i;
+  }
+  return -1;
+}
+
 export function currentVersionFromCargoToml(contents) {
-  const match = /^version\s*=\s*"([^"]+)"/m.exec(contents);
-  if (!match) throw new Error("Could not find package version in Cargo.toml.");
-  return match[1];
+  const lines = contents.split("\n");
+  const index = packageVersionLineIndex(lines);
+  if (index === -1) {
+    throw new Error("Could not find [package] version in Cargo.toml.");
+  }
+  return /"([^"]+)"/.exec(lines[index])[1];
 }
 
 // The three version-bearing files must already agree before a bump — otherwise
@@ -92,14 +111,16 @@ function replaceJsonVersion(contents, requestedVersion) {
 }
 
 function replaceCargoPackageVersion(contents, requestedVersion) {
-  const next = contents.replace(
-    /^version\s*=\s*"[^"]+"/m,
+  const lines = contents.split("\n");
+  const index = packageVersionLineIndex(lines);
+  if (index === -1) {
+    throw new Error("Could not find [package] version in Cargo.toml.");
+  }
+  lines[index] = lines[index].replace(
+    /version\s*=\s*"[^"]*"/,
     `version = "${requestedVersion}"`,
   );
-  if (next === contents) {
-    throw new Error("Could not find package version in Cargo.toml.");
-  }
-  return next;
+  return lines.join("\n");
 }
 
 async function main() {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "libc",
 ]
@@ -74,6 +74,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -246,9 +255,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -274,7 +283,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -282,7 +291,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -309,9 +318,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -349,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -360,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -379,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -410,7 +419,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -473,14 +482,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -643,7 +652,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -656,7 +665,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -691,7 +700,7 @@ dependencies = [
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2",
@@ -889,6 +898,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,7 +968,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -956,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1071,9 +1091,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1207,6 +1227,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1573,7 +1603,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1790,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1829,9 +1859,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2128,6 +2158,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2205,7 +2265,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -2304,14 +2364,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2348,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -2390,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -2426,6 +2486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2448,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2473,7 +2539,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
@@ -2487,7 +2553,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -2637,7 +2703,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2650,7 +2716,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2671,7 +2737,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
 ]
@@ -2682,7 +2748,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2715,7 +2781,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2742,8 +2808,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2754,9 +2821,21 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.12.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2765,7 +2844,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2777,7 +2856,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2808,7 +2887,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2822,7 +2901,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
 dependencies = [
- "jni",
+ "jni 0.21.1",
  "ndk 0.8.0",
  "ndk-context",
  "num-derive",
@@ -2844,6 +2923,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2873,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "os-scribe"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2892,7 +2977,9 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2900,6 +2987,20 @@ dependencies = [
  "urlencoding",
  "uuid",
  "zeroize",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3106,7 +3207,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3193,7 +3294,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -3385,16 +3486,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -3499,9 +3600,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3511,15 +3612,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3596,7 +3702,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3618,6 +3724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,6 +3744,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3657,6 +3802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3722,7 +3876,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3735,7 +3889,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3758,7 +3912,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cssparser",
  "derive_more",
  "log",
@@ -3836,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3980,6 +4134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,6 +4166,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4028,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4198,7 +4374,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -4242,7 +4418,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "chrono",
  "crc",
@@ -4419,11 +4595,11 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -4435,7 +4611,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk 0.9.0",
@@ -4469,6 +4645,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,7 +4678,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4504,7 +4691,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4625,6 +4812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,6 +4838,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4650,7 +4880,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4673,7 +4903,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5023,9 +5253,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5069,7 +5299,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http",
@@ -5161,9 +5391,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -5252,9 +5482,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -5313,9 +5543,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5412,9 +5642,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5425,9 +5655,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5435,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5445,9 +5675,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5458,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5506,7 +5736,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5514,9 +5744,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5586,6 +5816,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6281,7 +6520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -6335,7 +6574,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk 0.9.0",
  "objc2",
@@ -6383,10 +6622,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.2"
+name = "xattr"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6407,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6442,9 +6691,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.15.0"
+version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -6468,18 +6717,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6561,6 +6810,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6568,9 +6829,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
 dependencies = [
  "endi",
  "enumflags2",
@@ -6582,9 +6843,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.11.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -6595,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-scribe"
-version = "0.1.0"
+version = "0.0.1"
 description = "OS Scribe"
 authors = ["Open Software Network"]
 edition = "2021"
@@ -33,7 +33,9 @@ sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }
 tauri = { version = "2.8.0", features = ["macos-private-api"] }
 tauri-plugin-deep-link = "2"
+tauri-plugin-process = "2.3.1"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
+tauri-plugin-updater = "2.10.1"
 thiserror = "2.0"
 tokio = { version = "1.42", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
-    "deep-link:default"
+    "deep-link:default",
+    "process:allow-restart",
+    "updater:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,8 +8,12 @@ pub mod os_accounts;
 pub mod providers;
 pub mod scribe_api;
 
+use tauri::Emitter;
 #[cfg(target_os = "macos")]
 use tauri::Manager;
+
+const CHECK_FOR_UPDATES_MENU_ID: &str = "check_for_updates";
+const CHECK_FOR_UPDATES_EVENT: &str = "scribe://check-for-updates";
 
 pub fn run() {
     providers::load_local_env();
@@ -36,7 +40,17 @@ pub fn run() {
     }
 
     builder
+        // deep-link registers immediately after single-instance to keep the
+        // single-instance -> deep-link handoff (documented above) adjacent and
+        // obvious; process/updater are order-independent so they follow.
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .on_menu_event(|app, event| {
+            if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
+                let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap_app,
             commands::create_note,
@@ -86,6 +100,7 @@ pub fn run() {
         ])
         .manage(os_accounts::LoginFlow::default())
         .setup(|app| {
+            setup_app_menu(app)?;
             providers::setup(app);
             dictation::setup(app);
             os_accounts::setup_deep_link(app);
@@ -101,6 +116,106 @@ pub fn run() {
             tauri::RunEvent::Reopen { .. } => show_main_window(app),
             _ => {}
         });
+}
+
+fn setup_app_menu(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{
+        AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu, HELP_SUBMENU_ID,
+        WINDOW_SUBMENU_ID,
+    };
+
+    let handle = app.handle();
+    let pkg_info = handle.package_info();
+    let config = handle.config();
+    let about_metadata = AboutMetadata {
+        name: Some(pkg_info.name.clone()),
+        version: Some(pkg_info.version.to_string()),
+        copyright: config.bundle.copyright.clone(),
+        authors: config
+            .bundle
+            .publisher
+            .clone()
+            .map(|publisher| vec![publisher]),
+        ..Default::default()
+    };
+
+    let app_menu = Submenu::with_items(
+        handle,
+        pkg_info.name.clone(),
+        true,
+        &[
+            &PredefinedMenuItem::about(handle, None, Some(about_metadata))?,
+            &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(
+                handle,
+                CHECK_FOR_UPDATES_MENU_ID,
+                "Check for updates…",
+                true,
+                Some("CmdOrCtrl+Shift+U"),
+            )?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::services(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::hide(handle, None)?,
+            &PredefinedMenuItem::hide_others(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::quit(handle, None)?,
+        ],
+    )?;
+
+    let file_menu = Submenu::with_items(
+        handle,
+        "File",
+        true,
+        &[&PredefinedMenuItem::close_window(handle, None)?],
+    )?;
+    let edit_menu = Submenu::with_items(
+        handle,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(handle, None)?,
+            &PredefinedMenuItem::redo(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::cut(handle, None)?,
+            &PredefinedMenuItem::copy(handle, None)?,
+            &PredefinedMenuItem::paste(handle, None)?,
+            &PredefinedMenuItem::select_all(handle, None)?,
+        ],
+    )?;
+    let view_menu = Submenu::with_items(
+        handle,
+        "View",
+        true,
+        &[&PredefinedMenuItem::fullscreen(handle, None)?],
+    )?;
+    let window_menu = Submenu::with_id_and_items(
+        handle,
+        WINDOW_SUBMENU_ID,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(handle, None)?,
+            &PredefinedMenuItem::maximize(handle, None)?,
+            &PredefinedMenuItem::separator(handle)?,
+            &PredefinedMenuItem::close_window(handle, None)?,
+        ],
+    )?;
+    let help_menu = Submenu::with_id_and_items(handle, HELP_SUBMENU_ID, "Help", true, &[])?;
+
+    let menu = Menu::with_items(
+        handle,
+        &[
+            &app_menu,
+            &file_menu,
+            &edit_menu,
+            &view_menu,
+            &window_menu,
+            &help_menu,
+        ],
+    )?;
+    app.set_menu(menu)?;
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OS Scribe",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "identifier": "co.opensoftware.scribe",
   "build": {
     "beforeDevCommand": "./scripts/tauri-before-dev.sh",
@@ -58,10 +58,17 @@
       "desktop": {
         "schemes": ["osscribe"]
       }
+    },
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwMDUxRDBGNzYyRDU0MTgKUldRWVZDMTJEeDBGVUZWQ3VsVWxCdmhFbk9McWFVWjBGTEZZZHN0NFZRQjFZaFZRVzF4Sm9NdnkK",
+      "endpoints": [
+        "https://github.com/open-software-network/os-scribe-releases/releases/latest/download/latest.json"
+      ]
     }
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,6 +20,7 @@ import { PermissionBanner } from "../components/permissions/PermissionBanner";
 import { AppSettings } from "../components/settings/AppSettings";
 import { Sidebar, type SidebarView } from "../components/sidebar/Sidebar";
 import { BreadcrumbBar } from "../components/ui/BreadcrumbBar";
+import { Dialog } from "../components/ui/Dialog";
 import {
   assignNoteToFolder,
   bootstrapApp,
@@ -61,13 +62,25 @@ import type {
 } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
 import { shouldBlockOnSignIn } from "../lib/account-gate";
+import {
+  checkScribeUpdate,
+  relaunchScribe,
+  type ScribeUpdate,
+} from "../lib/updater";
 import { shouldPollProcessingStatus } from "./processing-polling";
 import { createInitialState, notesReducer } from "./state/app-state";
+import {
+  checkForScribeUpdate,
+  installScribeUpdate,
+  type UpdateInstallProgress,
+  type UpdatePromptPayload,
+} from "./update-decision";
 
 const SIDEBAR_DEFAULT_WIDTH = 240;
 const SIDEBAR_MIN_WIDTH = 188;
 const SIDEBAR_MAX_WIDTH = 320;
 const SIDEBAR_COLLAPSE_WIDTH = 160;
+const CHECK_FOR_UPDATES_EVENT = "scribe://check-for-updates";
 // Floor for the note card so the sidebar can't be dragged wide enough to
 // crush it into a sliver — it always keeps a usable width plus its gutters.
 const MAIN_PANEL_MIN_WIDTH = 420;
@@ -114,6 +127,12 @@ export function App() {
   const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
   const [accessibilityStatus, setAccessibilityStatus] = useState<string>();
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
+  const [pendingUpdate, setPendingUpdate] =
+    useState<UpdatePromptPayload<ScribeUpdate> | null>(null);
+  const [updateStatus, setUpdateStatus] = useState<string | null>(null);
+  const [installingUpdate, setInstallingUpdate] = useState(false);
+  const [updateProgress, setUpdateProgress] =
+    useState<UpdateInstallProgress | null>(null);
   const systemGranted = !!sourceReadiness?.sources.find(
     (source) => source.source === "system",
   )?.ready;
@@ -173,6 +192,56 @@ export function App() {
   useEffect(() => {
     preloadRecordingSounds();
   }, []);
+
+  // installingUpdate is read through a ref so runUpdateCheck keeps a stable
+  // identity across installs. Otherwise the launch effect and the manual-check
+  // listener below would tear down and re-fire every time installingUpdate
+  // toggles — re-triggering an unwanted launch-time check after an install.
+  const installingUpdateRef = useRef(false);
+  useEffect(() => {
+    installingUpdateRef.current = installingUpdate;
+  }, [installingUpdate]);
+
+  const runUpdateCheck = useCallback((mode: "launch" | "manual") => {
+    if (installingUpdateRef.current) return;
+    setUpdateStatus(mode === "manual" ? "Checking for updates..." : null);
+    void checkForScribeUpdate(
+      {
+        check: checkScribeUpdate,
+        prompt: (payload) => {
+          setUpdateStatus(null);
+          setUpdateProgress(null);
+          setPendingUpdate(payload);
+        },
+        reportNoUpdate: () => setUpdateStatus("OS Scribe is up to date."),
+        reportFailure: (message) =>
+          setUpdateStatus(`Update check failed: ${message}`),
+      },
+      mode,
+    );
+  }, []);
+
+  // Launch check: silent by design — a "no update" result shows nothing so it
+  // never interrupts the user (PRD user story 7) — and fired at most once per
+  // session, so a later install toggle can't re-trigger it.
+  const launchCheckedRef = useRef(false);
+  useEffect(() => {
+    if (appBlocked || launchCheckedRef.current) return;
+    launchCheckedRef.current = true;
+    runUpdateCheck("launch");
+  }, [appBlocked, runUpdateCheck]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen(CHECK_FOR_UPDATES_EVENT, () => runUpdateCheck("manual")).then(
+      (cleanup) => {
+        unlisten = cleanup;
+      },
+    );
+    return () => {
+      unlisten?.();
+    };
+  }, [runUpdateCheck]);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -1008,7 +1077,131 @@ export function App() {
           handleSetNoteFolder(noteId, folderId)
         }
       />
+      <UpdateDialog
+        payload={pendingUpdate}
+        status={updateStatus}
+        installing={installingUpdate}
+        progress={updateProgress}
+        onClose={() => {
+          if (installingUpdate) return;
+          setPendingUpdate(null);
+          setUpdateStatus(null);
+          setUpdateProgress(null);
+        }}
+        onInstall={() => {
+          if (!pendingUpdate || installingUpdate) return;
+          setInstallingUpdate(true);
+          setUpdateStatus(null);
+          void installScribeUpdate({
+            update: pendingUpdate.update,
+            relaunch: relaunchScribe,
+            reportProgress: setUpdateProgress,
+            reportFailure: (message) => {
+              setInstallingUpdate(false);
+              setUpdateStatus(`Update failed: ${message}`);
+            },
+          });
+        }}
+      />
     </main>
+  );
+}
+
+function UpdateDialog({
+  payload,
+  status,
+  installing,
+  progress,
+  onClose,
+  onInstall,
+}: {
+  payload: UpdatePromptPayload<ScribeUpdate> | null;
+  status: string | null;
+  installing: boolean;
+  progress: UpdateInstallProgress | null;
+  onClose: () => void;
+  onInstall: () => void;
+}) {
+  const percent =
+    progress?.contentLength && progress.contentLength > 0
+      ? Math.min(
+          100,
+          Math.round(
+            ((progress.downloadedBytes ?? 0) / progress.contentLength) * 100,
+          ),
+        )
+      : undefined;
+
+  return (
+    <Dialog
+      open={!!payload || !!status}
+      onClose={onClose}
+      title={payload ? `OS Scribe ${payload.version}` : "Software update"}
+      description={
+        payload
+          ? "A new version is available."
+          : (status ?? "Checking for updates...")
+      }
+      width={460}
+      disableBackdropClose={installing}
+      footer={
+        payload ? (
+          <>
+            <button
+              type="button"
+              className="primary-action"
+              disabled={installing}
+              onClick={onClose}
+            >
+              Later
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              disabled={installing}
+              onClick={onInstall}
+            >
+              {installing ? "Installing..." : "Install & relaunch"}
+            </button>
+          </>
+        ) : (
+          <button type="button" className="primary-action" onClick={onClose}>
+            Close
+          </button>
+        )
+      }
+    >
+      {payload ? (
+        <div className="update-dialog-body">
+          {payload.notes ? (
+            <div className="update-release-notes">{payload.notes}</div>
+          ) : (
+            <p className="dialog-field-hint">No release notes were provided.</p>
+          )}
+          {progress ? (
+            <div className="update-progress" aria-live="polite">
+              <div className="update-progress-row">
+                <span>
+                  {progress.state === "installing"
+                    ? "Installing update..."
+                    : "Downloading update..."}
+                </span>
+                {percent !== undefined ? <span>{percent}%</span> : null}
+              </div>
+              <div className="update-progress-track">
+                <div
+                  className="update-progress-fill"
+                  style={{ width: `${percent ?? 0}%` }}
+                />
+              </div>
+            </div>
+          ) : null}
+          {status ? <p className="dialog-field-hint">{status}</p> : null}
+        </div>
+      ) : (
+        <div />
+      )}
+    </Dialog>
   );
 }
 
@@ -1102,7 +1295,10 @@ function handleSidebarResizeStart(
     // rides the white, not the gray) since the bar is positioned off it too.
     if (mainPanel)
       mainPanel.style.marginLeft = width === 0 ? "var(--sp-3)" : "0px";
-    shell?.style.setProperty("--main-gutter", width === 0 ? "var(--sp-3)" : "0px");
+    shell?.style.setProperty(
+      "--main-gutter",
+      width === 0 ? "var(--sp-3)" : "0px",
+    );
     latestWidth = width;
   }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1098,6 +1098,7 @@ export function App() {
             reportProgress: setUpdateProgress,
             reportFailure: (message) => {
               setInstallingUpdate(false);
+              setUpdateProgress(null);
               setUpdateStatus(`Update failed: ${message}`);
             },
           });

--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -1,0 +1,126 @@
+export type UpdatePromptPayload<TUpdate> = {
+  update: TUpdate;
+  version: string;
+  notes?: string;
+};
+
+export type UpdateCheckMode = "launch" | "manual";
+
+export type DownloadEvent =
+  | { event: "Started"; data: { contentLength?: number } }
+  | { event: "Progress"; data: { chunkLength: number } }
+  | { event: "Finished" };
+
+export type UpdaterUpdate = {
+  version: string;
+  body?: string;
+  downloadAndInstall: (
+    onEvent?: (event: DownloadEvent) => void,
+  ) => Promise<void>;
+};
+
+export type UpdateCheckDeps<TUpdate extends UpdaterUpdate> = {
+  check: () => Promise<TUpdate | null>;
+  prompt: (payload: UpdatePromptPayload<TUpdate>) => void;
+  reportNoUpdate: () => void;
+  reportFailure: (message: string) => void;
+};
+
+export type InstallUpdateDeps<TUpdate extends UpdaterUpdate> = {
+  update: TUpdate;
+  relaunch: () => Promise<void>;
+  reportProgress: (progress: UpdateInstallProgress) => void;
+  reportFailure: (message: string) => void;
+};
+
+export type UpdateInstallProgress = {
+  state: "downloading" | "installing";
+  downloadedBytes?: number;
+  contentLength?: number;
+};
+
+export async function checkForScribeUpdate<TUpdate extends UpdaterUpdate>(
+  deps: UpdateCheckDeps<TUpdate>,
+  mode: UpdateCheckMode,
+) {
+  try {
+    const update = await deps.check();
+    if (!update) {
+      if (mode === "manual") deps.reportNoUpdate();
+      return;
+    }
+    deps.prompt({
+      update,
+      version: update.version,
+      notes: normalizeNotes(update.body),
+    });
+  } catch (error) {
+    deps.reportFailure(messageFromUnknown(error));
+  }
+}
+
+export async function installScribeUpdate<TUpdate extends UpdaterUpdate>({
+  update,
+  relaunch,
+  reportProgress,
+  reportFailure,
+}: InstallUpdateDeps<TUpdate>) {
+  let downloadedBytes = 0;
+  let contentLength: number | undefined;
+  // A multi-MB DMG fires thousands of Progress events; surfacing each as a state
+  // update would re-render the app on every network chunk. Throttle downloading
+  // ticks to whole-percent changes (or ~1MB steps when the total size is
+  // unknown). State transitions — Started and installing — always fire.
+  let lastPercent: number | undefined;
+  let lastReportedBytes = 0;
+  const UNKNOWN_LENGTH_STEP = 1_000_000;
+  try {
+    await update.downloadAndInstall((event) => {
+      if (event.event === "Started") {
+        downloadedBytes = 0;
+        contentLength = event.data.contentLength;
+        lastPercent = contentLength ? 0 : undefined;
+        lastReportedBytes = 0;
+        reportProgress({
+          state: "downloading",
+          downloadedBytes,
+          contentLength,
+        });
+        return;
+      }
+      if (event.event === "Progress") {
+        downloadedBytes += event.data.chunkLength;
+        if (contentLength && contentLength > 0) {
+          const percent = Math.round((downloadedBytes / contentLength) * 100);
+          if (percent === lastPercent) return;
+          lastPercent = percent;
+        } else if (downloadedBytes - lastReportedBytes < UNKNOWN_LENGTH_STEP) {
+          return;
+        } else {
+          lastReportedBytes = downloadedBytes;
+        }
+        reportProgress({
+          state: "downloading",
+          downloadedBytes,
+          contentLength,
+        });
+        return;
+      }
+      reportProgress({ state: "installing", downloadedBytes, contentLength });
+    });
+    await relaunch();
+  } catch (error) {
+    reportFailure(messageFromUnknown(error));
+  }
+}
+
+function normalizeNotes(notes?: string) {
+  const trimmed = notes?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function messageFromUnknown(error: unknown) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Update failed.";
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,0 +1,17 @@
+import { relaunch } from "@tauri-apps/plugin-process";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+
+export type ScribeUpdate = Update;
+
+export function checkScribeUpdate() {
+  // No explicit target: let the runtime report its own platform and match it
+  // against the manifest. We only publish darwin-aarch64 today (ADR-0001:
+  // Intel is intentionally unsupported), but that scope lives in the published
+  // manifest's `platforms` keys, not pinned here — so a future arch "just works"
+  // once its build is added, instead of silently requesting the aarch64 key.
+  return check();
+}
+
+export function relaunchScribe() {
+  return relaunch();
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5161,6 +5161,49 @@ input:focus-visible,
   gap: var(--sp-3);
 }
 
+.update-dialog-body {
+  display: grid;
+  gap: var(--sp-4);
+}
+
+.update-release-notes {
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre-wrap;
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.48;
+}
+
+.update-progress {
+  display: grid;
+  gap: var(--sp-2);
+}
+
+.update-progress-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.update-progress-track {
+  height: 8px;
+  overflow: hidden;
+  border-radius: var(--r-pill);
+  background: var(--surface-subtle);
+}
+
+.update-progress-fill {
+  height: 100%;
+  /* Floor so the bar stays visible at 0% / indeterminate (width can be 0). */
+  min-width: 8%;
+  border-radius: inherit;
+  background: var(--foreground);
+  transition: width var(--t-fast) var(--ease-out);
+}
+
 @keyframes dialog-backdrop-in {
   from {
     opacity: 0;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,14 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: vi.fn(async () => null),
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: vi.fn(async () => undefined),
+}));
 
 // jsdom ships no ResizeObserver; the SegmentedControl relies on one.
 if (!("ResizeObserver" in globalThis)) {
@@ -13,6 +21,23 @@ if (!("ResizeObserver" in globalThis)) {
 
 if (!document.elementFromPoint) {
   document.elementFromPoint = () => document.body;
+}
+
+if (!("localStorage" in globalThis) || !globalThis.localStorage) {
+  const values = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      key: (index: number) => Array.from(values.keys())[index] ?? null,
+      get length() {
+        return values.size;
+      },
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, String(value)),
+    },
+  });
 }
 
 if (!Range.prototype.getClientRects) {

--- a/src/test/update-decision.test.ts
+++ b/src/test/update-decision.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkForScribeUpdate,
+  installScribeUpdate,
+  type UpdaterUpdate,
+} from "../app/update-decision";
+
+function update(body?: string): UpdaterUpdate {
+  return {
+    version: "0.2.0",
+    body,
+    downloadAndInstall: vi.fn(async (onEvent) => {
+      onEvent?.({ event: "Started", data: { contentLength: 100 } });
+      onEvent?.({ event: "Progress", data: { chunkLength: 40 } });
+      onEvent?.({ event: "Finished" });
+    }),
+  };
+}
+
+describe("checkForScribeUpdate", () => {
+  it("prompts with version and release notes when an update is available", async () => {
+    const prompt = vi.fn();
+
+    await checkForScribeUpdate(
+      {
+        check: async () => update(" Fixes transcription. "),
+        prompt,
+        reportNoUpdate: vi.fn(),
+        reportFailure: vi.fn(),
+      },
+      "launch",
+    );
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: "0.2.0",
+        notes: "Fixes transcription.",
+      }),
+    );
+  });
+
+  it("does not prompt when no update is available", async () => {
+    const prompt = vi.fn();
+    const reportNoUpdate = vi.fn();
+
+    await checkForScribeUpdate(
+      {
+        check: async () => null,
+        prompt,
+        reportNoUpdate,
+        reportFailure: vi.fn(),
+      },
+      "launch",
+    );
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(reportNoUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reports no update for a manual check", async () => {
+    const reportNoUpdate = vi.fn();
+
+    await checkForScribeUpdate(
+      {
+        check: async () => null,
+        prompt: vi.fn(),
+        reportNoUpdate,
+        reportFailure: vi.fn(),
+      },
+      "manual",
+    );
+
+    expect(reportNoUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports failures without claiming success", async () => {
+    const prompt = vi.fn();
+    const reportFailure = vi.fn();
+
+    await checkForScribeUpdate(
+      {
+        check: async () => {
+          throw new Error("signature mismatch");
+        },
+        prompt,
+        reportNoUpdate: vi.fn(),
+        reportFailure,
+      },
+      "manual",
+    );
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(reportFailure).toHaveBeenCalledWith("signature mismatch");
+  });
+});
+
+describe("installScribeUpdate", () => {
+  it("reports download progress, installs, and relaunches", async () => {
+    const candidate = update("notes");
+    const relaunch = vi.fn(async () => undefined);
+    const reportProgress = vi.fn();
+
+    await installScribeUpdate({
+      update: candidate,
+      relaunch,
+      reportProgress,
+      reportFailure: vi.fn(),
+    });
+
+    expect(candidate.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(reportProgress).toHaveBeenCalledWith({
+      state: "downloading",
+      downloadedBytes: 40,
+      contentLength: 100,
+    });
+    expect(reportProgress).toHaveBeenCalledWith({
+      state: "installing",
+      downloadedBytes: 40,
+      contentLength: 100,
+    });
+    expect(relaunch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/version-bump.test.mjs
+++ b/src/test/version-bump.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  bumpVersionContents,
+  readCurrentVersion,
+  validateRequestedVersion,
+} from "../../scripts/bump-version.mjs";
+
+const files = {
+  tauriConf: '{\n  "productName": "OS Scribe",\n  "version": "0.1.0"\n}\n',
+  cargoToml: '[package]\nname = "os-scribe"\nversion = "0.1.0"\n',
+  packageJson: '{\n  "name": "os-scribe",\n  "version": "0.1.0"\n}\n',
+};
+
+describe("validateRequestedVersion", () => {
+  it("accepts a valid higher version", () => {
+    expect(validateRequestedVersion("0.1.0", "0.2.0")).toEqual({ ok: true });
+  });
+
+  it("rejects non-semver values", () => {
+    expect(validateRequestedVersion("0.1.0", "0.2")).toEqual({
+      ok: false,
+      reason: 'Requested version "0.2" is not valid semver (expected X.Y.Z).',
+    });
+  });
+
+  it("rejects equal and lower versions", () => {
+    expect(validateRequestedVersion("0.1.0", "0.1.0").ok).toBe(false);
+    expect(validateRequestedVersion("0.1.0", "0.0.9").ok).toBe(false);
+  });
+
+  it("rejects malformed versions", () => {
+    expect(validateRequestedVersion("0.1.0", "01.2.3").ok).toBe(false);
+    expect(validateRequestedVersion("0.1.0", "1.2.3-beta.1").ok).toBe(false);
+  });
+});
+
+describe("bumpVersionContents", () => {
+  it("updates all version-bearing files", () => {
+    const next = bumpVersionContents(files, "0.2.0");
+
+    expect(JSON.parse(next.tauriConf).version).toBe("0.2.0");
+    expect(next.cargoToml).toContain('version = "0.2.0"');
+    expect(JSON.parse(next.packageJson).version).toBe("0.2.0");
+  });
+});
+
+describe("readCurrentVersion", () => {
+  it("returns the shared version when all three files agree", () => {
+    expect(readCurrentVersion(files)).toEqual({ ok: true, version: "0.1.0" });
+  });
+
+  it("rejects drift across the version-bearing files", () => {
+    const drifted = {
+      ...files,
+      cargoToml: '[package]\nname = "os-scribe"\nversion = "0.1.1"\n',
+    };
+    expect(readCurrentVersion(drifted).ok).toBe(false);
+  });
+});

--- a/src/test/version-bump.test.mjs
+++ b/src/test/version-bump.test.mjs
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   bumpVersionContents,
+  currentVersionFromCargoToml,
   readCurrentVersion,
   validateRequestedVersion,
 } from "../../scripts/bump-version.mjs";
@@ -55,5 +56,21 @@ describe("readCurrentVersion", () => {
       cargoToml: '[package]\nname = "os-scribe"\nversion = "0.1.1"\n',
     };
     expect(readCurrentVersion(drifted).ok).toBe(false);
+  });
+});
+
+describe("currentVersionFromCargoToml", () => {
+  it("reads the [package] version, not another table's version", () => {
+    const cargo =
+      '[workspace.package]\nversion = "9.9.9"\n\n[package]\nname = "os-scribe"\nversion = "0.1.0"\n';
+    expect(currentVersionFromCargoToml(cargo)).toBe("0.1.0");
+  });
+
+  it("bumps the [package] version while leaving other tables untouched", () => {
+    const cargo =
+      '[workspace.package]\nversion = "9.9.9"\n\n[package]\nname = "os-scribe"\nversion = "0.1.0"\n';
+    const next = bumpVersionContents({ ...files, cargoToml: cargo }, "0.2.0");
+    expect(next.cargoToml).toContain('[workspace.package]\nversion = "9.9.9"');
+    expect(next.cargoToml).toContain('[package]\nname = "os-scribe"\nversion = "0.2.0"');
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["src/test/setup.ts"],
-    include: ["src/test/**/*.{test,spec}.{ts,tsx}"],
+    include: ["src/test/**/*.{test,spec}.{ts,tsx,mjs}"],
     css: true,
   },
 });


### PR DESCRIPTION
## Summary

In-app macOS auto-updates via the Tauri v2 updater plugin — replaces
delete-and-reinstall with **check → prompt → download → relaunch**. Decisions
recorded in `docs/adr/0001-auto-updates-via-tauri-updater.md`.

## What's included

- **Updater + process plugins** wired in `lib.rs` + capabilities; `tauri.conf.json`
  with embedded pubkey, `createUpdaterArtifacts`, and the releases-repo endpoint.
- **Frontend**: launch-only check (once per session) + manual "Check for updates"
  menu item, prompt with release notes, throttled download progress
  (`update-decision.ts`, `updater.ts`, `App.tsx`).
- **`scripts/bump-version.mjs`** — version-bump module: semver + strictly-greater
  guard + 3-file agreement check, with unit tests.
- **Release workflow** (`production-desktop-release`): `workflow_dispatch` with an
  explicit version → validate (env + anchored regex) → bump + commit → build,
  sign, notarize, updater-sign, and publish to the public `os-scribe-releases`
  repo via `tauri-action`.
- **CI auth via a GitHub App** (org-owned): mints a short-lived token scoped to
  both repos at run time — no personal PAT. The same App is the ruleset bypass
  actor for when `main` is protected.
- Runbook `docs/release-macos.md` updated to match.

## Decisions (ADR-0001)

- Single stable track; prompt UX; launch-only + manual menu.
- Artifacts hosted on a separate **public** `os-scribe-releases` repo (source
  stays private); endpoint repoints when the source repo goes public.
- `aarch64`-only; Intel intentionally unsupported.
- App version starts at **0.0.1**.

## Validation

- `pnpm lint` clean · `pnpm test` **105/105** (incl. `update-decision`,
  `version-bump`) · `pnpm test:rust` green · `actionlint` clean.
- Multi-agent pre-flight review run; code findings addressed. The "workflow shell
  injection" finding was a false positive — the input is already validated via
  `env` + an anchored `^X.Y.Z$` regex before any use.

## Prereqs done (human)

- Public `os-scribe-releases` repo created.
- Release GitHub App installed on **both** repos; secrets set: `RELEASE_APP_ID`,
  `RELEASE_APP_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)`.

## Releasing / test plan

1. Trigger `production-desktop-release` (workflow_dispatch) with a version
   **> 0.0.1** → first release lands in `os-scribe-releases` with `latest.json`.
2. First-run gate: `spctl --assess` + a real updater-delivered relaunch before
   retiring the fallback `scripts/build-signed-dmg.sh`.

## Out of scope

beta/staging channel · periodic background checks · Intel / Windows / Linux ·
silent install.

> Note: ADR-0001 prose still references `0.2.0` as the first updater build; the
> app now starts at `0.0.1` — reconcile in a follow-up.
