### PR TITLE
fix: pin tauri-action to v0.6.2 (v1 tag does not exist)

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -169,7 +169,7 @@ jobs:
           echo "path=$key_path" >> "$GITHUB_OUTPUT"
 
       - name: Build, sign, notarize, and publish updater release
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6.2
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}


### PR DESCRIPTION
The production release workflow failed at **Set up job** — `Unable to resolve action tauri-apps/tauri-action@v1, unable to find version v1`. tauri-action is still `0.x` (no `v1` tag); latest is `v0.6.2`. This pins it there.

Run that failed: https://github.com/open-software-network/os-scribe/actions/runs/26950242866

One-line CI fix — safe to squash-merge, then re-dispatch `production-desktop-release` with a version > 0.0.1.

### Heads-up for the next run
The build will now get past action resolution and into signing/notarizing. Two things to watch:
- The `TAURI_SIGNING_PRIVATE_KEY` secret must match the embedded pubkey (regenerated in #63 to `50051D0F…`), or clients reject the update at signature verification.
- The App must have **Contents: write** on both repos (confirmed installed).