### PR TITLE
Support dropped agent file attachments

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1,4 +1,5 @@
 use crate::domain::types::AppError;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -26,6 +27,7 @@ const HERMES_SOURCE_TARBALL_SHA256: &str =
 const FILESYSTEM_MAX_DEPTH: usize = 2;
 const FILESYSTEM_MAX_ENTRIES_PER_DIR: usize = 80;
 const HERMES_IMPORT_MAX_BYTES: u64 = 50 * 1024 * 1024;
+const HERMES_IMAGE_PREVIEW_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_BODY_BYTES: usize = 512 * 1024;
 
@@ -158,6 +160,12 @@ pub struct DownloadHermesFileRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct HermesFilePreviewRequest {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ImportHermesFileRequest {
     pub path: String,
 }
@@ -169,6 +177,7 @@ pub struct ImportedHermesFile {
     pub path: String,
     pub root_label: String,
     pub size: u64,
+    pub preview_data_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -579,6 +588,15 @@ pub async fn download_hermes_bridge_file(
 }
 
 #[tauri::command]
+pub async fn hermes_bridge_file_preview(
+    app: AppHandle,
+    request: HermesFilePreviewRequest,
+) -> Result<Option<String>, AppError> {
+    let requested = validate_hermes_file_path(&app, &request.path)?;
+    image_preview_data_url(&requested)
+}
+
+#[tauri::command]
 pub async fn import_hermes_bridge_file(
     app: AppHandle,
     request: ImportHermesFileRequest,
@@ -612,6 +630,7 @@ pub async fn import_hermes_bridge_file(
         path: destination.to_string_lossy().into_owned(),
         root_label: "Workspace".to_string(),
         size,
+        preview_data_url: image_preview_data_url(&destination)?,
     })
 }
 
@@ -736,6 +755,34 @@ fn unique_upload_path(upload_dir: &Path, source: &Path) -> Result<PathBuf, AppEr
         "hermes_file_import_failed",
         "Could not find an available attachment filename.",
     ))
+}
+
+fn image_preview_data_url(path: &Path) -> Result<Option<String>, AppError> {
+    let Some(mime_type) = image_mime_type(path) else {
+        return Ok(None);
+    };
+    let metadata = fs::metadata(path)
+        .map_err(|error| AppError::new("hermes_file_preview_failed", error.to_string()))?;
+    if metadata.len() > HERMES_IMAGE_PREVIEW_MAX_BYTES {
+        return Ok(None);
+    }
+    let bytes = fs::read(path)
+        .map_err(|error| AppError::new("hermes_file_preview_failed", error.to_string()))?;
+    Ok(Some(format!(
+        "data:{mime_type};base64,{}",
+        BASE64_STANDARD.encode(bytes)
+    )))
+}
+
+fn image_mime_type(path: &Path) -> Option<&'static str> {
+    let extension = path.extension()?.to_str()?.to_ascii_lowercase();
+    match extension.as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
 }
 
 pub fn shutdown(app: &tauri::AppHandle) {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -25,6 +25,7 @@ const HERMES_SOURCE_TARBALL_SHA256: &str =
     "287ead740a444d7e8c8e00a6d6e073d9b3329034f649a07b42e0a3f5b14686e4";
 const FILESYSTEM_MAX_DEPTH: usize = 2;
 const FILESYSTEM_MAX_ENTRIES_PER_DIR: usize = 80;
+const HERMES_IMPORT_MAX_BYTES: u64 = 50 * 1024 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_BODY_BYTES: usize = 512 * 1024;
 
@@ -153,6 +154,21 @@ pub struct DeleteHermesSessionRequest {
 #[serde(rename_all = "camelCase")]
 pub struct DownloadHermesFileRequest {
     pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportHermesFileRequest {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportedHermesFile {
+    pub name: String,
+    pub path: String,
+    pub root_label: String,
+    pub size: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -562,6 +578,43 @@ pub async fn download_hermes_bridge_file(
     Ok(destination.to_string_lossy().into_owned())
 }
 
+#[tauri::command]
+pub async fn import_hermes_bridge_file(
+    app: AppHandle,
+    request: ImportHermesFileRequest,
+) -> Result<ImportedHermesFile, AppError> {
+    let source = validate_dropped_file_path(&request.path)?;
+    let metadata = fs::metadata(&source)
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?;
+    if metadata.len() > HERMES_IMPORT_MAX_BYTES {
+        return Err(AppError::new(
+            "hermes_file_import_denied",
+            "Dropped files must be 50 MB or smaller.",
+        ));
+    }
+    let hermes_home = resolve_scribe_hermes_home(&app)?;
+    let upload_dir = hermes_home.join("workspace").join("uploads");
+    fs::create_dir_all(&upload_dir)
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?;
+    let destination = unique_upload_path(&upload_dir, &source)?;
+    fs::copy(&source, &destination)
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?;
+    let size = fs::metadata(&destination)
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?
+        .len();
+    let name = destination
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("attachment")
+        .to_string();
+    Ok(ImportedHermesFile {
+        name,
+        path: destination.to_string_lossy().into_owned(),
+        root_label: "Workspace".to_string(),
+        size,
+    })
+}
+
 fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, AppError> {
     let hermes_home = resolve_scribe_hermes_home(&app)?;
     let requested = PathBuf::from(path)
@@ -587,6 +640,25 @@ fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, App
         return Err(AppError::new(
             "hermes_file_download_denied",
             "Only files in this app's Hermes workspace or memory can be downloaded.",
+        ));
+    }
+    Ok(requested)
+}
+
+fn validate_dropped_file_path(path: &str) -> Result<PathBuf, AppError> {
+    let requested = PathBuf::from(path)
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?;
+    if !requested.is_file() {
+        return Err(AppError::new(
+            "hermes_file_import_failed",
+            "Only files can be attached to an agent message.",
+        ));
+    }
+    if is_hidden_secret_path(&requested) {
+        return Err(AppError::new(
+            "hermes_file_import_denied",
+            "Hidden or sensitive files cannot be attached.",
         ));
     }
     Ok(requested)
@@ -626,6 +698,43 @@ fn unique_download_path(downloads_dir: &Path, source: &Path) -> Result<PathBuf, 
     Err(AppError::new(
         "hermes_file_download_failed",
         "Could not find an available Downloads filename.",
+    ))
+}
+
+fn unique_upload_path(upload_dir: &Path, source: &Path) -> Result<PathBuf, AppError> {
+    let file_name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            AppError::new(
+                "hermes_file_import_failed",
+                "The dropped file does not have a usable filename.",
+            )
+        })?;
+    let candidate = upload_dir.join(file_name);
+    if !candidate.exists() {
+        return Ok(candidate);
+    }
+
+    let stem = source
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("attachment");
+    let extension = source.extension().and_then(|name| name.to_str());
+    for index in 1..1000 {
+        let file_name = match extension {
+            Some(extension) if !extension.is_empty() => format!("{stem} ({index}).{extension}"),
+            _ => format!("{stem} ({index})"),
+        };
+        let candidate = upload_dir.join(file_name);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(AppError::new(
+        "hermes_file_import_failed",
+        "Could not find an available attachment filename.",
     ))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ pub fn run() {
             hermes_bridge::hermes_bridge_messaging_platforms,
             hermes_bridge::hermes_bridge_filesystem_snapshot,
             hermes_bridge::download_hermes_bridge_file,
+            hermes_bridge::import_hermes_bridge_file,
             hermes_bridge::hermes_bridge_sessions,
             hermes_bridge::hermes_bridge_session_messages,
             hermes_bridge::delete_hermes_bridge_session,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ pub fn run() {
             hermes_bridge::hermes_bridge_messaging_platforms,
             hermes_bridge::hermes_bridge_filesystem_snapshot,
             hermes_bridge::download_hermes_bridge_file,
+            hermes_bridge::hermes_bridge_file_preview,
             hermes_bridge::import_hermes_bridge_file,
             hermes_bridge::hermes_bridge_sessions,
             hermes_bridge::hermes_bridge_session_messages,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -14,9 +14,11 @@ import {
   WrenchIcon,
   XIcon,
 } from "lucide-react";
+import { listen } from "@tauri-apps/api/event";
 import {
   type CSSProperties,
   type FormEvent,
+  type DragEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -35,6 +37,7 @@ import {
   hermesBridgeSkills,
   hermesBridgeStatus,
   hermesBridgeToolsets,
+  importHermesBridgeFile,
   listAgentTasks,
   downloadHermesBridgeFile,
   retryAgentTask,
@@ -53,6 +56,7 @@ import {
   type HermesBridgeStatus,
   type HermesFilesystemEntry,
   type HermesFilesystemSnapshot,
+  type ImportedHermesFile,
   type HermesMessagingEnvVarInfo,
   type HermesMessagingPlatformInfo,
   type HermesSessionInfo,
@@ -115,6 +119,14 @@ type AgentArtifact = {
   size?: number | null;
 };
 
+type AgentAttachment = ImportedHermesFile & {
+  id: string;
+};
+
+type TauriFileDropPayload = {
+  paths?: string[];
+};
+
 type HermesRuntimeSessionResponse = {
   session_id?: string;
   stored_session_id?: string;
@@ -130,6 +142,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const [selectedTaskId, setSelectedTaskId] = useState<string>();
   const [activePanel, setActivePanel] = useState<AgentPanel>("chat");
   const [draft, setDraft] = useState("");
+  const [attachments, setAttachments] = useState<AgentAttachment[]>([]);
+  const [dropActive, setDropActive] = useState(false);
+  const [importingFiles, setImportingFiles] = useState(false);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -504,6 +519,33 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   ]);
 
   useEffect(() => {
+    let disposed = false;
+    const unlisteners: Array<() => void> = [];
+    const installListener = async (eventName: string) => {
+      const unlisten = await listen<TauriFileDropPayload>(
+        eventName,
+        (event) => {
+          const paths = event.payload?.paths ?? [];
+          if (paths.length) {
+            void importDroppedFilePaths(paths);
+          }
+        },
+      );
+      if (disposed) {
+        unlisten();
+        return;
+      }
+      unlisteners.push(unlisten);
+    };
+    void installListener("tauri://drag-drop");
+    void installListener("tauri://file-drop");
+    return () => {
+      disposed = true;
+      for (const unlisten of unlisteners) unlisten();
+    };
+  }, []);
+
+  useEffect(() => {
     if (activePanel === "skills" && (!skills || !toolsets)) {
       void loadCapabilities();
     }
@@ -514,19 +556,71 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
 
   async function submit(event: FormEvent) {
     event.preventDefault();
-    const content = draft.trim();
-    if (!content || submitting) return;
+    const message = draft.trim();
+    if ((!message && !attachments.length) || submitting || importingFiles)
+      return;
+    const content = promptWithAttachments(message, attachments);
     setSubmitting(true);
     setDraft("");
     try {
       await submitHermesSession(content);
+      setAttachments([]);
       setError(null);
     } catch (err) {
-      setDraft(content);
+      setDraft(message);
       setError(messageFromError(err));
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function handleComposerDragOver(event: DragEvent<HTMLFormElement>) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setDropActive(true);
+  }
+
+  function handleComposerDrop(event: DragEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setDropActive(false);
+    const paths = Array.from(event.dataTransfer.files)
+      .map((file) => (file as File & { path?: string }).path)
+      .filter((path): path is string => Boolean(path));
+    if (!paths.length) {
+      setError("Drop files from Finder to attach them to the agent.");
+      return;
+    }
+    void importDroppedFilePaths(paths);
+  }
+
+  async function importDroppedFilePaths(paths: string[]) {
+    const uniquePaths = Array.from(new Set(paths.map((path) => path.trim())))
+      .filter(Boolean)
+      .slice(0, 8);
+    if (!uniquePaths.length) return;
+    setImportingFiles(true);
+    try {
+      const imported = await Promise.all(
+        uniquePaths.map((path) => importHermesBridgeFile(path)),
+      );
+      setAttachments((current) => [
+        ...current,
+        ...imported.map((file) => ({
+          ...file,
+          id: `${file.path}:${Date.now()}:${Math.random().toString(36)}`,
+        })),
+      ]);
+      setError(null);
+      void loadFilesystemSnapshot();
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setImportingFiles(false);
+    }
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((current) => current.filter((item) => item.id !== id));
   }
 
   async function submitHermesSession(content: string) {
@@ -1221,24 +1315,61 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         {activePanel === "chat" ? (
           <form
             className="agent-composer"
+            data-drop-active={dropActive ? "true" : undefined}
             onSubmit={(event) => void submit(event)}
+            onDragOver={handleComposerDragOver}
+            onDragEnter={() => setDropActive(true)}
+            onDragLeave={() => setDropActive(false)}
+            onDrop={handleComposerDrop}
           >
-            <textarea
-              value={draft}
-              onChange={(event) => setDraft(event.currentTarget.value)}
-              placeholder={
-                selectedHermesSessionId || selectedTask
-                  ? "Send a follow-up"
-                  : "Ask the agent to complete a desktop task"
-              }
-              rows={2}
-              onKeyDown={(event) => {
-                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-                  event.currentTarget.form?.requestSubmit();
+            <div className="agent-composer-input">
+              {attachments.length ? (
+                <div className="agent-attachment-list" aria-label="Attachments">
+                  {attachments.map((attachment) => (
+                    <div key={attachment.id} className="agent-attachment-chip">
+                      <FileIcon size={15} />
+                      <span>{attachment.name}</span>
+                      <em>{attachment.rootLabel}</em>
+                      <button
+                        type="button"
+                        aria-label={`Remove ${attachment.name}`}
+                        onClick={() => removeAttachment(attachment.id)}
+                      >
+                        <XIcon size={14} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <textarea
+                value={draft}
+                onChange={(event) => setDraft(event.currentTarget.value)}
+                placeholder={
+                  importingFiles
+                    ? "Attaching file..."
+                    : selectedHermesSessionId || selectedTask
+                      ? "Send a follow-up"
+                      : "Ask the agent to complete a desktop task"
                 }
-              }}
-            />
-            <button type="submit" disabled={submitting || !draft.trim()}>
+                rows={2}
+                onKeyDown={(event) => {
+                  if (
+                    (event.metaKey || event.ctrlKey) &&
+                    event.key === "Enter"
+                  ) {
+                    event.currentTarget.form?.requestSubmit();
+                  }
+                }}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={
+                submitting ||
+                importingFiles ||
+                (!draft.trim() && !attachments.length)
+              }
+            >
               {submitting ? <Spinner size={15} /> : <SendIcon size={15} />}
               <span>
                 {selectedHermesSessionId || selectedTask ? "Send" : "Create"}
@@ -2942,6 +3073,24 @@ function artifactsFromFilesystemSnapshot(
   return (snapshot?.roots ?? []).flatMap((root) =>
     filesystemEntriesToArtifacts(root.entries, root.label),
   );
+}
+
+function promptWithAttachments(
+  message: string,
+  attachments: AgentAttachment[],
+): string {
+  if (!attachments.length) return message;
+  return [
+    message || "Use the attached file(s).",
+    "",
+    "Attached files copied into the Scribe Hermes workspace:",
+    ...attachments.map(
+      (attachment) =>
+        `- ${attachment.name} (${attachment.rootLabel}): ${attachment.path}`,
+    ),
+    "",
+    "Use these workspace paths when inspecting or operating on the files.",
+  ].join("\n");
 }
 
 function filesystemEntriesToArtifacts(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -34,6 +34,7 @@ import {
   getAgentTask,
   hermesBridgeFilesystemSnapshot,
   hermesBridgeMessagingPlatforms,
+  hermesBridgeFilePreview,
   hermesBridgeSkills,
   hermesBridgeStatus,
   hermesBridgeToolsets,
@@ -117,6 +118,7 @@ type AgentArtifact = {
   path: string;
   rootLabel: string;
   size?: number | null;
+  previewDataUrl?: string | null;
 };
 
 type AgentAttachment = ImportedHermesFile & {
@@ -1327,7 +1329,15 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                 <div className="agent-attachment-list" aria-label="Attachments">
                   {attachments.map((attachment) => (
                     <div key={attachment.id} className="agent-attachment-chip">
-                      <FileIcon size={15} />
+                      {attachment.previewDataUrl ? (
+                        <img
+                          src={attachment.previewDataUrl}
+                          alt=""
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <FileIcon size={15} />
+                      )}
                       <span>{attachment.name}</span>
                       <em>{attachment.rootLabel}</em>
                       <button
@@ -2674,33 +2684,82 @@ function AgentArtifactList({
   return (
     <div className="agent-artifact-list" aria-label="Generated files">
       {artifacts.map((artifact) => (
-        <article key={artifact.path} className="agent-artifact-card">
-          <span className="agent-tool-icon">
-            <FileIcon size={14} />
-          </span>
-          <div>
-            <div className="agent-artifact-title">
-              <span>{artifact.name}</span>
-              <em>{artifact.rootLabel}</em>
-            </div>
-            <p>
-              {formatBytes(artifact.size)}
-              <span>{compactPath(artifact.path)}</span>
-            </p>
-          </div>
-          {onDownload ? (
-            <button
-              type="button"
-              aria-label={`Download ${artifact.name}`}
-              title="Download"
-              onClick={() => onDownload(artifact)}
-            >
-              <DownloadIcon size={16} />
-            </button>
-          ) : null}
-        </article>
+        <AgentArtifactCard
+          key={artifact.path}
+          artifact={artifact}
+          onDownload={onDownload}
+        />
       ))}
     </div>
+  );
+}
+
+function AgentArtifactCard({
+  artifact,
+  onDownload,
+}: {
+  artifact: AgentArtifact;
+  onDownload?: (artifact: AgentArtifact) => void;
+}) {
+  const [previewDataUrl, setPreviewDataUrl] = useState<string | null>(
+    artifact.previewDataUrl ?? null,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (artifact.previewDataUrl || !isPreviewableImagePath(artifact.path)) {
+      setPreviewDataUrl(artifact.previewDataUrl ?? null);
+      return;
+    }
+    hermesBridgeFilePreview(artifact.path)
+      .then((preview) => {
+        if (!cancelled) setPreviewDataUrl(preview);
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewDataUrl(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [artifact.path, artifact.previewDataUrl]);
+
+  return (
+    <article
+      className="agent-artifact-card"
+      data-has-preview={previewDataUrl ? "true" : undefined}
+    >
+      {previewDataUrl ? (
+        <img
+          className="agent-artifact-preview"
+          src={previewDataUrl}
+          alt={artifact.name}
+        />
+      ) : (
+        <span className="agent-tool-icon">
+          <FileIcon size={14} />
+        </span>
+      )}
+      <div>
+        <div className="agent-artifact-title">
+          <span>{artifact.name}</span>
+          <em>{artifact.rootLabel}</em>
+        </div>
+        <p>
+          {formatBytes(artifact.size)}
+          <span>{compactPath(artifact.path)}</span>
+        </p>
+      </div>
+      {onDownload ? (
+        <button
+          type="button"
+          aria-label={`Download ${artifact.name}`}
+          title="Download"
+          onClick={() => onDownload(artifact)}
+        >
+          <DownloadIcon size={16} />
+        </button>
+      ) : null}
+    </article>
   );
 }
 
@@ -3135,6 +3194,10 @@ function artifactsMentionedInText(
     seen.add(artifact.path);
     return true;
   });
+}
+
+function isPreviewableImagePath(path: string) {
+  return /\.(png|jpe?g|gif|webp)$/i.test(path);
 }
 
 function includesQuery(value: unknown, query: string) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -384,6 +384,7 @@ export type ImportedHermesFile = {
   path: string;
   rootLabel: string;
   size: number;
+  previewDataUrl?: string | null;
 };
 
 export type HermesSkillInfo = {
@@ -756,6 +757,12 @@ export async function hermesBridgeFilesystemSnapshot() {
 
 export async function downloadHermesBridgeFile(path: string) {
   return invoke<string>("download_hermes_bridge_file", { request: { path } });
+}
+
+export async function hermesBridgeFilePreview(path: string) {
+  return invoke<string | null>("hermes_bridge_file_preview", {
+    request: { path },
+  });
 }
 
 export async function importHermesBridgeFile(path: string) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -379,6 +379,13 @@ export type HermesFilesystemSnapshot = {
   roots: HermesFilesystemRoot[];
 };
 
+export type ImportedHermesFile = {
+  name: string;
+  path: string;
+  rootLabel: string;
+  size: number;
+};
+
 export type HermesSkillInfo = {
   name: string;
   description?: string;
@@ -749,6 +756,12 @@ export async function hermesBridgeFilesystemSnapshot() {
 
 export async function downloadHermesBridgeFile(path: string) {
   return invoke<string>("download_hermes_bridge_file", { request: { path } });
+}
+
+export async function importHermesBridgeFile(path: string) {
+  return invoke<ImportedHermesFile>("import_hermes_bridge_file", {
+    request: { path },
+  });
 }
 
 export async function hermesBridgeSessions(

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1579,8 +1579,66 @@ input:focus-visible,
   border-top: 1px solid var(--border-subtle);
 }
 
+.agent-composer[data-drop-active="true"] {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
 .agent-composer[data-hidden="true"] {
   display: none;
+}
+
+.agent-composer-input {
+  display: grid;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.agent-attachment-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+}
+
+.agent-attachment-chip {
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--sp-2);
+  max-width: min(100%, 360px);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2);
+  background: var(--surface-subtle);
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+}
+
+.agent-attachment-chip span {
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-attachment-chip em {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  font-style: normal;
+}
+
+.agent-attachment-chip button {
+  display: inline-grid;
+  place-items: center;
+  min-width: var(--control-xs);
+  min-height: var(--control-xs);
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.agent-attachment-chip button:hover {
+  color: var(--foreground);
 }
 
 .agent-composer textarea {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1341,6 +1341,19 @@ input:focus-visible,
   background: var(--surface-subtle);
 }
 
+.agent-artifact-card[data-has-preview="true"] {
+  max-width: 520px;
+}
+
+.agent-artifact-preview {
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  object-fit: cover;
+  background: var(--background);
+}
+
 .agent-artifact-title {
   display: flex;
   align-items: baseline;
@@ -1611,6 +1624,15 @@ input:focus-visible,
   background: var(--surface-subtle);
   color: var(--foreground);
   font-size: var(--fs-sm);
+}
+
+.agent-attachment-chip img {
+  width: var(--control-lg);
+  height: var(--control-lg);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  object-fit: cover;
+  background: var(--background);
 }
 
 .agent-attachment-chip span {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   createAgentTask: vi.fn(),
   getAgentTask: vi.fn(),
   hermesBridgeFilesystemSnapshot: vi.fn(),
+  hermesBridgeFilePreview: vi.fn(),
   hermesBridgeMessagingPlatforms: vi.fn(),
   hermesBridgeSkills: vi.fn(),
   hermesBridgeStatus: vi.fn(),
@@ -51,6 +52,7 @@ vi.mock("../lib/tauri", () => ({
   createAgentTask: mocks.createAgentTask,
   getAgentTask: mocks.getAgentTask,
   hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
+  hermesBridgeFilePreview: mocks.hermesBridgeFilePreview,
   hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
@@ -127,11 +129,15 @@ describe("AgentWorkspace", () => {
     mocks.listHermesSessions.mockResolvedValue([existingSession]);
     mocks.listHermesSessionMessages.mockResolvedValue([]);
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
+    mocks.hermesBridgeFilePreview.mockResolvedValue(null);
     mocks.importHermesBridgeFile.mockImplementation(async (path: string) => ({
       name: path.split("/").pop() ?? "attachment",
       path: `/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/${path.split("/").pop() ?? "attachment"}`,
       rootLabel: "Workspace",
       size: 1234,
+      previewDataUrl: path.endsWith(".png")
+        ? "data:image/png;base64,preview"
+        : null,
     }));
     mocks.downloadHermesBridgeFile.mockResolvedValue(
       "/Users/junho/Downloads/sample.pdf",
@@ -261,6 +267,48 @@ describe("AgentWorkspace", () => {
     expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(samplePath);
   });
 
+  it("renders generated workspace images as thumbnails", async () => {
+    const screenshotPath =
+      "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/screenshot.png";
+    mocks.hermesBridgeFilePreview.mockResolvedValue(
+      "data:image/png;base64,generated-preview",
+    );
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "screenshot.png",
+              path: screenshotPath,
+              kind: "file",
+              size: 2048,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: "I saved the screenshot as `screenshot.png`.",
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByRole("img", { name: "screenshot.png" }),
+    ).toHaveAttribute("src", "data:image/png;base64,generated-preview");
+    expect(mocks.hermesBridgeFilePreview).toHaveBeenCalledWith(screenshotPath);
+  });
+
   it("imports dropped files into the Hermes workspace before submitting", async () => {
     const user = userEvent.setup();
     render(<AgentWorkspace />);
@@ -282,6 +330,9 @@ describe("AgentWorkspace", () => {
     });
 
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    expect(
+      document.querySelector(".agent-attachment-chip img"),
+    ).toHaveAttribute("src", "data:image/png;base64,preview");
     await user.type(
       screen.getByPlaceholderText("Send a follow-up"),
       "what is in this image?",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeSkills: vi.fn(),
   hermesBridgeStatus: vi.fn(),
   hermesBridgeToolsets: vi.fn(),
+  importHermesBridgeFile: vi.fn(),
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
   retryAgentTask: vi.fn(),
@@ -30,6 +31,19 @@ const mocks = vi.hoisted(() => ({
   listHermesSessionMessages: vi.fn(),
   listHermesSessions: vi.fn(),
   gatewayRequest: vi.fn(),
+  eventHandlers: new Map<
+    string,
+    (event: { payload?: { paths?: string[] } }) => void
+  >(),
+  listen: vi.fn(
+    async (
+      eventName: string,
+      handler: (event: { payload?: { paths?: string[] } }) => void,
+    ) => {
+      mocks.eventHandlers.set(eventName, handler);
+      return () => mocks.eventHandlers.delete(eventName);
+    },
+  ),
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -41,6 +55,7 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
+  importHermesBridgeFile: mocks.importHermesBridgeFile,
   listAgentTasks: mocks.listAgentTasks,
   downloadHermesBridgeFile: mocks.downloadHermesBridgeFile,
   retryAgentTask: mocks.retryAgentTask,
@@ -53,6 +68,10 @@ vi.mock("../lib/tauri", () => ({
   toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform:
     mocks.updateHermesBridgeMessagingPlatform,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
 }));
 
 vi.mock("../lib/hermes-adapter", () => ({
@@ -108,6 +127,12 @@ describe("AgentWorkspace", () => {
     mocks.listHermesSessions.mockResolvedValue([existingSession]);
     mocks.listHermesSessionMessages.mockResolvedValue([]);
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
+    mocks.importHermesBridgeFile.mockImplementation(async (path: string) => ({
+      name: path.split("/").pop() ?? "attachment",
+      path: `/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/${path.split("/").pop() ?? "attachment"}`,
+      rootLabel: "Workspace",
+      size: 1234,
+    }));
     mocks.downloadHermesBridgeFile.mockResolvedValue(
       "/Users/junho/Downloads/sample.pdf",
     );
@@ -120,6 +145,9 @@ describe("AgentWorkspace", () => {
           session_id: "runtime-session-2",
           stored_session_id: "session-2",
         });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
       }
       return Promise.resolve({});
     });
@@ -231,5 +259,45 @@ describe("AgentWorkspace", () => {
     );
 
     expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(samplePath);
+  });
+
+  it("imports dropped files into the Hermes workspace before submitting", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listen).toHaveBeenCalledWith(
+        "tauri://drag-drop",
+        expect.any(Function),
+      ),
+    );
+
+    mocks.eventHandlers.get("tauri://drag-drop")?.({
+      payload: {
+        paths: [
+          "/Users/junho/Library/Application Support/CleanShot/media/screenshot.png",
+        ],
+      },
+    });
+
+    expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    await user.type(
+      screen.getByPlaceholderText("Send a follow-up"),
+      "what is in this image?",
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: expect.stringContaining(
+          "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
+        ),
+      }),
+    );
+    expect(mocks.importHermesBridgeFile).toHaveBeenCalledWith(
+      "/Users/junho/Library/Application Support/CleanShot/media/screenshot.png",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- copy dropped files into the Scribe-managed Hermes workspace before sending them to the agent
- show attached files as removable composer chips
- include workspace attachment paths in the Hermes prompt so image/file drops are actionable

## Verification
- `pnpm exec vitest run src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `pnpm run test:rust`