### PR TITLE
fix: prompt for helper accessibility so dictation can paste

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -70,6 +70,18 @@ func requestMicrophonePermission() {
     }
 }
 
+func requestAccessibilityPermission() {
+    // Prompting variant of AXIsProcessTrusted(): registers THIS helper in the
+    // Accessibility list and surfaces the system "control this computer"
+    // dialog. The silent AXIsProcessTrusted() used elsewhere never adds the
+    // helper to the list, so a fresh install would otherwise have nothing to
+    // toggle — the synthetic Cmd+V paste needs the helper trusted.
+    let promptKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+    let options = [promptKey: true] as CFDictionary
+    _ = AXIsProcessTrustedWithOptions(options)
+    emit("permission_status", permissionPayload())
+}
+
 func helperBundleIdentifier() -> String {
     Bundle.main.bundleIdentifier ?? "unknown"
 }
@@ -1488,6 +1500,10 @@ func handleCommandLine(_ line: String) {
         emit("permission_status", permissionPayload())
     case "request_microphone_permission":
         requestMicrophonePermission()
+    case "request_accessibility_permission":
+        runOnMain {
+            requestAccessibilityPermission()
+        }
     case "list_microphones":
         runOnMain {
             dictation.emitMicrophones()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -268,7 +268,7 @@ export function App() {
     };
   }, []);
 
-  const accessibilityBlocked = isDeniedPermission(accessibilityStatus);
+  const accessibilityBlocked = isAccessibilityBlocked(accessibilityStatus);
   // The Rust readiness check probes mic via cpal, which doesn't reflect
   // TCC denial. Trust the dictation helper's AVCaptureDevice status
   // instead — that's the authoritative macOS API for the mic privacy
@@ -328,6 +328,13 @@ export function App() {
     void dictationHelperCommand({
       type: "request_microphone_permission",
     }).catch(() => undefined);
+    // Check Accessibility on every app open. The helper grant is what lets
+    // dictation paste into other apps; without this poll a fresh install
+    // never learns the helper is untrusted (the focus refresh below doesn't
+    // fire at launch), so the paste-permission banner would stay hidden.
+    void dictationHelperCommand({ type: "get_permission_status" }).catch(
+      () => undefined,
+    );
     return () => {
       cancelled = true;
     };
@@ -1359,6 +1366,15 @@ function handleSidebarResizeStart(
 
 function isDeniedPermission(state?: string) {
   return state === "denied" || state === "restricted";
+}
+
+// Accessibility is a plain bool from the helper (AXIsProcessTrusted),
+// surfaced as "granted" | "missing" — not the mic's denied/restricted
+// vocabulary. Treat any known non-granted value as blocked so the paste
+// permission banner actually shows when access is missing. Undefined stays
+// non-blocking so the banner doesn't flash before the helper's first report.
+export function isAccessibilityBlocked(state?: string) {
+  return state !== undefined && state !== "granted";
 }
 
 function isCreateNoteShortcut(event: KeyboardEvent) {

--- a/src/components/permissions/PermissionBanner.tsx
+++ b/src/components/permissions/PermissionBanner.tsx
@@ -1,5 +1,5 @@
 import { IconLock } from "central-icons/IconLock";
-import { openPrivacySettings } from "../../lib/tauri";
+import { dictationHelperCommand, openPrivacySettings } from "../../lib/tauri";
 
 export function PermissionBanner() {
   return (
@@ -21,6 +21,14 @@ export function PermissionBanner() {
           type="button"
           className="btn btn-ghost"
           onClick={() => {
+            // Fire the helper's prompting check first: it registers the
+            // dictation helper in the Accessibility list (so there's a toggle
+            // to flip) and shows the native system dialog. Then open the pane
+            // as a reliable fallback for repeat clicks, where macOS suppresses
+            // the one-time dialog.
+            void dictationHelperCommand({
+              type: "request_accessibility_permission",
+            }).catch(() => undefined);
             void openPrivacySettings("accessibility");
           }}
         >

--- a/src/components/permissions/PermissionBanner.tsx
+++ b/src/components/permissions/PermissionBanner.tsx
@@ -23,13 +23,18 @@ export function PermissionBanner() {
           onClick={() => {
             // Fire the helper's prompting check first: it registers the
             // dictation helper in the Accessibility list (so there's a toggle
-            // to flip) and shows the native system dialog. Then open the pane
-            // as a reliable fallback for repeat clicks, where macOS suppresses
-            // the one-time dialog.
+            // to flip) and shows the native system dialog. Open the pane only
+            // after that IPC resolves — sequenced, not concurrent, so the
+            // registration lands before System Settings can steal focus from
+            // the prompt. The pane is the fallback for repeat clicks, where
+            // macOS suppresses the one-time dialog.
             void dictationHelperCommand({
               type: "request_accessibility_permission",
-            }).catch(() => undefined);
-            void openPrivacySettings("accessibility");
+            })
+              .catch(() => undefined)
+              .finally(() => {
+                void openPrivacySettings("accessibility");
+              });
           }}
         >
           Open System Settings

--- a/src/test/app-permissions.test.ts
+++ b/src/test/app-permissions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isAccessibilityBlocked } from "../app/App";
+
+// Regression: the dictation helper reports Accessibility as "granted" |
+// "missing" (AXIsProcessTrusted), not the microphone's denied/restricted
+// vocabulary. A fresh install reports "missing", and that MUST count as
+// blocked so the paste-permission banner shows — otherwise dictation
+// silently fails to paste into other apps (Cmd+V needs the helper trusted).
+describe("isAccessibilityBlocked", () => {
+  it("treats a fresh-install 'missing' grant as blocked", () => {
+    expect(isAccessibilityBlocked("missing")).toBe(true);
+  });
+
+  it("does not block once Accessibility is granted", () => {
+    expect(isAccessibilityBlocked("granted")).toBe(false);
+  });
+
+  it("stays non-blocking before the helper's first report", () => {
+    expect(isAccessibilityBlocked(undefined)).toBe(false);
+  });
+
+  it("treats any other non-granted status as blocked", () => {
+    expect(isAccessibilityBlocked("denied")).toBe(true);
+    expect(isAccessibilityBlocked("restricted")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

On the production release, dictation transcribes fine but never pastes into the focused textbox.

Dictation pastes by writing the transcript to the clipboard, then synthesizing **Cmd+V** from the **helper** process (`mac-dictation-helper`). That synthetic keystroke needs macOS **Accessibility** (TCC) permission granted to the helper's *own* code-signing identity (`co.opensoftware.scribe.dictation-helper`) — separate from the main app. Clipboard write needs no permission (manual paste works); the Cmd+V is silently dropped when the helper is untrusted.

The app never surfaced this:
- The helper reports accessibility as `granted` / `missing` (`AXIsProcessTrusted`).
- `accessibilityBlocked` went through `isDeniedPermission`, which only matches the mic's `denied` / `restricted` vocabulary — **never `missing`**.
- So a fresh install (accessibility ungranted → `missing`) → not blocked → `<PermissionBanner/>` never rendered → user never prompted.

## Fix

- **`App.tsx`** — `isAccessibilityBlocked()` treats `missing` as blocked (banner shows); `undefined` stays non-blocking to avoid a flash before the helper's first report. Added an explicit `get_permission_status` poll **on every app open** (the existing refresh only fired on window *focus*, which doesn't happen at launch).
- **`mac-dictation-helper/main.swift`** — new `request_accessibility_permission` command calls `AXIsProcessTrustedWithOptions(prompt:true)`, which **registers the helper in the Accessibility list** (so there's a toggle to flip) and shows the native system dialog. The silent `AXIsProcessTrusted()` used elsewhere never adds the helper.
- **`PermissionBanner.tsx`** — button fires the helper prompt before opening the pane (pane open kept as a reliable fallback for repeat clicks where macOS suppresses the one-time dialog).
- **`app-permissions.test.ts`** — regression test for the classification predicate.

## Verification

- `pnpm lint` (tsc) clean · `swiftc -typecheck` clean · 111/111 frontend tests pass · new regression test green.

**Needs on-device check** (signed helper + real TCC state can't be automated):
1. Fresh launch → "Accessibility needed" banner appears.
2. Click Open System Settings → native dialog appears, **OS Scribe Dictation Helper** is listed → toggle on.
3. Focus a textbox, dictate → text pastes.

## Follow-up (not blocking)

Mic and accessibility share one status predicate despite different vocabularies — splitting them would prevent this class of bug.