### PR TITLE
[codex] Tighten dictation event and provider mode handling

### DIFF
--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -3,7 +3,7 @@
 //! Scribe API, never here.
 
 use crate::domain::types::AppError;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::{
     fs,
     path::PathBuf,
@@ -46,20 +46,20 @@ pub struct ProviderModelSettingsResponse {
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SetVeniceModelRequest {
-    pub mode: String,
+    pub mode: ModelMode,
     pub model_id: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VeniceModelsRequest {
-    pub mode: String,
+    pub mode: ModelMode,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VeniceModelsResponse {
-    pub mode: String,
+    pub mode: ModelMode,
     pub model_type: String,
     pub selected_model: String,
     pub models: Vec<VeniceModelDto>,
@@ -184,12 +184,11 @@ pub fn set_venice_model(
     state: State<'_, ProviderSettingsState>,
     request: SetVeniceModelRequest,
 ) -> Result<ProviderModelSettings, AppError> {
-    let mode = model_mode(&request.mode)?;
     let model_id = request.model_id.trim();
     if model_id.is_empty() {
         return Err(AppError::new("provider_model_required", "Select a model."));
     }
-    update_settings(&state, |settings| match mode {
+    update_settings(&state, |settings| match request.mode {
         ModelMode::Transcription => {
             settings.transcription_provider =
                 transcription_provider_for_model(model_id).to_string();
@@ -204,9 +203,8 @@ pub async fn list_venice_models(
     state: State<'_, ProviderSettingsState>,
     request: VeniceModelsRequest,
 ) -> Result<VeniceModelsResponse, AppError> {
-    let mode = model_mode(&request.mode)?;
-    let model_type = mode.api_type();
-    let selected_model = selected_model_for_mode(&state, mode)?;
+    let model_type = request.mode.api_type();
+    let selected_model = selected_model_for_mode(&state, request.mode)?;
     let mut models = crate::scribe_api::list_models(model_type)
         .await?
         .into_iter()
@@ -219,7 +217,7 @@ pub async fn list_venice_models(
             .then_with(|| left.id.cmp(&right.id))
     });
     Ok(VeniceModelsResponse {
-        mode: mode.as_str().to_string(),
+        mode: request.mode,
         model_type: model_type.to_string(),
         selected_model,
         models,
@@ -353,35 +351,85 @@ fn selected_model_for_mode(
     })
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ModelMode {
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ModelMode {
     Transcription,
     Generation,
 }
 
-impl ModelMode {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Transcription => "transcription",
-            Self::Generation => "generation",
-        }
+impl<'de> Deserialize<'de> for ModelMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value).ok_or_else(|| serde::de::Error::custom("unknown provider model mode"))
     }
+}
 
+impl ModelMode {
     fn api_type(self) -> &'static str {
         match self {
             Self::Transcription => "asr",
             Self::Generation => "text",
         }
     }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "transcription" | "dictation" | "asr" => Some(Self::Transcription),
+            "generation" | "notes" | "text" => Some(Self::Generation),
+            _ => None,
+        }
+    }
 }
 
-fn model_mode(value: &str) -> Result<ModelMode, AppError> {
-    match value.trim() {
-        "transcription" | "dictation" | "asr" => Ok(ModelMode::Transcription),
-        "generation" | "notes" | "text" => Ok(ModelMode::Generation),
-        _ => Err(AppError::new(
-            "provider_model_mode_invalid",
-            "Unknown model mode.",
-        )),
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_mode_deserializes_canonical_values() {
+        assert_eq!(
+            serde_json::from_value::<ModelMode>(serde_json::json!("transcription")).unwrap(),
+            ModelMode::Transcription
+        );
+        assert_eq!(
+            serde_json::from_value::<ModelMode>(serde_json::json!("generation")).unwrap(),
+            ModelMode::Generation
+        );
+    }
+
+    #[test]
+    fn model_mode_deserializes_legacy_aliases() {
+        assert_eq!(
+            serde_json::from_value::<ModelMode>(serde_json::json!("asr")).unwrap(),
+            ModelMode::Transcription
+        );
+        assert_eq!(
+            serde_json::from_value::<ModelMode>(serde_json::json!("notes")).unwrap(),
+            ModelMode::Generation
+        );
+    }
+
+    #[test]
+    fn model_mode_rejects_unknown_values() {
+        assert!(serde_json::from_value::<ModelMode>(serde_json::json!("image")).is_err());
+    }
+
+    #[test]
+    fn venice_models_response_serializes_canonical_mode() {
+        let response = VeniceModelsResponse {
+            mode: ModelMode::Transcription,
+            model_type: "asr".to_string(),
+            selected_model: "nvidia/parakeet-tdt-0.6b-v3".to_string(),
+            models: Vec::new(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(response).unwrap()["mode"],
+            serde_json::json!("transcription")
+        );
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -62,10 +62,10 @@ import {
   type AgentSessionStatusDetail,
 } from "../lib/agent-events";
 import { notifyAgentSessionStatus } from "../lib/agent-notifications";
+import { parseDictationHelperEvent } from "../lib/dictation-events";
 import { titleFromPrompt } from "../lib/hermes-adapter";
 import type {
   BootstrapResponse,
-  DictationHelperEvent,
   NoteDto,
   RecordingStatusDto,
   AccountStatus,
@@ -278,7 +278,7 @@ export function App() {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     void listen<string>("dictation-event", (event) => {
-      const helperEvent = parseDictationEvent(event.payload);
+      const helperEvent = parseDictationHelperEvent(event.payload);
       if (!helperEvent) return;
       if (helperEvent.type === "agent_session_prompt") {
         const prompt = stringPayloadValue(helperEvent.payload?.prompt) ?? "";
@@ -1493,22 +1493,6 @@ function isCreateNoteShortcut(event: KeyboardEvent) {
     !event.altKey &&
     !event.shiftKey
   );
-}
-
-function parseDictationEvent(
-  payload: unknown,
-): DictationHelperEvent | undefined {
-  try {
-    if (typeof payload === "string") {
-      return JSON.parse(payload) as DictationHelperEvent;
-    }
-    if (payload && typeof payload === "object") {
-      return payload as DictationHelperEvent;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -31,6 +31,7 @@ import {
   type DictationSettingsDto,
   type DictationHistoryItemDto,
 } from "../../lib/tauri";
+import { parseDictationHelperEvent } from "../../lib/dictation-events";
 
 /** Which Settings section a "Set up" link drives to. */
 export type DictationSettingsTarget = "style" | "dictionary";
@@ -114,7 +115,7 @@ export function DictationHistoryView({
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     void listen<string>("dictation-event", (event) => {
-      const payload = parseDictationEvent(event.payload);
+      const payload = parseDictationHelperEvent(event.payload);
       if (payload?.type === "final_transcript") {
         void loadHistory();
       }
@@ -599,18 +600,6 @@ function isSameDate(left: Date, right: Date) {
     left.getMonth() === right.getMonth() &&
     left.getDate() === right.getDate()
   );
-}
-
-function parseDictationEvent(payload: unknown): { type?: string } | undefined {
-  try {
-    if (typeof payload === "string")
-      return JSON.parse(payload) as { type?: string };
-    if (payload && typeof payload === "object")
-      return payload as { type?: string };
-  } catch {
-    return undefined;
-  }
-  return undefined;
 }
 
 function messageFromError(err: unknown) {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -45,6 +45,7 @@ import {
   setStoredTheme,
   type ThemePreference,
 } from "../../lib/theme";
+import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { ProviderLogo } from "./ProviderLogo";
 import { AgentSettingsSection } from "./AgentSettingsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
@@ -237,7 +238,7 @@ export function AppSettings({
     }
 
     void listen<string>("dictation-event", (event) => {
-      const helperEvent = parseDictationEvent(event.payload);
+      const helperEvent = parseDictationHelperEvent(event.payload);
       if (helperEvent) handleHelperEvent(helperEvent);
     }).then((cleanup) => {
       unlisten = cleanup;
@@ -1259,22 +1260,6 @@ function modelOptions(models: VeniceModelDto[], selectedModel: string) {
     },
     ...models,
   ];
-}
-
-function parseDictationEvent(
-  payload: unknown,
-): DictationHelperEvent | undefined {
-  try {
-    if (typeof payload === "string") {
-      return JSON.parse(payload) as DictationHelperEvent;
-    }
-    if (payload && typeof payload === "object") {
-      return payload as DictationHelperEvent;
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
 }
 
 function shortcutFromCapturePayload(

--- a/src/lib/dictation-events.ts
+++ b/src/lib/dictation-events.ts
@@ -1,0 +1,17 @@
+import type { DictationHelperEvent } from "./tauri";
+
+export function parseDictationHelperEvent(
+  payload: unknown,
+): DictationHelperEvent | undefined {
+  try {
+    const value = typeof payload === "string" ? JSON.parse(payload) : payload;
+    if (!value || typeof value !== "object") return undefined;
+    const event = value as { type?: unknown };
+    if (typeof event.type !== "string" || event.type.trim() === "") {
+      return undefined;
+    }
+    return value as DictationHelperEvent;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/test/dictation-events.test.ts
+++ b/src/test/dictation-events.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseDictationHelperEvent } from "../lib/dictation-events";
+
+describe("parseDictationHelperEvent", () => {
+  it("parses valid JSON helper events", () => {
+    expect(
+      parseDictationHelperEvent(
+        JSON.stringify({
+          type: "final_transcript",
+          payload: { message: "Done" },
+        }),
+      ),
+    ).toEqual({
+      type: "final_transcript",
+      payload: { message: "Done" },
+    });
+  });
+
+  it("accepts object helper events", () => {
+    expect(parseDictationHelperEvent({ type: "permission_status" })?.type).toBe(
+      "permission_status",
+    );
+  });
+
+  it("ignores malformed payloads and events without a string type", () => {
+    expect(parseDictationHelperEvent("{")).toBeUndefined();
+    expect(parseDictationHelperEvent({ payload: {} })).toBeUndefined();
+    expect(parseDictationHelperEvent({ type: "" })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

This maintainability audit fixed two small cross-cutting issues found across the TypeScript and Tauri Rust surfaces:

- Centralized dictation helper event parsing in `src/lib/dictation-events.ts` so malformed helper payloads no longer rely on repeated unchecked `JSON.parse` casts in the main app, settings, and dictation history views.
- Replaced stringly typed provider model mode request/response fields in the Tauri provider model picker with a typed `ModelMode` enum that still accepts the existing legacy aliases (`asr`, `dictation`, `text`, `notes`) and serializes canonical frontend modes.

## Tests

- `pnpm exec prettier --check src/lib/dictation-events.ts src/test/dictation-events.test.ts src/app/App.tsx src/components/settings/AppSettings.tsx src/components/dictation/DictationHistoryView.tsx`
- `pnpm exec vitest run src/test/dictation-events.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml providers::tests::model_mode --lib`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `pnpm lint`
- `pnpm test`
- `pnpm test:rust`
- `cargo +1.95.0 check --manifest-path scribe-api/Cargo.toml`

Note: `cargo check --manifest-path scribe-api/Cargo.toml` with the default active toolchain failed before compilation because the workspace requires Rust 1.95 and the active default is 1.93.1; rerunning explicitly with the installed pinned `+1.95.0` toolchain passed.

## Residual Risk

- This PR intentionally leaves the HUD's local parser untouched because that entrypoint uses a narrower HUD-specific event type. It remains a candidate for a follow-up if the helper event contract is consolidated further.