### PR TITLE
[codex] Fix Hey June HUD dismissal

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1857,7 +1857,9 @@ fn dictation_event_visibility(event_type: Option<&str>) -> DictationEventVisibil
             | "final_transcript"
             | "paste_target",
         ) => DictationEventVisibility::Show,
-        Some("paste_completed" | "error" | "shutdown_ack") => DictationEventVisibility::Hide,
+        Some("paste_completed" | "agent_session_prompt" | "error" | "shutdown_ack") => {
+            DictationEventVisibility::Hide
+        }
         _ => DictationEventVisibility::Ignore,
     }
 }
@@ -2460,6 +2462,14 @@ mod tests {
             outcome.transcript.as_ref().map(|item| item.text.as_str()),
             Some("Hey, June, summarize the open document.")
         );
+    }
+
+    #[test]
+    fn agent_session_prompt_hides_dictation_hud() {
+        assert!(matches!(
+            dictation_event_visibility(Some("agent_session_prompt")),
+            DictationEventVisibility::Hide
+        ));
     }
 
     #[test]

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -377,6 +377,11 @@ async function handleDictationEventPayload(payload: unknown) {
     return;
   }
 
+  if (dictationEvent.type === "agent_session_prompt") {
+    void hideHud();
+    return;
+  }
+
   if (dictationEvent.type === "error") {
     // Rust pre-classifies via payload.silent so the HUD has one source of
     // truth for what counts as a "Nothing recorded" case.

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -163,6 +163,21 @@ describe("meeting detection HUD", () => {
     await vi.advanceTimersByTimeAsync(900);
     expect(hudElement().dataset.state).toBe("exiting");
   });
+
+  it("hides when a Hey June prompt starts an agent session", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("dictation-event", { type: "finalizing_transcript" });
+
+    await emit("dictation-event", {
+      type: "agent_session_prompt",
+      payload: { prompt: "summarize the open document." },
+    });
+
+    expect(hudElement().dataset.state).toBe("exiting");
+    await vi.advanceTimersByTimeAsync(160);
+    expect(mocks.hide).toHaveBeenCalledOnce();
+  });
 });
 
 async function loadHud() {


### PR DESCRIPTION
## Summary

- Treat `agent_session_prompt` as a terminal dictation event for HUD visibility.
- Hide the HUD webview immediately when a Hey June prompt starts an agent session.
- Add frontend and Rust regression coverage for the Hey June HUD dismissal path.

## Root Cause

The Hey June dictation flow emits `agent_session_prompt` and sends `discard_recording` to the helper instead of entering the normal paste path. The helper discard path only resets native recording state, so no `paste_completed` or `shutdown_ack` event arrived to dismiss the HUD. The overlay stayed in its previous finalizing/transcribing state after the agent request was already complete.

## Validation

- `pnpm test src/test/hud-meeting.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml agent_session_prompt_hides_dictation_hud`
- `cargo test --manifest-path src-tauri/Cargo.toml hey_june`