### PR TITLE
[fix] address meeting HUD review comments

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -727,15 +727,18 @@ export function App() {
   }, [selectedNoteId, sourceMode]);
 
   useEffect(() => {
+    let aborted = false;
     let unlisten: (() => void) | undefined;
     void listen(MEETING_START_TRANSCRIPTION_EVENT, () => {
       if (appBlocked || !bootstrapped) return;
       setActiveView("meetings");
       void handleStartRecording();
     }).then((cleanup) => {
-      unlisten = cleanup;
+      if (aborted) cleanup();
+      else unlisten = cleanup;
     });
     return () => {
+      aborted = true;
       unlisten?.();
     };
   }, [appBlocked, bootstrapped, handleStartRecording]);

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -122,12 +122,8 @@ function setHud(state: string, status: string) {
   // click pass-through whenever the state changes.
   if (state !== previous && hud) {
     hud.offsetWidth;
-    if (state === "meeting") {
-      clearStopHover();
-      pushPillBoundsToNative();
-    } else {
-      pushPillBoundsToNative();
-    }
+    if (state === "meeting") clearStopHover();
+    pushPillBoundsToNative();
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix the meeting-start event listener cleanup race in React strict mode.
- Simplify the meeting HUD pill-bounds refresh branch per review feedback.

## Validation
- `pnpm test -- src/test/app-meeting-start.test.tsx`
- `pnpm test -- src/test/hud-meeting.test.ts`
- `pnpm run lint`
- `pnpm run format`