### PR TITLE
[codex] Fix stuck recording restart

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -115,7 +115,7 @@ pub fn start_capture(
     if active.is_some() {
         return Err(AppError::new(
             "recording_already_active",
-            "A previous recording is still active. Scribe will save it locally before starting another recording.",
+            "A previous recording is still active. Scribe attempted to save it locally; please try again.",
         ));
     }
 
@@ -326,11 +326,12 @@ pub fn capture_status(session_id: &str) -> Result<RecordingStatusDto, AppError> 
     Ok(recording.status())
 }
 
-pub fn active_capture_session_id() -> Result<Option<String>, AppError> {
-    let active = lock_active()?;
-    Ok(active
-        .as_ref()
-        .map(|recording| recording.session_id.clone()))
+pub fn finish_active_capture() -> Result<Option<FinishedRecording>, AppError> {
+    let mut active = lock_active()?;
+    let Some(recording) = active.take() else {
+        return Ok(None);
+    };
+    finalize_recording(recording).map(Some)
 }
 
 pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
@@ -352,6 +353,10 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
             ),
         ));
     }
+    finalize_recording(recording)
+}
+
+fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, AppError> {
     let status = recording.status_with_state(RecordingState::Validating);
     let recording_dto = RecordingSessionDto {
         id: recording.session_id.clone(),

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -115,7 +115,7 @@ pub fn start_capture(
     if active.is_some() {
         return Err(AppError::new(
             "recording_already_active",
-            "A recording is already active.",
+            "A previous recording is still active. Scribe will save it locally before starting another recording.",
         ));
     }
 
@@ -324,6 +324,13 @@ pub fn capture_status(session_id: &str) -> Result<RecordingStatusDto, AppError> 
     let active = lock_active()?;
     let recording = active_for_session(active.as_ref(), session_id)?;
     Ok(recording.status())
+}
+
+pub fn active_capture_session_id() -> Result<Option<String>, AppError> {
+    let active = lock_active()?;
+    Ok(active
+        .as_ref()
+        .map(|recording| recording.session_id.clone()))
 }
 
 pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,8 +2,8 @@ use crate::{
     app_paths::AppPaths,
     audio::{
         capture::{
-            capture_status, finish_capture, microphone_permission_state, pause_capture,
-            resume_capture, start_capture,
+            active_capture_session_id, capture_status, finish_capture, microphone_permission_state,
+            pause_capture, resume_capture, start_capture,
         },
         recovery::scan_recoverable_recordings,
         validation::{
@@ -322,6 +322,7 @@ pub async fn start_recording(
             .unwrap_or_else(|| "The selected recording sources are not ready.".to_string());
         return Err(AppError::new("source_not_ready", message));
     }
+    finish_active_capture_before_start(&repos).await?;
     let started = start_capture(&paths, request.note_id.clone(), source_mode)?;
     repos
         .create_recording_session(
@@ -378,13 +379,27 @@ pub async fn finish_recording(
     app: AppHandle,
     request: SessionRequest,
 ) -> Result<FinishRecordingResponse, AppError> {
+    let repos = repositories(&app).await?;
+    finish_recording_session(&repos, &request.session_id).await
+}
+
+async fn finish_active_capture_before_start(repos: &Repositories) -> Result<(), AppError> {
+    if let Some(session_id) = active_capture_session_id()? {
+        finish_recording_session(repos, &session_id).await?;
+    }
+    Ok(())
+}
+
+async fn finish_recording_session(
+    repos: &Repositories,
+    session_id: &str,
+) -> Result<FinishRecordingResponse, AppError> {
     let finalization_started = Instant::now();
-    let finished = finish_capture(&request.session_id)?;
+    let finished = finish_capture(session_id)?;
     let finalization_ms = finalization_started
         .elapsed()
         .as_millis()
         .min(i64::MAX as u128) as i64;
-    let repos = repositories(&app).await?;
     repos
         .add_checkpoint(
             &finished.session_id,
@@ -576,7 +591,7 @@ pub async fn finish_recording(
     let mut note = repos.get_note(&finished.note_id).await?;
     note.queued_recordings = processing_queue::queued_behind(&finished.note_id);
 
-    let task_repos = repos.clone();
+    let task_repos = (*repos).clone();
     let task_note_id = finished.note_id.clone();
     let task_session_id = finished.session_id.clone();
     let task_source_mode = finished.source_mode;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use crate::{
     app_paths::AppPaths,
     audio::{
         capture::{
-            active_capture_session_id, capture_status, finish_capture, microphone_permission_state,
+            capture_status, finish_active_capture, finish_capture, microphone_permission_state,
             pause_capture, resume_capture, start_capture,
         },
         recovery::scan_recoverable_recordings,
@@ -380,22 +380,24 @@ pub async fn finish_recording(
     request: SessionRequest,
 ) -> Result<FinishRecordingResponse, AppError> {
     let repos = repositories(&app).await?;
-    finish_recording_session(&repos, &request.session_id).await
+    let finalization_started = Instant::now();
+    let finished = finish_capture(&request.session_id)?;
+    finish_recording_session(&repos, finished, finalization_started).await
 }
 
 async fn finish_active_capture_before_start(repos: &Repositories) -> Result<(), AppError> {
-    if let Some(session_id) = active_capture_session_id()? {
-        finish_recording_session(repos, &session_id).await?;
+    let finalization_started = Instant::now();
+    if let Some(finished) = finish_active_capture()? {
+        finish_recording_session(repos, finished, finalization_started).await?;
     }
     Ok(())
 }
 
 async fn finish_recording_session(
     repos: &Repositories,
-    session_id: &str,
+    finished: crate::audio::capture::FinishedRecording,
+    finalization_started: Instant,
 ) -> Result<FinishRecordingResponse, AppError> {
-    let finalization_started = Instant::now();
-    let finished = finish_capture(session_id)?;
     let finalization_ms = finalization_started
         .elapsed()
         .as_millis()


### PR DESCRIPTION
Fixes a stuck recording state where the backend still had an active capture but the UI could no longer stop it.
Starting a new recording now finalizes the previous active capture through the existing finish, validation, and processing path before starting the requested recording.
The fallback active-recording error copy now explains that Scribe saves the previous recording locally before continuing.
Validated with TypeScript checks, cargo check, focused Vitest recorder tests, and focused Rust source capture, recording validation, and recovery tests.