### PR TITLE
[codex] Harden legacy billing and Calendar auth

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -65,5 +65,12 @@
     "typescript": "^5",
     "vitest": "^4.1.6",
     "wait-on": "^9.0.10"
+  },
+  "pnpm": {
+    "overrides": {
+      "@hono/node-server": "1.19.13",
+      "hono": "4.12.21",
+      "postcss": "8.5.10"
+    }
   }
 }

--- a/legacy/pnpm-lock.yaml
+++ b/legacy/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@hono/node-server': 1.19.13
+  hono: 4.12.21
+  postcss: 8.5.10
+
 importers:
 
   .:
@@ -534,11 +539,11 @@ packages:
   '@hapi/topo@6.0.2':
     resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.21
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -590,105 +595,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -776,28 +765,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -1002,42 +987,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -1123,28 +1102,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1366,49 +1341,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2484,8 +2451,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -2823,28 +2790,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3202,12 +3165,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres@3.4.7:
@@ -4457,9 +4416,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
 
-  '@hono/node-server@1.19.11(hono@4.12.18)':
+  '@hono/node-server@1.19.13(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4704,13 +4663,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.21)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.18
+      hono: 4.12.21
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -4956,7 +4915,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.14
+      postcss: 8.5.10
       tailwindcss: 4.3.0
 
   '@testing-library/dom@10.4.1':
@@ -6566,7 +6525,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -7066,7 +7025,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -7261,13 +7220,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.14:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -8023,7 +7976,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.10
       rolldown: 1.0.0
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/legacy/pnpm-workspace.yaml
+++ b/legacy/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 onlyBuiltDependencies:
   - '@prisma/engines'
   - better-sqlite3

--- a/legacy/src/app/api/calendar/callback/route.ts
+++ b/legacy/src/app/api/calendar/callback/route.ts
@@ -1,15 +1,41 @@
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/db";
 import { getCalendarProvider } from "@/lib/providers/calendar";
+import { requireUser } from "@/lib/auth";
+import { verifyCalendarOAuthState } from "@/lib/calendar-oauth-state";
+import { encryptedCalendarTokens } from "@/lib/calendar-tokens";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const code = url.searchParams.get("code");
-  const workspaceId = url.searchParams.get("state");
+  const state = url.searchParams.get("state");
   const appUrl = process.env.APP_URL ?? "http://localhost:3000";
 
-  if (!code || !workspaceId) {
+  if (!code || !state) {
     redirect(`${appUrl}?calendar=missing_code`);
+  }
+
+  let statePayload: ReturnType<typeof verifyCalendarOAuthState>;
+  try {
+    statePayload = verifyCalendarOAuthState(state);
+  } catch {
+    redirect(`${appUrl}?calendar=invalid_state`);
+  }
+
+  let user: Awaited<ReturnType<typeof requireUser>>;
+  try {
+    user = await requireUser();
+  } catch {
+    redirect(`${appUrl}?calendar=invalid_state`);
+  }
+  if (statePayload.userId !== user.id) {
+    redirect(`${appUrl}?calendar=invalid_state`);
+  }
+  const membership = await prisma.membership.findFirst({
+    where: { userId: user.id, workspaceId: statePayload.workspaceId },
+  });
+  if (!membership) {
+    redirect(`${appUrl}?calendar=invalid_state`);
   }
 
   const provider = getCalendarProvider();
@@ -18,13 +44,14 @@ export async function GET(request: Request) {
   }
 
   const connected = await provider.connectWithCode(code);
+  const tokens = encryptedCalendarTokens(connected);
   await prisma.calendarConnection.upsert({
-    where: { workspaceId },
+    where: { workspaceId: statePayload.workspaceId },
     update: {
       provider: connected.provider,
       providerUserId: connected.providerUserId,
-      accessToken: connected.accessToken,
-      refreshToken: connected.refreshToken,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
       expiresAt: connected.expiresAt,
       events: {
         deleteMany: {},
@@ -32,11 +59,11 @@ export async function GET(request: Request) {
       },
     },
     create: {
-      workspaceId,
+      workspaceId: statePayload.workspaceId,
       provider: connected.provider,
       providerUserId: connected.providerUserId,
-      accessToken: connected.accessToken,
-      refreshToken: connected.refreshToken,
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
       expiresAt: connected.expiresAt,
       events: { create: connected.events },
     },

--- a/legacy/src/app/api/calendar/connect/route.ts
+++ b/legacy/src/app/api/calendar/connect/route.ts
@@ -2,25 +2,30 @@ import { getCalendarProvider } from "@/lib/providers/calendar";
 import { prisma } from "@/lib/db";
 import { handleRoute } from "@/lib/http";
 import { getWorkspaceContext } from "@/lib/workspace";
+import { createCalendarOAuthState } from "@/lib/calendar-oauth-state";
+import { encryptedCalendarTokens } from "@/lib/calendar-tokens";
 
 export async function POST() {
   return handleRoute(async () => {
     const { user, workspace } = await getWorkspaceContext();
     const provider = getCalendarProvider();
     if (provider.getAuthorizationUrl) {
-      const authorizationUrl = provider.getAuthorizationUrl(workspace.id);
+      const authorizationUrl = provider.getAuthorizationUrl(
+        createCalendarOAuthState({ userId: user.id, workspaceId: workspace.id }),
+      );
       return { authorizationUrl };
     }
 
     const connected = await provider.connect(user.email);
+    const tokens = encryptedCalendarTokens(connected);
 
     const connection = await prisma.calendarConnection.upsert({
       where: { workspaceId: workspace.id },
       update: {
         provider: connected.provider,
         providerUserId: connected.providerUserId,
-        accessToken: connected.accessToken,
-        refreshToken: connected.refreshToken,
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
         expiresAt: connected.expiresAt,
         events: {
           deleteMany: {},
@@ -31,8 +36,8 @@ export async function POST() {
         workspaceId: workspace.id,
         provider: connected.provider,
         providerUserId: connected.providerUserId,
-        accessToken: connected.accessToken,
-        refreshToken: connected.refreshToken,
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
         expiresAt: connected.expiresAt,
         events: { create: connected.events },
       },

--- a/legacy/src/lib/calendar-oauth-state.test.ts
+++ b/legacy/src/lib/calendar-oauth-state.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createCalendarOAuthState, verifyCalendarOAuthState } from "@/lib/calendar-oauth-state";
+
+describe("calendar OAuth state", () => {
+  afterEach(() => {
+    delete process.env.CALENDAR_OAUTH_STATE_SECRET;
+  });
+
+  it("round-trips signed user and workspace state", () => {
+    process.env.CALENDAR_OAUTH_STATE_SECRET = "state-secret";
+    const state = createCalendarOAuthState({
+      userId: "user_1",
+      workspaceId: "workspace_1",
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+
+    expect(verifyCalendarOAuthState(state, new Date("2026-06-01T00:05:00Z"))).toMatchObject({
+      userId: "user_1",
+      workspaceId: "workspace_1",
+    });
+  });
+
+  it("rejects tampered state", () => {
+    process.env.CALENDAR_OAUTH_STATE_SECRET = "state-secret";
+    const state = createCalendarOAuthState({ userId: "user_1", workspaceId: "workspace_1" });
+    const [payload, signature] = state.split(".");
+    const tampered = `${Buffer.from(JSON.stringify({ v: 1, userId: "user_1", workspaceId: "other", exp: 9999999999, nonce: "n" })).toString("base64url")}.${signature}`;
+
+    expect(payload).toBeTruthy();
+    expect(() => verifyCalendarOAuthState(tampered)).toThrow("Invalid calendar OAuth state");
+  });
+
+  it("rejects expired state", () => {
+    process.env.CALENDAR_OAUTH_STATE_SECRET = "state-secret";
+    const state = createCalendarOAuthState({
+      userId: "user_1",
+      workspaceId: "workspace_1",
+      now: new Date("2026-06-01T00:00:00Z"),
+    });
+
+    expect(() => verifyCalendarOAuthState(state, new Date("2026-06-01T00:11:00Z"))).toThrow(
+      "Expired calendar OAuth state",
+    );
+  });
+});

--- a/legacy/src/lib/calendar-oauth-state.ts
+++ b/legacy/src/lib/calendar-oauth-state.ts
@@ -1,0 +1,61 @@
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
+
+const STATE_TTL_SECONDS = 10 * 60;
+
+type CalendarOAuthStatePayload = {
+  v: 1;
+  userId: string;
+  workspaceId: string;
+  exp: number;
+  nonce: string;
+};
+
+export function createCalendarOAuthState(input: { userId: string; workspaceId: string; now?: Date }) {
+  const now = input.now ?? new Date();
+  const payload: CalendarOAuthStatePayload = {
+    v: 1,
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    exp: Math.floor(now.getTime() / 1000) + STATE_TTL_SECONDS,
+    nonce: randomBytes(16).toString("base64url"),
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return `${encodedPayload}.${sign(encodedPayload)}`;
+}
+
+export function verifyCalendarOAuthState(state: string, now = new Date()) {
+  const [encodedPayload, signature] = state.split(".");
+  if (!encodedPayload || !signature || state.split(".").length !== 2) {
+    throw new Error("Invalid calendar OAuth state");
+  }
+  if (!constantTimeEqual(signature, sign(encodedPayload))) {
+    throw new Error("Invalid calendar OAuth state");
+  }
+  const payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8")) as CalendarOAuthStatePayload;
+  if (payload.v !== 1 || !payload.userId || !payload.workspaceId || !payload.exp) {
+    throw new Error("Invalid calendar OAuth state");
+  }
+  if (payload.exp < Math.floor(now.getTime() / 1000)) {
+    throw new Error("Expired calendar OAuth state");
+  }
+  return payload;
+}
+
+function sign(payload: string) {
+  return createHmac("sha256", stateSecret()).update(payload).digest("base64url");
+}
+
+function stateSecret() {
+  const secret =
+    process.env.CALENDAR_OAUTH_STATE_SECRET || process.env.APP_ENCRYPTION_KEY || process.env.OPEN_NOTEPAD_SECRET;
+  if (!secret) {
+    throw new Error("CALENDAR_OAUTH_STATE_SECRET is required for Google Calendar OAuth");
+  }
+  return secret;
+}
+
+function constantTimeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}

--- a/legacy/src/lib/calendar-tokens.ts
+++ b/legacy/src/lib/calendar-tokens.ts
@@ -1,0 +1,9 @@
+import { encryptSecret } from "@/lib/crypto";
+import type { CalendarConnectionResult } from "@/lib/providers/calendar";
+
+export function encryptedCalendarTokens(connected: CalendarConnectionResult) {
+  return {
+    accessToken: connected.accessToken ? encryptSecret(connected.accessToken) : undefined,
+    refreshToken: connected.refreshToken ? encryptSecret(connected.refreshToken) : undefined,
+  };
+}

--- a/legacy/src/lib/crypto.ts
+++ b/legacy/src/lib/crypto.ts
@@ -9,7 +9,7 @@ function encryptionKey() {
     process.env.OPEN_NOTEPAD_SECRET;
 
   if (!secret) {
-    throw new Error("TRANSCRIPTION_SETTINGS_ENCRYPTION_KEY is required to save transcription API keys");
+    throw new Error("APP_ENCRYPTION_KEY is required to save encrypted secrets");
   }
 
   if (/^[a-f0-9]{64}$/i.test(secret)) {

--- a/legacy/src/lib/providers/billing.test.ts
+++ b/legacy/src/lib/providers/billing.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHmac } from "crypto";
 import { MockBillingProvider, StripeBillingProvider } from "@/lib/providers/billing";
 
 describe("MockBillingProvider", () => {
@@ -72,20 +73,23 @@ describe("StripeBillingProvider", () => {
   });
 
   it("parses checkout completion webhook payloads", async () => {
-    const provider = new StripeBillingProvider("sk_test_123", "price_123");
+    const webhookSecret = "whsec_test";
+    const provider = new StripeBillingProvider("sk_test_123", "price_123", webhookSecret);
+    const payload = JSON.stringify({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_123",
+          client_reference_id: "workspace_1",
+          customer: "cus_123",
+          subscription: "sub_123",
+        },
+      },
+    });
     const request = new Request("http://localhost/api/billing/webhook", {
       method: "POST",
-      body: JSON.stringify({
-        type: "checkout.session.completed",
-        data: {
-          object: {
-            id: "cs_test_123",
-            client_reference_id: "workspace_1",
-            customer: "cus_123",
-            subscription: "sub_123",
-          },
-        },
-      }),
+      headers: { "stripe-signature": stripeSignature(payload, webhookSecret) },
+      body: payload,
     });
 
     await expect(provider.parseWebhook(request)).resolves.toMatchObject({
@@ -96,4 +100,20 @@ describe("StripeBillingProvider", () => {
       status: "ACTIVE",
     });
   });
+
+  it("rejects unsigned webhook payloads", async () => {
+    const provider = new StripeBillingProvider("sk_test_123", "price_123", "whsec_test");
+    const request = new Request("http://localhost/api/billing/webhook", {
+      method: "POST",
+      body: JSON.stringify({ type: "checkout.session.completed", data: { object: {} } }),
+    });
+
+    await expect(provider.parseWebhook(request)).rejects.toThrow("Stripe webhook signature missing");
+  });
 });
+
+function stripeSignature(payload: string, secret: string) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = createHmac("sha256", secret).update(`${timestamp}.${payload}`).digest("hex");
+  return `t=${timestamp},v1=${signature}`;
+}

--- a/legacy/src/lib/providers/billing.ts
+++ b/legacy/src/lib/providers/billing.ts
@@ -1,3 +1,5 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
 export type CheckoutInput = {
   workspaceId: string;
   workspaceSlug: string;
@@ -48,6 +50,7 @@ export class StripeBillingProvider implements BillingProvider {
   constructor(
     private readonly secretKey = process.env.STRIPE_SECRET_KEY,
     private readonly priceId = process.env.STRIPE_PRICE_ID,
+    private readonly webhookSecret = process.env.STRIPE_WEBHOOK_SECRET,
   ) {}
 
   async createCheckout(input: CheckoutInput): Promise<CheckoutResult> {
@@ -116,7 +119,16 @@ export class StripeBillingProvider implements BillingProvider {
   }
 
   async parseWebhook(request: Request): Promise<BillingWebhookResult | null> {
-    const event = (await request.json()) as {
+    if (!this.webhookSecret) {
+      throw new Error("STRIPE_WEBHOOK_SECRET is required for Stripe billing webhooks");
+    }
+    const payload = await request.text();
+    verifyStripeWebhookSignature(
+      payload,
+      request.headers.get("stripe-signature"),
+      this.webhookSecret,
+    );
+    const event = JSON.parse(payload) as {
       type?: string;
       data?: {
         object?: {
@@ -167,4 +179,44 @@ export function getBillingProvider(): BillingProvider {
     return new StripeBillingProvider();
   }
   return new MockBillingProvider();
+}
+
+const STRIPE_WEBHOOK_TOLERANCE_SECONDS = 300;
+
+function verifyStripeWebhookSignature(
+  payload: string,
+  signatureHeader: string | null,
+  secret: string,
+) {
+  if (!signatureHeader) {
+    throw new Error("Stripe webhook signature missing");
+  }
+  const pairs = signatureHeader
+    .split(",")
+    .map((part) => part.split("=") as [string, string | undefined]);
+  const timestamp = pairs.find(([key]) => key === "t")?.[1];
+  const signatures = pairs
+    .filter(([key]) => key === "v1")
+    .map(([, value]) => value)
+    .filter(Boolean) as string[];
+  if (!timestamp || signatures.length === 0) {
+    throw new Error("Stripe webhook signature malformed");
+  }
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) {
+    throw new Error("Stripe webhook timestamp malformed");
+  }
+  const ageSeconds = Math.abs(Date.now() / 1000 - timestampSeconds);
+  if (ageSeconds > STRIPE_WEBHOOK_TOLERANCE_SECONDS) {
+    throw new Error("Stripe webhook timestamp outside tolerance");
+  }
+  const expected = createHmac("sha256", secret).update(`${timestamp}.${payload}`).digest("hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+  const valid = signatures.some((signature) => {
+    const signatureBuffer = Buffer.from(signature, "hex");
+    return signatureBuffer.length === expectedBuffer.length && timingSafeEqual(signatureBuffer, expectedBuffer);
+  });
+  if (!valid) {
+    throw new Error("Stripe webhook signature invalid");
+  }
 }

--- a/legacy/src/lib/providers/calendar.test.ts
+++ b/legacy/src/lib/providers/calendar.test.ts
@@ -22,12 +22,12 @@ describe("GoogleCalendarProvider", () => {
       "client_secret",
       "http://localhost:3000/api/calendar/callback",
     );
-    const url = provider.getAuthorizationUrl("workspace_1");
+    const url = provider.getAuthorizationUrl("signed_state");
 
     expect(url).toContain("https://accounts.google.com/o/oauth2/v2/auth?");
     expect(url).toContain("client_id=client_id");
     expect(url).toContain("calendar.readonly");
-    expect(url).toContain("state=workspace_1");
+    expect(url).toContain("state=signed_state");
   });
 
   it("exchanges auth codes and normalizes Google Calendar events", async () => {


### PR DESCRIPTION
## Summary

Hardens the legacy app billing and Calendar OAuth surfaces.

- Verifies Stripe webhook signatures with raw-body HMAC, timestamp tolerance, and `STRIPE_WEBHOOK_SECRET`.
- Replaces raw workspace-id Calendar OAuth `state` with a signed, expiring user/workspace-bound state token.
- Requires the callback session user to match the signed OAuth state and validates workspace membership before storing the connection.
- Encrypts newly stored Calendar access and refresh tokens using the existing secret encryption helper.
- Fixes `legacy/pnpm-workspace.yaml` so legacy pnpm commands/audit run under the current pnpm version.
- Adds pnpm overrides for patched `postcss`, `hono`, and `@hono/node-server` versions found by production audit.

## Why

The previous legacy Stripe webhook accepted unsigned JSON and could update workspace billing state from forged payloads. The Calendar callback trusted raw `state` as a workspace id and could overwrite a workspace connection without binding the callback to the initiating user/session. The legacy audit also could not run until the workspace file was fixed; once it ran, it found moderate transitive advisories that are now pinned to patched versions.

## Validation

- `pnpm install` from `legacy/`
- `pnpm db:generate` from `legacy/`
- `pnpm lint` from `legacy/`
- `pnpm typecheck` from `legacy/`
- `pnpm test` from `legacy/` (17 files, 77 tests)
- `pnpm audit --prod` from `legacy/` returned `No known vulnerabilities found`