### PR TITLE
[codex] Harden metering and recording paths

### DIFF
--- a/scribe-api/Cargo.lock
+++ b/scribe-api/Cargo.lock
@@ -175,6 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +276,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +326,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -462,6 +500,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1462,6 +1510,7 @@ dependencies = [
  "scribe-domain",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1540,6 +1589,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1982,6 +2042,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uncased"

--- a/scribe-api/Cargo.toml
+++ b/scribe-api/Cargo.toml
@@ -26,6 +26,7 @@ dotenvy = "0.15"
 figment = { version = "0.10", features = ["env", "toml"] }
 hound = "3.5"
 jsonwebtoken = "9"
+sha2 = "0.10"
 # Pure-Rust MP4/M4A parser used for duration probing on the /v1/dictate
 # path, where the desktop helper records AAC-in-MPEG-4. Hound is WAV-only.
 mp4 = "0.14"

--- a/scribe-api/crates/services/Cargo.toml
+++ b/scribe-api/crates/services/Cargo.toml
@@ -15,6 +15,7 @@ scribe-config.workspace = true
 scribe-domain.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -9,11 +9,8 @@ use scribe_domain::{
     ActionSlug, AgentChatCompleter, AgentChatCompletion, AgentChatRequest, Credits, ModelId,
     OsAccountsClient, Receipt, UserId,
 };
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-    sync::Arc,
-};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
 
 pub struct AgentChatServiceDeps {
     pub pricing: Arc<PricingTable>,
@@ -52,7 +49,7 @@ impl AgentChatService {
             hold_ttl_seconds: self.hold_ttl_seconds,
         })
         .await?;
-        let body_hash = body_hash(&params.body);
+        let body_digest = body_digest(&params.body);
         let completion = self
             .chat_completer
             .complete(AgentChatRequest {
@@ -70,7 +67,7 @@ impl AgentChatService {
             credits: charge_credits,
             idempotency_key: format!(
                 "agent_chat:{}:{}:{}",
-                params.user_id.0, params.model_id.0, body_hash
+                params.user_id.0, params.model_id.0, body_digest
             ),
         })
         .await?;
@@ -100,8 +97,41 @@ pub struct AgentChatOutput {
     pub receipt: Receipt,
 }
 
-fn body_hash(body: &serde_json::Value) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    body.to_string().hash(&mut hasher);
-    hasher.finish()
+fn body_digest(body: &serde_json::Value) -> String {
+    let digest = Sha256::digest(body.to_string().as_bytes());
+    hex_lower(&digest)
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::body_digest;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn body_digest_is_stable_full_sha256_hex() {
+        let body = json!({
+            "model": "text-model",
+            "messages": [{ "role": "user", "content": "hello" }],
+        });
+
+        let digest = body_digest(&body);
+
+        assert_eq!(
+            digest,
+            "8791c5ca4cef8d9ea68549494f84e20e5f8224958d7b7aebc484dedb7b48e4ce"
+        );
+        assert_eq!(digest.len(), 64);
+        assert!(digest.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
 }

--- a/src-tauri/src/app_paths.rs
+++ b/src-tauri/src/app_paths.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    io::{Error, ErrorKind},
+    path::{Component, Path, PathBuf},
+};
 
 #[derive(Debug, Clone)]
 pub struct AppPaths {
@@ -16,5 +19,92 @@ impl AppPaths {
             data_dir,
             recordings_dir,
         })
+    }
+
+    pub fn recording_session_dir(
+        &self,
+        note_id: &str,
+        session_id: &str,
+    ) -> std::io::Result<PathBuf> {
+        validate_recording_component("note_id", note_id)?;
+        validate_recording_component("session_id", session_id)?;
+        Ok(self.recordings_dir.join(note_id).join(session_id))
+    }
+
+    pub fn contained_recording_file(&self, path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+        let path = path.as_ref();
+        let canonical_path = path.canonicalize()?;
+        let canonical_recordings = self.recordings_dir.canonicalize()?;
+        if canonical_path.starts_with(&canonical_recordings) {
+            Ok(canonical_path)
+        } else {
+            Err(Error::new(
+                ErrorKind::PermissionDenied,
+                "recording path is outside the app recordings directory",
+            ))
+        }
+    }
+
+    pub fn remove_recording_file(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        let path = path.as_ref();
+        match self.contained_recording_file(path) {
+            Ok(path) => std::fs::remove_file(path),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn validate_recording_component(field: &'static str, value: &str) -> std::io::Result<()> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+        || Path::new(value)
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("{field} is not a valid recording path component"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppPaths;
+
+    #[test]
+    fn recording_session_dir_rejects_path_traversal_components() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = AppPaths::from_data_dir(temp.path().join("data")).expect("paths");
+
+        assert!(paths
+            .recording_session_dir("../outside", "session")
+            .is_err());
+        assert!(paths
+            .recording_session_dir("/tmp/outside", "session")
+            .is_err());
+        assert!(paths
+            .recording_session_dir("note", "session/child")
+            .is_err());
+    }
+
+    #[test]
+    fn contained_recording_file_rejects_symlink_escape() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let paths = AppPaths::from_data_dir(temp.path().join("data")).expect("paths");
+        let outside = temp.path().join("outside.wav");
+        std::fs::write(&outside, b"outside").expect("outside");
+        let inside_link = paths.recordings_dir.join("linked.wav");
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&outside, &inside_link).expect("symlink");
+            assert!(paths.contained_recording_file(&inside_link).is_err());
+        }
     }
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -134,7 +134,9 @@ pub fn start_capture(
     let channels = config.channels();
 
     let session_id = Uuid::new_v4().to_string();
-    let note_dir = paths.recordings_dir.join(&note_id).join(&session_id);
+    let note_dir = paths
+        .recording_session_dir(&note_id, &session_id)
+        .map_err(|error| AppError::new("invalid_recording_path", error.to_string()))?;
     std::fs::create_dir_all(&note_dir)
         .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
     let partial_path = note_dir.join("microphone.partial.wav");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -113,6 +113,7 @@ pub async fn update_note(app: AppHandle, request: UpdateNoteRequest) -> Result<N
 
 #[tauri::command]
 pub async fn delete_note(app: AppHandle, request: DeleteNoteRequest) -> Result<(), AppError> {
+    let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
     let audio_paths = repos
         .audio_artifact_paths_for_note(&request.note_id)
@@ -122,7 +123,7 @@ pub async fn delete_note(app: AppHandle, request: DeleteNoteRequest) -> Result<(
         if path.trim().is_empty() {
             continue;
         }
-        if let Err(error) = std::fs::remove_file(&path) {
+        if let Err(error) = paths.remove_recording_file(&path) {
             if error.kind() != std::io::ErrorKind::NotFound {
                 eprintln!("failed to remove deleted note audio {path}: {error}");
             }
@@ -506,6 +507,7 @@ pub async fn start_recording(
 ) -> Result<RecordingSessionDto, AppError> {
     let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
+    let note = repos.get_note(&request.note_id).await?;
     let source_mode = request.source_mode.unwrap_or_default();
     let readiness = recording_source_readiness(source_mode);
     if !readiness.ready {
@@ -518,10 +520,10 @@ pub async fn start_recording(
         return Err(AppError::new("source_not_ready", message));
     }
     finish_active_capture_before_start(&repos).await?;
-    let started = start_capture(&paths, request.note_id.clone(), source_mode)?;
+    let started = start_capture(&paths, note.id.clone(), source_mode)?;
     repos
         .create_recording_session(
-            &request.note_id,
+            &note.id,
             &started.session_id,
             source_mode,
             &started.partial_path.to_string_lossy(),
@@ -532,7 +534,7 @@ pub async fn start_recording(
     for source in &started.sources {
         repos
             .create_pending_source_artifact(
-                &request.note_id,
+                &note.id,
                 &started.session_id,
                 source.source.as_db(),
                 &source.partial_path.to_string_lossy(),
@@ -542,7 +544,7 @@ pub async fn start_recording(
     }
     Ok(RecordingSessionDto {
         id: started.session_id,
-        note_id: request.note_id,
+        note_id: note.id,
         source_mode,
         state: started.status.state,
         started_at: crate::db::repositories::timestamp(),
@@ -906,8 +908,9 @@ pub async fn retry_processing(
     app: AppHandle,
     request: RetryProcessingRequest,
 ) -> Result<NoteDto, AppError> {
+    let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
-    retry_from_saved_audio(&repos, &request.note_id).await
+    retry_from_saved_audio(&repos, &paths, &request.note_id).await
 }
 
 #[tauri::command]
@@ -915,6 +918,7 @@ pub async fn recover_recording(
     app: AppHandle,
     request: crate::domain::types::RecoverRecordingRequest,
 ) -> Result<NoteDto, AppError> {
+    let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
     let Some(info) = repos.recording_recovery_info(&request.session_id).await? else {
         return Err(AppError::new(
@@ -934,11 +938,15 @@ pub async fn recover_recording(
                 .into_iter()
                 .flatten()
             {
-                let _ = std::fs::remove_file(path);
+                let _ = paths
+                    .remove_recording_file(path)
+                    .map_err(|error| AppError::new("audio_delete_failed", error.to_string()));
             }
         }
         for path in [&info.partial_path, &info.final_path].into_iter().flatten() {
-            let _ = std::fs::remove_file(path);
+            let _ = paths
+                .remove_recording_file(path)
+                .map_err(|error| AppError::new("audio_delete_failed", error.to_string()));
         }
         return Ok(repos
             .mark_recording_discarded(&info.session_id, &info.note_id)
@@ -950,7 +958,7 @@ pub async fn recover_recording(
     if !source_paths.is_empty() {
         let mut valid_sources = Vec::new();
         for artifact in source_paths {
-            let Some(path) = recovery_source_path(&artifact) else {
+            let Some(path) = recovery_source_path(&paths, &artifact) else {
                 continue;
             };
             let validation = validate_audio_artifact(
@@ -1010,7 +1018,7 @@ pub async fn recover_recording(
         )
         .await;
     }
-    let path = recovery_audio_path(&info).ok_or_else(|| {
+    let path = recovery_audio_path(&paths, &info).ok_or_else(|| {
         AppError::new(
             "audio_artifact_missing",
             "No recoverable audio bytes are available.",
@@ -1087,25 +1095,37 @@ pub async fn recover_recording(
     .await
 }
 
-fn recovery_audio_path(info: &crate::db::repositories::RecordingRecoveryInfo) -> Option<PathBuf> {
+fn recovery_audio_path(
+    paths: &AppPaths,
+    info: &crate::db::repositories::RecordingRecoveryInfo,
+) -> Option<PathBuf> {
     for path in [&info.final_path, &info.partial_path].into_iter().flatten() {
-        if std::fs::metadata(path)
+        let Ok(path) = paths.contained_recording_file(path) else {
+            continue;
+        };
+        if std::fs::metadata(&path)
             .map(|metadata| metadata.len() > 0)
             .unwrap_or(false)
         {
-            return Some(PathBuf::from(path));
+            return Some(path);
         }
     }
     None
 }
 
-fn recovery_source_path(info: &crate::db::repositories::SourceArtifactPath) -> Option<PathBuf> {
+fn recovery_source_path(
+    paths: &AppPaths,
+    info: &crate::db::repositories::SourceArtifactPath,
+) -> Option<PathBuf> {
     for path in [&info.final_path, &info.partial_path].into_iter().flatten() {
-        if std::fs::metadata(path)
+        let Ok(path) = paths.contained_recording_file(path) else {
+            continue;
+        };
+        if std::fs::metadata(&path)
             .map(|metadata| metadata.len() > 0)
             .unwrap_or(false)
         {
-            return Some(PathBuf::from(path));
+            return Some(path);
         }
     }
     None

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1,4 +1,5 @@
 use crate::{
+    app_paths::AppPaths,
     audio::turns::{
         coalesce_turns_for_transcription, detect_turns, normalize_wav_for_transcription,
         split_wav_for_transcription, write_turn_wav, DetectionSource,
@@ -702,9 +703,20 @@ pub async fn process_saved_source_audio(
 
 pub async fn retry_from_saved_audio(
     repos: &Repositories,
+    paths: &AppPaths,
     note_id: &str,
 ) -> Result<NoteDto, AppError> {
-    let sources = repos.latest_valid_audio_artifact_paths(note_id).await?;
+    let sources = repos
+        .latest_valid_audio_artifact_paths(note_id)
+        .await?
+        .into_iter()
+        .filter_map(|(id, source, path, session_id)| {
+            paths
+                .contained_recording_file(path)
+                .ok()
+                .map(|path| (id, source, path, session_id))
+        })
+        .collect::<Vec<_>>();
     if sources.is_empty() {
         return Err(AppError::new(
             "audio_artifact_missing",
@@ -720,7 +732,7 @@ pub async fn retry_from_saved_audio(
             note_id,
             &session_id,
             &audio_artifact_id,
-            PathBuf::from(audio_path),
+            audio_path,
             note.title,
             note.generated_content,
             manual_notes,
@@ -738,7 +750,7 @@ pub async fn retry_from_saved_audio(
         RecordingSourceMode::MicrophonePlusSystem,
         sources
             .into_iter()
-            .map(|(id, source, path, _session_id)| (id, source, PathBuf::from(path)))
+            .map(|(id, source, path, _session_id)| (id, source, path))
             .collect(),
         note.title,
         note.generated_content,


### PR DESCRIPTION
## Summary

- Replace agent chat metering idempotency keys based on Rust `DefaultHasher` with a stable SHA-256 digest of the request body.
- Add recording path containment helpers so recording creation rejects traversal-style IDs and persisted recording file reads/deletes are constrained to the app recordings directory.
- Add focused regression tests for stable billing digests and recording path traversal/symlink escape handling.

## Security findings fixed

- Agent chat charge idempotency used `DefaultHasher`, which is not intended for durable billing identifiers and produces a short non-cryptographic value. Retries now use a full deterministic SHA-256 hex digest.
- Desktop recording paths were built from renderer-supplied note IDs and later read/deleted from persisted DB paths without canonical containment checks. Recording paths are now constrained to the app recordings root.

## Coordination note

Another desktop/Tauri audit lane independently found and is patching recording-path containment in the same area. This PR keeps the containment changes needed for this audit and test coverage; expect possible overlap to reconcile if both PRs land close together.

## Verification

- `cargo fmt --all -- --check` from `scribe-api`
- `cargo clippy --all-targets --all-features --locked -- -D warnings` from `scribe-api`
- `cargo test --all-targets --all-features --locked` from `scribe-api`
- `cargo fmt --all --check` from `src-tauri`
- `pnpm test:rust`
- `pnpm lint`
- `pnpm test`

Note: `pnpm lint` and `pnpm test` initially failed because this isolated worktree had no `node_modules`; `pnpm install --frozen-lockfile` resolved that without lockfile changes, and both commands then passed.