### PR TITLE
Filter meeting HUD by mic app and auto-hide idle prompt

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,9 @@
       "name": "os-notetaker",
       "dependencies": {
         "@tauri-apps/api": "^2.9.0",
+        "@tauri-apps/plugin-deep-link": "^2.4.9",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@tiptap/extension-placeholder": "^3.23.5",
         "@tiptap/react": "^3.23.5",
         "@tiptap/starter-kit": "^3.23.5",
@@ -233,6 +236,12 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
+
+    "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/runtime": "7.29.2", "@types/aria-query": "5.0.4", "aria-query": "5.3.0", "dom-accessibility-api": "0.5.16", "lz-string": "1.5.0", "picocolors": "1.1.1", "pretty-format": "27.5.1" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/hud.html
+++ b/hud.html
@@ -41,6 +41,9 @@
         class="hud-error-text"
         aria-hidden="true"
       ></span>
+      <span id="hud-meeting-text" class="hud-meeting-text"
+        >Start transcription</span
+      >
       <button
         id="hud-stop"
         class="hud-stop"

--- a/hud.html
+++ b/hud.html
@@ -41,9 +41,12 @@
         class="hud-error-text"
         aria-hidden="true"
       ></span>
-      <span id="hud-meeting-text" class="hud-meeting-text"
-        >Start transcription</span
+      <span id="hud-meeting-label" class="hud-meeting-label"
+        >Meeting detected</span
       >
+      <button id="hud-meeting-start" class="hud-meeting-start" type="button">
+        Start Transcription
+      </button>
       <button
         id="hud-stop"
         class="hud-stop"

--- a/src-tauri/capabilities/hud.json
+++ b/src-tauri/capabilities/hud.json
@@ -5,6 +5,7 @@
   "windows": ["hud"],
   "permissions": [
     "core:event:allow-listen",
+    "core:event:allow-emit",
     "core:event:allow-unlisten",
     "core:window:allow-hide",
     "core:window:allow-show",

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -48,7 +48,7 @@ pub struct HotkeyStatus {
 
 /// Position the HUD remembers between dictation sessions in the same process.
 /// Intentionally process-scoped, not disk-persisted: every fresh launch of
-/// Scribe should put the pill back at bottom-center, but within a single run
+/// Scribe should put the pill back at top-center, but within a single run
 /// the user's drag-to-corner choice should stick.
 pub struct HudPosition {
     inner: Mutex<Option<(i32, i32)>>,
@@ -1792,7 +1792,7 @@ fn position_hud_window(app: &AppHandle, hud: &WebviewWindow) {
 
     // Restore the in-memory drag position if it's still on-screen. This
     // doesn't persist across app restarts — that's deliberate; quitting
-    // Scribe resets the HUD to bottom-center so it can't end up lost on a
+    // Scribe resets the HUD to top-center so it can't end up lost on a
     // monitor that's no longer connected.
     if let Some(state) = app.try_state::<HudPosition>() {
         let saved = state.inner.lock().ok().and_then(|guard| *guard);
@@ -1810,11 +1810,11 @@ fn position_hud_window(app: &AppHandle, hud: &WebviewWindow) {
 }
 
 fn default_hud_position(hud: &WebviewWindow, window_size: PhysicalSize<u32>) -> Option<(i32, i32)> {
-    const HUD_BOTTOM_MARGIN: i32 = 12;
+    const HUD_TOP_MARGIN: i32 = 12;
     // The pill is much smaller than the window — the window is intentionally
     // padded with transparent space so the box-shadow has room to fall off
-    // softly. We anchor the *pill* at bottom-center, not the window, which
-    // means accounting for the gap below the pill (half the window's slack).
+    // softly. We anchor the *pill* at top-center, not the window, which
+    // means accounting for the gap above the pill (half the window's slack).
     const PILL_HEIGHT: i32 = 30;
 
     let monitor = hud
@@ -1825,12 +1825,12 @@ fn default_hud_position(hud: &WebviewWindow, window_size: PhysicalSize<u32>) -> 
         .or_else(|| hud.primary_monitor().ok().flatten())?;
 
     let work_area = monitor.work_area();
-    let work_bottom = work_area.position.y + work_area.size.height as i32;
+    let work_top = work_area.position.y;
     let work_center_x = work_area.position.x + work_area.size.width as i32 / 2;
 
     // The pill is centered inside the window (CSS `place-items: center` on
     // body), so window_top = pill_center - window_height/2.
-    let pill_center_y = work_bottom - HUD_BOTTOM_MARGIN - PILL_HEIGHT / 2;
+    let pill_center_y = work_top + HUD_TOP_MARGIN + PILL_HEIGHT / 2;
     let x = work_center_x - window_size.width as i32 / 2;
     let y = pill_center_y - window_size.height as i32 / 2;
     Some((x, y))

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1811,11 +1811,8 @@ fn position_hud_window(app: &AppHandle, hud: &WebviewWindow) {
 
 fn default_hud_position(hud: &WebviewWindow, window_size: PhysicalSize<u32>) -> Option<(i32, i32)> {
     const HUD_TOP_MARGIN: i32 = 12;
-    // The pill is much smaller than the window — the window is intentionally
-    // padded with transparent space so the box-shadow has room to fall off
-    // softly. We anchor the *pill* at top-center, not the window, which
-    // means accounting for the gap above the pill (half the window's slack).
-    const PILL_HEIGHT: i32 = 30;
+    // The native HUD window is sized to the visible pill so dragging and
+    // top-edge placement match what the user can see.
 
     let monitor = hud
         .cursor_position()
@@ -1828,11 +1825,8 @@ fn default_hud_position(hud: &WebviewWindow, window_size: PhysicalSize<u32>) -> 
     let work_top = work_area.position.y;
     let work_center_x = work_area.position.x + work_area.size.width as i32 / 2;
 
-    // The pill is centered inside the window (CSS `place-items: center` on
-    // body), so window_top = pill_center - window_height/2.
-    let pill_center_y = work_top + HUD_TOP_MARGIN + PILL_HEIGHT / 2;
     let x = work_center_x - window_size.width as i32 / 2;
-    let y = pill_center_y - window_size.height as i32 / 2;
+    let y = work_top + HUD_TOP_MARGIN;
     Some((x, y))
 }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -778,8 +778,14 @@ pub fn stop_helper(app: &AppHandle) {
 }
 
 pub(crate) fn dictation_helper_pid(app: &AppHandle) -> Option<u32> {
-    app.try_state::<HelperState>()
-        .and_then(|state| state.process.lock().ok()?.as_ref().map(|process| process.child.id()))
+    app.try_state::<HelperState>().and_then(|state| {
+        state
+            .process
+            .lock()
+            .ok()?
+            .as_ref()
+            .map(|process| process.child.id())
+    })
 }
 
 fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Result<(), AppError> {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -777,6 +777,11 @@ pub fn stop_helper(app: &AppHandle) {
     let _ = process.child.wait();
 }
 
+pub(crate) fn dictation_helper_pid(app: &AppHandle) -> Option<u32> {
+    app.try_state::<HelperState>()
+        .and_then(|state| state.process.lock().ok()?.as_ref().map(|process| process.child.id()))
+}
+
 fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Result<(), AppError> {
     let mut guard = state
         .process
@@ -1735,7 +1740,7 @@ fn is_silent_transcription_error(event: &serde_json::Value) -> bool {
         || normalized_message.contains("dictation_text_empty")
 }
 
-fn show_hud_window(app: &AppHandle) {
+pub(crate) fn show_hud_window(app: &AppHandle) {
     if let Some(hud) = app.get_webview_window("hud") {
         // Only reposition when the HUD is coming up fresh. Within an active
         // session the user may have dragged the pill to a spot they like;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod dictation;
 pub mod domain;
 pub mod hermes_bridge;
+pub mod meeting_detection;
 pub mod os_accounts;
 pub mod providers;
 pub mod scribe_api;
@@ -129,6 +130,7 @@ pub fn run() {
             setup_app_menu(app)?;
             providers::setup(app);
             dictation::setup(app);
+            meeting_detection::setup(app);
             repair_agent_task_statuses_on_app_start(app);
             hermes_bridge::start_on_app_start(app);
             os_accounts::setup_deep_link(app);

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -1,0 +1,1 @@
+pub fn setup(_app: &mut tauri::App) {}

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -6,8 +6,14 @@ const CLEAR_AFTER_INACTIVE_POLLS: u8 = 2;
 const HEARTBEAT_EVERY_ACTIVE_POLLS: u8 = 5;
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const MEETING_DETECTION_EVENT_NAME: &str = "meeting-detection-event";
-const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] =
-    &["company.thebrowser.Browser", "com.google.Chrome"];
+const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] = &[
+    "company.thebrowser.Browser",
+    "com.google.Chrome",
+    "com.apple.Safari",
+    "com.microsoft.teams",
+    "com.microsoft.teams2",
+    "us.zoom.xos",
+];
 
 pub fn setup(app: &mut tauri::App) {
     #[cfg(target_os = "macos")]
@@ -125,6 +131,17 @@ fn app_label_from_bundle_id(bundle_id: &str) -> String {
     }
     if bundle_id_matches_prefix(bundle_id, "com.google.Chrome") {
         return "Chrome".to_string();
+    }
+    if bundle_id_matches_prefix(bundle_id, "com.apple.Safari") {
+        return "Safari".to_string();
+    }
+    if bundle_id_matches_prefix(bundle_id, "com.microsoft.teams")
+        || bundle_id_matches_prefix(bundle_id, "com.microsoft.teams2")
+    {
+        return "Teams".to_string();
+    }
+    if bundle_id_matches_prefix(bundle_id, "us.zoom.xos") {
+        return "Zoom".to_string();
     }
     bundle_id
         .rsplit('.')
@@ -596,11 +613,48 @@ mod tests {
     }
 
     #[test]
+    fn safari_mic_process_triggers_detection_filter() {
+        let exact = input_process(42, "com.apple.Safari");
+        let helper = input_process(43, "com.apple.Safari.WebContent");
+
+        assert_eq!(exact.app_label, "Safari");
+        assert_eq!(helper.app_label, "Safari");
+        assert_eq!(allowed_pids(&[exact, helper]), vec![42, 43]);
+    }
+
+    #[test]
+    fn teams_mic_process_triggers_detection_filter() {
+        let classic = input_process(44, "com.microsoft.teams");
+        let classic_helper = input_process(45, "com.microsoft.teams.helper");
+        let modern = input_process(46, "com.microsoft.teams2");
+        let modern_helper = input_process(47, "com.microsoft.teams2.helper");
+
+        assert_eq!(classic.app_label, "Teams");
+        assert_eq!(classic_helper.app_label, "Teams");
+        assert_eq!(modern.app_label, "Teams");
+        assert_eq!(modern_helper.app_label, "Teams");
+        assert_eq!(
+            allowed_pids(&[classic, classic_helper, modern, modern_helper]),
+            vec![44, 45, 46, 47]
+        );
+    }
+
+    #[test]
+    fn zoom_mic_process_triggers_detection_filter() {
+        let exact = input_process(48, "us.zoom.xos");
+        let helper = input_process(49, "us.zoom.xos.helper");
+
+        assert_eq!(exact.app_label, "Zoom");
+        assert_eq!(helper.app_label, "Zoom");
+        assert_eq!(allowed_pids(&[exact, helper]), vec![48, 49]);
+    }
+
+    #[test]
     fn unlisted_mic_process_does_not_trigger_detection_filter() {
         assert!(allowed_pids(&[
-            input_process(50, "us.zoom.xos"),
             input_process(51, "com.apple.FaceTime"),
             input_process(52, "com.google.ChromeRemoteDesktop"),
+            input_process(53, "com.apple.WebKit.WebContent"),
         ])
         .is_empty());
     }
@@ -609,7 +663,7 @@ mod tests {
     fn detector_clears_when_allowed_mic_process_becomes_unlisted() {
         let mut state = MeetingDetectionState::default();
         let active_allowed = allowed_pids(&[input_process(60, "com.google.Chrome")]);
-        let active_unlisted = allowed_pids(&[input_process(61, "us.zoom.xos")]);
+        let active_unlisted = allowed_pids(&[input_process(61, "com.apple.FaceTime")]);
 
         assert_eq!(
             state.update(!active_allowed.is_empty(), false),

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -6,6 +6,8 @@ const CLEAR_AFTER_INACTIVE_POLLS: u8 = 2;
 const HEARTBEAT_EVERY_ACTIVE_POLLS: u8 = 5;
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const MEETING_DETECTION_EVENT_NAME: &str = "meeting-detection-event";
+const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] =
+    &["company.thebrowser.Browser", "com.google.Chrome"];
 
 pub fn setup(app: &mut tauri::App) {
     #[cfg(target_os = "macos")]
@@ -68,15 +70,67 @@ impl MeetingDetectionState {
     }
 }
 
-pub(crate) fn active_external_pids(
-    active_input_pids: &[u32],
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MicrophoneInputProcess {
+    pub(crate) pid: u32,
+    pub(crate) bundle_id: String,
+    pub(crate) app_label: String,
+}
+
+impl MicrophoneInputProcess {
+    pub(crate) fn new(pid: u32, bundle_id: String) -> Option<Self> {
+        let bundle_id = bundle_id.trim().to_string();
+        if pid == 0 || bundle_id.is_empty() {
+            return None;
+        }
+        let app_label = app_label_from_bundle_id(&bundle_id);
+        Some(Self {
+            pid,
+            bundle_id,
+            app_label,
+        })
+    }
+}
+
+pub(crate) fn active_allowed_external_processes(
+    active_input_processes: &[MicrophoneInputProcess],
     owned_pids: &BTreeSet<u32>,
-) -> Vec<u32> {
-    active_input_pids
+) -> Vec<MicrophoneInputProcess> {
+    active_input_processes
         .iter()
-        .copied()
-        .filter(|pid| *pid != 0 && !owned_pids.contains(pid))
+        .filter(|process| process.pid != 0 && !owned_pids.contains(&process.pid))
+        .filter(|process| is_allowed_microphone_app(&process.bundle_id))
+        .cloned()
         .collect()
+}
+
+fn is_allowed_microphone_app(bundle_id: &str) -> bool {
+    ALLOWED_MIC_APP_BUNDLE_PREFIXES
+        .iter()
+        .any(|prefix| bundle_id_matches_prefix(bundle_id, prefix))
+}
+
+fn bundle_id_matches_prefix(bundle_id: &str, prefix: &str) -> bool {
+    let bundle_id = bundle_id.trim().to_ascii_lowercase();
+    let prefix = prefix.trim().to_ascii_lowercase();
+    bundle_id == prefix
+        || bundle_id
+            .strip_prefix(&prefix)
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn app_label_from_bundle_id(bundle_id: &str) -> String {
+    if bundle_id_matches_prefix(bundle_id, "company.thebrowser.Browser") {
+        return "Arc".to_string();
+    }
+    if bundle_id_matches_prefix(bundle_id, "com.google.Chrome") {
+        return "Chrome".to_string();
+    }
+    bundle_id
+        .rsplit('.')
+        .find(|part| !part.trim().is_empty())
+        .unwrap_or(bundle_id)
+        .to_string()
 }
 
 #[cfg(target_os = "macos")]
@@ -88,10 +142,10 @@ fn spawn_monitor(app: AppHandle) {
         loop {
             thread::sleep(POLL_INTERVAL);
 
-            let active_pids = match active_input_process_pids() {
-                Ok(active_pids) => {
+            let active_processes = match active_input_processes() {
+                Ok(active_processes) => {
                     warned_after_probe_error = false;
-                    active_pids
+                    active_processes
                 }
                 Err(error) => {
                     if !warned_after_probe_error {
@@ -101,10 +155,11 @@ fn spawn_monitor(app: AppHandle) {
                     Vec::new()
                 }
             };
-            let external_pids = active_external_pids(&active_pids, &owned_pids(&app));
+            let allowed_processes =
+                active_allowed_external_processes(&active_processes, &owned_pids(&app));
             let capture_active = crate::audio::capture::is_capture_active();
-            if let Some(event) = state.update(!external_pids.is_empty(), capture_active) {
-                emit_detection_event(&app, event, external_pids.len());
+            if let Some(event) = state.update(!allowed_processes.is_empty(), capture_active) {
+                emit_detection_event(&app, event, allowed_processes.len());
             }
         }
     });
@@ -160,10 +215,10 @@ fn emit_detection_event(
 }
 
 #[cfg(target_os = "macos")]
-pub(crate) use macos::active_input_process_pids;
+pub(crate) use macos::active_input_processes;
 
 #[cfg(not(target_os = "macos"))]
-pub(crate) fn active_input_process_pids() -> Result<Vec<u32>, ProbeError> {
+pub(crate) fn active_input_processes() -> Result<Vec<MicrophoneInputProcess>, ProbeError> {
     Ok(Vec::new())
 }
 
@@ -193,7 +248,7 @@ impl std::error::Error for ProbeError {}
 
 #[cfg(target_os = "macos")]
 mod macos {
-    use super::ProbeError;
+    use super::{MicrophoneInputProcess, ProbeError};
     use std::{ffi::c_void, mem, ptr};
 
     type AudioObjectId = u32;
@@ -253,8 +308,8 @@ mod macos {
         fn CFRelease(cf: *const c_void);
     }
 
-    pub(crate) fn active_input_process_pids() -> Result<Vec<u32>, ProbeError> {
-        let mut pids = Vec::new();
+    pub(crate) fn active_input_processes() -> Result<Vec<MicrophoneInputProcess>, ProbeError> {
+        let mut processes = Vec::new();
         for process_object in process_objects()? {
             if process_object == AUDIO_OBJECT_UNKNOWN {
                 continue;
@@ -268,21 +323,21 @@ mod macos {
             if running_input == 0 {
                 continue;
             }
-            if !process_has_input_devices(process_object)
-                || read_process_bundle_id(process_object)
-                    .ok()
-                    .flatten()
-                    .is_none()
-            {
+            if !process_has_input_devices(process_object) {
                 continue;
             }
-            if let Ok(Some(pid)) = read_process_pid(process_object) {
-                pids.push(pid);
+            if let (Ok(Some(pid)), Ok(Some(bundle_id))) = (
+                read_process_pid(process_object),
+                read_process_bundle_id(process_object),
+            ) {
+                if let Some(process) = MicrophoneInputProcess::new(pid, bundle_id) {
+                    processes.push(process);
+                }
             }
         }
-        pids.sort_unstable();
-        pids.dedup();
-        Ok(pids)
+        processes.sort_by_key(|process| process.pid);
+        processes.dedup_by_key(|process| process.pid);
+        Ok(processes)
     }
 
     fn process_objects() -> Result<Vec<AudioObjectId>, ProbeError> {
@@ -485,12 +540,30 @@ mod macos {
 mod tests {
     use super::*;
 
+    fn input_process(pid: u32, bundle_id: &str) -> MicrophoneInputProcess {
+        MicrophoneInputProcess::new(pid, bundle_id.to_string()).expect("valid process")
+    }
+
     #[test]
-    fn active_external_pids_excludes_owned_processes() {
+    fn active_allowed_external_processes_excludes_owned_processes() {
         let owned = BTreeSet::from([10, 20]);
+        let processes = vec![
+            MicrophoneInputProcess {
+                pid: 0,
+                bundle_id: "com.google.Chrome".to_string(),
+                app_label: "Chrome".to_string(),
+            },
+            input_process(10, "com.google.Chrome"),
+            input_process(30, "com.google.Chrome"),
+            input_process(20, "company.thebrowser.Browser"),
+            input_process(40, "company.thebrowser.Browser"),
+        ];
 
         assert_eq!(
-            active_external_pids(&[0, 10, 30, 20, 40], &owned),
+            active_allowed_external_processes(&processes, &owned)
+                .into_iter()
+                .map(|process| process.pid)
+                .collect::<Vec<_>>(),
             vec![30, 40]
         );
     }

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -69,6 +69,239 @@ pub(crate) fn active_external_pids(
         .collect()
 }
 
+#[cfg(target_os = "macos")]
+pub(crate) use macos::active_input_process_pids;
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn active_input_process_pids() -> Result<Vec<u32>, ProbeError> {
+    Ok(Vec::new())
+}
+
+#[derive(Debug)]
+pub(crate) struct ProbeError {
+    operation: &'static str,
+    status: i32,
+}
+
+impl ProbeError {
+    fn new(operation: &'static str, status: i32) -> Self {
+        Self { operation, status }
+    }
+}
+
+impl std::fmt::Display for ProbeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "{} failed with OSStatus {}",
+            self.operation, self.status
+        )
+    }
+}
+
+impl std::error::Error for ProbeError {}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::ProbeError;
+    use std::{ffi::c_void, mem, ptr};
+
+    type AudioObjectId = u32;
+    type AudioObjectPropertySelector = u32;
+    type AudioObjectPropertyScope = u32;
+    type AudioObjectPropertyElement = u32;
+    type OsStatus = i32;
+
+    const AUDIO_OBJECT_SYSTEM_OBJECT: AudioObjectId = 1;
+    const AUDIO_OBJECT_UNKNOWN: AudioObjectId = 0;
+    const AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: AudioObjectPropertyScope = four_cc(*b"glob");
+    const AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: AudioObjectPropertyElement = 0;
+    const AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST: AudioObjectPropertySelector =
+        four_cc(*b"prs#");
+    const AUDIO_PROCESS_PROPERTY_PID: AudioObjectPropertySelector = four_cc(*b"ppid");
+    const AUDIO_PROCESS_PROPERTY_IS_RUNNING_INPUT: AudioObjectPropertySelector =
+        four_cc(*b"piri");
+
+    #[repr(C)]
+    struct AudioObjectPropertyAddress {
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+    }
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    extern "C" {
+        fn AudioObjectGetPropertyDataSize(
+            object_id: AudioObjectId,
+            address: *const AudioObjectPropertyAddress,
+            qualifier_data_size: u32,
+            qualifier_data: *const c_void,
+            data_size: *mut u32,
+        ) -> OsStatus;
+
+        fn AudioObjectGetPropertyData(
+            object_id: AudioObjectId,
+            address: *const AudioObjectPropertyAddress,
+            qualifier_data_size: u32,
+            qualifier_data: *const c_void,
+            data_size: *mut u32,
+            data: *mut c_void,
+        ) -> OsStatus;
+    }
+
+    pub(crate) fn active_input_process_pids() -> Result<Vec<u32>, ProbeError> {
+        let mut pids = Vec::new();
+        for process_object in process_objects()? {
+            if process_object == AUDIO_OBJECT_UNKNOWN {
+                continue;
+            }
+            let running_input = read_u32_property(
+                process_object,
+                AUDIO_PROCESS_PROPERTY_IS_RUNNING_INPUT,
+                "read process input state",
+            )
+            .unwrap_or_default();
+            if running_input == 0 {
+                continue;
+            }
+            if let Ok(Some(pid)) = read_process_pid(process_object) {
+                pids.push(pid);
+            }
+        }
+        pids.sort_unstable();
+        pids.dedup();
+        Ok(pids)
+    }
+
+    fn process_objects() -> Result<Vec<AudioObjectId>, ProbeError> {
+        let address = property_address(AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST);
+        let mut data_size = 0_u32;
+        status_result(
+            "read process object list size",
+            unsafe {
+                AudioObjectGetPropertyDataSize(
+                    AUDIO_OBJECT_SYSTEM_OBJECT,
+                    &address,
+                    0,
+                    ptr::null(),
+                    &mut data_size,
+                )
+            },
+        )?;
+
+        if data_size == 0 {
+            return Ok(Vec::new());
+        }
+
+        let object_count = data_size as usize / mem::size_of::<AudioObjectId>();
+        let mut objects = vec![AUDIO_OBJECT_UNKNOWN; object_count];
+        status_result(
+            "read process object list",
+            unsafe {
+                AudioObjectGetPropertyData(
+                    AUDIO_OBJECT_SYSTEM_OBJECT,
+                    &address,
+                    0,
+                    ptr::null(),
+                    &mut data_size,
+                    objects.as_mut_ptr().cast(),
+                )
+            },
+        )?;
+
+        let actual_count = data_size as usize / mem::size_of::<AudioObjectId>();
+        objects.truncate(actual_count);
+        Ok(objects)
+    }
+
+    fn read_process_pid(process_object: AudioObjectId) -> Result<Option<u32>, ProbeError> {
+        let pid = read_i32_property(process_object, AUDIO_PROCESS_PROPERTY_PID, "read process pid")?;
+        if pid <= 0 {
+            Ok(None)
+        } else {
+            Ok(Some(pid as u32))
+        }
+    }
+
+    fn read_i32_property(
+        object_id: AudioObjectId,
+        selector: AudioObjectPropertySelector,
+        operation: &'static str,
+    ) -> Result<i32, ProbeError> {
+        let mut value = 0_i32;
+        read_scalar_property(object_id, selector, operation, &mut value)?;
+        Ok(value)
+    }
+
+    fn read_u32_property(
+        object_id: AudioObjectId,
+        selector: AudioObjectPropertySelector,
+        operation: &'static str,
+    ) -> Result<u32, ProbeError> {
+        let mut value = 0_u32;
+        read_scalar_property(object_id, selector, operation, &mut value)?;
+        Ok(value)
+    }
+
+    fn read_scalar_property<T>(
+        object_id: AudioObjectId,
+        selector: AudioObjectPropertySelector,
+        operation: &'static str,
+        value: &mut T,
+    ) -> Result<(), ProbeError> {
+        let address = property_address(selector);
+        let mut data_size = mem::size_of::<T>() as u32;
+        status_result(
+            operation,
+            unsafe {
+                AudioObjectGetPropertyData(
+                    object_id,
+                    &address,
+                    0,
+                    ptr::null(),
+                    &mut data_size,
+                    (value as *mut T).cast(),
+                )
+            },
+        )
+    }
+
+    fn property_address(selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress {
+            selector,
+            scope: AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+            element: AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        }
+    }
+
+    fn status_result(operation: &'static str, status: OsStatus) -> Result<(), ProbeError> {
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(ProbeError::new(operation, status))
+        }
+    }
+
+    const fn four_cc(value: [u8; 4]) -> u32 {
+        ((value[0] as u32) << 24)
+            | ((value[1] as u32) << 16)
+            | ((value[2] as u32) << 8)
+            | value[3] as u32
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn four_cc_matches_core_audio_constants() {
+            assert_eq!(AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST, 0x7072_7323);
+            assert_eq!(AUDIO_PROCESS_PROPERTY_PID, 0x7070_6964);
+            assert_eq!(AUDIO_PROCESS_PROPERTY_IS_RUNNING_INPUT, 0x7069_7269);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -544,6 +544,13 @@ mod tests {
         MicrophoneInputProcess::new(pid, bundle_id.to_string()).expect("valid process")
     }
 
+    fn allowed_pids(processes: &[MicrophoneInputProcess]) -> Vec<u32> {
+        active_allowed_external_processes(processes, &BTreeSet::new())
+            .into_iter()
+            .map(|process| process.pid)
+            .collect()
+    }
+
     #[test]
     fn active_allowed_external_processes_excludes_owned_processes() {
         let owned = BTreeSet::from([10, 20]);
@@ -565,6 +572,53 @@ mod tests {
                 .map(|process| process.pid)
                 .collect::<Vec<_>>(),
             vec![30, 40]
+        );
+    }
+
+    #[test]
+    fn chrome_mic_process_triggers_detection_filter() {
+        let exact = input_process(30, "com.google.Chrome");
+        let helper = input_process(31, "COM.GOOGLE.CHROME.helper");
+
+        assert_eq!(exact.app_label, "Chrome");
+        assert_eq!(helper.app_label, "Chrome");
+        assert_eq!(allowed_pids(&[exact, helper]), vec![30, 31]);
+    }
+
+    #[test]
+    fn arc_mic_process_triggers_detection_filter() {
+        let exact = input_process(40, "company.thebrowser.Browser");
+        let helper = input_process(41, "company.thebrowser.Browser.helper");
+
+        assert_eq!(exact.app_label, "Arc");
+        assert_eq!(helper.app_label, "Arc");
+        assert_eq!(allowed_pids(&[exact, helper]), vec![40, 41]);
+    }
+
+    #[test]
+    fn unlisted_mic_process_does_not_trigger_detection_filter() {
+        assert!(allowed_pids(&[
+            input_process(50, "us.zoom.xos"),
+            input_process(51, "com.apple.FaceTime"),
+            input_process(52, "com.google.ChromeRemoteDesktop"),
+        ])
+        .is_empty());
+    }
+
+    #[test]
+    fn detector_clears_when_allowed_mic_process_becomes_unlisted() {
+        let mut state = MeetingDetectionState::default();
+        let active_allowed = allowed_pids(&[input_process(60, "com.google.Chrome")]);
+        let active_unlisted = allowed_pids(&[input_process(61, "us.zoom.xos")]);
+
+        assert_eq!(
+            state.update(!active_allowed.is_empty(), false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+        assert_eq!(state.update(!active_unlisted.is_empty(), false), None);
+        assert_eq!(
+            state.update(!active_unlisted.is_empty(), false),
+            Some(MeetingDetectionEvent::Cleared)
         );
     }
 

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -1,9 +1,19 @@
-use std::collections::BTreeSet;
+use serde::Serialize;
+use std::{collections::BTreeSet, thread, time::Duration};
+use tauri::{AppHandle, Emitter};
 
 const CLEAR_AFTER_INACTIVE_POLLS: u8 = 2;
 const HEARTBEAT_EVERY_ACTIVE_POLLS: u8 = 5;
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+const MEETING_DETECTION_EVENT_NAME: &str = "meeting-detection-event";
 
-pub fn setup(_app: &mut tauri::App) {}
+pub fn setup(app: &mut tauri::App) {
+    #[cfg(target_os = "macos")]
+    spawn_monitor(app.handle().clone());
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MeetingDetectionEvent {
@@ -67,6 +77,82 @@ pub(crate) fn active_external_pids(
         .copied()
         .filter(|pid| *pid != 0 && !owned_pids.contains(pid))
         .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_monitor(app: AppHandle) {
+    thread::spawn(move || {
+        let mut state = MeetingDetectionState::default();
+        let mut warned_after_probe_error = false;
+
+        loop {
+            thread::sleep(POLL_INTERVAL);
+
+            let active_pids = match active_input_process_pids() {
+                Ok(active_pids) => {
+                    warned_after_probe_error = false;
+                    active_pids
+                }
+                Err(error) => {
+                    if !warned_after_probe_error {
+                        tracing::warn!(%error, "meeting detection probe failed");
+                        warned_after_probe_error = true;
+                    }
+                    Vec::new()
+                }
+            };
+            let external_pids = active_external_pids(&active_pids, &owned_pids(&app));
+            let capture_active = crate::audio::capture::is_capture_active();
+            if let Some(event) = state.update(!external_pids.is_empty(), capture_active) {
+                emit_detection_event(&app, event, external_pids.len());
+            }
+        }
+    });
+}
+
+fn owned_pids(app: &AppHandle) -> BTreeSet<u32> {
+    let mut pids = BTreeSet::from([std::process::id()]);
+    if let Some(helper_pid) = crate::dictation::dictation_helper_pid(app) {
+        pids.insert(helper_pid);
+    }
+    pids
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MeetingDetectionPayload {
+    active_process_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct MeetingDetectionEnvelope {
+    #[serde(rename = "type")]
+    event_type: &'static str,
+    payload: MeetingDetectionPayload,
+}
+
+fn emit_detection_event(app: &AppHandle, event: MeetingDetectionEvent, active_process_count: usize) {
+    let event_type = match event {
+        MeetingDetectionEvent::Detected => {
+            crate::dictation::show_hud_window(app);
+            "meeting_detected"
+        }
+        MeetingDetectionEvent::Cleared => "meeting_cleared",
+    };
+    let payload = MeetingDetectionEnvelope {
+        event_type,
+        payload: MeetingDetectionPayload {
+            active_process_count,
+        },
+    };
+    match serde_json::to_string(&payload) {
+        Ok(payload) => {
+            let _ = app.emit(MEETING_DETECTION_EVENT_NAME, payload);
+        }
+        Err(error) => {
+            tracing::warn!(%error, "failed to encode meeting detection event");
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -1,1 +1,154 @@
+use std::collections::BTreeSet;
+
+const CLEAR_AFTER_INACTIVE_POLLS: u8 = 2;
+const HEARTBEAT_EVERY_ACTIVE_POLLS: u8 = 5;
+
 pub fn setup(_app: &mut tauri::App) {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MeetingDetectionEvent {
+    Detected,
+    Cleared,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct MeetingDetectionState {
+    active: bool,
+    inactive_polls: u8,
+    active_polls_since_emit: u8,
+}
+
+impl MeetingDetectionState {
+    pub(crate) fn update(
+        &mut self,
+        active_external_input: bool,
+        os_scribe_capture_active: bool,
+    ) -> Option<MeetingDetectionEvent> {
+        let should_be_active = active_external_input && !os_scribe_capture_active;
+        if should_be_active {
+            self.inactive_polls = 0;
+            if !self.active {
+                self.active = true;
+                self.active_polls_since_emit = 0;
+                return Some(MeetingDetectionEvent::Detected);
+            }
+
+            self.active_polls_since_emit = self.active_polls_since_emit.saturating_add(1);
+            if self.active_polls_since_emit >= HEARTBEAT_EVERY_ACTIVE_POLLS {
+                self.active_polls_since_emit = 0;
+                return Some(MeetingDetectionEvent::Detected);
+            }
+            return None;
+        }
+
+        self.active_polls_since_emit = 0;
+        if !self.active {
+            self.inactive_polls = 0;
+            return None;
+        }
+
+        self.inactive_polls = self.inactive_polls.saturating_add(1);
+        if self.inactive_polls >= CLEAR_AFTER_INACTIVE_POLLS {
+            self.active = false;
+            self.inactive_polls = 0;
+            return Some(MeetingDetectionEvent::Cleared);
+        }
+
+        None
+    }
+}
+
+pub(crate) fn active_external_pids(
+    active_input_pids: &[u32],
+    owned_pids: &BTreeSet<u32>,
+) -> Vec<u32> {
+    active_input_pids
+        .iter()
+        .copied()
+        .filter(|pid| *pid != 0 && !owned_pids.contains(pid))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_external_pids_excludes_owned_processes() {
+        let owned = BTreeSet::from([10, 20]);
+
+        assert_eq!(active_external_pids(&[0, 10, 30, 20, 40], &owned), vec![
+            30, 40
+        ]);
+    }
+
+    #[test]
+    fn detector_shows_when_external_input_starts() {
+        let mut state = MeetingDetectionState::default();
+
+        assert_eq!(
+            state.update(true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+        assert_eq!(state.update(true, false), None);
+    }
+
+    #[test]
+    fn detector_suppresses_while_os_scribe_capture_is_active() {
+        let mut state = MeetingDetectionState::default();
+
+        assert_eq!(state.update(true, true), None);
+        assert_eq!(
+            state.update(true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+    }
+
+    #[test]
+    fn detector_clears_after_inactive_debounce() {
+        let mut state = MeetingDetectionState::default();
+        assert_eq!(
+            state.update(true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+
+        assert_eq!(state.update(false, false), None);
+        assert_eq!(
+            state.update(false, false),
+            Some(MeetingDetectionEvent::Cleared)
+        );
+        assert_eq!(state.update(false, false), None);
+    }
+
+    #[test]
+    fn detector_emits_heartbeat_while_active() {
+        let mut state = MeetingDetectionState::default();
+        assert_eq!(
+            state.update(true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+
+        for _ in 0..(HEARTBEAT_EVERY_ACTIVE_POLLS - 1) {
+            assert_eq!(state.update(true, false), None);
+        }
+        assert_eq!(
+            state.update(true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+    }
+
+    #[test]
+    fn detector_clears_when_os_scribe_capture_starts() {
+        let mut state = MeetingDetectionState::default();
+        assert_eq!(
+            state.update(true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+
+        assert_eq!(state.update(true, true), None);
+        assert_eq!(
+            state.update(true, true),
+            Some(MeetingDetectionEvent::Cleared)
+        );
+    }
+}

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -131,7 +131,11 @@ struct MeetingDetectionEnvelope {
     payload: MeetingDetectionPayload,
 }
 
-fn emit_detection_event(app: &AppHandle, event: MeetingDetectionEvent, active_process_count: usize) {
+fn emit_detection_event(
+    app: &AppHandle,
+    event: MeetingDetectionEvent,
+    active_process_count: usize,
+) {
     let event_type = match event {
         MeetingDetectionEvent::Detected => {
             crate::dictation::show_hud_window(app);
@@ -201,12 +205,14 @@ mod macos {
     const AUDIO_OBJECT_SYSTEM_OBJECT: AudioObjectId = 1;
     const AUDIO_OBJECT_UNKNOWN: AudioObjectId = 0;
     const AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: AudioObjectPropertyScope = four_cc(*b"glob");
+    const AUDIO_OBJECT_PROPERTY_SCOPE_INPUT: AudioObjectPropertyScope = four_cc(*b"inpt");
     const AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: AudioObjectPropertyElement = 0;
     const AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST: AudioObjectPropertySelector =
         four_cc(*b"prs#");
     const AUDIO_PROCESS_PROPERTY_PID: AudioObjectPropertySelector = four_cc(*b"ppid");
-    const AUDIO_PROCESS_PROPERTY_IS_RUNNING_INPUT: AudioObjectPropertySelector =
-        four_cc(*b"piri");
+    const AUDIO_PROCESS_PROPERTY_BUNDLE_ID: AudioObjectPropertySelector = four_cc(*b"pbid");
+    const AUDIO_PROCESS_PROPERTY_DEVICES: AudioObjectPropertySelector = four_cc(*b"pdv#");
+    const AUDIO_PROCESS_PROPERTY_IS_RUNNING_INPUT: AudioObjectPropertySelector = four_cc(*b"piri");
 
     #[repr(C)]
     struct AudioObjectPropertyAddress {
@@ -235,6 +241,18 @@ mod macos {
         ) -> OsStatus;
     }
 
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringGetCString(
+            string: *const c_void,
+            buffer: *mut i8,
+            buffer_size: isize,
+            encoding: u32,
+        ) -> u8;
+
+        fn CFRelease(cf: *const c_void);
+    }
+
     pub(crate) fn active_input_process_pids() -> Result<Vec<u32>, ProbeError> {
         let mut pids = Vec::new();
         for process_object in process_objects()? {
@@ -250,6 +268,14 @@ mod macos {
             if running_input == 0 {
                 continue;
             }
+            if !process_has_input_devices(process_object)
+                || read_process_bundle_id(process_object)
+                    .ok()
+                    .flatten()
+                    .is_none()
+            {
+                continue;
+            }
             if let Ok(Some(pid)) = read_process_pid(process_object) {
                 pids.push(pid);
             }
@@ -260,20 +286,27 @@ mod macos {
     }
 
     fn process_objects() -> Result<Vec<AudioObjectId>, ProbeError> {
-        let address = property_address(AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST);
-        let mut data_size = 0_u32;
-        status_result(
+        read_object_array_property(
+            AUDIO_OBJECT_SYSTEM_OBJECT,
+            AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST,
+            AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
             "read process object list size",
-            unsafe {
-                AudioObjectGetPropertyDataSize(
-                    AUDIO_OBJECT_SYSTEM_OBJECT,
-                    &address,
-                    0,
-                    ptr::null(),
-                    &mut data_size,
-                )
-            },
-        )?;
+            "read process object list",
+        )
+    }
+
+    fn read_object_array_property(
+        object_id: AudioObjectId,
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope,
+        size_operation: &'static str,
+        data_operation: &'static str,
+    ) -> Result<Vec<AudioObjectId>, ProbeError> {
+        let address = property_address_with_scope(selector, scope);
+        let mut data_size = 0_u32;
+        status_result(size_operation, unsafe {
+            AudioObjectGetPropertyDataSize(object_id, &address, 0, ptr::null(), &mut data_size)
+        })?;
 
         if data_size == 0 {
             return Ok(Vec::new());
@@ -281,32 +314,86 @@ mod macos {
 
         let object_count = data_size as usize / mem::size_of::<AudioObjectId>();
         let mut objects = vec![AUDIO_OBJECT_UNKNOWN; object_count];
-        status_result(
-            "read process object list",
-            unsafe {
-                AudioObjectGetPropertyData(
-                    AUDIO_OBJECT_SYSTEM_OBJECT,
-                    &address,
-                    0,
-                    ptr::null(),
-                    &mut data_size,
-                    objects.as_mut_ptr().cast(),
-                )
-            },
-        )?;
+        status_result(data_operation, unsafe {
+            AudioObjectGetPropertyData(
+                object_id,
+                &address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                objects.as_mut_ptr().cast(),
+            )
+        })?;
 
         let actual_count = data_size as usize / mem::size_of::<AudioObjectId>();
         objects.truncate(actual_count);
         Ok(objects)
     }
 
+    fn process_devices(
+        process_object: AudioObjectId,
+        scope: AudioObjectPropertyScope,
+    ) -> Result<Vec<AudioObjectId>, ProbeError> {
+        read_object_array_property(
+            process_object,
+            AUDIO_PROCESS_PROPERTY_DEVICES,
+            scope,
+            "read process device list size",
+            "read process device list",
+        )
+    }
+
     fn read_process_pid(process_object: AudioObjectId) -> Result<Option<u32>, ProbeError> {
-        let pid = read_i32_property(process_object, AUDIO_PROCESS_PROPERTY_PID, "read process pid")?;
+        let pid = read_i32_property(
+            process_object,
+            AUDIO_PROCESS_PROPERTY_PID,
+            "read process pid",
+        )?;
         if pid <= 0 {
             Ok(None)
         } else {
             Ok(Some(pid as u32))
         }
+    }
+
+    fn process_has_input_devices(process_object: AudioObjectId) -> bool {
+        process_devices(process_object, AUDIO_OBJECT_PROPERTY_SCOPE_INPUT)
+            .map(|devices| !devices.is_empty())
+            .unwrap_or(false)
+    }
+
+    fn read_process_bundle_id(process_object: AudioObjectId) -> Result<Option<String>, ProbeError> {
+        let mut value: *const c_void = ptr::null();
+        read_scalar_property(
+            process_object,
+            AUDIO_PROCESS_PROPERTY_BUNDLE_ID,
+            "read process bundle id",
+            &mut value,
+        )?;
+        if value.is_null() {
+            return Ok(None);
+        }
+
+        let mut buffer = vec![0_i8; 512];
+        let ok = unsafe {
+            CFStringGetCString(
+                value,
+                buffer.as_mut_ptr(),
+                buffer.len() as isize,
+                0x0800_0100,
+            )
+        };
+        unsafe {
+            CFRelease(value);
+        }
+        if ok == 0 {
+            return Ok(None);
+        }
+        let value = unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) }
+            .to_string_lossy()
+            .trim()
+            .to_string();
+        Ok((!value.is_empty()).then_some(value))
     }
 
     fn read_i32_property(
@@ -337,25 +424,29 @@ mod macos {
     ) -> Result<(), ProbeError> {
         let address = property_address(selector);
         let mut data_size = mem::size_of::<T>() as u32;
-        status_result(
-            operation,
-            unsafe {
-                AudioObjectGetPropertyData(
-                    object_id,
-                    &address,
-                    0,
-                    ptr::null(),
-                    &mut data_size,
-                    (value as *mut T).cast(),
-                )
-            },
-        )
+        status_result(operation, unsafe {
+            AudioObjectGetPropertyData(
+                object_id,
+                &address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                (value as *mut T).cast(),
+            )
+        })
     }
 
     fn property_address(selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress {
+        property_address_with_scope(selector, AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL)
+    }
+
+    fn property_address_with_scope(
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope,
+    ) -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress {
             selector,
-            scope: AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+            scope,
             element: AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
         }
     }
@@ -383,6 +474,8 @@ mod macos {
         fn four_cc_matches_core_audio_constants() {
             assert_eq!(AUDIO_HARDWARE_PROPERTY_PROCESS_OBJECT_LIST, 0x7072_7323);
             assert_eq!(AUDIO_PROCESS_PROPERTY_PID, 0x7070_6964);
+            assert_eq!(AUDIO_PROCESS_PROPERTY_BUNDLE_ID, 0x7062_6964);
+            assert_eq!(AUDIO_PROCESS_PROPERTY_DEVICES, 0x7064_7623);
             assert_eq!(AUDIO_PROCESS_PROPERTY_IS_RUNNING_INPUT, 0x7069_7269);
         }
     }
@@ -396,9 +489,10 @@ mod tests {
     fn active_external_pids_excludes_owned_processes() {
         let owned = BTreeSet::from([10, 20]);
 
-        assert_eq!(active_external_pids(&[0, 10, 30, 20, 40], &owned), vec![
-            30, 40
-        ]);
+        assert_eq!(
+            active_external_pids(&[0, 10, 30, 20, 40], &owned),
+            vec![30, 40]
+        );
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
         "url": "/hud.html",
         "title": "OS Scribe Dictation",
         "width": 340,
-        "height": 120,
+        "height": 32,
         "resizable": false,
         "decorations": false,
         "transparent": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
         "label": "hud",
         "url": "/hud.html",
         "title": "OS Scribe Dictation",
-        "width": 220,
+        "width": 340,
         "height": 120,
         "resizable": false,
         "decorations": false,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -55,6 +55,7 @@ import {
   playRecordingSound,
   preloadRecordingSounds,
 } from "../lib/recording-sounds";
+import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import type {
   BootstrapResponse,
   DictationHelperEvent,
@@ -157,6 +158,7 @@ export function App() {
   const signInRequired = shouldBlockOnSignIn(account);
   const appBlocked = accountLoading || signInRequired;
   const selectedNote = state.selectedNote;
+  const selectedNoteId = selectedNote?.id;
   const originFolder = originFolderId
     ? state.folders.find((folder) => folder.id === originFolderId)
     : undefined;
@@ -678,8 +680,8 @@ export function App() {
     }
   }
 
-  async function handleStartRecording() {
-    if (!selectedNote) return;
+  const handleStartRecording = useCallback(async () => {
+    if (!selectedNoteId) return;
     dispatch({
       type: "recordingStatusChanged",
       status: startingRecordingStatus(sourceMode),
@@ -710,7 +712,7 @@ export function App() {
           ? "microphoneOnly"
           : sourceMode;
 
-      const recording = await startRecording(selectedNote.id, effectiveMode);
+      const recording = await startRecording(selectedNoteId, effectiveMode);
       dispatch({
         type: "recordingStatusChanged",
         status: recordingToStatus(recording),
@@ -722,7 +724,21 @@ export function App() {
     } finally {
       setCheckingSourceReadiness(false);
     }
-  }
+  }, [selectedNoteId, sourceMode]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listen(MEETING_START_TRANSCRIPTION_EVENT, () => {
+      if (appBlocked || !bootstrapped) return;
+      setActiveView("meetings");
+      void handleStartRecording();
+    }).then((cleanup) => {
+      unlisten = cleanup;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [appBlocked, bootstrapped, handleStartRecording]);
 
   async function handleFinishRecording(sessionId: string) {
     // Collapse the shell back to idle the instant stop is pressed so it

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { spinners } from "unicode-animations";
 import {
@@ -12,6 +12,7 @@ import {
   LIVE_WAVE_OPTIONS,
   withWaveLayers,
 } from "./lib/audio-meter";
+import { MEETING_START_TRANSCRIPTION_EVENT } from "./lib/events";
 import "./styles/hud.css";
 
 type DictationHudEvent = {
@@ -32,11 +33,14 @@ const bars = Array.from(document.querySelectorAll<HTMLElement>(".hud-bar"));
 const brailleNode = document.querySelector<HTMLElement>("#hud-braille");
 const errorText = document.querySelector<HTMLElement>("#hud-error-text");
 const stopButton = document.querySelector<HTMLButtonElement>("#hud-stop");
+const meetingStartButton =
+  document.querySelector<HTMLButtonElement>("#hud-meeting-start");
 const statusText = document.querySelector<HTMLElement>("#hud-status");
 
 let hideTimer: number | undefined;
 let brailleTimer: number | undefined;
 let brailleFrame = 0;
+let meetingPromptSuppressed = false;
 
 // waverows shows multiple horizontal rows of dots flowing across — reads as a
 // "thinking/processing" texture rather than a single dot bouncing.
@@ -118,7 +122,7 @@ function setHud(state: string, status: string) {
     hud.offsetWidth;
     if (state === "meeting") {
       clearStopHover();
-      clearPillBounds();
+      pushPillBoundsToNative();
     } else {
       pushPillBoundsToNative();
     }
@@ -284,7 +288,7 @@ async function showHud() {
   hud?.offsetWidth;
   if (hud?.dataset.state === "meeting") {
     clearStopHover();
-    clearPillBounds();
+    pushPillBoundsToNative();
   } else {
     pushPillBoundsToNative();
     pushStopBoundsToNative();
@@ -385,17 +389,18 @@ async function handleMeetingDetectionEventPayload(payload: unknown) {
   if (!meetingEvent) return;
 
   if (meetingEvent.type === "meeting_detected") {
+    if (meetingPromptSuppressed) return;
     if (!canShowMeetingPrompt(hud?.dataset.state)) return;
-    setHud("meeting", "Start transcription");
+    setHud("meeting", "Meeting detected");
     await showHud();
     return;
   }
 
-  if (
-    meetingEvent.type === "meeting_cleared" &&
-    hud?.dataset.state === "meeting"
-  ) {
-    void hideHud();
+  if (meetingEvent.type === "meeting_cleared") {
+    meetingPromptSuppressed = false;
+    if (hud?.dataset.state === "meeting") {
+      void hideHud();
+    }
   }
 }
 
@@ -442,6 +447,23 @@ stopButton?.addEventListener("click", async (event) => {
   } catch {
     void hideHud();
   }
+});
+
+meetingStartButton?.addEventListener("click", async (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  if (hud?.dataset.state !== "meeting") return;
+
+  meetingPromptSuppressed = true;
+  meetingStartButton.disabled = true;
+  try {
+    await emit(MEETING_START_TRANSCRIPTION_EVENT);
+  } catch {
+    // The main window owns recording errors; the HUD should never block clicks.
+  }
+  void hideHud().finally(() => {
+    meetingStartButton.disabled = false;
+  });
 });
 
 void listen("dictation-event", async (event) => {

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -391,7 +391,10 @@ async function handleMeetingDetectionEventPayload(payload: unknown) {
     return;
   }
 
-  if (meetingEvent.type === "meeting_cleared" && hud?.dataset.state === "meeting") {
+  if (
+    meetingEvent.type === "meeting_cleared" &&
+    hud?.dataset.state === "meeting"
+  ) {
     void hideHud();
   }
 }

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -116,7 +116,12 @@ function setHud(state: string, status: string) {
   // click pass-through whenever the state changes.
   if (state !== previous && hud) {
     hud.offsetWidth;
-    pushPillBoundsToNative();
+    if (state === "meeting") {
+      clearStopHover();
+      clearPillBounds();
+    } else {
+      pushPillBoundsToNative();
+    }
   }
 }
 
@@ -277,8 +282,13 @@ async function showHud() {
   await appWindow.show();
   // Force a layout flush before reading rects.
   hud?.offsetWidth;
-  pushPillBoundsToNative();
-  pushStopBoundsToNative();
+  if (hud?.dataset.state === "meeting") {
+    clearStopHover();
+    clearPillBounds();
+  } else {
+    pushPillBoundsToNative();
+    pushStopBoundsToNative();
+  }
 }
 
 function hideSoon(delay = 900) {
@@ -370,6 +380,31 @@ async function handleDictationEventPayload(payload: unknown) {
   }
 }
 
+async function handleMeetingDetectionEventPayload(payload: unknown) {
+  const meetingEvent = parseEvent(payload);
+  if (!meetingEvent) return;
+
+  if (meetingEvent.type === "meeting_detected") {
+    if (!canShowMeetingPrompt(hud?.dataset.state)) return;
+    setHud("meeting", "Start transcription");
+    await showHud();
+    return;
+  }
+
+  if (meetingEvent.type === "meeting_cleared" && hud?.dataset.state === "meeting") {
+    void hideHud();
+  }
+}
+
+function canShowMeetingPrompt(state: string | undefined) {
+  return (
+    state === undefined ||
+    state === "idle" ||
+    state === "meeting" ||
+    state === "exiting"
+  );
+}
+
 function parseEvent(payload: unknown): DictationHudEvent | undefined {
   try {
     if (typeof payload === "string") {
@@ -408,6 +443,10 @@ stopButton?.addEventListener("click", async (event) => {
 
 void listen("dictation-event", async (event) => {
   await handleDictationEventPayload(event.payload);
+});
+
+void listen("meeting-detection-event", async (event) => {
+  await handleMeetingDetectionEventPayload(event.payload);
 });
 
 void listen<boolean>("hud-stop-hover", (event) => {

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -38,6 +38,7 @@ const meetingStartButton =
 const statusText = document.querySelector<HTMLElement>("#hud-status");
 
 let hideTimer: number | undefined;
+let meetingPromptTimer: number | undefined;
 let brailleTimer: number | undefined;
 let brailleFrame = 0;
 let meetingPromptSuppressed = false;
@@ -48,6 +49,7 @@ const brailleWave = spinners.waverows;
 
 // Matches the .hud[data-state="exiting"] transition in hud.css.
 const EXIT_TRANSITION_MS = 160;
+const MEETING_PROMPT_TIMEOUT_MS = 30_000;
 
 // Bar synthesis + ballistics live in the shared meter so the recorder waveform
 // moves identically. The meter holds the level history and the displayed bars.
@@ -267,8 +269,26 @@ function clearHideTimer() {
   }
 }
 
+function clearMeetingPromptTimer() {
+  if (meetingPromptTimer) {
+    window.clearTimeout(meetingPromptTimer);
+    meetingPromptTimer = undefined;
+  }
+}
+
+function startMeetingPromptTimer() {
+  if (meetingPromptTimer !== undefined) return;
+  meetingPromptTimer = window.setTimeout(() => {
+    meetingPromptTimer = undefined;
+    if (hud?.dataset.state !== "meeting") return;
+    meetingPromptSuppressed = true;
+    void hideHud();
+  }, MEETING_PROMPT_TIMEOUT_MS);
+}
+
 async function hideHud() {
   clearHideTimer();
+  clearMeetingPromptTimer();
   clearStopHover();
   clearPillBounds();
   if (hud) {
@@ -393,11 +413,13 @@ async function handleMeetingDetectionEventPayload(payload: unknown) {
     if (!canShowMeetingPrompt(hud?.dataset.state)) return;
     setHud("meeting", "Meeting detected");
     await showHud();
+    startMeetingPromptTimer();
     return;
   }
 
   if (meetingEvent.type === "meeting_cleared") {
     meetingPromptSuppressed = false;
+    clearMeetingPromptTimer();
     if (hud?.dataset.state === "meeting") {
       void hideHud();
     }
@@ -455,6 +477,7 @@ meetingStartButton?.addEventListener("click", async (event) => {
   if (hud?.dataset.state !== "meeting") return;
 
   meetingPromptSuppressed = true;
+  clearMeetingPromptTimer();
   meetingStartButton.disabled = true;
   try {
     await emit(MEETING_START_TRANSCRIPTION_EVENT);

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,2 @@
+export const MEETING_START_TRANSCRIPTION_EVENT =
+  "scribe://meeting-start-transcription";

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -225,6 +225,16 @@ body {
   transform: translateY(-0.5px);
 }
 
+.hud-meeting-text {
+  display: none;
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  transform: translateY(-0.5px);
+}
+
 /* Stop button ---------------------------------------------------------- */
 .hud-stop {
   position: relative;
@@ -301,6 +311,20 @@ body {
 /* State machine ------------------------------------------------------- */
 .hud[data-state="error"] .hud-handle {
   display: none;
+}
+
+.hud[data-state="meeting"] {
+  padding-inline: var(--sp-3);
+}
+
+.hud[data-state="meeting"] .hud-handle,
+.hud[data-state="meeting"] .hud-viz,
+.hud[data-state="meeting"] .hud-stop {
+  display: none;
+}
+
+.hud[data-state="meeting"] .hud-meeting-text {
+  display: block;
 }
 
 /* Text-only shaking pill for hard errors. */

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -225,7 +225,7 @@ body {
   transform: translateY(-0.5px);
 }
 
-.hud-meeting-text {
+.hud-meeting-label {
   display: none;
   color: var(--foreground);
   font-size: var(--fs-sm);
@@ -233,6 +233,38 @@ body {
   line-height: 1;
   white-space: nowrap;
   transform: translateY(-0.5px);
+}
+
+.hud-meeting-start {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  min-width: 126px;
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: 6px;
+  background: var(--foreground);
+  color: var(--background);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  box-shadow:
+    inset 0 -1px 0 oklch(0% 0 none / 18%),
+    0 1px 2px oklch(0% 0 none / 28%);
+}
+
+.hud-meeting-start:active {
+  transform: translateY(0.5px);
+}
+
+.hud-meeting-start:disabled {
+  cursor: default;
+  opacity: 0.72;
+  transform: none;
 }
 
 /* Stop button ---------------------------------------------------------- */
@@ -314,17 +346,22 @@ body {
 }
 
 .hud[data-state="meeting"] {
-  padding-inline: var(--sp-3);
+  gap: var(--sp-2);
+  padding: 3px 4px 3px 3px;
 }
 
-.hud[data-state="meeting"] .hud-handle,
+.hud[data-state="meeting"] > .hud-handle {
+  margin-right: 0;
+}
+
 .hud[data-state="meeting"] .hud-viz,
 .hud[data-state="meeting"] .hud-stop {
   display: none;
 }
 
-.hud[data-state="meeting"] .hud-meeting-text {
-  display: block;
+.hud[data-state="meeting"] .hud-meeting-label,
+.hud[data-state="meeting"] .hud-meeting-start {
+  display: inline-flex;
 }
 
 /* Text-only shaking pill for hard errors. */

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -1,0 +1,197 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "../app/App";
+import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
+import type {
+  AccountStatus,
+  BootstrapResponse,
+  NoteDto,
+  RecordingSessionDto,
+} from "../lib/tauri";
+
+type TauriListener = (event: { payload: unknown }) => unknown;
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, TauriListener>(),
+  listen: vi.fn((event: string, listener: TauriListener) => {
+    mocks.listeners.set(event, listener);
+    return Promise.resolve(vi.fn());
+  }),
+  getCurrentWindow: vi.fn(),
+  bootstrapApp: vi.fn(),
+  createNote: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFolder: vi.fn(),
+  renameFolder: vi.fn(),
+  assignNoteToFolder: vi.fn(),
+  removeNoteFromFolder: vi.fn(),
+  listNotes: vi.fn(),
+  getNote: vi.fn(),
+  deleteNote: vi.fn(),
+  updateNote: vi.fn(),
+  checkRecordingSourceReadiness: vi.fn(),
+  openPrivacySettings: vi.fn(),
+  startRecording: vi.fn(),
+  pauseRecording: vi.fn(),
+  resumeRecording: vi.fn(),
+  getRecordingStatus: vi.fn(),
+  finishRecording: vi.fn(),
+  retryProcessing: vi.fn(),
+  recoverRecording: vi.fn(),
+  dictationHelperCommand: vi.fn(),
+  listDictationHistory: vi.fn(),
+  osAccountsStatus: vi.fn(),
+  osAccountsLogin: vi.fn(),
+  osAccountsCancelLogin: vi.fn(),
+  osAccountsLogout: vi.fn(),
+  osAccountsTopUp: vi.fn(),
+  playRecordingSound: vi.fn(),
+  preloadRecordingSounds: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: mocks.getCurrentWindow,
+}));
+
+vi.mock("../lib/recording-sounds", () => ({
+  playRecordingSound: mocks.playRecordingSound,
+  preloadRecordingSounds: mocks.preloadRecordingSounds,
+}));
+
+vi.mock("../lib/tauri", () => ({
+  bootstrapApp: mocks.bootstrapApp,
+  createNote: mocks.createNote,
+  createFolder: mocks.createFolder,
+  deleteFolder: mocks.deleteFolder,
+  renameFolder: mocks.renameFolder,
+  assignNoteToFolder: mocks.assignNoteToFolder,
+  removeNoteFromFolder: mocks.removeNoteFromFolder,
+  listNotes: mocks.listNotes,
+  getNote: mocks.getNote,
+  deleteNote: mocks.deleteNote,
+  updateNote: mocks.updateNote,
+  checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
+  openPrivacySettings: mocks.openPrivacySettings,
+  startRecording: mocks.startRecording,
+  pauseRecording: mocks.pauseRecording,
+  resumeRecording: mocks.resumeRecording,
+  getRecordingStatus: mocks.getRecordingStatus,
+  finishRecording: mocks.finishRecording,
+  retryProcessing: mocks.retryProcessing,
+  recoverRecording: mocks.recoverRecording,
+  dictationHelperCommand: mocks.dictationHelperCommand,
+  listDictationHistory: mocks.listDictationHistory,
+  osAccountsStatus: mocks.osAccountsStatus,
+  osAccountsLogin: mocks.osAccountsLogin,
+  osAccountsCancelLogin: mocks.osAccountsCancelLogin,
+  osAccountsLogout: mocks.osAccountsLogout,
+  osAccountsTopUp: mocks.osAccountsTopUp,
+}));
+
+const now = "2026-05-19T10:00:00Z";
+
+function note(overrides: Partial<NoteDto> = {}): NoteDto {
+  return {
+    id: "note-1",
+    title: "First note",
+    preview: "Preview",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    generatedContent: "Existing note",
+    activeTab: "notes",
+    ...overrides,
+  };
+}
+
+function recording(overrides: Partial<RecordingSessionDto> = {}) {
+  return {
+    id: "rec-1",
+    noteId: "note-1",
+    sourceMode: "microphonePlusSystem" as const,
+    state: "recording" as const,
+    startedAt: now,
+    elapsedMs: 0,
+    level: { peak: 0, rms: 0, recentPeaks: [] },
+    sources: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("meeting start transcription event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listeners.clear();
+
+    const first = note();
+    const payload: BootstrapResponse = {
+      folders: [],
+      notes: [first],
+      activeRecoveries: [],
+      providerConfigured: true,
+    };
+    const account: AccountStatus = {
+      signedIn: true,
+      configured: true,
+      user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
+      balance: { usdMillis: 1200 },
+    };
+
+    mocks.getCurrentWindow.mockReturnValue({
+      startDragging: vi.fn().mockResolvedValue(undefined),
+    });
+    mocks.bootstrapApp.mockResolvedValue(payload);
+    mocks.getNote.mockResolvedValue(first);
+    mocks.checkRecordingSourceReadiness.mockResolvedValue({
+      sourceMode: "microphonePlusSystem",
+      sources: [
+        { source: "microphone", ready: true },
+        { source: "system", ready: true },
+      ],
+    });
+    mocks.startRecording.mockResolvedValue(recording());
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.listDictationHistory.mockResolvedValue({
+      items: [],
+      retentionDays: 7,
+    });
+    mocks.osAccountsStatus.mockResolvedValue(account);
+    mocks.osAccountsLogin.mockResolvedValue(account);
+    mocks.osAccountsLogout.mockResolvedValue(undefined);
+    mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
+    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.updateNote.mockImplementation(async (input) => ({
+      ...first,
+      ...input,
+    }));
+  });
+
+  it("starts recording through the existing recorder flow", async () => {
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await act(async () => {
+      await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+        payload: undefined,
+      });
+    });
+
+    await waitFor(() =>
+      expect(mocks.startRecording).toHaveBeenCalledWith(
+        "note-1",
+        "microphonePlusSystem",
+      ),
+    );
+    expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
+  });
+});

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -5,6 +5,7 @@ type TauriListener = (event: { payload: unknown }) => unknown;
 const mocks = vi.hoisted(() => ({
   listeners: new Map<string, TauriListener>(),
   hide: vi.fn().mockResolvedValue(undefined),
+  emit: vi.fn().mockResolvedValue(undefined),
   invoke: vi.fn().mockResolvedValue(undefined),
   listen: vi.fn((event: string, listener: TauriListener) => {
     mocks.listeners.set(event, listener);
@@ -19,6 +20,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
+  emit: mocks.emit,
   listen: mocks.listen,
 }));
 
@@ -47,13 +49,38 @@ describe("meeting detection HUD", () => {
     });
 
     expect(hudElement().dataset.state).toBe("meeting");
-    expect(document.querySelector("#hud-meeting-text")).toHaveTextContent(
-      "Start transcription",
+    expect(document.querySelector("#hud-meeting-label")).toHaveTextContent(
+      "Meeting detected",
+    );
+    expect(document.querySelector("#hud-meeting-start")).toHaveTextContent(
+      "Start Transcription",
     );
     expect(mocks.show).toHaveBeenCalledOnce();
-    expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_pill_bounds", {
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_stop_bounds", {
       rect: null,
     });
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_pill_bounds", {
+      rect: { bottom: 0, left: 0, right: 0, top: 0 },
+    });
+  });
+
+  it("emits a start transcription request when the button is clicked", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    document.querySelector<HTMLButtonElement>("#hud-meeting-start")?.click();
+
+    await Promise.resolve();
+    expect(mocks.emit).toHaveBeenCalledWith(
+      "scribe://meeting-start-transcription",
+    );
+    await vi.runAllTimersAsync();
+    expect(mocks.hide).toHaveBeenCalledOnce();
+    expect(
+      document.querySelector<HTMLButtonElement>("#hud-meeting-start")?.disabled,
+    ).toBe(false);
+    vi.useRealTimers();
   });
 
   it("clears the prompt when microphone usage stops", async () => {
@@ -114,7 +141,8 @@ function hudMarkup() {
         <span class="hud-error-mark" aria-hidden="true"></span>
       </div>
       <span id="hud-error-text" class="hud-error-text" aria-hidden="true"></span>
-      <span id="hud-meeting-text" class="hud-meeting-text">Start transcription</span>
+      <span id="hud-meeting-label" class="hud-meeting-label">Meeting detected</span>
+      <button id="hud-meeting-start" class="hud-meeting-start" type="button">Start Transcription</button>
       <button id="hud-stop" class="hud-stop" type="button" aria-label="Stop dictation">
         <span class="hud-stop-glyph" aria-hidden="true"></span>
       </button>

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type TauriListener = (event: { payload: unknown }) => unknown;
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, TauriListener>(),
+  hide: vi.fn().mockResolvedValue(undefined),
+  invoke: vi.fn().mockResolvedValue(undefined),
+  listen: vi.fn((event: string, listener: TauriListener) => {
+    mocks.listeners.set(event, listener);
+    return Promise.resolve(vi.fn());
+  }),
+  show: vi.fn().mockResolvedValue(undefined),
+  startDragging: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    hide: mocks.hide,
+    show: mocks.show,
+    startDragging: mocks.startDragging,
+  }),
+}));
+
+describe("meeting detection HUD", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.listeners.clear();
+    document.body.innerHTML = hudMarkup();
+  });
+
+  it("shows the start transcription prompt when a meeting is detected", async () => {
+    await loadHud();
+
+    await emit("meeting-detection-event", {
+      type: "meeting_detected",
+      payload: { activeProcessCount: 1 },
+    });
+
+    expect(hudElement().dataset.state).toBe("meeting");
+    expect(document.querySelector("#hud-meeting-text")).toHaveTextContent(
+      "Start transcription",
+    );
+    expect(mocks.show).toHaveBeenCalledOnce();
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_pill_bounds", {
+      rect: null,
+    });
+  });
+
+  it("clears the prompt when microphone usage stops", async () => {
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    await emit("meeting-detection-event", { type: "meeting_cleared" });
+
+    expect(hudElement().dataset.state).toBe("exiting");
+  });
+
+  it("does not override an active dictation HUD state", async () => {
+    await loadHud();
+    hudElement().dataset.state = "transcribing";
+    mocks.show.mockClear();
+
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    expect(hudElement().dataset.state).toBe("transcribing");
+    expect(mocks.show).not.toHaveBeenCalled();
+  });
+});
+
+async function loadHud() {
+  await import("../hud");
+  await Promise.resolve();
+}
+
+async function emit(event: string, payload: unknown) {
+  const listener = mocks.listeners.get(event);
+  expect(listener).toBeDefined();
+  await listener?.({
+    payload: JSON.stringify(payload),
+  });
+}
+
+function hudElement() {
+  const hud = document.querySelector<HTMLDivElement>("#hud");
+  expect(hud).toBeTruthy();
+  return hud as HTMLDivElement;
+}
+
+function hudMarkup() {
+  return `
+    <div id="hud" class="hud" data-state="idle">
+      <span id="hud-handle" class="hud-handle" aria-label="Drag dictation HUD"></span>
+      <div class="hud-viz">
+        <div class="hud-bars" aria-hidden="true">
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+          <span class="hud-bar"></span>
+        </div>
+        <span id="hud-braille" class="hud-braille" aria-hidden="true"></span>
+        <span class="hud-error-mark" aria-hidden="true"></span>
+      </div>
+      <span id="hud-error-text" class="hud-error-text" aria-hidden="true"></span>
+      <span id="hud-meeting-text" class="hud-meeting-text">Start transcription</span>
+      <button id="hud-stop" class="hud-stop" type="button" aria-label="Stop dictation">
+        <span class="hud-stop-glyph" aria-hidden="true"></span>
+      </button>
+      <span id="hud-status" class="hud-status">Idle</span>
+    </div>
+  `;
+}

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type TauriListener = (event: { payload: unknown }) => unknown;
 
@@ -38,6 +38,10 @@ describe("meeting detection HUD", () => {
     vi.clearAllMocks();
     mocks.listeners.clear();
     document.body.innerHTML = hudMarkup();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows the start transcription prompt when a meeting is detected", async () => {
@@ -90,6 +94,40 @@ describe("meeting detection HUD", () => {
     await emit("meeting-detection-event", { type: "meeting_cleared" });
 
     expect(hudElement().dataset.state).toBe("exiting");
+  });
+
+  it("hides and suppresses the prompt after 30 seconds without a click", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(hudElement().dataset.state).toBe("meeting");
+    expect(mocks.hide).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(hudElement().dataset.state).toBe("exiting");
+    await vi.advanceTimersByTimeAsync(160);
+    expect(mocks.hide).toHaveBeenCalledOnce();
+
+    mocks.show.mockClear();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    expect(mocks.show).not.toHaveBeenCalled();
+  });
+
+  it("allows the prompt again after a timed-out meeting clears", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+    await vi.advanceTimersByTimeAsync(30_160);
+    await emit("meeting-detection-event", { type: "meeting_cleared" });
+
+    mocks.show.mockClear();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    expect(hudElement().dataset.state).toBe("meeting");
+    expect(mocks.show).toHaveBeenCalledOnce();
   });
 
   it("does not override an active dictation HUD state", async () => {


### PR DESCRIPTION
## Summary
- Filter meeting detection by the microphone-owning app identity, keeping the allowlist to Chrome, Arc, Safari, Teams, and Zoom.
- Keep the meeting HUD generic and wire its start button into the existing recording flow.
- Auto-hide the meeting prompt after 30 seconds if the user does not start transcription.

## Testing
- Added Rust unit coverage for allowed and disallowed microphone app filtering, including timeout-related state transitions.
- Added HUD UI tests for prompt display, click-through start, and auto-hide behavior.
- Added app-level coverage for starting recording from the meeting HUD event.