### PR TITLE
[codex] Hide approval options after choice

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -74,6 +74,7 @@ import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   completedHermesMessageText as completedHermesRuntimeMessageText,
+  type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
   type LiveHermesEvent,
@@ -182,7 +183,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     useState<HermesFilesystemSnapshot | null>(null);
   const [filesystemLoading, setFilesystemLoading] = useState(false);
   const [approvalSubmitting, setApprovalSubmitting] = useState<
-    Record<string, string>
+    Partial<Record<string, AgentApprovalChoice>>
   >({});
   const [clarifySubmitting, setClarifySubmitting] = useState<
     Record<string, string>
@@ -761,9 +762,10 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   }
 
   async function respondToApproval(
+    liveEventKey: string,
     sessionId: string,
     requestId: string,
-    choice: "once" | "session" | "always" | "deny",
+    choice: AgentApprovalChoice,
   ) {
     setApprovalSubmitting((current) => ({ ...current, [requestId]: choice }));
     try {
@@ -771,6 +773,11 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       await gateway.request("approval.respond", {
         session_id: sessionId,
         choice,
+      });
+      pushLiveEvent(liveEventKey, {
+        type: "approval.response",
+        session_id: sessionId,
+        payload: { request_id: requestId, choice },
       });
       setError(null);
     } catch (err) {
@@ -1088,6 +1095,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                   }
                   onApproval={(part, choice) =>
                     void respondToApproval(
+                      selectedHermesSessionId,
                       part.sessionId ?? selectedHermesSessionId,
                       part.id,
                       choice,
@@ -1168,7 +1176,12 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                       selectedTask.hermesSessionId ??
                       hermesSessions[selectedTask.id];
                     if (!sessionId) return;
-                    void respondToApproval(sessionId, part.id, choice);
+                    void respondToApproval(
+                      selectedTask.id,
+                      sessionId,
+                      part.id,
+                      choice,
+                    );
                   }}
                   onClarify={(part, answer) =>
                     void respondToClarify(selectedTask.id, part.id, answer)
@@ -2165,8 +2178,6 @@ function MessageBubble({ message }: { message: AgentMessageDto }) {
   );
 }
 
-type ApprovalChoice = "once" | "session" | "always" | "deny";
-
 function AgentChatTurnRow({
   approvalSubmitting,
   artifacts,
@@ -2176,12 +2187,12 @@ function AgentChatTurnRow({
   onDownloadArtifact,
   turn,
 }: {
-  approvalSubmitting: Record<string, string>;
+  approvalSubmitting: Partial<Record<string, AgentApprovalChoice>>;
   artifacts?: AgentArtifact[];
   clarifySubmitting: Record<string, string>;
   onApproval: (
     part: Extract<AgentChatPart, { type: "approval" }>,
-    choice: ApprovalChoice,
+    choice: AgentApprovalChoice,
   ) => void;
   onClarify: (
     part: Extract<AgentChatPart, { type: "clarify" }>,
@@ -2379,12 +2390,14 @@ function ApprovalPart({
 }: {
   onApproval: (
     part: Extract<AgentChatPart, { type: "approval" }>,
-    choice: ApprovalChoice,
+    choice: AgentApprovalChoice,
   ) => void;
   part: Extract<AgentChatPart, { type: "approval" }>;
-  submitting?: string;
+  submitting?: AgentApprovalChoice;
 }) {
   const disabled = Boolean(submitting) || part.status !== "pending";
+  const activeChoice = part.choice ?? submitting;
+  const resolved = part.status !== "pending" || activeChoice !== undefined;
   return (
     <article className="agent-approval-card" data-status={part.status}>
       <span className="agent-tool-icon">
@@ -2393,51 +2406,78 @@ function ApprovalPart({
       <div>
         <div className="agent-tool-title">
           <span>Approval required</span>
-          <span className="agent-tool-live-status" data-status="running">
+          <span
+            className="agent-tool-live-status"
+            data-status={part.status === "pending" ? "running" : "complete"}
+          >
             {part.status === "pending" ? "Waiting" : "Resolved"}
           </span>
         </div>
         <p>{part.description}</p>
         {part.command ? <pre>{part.command}</pre> : null}
-        <div className="agent-approval-actions">
-          <button
-            type="button"
-            disabled={disabled}
-            onClick={() => onApproval(part, "once")}
-          >
-            <CheckIcon size={14} />
-            {submitting === "once" ? "Approving" : "Approve once"}
-          </button>
-          <button
-            type="button"
-            disabled={disabled}
-            onClick={() => onApproval(part, "session")}
-          >
-            <CheckIcon size={14} />
-            {submitting === "session" ? "Approving" : "This session"}
-          </button>
-          {part.allowPermanent ? (
+        {resolved ? (
+          <p className="agent-approval-result" data-choice={activeChoice}>
+            {activeChoice === "deny" ? (
+              <XIcon size={14} />
+            ) : (
+              <CheckIcon size={14} />
+            )}
+            {approvalChoiceLabel(
+              activeChoice,
+              part.status === "pending" && submitting !== undefined,
+            )}
+          </p>
+        ) : (
+          <div className="agent-approval-actions">
             <button
               type="button"
               disabled={disabled}
-              onClick={() => onApproval(part, "always")}
+              onClick={() => onApproval(part, "once")}
             >
               <CheckIcon size={14} />
-              {submitting === "always" ? "Approving" : "Always"}
+              Approve once
             </button>
-          ) : null}
-          <button
-            type="button"
-            disabled={disabled}
-            onClick={() => onApproval(part, "deny")}
-          >
-            <XIcon size={14} />
-            {submitting === "deny" ? "Denying" : "Deny"}
-          </button>
-        </div>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onApproval(part, "session")}
+            >
+              <CheckIcon size={14} />
+              This session
+            </button>
+            {part.allowPermanent ? (
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => onApproval(part, "always")}
+              >
+                <CheckIcon size={14} />
+                Always
+              </button>
+            ) : null}
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onApproval(part, "deny")}
+            >
+              <XIcon size={14} />
+              Deny
+            </button>
+          </div>
+        )}
       </div>
     </article>
   );
+}
+
+function approvalChoiceLabel(choice?: AgentApprovalChoice, pending = false) {
+  if (choice === "once") return pending ? "Approving once" : "Approved once";
+  if (choice === "session")
+    return pending ? "Approving for this session" : "Approved for this session";
+  if (choice === "always")
+    return pending ? "Approving permanently" : "Always approved";
+  if (choice === "deny") return pending ? "Denying" : "Denied";
+  return "Resolved";
 }
 
 function ReasoningPart({

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -30,6 +30,8 @@ export type AgentChatToolPart = {
   status: "running" | "complete" | "failed";
 };
 
+export type AgentApprovalChoice = "once" | "session" | "always" | "deny";
+
 export type AgentChatApprovalPart = {
   type: "approval";
   id: string;
@@ -37,6 +39,7 @@ export type AgentChatApprovalPart = {
   command: string;
   description: string;
   allowPermanent: boolean;
+  choice?: AgentApprovalChoice;
   status: "pending" | "resolved";
 };
 
@@ -336,6 +339,26 @@ function appendLiveHermesEvents(
       continue;
     }
 
+    if (event.type === "approval.response") {
+      const payload = event.payload as Record<string, unknown> | undefined;
+      upsertApprovalPart(
+        (currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [],
+        {
+          id:
+            stringValue(payload?.request_id) ??
+            stringValue(payload?.id) ??
+            `approval:${event.receivedAt}`,
+          command: stringValue(payload?.command, true) ?? "",
+          description: stringValue(payload?.description, true) ?? "",
+          sessionId: event.session_id,
+          allowPermanent: payload?.allow_permanent !== false,
+          choice: approvalChoiceValue(payload?.choice),
+          status: "resolved",
+        },
+      );
+      continue;
+    }
+
     if (event.type === "error" && text) {
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
       upsertToolPart(currentAssistant.parts, {
@@ -465,7 +488,8 @@ function upsertApprovalPart(
   next: Pick<
     AgentChatApprovalPart,
     "id" | "command" | "description" | "allowPermanent" | "status"
-  > & { sessionId?: string },
+  > &
+    Partial<Pick<AgentChatApprovalPart, "choice" | "sessionId">>,
 ) {
   const existing = parts.find(
     (part): part is AgentChatApprovalPart =>
@@ -476,6 +500,7 @@ function upsertApprovalPart(
     existing.description = next.description || existing.description;
     existing.sessionId = next.sessionId || existing.sessionId;
     existing.allowPermanent = next.allowPermanent;
+    existing.choice = next.choice ?? existing.choice;
     existing.status = next.status;
     return;
   }
@@ -486,6 +511,7 @@ function upsertApprovalPart(
     command: next.command,
     description: next.description,
     allowPermanent: next.allowPermanent,
+    choice: next.choice,
     status: next.status,
   });
 }
@@ -707,6 +733,18 @@ function partText(part: AgentChatPart) {
   if (part.type === "clarify")
     return [part.question, part.answer ?? ""].join(" ");
   return part.text;
+}
+
+function approvalChoiceValue(value: unknown): AgentApprovalChoice | undefined {
+  if (
+    value === "once" ||
+    value === "session" ||
+    value === "always" ||
+    value === "deny"
+  ) {
+    return value;
+  }
+  return undefined;
 }
 
 function appendMessageText(current: string, next: string) {

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -13,6 +13,7 @@ export type HermesGatewayEventName =
   | "clarify.request"
   | "clarify.response"
   | "approval.request"
+  | "approval.response"
   | "error"
   | (string & {});
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1084,6 +1084,24 @@ input:focus-visible,
   opacity: 0.55;
 }
 
+.agent-approval-result {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  width: fit-content;
+  margin-top: var(--sp-3) !important;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface);
+  color: var(--foreground) !important;
+  font-size: var(--fs-sm) !important;
+}
+
+.agent-approval-result[data-choice="deny"] {
+  color: var(--destructive) !important;
+}
+
 .agent-safety-panel h3 {
   margin: 0;
   font-size: var(--fs-md);

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -176,4 +176,43 @@ describe("Agent chat runtime", () => {
       },
     ]);
   });
+
+  it("marks approval requests resolved after responses", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "approval.request",
+          session_id: "runtime-session",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            request_id: "approval-1",
+            command: "python script.py",
+            description: "Run this command?",
+            allow_permanent: true,
+          },
+        },
+        {
+          type: "approval.response",
+          session_id: "runtime-session",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { request_id: "approval-1", choice: "session" },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "approval",
+        id: "approval-1",
+        sessionId: "runtime-session",
+        command: "python script.py",
+        description: "Run this command?",
+        allowPermanent: true,
+        choice: "session",
+        status: "resolved",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Update the agent approval card so the choice buttons disappear once a user selects an approval option.

The UI now records an optimistic `approval.response` live event after Hermes accepts the response, resolves the matching approval part, and renders a compact outcome line such as `Approved for this session` or `Denied` instead of leaving the full button row visible.

## Root Cause

Approval requests tracked transient submit state only. After the response call finished, `approvalSubmitting` was cleared, but the pending approval part still had no stored selected choice, so the original options could reappear while the session continued.

## Validation

- `pnpm vitest run src/test/agent-chat-runtime.test.ts`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`

`pnpm run build` still emits the existing Vite large-chunk warning. In-app browser verification was not available in this thread.