### PR TITLE
Remove agent session first-click flicker

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,6 +62,7 @@ import type {
   NoteDto,
   RecordingStatusDto,
   AccountStatus,
+  HermesSessionInfo,
 } from "../lib/tauri";
 import type {
   RecordingSourceMode,
@@ -117,6 +118,8 @@ export function App() {
   );
   const [bootstrapped, setBootstrapped] = useState(false);
   const [activeView, setActiveView] = useState<SidebarView>("notes");
+  const [activeAgentSession, setActiveAgentSession] =
+    useState<HermesSessionInfo>();
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
   // note shows the same back-arrow + breadcrumb chrome folders use. Cleared
@@ -858,6 +861,9 @@ export function App() {
         activeView={activeView}
         onChangeView={(view) => {
           setActiveView(view);
+          if (view !== "agent") {
+            setActiveAgentSession(undefined);
+          }
           if (view === "folders") {
             setFolderReturnTarget(undefined);
             dispatch({ type: "folderSelected", folderId: undefined });
@@ -874,6 +880,14 @@ export function App() {
         onRemoveNoteFromFolder={(noteId, folderId) =>
           void handleRemoveNoteFromFolder(noteId, folderId)
         }
+        onNewAgentSession={() => {
+          setActiveAgentSession(undefined);
+          setActiveView("agent");
+        }}
+        onSelectAgentSession={(session) => {
+          setActiveAgentSession(session);
+          setActiveView("agent");
+        }}
         recoverableNoteIds={recoverableNoteIds}
         collapsed={sidebarCollapsed}
       />
@@ -940,7 +954,7 @@ export function App() {
                 }}
               />
             ) : activeView === "agent" ? (
-              <AgentWorkspace />
+              <AgentWorkspace initialSession={activeAgentSession} />
             ) : activeView === "notes" || activeView === "all-notes" ? (
               <NotesList
                 notes={state.notes}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2,6 +2,7 @@ import {
   BotIcon,
   CheckIcon,
   CircleStopIcon,
+  DownloadIcon,
   FileIcon,
   FolderIcon,
   FolderTreeIcon,
@@ -88,7 +89,6 @@ const AGENT_TITLE_TIMEOUT_MS = 2500;
 type AgentPanel = "chat" | "skills" | "messaging";
 
 export const AGENT_NEW_SESSION_EVENT = "scribe:agent:new-session";
-export const AGENT_SELECT_SESSION_EVENT = "scribe:agent:select-session";
 export const AGENT_DELETE_SESSION_EVENT = "scribe:agent:delete-session";
 export const AGENT_SESSIONS_CHANGED_EVENT = "scribe:agent:sessions-changed";
 export const AGENT_NEW_SESSION_PENDING_KEY = "scribe:agent:new-session-pending";
@@ -97,10 +97,6 @@ export type AgentSessionsChangedDetail = {
   sessions: HermesSessionInfo[];
   selectedSessionId?: string;
   workingSessionIds: string[];
-};
-
-type AgentSelectSessionDetail = {
-  sessionId: string;
 };
 
 export type AgentNewSessionDetail = {
@@ -347,16 +343,6 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       void startNewTask(detail?.prompt);
     }
 
-    function handleSelectSession(event: Event) {
-      const detail = (event as CustomEvent<AgentSelectSessionDetail>).detail;
-      if (!detail?.sessionId) return;
-      newSessionModeRef.current = false;
-      setNewSessionMode(false);
-      setActivePanel("chat");
-      setSelectedHermesSessionId(detail.sessionId);
-      setSelectedTaskId(undefined);
-    }
-
     function handleDeleteSession(event: Event) {
       const detail = (event as CustomEvent<AgentDeleteSessionDetail>).detail;
       if (!detail?.sessionId) return;
@@ -385,14 +371,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     }
 
     window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
-    window.addEventListener(AGENT_SELECT_SESSION_EVENT, handleSelectSession);
     window.addEventListener(AGENT_DELETE_SESSION_EVENT, handleDeleteSession);
     return () => {
       window.removeEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
-      window.removeEventListener(
-        AGENT_SELECT_SESSION_EVENT,
-        handleSelectSession,
-      );
       window.removeEventListener(
         AGENT_DELETE_SESSION_EVENT,
         handleDeleteSession,
@@ -2357,8 +2338,13 @@ function AgentArtifactList({
             </p>
           </div>
           {onDownload ? (
-            <button type="button" onClick={() => onDownload(artifact)}>
-              Download
+            <button
+              type="button"
+              aria-label={`Download ${artifact.name}`}
+              title="Download"
+              onClick={() => onDownload(artifact)}
+            >
+              <DownloadIcon size={16} />
             </button>
           ) : null}
         </article>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -123,7 +123,12 @@ type HermesRuntimeSessionResponse = {
   stored_session_id?: string;
 };
 
-export function AgentWorkspace() {
+type AgentWorkspaceProps = {
+  initialSession?: HermesSessionInfo;
+};
+
+export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
+  const initialSessionId = initialSession?.id;
   const [tasks, setTasks] = useState<AgentTaskDto[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string>();
   const [activePanel, setActivePanel] = useState<AgentPanel>("chat");
@@ -140,9 +145,10 @@ export function AgentWorkspace() {
   );
   const [hermesSessionItems, setHermesSessionItems] = useState<
     HermesSessionInfo[]
-  >([]);
-  const [selectedHermesSessionId, setSelectedHermesSessionId] =
-    useState<string>();
+  >(() => (initialSession ? [initialSession] : []));
+  const [selectedHermesSessionId, setSelectedHermesSessionId] = useState<
+    string | undefined
+  >(initialSessionId);
   const [newSessionMode, setNewSessionMode] = useState(false);
   const [hermesSessionMessages, setHermesSessionMessages] = useState<
     Record<string, HermesSessionMessage[]>
@@ -303,6 +309,22 @@ export function AgentWorkspace() {
     if (!bridge.running) return;
     void loadHermesSessions();
   }, [bridge.running, loadHermesSessions]);
+
+  useEffect(() => {
+    if (!initialSessionId) return;
+    newSessionModeRef.current = false;
+    setNewSessionMode(false);
+    setActivePanel("chat");
+    setSelectedHermesSessionId(initialSessionId);
+    setSelectedTaskId(undefined);
+    if (initialSession) {
+      setHermesSessionItems((current) =>
+        current.some((session) => session.id === initialSession.id)
+          ? current
+          : [initialSession, ...current],
+      );
+    }
+  }, [initialSession, initialSessionId]);
 
   useEffect(() => {
     window.dispatchEvent(

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -13,7 +13,6 @@ import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
-  AGENT_SELECT_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   markAgentNewSessionPending,
   type AgentSessionsChangedDetail,
@@ -44,6 +43,8 @@ type SidebarProps = {
   onDeleteNote: (noteId: string) => void;
   onOpenMoveDialog: (noteId: string) => void;
   onRemoveNoteFromFolder: (noteId: string, folderId: string) => void;
+  onNewAgentSession: () => void;
+  onSelectAgentSession: (session: HermesSessionInfo) => void;
   recoverableNoteIds?: ReadonlySet<string>;
   collapsed?: boolean;
 };
@@ -64,6 +65,8 @@ export function Sidebar({
   onDeleteNote,
   onOpenMoveDialog,
   onRemoveNoteFromFolder,
+  onNewAgentSession,
+  onSelectAgentSession,
   recoverableNoteIds,
   collapsed = false,
 }: SidebarProps) {
@@ -253,7 +256,7 @@ export function Sidebar({
           className="sidebar-nav-item"
           onClick={() => {
             markAgentNewSessionPending();
-            onChangeView("agent");
+            onNewAgentSession();
             dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
           }}
         >
@@ -322,11 +325,8 @@ export function Sidebar({
                   working={workingAgentSessionIds.has(session.id)}
                   deleting={deletingAgentSessionIds.has(session.id)}
                   onSelect={() => {
-                    onChangeView("agent");
                     setSelectedAgentSessionId(session.id);
-                    dispatchAgentEvent(AGENT_SELECT_SESSION_EVENT, {
-                      sessionId: session.id,
-                    });
+                    onSelectAgentSession(session);
                   }}
                   onDelete={() => {
                     setAgentSessionDeleteError(null);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1265,13 +1265,19 @@ input:focus-visible,
 }
 
 .agent-artifact-card button {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-sm);
   min-height: var(--control-sm);
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-sm);
-  padding: 0 var(--sp-3);
+  padding: 0;
   background: var(--secondary);
   color: var(--secondary-foreground);
-  font-size: var(--fs-sm);
+}
+
+.agent-artifact-card button:hover {
+  background: var(--tertiary);
 }
 
 .agent-reasoning {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -226,7 +226,9 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByLabelText("Generated files")).toBeInTheDocument();
     expect(screen.getAllByText("sample.pdf").length).toBeGreaterThan(0);
 
-    await user.click(screen.getByRole("button", { name: "Download" }));
+    await user.click(
+      screen.getByRole("button", { name: "Download sample.pdf" }),
+    );
 
     expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(samplePath);
   });

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -77,6 +77,8 @@ describe("Sidebar primary navigation", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
       />,
     );
 
@@ -97,6 +99,8 @@ describe("Sidebar primary navigation", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
       />,
     );
 
@@ -119,6 +123,8 @@ describe("Sidebar primary navigation", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
       />,
     );
 

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
-  AGENT_SELECT_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
 } from "../components/agent/AgentWorkspace";
 import { NotesList } from "../components/notes-list/NotesList";
@@ -67,6 +66,8 @@ describe("folders UI", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={() => onChangeView("agent")}
+        onSelectAgentSession={vi.fn()}
       />,
     );
 
@@ -89,7 +90,6 @@ describe("folders UI", () => {
     const user = userEvent.setup();
     const onChangeView = vi.fn();
     const onSelectAgentSession = vi.fn();
-    window.addEventListener(AGENT_SELECT_SESSION_EVENT, onSelectAgentSession);
     render(
       <Sidebar
         notes={notes}
@@ -99,6 +99,8 @@ describe("folders UI", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={onSelectAgentSession}
       />,
     );
 
@@ -128,15 +130,9 @@ describe("folders UI", () => {
       screen.getByRole("button", { name: /Researching Google/ }),
     );
 
-    expect(onChangeView).toHaveBeenCalledWith("agent");
-    await waitFor(() => expect(onSelectAgentSession).toHaveBeenCalled());
-    const detail = (onSelectAgentSession.mock.calls[0][0] as CustomEvent)
-      .detail;
-    expect(detail).toEqual({ sessionId: "session-1" });
-
-    window.removeEventListener(
-      AGENT_SELECT_SESSION_EVENT,
-      onSelectAgentSession,
+    expect(onChangeView).not.toHaveBeenCalled();
+    expect(onSelectAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-1" }),
     );
   });
 
@@ -150,6 +146,8 @@ describe("folders UI", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
       />,
     );
 
@@ -190,6 +188,8 @@ describe("folders UI", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
       />,
     );
 


### PR DESCRIPTION
## Summary
- Pass the selected agent session through App state before switching to the Agent workspace.
- Mount AgentWorkspace with the selected session metadata so the title/detail pane renders immediately on first click.
- Replace the delayed sidebar selection event for normal clicks with a direct callback while keeping existing new-session/delete events.

## Verification
- `pnpm exec vitest run src/test/agent-workspace.test.tsx src/test/folders.test.tsx src/test/folders-workspace.test.tsx`
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`