### PR TITLE
[codex] Fix frontend async session lifecycle

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -252,13 +252,16 @@ export function App() {
   }, [appBlocked, runUpdateCheck]);
 
   useEffect(() => {
+    let aborted = false;
     let unlisten: (() => void) | undefined;
     void listen(CHECK_FOR_UPDATES_EVENT, () => runUpdateCheck("manual")).then(
       (cleanup) => {
-        unlisten = cleanup;
+        if (aborted) cleanup();
+        else unlisten = cleanup;
       },
     );
     return () => {
+      aborted = true;
       unlisten?.();
     };
   }, [runUpdateCheck]);
@@ -276,6 +279,7 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    let aborted = false;
     let unlisten: (() => void) | undefined;
     void listen<string>("dictation-event", (event) => {
       const helperEvent = parseDictationEvent(event.payload);
@@ -312,9 +316,11 @@ export function App() {
       if (microphone) setMicrophoneStatus(microphone);
       if (accessibility) setAccessibilityStatus(accessibility);
     }).then((cleanup) => {
-      unlisten = cleanup;
+      if (aborted) cleanup();
+      else unlisten = cleanup;
     });
     return () => {
+      aborted = true;
       unlisten?.();
     };
   }, []);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -667,19 +667,22 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   }
 
   async function submitHermesSession(content: string) {
-    const titlePromise = selectedHermesSessionId
+    const targetSessionId = newSessionModeRef.current
+      ? undefined
+      : selectedHermesSessionId;
+    const titlePromise = targetSessionId
       ? undefined
       : agentSessionTitleForPrompt(content);
     const gateway = await ensureHermesGateway();
     const sessionTitle = titlePromise ? await titlePromise : undefined;
-    const created = selectedHermesSessionId
+    const created = targetSessionId
       ? undefined
       : await gateway.request<HermesRuntimeSessionResponse>("session.create", {
           title: sessionTitle ?? titleFromPrompt(content),
           cols: 96,
         });
     const storedSessionId =
-      selectedHermesSessionId ??
+      targetSessionId ??
       created?.stored_session_id ??
       created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -4,8 +4,6 @@ import {
   hermesBridgeSessions,
   type HermesSessionInfo,
   type HermesSessionMessage,
-  type HermesSessionMessagesResponse,
-  type HermesSessionsResponse,
 } from "./tauri";
 
 export type HermesSessionListOptions = {
@@ -40,17 +38,13 @@ export async function deleteHermesSession(sessionId: string) {
   await deleteHermesBridgeSession(sessionId);
 }
 
-export function normalizeHermesSessionsResponse(
-  response: HermesSessionsResponse,
-) {
+export function normalizeHermesSessionsResponse(response: unknown) {
   return extractList(response, "sessions")
     .filter(isHermesSessionInfo)
     .sort((a, b) => sessionTimestamp(b).localeCompare(sessionTimestamp(a)));
 }
 
-export function normalizeHermesSessionMessagesResponse(
-  response: HermesSessionMessagesResponse,
-) {
+export function normalizeHermesSessionMessagesResponse(response: unknown) {
   return extractList(response, "messages").flatMap(
     normalizeHermesSessionMessage,
   );
@@ -73,10 +67,11 @@ export function titleFromPrompt(prompt: string) {
   return `${title.slice(0, 69).trim()}...`;
 }
 
-function extractList<T extends object>(
-  response: T,
+function extractList(
+  response: unknown,
   preferredKey: "sessions" | "messages",
 ) {
+  if (!response || typeof response !== "object") return [];
   const record = response as Record<string, unknown>;
   const candidates = [
     record[preferredKey],

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -223,6 +223,33 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
+  it("creates a fresh Hermes session for a New Session prompt when an initial session is selected", async () => {
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    window.dispatchEvent(
+      new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+        detail: { prompt: "write a project update" },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
+        title: "Summarize Current Page",
+        cols: 96,
+      }),
+    );
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+      session_id: "runtime-session-2",
+      text: "write a project update",
+    });
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", {
+      session_id: "runtime-session-1",
+      text: "write a project update",
+    });
+  });
+
   it("renders generated workspace files mentioned by Hermes as downloadable artifacts", async () => {
     const user = userEvent.setup();
     const samplePath =

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -194,4 +194,35 @@ describe("meeting start transcription event", () => {
     );
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
   });
+
+  it("cleans up Tauri listeners that resolve after unmount", async () => {
+    const cleanups: Array<ReturnType<typeof vi.fn>> = [];
+    const pendingListeners: Array<
+      (cleanup: (typeof cleanups)[number]) => void
+    > = [];
+    mocks.listen.mockImplementation((event: string, listener: TauriListener) => {
+      mocks.listeners.set(event, listener);
+      return new Promise((resolve) => {
+        pendingListeners.push(resolve);
+      });
+    });
+
+    const { unmount } = render(<App />);
+
+    await waitFor(() => expect(mocks.listen).toHaveBeenCalled());
+    unmount();
+
+    await act(async () => {
+      for (const resolve of pendingListeners) {
+        const cleanup = vi.fn();
+        cleanups.push(cleanup);
+        resolve(cleanup);
+      }
+    });
+
+    expect(cleanups.length).toBeGreaterThan(0);
+    for (const cleanup of cleanups) {
+      expect(cleanup).toHaveBeenCalledOnce();
+    }
+  });
 });

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -57,6 +57,13 @@ describe("Hermes adapter", () => {
     expect(messages.map((message) => message.id)).toEqual(["1", "m2"]);
   });
 
+  it("treats malformed gateway responses as empty lists", () => {
+    expect(normalizeHermesSessionsResponse(null)).toEqual([]);
+    expect(normalizeHermesSessionsResponse("not-json")).toEqual([]);
+    expect(normalizeHermesSessionMessagesResponse(undefined)).toEqual([]);
+    expect(normalizeHermesSessionMessagesResponse(42)).toEqual([]);
+  });
+
   it("keeps session display helpers stable", () => {
     expect(
       sessionTimestamp({


### PR DESCRIPTION
## Summary

- Fixed event-driven Hermes New Session prompts so they always create a fresh session, even when AgentWorkspace was opened with an existing initial session selected.
- Hardened Hermes session/message normalization against malformed or null Tauri/gateway payloads so bad responses render as empty lists instead of crashing the webview.
- Fixed App Tauri listener cleanup for update and dictation listeners when listener registration resolves after component unmount.

## Verification

- `pnpm lint`
- `pnpm test`
- `pnpm test:rust`

## Notes

- An initial full `pnpm test` run hit a HUD race test failure that passed on immediate rerun; the final full suite passed.