### PR TITLE
[codex] Add account manage button

### DIFF
--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -148,14 +148,24 @@ export function AccountSettingsSection({
               </div>
               <div className="settings-row-control">
                 {account.signedIn ? (
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    disabled={busy}
-                    onClick={() => void handleSignOut()}
-                  >
-                    Sign out
-                  </button>
+                  <>
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      disabled={busy}
+                      onClick={() => void handleTopUp()}
+                    >
+                      Manage
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      disabled={busy}
+                      onClick={() => void handleSignOut()}
+                    >
+                      Sign out
+                    </button>
+                  </>
                 ) : busy ? (
                   <button
                     type="button"

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -257,6 +257,28 @@ describe("AppSettings", () => {
     });
   });
 
+  it("opens OS Accounts from Manage and Add funds in account settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Manage" }));
+    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Add funds" }));
+    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(2);
+  });
+
   it("updates dictation microphone and note recording source", async () => {
     const user = userEvent.setup();
     const onSourceModeChange = vi.fn();


### PR DESCRIPTION
## Summary

- Add a `Manage` button next to `Sign out` under Settings -> Account for signed-in users.
- Reuse the existing OS Accounts top-up/open-account command so `Manage` leads to the same destination as `Add funds`.
- Add a regression test covering both buttons calling the same account-management path.

## Impact

Signed-in users can now reach their OS Accounts management page directly from the Account row without going through the Billing section.

## Validation

- `pnpm vitest run src/test/app-settings.test.tsx`
- `pnpm run lint`