### PR TITLE
[codex] Harden API CI deploy supply chain

### DIFF
--- a/.github/actions/phala-deploy/action.yml
+++ b/.github/actions/phala-deploy/action.yml
@@ -66,12 +66,13 @@ runs:
           echo "::error::compose-file is missing the \${SCRIBE_IMAGE} placeholder."
           exit 1
         fi
+        if [[ ! "$IMAGE_REF" =~ ^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*(:[A-Za-z0-9_.-]{1,128}|@sha256:[a-f0-9]{64})$ ]]; then
+          echo "::error::image-ref must be a valid lowercase image repository with a tag or sha256 digest."
+          exit 1
+        fi
         rendered="${RUNNER_TEMP}/$(basename "$COMPOSE_FILE")"
-        sed "s|\${SCRIBE_IMAGE}|${IMAGE_REF}|g" "$COMPOSE_FILE" > "$rendered"
-        echo "Rendered compose for $IMAGE_REF:"
-        echo "----"
-        cat "$rendered"
-        echo "----"
+        perl -0pe 's/\$\{SCRIBE_IMAGE\}/$ENV{IMAGE_REF}/g' "$COMPOSE_FILE" > "$rendered"
+        echo "Rendered compose for $IMAGE_REF at $rendered."
         echo "rendered=${rendered}" >> "$GITHUB_OUTPUT"
 
     - name: Deploy CVM

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -25,9 +25,21 @@ jobs:
   verify:
     name: Verify source image
     runs-on: ubuntu-latest
+    outputs:
+      from-tag: ${{ steps.validate.outputs.from-tag }}
     env:
       FROM_TAG: ${{ inputs.from-tag }}
     steps:
+      - name: Validate source tag
+        id: validate
+        run: |
+          set -euo pipefail
+          if [[ "$FROM_TAG" != "staging" && ! "$FROM_TAG" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "::error::from-tag must be 'staging' or a 7-40 character lowercase hex commit SHA tag."
+            exit 1
+          fi
+          echo "from-tag=${FROM_TAG}" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -55,7 +67,7 @@ jobs:
       contents: write # push the digest-record git tag
       packages: write # retag :production
     env:
-      FROM_TAG: ${{ inputs.from-tag }}
+      FROM_TAG: ${{ needs.verify.outputs.from-tag }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -15,6 +15,9 @@ on:
       - ".github/actions/setup-rust/**"
       - ".github/actions/changed-paths/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: scribe-api-${{ github.ref }}
   cancel-in-progress: true

--- a/scribe-api/Dockerfile
+++ b/scribe-api/Dockerfile
@@ -14,9 +14,9 @@ FROM chef AS builder
 ENV CARGO_INCREMENTAL=0 \
     RUSTFLAGS="--remap-path-prefix=/app=. --remap-path-prefix=/usr/local/cargo=/cargo"
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --bin scribe
+RUN cargo build --release --locked --bin scribe
 
 FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS runtime
 # CA bundle copied from the pinned builder base instead of apt-installed:


### PR DESCRIPTION
## Summary
- Validate `promote-scribe-api` dispatch tags so production promotion only accepts `staging` or lowercase commit-SHA tags, then pass the validated tag to deploy.
- Harden the Phala deploy composite action by validating image refs, avoiding `sed` replacement semantics, and no longer dumping rendered compose files into logs.
- Make the API Docker build honor `Cargo.lock` during both `cargo chef cook` and the final release build.
- Set explicit read-only `contents` permissions for the scribe-api CI workflow.

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/promote-scribe-api.yml .github/workflows/scribe-api.yml .github/actions/phala-deploy/action.yml`
- `bash -n scripts/build-signed-dmg.sh scripts/cargo-os-scribe-runner.sh scripts/tauri-before-dev.sh scripts/run-scribe-api.sh`
- `cargo check --all-targets --all-features --locked` in `scribe-api/`
- Temporary install of `cargo-chef` 0.1.77 and `cargo chef cook --help` confirmed `--locked` is supported.
- Shell validation snippets for the promotion tag and image-ref regexes passed.
- `git diff --check`

## Residual Risks
- `shellcheck` and `actionlint` were not installed in the local environment.
- Docker daemon was unavailable locally (`/Users/junhohong/.docker/run/docker.sock` missing), so I could not run a full Docker image build in this worktree.