### PR TITLE
[codex] Fix agent clarify and reasoning rendering

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -184,6 +184,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const [approvalSubmitting, setApprovalSubmitting] = useState<
     Record<string, string>
   >({});
+  const [clarifySubmitting, setClarifySubmitting] = useState<
+    Record<string, string>
+  >({});
   const gatewayRef = useRef<HermesGatewayClient | null>(null);
   const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>({});
   const hydratedTaskIdsRef = useRef<Set<string>>(new Set());
@@ -789,6 +792,46 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     }
   }
 
+  async function respondToClarify(
+    liveEventKey: string,
+    requestId: string,
+    answer: string,
+  ) {
+    setClarifySubmitting((current) => ({ ...current, [requestId]: answer }));
+    try {
+      const gateway = await ensureHermesGateway();
+      await gateway.request("clarify.respond", {
+        request_id: requestId,
+        answer,
+      });
+      pushLiveEvent(liveEventKey, {
+        type: "clarify.response",
+        payload: { request_id: requestId, answer },
+      });
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setClarifySubmitting((current) => {
+        const next = { ...current };
+        delete next[requestId];
+        return next;
+      });
+    }
+  }
+
+  function pushLiveEvent(key: string, event: HermesGatewayEvent) {
+    const liveEvent = { ...event, receivedAt: new Date().toISOString() };
+    const nextEvents = [...(liveEventsRef.current[key] ?? []), liveEvent].slice(
+      -200,
+    );
+    liveEventsRef.current = {
+      ...liveEventsRef.current,
+      [key]: nextEvents,
+    };
+    setLiveEvents(liveEventsRef.current);
+  }
+
   async function startNewTask(prompt?: string) {
     clearPendingNewSessionRequest();
     newSessionModeRef.current = true;
@@ -1037,6 +1080,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                   turn={turn}
                   artifacts={chatArtifacts}
                   approvalSubmitting={approvalSubmitting}
+                  clarifySubmitting={clarifySubmitting}
                   onDownloadArtifact={(artifact) =>
                     void downloadHermesBridgeFile(artifact.path).catch(
                       (err: unknown) => setError(messageFromError(err)),
@@ -1047,6 +1091,13 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                       part.sessionId ?? selectedHermesSessionId,
                       part.id,
                       choice,
+                    )
+                  }
+                  onClarify={(part, answer) =>
+                    void respondToClarify(
+                      selectedHermesSessionId,
+                      part.id,
+                      answer,
                     )
                   }
                 />
@@ -1105,6 +1156,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                   turn={turn}
                   artifacts={chatArtifacts}
                   approvalSubmitting={approvalSubmitting}
+                  clarifySubmitting={clarifySubmitting}
                   onDownloadArtifact={(artifact) =>
                     void downloadHermesBridgeFile(artifact.path).catch(
                       (err: unknown) => setError(messageFromError(err)),
@@ -1118,6 +1170,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                     if (!sessionId) return;
                     void respondToApproval(sessionId, part.id, choice);
                   }}
+                  onClarify={(part, answer) =>
+                    void respondToClarify(selectedTask.id, part.id, answer)
+                  }
                 />
               ))}
             </div>
@@ -2115,15 +2170,22 @@ type ApprovalChoice = "once" | "session" | "always" | "deny";
 function AgentChatTurnRow({
   approvalSubmitting,
   artifacts,
+  clarifySubmitting,
   onApproval,
+  onClarify,
   onDownloadArtifact,
   turn,
 }: {
   approvalSubmitting: Record<string, string>;
   artifacts?: AgentArtifact[];
+  clarifySubmitting: Record<string, string>;
   onApproval: (
     part: Extract<AgentChatPart, { type: "approval" }>,
     choice: ApprovalChoice,
+  ) => void;
+  onClarify: (
+    part: Extract<AgentChatPart, { type: "clarify" }>,
+    answer: string,
   ) => void;
   onDownloadArtifact?: (artifact: AgentArtifact) => void;
   turn: AgentChatTurn;
@@ -2176,6 +2238,13 @@ function AgentChatTurnRow({
               submitting={approvalSubmitting[part.id]}
               onApproval={onApproval}
             />
+          ) : part.type === "clarify" ? (
+            <ClarifyPart
+              key={`${turn.id}:clarify:${part.id}`}
+              part={part}
+              submitting={clarifySubmitting[part.id]}
+              onClarify={onClarify}
+            />
           ) : (
             <AgentToolPartRow key={`${turn.id}:tool:${part.id}`} part={part} />
           ),
@@ -2186,6 +2255,117 @@ function AgentChatTurnRow({
         />
         {textParts.length === 0 && nonTextParts.length === 0 ? (
           <p className="agent-assistant-empty">Waiting for Hermes...</p>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function ClarifyPart({
+  onClarify,
+  part,
+  submitting,
+}: {
+  onClarify: (
+    part: Extract<AgentChatPart, { type: "clarify" }>,
+    answer: string,
+  ) => void;
+  part: Extract<AgentChatPart, { type: "clarify" }>;
+  submitting?: string;
+}) {
+  const [typing, setTyping] = useState(part.choices.length === 0);
+  const [draft, setDraft] = useState("");
+  const disabled = part.status !== "pending" || submitting !== undefined;
+
+  return (
+    <article className="agent-clarify-card" data-status={part.status}>
+      <span className="agent-tool-icon">
+        <MessageSquareIcon size={14} />
+      </span>
+      <div>
+        <div className="agent-tool-title">
+          <span>Clarify</span>
+          <span
+            className="agent-tool-live-status"
+            data-status={part.status === "pending" ? "running" : "complete"}
+          >
+            {part.status === "pending" ? "Waiting" : "Answered"}
+          </span>
+        </div>
+        <p>{part.question}</p>
+        {part.answer !== undefined ? (
+          <p className="agent-clarify-answer">
+            {part.answer.trim() ? part.answer : "Skipped"}
+          </p>
+        ) : null}
+        {part.status === "pending" ? (
+          <>
+            {!typing && part.choices.length ? (
+              <div className="agent-clarify-choices">
+                {part.choices.map((choice, index) => (
+                  <button
+                    type="button"
+                    key={`${index}:${choice}`}
+                    disabled={disabled}
+                    onClick={() => onClarify(part, choice)}
+                  >
+                    <span>{index + 1}</span>
+                    {choice}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  disabled={submitting !== undefined}
+                  onClick={() => setTyping(true)}
+                >
+                  <span>+</span>
+                  Other
+                </button>
+              </div>
+            ) : null}
+            {typing || !part.choices.length ? (
+              <form
+                className="agent-clarify-form"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  const answer = draft.trim();
+                  if (answer) onClarify(part, answer);
+                }}
+              >
+                <textarea
+                  value={draft}
+                  disabled={disabled}
+                  rows={3}
+                  placeholder="Type your answer"
+                  onChange={(event) => setDraft(event.currentTarget.value)}
+                />
+                <div>
+                  {part.choices.length ? (
+                    <button
+                      type="button"
+                      disabled={submitting !== undefined}
+                      onClick={() => {
+                        setDraft("");
+                        setTyping(false);
+                      }}
+                    >
+                      Back
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => onClarify(part, "")}
+                  >
+                    Skip
+                  </button>
+                  <button type="submit" disabled={disabled || !draft.trim()}>
+                    {submitting !== undefined ? "Sending" : "Send"}
+                  </button>
+                </div>
+              </form>
+            ) : null}
+          </>
         ) : null}
       </div>
     </article>

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -40,11 +40,22 @@ export type AgentChatApprovalPart = {
   status: "pending" | "resolved";
 };
 
+export type AgentChatClarifyPart = {
+  type: "clarify";
+  id: string;
+  sessionId?: string;
+  question: string;
+  choices: string[];
+  answer?: string;
+  status: "pending" | "resolved";
+};
+
 export type AgentChatPart =
   | AgentChatTextPart
   | AgentChatReasoningPart
   | AgentChatToolPart
-  | AgentChatApprovalPart;
+  | AgentChatApprovalPart
+  | AgentChatClarifyPart;
 
 export type AgentChatTurn = {
   id: string;
@@ -239,6 +250,14 @@ function appendLiveHermesEvents(
     }
 
     if (event.type.startsWith("tool.")) {
+      if (isClarifyToolEvent(event)) {
+        if (event.type.includes("complete") || event.type.includes("fail")) {
+          completePendingClarifyParts(
+            (currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [],
+          );
+        }
+        continue;
+      }
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
       currentAssistant.status =
         toolEventStatus(event) === "running"
@@ -256,6 +275,44 @@ function appendLiveHermesEvents(
         text,
         status: toolEventStatus(event),
       });
+      continue;
+    }
+
+    if (event.type === "clarify.request") {
+      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+      currentAssistant.status = "running";
+      const payload = event.payload as Record<string, unknown> | undefined;
+      upsertClarifyPart(currentAssistant.parts, {
+        id:
+          stringValue(payload?.request_id) ??
+          stringValue(payload?.id) ??
+          `clarify:${event.receivedAt}`,
+        sessionId: event.session_id,
+        question:
+          stringValue(payload?.question, true) ??
+          "Hermes needs clarification before continuing.",
+        choices: stringArrayValue(payload?.choices),
+        status: "pending",
+      });
+      continue;
+    }
+
+    if (event.type === "clarify.response") {
+      const payload = event.payload as Record<string, unknown> | undefined;
+      upsertClarifyPart(
+        (currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [],
+        {
+          id:
+            stringValue(payload?.request_id) ??
+            stringValue(payload?.id) ??
+            `clarify:${event.receivedAt}`,
+          sessionId: event.session_id,
+          question: stringValue(payload?.question, true) ?? "",
+          choices: stringArrayValue(payload?.choices),
+          answer: stringValue(payload?.answer, true) ?? "",
+          status: "resolved",
+        },
+      );
       continue;
     }
 
@@ -356,7 +413,7 @@ function appendReasoningPart(parts: AgentChatPart[], delta: string) {
     return;
   const last = parts.at(-1);
   if (last?.type === "reasoning") {
-    last.text = appendLogText(last.text, delta);
+    last.text = appendMessageText(last.text, delta);
     last.status = "running";
     return;
   }
@@ -370,6 +427,8 @@ function completeRunningParts(parts: AgentChatPart[]) {
     if (part.type === "tool" && part.status === "running")
       part.status = "complete";
     if (part.type === "approval" && part.status === "pending")
+      part.status = "resolved";
+    if (part.type === "clarify" && part.status === "pending")
       part.status = "resolved";
   }
 }
@@ -427,6 +486,34 @@ function upsertApprovalPart(
     command: next.command,
     description: next.description,
     allowPermanent: next.allowPermanent,
+    status: next.status,
+  });
+}
+
+function upsertClarifyPart(
+  parts: AgentChatPart[],
+  next: Pick<AgentChatClarifyPart, "id" | "question" | "choices" | "status"> &
+    Partial<Pick<AgentChatClarifyPart, "answer" | "sessionId">>,
+) {
+  const existing = parts.find(
+    (part): part is AgentChatClarifyPart =>
+      part.type === "clarify" && part.id === next.id,
+  );
+  if (existing) {
+    existing.question = next.question || existing.question;
+    existing.choices = next.choices.length ? next.choices : existing.choices;
+    existing.answer = next.answer ?? existing.answer;
+    existing.sessionId = next.sessionId || existing.sessionId;
+    existing.status = next.status;
+    return;
+  }
+  parts.push({
+    type: "clarify",
+    id: next.id,
+    sessionId: next.sessionId,
+    question: next.question,
+    choices: next.choices,
+    answer: next.answer,
     status: next.status,
   });
 }
@@ -580,6 +667,25 @@ function toolEventKey(event: HermesGatewayEvent) {
   );
 }
 
+function isClarifyToolEvent(event: HermesGatewayEvent) {
+  const payload = event.payload as Record<string, unknown> | undefined;
+  const name =
+    stringValue(payload?.name) ??
+    stringValue(payload?.tool_name) ??
+    stringValue(payload?.tool);
+  return name?.toLowerCase() === "clarify";
+}
+
+function completePendingClarifyParts(parts: AgentChatPart[]) {
+  const pending = [...parts]
+    .reverse()
+    .find(
+      (part): part is AgentChatClarifyPart =>
+        part.type === "clarify" && part.status === "pending",
+    );
+  if (pending) pending.status = "resolved";
+}
+
 function toolEventStatus(
   event: HermesGatewayEvent,
 ): AgentChatToolPart["status"] {
@@ -598,6 +704,8 @@ function toolStatus(status: AgentToolEventStatus): AgentChatToolPart["status"] {
 function partText(part: AgentChatPart) {
   if (part.type === "tool") return part.text;
   if (part.type === "approval") return part.command || part.description;
+  if (part.type === "clarify")
+    return [part.question, part.answer ?? ""].join(" ");
   return part.text;
 }
 
@@ -663,6 +771,12 @@ function appendLogText(current: string, next: string) {
       ? ""
       : "\n";
   return `${current}${separator}${next}`;
+}
+
+function stringArrayValue(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
 }
 
 function stringValue(value: unknown, preserveWhitespace = false) {

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -11,6 +11,7 @@ export type HermesGatewayEventName =
   | "tool.progress"
   | "tool.complete"
   | "clarify.request"
+  | "clarify.response"
   | "approval.request"
   | "error"
   | (string & {});

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -926,7 +926,8 @@ input:focus-visible,
 .agent-safety-panel,
 .agent-tool-event,
 .agent-hermes-event,
-.agent-approval-card {
+.agent-approval-card,
+.agent-clarify-card {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: var(--sp-4);
@@ -945,10 +946,103 @@ input:focus-visible,
   background: color-mix(in oklch, var(--warm-soft) 10%, var(--surface-subtle));
 }
 
-.agent-approval-card p {
+.agent-approval-card p,
+.agent-clarify-card p {
   margin: var(--sp-2) 0 0;
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.agent-clarify-card {
+  width: min(760px, 100%);
+}
+
+.agent-clarify-answer {
+  border-left: 2px solid var(--border-subtle);
+  padding-left: var(--sp-3);
+  color: var(--foreground) !important;
+}
+
+.agent-clarify-choices {
+  display: grid;
+  gap: var(--sp-2);
+  margin-top: var(--sp-3);
+}
+
+.agent-clarify-choices button,
+.agent-clarify-form button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--control-sm);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  padding: 0 var(--sp-3);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  font: inherit;
+}
+
+.agent-clarify-choices button {
+  justify-content: flex-start;
+  gap: var(--sp-3);
+  text-align: left;
+}
+
+.agent-clarify-choices button span {
+  display: inline-grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--r-xs);
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+}
+
+.agent-clarify-choices button:hover:not(:disabled),
+.agent-clarify-form button:hover:not(:disabled) {
+  background: var(--tertiary);
+}
+
+.agent-clarify-choices button:disabled,
+.agent-clarify-form button:disabled,
+.agent-clarify-form textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.agent-clarify-form {
+  display: grid;
+  gap: var(--sp-2);
+  margin-top: var(--sp-3);
+}
+
+.agent-clarify-form textarea {
+  width: 100%;
+  min-height: 84px;
+  resize: vertical;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  padding: var(--sp-3);
+  background: var(--surface);
+  color: var(--foreground);
+  font: inherit;
+  line-height: 1.45;
+}
+
+.agent-clarify-form textarea:focus {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.agent-clarify-form div {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-2);
 }
 
 .agent-approval-card pre {
@@ -1318,6 +1412,10 @@ input:focus-visible,
 
 .agent-reasoning[data-status="running"] summary span {
   color: var(--warm-strong);
+}
+
+.agent-reasoning[open] summary p {
+  display: none;
 }
 
 .agent-reasoning-body {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildHermesSessionChatTurns } from "../lib/agent-chat-runtime";
+import {
+  buildAgentChatTurns,
+  buildHermesSessionChatTurns,
+} from "../lib/agent-chat-runtime";
 import type { HermesSessionMessage } from "../lib/tauri";
 
 describe("Agent chat runtime", () => {
@@ -66,5 +69,111 @@ describe("Agent chat runtime", () => {
     );
 
     expect(textParts).toEqual(["Say hello", "Hello there", "Nested reply"]);
+  });
+
+  it("appends live reasoning deltas without inserting log line breaks", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {},
+        },
+        {
+          type: "thinking.delta",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: { text: "I should prefer" },
+        },
+        {
+          type: "thinking.delta",
+          receivedAt: "2026-06-04T10:00:00.200Z",
+          payload: { text: "ably use Homebrew." },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "reasoning",
+        text: "I should preferably use Homebrew.",
+        status: "running",
+      },
+    ]);
+  });
+
+  it("renders live clarify requests as answerable chat parts", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { tool_id: "tool-1", name: "clarify" },
+        },
+        {
+          type: "clarify.request",
+          session_id: "runtime-session",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: {
+            request_id: "clarify-1",
+            question: "Which email provider should I configure?",
+            choices: ["Gmail", "Fastmail"],
+          },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "clarify",
+        id: "clarify-1",
+        sessionId: "runtime-session",
+        question: "Which email provider should I configure?",
+        choices: ["Gmail", "Fastmail"],
+        status: "pending",
+      },
+    ]);
+  });
+
+  it("marks clarify requests resolved after responses or tool completion", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "clarify.request",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            request_id: "clarify-1",
+            question: "Use Gmail?",
+            choices: ["Yes", "No"],
+          },
+        },
+        {
+          type: "clarify.response",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { request_id: "clarify-1", answer: "Yes" },
+        },
+        {
+          type: "tool.complete",
+          receivedAt: "2026-06-04T10:00:02.000Z",
+          payload: { tool_id: "tool-1", name: "clarify" },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "clarify",
+        id: "clarify-1",
+        question: "Use Gmail?",
+        choices: ["Yes", "No"],
+        answer: "Yes",
+        status: "resolved",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two agent chat rendering problems and makes Hermes clarify prompts actionable in the Scribe agent workspace.

## Changes

- Treat `clarify.request` as a first-class chat part instead of showing it as a generic running terminal tool.
- Add clarify response UI with choices, free-form answers, skip support, and `clarify.respond` gateway wiring.
- Concatenate streamed reasoning deltas as prose rather than log lines, which avoids odd word breaks.
- Hide the reasoning preview while the expanded body is open to avoid duplicated text.
- Add regression coverage for reasoning delta concatenation and clarify request/response state.

## Root Cause

The UI only understood generic `tool.*` and approval events. Hermes emits a dedicated `clarify.request` event plus a `clarify.respond` RPC, so the previous renderer had no way to answer the prompt and left the card looking stuck on `Running`. Reasoning deltas also reused log-text concatenation, which inserted newlines between streamed text fragments.

## Validation

- `pnpm test`
- `pnpm run build`

Vite still reports the existing large chunk warning during build.