### PR TITLE
[codex] Recover dictation auto-detect recording

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1318,15 +1318,11 @@ final class DictationController {
         resetRecordingState()
 
         let nextRecordingURL = temporaryRecordingURL()
-        // Auto-detect now resolves to the system default input and records through
-        // the same low-latency capture path as a manually-selected mic, so it's
-        // just as snappy (instantaneous peak, accurate die-down). The
-        // AVAudioRecorder path below is only a fallback for when no capture device
-        // is available at all.
-        let captureDevice =
-            microphoneDevice(for: preferredMicrophoneID) ?? AVCaptureDevice.default(for: .audio)
-        if let captureDevice {
-            startSelectedDeviceRecording(device: captureDevice, url: nextRecordingURL)
+        // Preserve the legacy Auto-detect behavior: AVAudioRecorder delegates
+        // default-input selection and audio processing to macOS. The custom
+        // capture path is still used when the user explicitly pins a microphone.
+        if let selectedDevice = microphoneDevice(for: preferredMicrophoneID) {
+            startSelectedDeviceRecording(device: selectedDevice, url: nextRecordingURL)
             return
         }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -7,6 +7,7 @@ use crate::scribe_api::{
     cleanup_text, dictate_transcribe, DictateCleanupRequestParams, DictateTranscribeRequest,
     TranscriptionProviderResult,
 };
+use chrono::Utc;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{
     fs,
@@ -23,6 +24,8 @@ use tauri::{
 
 const DICTATION_TRANSCRIPTION_CONTEXT: &str = "Transcribe this as clean hands-free dictation for direct insertion into the active app. Preserve the speaker's intended words, language, and meaning. Remove filler sounds and accidental false starts when they are not meaningful, especially um, uh, ah, er, and a... stutters. Do not remove intentional articles such as a or an when they are grammatically needed. Convert spoken punctuation and formatting into text punctuation, including comma, period, question mark, exclamation point, colon, semicolon, dash, newline, and new paragraph. Convert quote/unquote, open quote/close quote, and start quote/end quote into actual quotation marks around the quoted words. Output only the dictated text.";
 const DICTATION_CLEANUP_TIMEOUT_MS: u64 = 15_000;
+const DICTATION_AUDIO_ACTIVITY_THRESHOLD: f32 = 0.04;
+const DICTATION_EVENT_LOG: &str = "dictation-events.log";
 
 pub struct HelperProcess {
     child: Child,
@@ -1189,11 +1192,11 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
 
     if matches!(event_type, Some("recording_ready")) {
         if let Some(event) = event.as_ref() {
-            match recording_path_from_event(event) {
-                Ok(audio_path) => {
+            match recording_ready_info_from_event(event) {
+                Ok(info) => {
                     let app = app.clone();
                     tauri::async_runtime::spawn(async move {
-                        transcribe_recording_ready(app, audio_path).await;
+                        transcribe_recording_ready(app, info).await;
                     });
                 }
                 Err(error) => {
@@ -1219,7 +1222,7 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
     }
 }
 
-async fn transcribe_recording_ready(app: AppHandle, audio_path: PathBuf) {
+async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInfo) {
     // Backstop for the toggle-start path (where the start-time gate in
     // send_dictation_command can't tell start from stop) and for tokens that
     // expired between start and finish.
@@ -1251,7 +1254,7 @@ async fn transcribe_recording_ready(app: AppHandle, audio_path: PathBuf) {
         Some(dictation_transcription_context(style).as_str()),
     );
     let result = dictate_transcribe(DictateTranscribeRequest {
-        audio_path,
+        audio_path: recording.audio_path,
         context: transcription_context,
         session_id: session_id.clone(),
         utterance_id: utterance_id.clone(),
@@ -1267,7 +1270,7 @@ async fn transcribe_recording_ready(app: AppHandle, audio_path: PathBuf) {
         utterance_id,
     )
     .await;
-    let outcome = outcome_from_transcription_result(result);
+    let outcome = outcome_from_transcription_result(result, recording.observed_audio_level);
     let state = app.state::<HelperState>();
     if let Err(error) = send_helper_command(&state, outcome.helper_command) {
         emit_dictation_event_value(&app, app_error_event(error));
@@ -1500,7 +1503,9 @@ fn extract_chat_completion_text(value: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn recording_path_from_event(event: &serde_json::Value) -> Result<PathBuf, AppError> {
+fn recording_ready_info_from_event(
+    event: &serde_json::Value,
+) -> Result<RecordingReadyInfo, AppError> {
     let path = event
         .get("payload")
         .and_then(|payload| payload.get("path"))
@@ -1513,7 +1518,25 @@ fn recording_path_from_event(event: &serde_json::Value) -> Result<PathBuf, AppEr
                 "Dictation helper did not provide a recording path.",
             )
         })?;
-    Ok(PathBuf::from(path))
+    Ok(RecordingReadyInfo {
+        audio_path: PathBuf::from(path),
+        observed_audio_level: observed_audio_level_from_event(event),
+    })
+}
+
+fn observed_audio_level_from_event(event: &serde_json::Value) -> Option<f32> {
+    let value = event
+        .get("payload")
+        .and_then(|payload| payload.get("observedAudioLevel"))?;
+    let level = value
+        .as_f64()
+        .map(|level| level as f32)
+        .or_else(|| value.as_str().and_then(|level| level.parse::<f32>().ok()))?;
+    if level.is_finite() {
+        Some(level)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -1523,8 +1546,15 @@ struct DictationTranscriptionOutcome {
     transcript: Option<TranscriptionProviderResult>,
 }
 
+#[derive(Debug)]
+struct RecordingReadyInfo {
+    audio_path: PathBuf,
+    observed_audio_level: Option<f32>,
+}
+
 fn outcome_from_transcription_result(
     result: Result<TranscriptionProviderResult, AppError>,
+    observed_audio_level: Option<f32>,
 ) -> DictationTranscriptionOutcome {
     match result {
         // Recorded silence / nothing to type is not a failure — discard quietly
@@ -1532,10 +1562,7 @@ fn outcome_from_transcription_result(
         // dismisses instead of flashing an error). Don't store an empty item.
         Ok(transcript) if transcript.text.trim().is_empty() => DictationTranscriptionOutcome {
             helper_command: serde_json::json!({ "type": "discard_recording" }),
-            event: Some(serde_json::json!({
-                "type": "error",
-                "payload": { "code": "no_speech", "message": "No speech detected." },
-            })),
+            event: Some(no_text_event_for_observed_audio(observed_audio_level)),
             transcript: None,
         },
         Ok(transcript) => {
@@ -1559,12 +1586,77 @@ fn outcome_from_transcription_result(
                 }
             }
         }
-        Err(error) => DictationTranscriptionOutcome {
-            helper_command: serde_json::json!({ "type": "discard_recording" }),
-            event: Some(app_error_event(error)),
-            transcript: None,
-        },
+        Err(error) => {
+            let event = promote_silent_error_if_audio_detected(
+                app_error_event(error),
+                observed_audio_level,
+            );
+            DictationTranscriptionOutcome {
+                helper_command: serde_json::json!({ "type": "discard_recording" }),
+                event: Some(event),
+                transcript: None,
+            }
+        }
     }
+}
+
+fn no_text_event_for_observed_audio(observed_audio_level: Option<f32>) -> serde_json::Value {
+    if probable_speech_detected(observed_audio_level) {
+        return audio_detected_but_no_text_event(None, None, observed_audio_level);
+    }
+    serde_json::json!({
+        "type": "error",
+        "payload": { "code": "no_speech", "message": "No speech detected." },
+    })
+}
+
+fn promote_silent_error_if_audio_detected(
+    event: serde_json::Value,
+    observed_audio_level: Option<f32>,
+) -> serde_json::Value {
+    if probable_speech_detected(observed_audio_level) && is_silent_transcription_error(&event) {
+        let payload = event.get("payload");
+        let underlying_code = payload
+            .and_then(|payload| payload.get("code"))
+            .and_then(serde_json::Value::as_str);
+        let underlying_message = payload
+            .and_then(|payload| payload.get("message"))
+            .and_then(serde_json::Value::as_str);
+        return audio_detected_but_no_text_event(
+            underlying_code,
+            underlying_message,
+            observed_audio_level,
+        );
+    }
+    event
+}
+
+fn audio_detected_but_no_text_event(
+    underlying_code: Option<&str>,
+    underlying_message: Option<&str>,
+    observed_audio_level: Option<f32>,
+) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "code": "dictation_audio_without_text",
+        "message": "Dictation detected audio but produced no text. Try again.",
+    });
+    if let Some(level) = observed_audio_level {
+        payload["observedAudioLevel"] = serde_json::json!(level);
+    }
+    if let Some(code) = underlying_code {
+        payload["underlyingCode"] = serde_json::json!(code);
+    }
+    if let Some(message) = underlying_message {
+        payload["underlyingMessage"] = serde_json::json!(message);
+    }
+    serde_json::json!({
+        "type": "error",
+        "payload": payload,
+    })
+}
+
+fn probable_speech_detected(observed_audio_level: Option<f32>) -> bool {
+    observed_audio_level.is_some_and(|level| level >= DICTATION_AUDIO_ACTIVITY_THRESHOLD)
 }
 
 fn agent_session_prompt_from_dictation(text: &str) -> Option<String> {
@@ -1630,10 +1722,84 @@ fn app_error_event(error: AppError) -> serde_json::Value {
 fn emit_dictation_event_value(app: &AppHandle, mut event: serde_json::Value) {
     annotate_silent_error(&mut event);
     let event_type = event.get("type").and_then(serde_json::Value::as_str);
+    append_dictation_event_log(app, event_type, &event);
     let line = event.to_string();
     update_latest_event(app, event_type, Some(line.clone()));
     update_hud_window(app, event_type, Some(&event));
     let _ = app.emit("dictation-event", line);
+}
+
+fn append_dictation_event_log(
+    app: &AppHandle,
+    event_type: Option<&str>,
+    event: &serde_json::Value,
+) {
+    let Some(event_type) = event_type else {
+        return;
+    };
+    if event_type == "audio_level" {
+        return;
+    }
+    let entry = dictation_event_log_entry(event_type, event);
+    let Ok(directory) = app.path().app_data_dir() else {
+        return;
+    };
+    if fs::create_dir_all(&directory).is_err() {
+        return;
+    }
+    let Ok(mut file) = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(directory.join(DICTATION_EVENT_LOG))
+    else {
+        return;
+    };
+    let _ = writeln!(file, "{entry}");
+}
+
+fn dictation_event_log_entry(event_type: &str, event: &serde_json::Value) -> serde_json::Value {
+    let payload = event.get("payload");
+    let text_chars = payload
+        .and_then(|payload| payload.get("text"))
+        .and_then(serde_json::Value::as_str)
+        .map(|text| text.chars().count());
+    let prompt_chars = payload
+        .and_then(|payload| payload.get("prompt"))
+        .and_then(serde_json::Value::as_str)
+        .map(|prompt| prompt.chars().count());
+    serde_json::json!({
+        "timestamp": Utc::now().to_rfc3339(),
+        "type": event_type,
+        "code": payload
+            .and_then(|payload| payload.get("code"))
+            .and_then(serde_json::Value::as_str),
+        "underlyingCode": payload
+            .and_then(|payload| payload.get("underlyingCode"))
+            .and_then(serde_json::Value::as_str),
+        "message": payload
+            .and_then(|payload| payload.get("message"))
+            .and_then(serde_json::Value::as_str),
+        "underlyingMessage": payload
+            .and_then(|payload| payload.get("underlyingMessage"))
+            .and_then(serde_json::Value::as_str),
+        "silent": payload
+            .and_then(|payload| payload.get("silent"))
+            .and_then(serde_json::Value::as_bool),
+        "path": payload
+            .and_then(|payload| payload.get("path"))
+            .and_then(serde_json::Value::as_str),
+        "observedAudioLevel": payload
+            .and_then(|payload| payload.get("observedAudioLevel"))
+            .cloned(),
+        "pasteTarget": payload
+            .and_then(|payload| payload.get("app"))
+            .and_then(serde_json::Value::as_str),
+        "provider": payload
+            .and_then(|payload| payload.get("provider"))
+            .and_then(serde_json::Value::as_str),
+        "textChars": text_chars,
+        "promptChars": prompt_chars,
+    })
 }
 
 /// Tag error events with `payload.silent: bool` so the HUD doesn't have to
@@ -2245,11 +2411,14 @@ mod tests {
 
     #[test]
     fn successful_transcription_maps_to_paste_command() {
-        let outcome = outcome_from_transcription_result(Ok(TranscriptionProviderResult {
-            text: "Paste this transcript.".to_string(),
-            language: Some("en".to_string()),
-            provider: crate::providers::VENICE_PROVIDER.to_string(),
-        }));
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "Paste this transcript.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            None,
+        );
 
         assert_eq!(
             outcome.helper_command,
@@ -2267,11 +2436,14 @@ mod tests {
 
     #[test]
     fn hey_june_transcription_maps_to_agent_session_event() {
-        let outcome = outcome_from_transcription_result(Ok(TranscriptionProviderResult {
-            text: "Hey, June, summarize the open document.".to_string(),
-            language: Some("en".to_string()),
-            provider: crate::providers::VENICE_PROVIDER.to_string(),
-        }));
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "Hey, June, summarize the open document.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            None,
+        );
 
         assert_eq!(
             outcome.helper_command,
@@ -2308,11 +2480,14 @@ mod tests {
 
     #[test]
     fn empty_transcription_discards_silently() {
-        let outcome = outcome_from_transcription_result(Ok(TranscriptionProviderResult {
-            text: "   ".to_string(),
-            language: None,
-            provider: crate::providers::VENICE_PROVIDER.to_string(),
-        }));
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "   ".to_string(),
+                language: None,
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            None,
+        );
 
         assert_eq!(
             outcome.helper_command,
@@ -2321,6 +2496,49 @@ mod tests {
         assert!(outcome.transcript.is_none());
         let event = outcome.event.expect("empty capture emits an event");
         assert!(is_silent_transcription_error(&event));
+    }
+
+    #[test]
+    fn empty_transcription_with_detected_audio_is_visible_error() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "   ".to_string(),
+                language: None,
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            Some(DICTATION_AUDIO_ACTIVITY_THRESHOLD),
+        );
+
+        let event = outcome.event.expect("empty capture emits an event");
+        assert_eq!(event["payload"]["code"], "dictation_audio_without_text");
+        assert_eq!(
+            event["payload"]["message"],
+            "Dictation detected audio but produced no text. Try again."
+        );
+        let observed = event["payload"]["observedAudioLevel"]
+            .as_f64()
+            .expect("observed audio level");
+        assert!((observed - 0.04).abs() < 0.001);
+        assert!(!is_silent_transcription_error(&event));
+    }
+
+    #[test]
+    fn recording_ready_info_includes_observed_audio_level() {
+        let event = serde_json::json!({
+            "type": "recording_ready",
+            "payload": {
+                "path": "/tmp/os-scribe-dictation-test.m4a",
+                "observedAudioLevel": "0.1732",
+            }
+        });
+
+        let info = recording_ready_info_from_event(&event).expect("recording info");
+
+        assert_eq!(
+            info.audio_path,
+            PathBuf::from("/tmp/os-scribe-dictation-test.m4a")
+        );
+        assert_eq!(info.observed_audio_level, Some(0.1732));
     }
 
     #[test]
@@ -2333,11 +2551,52 @@ mod tests {
     }
 
     #[test]
+    fn dictation_event_log_redacts_transcript_text() {
+        let event = serde_json::json!({
+            "type": "final_transcript",
+            "payload": {
+                "text": "Sensitive dictated sentence."
+            }
+        });
+
+        let entry = dictation_event_log_entry("final_transcript", &event);
+
+        assert_eq!(entry["type"], "final_transcript");
+        assert_eq!(entry["textChars"], 28);
+        assert!(entry.to_string().contains("textChars"));
+        assert!(!entry.to_string().contains("Sensitive dictated sentence"));
+    }
+
+    #[test]
+    fn dictation_event_log_records_silent_error_code() {
+        let mut event = serde_json::json!({
+            "type": "error",
+            "payload": {
+                "code": "missing_recording",
+                "message": "No recorded audio was available to transcribe."
+            }
+        });
+        annotate_silent_error(&mut event);
+
+        let entry = dictation_event_log_entry("error", &event);
+
+        assert_eq!(entry["code"], "missing_recording");
+        assert_eq!(entry["silent"], true);
+        assert_eq!(
+            entry["message"],
+            "No recorded audio was available to transcribe."
+        );
+    }
+
+    #[test]
     fn failed_transcription_maps_to_discard_and_error() {
-        let outcome = outcome_from_transcription_result(Err(AppError::new(
-            "transcription_failed",
-            "The provider failed.",
-        )));
+        let outcome = outcome_from_transcription_result(
+            Err(AppError::new(
+                "transcription_failed",
+                "The provider failed.",
+            )),
+            None,
+        );
 
         assert_eq!(
             outcome.helper_command,
@@ -2354,6 +2613,20 @@ mod tests {
             }))
         );
         assert!(outcome.transcript.is_none());
+    }
+
+    #[test]
+    fn no_speech_error_with_detected_audio_is_visible_error() {
+        let outcome = outcome_from_transcription_result(
+            Err(AppError::new("scribe_request_failed", "no_speech")),
+            Some(0.2),
+        );
+
+        let event = outcome.event.expect("no speech emits an event");
+        assert_eq!(event["payload"]["code"], "dictation_audio_without_text");
+        assert_eq!(event["payload"]["underlyingCode"], "scribe_request_failed");
+        assert_eq!(event["payload"]["underlyingMessage"], "no_speech");
+        assert!(!is_silent_transcription_error(&event));
     }
 
     #[test]

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -14,6 +14,8 @@ const DEFAULT_SCRIBE_API_URL: &str = "https://scribe-api.opensoftware.network";
 const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "nvidia-nemotron-3-nano-30b-a3b";
 const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 const AGENT_HTTP_TIMEOUT: Duration = Duration::from_secs(600);
+const AGENT_PROXY_MAX_MESSAGES: usize = 64;
+const AGENT_PROXY_MAX_INSTRUCTION_MESSAGES: usize = 4;
 const AGENT_TITLE_MAX_CHARS: usize = 48;
 const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 const ERR_TOKEN_EXPIRED: i64 = 3001;
@@ -285,6 +287,7 @@ pub async fn list_models(model_type: &str) -> Result<Vec<ModelDto>, AppError> {
 pub async fn proxy_agent_chat_completions(
     mut body: serde_json::Value,
 ) -> Result<RawScribeResponse, AppError> {
+    limit_agent_chat_messages_for_proxy(&mut body);
     if let Some(object) = body.as_object_mut() {
         object.insert(
             "model".to_string(),
@@ -320,6 +323,125 @@ pub async fn proxy_agent_chat_completions(
         });
     }
     Err(AppError::new("unauthorized", "Not signed in."))
+}
+
+fn limit_agent_chat_messages_for_proxy(body: &mut serde_json::Value) {
+    limit_agent_chat_messages(body, AGENT_PROXY_MAX_MESSAGES);
+}
+
+fn limit_agent_chat_messages(body: &mut serde_json::Value, max_messages: usize) {
+    let Some(messages) = body
+        .as_object_mut()
+        .and_then(|object| object.get_mut("messages"))
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    if max_messages == 0 || messages.len() <= max_messages {
+        return;
+    }
+
+    let instruction_count = messages
+        .iter()
+        .take_while(|message| is_agent_instruction_message(message))
+        .count();
+    let mut next_messages = messages
+        .iter()
+        .take(instruction_count.min(AGENT_PROXY_MAX_INSTRUCTION_MESSAGES))
+        .cloned()
+        .collect::<Vec<_>>();
+    let remaining_capacity = max_messages.saturating_sub(next_messages.len());
+    if remaining_capacity == 0 {
+        *messages = next_messages;
+        return;
+    }
+
+    let tail = agent_message_chunks(&messages[instruction_count..]);
+    let mut suffix = Vec::new();
+    let mut suffix_len = 0usize;
+    for chunk in tail.into_iter().rev() {
+        if suffix_len + chunk.len() > remaining_capacity {
+            break;
+        }
+        suffix_len += chunk.len();
+        suffix.push(chunk);
+    }
+    suffix.reverse();
+
+    for chunk in suffix {
+        next_messages.extend(chunk);
+    }
+    drop_leading_orphan_tool_messages(&mut next_messages);
+    *messages = next_messages;
+}
+
+fn is_agent_instruction_message(message: &serde_json::Value) -> bool {
+    matches!(agent_message_role(message), Some("system" | "developer"))
+}
+
+fn agent_message_chunks(messages: &[serde_json::Value]) -> Vec<Vec<serde_json::Value>> {
+    let mut chunks = Vec::new();
+    let mut index = 0usize;
+    while index < messages.len() {
+        let message = &messages[index];
+        let mut chunk = vec![message.clone()];
+        index += 1;
+
+        if agent_message_role(message) == Some("assistant") {
+            let tool_call_ids = agent_tool_call_ids(message);
+            if !tool_call_ids.is_empty() {
+                while index < messages.len()
+                    && agent_tool_message_matches(&messages[index], &tool_call_ids)
+                {
+                    chunk.push(messages[index].clone());
+                    index += 1;
+                }
+            }
+        }
+
+        chunks.push(chunk);
+    }
+    chunks
+}
+
+fn agent_message_role(message: &serde_json::Value) -> Option<&str> {
+    message.get("role").and_then(serde_json::Value::as_str)
+}
+
+fn agent_tool_call_ids(message: &serde_json::Value) -> Vec<String> {
+    message
+        .get("tool_calls")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|tool_call| tool_call.get("id").and_then(serde_json::Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+fn agent_tool_message_matches(message: &serde_json::Value, tool_call_ids: &[String]) -> bool {
+    if agent_message_role(message) != Some("tool") {
+        return false;
+    }
+    message
+        .get("tool_call_id")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|id| tool_call_ids.iter().any(|candidate| candidate == id))
+}
+
+fn drop_leading_orphan_tool_messages(messages: &mut Vec<serde_json::Value>) {
+    loop {
+        let first_non_instruction = messages
+            .iter()
+            .position(|message| !is_agent_instruction_message(message));
+        let Some(index) = first_non_instruction else {
+            return;
+        };
+        if agent_message_role(&messages[index]) != Some("tool") {
+            return;
+        }
+        messages.remove(index);
+    }
 }
 
 pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppError> {
@@ -573,6 +695,59 @@ mod tests {
             Some("Create a Quarterly Planning Briefing With Follow")
         );
         assert_eq!(clean_agent_session_title("   "), None);
+    }
+
+    #[test]
+    fn agent_proxy_limits_messages_while_preserving_latest_context() {
+        let mut body = serde_json::json!({
+            "messages": std::iter::once(serde_json::json!({
+                "role": "system",
+                "content": "system prompt"
+            }))
+            .chain((0..8).map(|index| serde_json::json!({
+                "role": "user",
+                "content": format!("message {index}")
+            })))
+            .collect::<Vec<_>>()
+        });
+
+        limit_agent_chat_messages(&mut body, 5);
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 5);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["content"], "message 4");
+        assert_eq!(messages[4]["content"], "message 7");
+    }
+
+    #[test]
+    fn agent_proxy_keeps_tool_call_messages_together() {
+        let mut body = serde_json::json!({
+            "messages": [
+                { "role": "system", "content": "system prompt" },
+                { "role": "user", "content": "old context" },
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": { "name": "browser_console", "arguments": "{}" }
+                    }]
+                },
+                { "role": "tool", "tool_call_id": "call_1", "content": "result" },
+                { "role": "user", "content": "next request" }
+            ]
+        });
+
+        limit_agent_chat_messages(&mut body, 4);
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[3]["content"], "next request");
     }
 }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -381,19 +381,15 @@ async function handleDictationEventPayload(payload: unknown) {
     // Rust pre-classifies via payload.silent so the HUD has one source of
     // truth for what counts as a "Nothing recorded" case.
     if (dictationEvent.payload?.silent === true) {
-      // Silent (nothing recorded) shouldn't look like a failure — just dismiss.
-      void hideHud();
+      setHud("silent-error", "Nothing recorded");
+      await showHud();
+      hideSoon(900);
       return;
     }
-    const code = String(dictationEvent.payload?.code ?? "");
-    if (code === "not_signed_in") {
-      setHud(
-        "error",
-        String(dictationEvent.payload?.message ?? "Sign in to use dictation"),
-      );
-    } else {
-      setHud("error", "Error");
-    }
+    const message = String(
+      dictationEvent.payload?.message ?? "Dictation failed.",
+    ).trim();
+    setHud("error", message || "Dictation failed.");
     await showHud();
     // Hold long enough for the shake to finish and the message to read.
     hideSoon(1800);

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -221,6 +221,9 @@ body {
   font-size: var(--fs-sm);
   font-weight: 500;
   line-height: 1;
+  max-width: min(460px, calc(100vw - 96px));
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   transform: translateY(-0.5px);
 }
@@ -341,7 +344,8 @@ body {
 }
 
 /* State machine ------------------------------------------------------- */
-.hud[data-state="error"] .hud-handle {
+.hud[data-state="error"] .hud-handle,
+.hud[data-state="silent-error"] .hud-handle {
   display: none;
 }
 
@@ -374,6 +378,11 @@ body {
   animation: hud-shake 380ms var(--ease-out);
 }
 
+.hud[data-state="silent-error"] {
+  gap: var(--sp-2);
+  padding-inline: var(--sp-3) var(--sp-4);
+}
+
 .hud[data-state="transcribing"] .hud-viz,
 .hud[data-state="pasting"] .hud-viz {
   /* Braille replaces the bars + stop-button footprint while the handle stays
@@ -381,13 +390,15 @@ body {
   width: 88px;
 }
 
-.hud[data-state="error"] .hud-viz {
+.hud[data-state="error"] .hud-viz,
+.hud[data-state="silent-error"] .hud-viz {
   display: none;
 }
 
 .hud[data-state="transcribing"] .hud-bars,
 .hud[data-state="pasting"] .hud-bars,
-.hud[data-state="error"] .hud-bars {
+.hud[data-state="error"] .hud-bars,
+.hud[data-state="silent-error"] .hud-bars {
   display: none;
 }
 
@@ -396,14 +407,16 @@ body {
   display: flex;
 }
 
-.hud[data-state="error"] .hud-error-text {
+.hud[data-state="error"] .hud-error-text,
+.hud[data-state="silent-error"] .hud-error-text {
   display: block;
 }
 
 /* Stop button only matters while we're still capturing audio. */
 .hud[data-state="transcribing"] .hud-stop,
 .hud[data-state="pasting"] .hud-stop,
-.hud[data-state="error"] .hud-stop {
+.hud[data-state="error"] .hud-stop,
+.hud[data-state="silent-error"] .hud-stop {
   display: none;
 }
 

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -140,6 +140,29 @@ describe("meeting detection HUD", () => {
     expect(hudElement().dataset.state).toBe("transcribing");
     expect(mocks.show).not.toHaveBeenCalled();
   });
+
+  it("surfaces silent dictation failures as nothing recorded", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "missing_recording",
+        message: "No recorded audio was available to transcribe.",
+        silent: true,
+      },
+    });
+
+    expect(hudElement().dataset.state).toBe("silent-error");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent(
+      "Nothing recorded",
+    );
+    expect(mocks.show).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(900);
+    expect(hudElement().dataset.state).toBe("exiting");
+  });
 });
 
 async function loadHud() {


### PR DESCRIPTION
## Summary

- Restore legacy Auto-detect dictation recording behavior by keeping `AVAudioRecorder` for the default mic path while preserving the custom capture path for explicitly selected microphones.
- Surface silent dictation terminal failures as a brief `Nothing recorded` HUD state instead of disappearing immediately.
- Add a redacted local dictation event log so future dropped dictations can be diagnosed without storing transcript text.
- Trim proxied agent chat messages before sending to Scribe API while preserving leading instructions, recent context, and assistant/tool message groups.

## Root Cause

The June 5 helper change made Auto-detect/default mic resolve through `AVCaptureDevice.default(for: .audio)` and the custom `SelectedDeviceRecorder` path. For users with no pinned microphone, that changed the actual recording pipeline from the older high-level `AVAudioRecorder` path to a custom capture-session writer. Recent lost dictation symptoms lined up with low recorded levels and `no_speech` transcription responses.

The app also hid silent transcription failures immediately, which made failed recordings look like they completed and vanished.

Separately, the local agent proxy could still send too many messages to Scribe API even after server-side limits were relaxed/deployed elsewhere, so the desktop app now trims defensively before proxying.

## Validation

- `cargo test dictation::tests --manifest-path src-tauri/Cargo.toml`
- `cargo test scribe_api::tests --manifest-path src-tauri/Cargo.toml`
- `pnpm exec vitest run src/test/hud-meeting.test.ts`
- `pnpm run lint`
- `git diff --check`