### PR TITLE
Revamp sidebar agent UX

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -109,7 +109,7 @@ export function App() {
   const [sidebarTransition, setSidebarTransition] = useState<"none" | "smooth">(
     "none",
   );
-  const [activeView, setActiveView] = useState<SidebarView>("notes");
+  const [activeView, setActiveView] = useState<SidebarView>("meetings");
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
   // note shows the same back-arrow + breadcrumb chrome folders use. Cleared
@@ -290,7 +290,7 @@ export function App() {
           startOnFreshNoteRef.current = false;
           const note = await createNote(undefined);
           dispatch({ type: "noteLoaded", note });
-          setActiveView("notes");
+          setActiveView("meetings");
           return;
         }
         const firstNoteId = seeded.payload.notes[0]?.id;
@@ -443,7 +443,7 @@ export function App() {
         dispatch({ type: "noteLoaded", note });
         setOriginFolderId(undefined);
         setOriginAllNotes(false);
-        setActiveView("notes");
+        setActiveView("meetings");
       } catch (err) {
         setError(messageFromError(err));
       }
@@ -472,7 +472,7 @@ export function App() {
     if (state.selectedNoteId !== noteId) {
       await handleSelectNote(noteId);
     }
-    setActiveView("notes");
+    setActiveView("meetings");
     setFolderReturnTarget(undefined);
   }
 
@@ -569,7 +569,7 @@ export function App() {
       setOriginFolderId(undefined);
       setOriginAllNotes(true);
       setFolderReturnTarget(undefined);
-      setActiveView("notes");
+      setActiveView("meetings");
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -605,7 +605,7 @@ export function App() {
       setOriginFolderId(folderId);
       setOriginAllNotes(false);
       setFolderReturnTarget(undefined);
-      setActiveView("notes");
+      setActiveView("meetings");
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -804,7 +804,7 @@ export function App() {
             setFolderReturnTarget(undefined);
             dispatch({ type: "folderSelected", folderId: undefined });
           }
-          if (view !== "notes") {
+          if (view !== "meetings" && view !== "notes") {
             setOriginFolderId(undefined);
             setOriginAllNotes(false);
             setFolderReturnTarget(undefined);
@@ -931,7 +931,7 @@ export function App() {
                     void handleSelectNoteFromFolder(noteId, folderId);
                   } else {
                     void handleSelectNote(noteId).then(() =>
-                      setActiveView("notes"),
+                      setActiveView("meetings"),
                     );
                   }
                 }}
@@ -969,25 +969,25 @@ export function App() {
                           setOriginFolderId(undefined);
                         },
                       },
-                      { label: selectedNote.title.trim() || "New note" },
+                      { label: selectedNote.title.trim() || "New meeting" },
                     ]}
                   />
                 ) : originAllNotes ? (
                   <BreadcrumbBar
-                    backLabel="Back to All notes"
+                    backLabel="Back to All meetings"
                     onBack={() => {
                       setActiveView("all-notes");
                       setOriginAllNotes(false);
                     }}
                     items={[
                       {
-                        label: "All notes",
+                        label: "All meetings",
                         onClick: () => {
                           setActiveView("all-notes");
                           setOriginAllNotes(false);
                         },
                       },
-                      { label: selectedNote.title.trim() || "New note" },
+                      { label: selectedNote.title.trim() || "New meeting" },
                     ]}
                   />
                 ) : null}
@@ -1053,7 +1053,7 @@ export function App() {
                     dispatch({ type: "folderSelected", folderId });
                     setFolderReturnTarget({
                       noteId: selectedNote.id,
-                      label: selectedNote.title.trim() || "New note",
+                      label: selectedNote.title.trim() || "New meeting",
                     });
                     setOriginFolderId(undefined);
                   }}
@@ -1074,7 +1074,7 @@ export function App() {
                   className="primary-action"
                   onClick={() => void handleCreateNote(null)}
                 >
-                  New note
+                  New meeting
                 </button>
               </section>
             )}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -228,6 +228,7 @@ export function App() {
   // session, so a later install toggle can't re-trigger it.
   const launchCheckedRef = useRef(false);
   useEffect(() => {
+    if (import.meta.env.DEV) return;
     if (appBlocked || launchCheckedRef.current) return;
     launchCheckedRef.current = true;
     runUpdateCheck("launch");

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -109,6 +109,7 @@ export function App() {
   const [sidebarTransition, setSidebarTransition] = useState<"none" | "smooth">(
     "none",
   );
+  const [bootstrapped, setBootstrapped] = useState(false);
   const [activeView, setActiveView] = useState<SidebarView>("meetings");
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
@@ -284,6 +285,7 @@ export function App() {
         dispatch({ type: "bootstrapLoaded", payload: seeded.payload });
         if (seeded.fakeNote) {
           dispatch({ type: "noteLoaded", note: seeded.fakeNote });
+          setBootstrapped(true);
           return;
         }
         if (startOnFreshNoteRef.current || seeded.payload.notes.length === 0) {
@@ -291,6 +293,7 @@ export function App() {
           const note = await createNote(undefined);
           dispatch({ type: "noteLoaded", note });
           setActiveView("meetings");
+          setBootstrapped(true);
           return;
         }
         const firstNoteId = seeded.payload.notes[0]?.id;
@@ -300,6 +303,7 @@ export function App() {
         } else {
           setActiveView("settings");
         }
+        setBootstrapped(true);
       })
       .catch((err: unknown) => setError(messageFromError(err)));
   }, [appBlocked]);
@@ -450,6 +454,26 @@ export function App() {
     },
     [state.selectedFolderId],
   );
+
+  useEffect(() => {
+    if (
+      appBlocked ||
+      !bootstrapped ||
+      activeView !== "meetings" ||
+      selectedNote ||
+      state.selectedNoteId
+    ) {
+      return;
+    }
+    void handleCreateNote(null);
+  }, [
+    activeView,
+    appBlocked,
+    bootstrapped,
+    handleCreateNote,
+    selectedNote,
+    state.selectedNoteId,
+  ]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -1068,15 +1092,7 @@ export function App() {
                 />
               </div>
             ) : (
-              <section className="editor-empty">
-                <button
-                  type="button"
-                  className="primary-action"
-                  onClick={() => void handleCreateNote(null)}
-                >
-                  New meeting
-                </button>
-              </section>
+              <section className="editor-empty" aria-label="Opening meeting" />
             )}
           </div>
         </div>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -110,7 +110,7 @@ export function App() {
     "none",
   );
   const [bootstrapped, setBootstrapped] = useState(false);
-  const [activeView, setActiveView] = useState<SidebarView>("meetings");
+  const [activeView, setActiveView] = useState<SidebarView>("notes");
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
   // note shows the same back-arrow + breadcrumb chrome folders use. Cleared
@@ -818,10 +818,7 @@ export function App() {
         <SidebarToggleGlyph />
       </button>
       <Sidebar
-        folders={state.folders}
         notes={state.notes}
-        selectedNoteId={state.selectedNoteId}
-        selectedFolderId={state.selectedFolderId}
         activeView={activeView}
         onChangeView={(view) => {
           setActiveView(view);
@@ -835,14 +832,6 @@ export function App() {
             setFolderReturnTarget(undefined);
           }
         }}
-        onCreateFolder={() => {
-          setActiveView("folders");
-          setFolderReturnTarget(undefined);
-          dispatch({ type: "folderSelected", folderId: undefined });
-        }}
-        onCreateNote={() => void handleCreateNote(null)}
-        onSelectAll={() => handleSelectFolder(undefined)}
-        onSelectFolder={(folderId) => handleSelectFolder(folderId)}
         onSelectNote={(noteId) => void handleSelectNote(noteId)}
         onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
         onOpenMoveDialog={(noteId) => setMoveDialogNoteId(noteId)}
@@ -916,7 +905,7 @@ export function App() {
               />
             ) : activeView === "agent" ? (
               <AgentWorkspace />
-            ) : activeView === "all-notes" ? (
+            ) : activeView === "notes" || activeView === "all-notes" ? (
               <NotesList
                 notes={state.notes}
                 selectedNoteId={state.selectedNoteId}
@@ -994,25 +983,25 @@ export function App() {
                           setOriginFolderId(undefined);
                         },
                       },
-                      { label: selectedNote.title.trim() || "New meeting" },
+                      { label: selectedNote.title.trim() || "New note" },
                     ]}
                   />
                 ) : originAllNotes ? (
                   <BreadcrumbBar
-                    backLabel="Back to All meetings"
+                    backLabel="Back to Notes"
                     onBack={() => {
                       setActiveView("all-notes");
                       setOriginAllNotes(false);
                     }}
                     items={[
                       {
-                        label: "All meetings",
+                        label: "Notes",
                         onClick: () => {
                           setActiveView("all-notes");
                           setOriginAllNotes(false);
                         },
                       },
-                      { label: selectedNote.title.trim() || "New meeting" },
+                      { label: selectedNote.title.trim() || "New note" },
                     ]}
                   />
                 ) : null}
@@ -1078,7 +1067,7 @@ export function App() {
                     dispatch({ type: "folderSelected", folderId });
                     setFolderReturnTarget({
                       noteId: selectedNote.id,
-                      label: selectedNote.title.trim() || "New meeting",
+                      label: selectedNote.title.trim() || "New note",
                     });
                     setOriginFolderId(undefined);
                   }}
@@ -1093,7 +1082,7 @@ export function App() {
                 />
               </div>
             ) : (
-              <section className="editor-empty" aria-label="Opening meeting" />
+              <section className="editor-empty" aria-label="Opening note" />
             )}
           </div>
         </div>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -82,7 +82,21 @@ const POLLED_STATUSES = new Set<AgentTaskStatus>([
   "waitingForUser",
 ]);
 
-type AgentPanel = "chat" | "skills" | "messaging" | "files";
+type AgentPanel = "chat" | "skills" | "messaging";
+
+export const AGENT_NEW_SESSION_EVENT = "scribe:agent:new-session";
+export const AGENT_SELECT_SESSION_EVENT = "scribe:agent:select-session";
+export const AGENT_SESSIONS_CHANGED_EVENT = "scribe:agent:sessions-changed";
+
+export type AgentSessionsChangedDetail = {
+  sessions: HermesSessionInfo[];
+  selectedSessionId?: string;
+  workingSessionIds: string[];
+};
+
+type AgentSelectSessionDetail = {
+  sessionId: string;
+};
 
 type HermesRuntimeSessionResponse = {
   session_id?: string;
@@ -258,6 +272,45 @@ export function AgentWorkspace() {
   }, [bridge.running, loadHermesSessions]);
 
   useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent<AgentSessionsChangedDetail>(
+        AGENT_SESSIONS_CHANGED_EVENT,
+        {
+          detail: {
+            sessions: hermesSessionItems,
+            selectedSessionId: selectedHermesSessionId,
+            workingSessionIds: Array.from(workingSessionIds),
+          },
+        },
+      ),
+    );
+  }, [hermesSessionItems, selectedHermesSessionId, workingSessionIds]);
+
+  useEffect(() => {
+    function handleNewSession() {
+      void startNewTask();
+    }
+
+    function handleSelectSession(event: Event) {
+      const detail = (event as CustomEvent<AgentSelectSessionDetail>).detail;
+      if (!detail?.sessionId) return;
+      setActivePanel("chat");
+      setSelectedHermesSessionId(detail.sessionId);
+      setSelectedTaskId(undefined);
+    }
+
+    window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
+    window.addEventListener(AGENT_SELECT_SESSION_EVENT, handleSelectSession);
+    return () => {
+      window.removeEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
+      window.removeEventListener(
+        AGENT_SELECT_SESSION_EVENT,
+        handleSelectSession,
+      );
+    };
+  }, []);
+
+  useEffect(() => {
     if (!bridge.running || !selectedHermesSessionId) return;
     let cancelled = false;
     listHermesSessionMessages(selectedHermesSessionId)
@@ -374,9 +427,6 @@ export function AgentWorkspace() {
     }
     if (activePanel === "messaging" && !messagingPlatforms) {
       void loadMessagingPlatforms();
-    }
-    if (activePanel === "files" && !filesystemSnapshot) {
-      void loadFilesystemSnapshot();
     }
   }, [activePanel]);
 
@@ -843,247 +893,197 @@ export function AgentWorkspace() {
           void setMessagingPlatformEnabled(platform, enabled)
         }
       />
-    ) : activePanel === "files" ? (
-      <FilesystemPanel
-        loading={filesystemLoading}
-        query={capabilityQuery}
-        snapshot={filesystemSnapshot}
-        onQueryChange={setCapabilityQuery}
-        onRefresh={() => void loadFilesystemSnapshot()}
-      />
     ) : null;
 
   return (
     <section className="agent-workspace" aria-label="Agent">
-      <aside className="agent-task-rail" aria-label="Agent tasks">
-        <header className="agent-rail-header">
-          <div>
-            <h1>Agent</h1>
-            <p>
-              {bridge.running
-                ? `Hermes bridge running on ${bridge.connection?.port ?? "local"}`
-                : "Desktop tasks with private local-tool policy."}
-            </p>
-          </div>
-          <PanelTabs activePanel={activePanel} onChange={setActivePanel} />
-          <div className="agent-rail-actions">
-            {activePanel === "chat" ? (
-              <button
-                type="button"
-                className="agent-new-task"
-                onClick={() => void startNewTask()}
-              >
-                New session
-              </button>
-            ) : null}
-            {!bridge.running ? (
-              <button
-                type="button"
-                className="agent-new-task"
-                disabled={bridgeStarting}
-                onClick={() => void startBridge()}
-              >
-                {bridgeStarting ? "Starting Hermes" : "Start Hermes"}
-              </button>
-            ) : null}
-          </div>
-        </header>
-
-        {activePanel !== "chat" ? null : (loading || hermesSessionsLoading) &&
-          !hermesSessionItems.length ? (
-          <div className="agent-loading">
-            <Spinner size={16} />
-          </div>
-        ) : hermesSessionItems.length ? (
-          <div className="agent-task-list">
-            {hermesSessionItems.map((session) => (
-              <button
-                key={session.id}
-                type="button"
-                className="agent-task-row"
-                data-active={session.id === selectedHermesSessionId}
-                onClick={() => {
-                  setSelectedHermesSessionId(session.id);
-                  setSelectedTaskId(undefined);
-                }}
-              >
-                <span className="agent-task-row-title">
-                  {session.title || session.preview || "Untitled session"}
-                </span>
-                <span className="agent-task-row-meta">
-                  <ActivityIndicator
-                    active={workingSessionIds.has(session.id)}
-                  />
-                  <span>{relativeDate(sessionTimestamp(session))}</span>
-                </span>
-                {!workingSessionIds.has(session.id) && session.preview ? (
-                  <span className="agent-task-row-summary">
-                    {session.preview}
-                  </span>
-                ) : null}
-              </button>
-            ))}
-          </div>
-        ) : tasks.length ? (
-          <div className="agent-task-list">
-            {tasks.map((task) => (
-              <button
-                key={task.id}
-                type="button"
-                className="agent-task-row"
-                data-active={task.id === selectedTask?.id}
-                onClick={() => {
-                  setSelectedTaskId(task.id);
-                  setSelectedHermesSessionId(task.hermesSessionId);
-                }}
-              >
-                <span className="agent-task-row-title">{task.title}</span>
-                <span className="agent-task-row-meta">
-                  <ActivityIndicator active={workingTaskIds.has(task.id)} />
-                  <span>{relativeDate(task.updatedAt)}</span>
-                </span>
-                {workingTaskIds.has(task.id) ? (
-                  <span className="agent-task-row-summary">Working now.</span>
-                ) : null}
-              </button>
-            ))}
-          </div>
-        ) : (
-          <EmptyState
-            icon={<BotIcon size={22} />}
-            title="No agent tasks"
-            description="Ask the agent to do something on your desktop."
-            label="No agent tasks"
-          />
-        )}
-      </aside>
-
       <section className="agent-main" aria-label="Agent task details">
         {error ? <p className="error-banner">{error}</p> : null}
-        {managementPanel ??
-          (selectedHermesSessionId ? (
-            <>
-              <header className="agent-detail-header">
-                <div className="agent-detail-title">
-                  <ActivityIndicator
-                    active={workingSessionIds.has(selectedHermesSessionId)}
-                    large
-                  />
-                  <div>
-                    <h2>
-                      {selectedHermesSession?.title ||
-                        selectedHermesSession?.preview ||
-                        "Untitled session"}
-                    </h2>
-                  </div>
+        {managementPanel ? (
+          <>
+            <header className="agent-detail-header">
+              <div className="agent-detail-title">
+                <BotIcon size={18} />
+                <div>
+                  <h2>Agent</h2>
+                  <p>
+                    {bridge.running
+                      ? `Hermes bridge running on ${bridge.connection?.port ?? "local"}`
+                      : "Desktop tasks with private local-tool policy."}
+                  </p>
                 </div>
-                <div className="agent-actions">
+              </div>
+              <div className="agent-actions">
+                <PanelTabs
+                  activePanel={activePanel}
+                  onChange={setActivePanel}
+                />
+              </div>
+            </header>
+            {managementPanel}
+          </>
+        ) : selectedHermesSessionId ? (
+          <>
+            <header className="agent-detail-header">
+              <div className="agent-detail-title">
+                <ActivityIndicator
+                  active={workingSessionIds.has(selectedHermesSessionId)}
+                  large
+                />
+                <div>
+                  <h2>
+                    {selectedHermesSession?.title ||
+                      selectedHermesSession?.preview ||
+                      "Untitled session"}
+                  </h2>
+                </div>
+              </div>
+              <div className="agent-actions">
+                <PanelTabs
+                  activePanel={activePanel}
+                  onChange={setActivePanel}
+                />
+                <button
+                  type="button"
+                  className="agent-icon-button"
+                  aria-label="Refresh session"
+                  onClick={() =>
+                    void refreshHermesSession(selectedHermesSessionId)
+                  }
+                >
+                  <RotateCwIcon size={15} />
+                </button>
+              </div>
+            </header>
+            <div ref={listRef} className="agent-timeline">
+              <SafetyPanel />
+              {buildHermesSessionChatTurns(
+                selectedHermesMessages,
+                liveEvents[selectedHermesSessionId] ?? [],
+              ).map((turn) => (
+                <AgentChatTurnRow
+                  key={turn.id}
+                  turn={turn}
+                  approvalSubmitting={approvalSubmitting}
+                  onApproval={(part, choice) =>
+                    void respondToApproval(
+                      part.sessionId ?? selectedHermesSessionId,
+                      part.id,
+                      choice,
+                    )
+                  }
+                />
+              ))}
+            </div>
+          </>
+        ) : selectedTask ? (
+          <>
+            <header className="agent-detail-header">
+              <div className="agent-detail-title">
+                <ActivityIndicator
+                  active={workingTaskIds.has(selectedTask.id)}
+                  large
+                />
+                <div>
+                  <h2>{selectedTask.title}</h2>
+                  {workingTaskIds.has(selectedTask.id) ? (
+                    <p>Working now.</p>
+                  ) : null}
+                </div>
+              </div>
+              <div className="agent-actions">
+                <PanelTabs
+                  activePanel={activePanel}
+                  onChange={setActivePanel}
+                />
+                {selectedTask.status !== "cancelled" &&
+                selectedTask.status !== "completed" ? (
                   <button
                     type="button"
                     className="agent-icon-button"
-                    aria-label="Refresh session"
-                    onClick={() =>
-                      void refreshHermesSession(selectedHermesSessionId)
-                    }
+                    aria-label="Cancel task"
+                    onClick={() => void cancelTask(selectedTask.id)}
+                  >
+                    <CircleStopIcon size={15} />
+                  </button>
+                ) : null}
+                {selectedTask.status === "failed" ||
+                selectedTask.status === "paused" ? (
+                  <button
+                    type="button"
+                    className="agent-icon-button"
+                    aria-label="Retry task"
+                    onClick={() => void retryTask(selectedTask.id)}
                   >
                     <RotateCwIcon size={15} />
                   </button>
-                </div>
-              </header>
-              <div ref={listRef} className="agent-timeline">
-                <SafetyPanel />
-                {buildHermesSessionChatTurns(
-                  selectedHermesMessages,
-                  liveEvents[selectedHermesSessionId] ?? [],
-                ).map((turn) => (
-                  <AgentChatTurnRow
-                    key={turn.id}
-                    turn={turn}
-                    approvalSubmitting={approvalSubmitting}
-                    onApproval={(part, choice) =>
-                      void respondToApproval(
-                        part.sessionId ?? selectedHermesSessionId,
-                        part.id,
-                        choice,
-                      )
-                    }
-                  />
-                ))}
+                ) : null}
               </div>
-            </>
-          ) : selectedTask ? (
-            <>
-              <header className="agent-detail-header">
-                <div className="agent-detail-title">
-                  <ActivityIndicator
-                    active={workingTaskIds.has(selectedTask.id)}
-                    large
-                  />
-                  <div>
-                    <h2>{selectedTask.title}</h2>
-                    {workingTaskIds.has(selectedTask.id) ? (
-                      <p>Working now.</p>
-                    ) : null}
-                  </div>
+            </header>
+            <div ref={listRef} className="agent-timeline">
+              <SafetyPanel />
+              {buildAgentChatTurns(
+                selectedTask.messages,
+                selectedTask.toolEvents,
+                liveEvents[selectedTask.id] ?? [],
+              ).map((turn) => (
+                <AgentChatTurnRow
+                  key={turn.id}
+                  turn={turn}
+                  approvalSubmitting={approvalSubmitting}
+                  onApproval={(part, choice) => {
+                    const sessionId =
+                      part.sessionId ??
+                      selectedTask.hermesSessionId ??
+                      hermesSessions[selectedTask.id];
+                    if (!sessionId) return;
+                    void respondToApproval(sessionId, part.id, choice);
+                  }}
+                />
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <header className="agent-detail-header">
+              <div className="agent-detail-title">
+                <BotIcon size={18} />
+                <div>
+                  <h2>Agent</h2>
+                  <p>
+                    {bridge.running
+                      ? `Hermes bridge running on ${bridge.connection?.port ?? "local"}`
+                      : "Desktop tasks with private local-tool policy."}
+                  </p>
                 </div>
-                <div className="agent-actions">
-                  {selectedTask.status !== "cancelled" &&
-                  selectedTask.status !== "completed" ? (
-                    <button
-                      type="button"
-                      className="agent-icon-button"
-                      aria-label="Cancel task"
-                      onClick={() => void cancelTask(selectedTask.id)}
-                    >
-                      <CircleStopIcon size={15} />
-                    </button>
-                  ) : null}
-                  {selectedTask.status === "failed" ||
-                  selectedTask.status === "paused" ? (
-                    <button
-                      type="button"
-                      className="agent-icon-button"
-                      aria-label="Retry task"
-                      onClick={() => void retryTask(selectedTask.id)}
-                    >
-                      <RotateCwIcon size={15} />
-                    </button>
-                  ) : null}
-                </div>
-              </header>
-              <div ref={listRef} className="agent-timeline">
-                <SafetyPanel />
-                {buildAgentChatTurns(
-                  selectedTask.messages,
-                  selectedTask.toolEvents,
-                  liveEvents[selectedTask.id] ?? [],
-                ).map((turn) => (
-                  <AgentChatTurnRow
-                    key={turn.id}
-                    turn={turn}
-                    approvalSubmitting={approvalSubmitting}
-                    onApproval={(part, choice) => {
-                      const sessionId =
-                        part.sessionId ??
-                        selectedTask.hermesSessionId ??
-                        hermesSessions[selectedTask.id];
-                      if (!sessionId) return;
-                      void respondToApproval(sessionId, part.id, choice);
-                    }}
-                  />
-                ))}
               </div>
-            </>
-          ) : (
+              <div className="agent-actions">
+                <PanelTabs
+                  activePanel={activePanel}
+                  onChange={setActivePanel}
+                />
+                {!bridge.running ? (
+                  <button
+                    type="button"
+                    className="agent-new-task"
+                    disabled={bridgeStarting}
+                    onClick={() => void startBridge()}
+                  >
+                    {bridgeStarting ? "Starting Hermes" : "Start Hermes"}
+                  </button>
+                ) : null}
+              </div>
+            </header>
             <div className="agent-compose-empty">
               <EmptyState
                 icon={<BotIcon size={24} />}
-                title="Start an agent task"
-                description="Create a task and the agent will track chat, status, and local-tool activity separately from your notes."
-                label="Start an agent task"
+                title="Start an agent session"
+                description="Use New Session in the sidebar, then ask the agent to complete a desktop task."
+                label="Start an agent session"
               />
             </div>
-          ))}
+          </>
+        )}
 
         {activePanel === "chat" ? (
           <form
@@ -1411,14 +1411,6 @@ function PanelTabs({
       >
         <MessageSquareIcon size={14} />
         Messaging
-      </button>
-      <button
-        type="button"
-        aria-selected={activePanel === "files"}
-        onClick={() => onChange("files")}
-      >
-        <FolderTreeIcon size={14} />
-        Files
       </button>
     </div>
   );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -873,18 +873,6 @@ export function AgentWorkspace() {
                   </h2>
                 </div>
               </div>
-              <div className="agent-actions">
-                <button
-                  type="button"
-                  className="agent-icon-button"
-                  aria-label="Refresh session"
-                  onClick={() =>
-                    void refreshHermesSession(selectedHermesSessionId)
-                  }
-                >
-                  <RotateCwIcon size={15} />
-                </button>
-              </div>
             </header>
             <div ref={listRef} className="agent-timeline">
               <SafetyPanel />

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -87,6 +87,7 @@ type AgentPanel = "chat" | "skills" | "messaging";
 export const AGENT_NEW_SESSION_EVENT = "scribe:agent:new-session";
 export const AGENT_SELECT_SESSION_EVENT = "scribe:agent:select-session";
 export const AGENT_SESSIONS_CHANGED_EVENT = "scribe:agent:sessions-changed";
+export const AGENT_NEW_SESSION_PENDING_KEY = "scribe:agent:new-session-pending";
 
 export type AgentSessionsChangedDetail = {
   sessions: HermesSessionInfo[];
@@ -123,6 +124,7 @@ export function AgentWorkspace() {
   >([]);
   const [selectedHermesSessionId, setSelectedHermesSessionId] =
     useState<string>();
+  const [newSessionMode, setNewSessionMode] = useState(false);
   const [hermesSessionMessages, setHermesSessionMessages] = useState<
     Record<string, HermesSessionMessage[]>
   >({});
@@ -164,6 +166,7 @@ export function AgentWorkspace() {
   const gatewayRef = useRef<HermesGatewayClient | null>(null);
   const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>({});
   const hydratedTaskIdsRef = useRef<Set<string>>(new Set());
+  const newSessionModeRef = useRef(false);
   const listRef = useRef<HTMLDivElement | null>(null);
 
   const setTaskWorking = useCallback((taskId: string, working: boolean) => {
@@ -226,7 +229,11 @@ export function AgentWorkspace() {
     try {
       const response = await listAgentTasks();
       setTasks(response.items);
-      setSelectedTaskId((current) => current ?? response.items[0]?.id);
+      setSelectedTaskId((current) =>
+        newSessionModeRef.current
+          ? undefined
+          : (current ?? response.items[0]?.id),
+      );
       setError(null);
     } catch (err) {
       setError(messageFromError(err));
@@ -242,6 +249,7 @@ export function AgentWorkspace() {
       const sessions = await listHermesSessions();
       setHermesSessionItems(sessions);
       setSelectedHermesSessionId((current) => {
+        if (newSessionModeRef.current) return undefined;
         if (current && sessions.some((session) => session.id === current)) {
           return current;
         }
@@ -294,9 +302,15 @@ export function AgentWorkspace() {
     function handleSelectSession(event: Event) {
       const detail = (event as CustomEvent<AgentSelectSessionDetail>).detail;
       if (!detail?.sessionId) return;
+      newSessionModeRef.current = false;
+      setNewSessionMode(false);
       setActivePanel("chat");
       setSelectedHermesSessionId(detail.sessionId);
       setSelectedTaskId(undefined);
+    }
+
+    if (hasPendingNewSessionRequest()) {
+      void startNewTask();
     }
 
     window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
@@ -410,7 +424,8 @@ export function AgentWorkspace() {
   }, [bridge.running, selectedHermesSessionId, workingSessionIds]);
 
   useEffect(() => {
-    listRef.current?.scrollTo({
+    if (typeof listRef.current?.scrollTo !== "function") return;
+    listRef.current.scrollTo({
       top: listRef.current.scrollHeight,
       behavior: "smooth",
     });
@@ -472,6 +487,8 @@ export function AgentWorkspace() {
     if (!runtimeSessionId)
       throw new Error("Hermes did not resume the session.");
     const createdAt = new Date().toISOString();
+    newSessionModeRef.current = false;
+    setNewSessionMode(false);
     setRuntimeSessionIds((current) => ({
       ...current,
       [storedSessionId]: runtimeSessionId,
@@ -694,6 +711,9 @@ export function AgentWorkspace() {
   }
 
   async function startNewTask() {
+    clearPendingNewSessionRequest();
+    newSessionModeRef.current = true;
+    setNewSessionMode(true);
     setActivePanel("chat");
     setSelectedTaskId(undefined);
     setSelectedHermesSessionId(undefined);
@@ -857,7 +877,7 @@ export function AgentWorkspace() {
     <section className="agent-workspace" aria-label="Agent">
       <section className="agent-main" aria-label="Agent task details">
         {error ? <p className="error-banner">{error}</p> : null}
-        {selectedHermesSessionId ? (
+        {!newSessionMode && selectedHermesSessionId ? (
           <>
             <header className="agent-detail-header">
               <div className="agent-detail-title">
@@ -895,7 +915,7 @@ export function AgentWorkspace() {
               ))}
             </div>
           </>
-        ) : selectedTask ? (
+        ) : !newSessionMode && selectedTask ? (
           <>
             <header className="agent-detail-header">
               <div className="agent-detail-title">
@@ -2695,4 +2715,20 @@ function messageFromError(err: unknown) {
     return String((err as { message: unknown }).message);
   }
   return String(err);
+}
+
+function hasPendingNewSessionRequest() {
+  try {
+    return window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY) != null;
+  } catch {
+    return false;
+  }
+}
+
+function clearPendingNewSessionRequest() {
+  try {
+    window.sessionStorage.removeItem(AGENT_NEW_SESSION_PENDING_KEY);
+  } catch {
+    // Session storage can be unavailable in restricted webviews.
+  }
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1518,7 +1518,7 @@ export function MessagingPanel({
   );
 }
 
-function FilesystemPanel({
+export function FilesystemPanel({
   loading,
   query,
   snapshot,
@@ -1564,7 +1564,10 @@ function FilesystemPanel({
             <section key={root.id} className="agent-files-root">
               <header>
                 <div>
-                  <h3>{root.label}</h3>
+                  <h3 className="agent-files-root-title">
+                    <BotIcon size={14} />
+                    {root.label}
+                  </h3>
                   <p>{root.description}</p>
                 </div>
                 <code>{compactPath(root.path)}</code>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -853,76 +853,11 @@ export function AgentWorkspace() {
     }
   }
 
-  const managementPanel =
-    activePanel === "skills" ? (
-      <SkillsToolsPanel
-        loading={capabilityLoading}
-        query={capabilityQuery}
-        saving={capabilitySaving}
-        skills={skills}
-        toolsets={toolsets}
-        onQueryChange={setCapabilityQuery}
-        onRefresh={() => void loadCapabilities()}
-        onToggleSkill={(skill, enabled) => void setSkillEnabled(skill, enabled)}
-        onToggleToolset={(toolset, enabled) =>
-          void setToolsetEnabled(toolset, enabled)
-        }
-      />
-    ) : activePanel === "messaging" ? (
-      <MessagingPanel
-        loading={capabilityLoading}
-        platforms={messagingPlatforms}
-        query={capabilityQuery}
-        saving={capabilitySaving}
-        selectedPlatformId={selectedMessagingPlatformId}
-        envEdits={messagingEnvEdits}
-        onQueryChange={setCapabilityQuery}
-        onRefresh={() => void loadMessagingPlatforms()}
-        onSelectPlatform={(platform) => {
-          setSelectedMessagingPlatformId(platform.id);
-          setMessagingEnvEdits({});
-        }}
-        onEditEnv={(key, value) =>
-          setMessagingEnvEdits((current) => ({
-            ...current,
-            [key]: value,
-          }))
-        }
-        onSaveEnv={(platform) => void saveMessagingPlatformEnv(platform)}
-        onToggle={(platform, enabled) =>
-          void setMessagingPlatformEnabled(platform, enabled)
-        }
-      />
-    ) : null;
-
   return (
     <section className="agent-workspace" aria-label="Agent">
       <section className="agent-main" aria-label="Agent task details">
         {error ? <p className="error-banner">{error}</p> : null}
-        {managementPanel ? (
-          <>
-            <header className="agent-detail-header">
-              <div className="agent-detail-title">
-                <BotIcon size={18} />
-                <div>
-                  <h2>Agent</h2>
-                  <p>
-                    {bridge.running
-                      ? `Hermes bridge running on ${bridge.connection?.port ?? "local"}`
-                      : "Desktop tasks with private local-tool policy."}
-                  </p>
-                </div>
-              </div>
-              <div className="agent-actions">
-                <PanelTabs
-                  activePanel={activePanel}
-                  onChange={setActivePanel}
-                />
-              </div>
-            </header>
-            {managementPanel}
-          </>
-        ) : selectedHermesSessionId ? (
+        {selectedHermesSessionId ? (
           <>
             <header className="agent-detail-header">
               <div className="agent-detail-title">
@@ -939,10 +874,6 @@ export function AgentWorkspace() {
                 </div>
               </div>
               <div className="agent-actions">
-                <PanelTabs
-                  activePanel={activePanel}
-                  onChange={setActivePanel}
-                />
                 <button
                   type="button"
                   className="agent-icon-button"
@@ -992,10 +923,6 @@ export function AgentWorkspace() {
                 </div>
               </div>
               <div className="agent-actions">
-                <PanelTabs
-                  activePanel={activePanel}
-                  onChange={setActivePanel}
-                />
                 {selectedTask.status !== "cancelled" &&
                 selectedTask.status !== "completed" ? (
                   <button
@@ -1058,10 +985,6 @@ export function AgentWorkspace() {
                 </div>
               </div>
               <div className="agent-actions">
-                <PanelTabs
-                  activePanel={activePanel}
-                  onChange={setActivePanel}
-                />
                 {!bridge.running ? (
                   <button
                     type="button"
@@ -1416,7 +1339,7 @@ function PanelTabs({
   );
 }
 
-function SkillsToolsPanel({
+export function SkillsToolsPanel({
   loading,
   query,
   saving,
@@ -1503,7 +1426,7 @@ function SkillsToolsPanel({
   );
 }
 
-function MessagingPanel({
+export function MessagingPanel({
   envEdits,
   loading,
   platforms,

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -15,6 +15,14 @@ import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconSortArrowUpDown } from "central-icons/IconSortArrowUpDown";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import {
+  hermesBridgeFilesystemSnapshot,
+  type HermesFilesystemEntry,
+  type HermesFilesystemRoot,
+  type HermesFilesystemSnapshot,
+  type FolderDto,
+  type NoteListItemDto,
+} from "../../lib/tauri";
+import {
   type DragEvent,
   useEffect,
   useLayoutEffect,
@@ -23,7 +31,6 @@ import {
   useState,
 } from "react";
 import { NOTE_DND_MIME } from "../../lib/dnd";
-import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
 import { BreadcrumbBar } from "../ui/BreadcrumbBar";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
@@ -100,6 +107,10 @@ function FolderList({
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [editId, setEditId] = useState<string | null>(null);
+  const [filesystemSnapshot, setFilesystemSnapshot] =
+    useState<HermesFilesystemSnapshot | null>(null);
+  const [selectedFileRootId, setSelectedFileRootId] =
+    useState<string>("workspace");
   const deleteFolderTarget = folders.find((f) => f.id === deleteId);
   const editFolderTarget = folders.find((f) => f.id === editId);
 
@@ -118,6 +129,31 @@ function FolderList({
       window.removeEventListener("keydown", onKey);
     };
   }, [menu]);
+
+  useEffect(() => {
+    let cancelled = false;
+    hermesBridgeFilesystemSnapshot()
+      .then((snapshot) => {
+        if (!cancelled) setFilesystemSnapshot(snapshot);
+      })
+      .catch(() => {
+        if (!cancelled) setFilesystemSnapshot({ roots: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hermesFileRoots = useMemo(
+    () =>
+      (filesystemSnapshot?.roots ?? []).filter(
+        (root) => root.id === "workspace" || root.id === "memory",
+      ),
+    [filesystemSnapshot],
+  );
+  const selectedFileRoot =
+    hermesFileRoots.find((root) => root.id === selectedFileRootId) ??
+    hermesFileRoots[0];
 
   const sortedAndFiltered = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -228,6 +264,43 @@ function FolderList({
           ))}
         </div>
       )}
+
+      {hermesFileRoots.length ? (
+        <section className="folders-hermes-files" aria-label="Agent files">
+          <header className="folders-hermes-header">
+            <div>
+              <h2>Agent files</h2>
+              <p>Workspace outputs and persistent memory from Hermes.</p>
+            </div>
+          </header>
+          <div className="folders-grid folders-hermes-grid" role="list">
+            {hermesFileRoots.map((root) => (
+              <button
+                key={root.id}
+                type="button"
+                className="folder-card folders-file-root-card"
+                data-active={root.id === selectedFileRoot?.id}
+                onClick={() => setSelectedFileRootId(root.id)}
+              >
+                <span className="folder-card-icon">
+                  <IconFolderOpen size={18} />
+                </span>
+                <span className="folder-card-name">{root.label}</span>
+                <span className="folder-card-meta">
+                  {root.entries.length}{" "}
+                  {root.entries.length === 1 ? "entry" : "entries"}
+                </span>
+                <span className="folder-card-description">
+                  {root.description}
+                </span>
+              </button>
+            ))}
+          </div>
+          {selectedFileRoot ? (
+            <HermesRootEntries root={selectedFileRoot} />
+          ) : null}
+        </section>
+      ) : null}
 
       {menu ? (
         <FolderCardMenu
@@ -351,6 +424,67 @@ function SortDropdown({
 }
 
 type MenuState = { folderId: string; right: number; top: number };
+
+function HermesRootEntries({ root }: { root: HermesFilesystemRoot }) {
+  return (
+    <div className="folders-file-root-detail">
+      <div className="folders-file-root-title">
+        <h3>{root.label}</h3>
+        <code>{compactPath(root.path)}</code>
+      </div>
+      {root.entries.length ? (
+        <div className="folders-file-list">
+          {root.entries.map((entry) => (
+            <HermesFileEntry key={entry.path} entry={entry} level={0} />
+          ))}
+        </div>
+      ) : (
+        <p className="folders-empty">No visible entries.</p>
+      )}
+    </div>
+  );
+}
+
+function HermesFileEntry({
+  entry,
+  level,
+}: {
+  entry: HermesFilesystemEntry;
+  level: number;
+}) {
+  const isDirectory = entry.kind === "directory";
+  return (
+    <div>
+      <div
+        className="folders-file-entry"
+        style={{ paddingLeft: 12 + level * 18 }}
+      >
+        {isDirectory ? <IconFolder1 size={14} /> : <IconNoteText size={14} />}
+        <span>{entry.name}</span>
+        <small>
+          {isDirectory
+            ? "Folder"
+            : entry.size != null
+              ? formatBytes(entry.size)
+              : "File"}
+        </small>
+      </div>
+      {entry.children?.map((child) => (
+        <HermesFileEntry key={child.path} entry={child} level={level + 1} />
+      ))}
+    </div>
+  );
+}
+
+function compactPath(path: string) {
+  return path.replace(/^\/Users\/[^/]+/, "~");
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 function FolderCard({
   folder,

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -95,6 +95,7 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
 function FolderList({
   folders,
   notes,
+  onSelectNote,
   onSelectFolder,
   onCreateFolder,
   onRenameFolder,
@@ -183,13 +184,23 @@ function FolderList({
     });
   }, [folders, query, sort]);
 
+  const filteredMeetingNotes = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    const filtered = normalized
+      ? notes.filter((note) =>
+          `${note.title} ${note.preview}`.toLowerCase().includes(normalized),
+        )
+      : notes;
+    return [...filtered].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }, [notes, query]);
+
   return (
     <section className="folders-workspace" aria-label="Folders">
       <header className="folders-header">
         <div className="folders-heading">
           <h1>Folders</h1>
           <p className="folders-subtitle">
-            Group notes by project, client, or topic.
+            Saved meetings, folders, and agent files.
           </p>
         </div>
         <button
@@ -202,27 +213,69 @@ function FolderList({
         </button>
       </header>
 
-      {folders.length > 0 ? (
-        <div className="folders-controls">
-          <label className="folders-search">
-            <IconMagnifyingGlass size={14} />
-            <input
-              type="search"
-              placeholder="Search"
-              value={query}
-              onChange={(event) => setQuery(event.currentTarget.value)}
-            />
-          </label>
-          <SortDropdown value={sort} onChange={setSort} />
-        </div>
-      ) : null}
+      <div className="folders-controls">
+        <label className="folders-search">
+          <IconMagnifyingGlass size={14} />
+          <input
+            type="search"
+            aria-label="Search folders and meetings"
+            placeholder="Search"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+          />
+        </label>
+        <SortDropdown value={sort} onChange={setSort} />
+      </div>
+
+      <section className="folders-meetings-files" aria-label="Meetings">
+        <header className="folders-hermes-header">
+          <div>
+            <h2>Meetings</h2>
+            <p>Saved meeting notes from recording and editing.</p>
+          </div>
+          <span className="folders-section-count">
+            {notes.length} {notes.length === 1 ? "meeting" : "meetings"}
+          </span>
+        </header>
+        {filteredMeetingNotes.length ? (
+          <div className="folders-meetings-list">
+            {filteredMeetingNotes.slice(0, 12).map((note) => (
+              <button
+                key={note.id}
+                type="button"
+                className="folders-meeting-row"
+                onClick={() => onSelectNote(note.id)}
+              >
+                <span className="folders-meeting-icon">
+                  <IconNoteText size={14} />
+                </span>
+                <span className="folders-meeting-body">
+                  <span className="folders-meeting-title">
+                    {note.title.trim() || "New meeting"}
+                  </span>
+                  <span className="folders-meeting-preview">
+                    {note.preview.trim() || "No preview yet"}
+                  </span>
+                </span>
+                <span className="folders-meeting-time">
+                  {formatNoteTime(note.updatedAt)}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <p className="folders-empty">
+            {notes.length === 0 ? "No meetings yet." : "No meetings match."}
+          </p>
+        )}
+      </section>
 
       {folders.length === 0 ? (
         <EmptyState
           label="No folders yet"
           icon={<IconFoldersFilled size={28} />}
           title="No folders yet"
-          description="Group related notes by project, client, or topic."
+          description="Group related meetings by project, client, or topic."
         />
       ) : sortedAndFiltered.length === 0 ? (
         <div className="folders-empty">

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -11,6 +11,7 @@ import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPageSearch } from "central-icons/IconPageSearch";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { IconRobot } from "central-icons/IconRobot";
 import { IconSortArrowUpDown } from "central-icons/IconSortArrowUpDown";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import {
@@ -291,6 +292,7 @@ function FolderList({
               root.entries.length === 1 ? "entry" : "entries"
             }`}
             icon={<IconFolderOpen size={18} />}
+            badge={<IconRobot size={12} />}
             onOpen={() => setSelectedVirtualFolder(root.id as VirtualFolderId)}
           />
         ))}
@@ -466,12 +468,14 @@ function VirtualFolderCard({
   meta,
   description,
   icon,
+  badge,
   onOpen,
 }: {
   name: string;
   meta: string;
   description: string;
   icon: ReactNode;
+  badge?: ReactNode;
   onOpen: () => void;
 }) {
   return (
@@ -480,7 +484,17 @@ function VirtualFolderCard({
       className="folder-card folders-virtual-folder-card"
       onClick={onOpen}
     >
-      <span className="folder-card-icon">{icon}</span>
+      <span className="folder-card-icon folders-virtual-folder-icon">
+        {icon}
+        {badge ? (
+          <span
+            className="folders-agent-folder-badge"
+            aria-label="Agent folder"
+          >
+            {badge}
+          </span>
+        ) : null}
+      </span>
       <span className="folder-card-name">{name}</span>
       <span className="folder-card-meta">{meta}</span>
       <span className="folder-card-description">{description}</span>

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -11,17 +11,9 @@ import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPageSearch } from "central-icons/IconPageSearch";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
-import { IconRobot } from "central-icons/IconRobot";
 import { IconSortArrowUpDown } from "central-icons/IconSortArrowUpDown";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import {
-  hermesBridgeFilesystemSnapshot,
-  type HermesFilesystemEntry,
-  type HermesFilesystemRoot,
-  type HermesFilesystemSnapshot,
-  type FolderDto,
-  type NoteListItemDto,
-} from "../../lib/tauri";
+import { type FolderDto, type NoteListItemDto } from "../../lib/tauri";
 import {
   type DragEvent,
   type ReactNode,
@@ -84,7 +76,7 @@ export function FoldersWorkspace(props: FoldersWorkspaceProps) {
 /* List view -------------------------------------------------------- */
 
 type SortKey = "updated" | "created" | "name" | "nameDesc";
-type VirtualFolderId = "meetings" | "workspace" | "memory";
+type VirtualFolderId = "meetings";
 
 const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: "updated", label: "Recent" },
@@ -109,8 +101,6 @@ function FolderList({
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [editId, setEditId] = useState<string | null>(null);
-  const [filesystemSnapshot, setFilesystemSnapshot] =
-    useState<HermesFilesystemSnapshot | null>(null);
   const [selectedVirtualFolder, setSelectedVirtualFolder] =
     useState<VirtualFolderId | null>(null);
   const deleteFolderTarget = folders.find((f) => f.id === deleteId);
@@ -131,31 +121,6 @@ function FolderList({
       window.removeEventListener("keydown", onKey);
     };
   }, [menu]);
-
-  useEffect(() => {
-    let cancelled = false;
-    hermesBridgeFilesystemSnapshot()
-      .then((snapshot) => {
-        if (!cancelled) setFilesystemSnapshot(snapshot);
-      })
-      .catch(() => {
-        if (!cancelled) setFilesystemSnapshot({ roots: [] });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const hermesFileRoots = useMemo(
-    () =>
-      (filesystemSnapshot?.roots ?? []).filter(
-        (root) => root.id === "workspace" || root.id === "memory",
-      ),
-    [filesystemSnapshot],
-  );
-  const selectedFileRoot = hermesFileRoots.find(
-    (root) => root.id === selectedVirtualFolder,
-  );
 
   const normalizedQuery = query.trim().toLowerCase();
 
@@ -197,35 +162,19 @@ function FolderList({
     return [...filtered].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   }, [notes, normalizedQuery]);
 
-  const visibleHermesRoots = useMemo(() => {
-    if (!normalizedQuery) return hermesFileRoots;
-    return hermesFileRoots.filter((root) =>
-      `${root.label} ${root.description} ${root.path} ${root.entries
-        .map((entry) => entry.name)
-        .join(" ")}`
-        .toLowerCase()
-        .includes(normalizedQuery),
-    );
-  }, [hermesFileRoots, normalizedQuery]);
-
-  const showMeetingsFolder =
+  const showNotesFolder =
     !normalizedQuery ||
-    "meetings saved meeting notes recording editing".includes(
-      normalizedQuery,
-    ) ||
+    "notes saved notes recording editing".includes(normalizedQuery) ||
     filteredMeetingNotes.length > 0;
 
-  const hasTopLevelMatches =
-    showMeetingsFolder ||
-    sortedAndFiltered.length > 0 ||
-    visibleHermesRoots.length > 0;
+  const hasTopLevelMatches = showNotesFolder || sortedAndFiltered.length > 0;
 
   const closeVirtualFolder = () => setSelectedVirtualFolder(null);
 
   let content: ReactNode;
   if (selectedVirtualFolder === "meetings") {
     content = (
-      <MeetingsFolderDetail
+      <NotesFolderDetail
         notes={filteredMeetingNotes}
         totalNotes={notes.length}
         query={query}
@@ -233,21 +182,14 @@ function FolderList({
         onSelectNote={onSelectNote}
       />
     );
-  } else if (selectedFileRoot) {
-    content = (
-      <AgentFileRootDetail
-        root={selectedFileRoot}
-        onBack={closeVirtualFolder}
-      />
-    );
   } else {
     content = hasTopLevelMatches ? (
       <div className="folders-grid" role="list">
-        {showMeetingsFolder ? (
+        {showNotesFolder ? (
           <VirtualFolderCard
-            name="Meetings"
-            description="Saved meeting notes from recording and editing."
-            meta={`${notes.length} ${notes.length === 1 ? "meeting" : "meetings"}`}
+            name="Notes"
+            description="Saved notes from recording and editing."
+            meta={`${notes.length} ${notes.length === 1 ? "note" : "notes"}`}
             icon={<IconNoteText size={18} />}
             onOpen={() => setSelectedVirtualFolder("meetings")}
           />
@@ -283,19 +225,6 @@ function FolderList({
             }}
           />
         ))}
-        {visibleHermesRoots.map((root) => (
-          <VirtualFolderCard
-            key={root.id}
-            name={root.label}
-            description={root.description}
-            meta={`${root.entries.length} ${
-              root.entries.length === 1 ? "entry" : "entries"
-            }`}
-            icon={<IconFolderOpen size={18} />}
-            badge={<IconRobot size={12} />}
-            onOpen={() => setSelectedVirtualFolder(root.id as VirtualFolderId)}
-          />
-        ))}
       </div>
     ) : (
       <div className="folders-empty">
@@ -310,8 +239,7 @@ function FolderList({
         <div className="folders-heading">
           <h1>Folders</h1>
           <p className="folders-subtitle">
-            Top-level folders for meetings, saved folders, workspace, and
-            memory.
+            Top-level folders for notes and saved folders.
           </p>
         </div>
         <button
@@ -329,7 +257,7 @@ function FolderList({
           <IconMagnifyingGlass size={14} />
           <input
             type="search"
-            aria-label="Search folders and meetings"
+            aria-label="Search folders and notes"
             placeholder="Search"
             value={query}
             onChange={(event) => setQuery(event.currentTarget.value)}
@@ -502,7 +430,7 @@ function VirtualFolderCard({
   );
 }
 
-function MeetingsFolderDetail({
+function NotesFolderDetail({
   notes,
   totalNotes,
   query,
@@ -516,20 +444,20 @@ function MeetingsFolderDetail({
   onSelectNote: (noteId: string) => void;
 }) {
   return (
-    <section className="folders-virtual-detail" aria-label="Meetings">
+    <section className="folders-virtual-detail" aria-label="Notes">
       <BreadcrumbBar
         backLabel="Back to folders"
         onBack={onBack}
-        items={[{ label: "Folders", onClick: onBack }, { label: "Meetings" }]}
+        items={[{ label: "Folders", onClick: onBack }, { label: "Notes" }]}
       />
       <section className="folders-meetings-files">
         <header className="folders-hermes-header">
           <div>
-            <h2>Meetings</h2>
-            <p>Saved meeting notes from recording and editing.</p>
+            <h2>Notes</h2>
+            <p>Saved notes from recording and editing.</p>
           </div>
           <span className="folders-section-count">
-            {totalNotes} {totalNotes === 1 ? "meeting" : "meetings"}
+            {totalNotes} {totalNotes === 1 ? "note" : "notes"}
           </span>
         </header>
         {notes.length ? (
@@ -546,7 +474,7 @@ function MeetingsFolderDetail({
                 </span>
                 <span className="folders-meeting-body">
                   <span className="folders-meeting-title">
-                    {note.title.trim() || "New meeting"}
+                    {note.title.trim() || "New note"}
                   </span>
                   <span className="folders-meeting-preview">
                     {note.preview.trim() || "No preview yet"}
@@ -560,92 +488,12 @@ function MeetingsFolderDetail({
           </div>
         ) : (
           <p className="folders-empty">
-            {query.trim() ? "No meetings match." : "No meetings yet."}
+            {query.trim() ? "No notes match." : "No notes yet."}
           </p>
         )}
       </section>
     </section>
   );
-}
-
-function AgentFileRootDetail({
-  root,
-  onBack,
-}: {
-  root: HermesFilesystemRoot;
-  onBack: () => void;
-}) {
-  return (
-    <section className="folders-virtual-detail" aria-label={root.label}>
-      <BreadcrumbBar
-        backLabel="Back to folders"
-        onBack={onBack}
-        items={[{ label: "Folders", onClick: onBack }, { label: root.label }]}
-      />
-      <HermesRootEntries root={root} />
-    </section>
-  );
-}
-
-function HermesRootEntries({ root }: { root: HermesFilesystemRoot }) {
-  return (
-    <div className="folders-file-root-detail">
-      <div className="folders-file-root-title">
-        <h3>{root.label}</h3>
-        <code>{compactPath(root.path)}</code>
-      </div>
-      {root.entries.length ? (
-        <div className="folders-file-list">
-          {root.entries.map((entry) => (
-            <HermesFileEntry key={entry.path} entry={entry} level={0} />
-          ))}
-        </div>
-      ) : (
-        <p className="folders-empty">No visible entries.</p>
-      )}
-    </div>
-  );
-}
-
-function HermesFileEntry({
-  entry,
-  level,
-}: {
-  entry: HermesFilesystemEntry;
-  level: number;
-}) {
-  const isDirectory = entry.kind === "directory";
-  return (
-    <div>
-      <div
-        className="folders-file-entry"
-        style={{ paddingLeft: 12 + level * 18 }}
-      >
-        {isDirectory ? <IconFolder1 size={14} /> : <IconNoteText size={14} />}
-        <span>{entry.name}</span>
-        <small>
-          {isDirectory
-            ? "Folder"
-            : entry.size != null
-              ? formatBytes(entry.size)
-              : "File"}
-        </small>
-      </div>
-      {entry.children?.map((child) => (
-        <HermesFileEntry key={child.path} entry={child} level={level + 1} />
-      ))}
-    </div>
-  );
-}
-
-function compactPath(path: string) {
-  return path.replace(/^\/Users\/[^/]+/, "~");
-}
-
-function formatBytes(bytes: number) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function FolderCard({

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -2,7 +2,6 @@ import { IconCheckmark1 } from "central-icons-filled/IconCheckmark1";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
 import { IconFolder1 } from "central-icons/IconFolder1";
-import { IconFolders as IconFoldersFilled } from "central-icons-filled/IconFolders";
 import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
 import { IconFolderDelete } from "central-icons/IconFolderDelete";
 import { IconFolderOpen } from "central-icons/IconFolderOpen";
@@ -24,6 +23,7 @@ import {
 } from "../../lib/tauri";
 import {
   type DragEvent,
+  type ReactNode,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -33,7 +33,6 @@ import {
 import { NOTE_DND_MIME } from "../../lib/dnd";
 import { BreadcrumbBar } from "../ui/BreadcrumbBar";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
-import { EmptyState } from "../ui/EmptyState";
 import { AddNotesToFolderDialog } from "./AddNotesToFolderDialog";
 import { CreateFolderDialog } from "./CreateFolderDialog";
 import { EditFolderDialog } from "./EditFolderDialog";
@@ -84,6 +83,7 @@ export function FoldersWorkspace(props: FoldersWorkspaceProps) {
 /* List view -------------------------------------------------------- */
 
 type SortKey = "updated" | "created" | "name" | "nameDesc";
+type VirtualFolderId = "meetings" | "workspace" | "memory";
 
 const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: "updated", label: "Recent" },
@@ -110,8 +110,8 @@ function FolderList({
   const [editId, setEditId] = useState<string | null>(null);
   const [filesystemSnapshot, setFilesystemSnapshot] =
     useState<HermesFilesystemSnapshot | null>(null);
-  const [selectedFileRootId, setSelectedFileRootId] =
-    useState<string>("workspace");
+  const [selectedVirtualFolder, setSelectedVirtualFolder] =
+    useState<VirtualFolderId | null>(null);
   const deleteFolderTarget = folders.find((f) => f.id === deleteId);
   const editFolderTarget = folders.find((f) => f.id === editId);
 
@@ -152,17 +152,18 @@ function FolderList({
       ),
     [filesystemSnapshot],
   );
-  const selectedFileRoot =
-    hermesFileRoots.find((root) => root.id === selectedFileRootId) ??
-    hermesFileRoots[0];
+  const selectedFileRoot = hermesFileRoots.find(
+    (root) => root.id === selectedVirtualFolder,
+  );
+
+  const normalizedQuery = query.trim().toLowerCase();
 
   const sortedAndFiltered = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    const filtered = normalized
+    const filtered = normalizedQuery
       ? folders.filter((folder) =>
           `${folder.name} ${folder.description ?? ""}`
             .toLowerCase()
-            .includes(normalized),
+            .includes(normalizedQuery),
         )
       : folders;
     return [...filtered].sort((a, b) => {
@@ -182,17 +183,124 @@ function FolderList({
           return b.updatedAt.localeCompare(a.updatedAt);
       }
     });
-  }, [folders, query, sort]);
+  }, [folders, normalizedQuery, sort]);
 
   const filteredMeetingNotes = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    const filtered = normalized
+    const filtered = normalizedQuery
       ? notes.filter((note) =>
-          `${note.title} ${note.preview}`.toLowerCase().includes(normalized),
+          `${note.title} ${note.preview}`
+            .toLowerCase()
+            .includes(normalizedQuery),
         )
       : notes;
     return [...filtered].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-  }, [notes, query]);
+  }, [notes, normalizedQuery]);
+
+  const visibleHermesRoots = useMemo(() => {
+    if (!normalizedQuery) return hermesFileRoots;
+    return hermesFileRoots.filter((root) =>
+      `${root.label} ${root.description} ${root.path} ${root.entries
+        .map((entry) => entry.name)
+        .join(" ")}`
+        .toLowerCase()
+        .includes(normalizedQuery),
+    );
+  }, [hermesFileRoots, normalizedQuery]);
+
+  const showMeetingsFolder =
+    !normalizedQuery ||
+    "meetings saved meeting notes recording editing".includes(
+      normalizedQuery,
+    ) ||
+    filteredMeetingNotes.length > 0;
+
+  const hasTopLevelMatches =
+    showMeetingsFolder ||
+    sortedAndFiltered.length > 0 ||
+    visibleHermesRoots.length > 0;
+
+  const closeVirtualFolder = () => setSelectedVirtualFolder(null);
+
+  let content: ReactNode;
+  if (selectedVirtualFolder === "meetings") {
+    content = (
+      <MeetingsFolderDetail
+        notes={filteredMeetingNotes}
+        totalNotes={notes.length}
+        query={query}
+        onBack={closeVirtualFolder}
+        onSelectNote={onSelectNote}
+      />
+    );
+  } else if (selectedFileRoot) {
+    content = (
+      <AgentFileRootDetail
+        root={selectedFileRoot}
+        onBack={closeVirtualFolder}
+      />
+    );
+  } else {
+    content = hasTopLevelMatches ? (
+      <div className="folders-grid" role="list">
+        {showMeetingsFolder ? (
+          <VirtualFolderCard
+            name="Meetings"
+            description="Saved meeting notes from recording and editing."
+            meta={`${notes.length} ${notes.length === 1 ? "meeting" : "meetings"}`}
+            icon={<IconNoteText size={18} />}
+            onOpen={() => setSelectedVirtualFolder("meetings")}
+          />
+        ) : null}
+        {sortedAndFiltered.map((folder) => (
+          <FolderCard
+            key={folder.id}
+            folder={folder}
+            notes={notes}
+            menuOpen={menu?.folderId === folder.id}
+            onOpen={() => onSelectFolder(folder.id)}
+            onDropNote={(noteId) => {
+              const note = notes.find((item) => item.id === noteId);
+              if (
+                !note ||
+                (note.folderIds.length === 1 && note.folderIds[0] === folder.id)
+              ) {
+                return;
+              }
+              void onAssignNoteToFolder(noteId, folder.id);
+            }}
+            onOpenMenu={(anchor) => {
+              if (menu?.folderId === folder.id) {
+                setMenu(null);
+                return;
+              }
+              const rect = anchor.getBoundingClientRect();
+              setMenu({
+                folderId: folder.id,
+                right: window.innerWidth - rect.right,
+                top: rect.bottom + 4,
+              });
+            }}
+          />
+        ))}
+        {visibleHermesRoots.map((root) => (
+          <VirtualFolderCard
+            key={root.id}
+            name={root.label}
+            description={root.description}
+            meta={`${root.entries.length} ${
+              root.entries.length === 1 ? "entry" : "entries"
+            }`}
+            icon={<IconFolderOpen size={18} />}
+            onOpen={() => setSelectedVirtualFolder(root.id as VirtualFolderId)}
+          />
+        ))}
+      </div>
+    ) : (
+      <div className="folders-empty">
+        <p>No folders match “{query.trim()}”.</p>
+      </div>
+    );
+  }
 
   return (
     <section className="folders-workspace" aria-label="Folders">
@@ -200,7 +308,8 @@ function FolderList({
         <div className="folders-heading">
           <h1>Folders</h1>
           <p className="folders-subtitle">
-            Saved meetings, folders, and agent files.
+            Top-level folders for meetings, saved folders, workspace, and
+            memory.
           </p>
         </div>
         <button
@@ -227,133 +336,7 @@ function FolderList({
         <SortDropdown value={sort} onChange={setSort} />
       </div>
 
-      <section className="folders-meetings-files" aria-label="Meetings">
-        <header className="folders-hermes-header">
-          <div>
-            <h2>Meetings</h2>
-            <p>Saved meeting notes from recording and editing.</p>
-          </div>
-          <span className="folders-section-count">
-            {notes.length} {notes.length === 1 ? "meeting" : "meetings"}
-          </span>
-        </header>
-        {filteredMeetingNotes.length ? (
-          <div className="folders-meetings-list">
-            {filteredMeetingNotes.slice(0, 12).map((note) => (
-              <button
-                key={note.id}
-                type="button"
-                className="folders-meeting-row"
-                onClick={() => onSelectNote(note.id)}
-              >
-                <span className="folders-meeting-icon">
-                  <IconNoteText size={14} />
-                </span>
-                <span className="folders-meeting-body">
-                  <span className="folders-meeting-title">
-                    {note.title.trim() || "New meeting"}
-                  </span>
-                  <span className="folders-meeting-preview">
-                    {note.preview.trim() || "No preview yet"}
-                  </span>
-                </span>
-                <span className="folders-meeting-time">
-                  {formatNoteTime(note.updatedAt)}
-                </span>
-              </button>
-            ))}
-          </div>
-        ) : (
-          <p className="folders-empty">
-            {notes.length === 0 ? "No meetings yet." : "No meetings match."}
-          </p>
-        )}
-      </section>
-
-      {folders.length === 0 ? (
-        <EmptyState
-          label="No folders yet"
-          icon={<IconFoldersFilled size={28} />}
-          title="No folders yet"
-          description="Group related meetings by project, client, or topic."
-        />
-      ) : sortedAndFiltered.length === 0 ? (
-        <div className="folders-empty">
-          <p>No folders match “{query.trim()}”.</p>
-        </div>
-      ) : (
-        <div className="folders-grid" role="list">
-          {sortedAndFiltered.map((folder) => (
-            <FolderCard
-              key={folder.id}
-              folder={folder}
-              notes={notes}
-              menuOpen={menu?.folderId === folder.id}
-              onOpen={() => onSelectFolder(folder.id)}
-              onDropNote={(noteId) => {
-                const note = notes.find((item) => item.id === noteId);
-                if (
-                  !note ||
-                  (note.folderIds.length === 1 &&
-                    note.folderIds[0] === folder.id)
-                ) {
-                  return;
-                }
-                void onAssignNoteToFolder(noteId, folder.id);
-              }}
-              onOpenMenu={(anchor) => {
-                if (menu?.folderId === folder.id) {
-                  setMenu(null);
-                  return;
-                }
-                const rect = anchor.getBoundingClientRect();
-                setMenu({
-                  folderId: folder.id,
-                  right: window.innerWidth - rect.right,
-                  top: rect.bottom + 4,
-                });
-              }}
-            />
-          ))}
-        </div>
-      )}
-
-      {hermesFileRoots.length ? (
-        <section className="folders-hermes-files" aria-label="Agent files">
-          <header className="folders-hermes-header">
-            <div>
-              <h2>Agent files</h2>
-              <p>Workspace outputs and persistent memory from Hermes.</p>
-            </div>
-          </header>
-          <div className="folders-grid folders-hermes-grid" role="list">
-            {hermesFileRoots.map((root) => (
-              <button
-                key={root.id}
-                type="button"
-                className="folder-card folders-file-root-card"
-                data-active={root.id === selectedFileRoot?.id}
-                onClick={() => setSelectedFileRootId(root.id)}
-              >
-                <span className="folder-card-icon">
-                  <IconFolderOpen size={18} />
-                </span>
-                <span className="folder-card-name">{root.label}</span>
-                <span className="folder-card-meta">
-                  {root.entries.length}{" "}
-                  {root.entries.length === 1 ? "entry" : "entries"}
-                </span>
-                <span className="folder-card-description">
-                  {root.description}
-                </span>
-              </button>
-            ))}
-          </div>
-          {selectedFileRoot ? (
-            <HermesRootEntries root={selectedFileRoot} />
-          ) : null}
-        </section>
-      ) : null}
+      {content}
 
       {menu ? (
         <FolderCardMenu
@@ -477,6 +460,118 @@ function SortDropdown({
 }
 
 type MenuState = { folderId: string; right: number; top: number };
+
+function VirtualFolderCard({
+  name,
+  meta,
+  description,
+  icon,
+  onOpen,
+}: {
+  name: string;
+  meta: string;
+  description: string;
+  icon: ReactNode;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="folder-card folders-virtual-folder-card"
+      onClick={onOpen}
+    >
+      <span className="folder-card-icon">{icon}</span>
+      <span className="folder-card-name">{name}</span>
+      <span className="folder-card-meta">{meta}</span>
+      <span className="folder-card-description">{description}</span>
+    </button>
+  );
+}
+
+function MeetingsFolderDetail({
+  notes,
+  totalNotes,
+  query,
+  onBack,
+  onSelectNote,
+}: {
+  notes: NoteListItemDto[];
+  totalNotes: number;
+  query: string;
+  onBack: () => void;
+  onSelectNote: (noteId: string) => void;
+}) {
+  return (
+    <section className="folders-virtual-detail" aria-label="Meetings">
+      <BreadcrumbBar
+        backLabel="Back to folders"
+        onBack={onBack}
+        items={[{ label: "Folders", onClick: onBack }, { label: "Meetings" }]}
+      />
+      <section className="folders-meetings-files">
+        <header className="folders-hermes-header">
+          <div>
+            <h2>Meetings</h2>
+            <p>Saved meeting notes from recording and editing.</p>
+          </div>
+          <span className="folders-section-count">
+            {totalNotes} {totalNotes === 1 ? "meeting" : "meetings"}
+          </span>
+        </header>
+        {notes.length ? (
+          <div className="folders-meetings-list">
+            {notes.map((note) => (
+              <button
+                key={note.id}
+                type="button"
+                className="folders-meeting-row"
+                onClick={() => onSelectNote(note.id)}
+              >
+                <span className="folders-meeting-icon">
+                  <IconNoteText size={14} />
+                </span>
+                <span className="folders-meeting-body">
+                  <span className="folders-meeting-title">
+                    {note.title.trim() || "New meeting"}
+                  </span>
+                  <span className="folders-meeting-preview">
+                    {note.preview.trim() || "No preview yet"}
+                  </span>
+                </span>
+                <span className="folders-meeting-time">
+                  {formatNoteTime(note.updatedAt)}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <p className="folders-empty">
+            {query.trim() ? "No meetings match." : "No meetings yet."}
+          </p>
+        )}
+      </section>
+    </section>
+  );
+}
+
+function AgentFileRootDetail({
+  root,
+  onBack,
+}: {
+  root: HermesFilesystemRoot;
+  onBack: () => void;
+}) {
+  return (
+    <section className="folders-virtual-detail" aria-label={root.label}>
+      <BreadcrumbBar
+        backLabel="Back to folders"
+        onBack={onBack}
+        items={[{ label: "Folders", onClick: onBack }, { label: root.label }]}
+      />
+      <HermesRootEntries root={root} />
+    </section>
+  );
+}
 
 function HermesRootEntries({ root }: { root: HermesFilesystemRoot }) {
   return (

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useState } from "react";
+import { MessagingPanel, SkillsToolsPanel } from "../agent/AgentWorkspace";
+import {
+  hermesBridgeMessagingPlatforms,
+  hermesBridgeSkills,
+  hermesBridgeToolsets,
+  toggleHermesBridgeSkill,
+  toggleHermesBridgeToolset,
+  updateHermesBridgeMessagingPlatform,
+  type HermesMessagingPlatformInfo,
+  type HermesSkillInfo,
+  type HermesToolsetInfo,
+} from "../../lib/tauri";
+
+type AgentSettingsPanel = "skills" | "messaging";
+
+export function AgentSettingsSection() {
+  const [panel, setPanel] = useState<AgentSettingsPanel>("skills");
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [skills, setSkills] = useState<HermesSkillInfo[] | null>(null);
+  const [toolsets, setToolsets] = useState<HermesToolsetInfo[] | null>(null);
+  const [platforms, setPlatforms] = useState<
+    HermesMessagingPlatformInfo[] | null
+  >(null);
+  const [selectedPlatformId, setSelectedPlatformId] = useState<string>();
+  const [envEdits, setEnvEdits] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (panel === "skills" && (!skills || !toolsets)) {
+      void loadCapabilities();
+    }
+    if (panel === "messaging" && !platforms) {
+      void loadMessagingPlatforms();
+    }
+  }, [panel]);
+
+  async function loadCapabilities() {
+    setLoading(true);
+    try {
+      const [nextSkills, nextToolsets] = await Promise.all([
+        hermesBridgeSkills(),
+        hermesBridgeToolsets(),
+      ]);
+      setSkills(nextSkills);
+      setToolsets(nextToolsets);
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadMessagingPlatforms() {
+    setLoading(true);
+    try {
+      const response = await hermesBridgeMessagingPlatforms();
+      setPlatforms(response.platforms);
+      setSelectedPlatformId((current) => {
+        if (current && response.platforms.some((item) => item.id === current)) {
+          return current;
+        }
+        return response.platforms[0]?.id;
+      });
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function setSkillEnabled(skill: HermesSkillInfo, enabled: boolean) {
+    setSaving(`skill:${skill.name}`);
+    try {
+      await toggleHermesBridgeSkill({ name: skill.name, enabled });
+      setSkills(
+        (current) =>
+          current?.map((item) =>
+            item.name === skill.name ? { ...item, enabled } : item,
+          ) ?? current,
+      );
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function setToolsetEnabled(
+    toolset: HermesToolsetInfo,
+    enabled: boolean,
+  ) {
+    setSaving(`toolset:${toolset.name}`);
+    try {
+      await toggleHermesBridgeToolset({ name: toolset.name, enabled });
+      setToolsets(
+        (current) =>
+          current?.map((item) =>
+            item.name === toolset.name ? { ...item, enabled } : item,
+          ) ?? current,
+      );
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function setMessagingPlatformEnabled(
+    platform: HermesMessagingPlatformInfo,
+    enabled: boolean,
+  ) {
+    setSaving(`messaging:${platform.id}`);
+    try {
+      await updateHermesBridgeMessagingPlatform({
+        platformId: platform.id,
+        enabled,
+      });
+      setPlatforms(
+        (current) =>
+          current?.map((item) =>
+            item.id === platform.id ? { ...item, enabled } : item,
+          ) ?? current,
+      );
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  async function saveMessagingPlatformEnv(
+    platform: HermesMessagingPlatformInfo,
+  ) {
+    const env = Object.fromEntries(
+      Object.entries(envEdits)
+        .map(([key, value]) => [key, value.trim()])
+        .filter(([, value]) => value.length > 0),
+    );
+    if (!Object.keys(env).length) return;
+    setSaving(`env:${platform.id}`);
+    try {
+      await updateHermesBridgeMessagingPlatform({
+        platformId: platform.id,
+        env,
+      });
+      setEnvEdits({});
+      await loadMessagingPlatforms();
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  return (
+    <section className="settings-group" aria-labelledby="agent-heading">
+      <h2 id="agent-heading" className="settings-group-heading">
+        Agent
+      </h2>
+      <p className="settings-group-description">
+        Configure Hermes capabilities and external messaging channels.
+      </p>
+      <div className="settings-card settings-agent-card">
+        <div
+          className="settings-section-tabs"
+          role="tablist"
+          aria-label="Agent settings"
+        >
+          <button
+            type="button"
+            aria-selected={panel === "skills"}
+            onClick={() => {
+              setPanel("skills");
+              setQuery("");
+            }}
+          >
+            Skills
+          </button>
+          <button
+            type="button"
+            aria-selected={panel === "messaging"}
+            onClick={() => {
+              setPanel("messaging");
+              setQuery("");
+            }}
+          >
+            Messaging
+          </button>
+        </div>
+        {error ? <p className="settings-row-error">{error}</p> : null}
+        {panel === "skills" ? (
+          <SkillsToolsPanel
+            loading={loading}
+            query={query}
+            saving={saving}
+            skills={skills}
+            toolsets={toolsets}
+            onQueryChange={setQuery}
+            onRefresh={() => void loadCapabilities()}
+            onToggleSkill={(skill, enabled) =>
+              void setSkillEnabled(skill, enabled)
+            }
+            onToggleToolset={(toolset, enabled) =>
+              void setToolsetEnabled(toolset, enabled)
+            }
+          />
+        ) : (
+          <MessagingPanel
+            loading={loading}
+            platforms={platforms}
+            query={query}
+            saving={saving}
+            selectedPlatformId={selectedPlatformId}
+            envEdits={envEdits}
+            onQueryChange={setQuery}
+            onRefresh={() => void loadMessagingPlatforms()}
+            onSelectPlatform={(platform) => {
+              setSelectedPlatformId(platform.id);
+              setEnvEdits({});
+            }}
+            onEditEnv={(key, value) =>
+              setEnvEdits((current) => ({ ...current, [key]: value }))
+            }
+            onSaveEnv={(platform) => void saveMessagingPlatformEnv(platform)}
+            onToggle={(platform, enabled) =>
+              void setMessagingPlatformEnabled(platform, enabled)
+            }
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function messageFromError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unable to update agent settings.";
+}

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
-import { MessagingPanel, SkillsToolsPanel } from "../agent/AgentWorkspace";
 import {
+  FilesystemPanel,
+  MessagingPanel,
+  SkillsToolsPanel,
+} from "../agent/AgentWorkspace";
+import {
+  hermesBridgeFilesystemSnapshot,
   hermesBridgeMessagingPlatforms,
   hermesBridgeSkills,
   hermesBridgeToolsets,
@@ -10,9 +15,10 @@ import {
   type HermesMessagingPlatformInfo,
   type HermesSkillInfo,
   type HermesToolsetInfo,
+  type HermesFilesystemSnapshot,
 } from "../../lib/tauri";
 
-type AgentSettingsPanel = "skills" | "messaging";
+type AgentSettingsPanel = "skills" | "messaging" | "files";
 
 export function AgentSettingsSection() {
   const [panel, setPanel] = useState<AgentSettingsPanel>("skills");
@@ -25,6 +31,8 @@ export function AgentSettingsSection() {
   const [platforms, setPlatforms] = useState<
     HermesMessagingPlatformInfo[] | null
   >(null);
+  const [filesystemSnapshot, setFilesystemSnapshot] =
+    useState<HermesFilesystemSnapshot | null>(null);
   const [selectedPlatformId, setSelectedPlatformId] = useState<string>();
   const [envEdits, setEnvEdits] = useState<Record<string, string>>({});
 
@@ -34,6 +42,9 @@ export function AgentSettingsSection() {
     }
     if (panel === "messaging" && !platforms) {
       void loadMessagingPlatforms();
+    }
+    if (panel === "files" && !filesystemSnapshot) {
+      void loadFilesystemSnapshot();
     }
   }, [panel]);
 
@@ -64,6 +75,23 @@ export function AgentSettingsSection() {
           return current;
         }
         return response.platforms[0]?.id;
+      });
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function loadFilesystemSnapshot() {
+    setLoading(true);
+    try {
+      const snapshot = await hermesBridgeFilesystemSnapshot();
+      setFilesystemSnapshot({
+        roots: snapshot.roots.filter(
+          (root) => root.id === "workspace" || root.id === "memory",
+        ),
       });
       setError(null);
     } catch (err) {
@@ -191,6 +219,16 @@ export function AgentSettingsSection() {
           >
             Messaging
           </button>
+          <button
+            type="button"
+            aria-selected={panel === "files"}
+            onClick={() => {
+              setPanel("files");
+              setQuery("");
+            }}
+          >
+            Files
+          </button>
         </div>
         {error ? <p className="settings-row-error">{error}</p> : null}
         {panel === "skills" ? (
@@ -209,7 +247,7 @@ export function AgentSettingsSection() {
               void setToolsetEnabled(toolset, enabled)
             }
           />
-        ) : (
+        ) : panel === "messaging" ? (
           <MessagingPanel
             loading={loading}
             platforms={platforms}
@@ -230,6 +268,14 @@ export function AgentSettingsSection() {
             onToggle={(platform, enabled) =>
               void setMessagingPlatformEnabled(platform, enabled)
             }
+          />
+        ) : (
+          <FilesystemPanel
+            loading={loading}
+            query={query}
+            snapshot={filesystemSnapshot}
+            onQueryChange={setQuery}
+            onRefresh={() => void loadFilesystemSnapshot()}
           />
         )}
       </div>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -125,6 +125,23 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   generationModel: "zai-org-glm-5",
 };
 
+type SettingsTab =
+  | "account"
+  | "dictation"
+  | "audio"
+  | "models"
+  | "agent"
+  | "about";
+
+const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
+  { id: "account", label: "Account" },
+  { id: "dictation", label: "Dictation" },
+  { id: "audio", label: "Audio" },
+  { id: "models", label: "Models" },
+  { id: "agent", label: "Agent" },
+  { id: "about", label: "About" },
+];
+
 type AppSettingsProps = {
   account: AccountStatus;
   accountLoading: boolean;
@@ -170,6 +187,7 @@ export function AppSettings({
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [pickerMode, setPickerMode] = useState<ProviderModelMode>();
   const [modelSearch, setModelSearch] = useState("");
+  const [activeTab, setActiveTab] = useState<SettingsTab>("account");
   const micWrapRef = useRef<HTMLDivElement>(null);
   const systemOn = sourceMode === "microphonePlusSystem";
   const systemReadiness = sourceReadiness?.sources.find(
@@ -435,265 +453,317 @@ export function AppSettings({
         </p>
       </header>
 
-      <nav className="settings-nav" aria-label="Settings sections">
-        <a href="#account-heading">Account</a>
-        <a href="#dictation-heading">Dictation</a>
-        <a href="#audio-heading">Audio</a>
-        <a href="#models-heading">Models</a>
-        <a href="#agent-heading">Agent</a>
-        <a href="#about-heading">About</a>
+      <nav
+        className="settings-nav"
+        role="tablist"
+        aria-label="Settings sections"
+      >
+        {SETTINGS_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`settings-panel-${tab.id}`}
+            id={`settings-tab-${tab.id}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
       </nav>
 
-      <AccountSettingsSection
-        account={account}
-        loading={accountLoading}
-        onAccountChanged={onAccountChanged}
-        onRefresh={onAccountRefresh}
-      />
-
-      <section className="settings-group" aria-labelledby="appearance-heading">
-        <h2 id="appearance-heading" className="settings-group-heading">
-          Appearance
-        </h2>
-        <div className="settings-card">
-          <div className="settings-rows">
-            <div className="settings-row">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title">Theme</h3>
-                <p className="settings-row-description">
-                  Match the system or force light or dark mode.
-                </p>
-              </div>
-              <div className="settings-row-control">
-                <SegmentedControl<ThemePreference>
-                  aria-label="App theme"
-                  value={theme}
-                  options={THEME_OPTIONS}
-                  onValueChange={(next) => {
-                    setTheme(next);
-                    setStoredTheme(next);
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="settings-group" aria-labelledby="dictation-heading">
-        <h2 id="dictation-heading" className="settings-group-heading">
-          Dictation
-        </h2>
-        <div className="settings-card">
-          <div className="settings-rows">
-            <ShortcutRow
-              title="Push to talk"
-              description="Hold this shortcut to dictate, then release to paste."
-              shortcut={settings.pushToTalkShortcut}
-              capturing={capturingShortcut === "push_to_talk"}
-              disabled={
-                !!capturingShortcut && capturingShortcut !== "push_to_talk"
-              }
-              error={
-                capturingShortcut === "push_to_talk" ? shortcutError : undefined
-              }
-              onChange={() => void startShortcutCapture("push_to_talk")}
-              onCancel={() => void cancelShortcutCapture()}
+      <div
+        className="settings-tab-panel"
+        role="tabpanel"
+        id={`settings-panel-${activeTab}`}
+        aria-labelledby={`settings-tab-${activeTab}`}
+      >
+        {activeTab === "account" ? (
+          <>
+            <AccountSettingsSection
+              account={account}
+              loading={accountLoading}
+              onAccountChanged={onAccountChanged}
+              onRefresh={onAccountRefresh}
             />
 
-            <ShortcutRow
-              title="Toggle dictation"
-              description="Press this shortcut to start or stop dictation."
-              shortcut={settings.toggleShortcut}
-              capturing={capturingShortcut === "toggle"}
-              disabled={!!capturingShortcut && capturingShortcut !== "toggle"}
-              error={capturingShortcut === "toggle" ? shortcutError : undefined}
-              onChange={() => void startShortcutCapture("toggle")}
-              onCancel={() => void cancelShortcutCapture()}
-            />
-          </div>
-        </div>
-      </section>
-
-      <StyleSettingsSection />
-
-      <section className="settings-group" aria-labelledby="audio-heading">
-        <h2 id="audio-heading" className="settings-group-heading">
-          Audio
-        </h2>
-        <div className="settings-card">
-          <div className="settings-rows">
-            <div className="settings-row">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title">Microphone</h3>
-                <p className="settings-row-description">
-                  Input device used for dictation.
-                </p>
-              </div>
-              <div className="settings-row-control" ref={micWrapRef}>
-                <button
-                  type="button"
-                  className="select-trigger"
-                  aria-haspopup="listbox"
-                  aria-expanded={micOpen}
-                  onClick={() => {
-                    setMicOpen((value) => !value);
-                    void requestMicrophones();
-                  }}
-                >
-                  <span>{microphoneName}</span>
-                  <IconChevronDownSmall size={14} />
-                </button>
-                {micOpen ? (
-                  // 2px = (trigger 32 - item 28) / 2, so the selected item
-                  // overlays the trigger label exactly with no visual jump.
-                  <ul
-                    className="select-popover"
-                    role="listbox"
-                    style={{ top: -(2 + selectedMicrophoneIndex * 28) }}
-                  >
-                    {microphoneOptions.map((option) => {
-                      const selected =
-                        (option.id ?? "") === (settings.microphone.id ?? "");
-                      return (
-                        <li key={option.id ?? "auto"}>
-                          <button
-                            type="button"
-                            role="option"
-                            aria-selected={selected}
-                            data-selected={selected}
-                            onClick={() =>
-                              void selectMicrophone(
-                                option.id,
-                                option.id ? option.name : undefined,
-                              )
-                            }
-                          >
-                            <span>{option.name}</span>
-                            <span className="select-check" aria-hidden>
-                              {selected ? (
-                                <IconCheckmark1Small size={14} />
-                              ) : null}
-                            </span>
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                ) : null}
-              </div>
-            </div>
-
-            {systemUnsupported ? null : (
-              <div className="settings-row">
-                <div className="settings-row-info">
-                  <h3 className="settings-row-title">System audio</h3>
-                  <p className="settings-row-description">
-                    Capture audio from other apps along with your microphone.
-                  </p>
+            <section
+              className="settings-group"
+              aria-labelledby="appearance-heading"
+            >
+              <h2 id="appearance-heading" className="settings-group-heading">
+                Appearance
+              </h2>
+              <div className="settings-card">
+                <div className="settings-rows">
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Theme</h3>
+                      <p className="settings-row-description">
+                        Match the system or force light or dark mode.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <SegmentedControl<ThemePreference>
+                        aria-label="App theme"
+                        value={theme}
+                        options={THEME_OPTIONS}
+                        onValueChange={(next) => {
+                          setTheme(next);
+                          setStoredTheme(next);
+                        }}
+                      />
+                    </div>
+                  </div>
                 </div>
-                <div className="settings-row-control">
-                  {systemDenied ? (
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      onClick={onEnableSystemAudio}
-                    >
-                      Enable
-                    </button>
-                  ) : null}
-                  <Switch
-                    checked={systemOn}
-                    disabled={checkingSourceReadiness || systemDenied}
-                    aria-label="Capture system audio for notes"
-                    onCheckedChange={(next) =>
-                      onSourceModeChange(
-                        next ? "microphonePlusSystem" : "microphoneOnly",
-                      )
+              </div>
+            </section>
+          </>
+        ) : null}
+
+        {activeTab === "dictation" ? (
+          <>
+            <section
+              className="settings-group"
+              aria-labelledby="dictation-heading"
+            >
+              <h2 id="dictation-heading" className="settings-group-heading">
+                Dictation
+              </h2>
+              <div className="settings-card">
+                <div className="settings-rows">
+                  <ShortcutRow
+                    title="Push to talk"
+                    description="Hold this shortcut to dictate, then release to paste."
+                    shortcut={settings.pushToTalkShortcut}
+                    capturing={capturingShortcut === "push_to_talk"}
+                    disabled={
+                      !!capturingShortcut &&
+                      capturingShortcut !== "push_to_talk"
                     }
+                    error={
+                      capturingShortcut === "push_to_talk"
+                        ? shortcutError
+                        : undefined
+                    }
+                    onChange={() => void startShortcutCapture("push_to_talk")}
+                    onCancel={() => void cancelShortcutCapture()}
+                  />
+
+                  <ShortcutRow
+                    title="Toggle dictation"
+                    description="Press this shortcut to start or stop dictation."
+                    shortcut={settings.toggleShortcut}
+                    capturing={capturingShortcut === "toggle"}
+                    disabled={
+                      !!capturingShortcut && capturingShortcut !== "toggle"
+                    }
+                    error={
+                      capturingShortcut === "toggle" ? shortcutError : undefined
+                    }
+                    onChange={() => void startShortcutCapture("toggle")}
+                    onCancel={() => void cancelShortcutCapture()}
                   />
                 </div>
               </div>
-            )}
-          </div>
-        </div>
-      </section>
+            </section>
 
-      <ModelPickerDialog
-        open={!!pickerMode}
-        mode={pickerMode ?? "transcription"}
-        value={pickerValue}
-        options={pickerOptions}
-        search={modelSearch}
-        onSearchChange={setModelSearch}
-        onClose={() => setPickerMode(undefined)}
-        onSelect={(modelId) => {
-          if (!pickerMode) return;
-          void selectVeniceModel(pickerMode, modelId);
-          setPickerMode(undefined);
-        }}
-      />
+            <StyleSettingsSection />
 
-      <section className="settings-group" aria-labelledby="models-heading">
-        <h2 id="models-heading" className="settings-group-heading">
-          AI models
-        </h2>
-        <div className="settings-card">
-          <div className="settings-rows">
-            <ModelRow
-              title="Transcription"
-              description="Speech-to-text for note recordings and dictation."
-              value={providerSettings.transcriptionModel}
-              options={transcriptionOptions}
-              onOpen={() => openModelPicker("transcription")}
-            />
-            <ModelRow
-              title="Text"
-              description="Used for generated notes and agent responses."
-              value={providerSettings.generationModel}
-              options={generationOptions}
-              onOpen={() => openModelPicker("generation")}
-            />
-          </div>
-        </div>
-      </section>
+            <DictionarySettingsSection />
+          </>
+        ) : null}
 
-      <DictionarySettingsSection />
+        {activeTab === "audio" ? (
+          <section className="settings-group" aria-labelledby="audio-heading">
+            <h2 id="audio-heading" className="settings-group-heading">
+              Audio
+            </h2>
+            <div className="settings-card">
+              <div className="settings-rows">
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">Microphone</h3>
+                    <p className="settings-row-description">
+                      Input device used for dictation.
+                    </p>
+                  </div>
+                  <div className="settings-row-control" ref={micWrapRef}>
+                    <button
+                      type="button"
+                      className="select-trigger"
+                      aria-haspopup="listbox"
+                      aria-expanded={micOpen}
+                      onClick={() => {
+                        setMicOpen((value) => !value);
+                        void requestMicrophones();
+                      }}
+                    >
+                      <span>{microphoneName}</span>
+                      <IconChevronDownSmall size={14} />
+                    </button>
+                    {micOpen ? (
+                      // 2px = (trigger 32 - item 28) / 2, so the selected item
+                      // overlays the trigger label exactly with no visual jump.
+                      <ul
+                        className="select-popover"
+                        role="listbox"
+                        style={{ top: -(2 + selectedMicrophoneIndex * 28) }}
+                      >
+                        {microphoneOptions.map((option) => {
+                          const selected =
+                            (option.id ?? "") ===
+                            (settings.microphone.id ?? "");
+                          return (
+                            <li key={option.id ?? "auto"}>
+                              <button
+                                type="button"
+                                role="option"
+                                aria-selected={selected}
+                                data-selected={selected}
+                                onClick={() =>
+                                  void selectMicrophone(
+                                    option.id,
+                                    option.id ? option.name : undefined,
+                                  )
+                                }
+                              >
+                                <span>{option.name}</span>
+                                <span className="select-check" aria-hidden>
+                                  {selected ? (
+                                    <IconCheckmark1Small size={14} />
+                                  ) : null}
+                                </span>
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    ) : null}
+                  </div>
+                </div>
 
-      <AgentSettingsSection />
-
-      <section className="settings-group" aria-labelledby="about-heading">
-        <h2 id="about-heading" className="settings-group-heading">
-          About
-        </h2>
-        <div className="settings-card">
-          <div className="settings-rows">
-            <div className="settings-row settings-row-meta">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title settings-meta-label">
-                  Release version
-                </h3>
-              </div>
-              <div className="settings-row-control">
-                <span className="settings-meta-value">{APP_VERSION}</span>
+                {systemUnsupported ? null : (
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">System audio</h3>
+                      <p className="settings-row-description">
+                        Capture audio from other apps along with your
+                        microphone.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      {systemDenied ? (
+                        <button
+                          type="button"
+                          className="btn btn-secondary"
+                          onClick={onEnableSystemAudio}
+                        >
+                          Enable
+                        </button>
+                      ) : null}
+                      <Switch
+                        checked={systemOn}
+                        disabled={checkingSourceReadiness || systemDenied}
+                        aria-label="Capture system audio for notes"
+                        onCheckedChange={(next) =>
+                          onSourceModeChange(
+                            next ? "microphonePlusSystem" : "microphoneOnly",
+                          )
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
+          </section>
+        ) : null}
 
-            <div className="settings-row settings-row-meta">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title settings-meta-label">
-                  Commit
-                </h3>
+        {activeTab === "models" ? (
+          <>
+            <ModelPickerDialog
+              open={!!pickerMode}
+              mode={pickerMode ?? "transcription"}
+              value={pickerValue}
+              options={pickerOptions}
+              search={modelSearch}
+              onSearchChange={setModelSearch}
+              onClose={() => setPickerMode(undefined)}
+              onSelect={(modelId) => {
+                if (!pickerMode) return;
+                void selectVeniceModel(pickerMode, modelId);
+                setPickerMode(undefined);
+              }}
+            />
+
+            <section
+              className="settings-group"
+              aria-labelledby="models-heading"
+            >
+              <h2 id="models-heading" className="settings-group-heading">
+                AI models
+              </h2>
+              <div className="settings-card">
+                <div className="settings-rows">
+                  <ModelRow
+                    title="Transcription"
+                    description="Speech-to-text for note recordings and dictation."
+                    value={providerSettings.transcriptionModel}
+                    options={transcriptionOptions}
+                    onOpen={() => openModelPicker("transcription")}
+                  />
+                  <ModelRow
+                    title="Text"
+                    description="Used for generated notes and agent responses."
+                    value={providerSettings.generationModel}
+                    options={generationOptions}
+                    onOpen={() => openModelPicker("generation")}
+                  />
+                </div>
               </div>
-              <div className="settings-row-control">
-                <span className="settings-meta-value settings-meta-value-mono">
-                  {APP_COMMIT_HASH}
-                </span>
+            </section>
+          </>
+        ) : null}
+
+        {activeTab === "agent" ? <AgentSettingsSection /> : null}
+
+        {activeTab === "about" ? (
+          <section className="settings-group" aria-labelledby="about-heading">
+            <h2 id="about-heading" className="settings-group-heading">
+              About
+            </h2>
+            <div className="settings-card">
+              <div className="settings-rows">
+                <div className="settings-row settings-row-meta">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title settings-meta-label">
+                      Release version
+                    </h3>
+                  </div>
+                  <div className="settings-row-control">
+                    <span className="settings-meta-value">{APP_VERSION}</span>
+                  </div>
+                </div>
+
+                <div className="settings-row settings-row-meta">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title settings-meta-label">
+                      Commit
+                    </h3>
+                  </div>
+                  <div className="settings-row-control">
+                    <span className="settings-meta-value settings-meta-value-mono">
+                      {APP_COMMIT_HASH}
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-      </section>
+          </section>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -46,6 +46,7 @@ import {
   type ThemePreference,
 } from "../../lib/theme";
 import { ProviderLogo } from "./ProviderLogo";
+import { AgentSettingsSection } from "./AgentSettingsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
 import { StyleSettingsSection } from "./StyleSettingsSection";
 
@@ -430,9 +431,18 @@ export function AppSettings({
       <header className="settings-header">
         <h1 className="settings-title">Settings</h1>
         <p className="settings-description">
-          Manage audio, dictation, and AI models for notes.
+          Manage audio, dictation, AI models, and agent capabilities.
         </p>
       </header>
+
+      <nav className="settings-nav" aria-label="Settings sections">
+        <a href="#account-heading">Account</a>
+        <a href="#dictation-heading">Dictation</a>
+        <a href="#audio-heading">Audio</a>
+        <a href="#models-heading">Models</a>
+        <a href="#agent-heading">Agent</a>
+        <a href="#about-heading">About</a>
+      </nav>
 
       <AccountSettingsSection
         account={account}
@@ -649,6 +659,8 @@ export function AppSettings({
       </section>
 
       <DictionarySettingsSection />
+
+      <AgentSettingsSection />
 
       <section className="settings-group" aria-labelledby="about-heading">
         <h2 id="about-heading" className="settings-group-heading">

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -241,18 +241,6 @@ export function Sidebar({
           </span>
           <span className="sidebar-nav-label">Dictation</span>
         </button>
-        <button
-          type="button"
-          className="sidebar-nav-item"
-          data-active={activeView === "agent"}
-          aria-current={activeView === "agent" ? "page" : undefined}
-          onClick={() => onChangeView("agent")}
-        >
-          <span className="sidebar-nav-icon">
-            <BotIcon size={16} />
-          </span>
-          <span className="sidebar-nav-label">Agent</span>
-        </button>
       </nav>
 
       <section

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -11,11 +11,23 @@ import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import { BotIcon } from "lucide-react";
 import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AGENT_NEW_SESSION_EVENT,
+  AGENT_SELECT_SESSION_EVENT,
+  AGENT_SESSIONS_CHANGED_EVENT,
+  type AgentSessionsChangedDetail,
+} from "../agent/AgentWorkspace";
+import { listHermesSessions, sessionTimestamp } from "../../lib/hermes-adapter";
 import { NOTE_DND_MIME } from "../../lib/dnd";
-import type { FolderDto, NoteListItemDto } from "../../lib/tauri";
+import type {
+  FolderDto,
+  HermesSessionInfo,
+  NoteListItemDto,
+} from "../../lib/tauri";
 
 export type SidebarView =
   | "notes"
+  | "meetings"
   | "all-notes"
   | "settings"
   | "folders"
@@ -63,6 +75,12 @@ export function Sidebar({
 }: SidebarProps) {
   const [query, setQuery] = useState("");
   const [menu, setMenu] = useState<MenuState | null>(null);
+  const [agentSessions, setAgentSessions] = useState<HermesSessionInfo[]>([]);
+  const [selectedAgentSessionId, setSelectedAgentSessionId] =
+    useState<string>();
+  const [workingAgentSessionIds, setWorkingAgentSessionIds] = useState<
+    Set<string>
+  >(() => new Set());
   const filteredNotes = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     if (!normalized) return notes;
@@ -70,6 +88,22 @@ export function Sidebar({
       `${note.title} ${note.preview}`.toLowerCase().includes(normalized),
     );
   }, [notes, query]);
+
+  const filteredAgentSessions = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return agentSessions;
+    return agentSessions.filter((session) =>
+      `${session.title ?? ""} ${session.preview ?? ""}`
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [agentSessions, query]);
+
+  function dispatchAgentEvent<T>(name: string, detail?: T) {
+    window.setTimeout(() => {
+      window.dispatchEvent(new CustomEvent(name, { detail }));
+    }, 0);
+  }
 
   useEffect(() => {
     if (!menu) return;
@@ -89,6 +123,47 @@ export function Sidebar({
       window.removeEventListener("keydown", onKeyDown);
     };
   }, [menu]);
+
+  useEffect(() => {
+    let cancelled = false;
+    listHermesSessions({ limit: 12 })
+      .then((sessions) => {
+        if (!cancelled) {
+          setAgentSessions((current) =>
+            current.length > 0 ? current : sessions,
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAgentSessions((current) => (current.length > 0 ? current : []));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleSessionsChanged(event: Event) {
+      const detail = (event as CustomEvent<AgentSessionsChangedDetail>).detail;
+      if (!detail) return;
+      setAgentSessions(detail.sessions);
+      setSelectedAgentSessionId(detail.selectedSessionId);
+      setWorkingAgentSessionIds(new Set(detail.workingSessionIds));
+    }
+
+    window.addEventListener(
+      AGENT_SESSIONS_CHANGED_EVENT,
+      handleSessionsChanged,
+    );
+    return () => {
+      window.removeEventListener(
+        AGENT_SESSIONS_CHANGED_EVENT,
+        handleSessionsChanged,
+      );
+    };
+  }, []);
 
   // Right-aligns the popover with the overflow button and parks it just
   // below — keeps it tucked next to the trigger rather than flying off to
@@ -139,18 +214,21 @@ export function Sidebar({
         <button
           type="button"
           className="sidebar-nav-item"
+          data-active={activeView === "meetings" || activeView === "notes"}
+          aria-current={
+            activeView === "meetings" || activeView === "notes"
+              ? "page"
+              : undefined
+          }
           onClick={() => {
-            onChangeView("notes");
-            onCreateNote();
+            onChangeView("meetings");
+            if (!selectedNoteId && notes.length === 0) onCreateNote();
           }}
         >
           <span className="sidebar-nav-icon">
-            <IconPlusMedium size={15} />
+            <IconNoteText size={15} />
           </span>
-          <span className="sidebar-nav-label">New note</span>
-          <kbd className="sidebar-search-kbd sidebar-nav-shortcut" aria-hidden>
-            ⌘N
-          </kbd>
+          <span className="sidebar-nav-label">Meetings</span>
         </button>
         <button
           type="button"
@@ -191,47 +269,53 @@ export function Sidebar({
       </nav>
 
       <section
-        className="sidebar-section"
-        aria-label="Notes"
-        data-active={activeView === "notes"}
+        className="sidebar-section sidebar-agent-section"
+        aria-label="Agent sessions"
+        data-active={activeView === "agent"}
       >
         <div className="section-title section-title-with-action">
           <button
             type="button"
             className="section-title-label section-title-open"
-            onClick={() => onChangeView("all-notes")}
+            onClick={() => onChangeView("agent")}
           >
-            Notes <span className="section-count">{notes.length}</span>
+            Agent
           </button>
           <button
             type="button"
             className="section-view-all"
-            onClick={() => onChangeView("all-notes")}
+            onClick={() => {
+              onChangeView("agent");
+              dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
+            }}
           >
-            View all
+            New Session +
           </button>
         </div>
         <div className="notes-nav-wrap">
           <div className="notes-nav">
-            {filteredNotes.length > 0 ? (
-              filteredNotes.map((note) => (
-                <NoteRow
-                  key={note.id}
-                  note={note}
+            {filteredAgentSessions.length > 0 ? (
+              filteredAgentSessions.map((session) => (
+                <AgentSessionRow
+                  key={session.id}
+                  session={session}
                   selected={
-                    activeView === "notes" && selectedNoteId === note.id
+                    activeView === "agent" &&
+                    selectedAgentSessionId === session.id
                   }
-                  recoverable={recoverableNoteIds?.has(note.id) ?? false}
+                  working={workingAgentSessionIds.has(session.id)}
                   onSelect={() => {
-                    onChangeView("notes");
-                    onSelectNote(note.id);
+                    onChangeView("agent");
+                    setSelectedAgentSessionId(session.id);
+                    dispatchAgentEvent(AGENT_SELECT_SESSION_EVENT, {
+                      sessionId: session.id,
+                    });
                   }}
-                  onOpenMenu={(anchor) => openMenuForNote(note.id, anchor)}
                 />
               ))
             ) : (
               <div className="sidebar-empty">
-                {notes.length === 0 ? "No notes yet" : "No matches"}
+                {agentSessions.length === 0 ? "No sessions yet" : "No matches"}
               </div>
             )}
           </div>
@@ -364,6 +448,55 @@ function NoteRow({
   );
 }
 
+function AgentSessionRow({
+  session,
+  selected,
+  working,
+  onSelect,
+}: {
+  session: HermesSessionInfo;
+  selected: boolean;
+  working: boolean;
+  onSelect: () => void;
+}) {
+  const title = session.title || session.preview || "Untitled session";
+  return (
+    <article className="note-row agent-sidebar-row" data-selected={selected}>
+      <div
+        className="note-row-main"
+        role="button"
+        tabIndex={0}
+        onClick={onSelect}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelect();
+          }
+        }}
+      >
+        <span className="note-row-icon">
+          <BotIcon size={15} />
+        </span>
+        <span className="note-row-title">
+          <span className="note-row-title-text">{title}</span>
+          {working ? (
+            <span
+              className="agent-sidebar-working"
+              aria-label="Working"
+              title="Working"
+            />
+          ) : null}
+        </span>
+        <span className="agent-sidebar-preview">
+          {working
+            ? "Working now"
+            : session.preview || relativeDate(sessionTimestamp(session))}
+        </span>
+      </div>
+    </article>
+  );
+}
+
 function NoteContextMenu({
   noteId,
   right,
@@ -437,4 +570,15 @@ function NoteContextMenu({
       </button>
     </div>
   );
+}
+
+function relativeDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -207,7 +207,7 @@ export function Sidebar({
           <span className="sidebar-nav-icon">
             <IconPlusMedium size={15} />
           </span>
-          <span className="sidebar-nav-label">New Session +</span>
+          <span className="sidebar-nav-label">New Session</span>
         </button>
         <button
           type="button"

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import { BotIcon } from "lucide-react";
 import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   AGENT_NEW_SESSION_EVENT,
+  AGENT_NEW_SESSION_PENDING_KEY,
   AGENT_SELECT_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   type AgentSessionsChangedDetail,
@@ -200,6 +201,7 @@ export function Sidebar({
           type="button"
           className="sidebar-nav-item"
           onClick={() => {
+            markAgentNewSessionPending();
             onChangeView("agent");
             dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
           }}
@@ -336,6 +338,18 @@ export function Sidebar({
       ) : null}
     </aside>
   );
+}
+
+function markAgentNewSessionPending() {
+  try {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      String(Date.now()),
+    );
+  } catch {
+    // Session storage can be unavailable in restricted webviews; the event path
+    // still handles already-mounted Agent workspaces.
+  }
 }
 
 function NoteRow({

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -487,11 +487,6 @@ function AgentSessionRow({
             />
           ) : null}
         </span>
-        <span className="agent-sidebar-preview">
-          {working
-            ? "Working now"
-            : session.preview || relativeDate(sessionTimestamp(session))}
-        </span>
       </div>
     </article>
   );

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { IconDotGrid1x3Vertical } from "central-icons/IconDotGrid1x3Vertical";
 import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
 import { IconFolderDelete } from "central-icons/IconFolderDelete";
-import { IconFolders } from "central-icons/IconFolders";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconMoveFolder } from "central-icons/IconMoveFolder";
@@ -19,11 +18,7 @@ import {
 } from "../agent/AgentWorkspace";
 import { listHermesSessions, sessionTimestamp } from "../../lib/hermes-adapter";
 import { NOTE_DND_MIME } from "../../lib/dnd";
-import type {
-  FolderDto,
-  HermesSessionInfo,
-  NoteListItemDto,
-} from "../../lib/tauri";
+import type { HermesSessionInfo, NoteListItemDto } from "../../lib/tauri";
 
 export type SidebarView =
   | "notes"
@@ -35,16 +30,9 @@ export type SidebarView =
   | "agent";
 
 type SidebarProps = {
-  folders: FolderDto[];
   notes: NoteListItemDto[];
-  selectedNoteId?: string;
-  selectedFolderId?: string;
   activeView: SidebarView;
   onChangeView: (view: SidebarView) => void;
-  onCreateFolder: () => void;
-  onCreateNote: () => void;
-  onSelectAll: () => void;
-  onSelectFolder: (folderId: string) => void;
   onSelectNote: (noteId: string) => void;
   onDeleteNote: (noteId: string) => void;
   onOpenMoveDialog: (noteId: string) => void;
@@ -60,12 +48,9 @@ type MenuState = {
 };
 
 export function Sidebar({
-  folders,
   notes,
-  selectedNoteId,
   activeView,
   onChangeView,
-  onCreateNote,
   onSelectNote,
   onDeleteNote,
   onOpenMoveDialog,
@@ -214,6 +199,19 @@ export function Sidebar({
         <button
           type="button"
           className="sidebar-nav-item"
+          onClick={() => {
+            onChangeView("agent");
+            dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
+          }}
+        >
+          <span className="sidebar-nav-icon">
+            <IconPlusMedium size={15} />
+          </span>
+          <span className="sidebar-nav-label">New Session +</span>
+        </button>
+        <button
+          type="button"
+          className="sidebar-nav-item"
           data-active={activeView === "meetings" || activeView === "notes"}
           aria-current={
             activeView === "meetings" || activeView === "notes"
@@ -221,26 +219,13 @@ export function Sidebar({
               : undefined
           }
           onClick={() => {
-            onChangeView("meetings");
-            if (!selectedNoteId && notes.length === 0) onCreateNote();
+            onChangeView("notes");
           }}
         >
           <span className="sidebar-nav-icon">
             <IconNoteText size={15} />
           </span>
-          <span className="sidebar-nav-label">Meetings</span>
-        </button>
-        <button
-          type="button"
-          className="sidebar-nav-item"
-          data-active={activeView === "folders"}
-          aria-current={activeView === "folders" ? "page" : undefined}
-          onClick={() => onChangeView("folders")}
-        >
-          <span className="sidebar-nav-icon">
-            <IconFolders size={16} />
-          </span>
-          <span className="sidebar-nav-label">Folders</span>
+          <span className="sidebar-nav-label">Notes</span>
         </button>
         <button
           type="button"
@@ -286,10 +271,9 @@ export function Sidebar({
             className="section-view-all"
             onClick={() => {
               onChangeView("agent");
-              dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
             }}
           >
-            New Session +
+            View all
           </button>
         </div>
         <div className="notes-nav-wrap">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -219,8 +219,7 @@ input:focus-visible,
 
 .agent-workspace {
   display: grid;
-  grid-template-columns: minmax(230px, 292px) minmax(0, 1fr);
-  gap: var(--sp-6);
+  grid-template-columns: minmax(0, 1fr);
   width: min(100%, 1120px);
   min-height: 0;
   max-height: 100%;
@@ -417,7 +416,7 @@ input:focus-visible,
 
 .agent-rail-header .agent-panel-tabs {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   width: 100%;
 }
 
@@ -1426,7 +1425,7 @@ input:focus-visible,
 @media (max-width: 980px) {
   .agent-workspace {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(180px, 32vh) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
   }
 
   .agent-detail-title h2 {
@@ -1832,6 +1831,10 @@ input:focus-visible,
   opacity: 1;
 }
 
+.sidebar-agent-section .section-view-all {
+  opacity: 1;
+}
+
 .section-title-with-action:hover .section-view-all:hover {
   background: color-mix(in oklch, var(--muted) 55%, transparent);
   color: var(--foreground);
@@ -2064,6 +2067,32 @@ input:focus-visible,
 .note-row-menu:hover {
   background: oklch(0% 0 none / 6%);
   color: var(--foreground);
+}
+
+.agent-sidebar-row .note-row-main {
+  grid-template-rows: auto auto;
+}
+
+.agent-sidebar-row .note-row-icon {
+  grid-row: 1 / span 2;
+}
+
+.agent-sidebar-preview {
+  grid-column: 2;
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-sidebar-working {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--r-pill);
+  background: var(--warm-strong);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--warm-strong) 20%, transparent);
 }
 
 .sidebar[data-collapsed="true"] .note-row-menu,
@@ -5136,6 +5165,102 @@ input:focus-visible,
   display: grid;
   gap: var(--sp-3);
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.folders-hermes-files {
+  display: grid;
+  gap: var(--sp-4);
+  margin-top: var(--sp-8);
+}
+
+.folders-hermes-header h2,
+.folders-file-root-title h3 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--fs-lg);
+  font-weight: 600;
+}
+
+.folders-hermes-header p {
+  margin: var(--sp-1) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.folders-hermes-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.folders-file-root-card[data-active="true"] {
+  border-color: var(--focus-ring);
+  box-shadow: 0 0 0 1px var(--focus-ring);
+}
+
+.folders-file-root-card .folder-card-name,
+.folders-file-root-card .folder-card-meta,
+.folders-file-root-card .folder-card-description {
+  grid-column: 2 / span 2;
+}
+
+.folders-file-root-card .folder-card-name {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.folders-file-root-card .folder-card-meta,
+.folders-file-root-card .folder-card-description {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.folders-file-root-detail {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--card);
+}
+
+.folders-file-root-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  padding: var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.folders-file-root-title code {
+  overflow: hidden;
+  max-width: 48%;
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folders-file-entry {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-2);
+  min-height: 34px;
+  padding: 0 var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+}
+
+.folders-file-entry span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folders-file-entry small {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
 }
 
 /* Slim, click-anywhere card. The article itself is `role=button`, so

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5167,10 +5167,18 @@ input:focus-visible,
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
+.folders-meetings-files,
 .folders-hermes-files {
   display: grid;
   gap: var(--sp-4);
   margin-top: var(--sp-8);
+}
+
+.folders-hermes-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--sp-4);
 }
 
 .folders-hermes-header h2,
@@ -5185,6 +5193,82 @@ input:focus-visible,
   margin: var(--sp-1) 0 0;
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
+}
+
+.folders-section-count {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  white-space: nowrap;
+}
+
+.folders-meetings-list {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--card);
+}
+
+.folders-meeting-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--sp-3);
+  align-items: center;
+  width: 100%;
+  padding: var(--sp-3) var(--sp-4);
+  border: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.folders-meeting-row:last-child {
+  border-bottom: 0;
+}
+
+.folders-meeting-row:hover,
+.folders-meeting-row:focus-visible {
+  background: color-mix(in oklch, var(--muted) 38%, transparent);
+}
+
+.folders-meeting-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  color: var(--muted-foreground);
+  background: color-mix(in oklch, var(--muted) 34%, transparent);
+}
+
+.folders-meeting-body {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.folders-meeting-title,
+.folders-meeting-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folders-meeting-title {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: 600;
+}
+
+.folders-meeting-preview,
+.folders-meeting-time {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.folders-meeting-time {
+  white-space: nowrap;
 }
 
 .folders-hermes-grid {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3835,21 +3835,33 @@ input:focus-visible,
   backdrop-filter: blur(18px);
 }
 
-.settings-nav a {
+.settings-nav button {
   display: inline-flex;
   align-items: center;
   min-height: var(--control-sm);
   padding: 0 var(--sp-3);
+  border: 0;
   border-radius: var(--r-sm);
+  background: transparent;
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
-  text-decoration: none;
+  cursor: pointer;
 }
 
-.settings-nav a:hover,
-.settings-nav a:focus-visible {
+.settings-nav button:hover,
+.settings-nav button:focus-visible,
+.settings-nav button[aria-selected="true"] {
   background: var(--secondary);
   color: var(--foreground);
+}
+
+.settings-nav button[aria-selected="true"] {
+  box-shadow: 0 0 0 1px var(--border-subtle);
+}
+
+.settings-tab-panel {
+  display: grid;
+  gap: var(--sp-10);
 }
 
 .settings-title {
@@ -5349,6 +5361,29 @@ input:focus-visible,
 
 .folders-virtual-folder-card {
   border-color: transparent;
+}
+
+.folders-virtual-folder-icon {
+  position: relative;
+}
+
+.folders-agent-folder-badge {
+  position: absolute;
+  right: -6px;
+  bottom: -6px;
+  display: inline-grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--card);
+  border-radius: var(--r-pill);
+  background: color-mix(in oklch, var(--foreground) 88%, var(--background));
+  color: var(--background);
+}
+
+.folders-agent-folder-badge > svg {
+  width: 10px;
+  height: 10px;
 }
 
 .folders-virtual-folder-card .folder-card-name,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -628,6 +628,16 @@ input:focus-visible,
   text-transform: none;
 }
 
+.agent-files-root-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.agent-files-root-title svg {
+  color: var(--muted-foreground);
+}
+
 .agent-files-root p {
   margin: var(--sp-1) 0 0;
   color: var(--muted-foreground);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5234,11 +5234,20 @@ input:focus-visible,
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
+.folders-virtual-detail {
+  display: grid;
+  gap: var(--sp-4);
+}
+
 .folders-meetings-files,
 .folders-hermes-files {
   display: grid;
   gap: var(--sp-4);
   margin-top: var(--sp-8);
+}
+
+.folders-virtual-detail .folders-meetings-files {
+  margin-top: 0;
 }
 
 .folders-hermes-header {
@@ -5338,28 +5347,24 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-.folders-hermes-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.folders-virtual-folder-card {
+  border-color: transparent;
 }
 
-.folders-file-root-card[data-active="true"] {
-  border-color: var(--focus-ring);
-  box-shadow: 0 0 0 1px var(--focus-ring);
-}
-
-.folders-file-root-card .folder-card-name,
-.folders-file-root-card .folder-card-meta,
-.folders-file-root-card .folder-card-description {
+.folders-virtual-folder-card .folder-card-name,
+.folders-virtual-folder-card .folder-card-meta,
+.folders-virtual-folder-card .folder-card-description {
   grid-column: 2 / span 2;
 }
 
-.folders-file-root-card .folder-card-name {
+.folders-virtual-folder-card .folder-card-name {
   color: var(--foreground);
+  font-size: var(--fs-lg);
   font-weight: 600;
 }
 
-.folders-file-root-card .folder-card-meta,
-.folders-file-root-card .folder-card-description {
+.folders-virtual-folder-card .folder-card-meta,
+.folders-virtual-folder-card .folder-card-description {
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2070,20 +2070,11 @@ input:focus-visible,
 }
 
 .agent-sidebar-row .note-row-main {
-  grid-template-rows: auto auto;
+  grid-template-rows: auto;
 }
 
 .agent-sidebar-row .note-row-icon {
-  grid-row: 1 / span 2;
-}
-
-.agent-sidebar-preview {
-  grid-column: 2;
-  overflow: hidden;
-  color: var(--muted-foreground);
-  font-size: var(--fs-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  grid-row: 1;
 }
 
 .agent-sidebar-working {
@@ -3829,6 +3820,38 @@ input:focus-visible,
   margin-bottom: var(--sp-8);
 }
 
+.settings-nav {
+  position: sticky;
+  top: var(--sp-4);
+  z-index: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-8);
+  padding: var(--sp-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--background) 88%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.settings-nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--control-sm);
+  padding: 0 var(--sp-3);
+  border-radius: var(--r-sm);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  text-decoration: none;
+}
+
+.settings-nav a:hover,
+.settings-nav a:focus-visible {
+  background: var(--secondary);
+  color: var(--foreground);
+}
+
 .settings-title {
   margin: 0;
   color: var(--foreground);
@@ -3935,6 +3958,50 @@ input:focus-visible,
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
   background: var(--card);
+}
+
+.settings-agent-card {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  min-height: 640px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.settings-agent-card .settings-row-error {
+  margin: var(--sp-4) var(--sp-5) 0;
+}
+
+.settings-agent-card .agent-management-panel {
+  min-height: 0;
+}
+
+.settings-agent-card .agent-messaging-layout {
+  min-height: 540px;
+}
+
+.settings-section-tabs {
+  display: flex;
+  gap: var(--sp-1);
+  padding: var(--sp-2);
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in oklch, var(--muted) 22%, transparent);
+}
+
+.settings-section-tabs button {
+  min-height: var(--control-sm);
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.settings-section-tabs button[aria-selected="true"] {
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 0 0 1px var(--border-subtle);
 }
 
 .settings-rows {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AGENT_NEW_SESSION_EVENT,
+  AGENT_NEW_SESSION_PENDING_KEY,
+  AgentWorkspace,
+} from "../components/agent/AgentWorkspace";
+
+const mocks = vi.hoisted(() => ({
+  cancelAgentTask: vi.fn(),
+  createAgentTask: vi.fn(),
+  getAgentTask: vi.fn(),
+  hermesBridgeFilesystemSnapshot: vi.fn(),
+  hermesBridgeMessagingPlatforms: vi.fn(),
+  hermesBridgeSkills: vi.fn(),
+  hermesBridgeStatus: vi.fn(),
+  hermesBridgeToolsets: vi.fn(),
+  listAgentTasks: vi.fn(),
+  retryAgentTask: vi.fn(),
+  saveAgentAssistantMessage: vi.fn(),
+  saveAgentHermesSession: vi.fn(),
+  sendAgentMessage: vi.fn(),
+  startHermesBridge: vi.fn(),
+  toggleHermesBridgeSkill: vi.fn(),
+  toggleHermesBridgeToolset: vi.fn(),
+  updateHermesBridgeMessagingPlatform: vi.fn(),
+  listHermesSessionMessages: vi.fn(),
+  listHermesSessions: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  cancelAgentTask: mocks.cancelAgentTask,
+  createAgentTask: mocks.createAgentTask,
+  getAgentTask: mocks.getAgentTask,
+  hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
+  hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
+  hermesBridgeSkills: mocks.hermesBridgeSkills,
+  hermesBridgeStatus: mocks.hermesBridgeStatus,
+  hermesBridgeToolsets: mocks.hermesBridgeToolsets,
+  listAgentTasks: mocks.listAgentTasks,
+  retryAgentTask: mocks.retryAgentTask,
+  saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
+  saveAgentHermesSession: mocks.saveAgentHermesSession,
+  sendAgentMessage: mocks.sendAgentMessage,
+  startHermesBridge: mocks.startHermesBridge,
+  toggleHermesBridgeSkill: mocks.toggleHermesBridgeSkill,
+  toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
+  updateHermesBridgeMessagingPlatform:
+    mocks.updateHermesBridgeMessagingPlatform,
+}));
+
+vi.mock("../lib/hermes-adapter", () => ({
+  listHermesSessionMessages: mocks.listHermesSessionMessages,
+  listHermesSessions: mocks.listHermesSessions,
+  sessionTimestamp: (session: { last_active?: string; started_at?: string }) =>
+    session.last_active ?? session.started_at ?? "",
+  titleFromPrompt: (prompt: string) => prompt.trim() || "Untitled session",
+}));
+
+vi.mock("../lib/hermes-gateway", () => ({
+  HermesGatewayClient: class {
+    connect = vi.fn();
+    close = vi.fn();
+    onEvent = vi.fn(() => vi.fn());
+    request = vi.fn();
+  },
+}));
+
+const existingTask = {
+  id: "task-1",
+  title: "Existing task",
+  prompt: "Existing task",
+  status: "completed",
+  progressSummary: "",
+  createdAt: "2026-06-04T12:00:00Z",
+  updatedAt: "2026-06-04T12:00:00Z",
+  messages: [],
+  toolEvents: [],
+};
+
+const existingSession = {
+  id: "session-1",
+  title: "Existing session",
+  preview: "Existing preview",
+  last_active: "2026-06-04T12:00:00Z",
+};
+
+describe("AgentWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    mocks.listAgentTasks.mockResolvedValue({ items: [existingTask] });
+    mocks.getAgentTask.mockResolvedValue(existingTask);
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
+    });
+    mocks.listHermesSessions.mockResolvedValue([existingSession]);
+    mocks.listHermesSessionMessages.mockResolvedValue([]);
+  });
+
+  it("honors a pending New Session request instead of selecting existing work", async () => {
+    window.sessionStorage.setItem(AGENT_NEW_SESSION_PENDING_KEY, "1");
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByText("Start an agent session"),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(mocks.listHermesSessions).toHaveBeenCalled());
+    expect(screen.queryByText("Existing session")).toBeNull();
+    expect(screen.queryByText("Existing task")).toBeNull();
+    expect(
+      window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY),
+    ).toBeNull();
+  });
+
+  it("keeps the blank composer after a New Session event during refresh", async () => {
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+
+    expect(
+      await screen.findByText("Start an agent session"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Existing session")).toBeNull();
+  });
+});

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -226,6 +226,7 @@ describe("AppSettings", () => {
       }),
     });
 
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
     await user.click(
       screen.getByRole("button", { name: /Auto-detect|USB Mic/ }),
     );
@@ -254,6 +255,7 @@ describe("AppSettings", () => {
       />,
     );
 
+    await user.click(screen.getByRole("tab", { name: "Dictation" }));
     expect(await screen.findByText("Push to talk")).toBeInTheDocument();
     expect(screen.getByText("Toggle dictation")).toBeInTheDocument();
     expect(
@@ -368,6 +370,7 @@ describe("AppSettings", () => {
     await waitFor(() =>
       expect(mocks.listVeniceModels).toHaveBeenCalledWith("transcription"),
     );
+    await user.click(screen.getByRole("tab", { name: "Models" }));
     await user.click(
       await screen.findByRole("button", {
         name: "Change transcription model",
@@ -420,6 +423,8 @@ describe("AppSettings", () => {
       />,
     );
 
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("tab", { name: "About" }));
     expect(await screen.findByText("Release version")).toBeInTheDocument();
     expect(screen.getByText(APP_VERSION)).toBeInTheDocument();
     expect(screen.getByText("Commit")).toBeInTheDocument();

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -18,6 +18,13 @@ const mocks = vi.hoisted(() => ({
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
   osAccountsTopUp: vi.fn(),
+  hermesBridgeSkills: vi.fn(),
+  hermesBridgeToolsets: vi.fn(),
+  hermesBridgeMessagingPlatforms: vi.fn(),
+  hermesBridgeFilesystemSnapshot: vi.fn(),
+  toggleHermesBridgeSkill: vi.fn(),
+  toggleHermesBridgeToolset: vi.fn(),
+  updateHermesBridgeMessagingPlatform: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
@@ -35,6 +42,14 @@ vi.mock("../lib/tauri", () => ({
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
   osAccountsTopUp: mocks.osAccountsTopUp,
+  hermesBridgeSkills: mocks.hermesBridgeSkills,
+  hermesBridgeToolsets: mocks.hermesBridgeToolsets,
+  hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
+  hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
+  toggleHermesBridgeSkill: mocks.toggleHermesBridgeSkill,
+  toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
+  updateHermesBridgeMessagingPlatform:
+    mocks.updateHermesBridgeMessagingPlatform,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -192,6 +207,50 @@ describe("AppSettings", () => {
       ...baseSettings,
       microphone: { id, name },
     }));
+    mocks.hermesBridgeSkills.mockResolvedValue([]);
+    mocks.hermesBridgeToolsets.mockResolvedValue([]);
+    mocks.hermesBridgeMessagingPlatforms.mockResolvedValue({ platforms: [] });
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "sample.pdf",
+              path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/sample.pdf",
+              kind: "file",
+              size: 1700,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+        {
+          id: "memory",
+          label: "Memory",
+          path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/memory",
+          description: "Persistent Hermes memory files and stores.",
+          entries: [
+            {
+              name: "USER.md",
+              path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/memory/USER.md",
+              kind: "file",
+              size: 39,
+              modifiedAt: "2026-06-04T18:47:00Z",
+            },
+          ],
+        },
+        {
+          id: "logs",
+          label: "Logs",
+          path: "/tmp/hermes/logs",
+          description: "Internal logs.",
+          entries: [],
+        },
+      ],
+    });
     mocks.listen.mockImplementation((_event, handler) => {
       mocks.eventHandler = handler;
       return Promise.resolve(vi.fn());
@@ -429,5 +488,30 @@ describe("AppSettings", () => {
     expect(screen.getByText(APP_VERSION)).toBeInTheDocument();
     expect(screen.getByText("Commit")).toBeInTheDocument();
     expect(screen.getByText(APP_COMMIT_HASH)).toBeInTheDocument();
+  });
+
+  it("shows agent workspace and memory files inside Agent settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Agent" }));
+    await user.click(screen.getByRole("button", { name: "Files" }));
+
+    expect(await screen.findByText("Workspace")).toBeInTheDocument();
+    expect(screen.getByText("Memory")).toBeInTheDocument();
+    expect(screen.getByText("sample.pdf")).toBeInTheDocument();
+    expect(screen.getByText("USER.md")).toBeInTheDocument();
+    expect(screen.queryByText("Logs")).toBeNull();
   });
 });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -194,6 +194,9 @@ describe("App shortcuts", () => {
 
     render(<App />);
 
+    await user.click(
+      await screen.findByRole("button", { name: /^First note/ }),
+    );
     await screen.findByDisplayValue("First note");
     fireEvent.click(
       screen.getByRole("button", { name: "Open Testing folder" }),
@@ -263,6 +266,11 @@ describe("App shortcuts", () => {
       balance: { usdMillis: 1200 },
     });
 
-    expect(await screen.findByDisplayValue("First note")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Notes" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^First note/ }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -179,6 +179,10 @@ describe("FoldersWorkspace — list view", () => {
       screen.getByRole("heading", { name: "Folders" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("All notes")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Meetings/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Roadmap")).toBeNull();
     expect(screen.getByText("Ideas")).toBeInTheDocument();
     expect(screen.getByText("Work")).toBeInTheDocument();
     const workCard = screen.getByText("Work").closest("article");
@@ -191,6 +195,21 @@ describe("FoldersWorkspace — list view", () => {
     expect(
       within(ideasCard as HTMLElement).getByText(/0 notes/),
     ).toBeInTheDocument();
+  });
+
+  it("opens the meetings folder before showing meeting notes", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    render(<FoldersWorkspace {...props} />);
+
+    await user.click(screen.getByRole("button", { name: /Meetings/ }));
+
+    expect(
+      screen.getByRole("heading", { name: "Meetings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Roadmap")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Roadmap/ }));
+    expect(props.onSelectNote).toHaveBeenCalledWith("note-1");
   });
 
   it("opens the create dialog and submits name + description", async () => {

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -64,22 +64,15 @@ function baseProps() {
   };
 }
 
-describe("Sidebar — Folders nav item", () => {
-  it("activates the folders view when clicked", async () => {
+describe("Sidebar primary navigation", () => {
+  it("shows Notes instead of Folders in primary navigation", async () => {
     const user = userEvent.setup();
     const onChangeView = vi.fn();
     render(
       <Sidebar
-        folders={folders}
         notes={notes}
-        selectedNoteId={undefined}
-        selectedFolderId={undefined}
         activeView="notes"
         onChangeView={onChangeView}
-        onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
@@ -87,32 +80,9 @@ describe("Sidebar — Folders nav item", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /Folders/ }));
-    expect(onChangeView).toHaveBeenCalledWith("folders");
-  });
-
-  it("does not render the folder count badge", () => {
-    render(
-      <Sidebar
-        folders={folders}
-        notes={notes}
-        selectedNoteId={undefined}
-        selectedFolderId={undefined}
-        activeView="notes"
-        onChangeView={vi.fn()}
-        onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
-        onSelectNote={vi.fn()}
-        onDeleteNote={vi.fn()}
-        onOpenMoveDialog={vi.fn()}
-        onRemoveNoteFromFolder={vi.fn()}
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: /Folders/ });
-    expect(button.textContent?.replace(/\s/g, "")).toBe("Folders");
+    expect(screen.queryByRole("button", { name: /Folders/ })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Notes" }));
+    expect(onChangeView).toHaveBeenCalledWith("notes");
   });
 
   it("renders settings as a sidebar footer action", async () => {
@@ -120,16 +90,9 @@ describe("Sidebar — Folders nav item", () => {
     const onChangeView = vi.fn();
     render(
       <Sidebar
-        folders={folders}
         notes={notes}
-        selectedNoteId={undefined}
-        selectedFolderId={undefined}
         activeView="notes"
         onChangeView={onChangeView}
-        onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
@@ -149,16 +112,9 @@ describe("Sidebar — Folders nav item", () => {
     const onChangeView = vi.fn();
     render(
       <Sidebar
-        folders={folders}
         notes={notes}
-        selectedNoteId={undefined}
-        selectedFolderId={undefined}
         activeView="settings"
         onChangeView={onChangeView}
-        onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
@@ -179,9 +135,7 @@ describe("FoldersWorkspace — list view", () => {
       screen.getByRole("heading", { name: "Folders" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("All notes")).toBeNull();
-    expect(
-      screen.getByRole("button", { name: /Meetings/ }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Notes/ })).toBeInTheDocument();
     expect(screen.queryByText("Roadmap")).toBeNull();
     expect(screen.getByText("Ideas")).toBeInTheDocument();
     expect(screen.getByText("Work")).toBeInTheDocument();
@@ -197,16 +151,14 @@ describe("FoldersWorkspace — list view", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens the meetings folder before showing meeting notes", async () => {
+  it("opens the notes folder before showing saved notes", async () => {
     const user = userEvent.setup();
     const props = baseProps();
     render(<FoldersWorkspace {...props} />);
 
-    await user.click(screen.getByRole("button", { name: /Meetings/ }));
+    await user.click(screen.getByRole("button", { name: /Notes/ }));
 
-    expect(
-      screen.getByRole("heading", { name: "Meetings" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Notes" })).toBeInTheDocument();
     expect(screen.getByText("Roadmap")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Roadmap/ }));
     expect(props.onSelectNote).toHaveBeenCalledWith("note-1");

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -1,6 +1,11 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import {
+  AGENT_NEW_SESSION_EVENT,
+  AGENT_SELECT_SESSION_EVENT,
+  AGENT_SESSIONS_CHANGED_EVENT,
+} from "../components/agent/AgentWorkspace";
 import { NotesList } from "../components/notes-list/NotesList";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import type { FolderDto, NoteListItemDto } from "../lib/tauri";
@@ -34,23 +39,25 @@ const notes: NoteListItemDto[] = [
 ];
 
 describe("folders UI", () => {
-  it("renders notes in the sidebar and filters them", async () => {
+  it("renders the meetings entry and starts agent sessions from the sidebar", async () => {
     const user = userEvent.setup();
-    const onSelectNote = vi.fn();
     const onCreateNote = vi.fn();
+    const onChangeView = vi.fn();
+    const onNewSession = vi.fn();
+    window.addEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
     render(
       <Sidebar
         folders={folders}
         notes={notes}
         selectedNoteId="note-2"
         selectedFolderId={undefined}
-        activeView="notes"
-        onChangeView={vi.fn()}
+        activeView="meetings"
+        onChangeView={onChangeView}
         onCreateFolder={vi.fn()}
         onCreateNote={onCreateNote}
         onSelectAll={vi.fn()}
         onSelectFolder={vi.fn()}
-        onSelectNote={onSelectNote}
+        onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
@@ -58,20 +65,27 @@ describe("folders UI", () => {
     );
 
     expect(screen.getByText("Scribe")).toBeInTheDocument();
-    expect(screen.getByText("Second")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Meetings" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Agent" })).toHaveLength(2);
 
-    await user.type(screen.getByPlaceholderText("Search"), "second");
-    await user.click(screen.getAllByRole("button", { name: /Second/ })[0]);
+    await user.click(screen.getByRole("button", { name: "Meetings" }));
+    await user.click(screen.getByRole("button", { name: "New Session +" }));
 
-    await user.click(screen.getByRole("button", { name: "New note" }));
+    expect(onChangeView).toHaveBeenCalledWith("meetings");
+    expect(onChangeView).toHaveBeenCalledWith("agent");
+    expect(onCreateNote).not.toHaveBeenCalled();
+    await waitFor(() => expect(onNewSession).toHaveBeenCalled());
 
-    expect(onSelectNote).toHaveBeenCalledWith("note-2");
-    expect(onCreateNote).toHaveBeenCalled();
+    window.removeEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
   });
 
-  it("opens the all-notes view from the Notes header actions", async () => {
+  it("renders agent sessions in the sidebar and selects them", async () => {
     const user = userEvent.setup();
     const onChangeView = vi.fn();
+    const onSelectAgentSession = vi.fn();
+    window.addEventListener(AGENT_SELECT_SESSION_EVENT, onSelectAgentSession);
     render(
       <Sidebar
         folders={folders}
@@ -91,39 +105,42 @@ describe("folders UI", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /^Notes/ }));
-    await user.click(screen.getByRole("button", { name: "View all" }));
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, {
+          detail: {
+            sessions: [
+              {
+                id: "session-1",
+                title: "Researching Google",
+                preview: "Generate a PDF",
+                last_active: "2026-06-04T19:00:00Z",
+              },
+            ],
+            selectedSessionId: "session-1",
+            workingSessionIds: ["session-1"],
+          },
+        }),
+      );
+    });
 
-    expect(onChangeView).toHaveBeenCalledWith("all-notes");
-    expect(onChangeView).toHaveBeenCalledTimes(2);
-  });
+    expect(await screen.findByText("Researching Google")).toBeInTheDocument();
+    expect(screen.getByLabelText("Working")).toBeInTheDocument();
 
-  it("opens note actions from right click and deletes", async () => {
-    const user = userEvent.setup();
-    const onDeleteNote = vi.fn();
-    render(
-      <Sidebar
-        folders={folders}
-        notes={notes}
-        selectedNoteId="note-2"
-        selectedFolderId={undefined}
-        activeView="notes"
-        onChangeView={vi.fn()}
-        onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
-        onSelectNote={vi.fn()}
-        onDeleteNote={onDeleteNote}
-        onOpenMoveDialog={vi.fn()}
-        onRemoveNoteFromFolder={vi.fn()}
-      />,
+    await user.click(
+      screen.getByRole("button", { name: /Researching Google/ }),
     );
 
-    fireEvent.contextMenu(screen.getByText("Second").closest("article")!);
-    await user.click(screen.getByRole("menuitem", { name: "Delete note" }));
+    expect(onChangeView).toHaveBeenCalledWith("agent");
+    await waitFor(() => expect(onSelectAgentSession).toHaveBeenCalled());
+    const detail = (onSelectAgentSession.mock.calls[0][0] as CustomEvent)
+      .detail;
+    expect(detail).toEqual({ sessionId: "session-1" });
 
-    expect(onDeleteNote).toHaveBeenCalledWith("note-2");
+    window.removeEventListener(
+      AGENT_SELECT_SESSION_EVENT,
+      onSelectAgentSession,
+    );
   });
 
   it("shows notes with placeholders and selects notes", async () => {

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -54,7 +54,7 @@ describe("folders UI", () => {
     expect(screen.getByText("Scribe")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Notes" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Folders" })).toBeNull();
-    expect(screen.getAllByRole("button", { name: "Agent" })).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Agent" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Notes" }));
     await user.click(screen.getByRole("button", { name: "New Session" }));

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -57,7 +57,7 @@ describe("folders UI", () => {
     expect(screen.getAllByRole("button", { name: "Agent" })).toHaveLength(2);
 
     await user.click(screen.getByRole("button", { name: "Notes" }));
-    await user.click(screen.getByRole("button", { name: "New Session +" }));
+    await user.click(screen.getByRole("button", { name: "New Session" }));
 
     expect(onChangeView).toHaveBeenCalledWith("notes");
     expect(onChangeView).toHaveBeenCalledWith("agent");

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -8,14 +8,9 @@ import {
 } from "../components/agent/AgentWorkspace";
 import { NotesList } from "../components/notes-list/NotesList";
 import { Sidebar } from "../components/sidebar/Sidebar";
-import type { FolderDto, NoteListItemDto } from "../lib/tauri";
+import type { NoteListItemDto } from "../lib/tauri";
 
 const now = "2026-05-19T10:00:00Z";
-
-const folders: FolderDto[] = [
-  { id: "folder-1", name: "Ideas", createdAt: now, updatedAt: now },
-  { id: "folder-2", name: "Work", createdAt: now, updatedAt: now },
-];
 
 const notes: NoteListItemDto[] = [
   {
@@ -39,24 +34,16 @@ const notes: NoteListItemDto[] = [
 ];
 
 describe("folders UI", () => {
-  it("renders the meetings entry and starts agent sessions from the sidebar", async () => {
+  it("renders the notes entry and starts agent sessions from the sidebar", async () => {
     const user = userEvent.setup();
-    const onCreateNote = vi.fn();
     const onChangeView = vi.fn();
     const onNewSession = vi.fn();
     window.addEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
     render(
       <Sidebar
-        folders={folders}
         notes={notes}
-        selectedNoteId="note-2"
-        selectedFolderId={undefined}
-        activeView="meetings"
+        activeView="notes"
         onChangeView={onChangeView}
-        onCreateFolder={vi.fn()}
-        onCreateNote={onCreateNote}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
@@ -65,17 +52,15 @@ describe("folders UI", () => {
     );
 
     expect(screen.getByText("Scribe")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Meetings" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Notes" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Folders" })).toBeNull();
     expect(screen.getAllByRole("button", { name: "Agent" })).toHaveLength(2);
 
-    await user.click(screen.getByRole("button", { name: "Meetings" }));
+    await user.click(screen.getByRole("button", { name: "Notes" }));
     await user.click(screen.getByRole("button", { name: "New Session +" }));
 
-    expect(onChangeView).toHaveBeenCalledWith("meetings");
+    expect(onChangeView).toHaveBeenCalledWith("notes");
     expect(onChangeView).toHaveBeenCalledWith("agent");
-    expect(onCreateNote).not.toHaveBeenCalled();
     await waitFor(() => expect(onNewSession).toHaveBeenCalled());
 
     window.removeEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
@@ -88,16 +73,9 @@ describe("folders UI", () => {
     window.addEventListener(AGENT_SELECT_SESSION_EVENT, onSelectAgentSession);
     render(
       <Sidebar
-        folders={folders}
         notes={notes}
-        selectedNoteId="note-2"
-        selectedFolderId={undefined}
         activeView="notes"
         onChangeView={onChangeView}
-        onCreateFolder={vi.fn()}
-        onCreateNote={vi.fn()}
-        onSelectAll={vi.fn()}
-        onSelectFolder={vi.fn()}
         onSelectNote={vi.fn()}
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}


### PR DESCRIPTION
## Summary
- move agent sessions into the sidebar with deterministic New Session behavior
- restore Notes as the primary notes view and simplify folder navigation
- move Hermes skills, messaging, workspace, and memory management into Settings > Agent

## Review
- Security: no new raw HTML injection, eval, dynamic script execution, or direct filesystem mutation paths were added in the frontend; Hermes files are read through existing Tauri bridge snapshot commands and filtered to Workspace/Memory in settings.
- Quality: New Session now uses explicit pending/new-session state to avoid async auto-selection races; settings tabs are real panels; tests cover sidebar session selection, new-session behavior, and Agent settings files filtering.

## Tests
- pnpm run lint
- pnpm run test
- pnpm run build
- cargo test --manifest-path src-tauri/Cargo.toml
