### PR TITLE
[codex] Fix long dual-source recording stability

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -949,6 +949,17 @@ final class SelectedDeviceRecorder: NSObject, AVCaptureAudioDataOutputSampleBuff
     private var finishHandler: ((Error?) -> Void)?
     private let failureHandler: (Error) -> Void
     private let levelHandler: (Float) -> Void
+    // Coalesce per-buffer levels to ~25Hz before emitting, matching the
+    // AVAudioRecorder metering timer. AVCaptureAudioDataOutput delivers buffers
+    // far faster than that (faster still for aggregate "system + mic" devices),
+    // so emitting one event per buffer floods the IPC channel — the HUD's event
+    // queue grows unbounded over a long recording until the waveform visibly
+    // lags and then freezes. Track the peak across skipped buffers so loud
+    // transients still register. All accesses happen on `queue` (the capture
+    // delegate queue), so no locking is needed.
+    private var lastLevelEmit: TimeInterval = 0
+    private var pendingPeak: Float = 0
+    private let levelEmitInterval: TimeInterval = 0.04
 
     init(
         device: AVCaptureDevice,
@@ -1007,6 +1018,7 @@ final class SelectedDeviceRecorder: NSObject, AVCaptureAudioDataOutputSampleBuff
             isStopping = true
             finishHandler = completion
             session.stopRunning()
+            flushPendingLevel()
             output.setSampleBufferDelegate(nil, queue: nil)
 
             guard didStartWriting else {
@@ -1089,7 +1101,26 @@ final class SelectedDeviceRecorder: NSObject, AVCaptureAudioDataOutputSampleBuff
         for sample in samples {
             peak = max(peak, abs(Float(sample) / Float(Int16.max)))
         }
-        levelHandler(peak)
+        pendingPeak = max(pendingPeak, peak)
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now - lastLevelEmit >= levelEmitInterval else {
+            return
+        }
+        emitPendingLevel(at: now)
+    }
+
+    private func flushPendingLevel() {
+        guard pendingPeak > 0 else {
+            return
+        }
+        emitPendingLevel(at: ProcessInfo.processInfo.systemUptime)
+    }
+
+    private func emitPendingLevel(at now: TimeInterval) {
+        lastLevelEmit = now
+        let coalesced = pendingPeak
+        pendingPeak = 0
+        levelHandler(coalesced)
     }
 
     private func fail(_ error: Error) {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -326,6 +326,13 @@ pub fn capture_status(session_id: &str) -> Result<RecordingStatusDto, AppError> 
     Ok(recording.status())
 }
 
+pub fn is_capture_active() -> bool {
+    ACTIVE_RECORDING
+        .lock()
+        .map(|active| active.is_some())
+        .unwrap_or(false)
+}
+
 pub fn finish_active_capture() -> Result<Option<FinishedRecording>, AppError> {
     let mut active = lock_active()?;
     let Some(recording) = active.take() else {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,8 +2,8 @@ use crate::{
     app_paths::AppPaths,
     audio::{
         capture::{
-            capture_status, finish_active_capture, finish_capture, microphone_permission_state,
-            pause_capture, resume_capture, start_capture,
+            capture_status, finish_active_capture, finish_capture, is_capture_active,
+            microphone_permission_state, pause_capture, resume_capture, start_capture,
         },
         recovery::scan_recoverable_recordings,
         validation::{
@@ -681,7 +681,7 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
         let mut system = crate::audio::system_macos::system_audio_readiness();
-        if system.ready {
+        if should_probe_system_audio_permission(system.ready, is_capture_active()) {
             if let Err(error) = crate::audio::system_macos::helper_permission_check() {
                 system.ready = false;
                 system.permission_state = "denied".to_string();
@@ -700,6 +700,10 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
         checked_at: crate::db::repositories::timestamp(),
         sources,
     }
+}
+
+fn should_probe_system_audio_permission(system_ready: bool, capture_active: bool) -> bool {
+    system_ready && !capture_active
 }
 
 #[tauri::command]
@@ -936,4 +940,20 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
         .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?;
     AppPaths::from_data_dir(data_dir)
         .map_err(|error| AppError::new("storage_unavailable", error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_probe_system_audio_permission;
+
+    #[test]
+    fn skips_system_audio_permission_probe_while_capture_is_active() {
+        assert!(!should_probe_system_audio_permission(true, true));
+    }
+
+    #[test]
+    fn probes_system_audio_permission_only_when_available_and_idle() {
+        assert!(should_probe_system_audio_permission(true, false));
+        assert!(!should_probe_system_audio_permission(false, false));
+    }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -346,17 +346,24 @@ export function App() {
   // accessibility state via the dictation-event listener above.
   useEffect(() => {
     if (appBlocked) return;
+    const recordingState = state.recordingStatus?.state;
+    const captureActive =
+      recordingState === "recording" ||
+      recordingState === "paused" ||
+      recordingState === "finalizing" ||
+      recordingState === "validating";
     function refresh() {
-      void checkRecordingSourceReadiness("microphonePlusSystem")
-        .then(setSourceReadiness)
-        .catch(() => undefined);
       void dictationHelperCommand({ type: "get_permission_status" }).catch(
         () => undefined,
       );
+      if (captureActive) return;
+      void checkRecordingSourceReadiness("microphonePlusSystem")
+        .then(setSourceReadiness)
+        .catch(() => undefined);
     }
     window.addEventListener("focus", refresh);
     return () => window.removeEventListener("focus", refresh);
-  }, [appBlocked]);
+  }, [appBlocked, state.recordingStatus?.state]);
 
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");


### PR DESCRIPTION
## Summary

- Throttle selected-device dictation audio-level events to ~25Hz while preserving peak levels, preventing HUD waveform event backlog on long system+mic recordings.
- Prevent system-audio readiness probes from terminating the active system recorder during an ongoing capture.
- Skip focus-triggered source readiness refresh while recording/finalizing/validating.

## Root Cause

Long selected-device dictation recordings emitted an `audio_level` event for every capture buffer, which could flood the Tauri event path and leave the HUD rendering stale waveform data.

Separately, system-audio readiness checks run a permission probe that terminates existing system-audio helpers. The app could trigger that readiness check on window focus during an active recording, killing the real system recorder while microphone capture continued.

## Validation

- `git pull --ff-only origin main`
- `swiftc -typecheck src-tauri/native/mac-dictation-helper/main.swift`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::tests::`
- `pnpm test -- app-shortcut`
- `pnpm exec tsc --noEmit`