### PR TITLE
fix: sign nested helpers in release build + correct updater json input

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -72,13 +72,14 @@ jobs:
           restore-keys: |
             cargo-registry-${{ runner.os }}-
 
-      - name: Cache cargo target
-        uses: actions/cache@v4
-        with:
-          path: src-tauri/target
-          key: tauri-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            tauri-target-${{ runner.os }}-
+      # NOTE: intentionally no `src-tauri/target` cache. A restored target lets
+      # Cargo treat build.rs as fresh and skip it during the signed build — so
+      # the nested Swift helper apps keep whatever signature they got the first
+      # time they were built (ad-hoc, from `pnpm test:rust` which runs without a
+      # signing identity) and notarization rejects them ("not signed with a valid
+      # Developer ID / no secure timestamp / no hardened runtime"). A clean
+      # compile forces build.rs to run under tauri-action's keychain + identity
+      # and re-sign the helpers (`codesign --force --deep …` in build.rs).
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
@@ -196,8 +197,10 @@ jobs:
           # raw (## headings, @-mentions). Keep notes = the plain releaseBody.
           generateReleaseNotes: false
           args: --bundles app,dmg --target aarch64-apple-darwin
-          uploadUpdaterJson: true
-          uploadUpdaterSignatures: true
+          # v0.6.x input name (was uploadUpdaterJson/uploadUpdaterSignatures,
+          # which this version ignores). Generates + uploads latest.json; the
+          # .sig updater signatures are uploaded alongside it automatically.
+          includeUpdaterJson: true
 
       # Push the version bump to main only AFTER the release is published, so a
       # build/notarize failure never leaves an orphan `release:` commit on main

--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -15,6 +15,13 @@ concurrency:
   group: production-desktop-release
   cancel-in-progress: false
 
+# Opt the bundled JS actions (checkout, cache, setup-node, create-github-app-token,
+# pnpm/action-setup) into the Node 24 runtime — Node 20 is deprecated and will be
+# forced off the runners. Independent of node-version below (the Node our own build
+# scripts run on).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     name: Release production macOS app
@@ -53,7 +60,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Setup Rust


### PR DESCRIPTION
Second-run failure: notarization rejected the build — the two Swift helper binaries (`os-scribe-dictation-helper`, `os-scribe-system-audio-recorder`) were **ad-hoc signed** (no Developer ID, no secure timestamp, no hardened runtime).

Run: https://github.com/open-software-network/os-scribe/actions/runs/26950730456

### Root cause (two compounding workflow bugs)
1. **`Run release checks` runs `cargo test` before the signed build.** That triggers `build.rs`, which builds the helper `.app`s into `.tauri-helper/` and signs them — but that step has **no `APPLE_SIGNING_IDENTITY`**, so `build.rs` falls back to ad-hoc `codesign -` (no timestamp, no runtime).
2. **`Cache cargo target` restores a compiled target**, so when `tauri-action` runs the real signed build, Cargo treats `build.rs` as fresh and **skips it** — the ad-hoc helpers are never re-signed.

`build.rs` already re-signs with `codesign --force --deep … --sign $APPLE_SIGNING_IDENTITY --timestamp --options runtime` whenever it runs with an identity present (`tauri-action` sets up the keychain). It just wasn't running.

### Fix
- **Remove `Cache cargo target`** → the signed build compiles clean, `build.rs` runs under `tauri-action`'s keychain + identity and re-signs the helpers with the Developer ID. (Matches the proven `build-signed-dmg.sh` staging flow, which has no pre-build `cargo test`.) Costs a few extra minutes per release; releases are manual + infrequent.
- **`includeUpdaterJson: true`** replaces `uploadUpdaterJson`/`uploadUpdaterSignatures`, which v0.6.2 silently ignores (it warned: *unexpected input(s)*). Without this, `latest.json` wouldn't be generated. `.sig` files upload alongside automatically.

### Note
The build got all the way through bump → checks → 7-min build → notarize, so everything before signing is now proven. After merge, re-dispatch with a version > 0.0.1. Still watch for the `TAURI_SIGNING_PRIVATE_KEY` ↔ embedded-pubkey match on the *publish* step.