### PR TITLE
[codex] Harden Scribe API inputs and logs

### DIFF
--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -1,6 +1,6 @@
 use crate::{
     auth::authenticated_user, error::ApiError, handlers::notes::require_priced_model,
-    state::ApiState,
+    state::ApiState, validation,
 };
 use axum::{
     Json,
@@ -24,6 +24,8 @@ pub(crate) async fn chat_completions(
         .filter(|value| !value.is_empty())
         .ok_or_else(|| ApiError::bad_request("model_required"))?
         .to_string();
+    validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
+    validation::validate_agent_chat_body(&body)?;
     require_priced_model(&state, &model_id)?;
     if let Some(object) = body.as_object_mut() {
         object.insert(

--- a/scribe-api/crates/api/src/handlers/dictate.rs
+++ b/scribe-api/crates/api/src/handlers/dictate.rs
@@ -6,6 +6,7 @@ use crate::{
     handlers::notes::{require_priced_model, required},
     multipart::MultipartFields,
     state::ApiState,
+    validation,
 };
 use axum::{
     Json,
@@ -29,7 +30,18 @@ pub(crate) async fn transcribe(
     let audio = form.required_audio()?;
     validate_audio(&audio)?;
     let model_id = form.required_text("model")?;
+    validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
     require_priced_model(&state, &model_id)?;
+    let session_id = form.required_text("sessionId")?;
+    validation::validate_text_len("session_id", &session_id, validation::MAX_ID_CHARS)?;
+    let utterance_id = form.required_text("utteranceId")?;
+    validation::validate_text_len("utterance_id", &utterance_id, validation::MAX_ID_CHARS)?;
+    let context = form.optional_text("context");
+    validation::validate_optional_text_len(
+        "context",
+        context.as_deref(),
+        validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
+    )?;
     let filename = form
         .take_filename()
         .unwrap_or_else(|| "dictation.wav".to_string());
@@ -37,11 +49,11 @@ pub(crate) async fn transcribe(
         .dictate()
         .transcribe(DictateTranscribeParams {
             user_id,
-            session_id: form.required_text("sessionId")?,
-            utterance_id: form.required_text("utteranceId")?,
+            session_id,
+            utterance_id,
             audio,
             filename,
-            context: form.optional_text("context"),
+            context,
             model_id: ModelId(model_id),
         })
         .await?;
@@ -56,7 +68,9 @@ pub(crate) async fn cleanup(
     Json(request): Json<DictateCleanupRequest>,
 ) -> Result<Json<ApiResponse<DictateCleanupResponse>>, ApiError> {
     let user_id = authenticated_user(&state, &headers).await?;
+    request.validate()?;
     let model_id = required(request.model, "model_required")?;
+    validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
     require_priced_model(&state, &model_id)?;
     let output = state
         .dictate()
@@ -71,6 +85,29 @@ pub(crate) async fn cleanup(
         })
         .await?;
     Ok(Json(ApiResponse::ok(DictateCleanupResponse::from(output))))
+}
+
+impl DictateCleanupRequest {
+    fn validate(&self) -> Result<(), ApiError> {
+        validation::validate_optional_text_len(
+            "session_id",
+            self.session_id.as_deref(),
+            validation::MAX_ID_CHARS,
+        )?;
+        validation::validate_optional_text_len(
+            "utterance_id",
+            self.utterance_id.as_deref(),
+            validation::MAX_ID_CHARS,
+        )?;
+        validation::validate_text_len("text", &self.text, validation::MAX_DICTATION_TEXT_CHARS)?;
+        validation::validate_optional_text_len(
+            "dictionary_context",
+            self.dictionary_context.as_deref(),
+            validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
+        )?;
+        validation::validate_text_len("style", &self.style, validation::MAX_DICTATION_STYLE_CHARS)?;
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -1,6 +1,6 @@
 use crate::{
     audio::validate_audio, auth::authenticated_user, envelope::ApiResponse, error::ApiError,
-    multipart::MultipartFields, state::ApiState,
+    multipart::MultipartFields, state::ApiState, validation,
 };
 use axum::{
     Json,
@@ -24,7 +24,18 @@ pub(crate) async fn transcribe(
     let audio = form.required_audio()?;
     validate_audio(&audio)?;
     let model_id = form.required_text("model")?;
+    validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
     require_priced_model(&state, &model_id)?;
+    let title = form.required_text("title")?;
+    validation::validate_text_len("title", &title, validation::MAX_TITLE_CHARS)?;
+    let context = form.optional_text("context");
+    validation::validate_optional_text_len(
+        "context",
+        context.as_deref(),
+        validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
+    )?;
+    let note_id = form.required_text("noteId")?;
+    validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;
     let filename = form
         .take_filename()
         .unwrap_or_else(|| "recording.wav".to_string());
@@ -32,11 +43,11 @@ pub(crate) async fn transcribe(
         .note_transcribe()
         .transcribe(NoteTranscribeParams {
             user_id,
-            note_id: form.required_text("noteId")?,
+            note_id,
             audio,
             filename,
-            title: form.required_text("title")?,
-            context: form.optional_text("context"),
+            title,
+            context,
             model_id: ModelId(model_id),
         })
         .await?;
@@ -49,7 +60,9 @@ pub(crate) async fn generate(
     Json(request): Json<GenerateRequest>,
 ) -> Result<Json<ApiResponse<GenerateResponse>>, ApiError> {
     let user_id = authenticated_user(&state, &headers).await?;
+    request.validate()?;
     let model_id = required(request.model, "model_required")?;
+    validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
     require_priced_model(&state, &model_id)?;
     let output = state
         .note_generate()
@@ -66,6 +79,43 @@ pub(crate) async fn generate(
         })
         .await?;
     Ok(Json(ApiResponse::ok(GenerateResponse::from(output))))
+}
+
+impl GenerateRequest {
+    fn validate(&self) -> Result<(), ApiError> {
+        validation::validate_optional_text_len(
+            "note_id",
+            self.note_id.as_deref(),
+            validation::MAX_ID_CHARS,
+        )?;
+        validation::validate_optional_text_len(
+            "prompt_version",
+            self.prompt_version.as_deref(),
+            validation::MAX_ID_CHARS,
+        )?;
+        validation::validate_text_len("title", &self.title, validation::MAX_TITLE_CHARS)?;
+        validation::validate_text_len(
+            "transcript",
+            &self.transcript,
+            validation::MAX_NOTE_TRANSCRIPT_CHARS,
+        )?;
+        validation::validate_optional_text_len(
+            "manual_notes",
+            self.manual_notes.as_deref(),
+            validation::MAX_NOTE_MANUAL_NOTES_CHARS,
+        )?;
+        validation::validate_optional_text_len(
+            "language",
+            self.language.as_deref(),
+            validation::MAX_LANGUAGE_CHARS,
+        )?;
+        validation::validate_optional_text_len(
+            "existing_generated_note",
+            self.existing_generated_note.as_deref(),
+            validation::MAX_EXISTING_NOTE_CHARS,
+        )?;
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 mod handlers;
 mod multipart;
 mod state;
+mod validation;
 
 use axum::{
     Router,

--- a/scribe-api/crates/api/src/validation.rs
+++ b/scribe-api/crates/api/src/validation.rs
@@ -58,6 +58,9 @@ fn validate_output_tokens(value: Option<&Value>, field: &str) -> Result<(), ApiE
     let Some(value) = value else {
         return Ok(());
     };
+    if value.is_null() {
+        return Ok(());
+    }
     let Some(tokens) = value.as_u64() else {
         return Err(ApiError::bad_request(format!("{field}_invalid")));
     };
@@ -137,6 +140,31 @@ mod tests {
             }))
             .is_err()
         );
+    }
+
+    #[test]
+    fn agent_body_accepts_null_output_tokens() {
+        assert!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": [{ "role": "user", "content": "hello" }],
+                "max_tokens": null,
+                "max_completion_tokens": null,
+            }))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn agent_body_rejects_negative_output_tokens() {
+        assert!(matches!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": [{ "role": "user", "content": "hello" }],
+                "max_tokens": -1,
+            })),
+            Err(ApiError::BadRequest { message, .. }) if message == "max_tokens_invalid"
+        ));
     }
 
     #[test]

--- a/scribe-api/crates/api/src/validation.rs
+++ b/scribe-api/crates/api/src/validation.rs
@@ -1,0 +1,154 @@
+use crate::error::ApiError;
+use serde_json::Value;
+
+pub(crate) const MAX_ID_CHARS: usize = 128;
+pub(crate) const MAX_MODEL_CHARS: usize = 128;
+pub(crate) const MAX_TITLE_CHARS: usize = 512;
+pub(crate) const MAX_LANGUAGE_CHARS: usize = 64;
+pub(crate) const MAX_TRANSCRIPTION_CONTEXT_CHARS: usize = 20_000;
+pub(crate) const MAX_NOTE_TRANSCRIPT_CHARS: usize = 200_000;
+pub(crate) const MAX_NOTE_MANUAL_NOTES_CHARS: usize = 50_000;
+pub(crate) const MAX_EXISTING_NOTE_CHARS: usize = 200_000;
+pub(crate) const MAX_DICTATION_TEXT_CHARS: usize = 20_000;
+pub(crate) const MAX_DICTATION_STYLE_CHARS: usize = 4_000;
+pub(crate) const MAX_AGENT_MESSAGES: usize = 64;
+pub(crate) const MAX_AGENT_STRING_CHARS: usize = 100_000;
+pub(crate) const MAX_AGENT_TOTAL_STRING_CHARS: usize = 240_000;
+pub(crate) const MAX_AGENT_JSON_DEPTH: usize = 16;
+pub(crate) const MAX_AGENT_OUTPUT_TOKENS: u64 = 8_192;
+
+pub(crate) fn validate_text_len(
+    field: &str,
+    value: &str,
+    max_chars: usize,
+) -> Result<(), ApiError> {
+    if value.chars().count() > max_chars {
+        return Err(ApiError::bad_request(format!("{field}_too_long")));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_optional_text_len(
+    field: &str,
+    value: Option<&str>,
+    max_chars: usize,
+) -> Result<(), ApiError> {
+    if let Some(value) = value {
+        validate_text_len(field, value, max_chars)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_agent_chat_body(body: &Value) -> Result<(), ApiError> {
+    let Some(object) = body.as_object() else {
+        return Err(ApiError::bad_request("invalid_chat_completion_body"));
+    };
+    if let Some(messages) = object.get("messages").and_then(Value::as_array)
+        && messages.len() > MAX_AGENT_MESSAGES
+    {
+        return Err(ApiError::bad_request("messages_too_many"));
+    }
+    validate_output_tokens(object.get("max_tokens"), "max_tokens")?;
+    validate_output_tokens(object.get("max_completion_tokens"), "max_completion_tokens")?;
+    let mut total_string_chars = 0usize;
+    validate_json_shape(body, 0, &mut total_string_chars)
+}
+
+fn validate_output_tokens(value: Option<&Value>, field: &str) -> Result<(), ApiError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let Some(tokens) = value.as_u64() else {
+        return Err(ApiError::bad_request(format!("{field}_invalid")));
+    };
+    if tokens > MAX_AGENT_OUTPUT_TOKENS {
+        return Err(ApiError::bad_request(format!("{field}_too_large")));
+    }
+    Ok(())
+}
+
+fn validate_json_shape(
+    value: &Value,
+    depth: usize,
+    total_string_chars: &mut usize,
+) -> Result<(), ApiError> {
+    if depth > MAX_AGENT_JSON_DEPTH {
+        return Err(ApiError::bad_request("json_too_deep"));
+    }
+    match value {
+        Value::String(text) => {
+            let chars = text.chars().count();
+            if chars > MAX_AGENT_STRING_CHARS {
+                return Err(ApiError::bad_request("string_too_long"));
+            }
+            *total_string_chars = total_string_chars.saturating_add(chars);
+            if *total_string_chars > MAX_AGENT_TOTAL_STRING_CHARS {
+                return Err(ApiError::bad_request("prompt_too_long"));
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                validate_json_shape(item, depth + 1, total_string_chars)?;
+            }
+        }
+        Value::Object(object) => {
+            for value in object.values() {
+                validate_json_shape(value, depth + 1, total_string_chars)?;
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn text_length_rejects_over_limit_values() {
+        assert!(validate_text_len("title", "abc", 3).is_ok());
+        assert!(validate_text_len("title", "abcd", 3).is_err());
+    }
+
+    #[test]
+    fn agent_body_rejects_too_many_messages() {
+        let messages = (0..=MAX_AGENT_MESSAGES)
+            .map(|_| json!({ "role": "user", "content": "hello" }))
+            .collect::<Vec<_>>();
+
+        assert!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": messages,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn agent_body_rejects_excessive_output_tokens() {
+        assert!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": [{ "role": "user", "content": "hello" }],
+                "max_tokens": MAX_AGENT_OUTPUT_TOKENS + 1,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn agent_body_rejects_aggregate_prompt_strings() {
+        let text = "a".repeat(MAX_AGENT_TOTAL_STRING_CHARS + 1);
+
+        assert!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": [{ "role": "user", "content": text }],
+            }))
+            .is_err()
+        );
+    }
+}

--- a/scribe-api/crates/providers/src/openai.rs
+++ b/scribe-api/crates/providers/src/openai.rs
@@ -60,7 +60,7 @@ impl Transcriber for OpenAiTranscriber {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            tracing::error!(%status, %url, model = %model_id, body = %body, "openai: non-success response");
+            tracing::error!(%status, %url, model = %model_id, body_bytes = body.len(), "openai: non-success response");
             return Err(DomainError::UpstreamProvider);
         }
         let parsed = response

--- a/scribe-api/crates/providers/src/os_accounts.rs
+++ b/scribe-api/crates/providers/src/os_accounts.rs
@@ -54,16 +54,15 @@ impl OsAccountsClient for OsAccountsHttpClient {
         let status = response.status();
         if status.is_server_error() {
             let body = response.text().await.unwrap_or_default();
-            tracing::error!(%status, %url, body = %body, "os_accounts: authorize server error");
+            tracing::error!(%status, %url, body_bytes = body.len(), "os_accounts: authorize server error");
             return Err(DomainError::UpstreamProvider);
         }
-        // Read body once so we can both parse and log it on failure.
         let raw = response.text().await.map_err(|error| {
             tracing::error!(%error, %url, "os_accounts: authorize body read failed");
             DomainError::UpstreamProvider
         })?;
         let envelope: Envelope<AuthorizationWire> = serde_json::from_str(&raw).map_err(|error| {
-            tracing::error!(%error, %url, body = %raw, "os_accounts: authorize JSON parse failed");
+            tracing::error!(%error, %url, body_bytes = raw.len(), "os_accounts: authorize JSON parse failed");
             DomainError::UpstreamProvider
         })?;
         if envelope.success {
@@ -71,7 +70,7 @@ impl OsAccountsClient for OsAccountsHttpClient {
                 .data
                 .map(Authorization::from)
                 .ok_or_else(|| {
-                    tracing::error!(%url, body = %raw, "os_accounts: authorize success envelope missing data");
+                    tracing::error!(%url, body_bytes = raw.len(), "os_accounts: authorize success envelope missing data");
                     DomainError::UpstreamProvider
                 })?;
             tracing::info!(
@@ -92,7 +91,13 @@ impl OsAccountsClient for OsAccountsHttpClient {
                 reason: Some("insufficient_available_balance".to_string()),
             });
         }
-        tracing::error!(%status, %url, body = %raw, "os_accounts: authorize denied");
+        tracing::error!(
+            %status,
+            %url,
+            body_bytes = raw.len(),
+            error_code = ?envelope.error_code,
+            "os_accounts: authorize denied"
+        );
         Err(DomainError::UpstreamProvider)
     }
 
@@ -133,7 +138,7 @@ impl OsAccountsHttpClient {
         let status = response.status();
         if status.is_server_error() {
             let body = response.text().await.unwrap_or_default();
-            tracing::error!(%status, %url, body = %body, "os_accounts: charge server error (retryable)");
+            tracing::error!(%status, %url, body_bytes = body.len(), "os_accounts: charge server error (retryable)");
             return Err(ChargeError::Retryable);
         }
         let raw = response.text().await.map_err(|error| {
@@ -141,7 +146,7 @@ impl OsAccountsHttpClient {
             ChargeError::Domain(DomainError::UpstreamProvider)
         })?;
         let envelope: Envelope<ReceiptWire> = serde_json::from_str(&raw).map_err(|error| {
-            tracing::error!(%error, %url, body = %raw, "os_accounts: charge JSON parse failed");
+            tracing::error!(%error, %url, body_bytes = raw.len(), "os_accounts: charge JSON parse failed");
             ChargeError::Domain(DomainError::UpstreamProvider)
         })?;
         if envelope.success {
@@ -149,12 +154,12 @@ impl OsAccountsHttpClient {
                 .data
                 .map(Receipt::from)
                 .ok_or_else(|| {
-                    tracing::error!(%url, body = %raw, "os_accounts: charge success envelope missing data");
+                    tracing::error!(%url, body_bytes = raw.len(), "os_accounts: charge success envelope missing data");
                     ChargeError::Domain(DomainError::UpstreamProvider)
                 });
         }
         if envelope.error_code == Some(ERR_INSUFFICIENT_CREDITS) {
-            tracing::warn!(%url, body = %raw, "os_accounts: charge denied — insufficient credits");
+            tracing::warn!(%url, body_bytes = raw.len(), "os_accounts: charge denied — insufficient credits");
             return Err(ChargeError::Domain(DomainError::InsufficientCredits));
         }
         if envelope.error_code == Some(ERR_IDEMPOTENCY_KEY_COLLISION) {
@@ -169,7 +174,7 @@ impl OsAccountsHttpClient {
             // value and the original settlement is visible to accounting/audit.
             tracing::warn!(
                 %url,
-                body = %raw,
+                body_bytes = raw.len(),
                 reported_credits = body.credits,
                 "os_accounts: charge replayed — idempotency key already settled; \
                  credits_charged reflects the requested estimate, not the settled amount"
@@ -179,7 +184,13 @@ impl OsAccountsHttpClient {
                 idempotent_replay: true,
             });
         }
-        tracing::error!(%status, %url, body = %raw, "os_accounts: charge denied");
+        tracing::error!(
+            %status,
+            %url,
+            body_bytes = raw.len(),
+            error_code = ?envelope.error_code,
+            "os_accounts: charge denied"
+        );
         Err(ChargeError::Domain(DomainError::UpstreamProvider))
     }
 }

--- a/scribe-api/crates/providers/src/venice.rs
+++ b/scribe-api/crates/providers/src/venice.rs
@@ -58,7 +58,7 @@ impl VeniceModelCatalog {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            tracing::warn!(%status, %url, model_type, body = %body, "venice: model catalog non-success response");
+            tracing::warn!(%status, %url, model_type, body_bytes = body.len(), "venice: model catalog non-success response");
             return Err(DomainError::UpstreamProvider);
         }
         response
@@ -117,7 +117,7 @@ impl Transcriber for VeniceTranscriber {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            tracing::error!(%status, %url, model = %model_id, body = %body, "venice: non-success response");
+            tracing::error!(%status, %url, model = %model_id, body_bytes = body.len(), "venice: non-success response");
             return Err(DomainError::UpstreamProvider);
         }
         let parsed = response
@@ -358,12 +358,11 @@ impl VeniceChat {
             DomainError::UpstreamProvider
         })?;
         if !status.is_success() {
-            let body_preview = String::from_utf8_lossy(&body);
             tracing::error!(
                 %status,
                 %url,
                 model = %model.0,
-                body = %body_preview,
+                body_bytes = body.len(),
                 "venice: agent chat non-success response"
             );
             return Err(DomainError::UpstreamProvider);


### PR DESCRIPTION
## Summary

Hardens Scribe API request boundaries and provider logging without changing the accepted billing cap behavior.

- Adds field-level request validation for note generation, dictation cleanup, transcription metadata/context, and raw agent chat bodies.
- Bounds agent chat message count, JSON depth, aggregate prompt strings, and requested output tokens.
- Redacts raw upstream response bodies from OpenAI, Venice, and OS Accounts logs, retaining status, URL, model/action context, byte length, and structured error codes where available.
- Adds unit coverage for the new validation helpers.

## Why

The previous API relied mostly on coarse route body limits. Large prompt fields and raw chat payloads could still drive expensive or slow upstream calls within the body cap. Provider error logging also included raw upstream bodies that may contain transcript, prompt, token, or billing details.

## Validation

- `cargo test` from `scribe-api/`
- `cargo clippy --all-targets -- -D warnings` from `scribe-api/`
- `rg -n "body = %|body = \\?|body_preview|%raw|%body" scribe-api/crates/providers/src` returned no matches