### PR TITLE
[codex] add settings permissions tab

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -410,6 +410,16 @@ export function App() {
     void openPrivacySettings("microphone");
   }
 
+  function handleEnableAccessibility() {
+    void dictationHelperCommand({ type: "request_accessibility_permission" })
+      .catch(() => undefined)
+      .finally(() => {
+        window.setTimeout(() => {
+          void openPrivacySettings("accessibility");
+        }, 200);
+      });
+  }
+
   useEffect(() => {
     if (
       !state.recordingStatus ||
@@ -938,9 +948,13 @@ export function App() {
                 sourceMode={sourceMode}
                 sourceReadiness={sourceReadiness}
                 checkingSourceReadiness={checkingSourceReadiness}
+                microphonePermissionStatus={microphoneStatus}
+                accessibilityPermissionStatus={accessibilityStatus}
                 onAccountChanged={handleAccountChanged}
                 onAccountRefresh={refreshAccount}
                 onSourceModeChange={handleSourceModeChange}
+                onEnableMicrophone={handleEnableMicrophone}
+                onEnableAccessibility={handleEnableAccessibility}
                 onEnableSystemAudio={handleEnableSystemAudio}
               />
             ) : activeView === "dictation" ? (

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -129,6 +129,7 @@ type SettingsTab =
   | "account"
   | "dictation"
   | "audio"
+  | "permissions"
   | "models"
   | "agent"
   | "about";
@@ -137,6 +138,7 @@ const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: "account", label: "Account" },
   { id: "dictation", label: "Dictation" },
   { id: "audio", label: "Audio" },
+  { id: "permissions", label: "Permissions" },
   { id: "models", label: "Models" },
   { id: "agent", label: "Agent" },
   { id: "about", label: "About" },
@@ -148,9 +150,13 @@ type AppSettingsProps = {
   sourceMode: RecordingSourceMode;
   sourceReadiness?: RecordingSourceReadinessDto;
   checkingSourceReadiness: boolean;
+  microphonePermissionStatus?: string;
+  accessibilityPermissionStatus?: string;
   onAccountChanged: (next: AccountStatus) => void;
   onAccountRefresh: () => Promise<AccountStatus | undefined>;
   onSourceModeChange: (mode: RecordingSourceMode) => void;
+  onEnableMicrophone?: () => void;
+  onEnableAccessibility?: () => void;
   onEnableSystemAudio: () => void;
 };
 
@@ -160,9 +166,13 @@ export function AppSettings({
   sourceMode,
   sourceReadiness,
   checkingSourceReadiness,
+  microphonePermissionStatus,
+  accessibilityPermissionStatus,
   onAccountChanged,
   onAccountRefresh,
   onSourceModeChange,
+  onEnableMicrophone,
+  onEnableAccessibility,
   onEnableSystemAudio,
 }: AppSettingsProps) {
   const [settings, setSettings] =
@@ -192,6 +202,9 @@ export function AppSettings({
   const systemOn = sourceMode === "microphonePlusSystem";
   const systemReadiness = sourceReadiness?.sources.find(
     (source) => source.source === "system",
+  );
+  const microphoneReadiness = sourceReadiness?.sources.find(
+    (source) => source.source === "microphone",
   );
   const systemState = systemReadiness?.permissionState;
   const systemDenied = systemState === "denied" || systemState === "restricted";
@@ -681,6 +694,48 @@ export function AppSettings({
           </section>
         ) : null}
 
+        {activeTab === "permissions" ? (
+          <section
+            className="settings-group"
+            aria-labelledby="permissions-heading"
+          >
+            <h2 id="permissions-heading" className="settings-group-heading">
+              System permissions
+            </h2>
+            <p className="settings-group-description">
+              macOS access used for recording audio, pasting dictation, and
+              capturing system sound.
+            </p>
+            <div className="settings-card">
+              <div className="settings-rows">
+                <PermissionRow
+                  title="Microphone"
+                  description="Record dictation and note audio."
+                  status={permissionStatus(
+                    microphonePermissionStatus ??
+                      microphoneReadiness?.permissionState,
+                  )}
+                  onManage={onEnableMicrophone}
+                />
+
+                <PermissionRow
+                  title="Accessibility"
+                  description="Paste dictated text into the active app."
+                  status={permissionStatus(accessibilityPermissionStatus)}
+                  onManage={onEnableAccessibility}
+                />
+
+                <PermissionRow
+                  title="System audio"
+                  description="Record audio from other apps when system audio is enabled."
+                  status={sourcePermissionStatus(systemReadiness)}
+                  onManage={onEnableSystemAudio}
+                />
+              </div>
+            </div>
+          </section>
+        ) : null}
+
         {activeTab === "models" ? (
           <>
             <ModelPickerDialog
@@ -766,6 +821,83 @@ export function AppSettings({
       </div>
     </div>
   );
+}
+
+type PermissionStatusTone =
+  | "allowed"
+  | "attention"
+  | "blocked"
+  | "unsupported"
+  | "unknown";
+
+type PermissionStatusView = {
+  label: string;
+  tone: PermissionStatusTone;
+};
+
+function PermissionRow({
+  title,
+  description,
+  status,
+  onManage,
+}: {
+  title: string;
+  description: string;
+  status: PermissionStatusView;
+  onManage?: () => void;
+}) {
+  const actionDisabled = status.tone === "unsupported" || !onManage;
+  return (
+    <div className="settings-row">
+      <div className="settings-row-info">
+        <h3 className="settings-row-title">{title}</h3>
+        <p className="settings-row-description">{description}</p>
+      </div>
+      <div className="settings-row-control settings-permission-control">
+        <span className="settings-permission-status" data-status={status.tone}>
+          {status.label}
+        </span>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={actionDisabled}
+          aria-label={`Manage ${title} permission`}
+          onClick={onManage}
+        >
+          Manage
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function permissionStatus(state?: string): PermissionStatusView {
+  switch (state) {
+    case "granted":
+      return { label: "Allowed", tone: "allowed" };
+    case "denied":
+      return { label: "Blocked", tone: "blocked" };
+    case "restricted":
+      return { label: "Restricted", tone: "blocked" };
+    case "missing":
+      return { label: "Needs access", tone: "attention" };
+    case "not_determined":
+      return { label: "Not requested", tone: "attention" };
+    case "unsupported":
+      return { label: "Unsupported", tone: "unsupported" };
+    case "unknown":
+      return { label: "Unknown", tone: "unknown" };
+    default:
+      return { label: "Checking", tone: "unknown" };
+  }
+}
+
+function sourcePermissionStatus(
+  source?: RecordingSourceReadinessDto["sources"][number],
+): PermissionStatusView {
+  if (!source) return { label: "Checking", tone: "unknown" };
+  if (source.ready) return { label: "Allowed", tone: "allowed" };
+  return permissionStatus(source.permissionState);
 }
 
 function ModelRow({

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4349,6 +4349,54 @@ input:focus-visible,
   justify-content: flex-end;
 }
 
+.settings-permission-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 var(--sp-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.settings-permission-status[data-status="allowed"] {
+  border-color: color-mix(in oklch, var(--success) 24%, var(--border-subtle));
+  background: color-mix(in oklch, var(--success) 10%, var(--surface-subtle));
+  color: color-mix(in oklch, var(--success) 76%, var(--foreground));
+}
+
+.settings-permission-status[data-status="attention"] {
+  border-color: color-mix(
+    in oklch,
+    var(--warm-strong) 28%,
+    var(--border-subtle)
+  );
+  background: color-mix(
+    in oklch,
+    var(--warm-strong) 12%,
+    var(--surface-subtle)
+  );
+  color: color-mix(in oklch, var(--warm-strong) 76%, var(--foreground));
+}
+
+.settings-permission-status[data-status="blocked"] {
+  border-color: color-mix(
+    in oklch,
+    var(--destructive) 26%,
+    var(--border-subtle)
+  );
+  background: color-mix(
+    in oklch,
+    var(--destructive) 10%,
+    var(--surface-subtle)
+  );
+  color: color-mix(in oklch, var(--destructive) 76%, var(--foreground));
+}
+
 .settings-model-control {
   width: min(420px, 44vw);
   justify-content: flex-end;

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppSettings } from "../components/settings/AppSettings";
@@ -319,6 +319,99 @@ describe("AppSettings", () => {
       screen.getByRole("switch", { name: "Capture system audio for notes" }),
     );
     expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+  });
+
+  it("lists system permissions with status and manage actions", async () => {
+    const user = userEvent.setup();
+    const onEnableMicrophone = vi.fn();
+    const onEnableAccessibility = vi.fn();
+    const onEnableSystemAudio = vi.fn();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        sourceReadiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: false,
+          checkedAt: "2026-06-08T12:00:00Z",
+          sources: [
+            {
+              source: "microphone",
+              required: true,
+              ready: false,
+              permissionState: "denied",
+              deviceAvailable: false,
+              captureAvailable: false,
+              recoveryAction: "openMicrophoneSettings",
+            },
+            {
+              source: "system",
+              required: true,
+              ready: false,
+              permissionState: "denied",
+              deviceAvailable: true,
+              captureAvailable: false,
+              recoveryAction: "openSystemAudioSettings",
+            },
+          ],
+        }}
+        checkingSourceReadiness={false}
+        microphonePermissionStatus="denied"
+        accessibilityPermissionStatus="missing"
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableMicrophone={onEnableMicrophone}
+        onEnableAccessibility={onEnableAccessibility}
+        onEnableSystemAudio={onEnableSystemAudio}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Permissions" }));
+
+    const microphoneRow = screen
+      .getByText("Microphone")
+      .closest(".settings-row");
+    const accessibilityRow = screen
+      .getByText("Accessibility")
+      .closest(".settings-row");
+    const systemAudioRow = screen
+      .getByText("System audio")
+      .closest(".settings-row");
+
+    expect(microphoneRow).not.toBeNull();
+    expect(accessibilityRow).not.toBeNull();
+    expect(systemAudioRow).not.toBeNull();
+    expect(
+      within(microphoneRow as HTMLElement).getByText("Blocked"),
+    ).toBeInTheDocument();
+    expect(
+      within(accessibilityRow as HTMLElement).getByText("Needs access"),
+    ).toBeInTheDocument();
+    expect(
+      within(systemAudioRow as HTMLElement).getByText("Blocked"),
+    ).toBeInTheDocument();
+
+    await user.click(
+      within(microphoneRow as HTMLElement).getByRole("button", {
+        name: "Manage Microphone permission",
+      }),
+    );
+    await user.click(
+      within(accessibilityRow as HTMLElement).getByRole("button", {
+        name: "Manage Accessibility permission",
+      }),
+    );
+    await user.click(
+      within(systemAudioRow as HTMLElement).getByRole("button", {
+        name: "Manage System audio permission",
+      }),
+    );
+
+    expect(onEnableMicrophone).toHaveBeenCalledTimes(1);
+    expect(onEnableAccessibility).toHaveBeenCalledTimes(1);
+    expect(onEnableSystemAudio).toHaveBeenCalledTimes(1);
   });
 
   it("records push-to-talk and toggle dictation shortcuts in settings", async () => {


### PR DESCRIPTION
## Summary

Adds a new Settings > Permissions tab that lists the macOS system permissions OS Scribe asks for: Microphone, Accessibility, and System audio. Each row shows the current known status and includes a Manage action that routes users to the relevant permission flow.

## Details

- Threads existing microphone and Accessibility helper status into Settings.
- Reuses recording source readiness for System audio status.
- Adds compact status badges for allowed, attention-needed, blocked, unsupported, and checking states.
- Covers the new tab with an AppSettings regression test.

## Validation

- `pnpm test -- src/test/app-settings.test.tsx`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`