### PR TITLE
[codex] Gate meeting detection on sign-in

### DIFF
--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -39,9 +39,14 @@ pub(crate) struct MeetingDetectionState {
 impl MeetingDetectionState {
     pub(crate) fn update(
         &mut self,
+        signed_in: bool,
         active_external_input: bool,
         os_scribe_capture_active: bool,
     ) -> Option<MeetingDetectionEvent> {
+        if !signed_in {
+            return self.clear();
+        }
+
         let should_be_active = active_external_input && !os_scribe_capture_active;
         if should_be_active {
             self.inactive_polls = 0;
@@ -72,6 +77,16 @@ impl MeetingDetectionState {
             return Some(MeetingDetectionEvent::Cleared);
         }
 
+        None
+    }
+
+    fn clear(&mut self) -> Option<MeetingDetectionEvent> {
+        self.inactive_polls = 0;
+        self.active_polls_since_emit = 0;
+        if self.active {
+            self.active = false;
+            return Some(MeetingDetectionEvent::Cleared);
+        }
         None
     }
 }
@@ -159,6 +174,13 @@ fn spawn_monitor(app: AppHandle) {
         loop {
             thread::sleep(POLL_INTERVAL);
 
+            if !crate::os_accounts::cached_signed_in() {
+                if let Some(event) = state.update(false, false, false) {
+                    emit_detection_event(&app, event, 0);
+                }
+                continue;
+            }
+
             let active_processes = match active_input_processes() {
                 Ok(active_processes) => {
                     warned_after_probe_error = false;
@@ -175,7 +197,7 @@ fn spawn_monitor(app: AppHandle) {
             let allowed_processes =
                 active_allowed_external_processes(&active_processes, &owned_pids(&app));
             let capture_active = crate::audio::capture::is_capture_active();
-            if let Some(event) = state.update(!allowed_processes.is_empty(), capture_active) {
+            if let Some(event) = state.update(true, !allowed_processes.is_empty(), capture_active) {
                 emit_detection_event(&app, event, allowed_processes.len());
             }
         }
@@ -666,12 +688,12 @@ mod tests {
         let active_unlisted = allowed_pids(&[input_process(61, "com.apple.FaceTime")]);
 
         assert_eq!(
-            state.update(!active_allowed.is_empty(), false),
+            state.update(true, !active_allowed.is_empty(), false),
             Some(MeetingDetectionEvent::Detected)
         );
-        assert_eq!(state.update(!active_unlisted.is_empty(), false), None);
+        assert_eq!(state.update(true, !active_unlisted.is_empty(), false), None);
         assert_eq!(
-            state.update(!active_unlisted.is_empty(), false),
+            state.update(true, !active_unlisted.is_empty(), false),
             Some(MeetingDetectionEvent::Cleared)
         );
     }
@@ -681,19 +703,46 @@ mod tests {
         let mut state = MeetingDetectionState::default();
 
         assert_eq!(
-            state.update(true, false),
+            state.update(true, true, false),
             Some(MeetingDetectionEvent::Detected)
         );
-        assert_eq!(state.update(true, false), None);
+        assert_eq!(state.update(true, true, false), None);
+    }
+
+    #[test]
+    fn detector_suppresses_until_user_is_signed_in() {
+        let mut state = MeetingDetectionState::default();
+
+        assert_eq!(state.update(false, true, false), None);
+        assert_eq!(state.update(false, true, false), None);
+        assert_eq!(
+            state.update(true, true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+    }
+
+    #[test]
+    fn detector_clears_immediately_when_user_signs_out() {
+        let mut state = MeetingDetectionState::default();
+
+        assert_eq!(
+            state.update(true, true, false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+        assert_eq!(
+            state.update(false, true, false),
+            Some(MeetingDetectionEvent::Cleared)
+        );
+        assert_eq!(state.update(false, true, false), None);
     }
 
     #[test]
     fn detector_suppresses_while_os_scribe_capture_is_active() {
         let mut state = MeetingDetectionState::default();
 
-        assert_eq!(state.update(true, true), None);
+        assert_eq!(state.update(true, true, true), None);
         assert_eq!(
-            state.update(true, false),
+            state.update(true, true, false),
             Some(MeetingDetectionEvent::Detected)
         );
     }
@@ -702,31 +751,31 @@ mod tests {
     fn detector_clears_after_inactive_debounce() {
         let mut state = MeetingDetectionState::default();
         assert_eq!(
-            state.update(true, false),
+            state.update(true, true, false),
             Some(MeetingDetectionEvent::Detected)
         );
 
-        assert_eq!(state.update(false, false), None);
+        assert_eq!(state.update(true, false, false), None);
         assert_eq!(
-            state.update(false, false),
+            state.update(true, false, false),
             Some(MeetingDetectionEvent::Cleared)
         );
-        assert_eq!(state.update(false, false), None);
+        assert_eq!(state.update(true, false, false), None);
     }
 
     #[test]
     fn detector_emits_heartbeat_while_active() {
         let mut state = MeetingDetectionState::default();
         assert_eq!(
-            state.update(true, false),
+            state.update(true, true, false),
             Some(MeetingDetectionEvent::Detected)
         );
 
         for _ in 0..(HEARTBEAT_EVERY_ACTIVE_POLLS - 1) {
-            assert_eq!(state.update(true, false), None);
+            assert_eq!(state.update(true, true, false), None);
         }
         assert_eq!(
-            state.update(true, false),
+            state.update(true, true, false),
             Some(MeetingDetectionEvent::Detected)
         );
     }
@@ -735,13 +784,13 @@ mod tests {
     fn detector_clears_when_os_scribe_capture_starts() {
         let mut state = MeetingDetectionState::default();
         assert_eq!(
-            state.update(true, false),
+            state.update(true, true, false),
             Some(MeetingDetectionEvent::Detected)
         );
 
-        assert_eq!(state.update(true, true), None);
+        assert_eq!(state.update(true, true, true), None);
         assert_eq!(
-            state.update(true, true),
+            state.update(true, true, true),
             Some(MeetingDetectionEvent::Cleared)
         );
     }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -11,7 +11,14 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{error::Error as StdError, sync::OnceLock, time::Duration};
+use std::{
+    error::Error as StdError,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        OnceLock,
+    },
+    time::Duration,
+};
 use tokio::sync::Mutex as AsyncMutex;
 #[cfg(debug_assertions)]
 use tokio::{
@@ -42,6 +49,7 @@ const ERR_TOKEN_EXPIRED: i64 = 3001;
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 static REFRESH_LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
 static ENV_LOADED: OnceLock<()> = OnceLock::new();
+static SIGNED_IN_CACHE: AtomicBool = AtomicBool::new(false);
 
 #[derive(Deserialize)]
 struct Envelope<T> {
@@ -123,6 +131,14 @@ impl From<BalanceWire> for AccountBalance {
             usd_millis: w.usd_millis,
         }
     }
+}
+
+pub(crate) fn cached_signed_in() -> bool {
+    SIGNED_IN_CACHE.load(Ordering::Relaxed)
+}
+
+fn set_cached_signed_in(signed_in: bool) {
+    SIGNED_IN_CACHE.store(signed_in, Ordering::Relaxed);
 }
 
 struct Config {
@@ -226,22 +242,29 @@ pub struct LoginFlow {
 pub async fn os_accounts_status() -> Result<AccountStatus, AppError> {
     let cfg = Config::load();
     if load_tokens().await.is_none() {
+        set_cached_signed_in(false);
         return Ok(AccountStatus {
             configured: cfg.configured(),
             ..Default::default()
         });
     }
     match fetch_snapshot(&cfg).await {
-        Ok((user, balance)) => Ok(AccountStatus {
-            signed_in: true,
-            configured: cfg.configured(),
-            user: Some(user),
-            balance: Some(balance),
-        }),
-        Err(_) => Ok(AccountStatus {
-            configured: cfg.configured(),
-            ..Default::default()
-        }),
+        Ok((user, balance)) => {
+            set_cached_signed_in(true);
+            Ok(AccountStatus {
+                signed_in: true,
+                configured: cfg.configured(),
+                user: Some(user),
+                balance: Some(balance),
+            })
+        }
+        Err(_) => {
+            set_cached_signed_in(false);
+            Ok(AccountStatus {
+                configured: cfg.configured(),
+                ..Default::default()
+            })
+        }
     }
 }
 
@@ -289,6 +312,7 @@ pub async fn os_accounts_login(
     store_tokens(&pair).await?;
 
     let (user, balance) = fetch_snapshot(&cfg).await?;
+    set_cached_signed_in(true);
     Ok(AccountStatus {
         signed_in: true,
         configured: true,
@@ -324,6 +348,7 @@ pub async fn os_accounts_logout() -> Result<(), AppError> {
             .await;
     }
     clear_tokens().await;
+    set_cached_signed_in(false);
     Ok(())
 }
 
@@ -631,9 +656,13 @@ async fn exchange_code(
 /// already refreshed.
 async fn refresh_locked(cfg: &Config) -> Result<String, AppError> {
     let _guard = refresh_lock().lock().await;
-    let pair = load_tokens()
-        .await
-        .ok_or_else(|| AppError::new("signed_out", "Not signed in."))?;
+    let pair = match load_tokens().await {
+        Some(pair) => pair,
+        None => {
+            set_cached_signed_in(false);
+            return Err(AppError::new("signed_out", "Not signed in."));
+        }
+    };
     let resp: Envelope<TokenPair> = http_client()
         .post(format!(
             "{}/auth/refresh",
@@ -652,21 +681,33 @@ async fn refresh_locked(cfg: &Config) -> Result<String, AppError> {
         .ok_or_else(|| AppError::new("session_expired", "Your session expired. Sign in again."))?;
     let access = fresh.access_token.clone();
     store_tokens(&fresh).await?;
+    set_cached_signed_in(true);
     Ok(access)
 }
 
 /// Read the current access token without refreshing.
 pub async fn access_token() -> Result<String, AppError> {
-    let pair = load_tokens()
-        .await
-        .ok_or_else(|| AppError::new("signed_out", "Not signed in."))?;
+    let pair = match load_tokens().await {
+        Some(pair) => pair,
+        None => {
+            set_cached_signed_in(false);
+            return Err(AppError::new("signed_out", "Not signed in."));
+        }
+    };
     // Pre-emptively refresh if the cached token is expired or within 30s of
     // expiry. Otherwise multipart uploads (which can't replay their body on a
     // 401) would burn a request before discovering the token was stale.
     if access_token_is_stale(&pair.access_token) {
         let cfg = Config::load();
-        return refresh_locked(&cfg).await;
+        return match refresh_locked(&cfg).await {
+            Ok(access) => Ok(access),
+            Err(error) => {
+                set_cached_signed_in(false);
+                Err(error)
+            }
+        };
     }
+    set_cached_signed_in(true);
     Ok(pair.access_token.clone())
 }
 
@@ -696,7 +737,13 @@ fn access_token_is_stale(jwt: &str) -> bool {
 /// Force a token refresh and return the new access token.
 pub async fn refresh_access_token() -> Result<String, AppError> {
     let cfg = Config::load();
-    refresh_locked(&cfg).await
+    match refresh_locked(&cfg).await {
+        Ok(access) => Ok(access),
+        Err(error) => {
+            set_cached_signed_in(false);
+            Err(error)
+        }
+    }
 }
 
 async fn authed_get<T: for<'de> Deserialize<'de>>(cfg: &Config, path: &str) -> Result<T, AppError> {


### PR DESCRIPTION
## Summary

- Gate the macOS meeting detection state machine on OS Accounts signed-in state.
- Cache signed-in state in the OS Accounts module so the monitor can skip CoreAudio probing while signed out.
- Clear any active meeting prompt immediately when the user signs out.

## Why

Meeting detection previously started at app setup and could detect allowed microphone apps before the user had logged in. This keeps detection behavior behind the same account gate as the rest of the recording/transcription flow.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml meeting_detection`
- `cargo test --manifest-path src-tauri/Cargo.toml`