### PR TITLE
[codex] Sync agent docs with active plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,9 @@
 <!-- SPECKIT START -->
+
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read
+`specs/003-conversation-turns/plan.md`.
+
 <!-- SPECKIT END -->
 
 ## UI conventions


### PR DESCRIPTION
## Summary

Aligns the root `CLAUDE.md` Spec Kit instruction with `AGENTS.md` by naming the concrete active plan file: `specs/003-conversation-turns/plan.md`.

## Why

The review found instruction drift around project context. There is no tracked repository reference to `RTK.md`; the tracked inconsistency was `CLAUDE.md` saying only “read the current plan” while `AGENTS.md` points to the exact plan.

## Validation

- Documentation-only change; no runtime checks run.