### PR TITLE
[codex] Fix Hermes session history reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,21 @@ The selected transcription and cleanup models are executed server-side through
 Scribe API, so missing provider keys surface in the Scribe API logs rather than
 the desktop process.
 
-The default shortcut is bare `Fn`/Globe and the default activation mode is `Push-to-talk`. If macOS opens emoji, input-source, or system dictation UI when pressing Fn, set System Settings > Keyboard > "Press Fn key to" or "Press Globe key to" to `Do Nothing`. Settings records the shortcut you press, including bare `Fn`/Globe, `Fn+Space`, or another shortcut with Cmd, Ctrl, Opt, Shift, or Fn plus one supported non-modifier key. Push-to-talk for custom shortcuts depends on macOS exposing both key-down and key-up events for that shortcut.
+The default push-to-talk shortcut is `Ctrl+Opt+D`; toggle dictation defaults to `Ctrl+Opt+T`. Settings records shortcuts with Cmd, Ctrl, Opt, Shift, or Fn plus one supported non-modifier key. Modifier-only shortcuts such as bare Fn/Globe or Ctrl+Opt are rejected because macOS does not expose them as reliable global key chords for all keyboards.
 
 Manual validation:
 
 1. Launch Scribe API with OS Accounts, OpenAI, and Venice env configured.
 2. Grant microphone and Accessibility permissions.
 3. Focus a text field in TextEdit, VS Code, or a browser.
-4. In Settings, press Change, record `Fn`/Globe, and choose `Push-to-talk`.
-5. Hold Fn/Globe to start dictation.
+4. In Settings, confirm push-to-talk shows `Ctrl+Opt+D`.
+5. Hold `Ctrl+Opt+D` to start dictation.
 6. Speak a short sentence.
-7. Release Fn/Globe to stop, transcribe, and paste.
-8. Switch activation mode to `Toggle`.
-9. Press Fn/Globe once to start dictation, then press it again to stop.
-10. Confirm the HUD transitions through listening, transcribing, pasting, and success.
-11. Confirm the transcript appears in the original focused text field.
-12. Select a microphone in Settings, restart, and confirm the selection persists.
+7. Release `Ctrl+Opt+D` to stop, transcribe, and paste.
+8. Press `Ctrl+Opt+T` once to start toggle dictation, then press it again to stop.
+9. Confirm the HUD transitions through listening, transcribing, pasting, and success.
+10. Confirm the transcript appears in the original focused text field.
+11. Select a microphone in Settings, restart, and confirm the selection persists.
 
 ## macOS Audio Permission Debugging
 

--- a/scribe-api/crates/api/src/handlers/dictate.rs
+++ b/scribe-api/crates/api/src/handlers/dictate.rs
@@ -42,6 +42,12 @@ pub(crate) async fn transcribe(
         context.as_deref(),
         validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
     )?;
+    let language = form.optional_text("language");
+    validation::validate_optional_text_len(
+        "language",
+        language.as_deref(),
+        validation::MAX_LANGUAGE_CHARS,
+    )?;
     let filename = form
         .take_filename()
         .unwrap_or_else(|| "dictation.wav".to_string());
@@ -54,6 +60,7 @@ pub(crate) async fn transcribe(
             audio,
             filename,
             context,
+            language,
             model_id: ModelId(model_id),
         })
         .await?;

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -34,6 +34,12 @@ pub(crate) async fn transcribe(
         context.as_deref(),
         validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
     )?;
+    let language = form.optional_text("language");
+    validation::validate_optional_text_len(
+        "language",
+        language.as_deref(),
+        validation::MAX_LANGUAGE_CHARS,
+    )?;
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;
     let filename = form
@@ -48,6 +54,7 @@ pub(crate) async fn transcribe(
             filename,
             title,
             context,
+            language,
             model_id: ModelId(model_id),
         })
         .await?;

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -116,6 +116,7 @@ pub struct TranscriptionRequest {
     pub filename: String,
     pub title: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub model: ModelId,
 }
 

--- a/scribe-api/crates/providers/src/openai.rs
+++ b/scribe-api/crates/providers/src/openai.rs
@@ -46,6 +46,14 @@ impl Transcriber for OpenAiTranscriber {
         {
             form = form.text("prompt", prompt.to_string());
         }
+        if let Some(language) = request
+            .language
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            form = form.text("language", language.to_string());
+        }
         let response = self
             .http
             .post(&url)

--- a/scribe-api/crates/providers/src/routing.rs
+++ b/scribe-api/crates/providers/src/routing.rs
@@ -45,7 +45,7 @@ mod tests {
     use serde_json::json;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{header, method, path},
+        matchers::{body_string_contains, header, method, path},
     };
 
     #[tokio::test]
@@ -54,6 +54,8 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/audio/transcriptions"))
             .and(header("authorization", "Bearer openai_key"))
+            .and(body_string_contains(r#"name="language""#))
+            .and(body_string_contains("es"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "text": "Transcribed text"
             })))
@@ -80,6 +82,7 @@ mod tests {
                 filename: "recording.wav".to_string(),
                 title: "Title".to_string(),
                 context: Some("Prompt context".to_string()),
+                language: Some("es".to_string()),
                 model: ModelId("gpt-4o-mini-transcribe".to_string()),
             })
             .await;

--- a/scribe-api/crates/services/src/dictate.rs
+++ b/scribe-api/crates/services/src/dictate.rs
@@ -77,6 +77,7 @@ impl DictateService {
                 filename: params.filename,
                 title: "Dictation".to_string(),
                 context: params.context,
+                language: params.language,
                 model: params.model_id.clone(),
             })
             .await?;
@@ -158,6 +159,7 @@ pub struct DictateTranscribeParams {
     pub audio: Vec<u8>,
     pub filename: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub model_id: ModelId,
 }
 

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -179,6 +179,7 @@ mod tests {
                 audio: vec![1, 2, 3],
                 filename: "dictation.wav".to_string(),
                 context: Some("Writing style: formal.".to_string()),
+                language: Some("es".to_string()),
                 model_id: ModelId("audio-model".to_string()),
             })
             .await
@@ -193,6 +194,7 @@ mod tests {
             transcriber.last_context(),
             Some("Writing style: formal.".to_string())
         );
+        assert_eq!(transcriber.last_language(), Some("es".to_string()));
         assert_eq!(
             wait_for_charge_idempotency_key(&os_accounts).await,
             Some("dictate_transcribe:usr_123:session_1:utt_2".to_string())
@@ -497,11 +499,19 @@ mod tests {
     #[derive(Default)]
     struct RecordingTranscriber {
         last_context: Mutex<Option<String>>,
+        last_language: Mutex<Option<String>>,
     }
 
     impl RecordingTranscriber {
         fn last_context(&self) -> Option<String> {
             self.last_context
+                .lock()
+                .ok()
+                .and_then(|value| value.clone())
+        }
+
+        fn last_language(&self) -> Option<String> {
+            self.last_language
                 .lock()
                 .ok()
                 .and_then(|value| value.clone())
@@ -516,6 +526,9 @@ mod tests {
         ) -> Result<Transcript, DomainError> {
             if let Ok(mut last_context) = self.last_context.lock() {
                 *last_context = request.context;
+            }
+            if let Ok(mut last_language) = self.last_language.lock() {
+                *last_language = request.language;
             }
             Ok(Transcript {
                 text: "Transcript".to_string(),

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -91,6 +91,7 @@ impl NoteTranscribeService {
                 filename: params.filename,
                 title: params.title,
                 context: params.context,
+                language: params.language,
                 model: params.model_id.clone(),
             })
             .await?;
@@ -131,6 +132,7 @@ pub struct NoteTranscribeParams {
     pub filename: String,
     pub title: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub model_id: ModelId,
 }
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -228,11 +228,11 @@ struct MonitoredShortcut {
     let modifiers: ShortcutModifiers
     let pressCount: Int
 
-    static let bareFn = MonitoredShortcut(
-        keyCode: 0,
-        code: "Fn",
-        label: "Fn",
-        modifiers: ShortcutModifiers(function: true),
+    static let defaultPushToTalk = MonitoredShortcut(
+        keyCode: 0x02,
+        code: "KeyD",
+        label: "Ctrl+Opt+D",
+        modifiers: ShortcutModifiers(control: true, option: true),
         pressCount: 1
     )
 
@@ -335,11 +335,11 @@ final class ShortcutKeyMonitor {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var shortcuts: [ShortcutKind: MonitoredShortcut] = [
-        .pushToTalk: .bareFn,
+        .pushToTalk: .defaultPushToTalk,
         .toggle: MonitoredShortcut(
-            keyCode: 0x31,
-            code: "Space",
-            label: "Ctrl+Opt+Space",
+            keyCode: 0x11,
+            code: "KeyT",
+            label: "Ctrl+Opt+T",
             modifiers: ShortcutModifiers(control: true, option: true),
             pressCount: 1
         ),
@@ -367,7 +367,7 @@ final class ShortcutKeyMonitor {
 
         if globalMonitor == nil, eventTap == nil {
             emit("fn_monitor_unavailable", [
-                "message": "Could not monitor Fn/Globe key events.",
+                "message": "Could not monitor global shortcut key events.",
             ])
         }
     }
@@ -391,7 +391,12 @@ final class ShortcutKeyMonitor {
         }
 
         let isDown = flags.contains(.maskSecondaryFn)
-        let identity = ShortcutIdentity(MonitoredShortcut.bareFn)
+        let identity = ShortcutIdentity(MonitoredShortcut(
+            keyCode: 0,
+            code: "Fn",
+            label: "Fn",
+            modifiers: ShortcutModifiers(function: true)
+        ))
         if isDown {
             handlePhysicalDown(identity: identity)
         } else {
@@ -501,7 +506,12 @@ final class ShortcutKeyMonitor {
             handlePhysicalUp(identity: identity)
         case .flagsChanged:
             if hasBareFnShortcut {
-                let identity = ShortcutIdentity(MonitoredShortcut.bareFn)
+                let identity = ShortcutIdentity(MonitoredShortcut(
+                    keyCode: 0,
+                    code: "Fn",
+                    label: "Fn",
+                    modifiers: ShortcutModifiers(function: true)
+                ))
                 if event.modifierFlags.contains(.function) {
                     handlePhysicalDown(identity: identity)
                 } else {
@@ -589,15 +599,10 @@ final class ShortcutKeyMonitor {
             guard let self else {
                 return
             }
-            self.finishCapture(
-                MonitoredShortcut(
-                    keyCode: 0,
-                    code: "Fn",
-                    label: "Fn",
-                    modifiers: ShortcutModifiers(function: true),
-                    pressCount: self.capturePressCount
-                )
-            )
+            self.pendingBareFnCapture = nil
+            emit("shortcut_capture_error", [
+                "message": "Shortcut must include a supported non-modifier key.",
+            ])
         }
         pendingBareFnCapture = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -91,8 +91,8 @@ pub struct DictationSettings {
 impl Default for DictationSettings {
     fn default() -> Self {
         Self {
-            push_to_talk_shortcut: DictationShortcutSetting::bare_fn(),
-            toggle_shortcut: DictationShortcutSetting::control_option_space(),
+            push_to_talk_shortcut: DictationShortcutSetting::control_option_d(),
+            toggle_shortcut: DictationShortcutSetting::control_option_t(),
             microphone: DictationMicrophoneSetting::default(),
             style: DictationStyle::Standard,
         }
@@ -133,10 +133,12 @@ impl<'de> Deserialize<'de> for DictationSettings {
         Ok(Self {
             push_to_talk_shortcut: settings
                 .push_to_talk_shortcut
-                .unwrap_or_else(DictationShortcutSetting::bare_fn),
+                .map(|shortcut| shortcut.normalized_or_default(DictationShortcutKind::PushToTalk))
+                .unwrap_or_else(DictationShortcutSetting::control_option_d),
             toggle_shortcut: settings
                 .toggle_shortcut
-                .unwrap_or_else(DictationShortcutSetting::control_option_space),
+                .map(|shortcut| shortcut.normalized_or_default(DictationShortcutKind::Toggle))
+                .unwrap_or_else(DictationShortcutSetting::control_option_t),
             microphone: settings.microphone.unwrap_or(microphone),
             style: settings.style.unwrap_or_default(),
         })
@@ -213,15 +215,16 @@ impl<'de> Deserialize<'de> for DictationShortcutSetting {
 }
 
 impl DictationShortcutSetting {
-    fn bare_fn() -> Self {
+    fn control_option_d() -> Self {
         Self {
-            key_code: 0,
-            code: "Fn".to_string(),
+            key_code: 0x02,
+            code: "KeyD".to_string(),
             modifiers: DictationShortcutModifiers {
-                function: true,
+                control: true,
+                option: true,
                 ..DictationShortcutModifiers::default()
             },
-            label: "Fn".to_string(),
+            label: "Ctrl+Opt+D".to_string(),
             press_count: 1,
         }
     }
@@ -240,11 +243,46 @@ impl DictationShortcutSetting {
         }
     }
 
+    fn control_option_t() -> Self {
+        Self {
+            key_code: 0x11,
+            code: "KeyT".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                option: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+Opt+T".to_string(),
+            press_count: 1,
+        }
+    }
+
     fn same_trigger_as(&self, other: &Self) -> bool {
         self.key_code == other.key_code
             && self.code == other.code
             && self.modifiers == other.modifiers
             && self.press_count == other.press_count
+    }
+
+    fn normalized_or_default(mut self, kind: DictationShortcutKind) -> Self {
+        let Some(key_code) = key_code_for_code(&self.code) else {
+            return default_shortcut_for_kind(kind);
+        };
+        if !self.modifiers.has_any() || self.is_bare_fn() {
+            return default_shortcut_for_kind(kind);
+        }
+        self.key_code = key_code;
+        if kind == DictationShortcutKind::Toggle
+            && self.same_trigger_as(&DictationShortcutSetting::control_option_space())
+        {
+            return DictationShortcutSetting::control_option_t();
+        }
+        self.press_count = if self.press_count == 2 { 2 } else { 1 };
+        self
+    }
+
+    fn is_bare_fn(&self) -> bool {
+        is_bare_fn_input(&self.code, &self.modifiers)
     }
 }
 
@@ -256,6 +294,12 @@ pub struct DictationShortcutModifiers {
     pub option: bool,
     pub shift: bool,
     pub function: bool,
+}
+
+impl DictationShortcutModifiers {
+    fn has_any(&self) -> bool {
+        self.command || self.control || self.option || self.shift || self.function
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -378,27 +422,14 @@ impl DictationShortcutInput {
 
         let press_count = 1;
 
-        if is_bare_fn_input(&self.code, &self.modifiers) {
-            return Ok(DictationShortcutSetting {
-                press_count,
-                label: "Fn".to_string(),
-                ..DictationShortcutSetting::bare_fn()
-            });
-        }
-
         let key_code = key_code_for_code(&self.code).ok_or_else(|| {
             AppError::new(
                 "dictation_shortcut_unsupported",
-                "Shortcut key is not supported.",
+                "Shortcut must include a supported non-modifier key.",
             )
         })?;
 
-        let has_modifier = self.modifiers.command
-            || self.modifiers.control
-            || self.modifiers.option
-            || self.modifiers.shift
-            || self.modifiers.function;
-        if !has_modifier {
+        if !self.modifiers.has_any() {
             return Err(AppError::new(
                 "dictation_shortcut_modifier_required",
                 "Shortcut must include at least one modifier key.",
@@ -421,7 +452,7 @@ fn is_bare_fn_input(code: &str, modifiers: &DictationShortcutModifiers) -> bool 
 
 fn legacy_shortcut_setting(id: &str) -> Option<DictationShortcutSetting> {
     match id {
-        "bare_fn" | "fn" => Some(DictationShortcutSetting::bare_fn()),
+        "bare_fn" | "fn" => Some(DictationShortcutSetting::control_option_d()),
         "fn_space" => Some(DictationShortcutSetting {
             key_code: 0x31,
             code: "Space".to_string(),
@@ -432,23 +463,20 @@ fn legacy_shortcut_setting(id: &str) -> Option<DictationShortcutSetting> {
             label: "Fn+Space".to_string(),
             press_count: 1,
         }),
-        "control_option_space" => Some(DictationShortcutSetting {
-            key_code: 0x31,
-            code: "Space".to_string(),
-            modifiers: DictationShortcutModifiers {
-                control: true,
-                option: true,
-                ..DictationShortcutModifiers::default()
-            },
-            label: "Ctrl+Opt+Space".to_string(),
-            press_count: 1,
-        }),
+        "control_option_space" => Some(DictationShortcutSetting::control_option_t()),
         _ => None,
     }
 }
 
 fn no_standard_modifiers(modifiers: &DictationShortcutModifiers) -> bool {
     !modifiers.command && !modifiers.control && !modifiers.option && !modifiers.shift
+}
+
+fn default_shortcut_for_kind(kind: DictationShortcutKind) -> DictationShortcutSetting {
+    match kind {
+        DictationShortcutKind::PushToTalk => DictationShortcutSetting::control_option_d(),
+        DictationShortcutKind::Toggle => DictationShortcutSetting::control_option_t(),
+    }
 }
 
 pub fn setup(app: &mut tauri::App) {
@@ -2192,16 +2220,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_settings_use_fn_and_double_fn() {
+    fn default_settings_use_keyboard_shortcuts_without_bare_fn() {
         let settings = DictationSettings::default();
 
         assert_eq!(
             settings.push_to_talk_shortcut,
-            DictationShortcutSetting::bare_fn()
+            DictationShortcutSetting::control_option_d()
         );
         assert_eq!(
             settings.toggle_shortcut,
-            DictationShortcutSetting::control_option_space()
+            DictationShortcutSetting::control_option_t()
         );
         assert_eq!(settings.style, DictationStyle::Standard);
     }
@@ -2215,11 +2243,11 @@ mod tests {
 
         assert_eq!(
             settings.push_to_talk_shortcut,
-            DictationShortcutSetting::bare_fn()
+            DictationShortcutSetting::control_option_d()
         );
         assert_eq!(
             settings.toggle_shortcut,
-            DictationShortcutSetting::control_option_space()
+            DictationShortcutSetting::control_option_t()
         );
         assert_eq!(settings.microphone.id.as_deref(), Some("usb"));
         assert_eq!(settings.microphone.name.as_deref(), Some("USB Mic"));
@@ -2227,28 +2255,54 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_new_shortcut_settings() {
+    fn deserializes_new_shortcut_settings_and_migrates_bare_fn_push_to_talk() {
         let settings: DictationSettings = serde_json::from_str(
             r#"{"pushToTalkShortcut":{"keyCode":0,"code":"Fn","modifiers":{"command":false,"control":false,"option":false,"shift":false,"function":true},"label":"Fn","pressCount":1},"toggleShortcut":{"keyCode":49,"code":"Space","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt+Space","pressCount":1},"microphone":{"id":null,"name":null}}"#,
         )
         .expect("new settings should deserialize");
 
+        assert_eq!(
+            settings.push_to_talk_shortcut,
+            DictationShortcutSetting::control_option_d()
+        );
         assert_eq!(settings.push_to_talk_shortcut.press_count, 1);
         assert_eq!(settings.toggle_shortcut.press_count, 1);
         assert_eq!(settings.style, DictationStyle::Standard);
         assert!(settings
             .toggle_shortcut
-            .same_trigger_as(&DictationShortcutSetting {
-                key_code: 0x31,
-                code: "Space".to_string(),
-                modifiers: DictationShortcutModifiers {
-                    control: true,
-                    option: true,
-                    ..DictationShortcutModifiers::default()
-                },
-                label: "Ctrl+Opt+Space".to_string(),
-                press_count: 1,
-            }));
+            .same_trigger_as(&DictationShortcutSetting::control_option_t()));
+    }
+
+    #[test]
+    fn deserializes_control_letter_and_digit_shortcuts() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"pushToTalkShortcut":{"keyCode":999,"code":"KeyT","modifiers":{"command":false,"control":true,"option":false,"shift":false,"function":false},"label":"Ctrl+T","pressCount":1},"toggleShortcut":{"keyCode":999,"code":"Digit1","modifiers":{"command":false,"control":true,"option":false,"shift":false,"function":false},"label":"Ctrl+1","pressCount":1},"microphone":{"id":null,"name":null}}"#,
+        )
+        .expect("control shortcuts should deserialize");
+
+        assert_eq!(settings.push_to_talk_shortcut.key_code, 0x11);
+        assert_eq!(settings.push_to_talk_shortcut.code, "KeyT");
+        assert_eq!(settings.push_to_talk_shortcut.label, "Ctrl+T");
+        assert_eq!(settings.toggle_shortcut.key_code, 0x12);
+        assert_eq!(settings.toggle_shortcut.code, "Digit1");
+        assert_eq!(settings.toggle_shortcut.label, "Ctrl+1");
+    }
+
+    #[test]
+    fn deserializes_unsupported_modifier_only_shortcuts_to_defaults() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"pushToTalkShortcut":{"keyCode":59,"code":"ControlLeft","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt","pressCount":1},"toggleShortcut":{"keyCode":0,"code":"Fn","modifiers":{"command":false,"control":false,"option":false,"shift":false,"function":true},"label":"Fn","pressCount":1},"microphone":{"id":null,"name":null}}"#,
+        )
+        .expect("settings should deserialize");
+
+        assert_eq!(
+            settings.push_to_talk_shortcut,
+            DictationShortcutSetting::control_option_d()
+        );
+        assert_eq!(
+            settings.toggle_shortcut,
+            DictationShortcutSetting::control_option_t()
+        );
     }
 
     #[test]
@@ -2262,8 +2316,8 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_input_accepts_bare_fn() {
-        let shortcut = DictationShortcutInput {
+    fn shortcut_input_rejects_bare_fn() {
+        let err = DictationShortcutInput {
             code: "Fn".to_string(),
             modifiers: DictationShortcutModifiers {
                 function: true,
@@ -2273,26 +2327,48 @@ mod tests {
             press_count: None,
         }
         .into_setting()
-        .expect("bare Fn should be accepted");
+        .expect_err("bare Fn should be rejected");
 
-        assert_eq!(shortcut, DictationShortcutSetting::bare_fn());
+        assert_eq!(err.code, "dictation_shortcut_unsupported");
     }
 
     #[test]
-    fn shortcut_input_normalizes_double_press_to_single_press() {
+    fn shortcut_input_accepts_control_letter_and_normalizes_press_count() {
         let shortcut = DictationShortcutInput {
-            code: "Fn".to_string(),
+            code: "KeyT".to_string(),
             modifiers: DictationShortcutModifiers {
-                function: true,
+                control: true,
                 ..DictationShortcutModifiers::default()
             },
-            label: "Fn".to_string(),
+            label: "Ctrl+T".to_string(),
             press_count: Some(2),
         }
         .into_setting()
-        .expect("bare Fn should be accepted");
+        .expect("control letter should be accepted");
 
-        assert_eq!(shortcut, DictationShortcutSetting::bare_fn());
+        assert_eq!(shortcut.key_code, 0x11);
+        assert_eq!(shortcut.code, "KeyT");
+        assert!(shortcut.modifiers.control);
+        assert_eq!(shortcut.press_count, 1);
+    }
+
+    #[test]
+    fn shortcut_input_accepts_control_digit() {
+        let shortcut = DictationShortcutInput {
+            code: "Digit1".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+1".to_string(),
+            press_count: Some(1),
+        }
+        .into_setting()
+        .expect("control digit should be accepted");
+
+        assert_eq!(shortcut.key_code, 0x12);
+        assert_eq!(shortcut.code, "Digit1");
+        assert!(shortcut.modifiers.control);
     }
 
     #[test]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -14,7 +14,7 @@ use std::{
     io::{BufRead, BufReader, Write},
     path::PathBuf,
     process::{Child, ChildStdin, Command, Stdio},
-    sync::Mutex,
+    sync::{Mutex, OnceLock},
     thread,
     time::Duration,
 };
@@ -26,6 +26,8 @@ const DICTATION_TRANSCRIPTION_CONTEXT: &str = "Transcribe this as clean hands-fr
 const DICTATION_CLEANUP_TIMEOUT_MS: u64 = 15_000;
 const DICTATION_AUDIO_ACTIVITY_THRESHOLD: f32 = 0.04;
 const DICTATION_EVENT_LOG: &str = "dictation-events.log";
+
+static SETTINGS_CACHE: OnceLock<Mutex<DictationSettings>> = OnceLock::new();
 
 pub struct HelperProcess {
     child: Child,
@@ -79,6 +81,13 @@ pub struct HudHoverState {
     last_passthrough: std::sync::atomic::AtomicBool,
 }
 
+pub fn configured_transcription_language() -> Option<String> {
+    settings_store()
+        .lock()
+        .ok()
+        .and_then(|settings| settings.language.clone())
+}
+
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DictationSettings {
@@ -86,6 +95,7 @@ pub struct DictationSettings {
     pub toggle_shortcut: DictationShortcutSetting,
     pub microphone: DictationMicrophoneSetting,
     pub style: DictationStyle,
+    pub language: Option<String>,
 }
 
 impl Default for DictationSettings {
@@ -95,6 +105,7 @@ impl Default for DictationSettings {
             toggle_shortcut: DictationShortcutSetting::control_option_space(),
             microphone: DictationMicrophoneSetting::default(),
             style: DictationStyle::Standard,
+            language: None,
         }
     }
 }
@@ -111,6 +122,7 @@ impl<'de> Deserialize<'de> for DictationSettings {
             toggle_shortcut: Option<DictationShortcutSetting>,
             microphone: Option<DictationMicrophoneSetting>,
             style: Option<DictationStyle>,
+            language: Option<String>,
         }
 
         let value = serde_json::Value::deserialize(deserializer)?;
@@ -139,6 +151,7 @@ impl<'de> Deserialize<'de> for DictationSettings {
                 .unwrap_or_else(DictationShortcutSetting::control_option_space),
             microphone: settings.microphone.unwrap_or(microphone),
             style: settings.style.unwrap_or_default(),
+            language: normalize_language(settings.language),
         })
     }
 }
@@ -607,6 +620,17 @@ pub fn set_dictation_style(
 }
 
 #[tauri::command]
+pub fn set_dictation_language(
+    state: State<'_, DictationSettingsState>,
+    language: Option<String>,
+) -> Result<DictationSettings, AppError> {
+    let language = normalize_language(language);
+    update_settings(&state, |settings| {
+        settings.language = language;
+    })
+}
+
+#[tauri::command]
 pub fn dictation_helper_command(
     state: State<'_, HelperState>,
     command: serde_json::Value,
@@ -1025,6 +1049,7 @@ fn settings_path(app: &AppHandle) -> Option<PathBuf> {
 fn manage_settings(app: &AppHandle) {
     let path = settings_path(app).unwrap_or_else(|| PathBuf::from("dictation-settings.json"));
     let settings = load_settings(app);
+    replace_current_settings(settings.clone());
     app.manage(DictationSettingsState {
         path,
         settings: Mutex::new(settings),
@@ -1042,6 +1067,27 @@ fn load_settings(app: &AppHandle) -> DictationSettings {
         .unwrap_or_default()
 }
 
+fn normalize_language(language: Option<String>) -> Option<String> {
+    language
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| {
+            value.len() == 2
+                && value
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase())
+        })
+}
+
+fn settings_store() -> &'static Mutex<DictationSettings> {
+    SETTINGS_CACHE.get_or_init(|| Mutex::new(DictationSettings::default()))
+}
+
+fn replace_current_settings(settings: DictationSettings) {
+    if let Ok(mut current) = settings_store().lock() {
+        *current = settings;
+    }
+}
+
 fn update_settings(
     state: &DictationSettingsState,
     update: impl FnOnce(&mut DictationSettings),
@@ -1052,6 +1098,7 @@ fn update_settings(
         .map_err(|_| AppError::new("dictation_settings_unavailable", "Settings lock failed."))?;
     update(&mut settings);
     save_settings(state, &settings)?;
+    replace_current_settings(settings.clone());
     Ok(settings.clone())
 }
 
@@ -1243,9 +1290,9 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
         }
     };
     let provider_for_cleanup = provider.clone();
-    let style = current_dictation_settings(&app)
-        .map(|settings| settings.style)
-        .unwrap_or_default();
+    let current_settings = current_dictation_settings(&app).unwrap_or_default();
+    let style = current_settings.style;
+    let language = current_settings.language;
     let dictionary_context = dictionary_context_for_app(&app).await;
     let session_id = dictation_session_id();
     let utterance_id = uuid::Uuid::new_v4().to_string();
@@ -1256,6 +1303,7 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     let result = dictate_transcribe(DictateTranscribeRequest {
         audio_path: recording.audio_path,
         context: transcription_context,
+        language,
         session_id: session_id.clone(),
         utterance_id: utterance_id.clone(),
     })
@@ -2204,6 +2252,7 @@ mod tests {
             DictationShortcutSetting::control_option_space()
         );
         assert_eq!(settings.style, DictationStyle::Standard);
+        assert_eq!(settings.language, None);
     }
 
     #[test]
@@ -2224,6 +2273,7 @@ mod tests {
         assert_eq!(settings.microphone.id.as_deref(), Some("usb"));
         assert_eq!(settings.microphone.name.as_deref(), Some("USB Mic"));
         assert_eq!(settings.style, DictationStyle::Standard);
+        assert_eq!(settings.language, None);
     }
 
     #[test]
@@ -2236,6 +2286,7 @@ mod tests {
         assert_eq!(settings.push_to_talk_shortcut.press_count, 1);
         assert_eq!(settings.toggle_shortcut.press_count, 1);
         assert_eq!(settings.style, DictationStyle::Standard);
+        assert_eq!(settings.language, None);
         assert!(settings
             .toggle_shortcut
             .same_trigger_as(&DictationShortcutSetting {
@@ -2259,6 +2310,26 @@ mod tests {
         .expect("style settings should deserialize");
 
         assert_eq!(settings.style, DictationStyle::CasualLowercase);
+    }
+
+    #[test]
+    fn deserializes_default_transcription_language() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"pushToTalkShortcut":{"keyCode":0,"code":"Fn","modifiers":{"command":false,"control":false,"option":false,"shift":false,"function":true},"label":"Fn","pressCount":1},"toggleShortcut":{"keyCode":49,"code":"Space","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt+Space","pressCount":1},"microphone":{"id":null,"name":null},"language":"ES"}"#,
+        )
+        .expect("language settings should deserialize");
+
+        assert_eq!(settings.language.as_deref(), Some("es"));
+    }
+
+    #[test]
+    fn ignores_invalid_default_transcription_language() {
+        assert_eq!(normalize_language(Some("english".to_string())), None);
+        assert_eq!(normalize_language(Some(" e ".to_string())), None);
+        assert_eq!(
+            normalize_language(Some(" en ".to_string())).as_deref(),
+            Some("en")
+        );
     }
 
     #[test]
@@ -2351,6 +2422,7 @@ mod tests {
             },
             microphone: DictationMicrophoneSetting::default(),
             style: DictationStyle::Standard,
+            language: None,
         };
 
         assert!(validate_shortcut_update(

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -856,6 +856,7 @@ async fn transcribe_prepared_audio(
     transcriber: TurnTranscriber,
     request: TranscribePreparedAudioRequest,
 ) -> Result<TranscriptionProviderResult, AppError> {
+    let request_language = crate::dictation::configured_transcription_language();
     let chunk_dir = request.temp_dir.join("chunks");
     let audio_paths = if request.audio_path.exists() {
         split_wav_for_transcription(&request.audio_path, &chunk_dir, &request.chunk_stem)?
@@ -868,6 +869,7 @@ async fn transcribe_prepared_audio(
             audio_path: audio_paths.into_iter().next().unwrap_or(request.audio_path),
             title: request.title,
             context: request.base_context,
+            language: request_language,
             operation_id: Some(request.operation_id),
         })
         .await;
@@ -887,6 +889,7 @@ async fn transcribe_prepared_audio(
             audio_path,
             title: request.title.clone(),
             context,
+            language: request_language.clone(),
             operation_id: Some(format!("{}-chunk-{index}", request.operation_id)),
         })
         .await?;

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -154,6 +154,14 @@ pub struct DeleteHermesSessionRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct EnsureHermesSessionRequest {
+    pub session_id: String,
+    pub title: Option<String>,
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DownloadHermesFileRequest {
     pub path: String,
 }
@@ -505,6 +513,48 @@ pub async fn hermes_bridge_sessions(
         None,
     )
     .await
+}
+
+#[tauri::command]
+pub async fn ensure_hermes_bridge_session(
+    bridge: State<'_, HermesBridge>,
+    request: EnsureHermesSessionRequest,
+) -> Result<serde_json::Value, AppError> {
+    let session_id = request.session_id.trim();
+    if session_id.is_empty() {
+        return Err(AppError::new(
+            "hermes_session_id_required",
+            "Hermes session ID is required.",
+        ));
+    }
+    let mut body = serde_json::json!({ "id": session_id });
+    if let Some(title) = request
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body["title"] = serde_json::Value::String(title.to_string());
+    }
+    if let Some(model) = request
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body["model"] = serde_json::Value::String(model.to_string());
+    }
+    match hermes_api_json(&bridge, reqwest::Method::POST, "/api/sessions", Some(body)).await {
+        Ok(value) => Ok(value),
+        Err(error) if error.code == "hermes_bridge_api_failed" && error.message.contains("409") => {
+            Ok(serde_json::json!({
+                "object": "hermes.session.ensure",
+                "id": session_id,
+                "created": false
+            }))
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -546,7 +546,10 @@ pub async fn ensure_hermes_bridge_session(
     }
     match hermes_api_json(&bridge, reqwest::Method::POST, "/api/sessions", Some(body)).await {
         Ok(value) => Ok(value),
-        Err(error) if error.code == "hermes_bridge_api_failed" && error.message.contains("409") => {
+        Err(error)
+            if error.code == "hermes_bridge_api_failed"
+                && error.message.starts_with("Hermes API returned 409") =>
+        {
             Ok(serde_json::json!({
                 "object": "hermes.session.ensure",
                 "id": session_id,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,7 @@ pub fn run() {
             hermes_bridge::hermes_bridge_file_preview,
             hermes_bridge::import_hermes_bridge_file,
             hermes_bridge::hermes_bridge_sessions,
+            hermes_bridge::ensure_hermes_bridge_session,
             hermes_bridge::hermes_bridge_session_messages,
             hermes_bridge::delete_hermes_bridge_session,
             hermes_bridge::start_hermes_bridge,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
             dictation::set_dictation_shortcut,
             dictation::set_dictation_microphone,
             dictation::set_dictation_style,
+            dictation::set_dictation_language,
             dictation::dictation_helper_command,
             dictation::dictation_hud_set_stop_bounds,
             dictation::dictation_hud_set_pill_bounds,

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -29,6 +29,7 @@ pub struct TranscriptionRequest {
     pub audio_path: PathBuf,
     pub title: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub operation_id: Option<String>,
 }
 
@@ -84,6 +85,7 @@ pub struct GenerationProviderResult {
 pub struct DictateTranscribeRequest {
     pub audio_path: PathBuf,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub session_id: String,
     pub utterance_id: String,
 }
@@ -196,6 +198,9 @@ pub async fn transcribe_saved_audio(
     {
         form = form.text("context", context.to_string());
     }
+    if let Some(language) = normalized_language(request.language.as_deref()) {
+        form = form.text("language", language.to_string());
+    }
     let response: TranscribeResponse = post_multipart("/v1/notes/transcribe", form).await?;
     Ok(TranscriptionProviderResult {
         text: response.text,
@@ -252,11 +257,23 @@ pub async fn dictate_transcribe(
     {
         form = form.text("context", context.to_string());
     }
+    if let Some(language) = normalized_language(request.language.as_deref()) {
+        form = form.text("language", language.to_string());
+    }
     let response: TranscribeResponse = post_multipart("/v1/dictate", form).await?;
     Ok(TranscriptionProviderResult {
         text: response.text,
         language: response.language,
         provider: response.provider,
+    })
+}
+
+fn normalized_language(language: Option<&str>) -> Option<&str> {
+    language.map(str::trim).filter(|value| {
+        value.len() == 2
+            && value
+                .chars()
+                .all(|character| character.is_ascii_lowercase())
     })
 }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -32,6 +32,7 @@ import {
   cancelAgentTask,
   createAgentTask,
   getAgentTask,
+  ensureHermesBridgeSession,
   hermesBridgeFilesystemSnapshot,
   hermesBridgeMessagingPlatforms,
   hermesBridgeFilePreview,
@@ -181,6 +182,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const [pendingHermesMessages, setPendingHermesMessages] = useState<
     Record<string, HermesSessionMessage[]>
   >({});
+  const pendingHermesMessagesRef = useRef<
+    Record<string, HermesSessionMessage[]>
+  >({});
   const [hermesSessionsLoading, setHermesSessionsLoading] = useState(false);
   const [liveEvents, setLiveEvents] = useState<
     Record<string, LiveHermesEvent[]>
@@ -226,6 +230,10 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const sessionTitleOverridesRef = useRef<Record<string, string>>({});
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    pendingHermesMessagesRef.current = pendingHermesMessages;
+  }, [pendingHermesMessages]);
 
   const setTaskWorking = useCallback((taskId: string, working: boolean) => {
     setWorkingTaskIds((current) => {
@@ -324,10 +332,27 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     setHermesSessionsLoading(true);
     try {
       const sessions = applySessionTitleOverrides(await listHermesSessions());
-      setHermesSessionItems(sessions);
+      const pendingMessages = pendingHermesMessagesRef.current;
+      setHermesSessionItems((current) =>
+        mergeActiveHermesSessions(sessions, current, {
+          selectedSessionId: selectedHermesSessionId,
+          workingSessionIds,
+          waitingSessionIds,
+          pendingMessages,
+        }),
+      );
       setSelectedHermesSessionId((current) => {
         if (newSessionModeRef.current) return undefined;
-        if (current && sessions.some((session) => session.id === current)) {
+        if (
+          current &&
+          (sessions.some((session) => session.id === current) ||
+            shouldRetainHermesSessionId(current, {
+              selectedSessionId: current,
+              workingSessionIds,
+              waitingSessionIds,
+              pendingMessages,
+            }))
+        ) {
           return current;
         }
         const taskSession = selectedTask?.hermesSessionId;
@@ -345,7 +370,13 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     } finally {
       setHermesSessionsLoading(false);
     }
-  }, [bridge.running, selectedTask?.hermesSessionId]);
+  }, [
+    bridge.running,
+    selectedHermesSessionId,
+    selectedTask?.hermesSessionId,
+    waitingSessionIds,
+    workingSessionIds,
+  ]);
 
   useEffect(() => {
     void loadTasks();
@@ -411,7 +442,11 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         return next;
       });
       setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
-      setPendingHermesMessages((current) => omitRecordKey(current, sessionId));
+      setPendingHermesMessages((current) => {
+        const next = omitRecordKey(current, sessionId);
+        pendingHermesMessagesRef.current = next;
+        return next;
+      });
       setWorkingSessionIds((current) => {
         const next = new Set(current);
         next.delete(sessionId);
@@ -448,19 +483,26 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     listHermesSessionMessages(selectedHermesSessionId)
       .then((messages) => {
         if (cancelled) return;
+        const retainedPending = retainUnpersistedPendingMessages(
+          pendingHermesMessagesRef.current[selectedHermesSessionId] ?? [],
+          messages,
+        );
         setHermesSessionMessages((current) => ({
           ...current,
           [selectedHermesSessionId]: messages,
         }));
-        setPendingHermesMessages((current) => ({
-          ...current,
-          [selectedHermesSessionId]: retainUnpersistedPendingMessages(
-            current[selectedHermesSessionId] ?? [],
-            messages,
-          ),
-        }));
+        setPendingHermesMessages((current) => {
+          const next = {
+            ...current,
+            [selectedHermesSessionId]: retainedPending,
+          };
+          pendingHermesMessagesRef.current = next;
+          return next;
+        });
         void suggestTitleForUntitledSession(selectedHermesSessionId, messages);
-        if (sessionHasAssistantAfterLatestUser(messages)) {
+        if (
+          sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])
+        ) {
           setSessionWorking(selectedHermesSessionId, false);
           setSessionWaiting(selectedHermesSessionId, false);
           liveEventsRef.current = {
@@ -682,9 +724,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
           cols: 96,
         });
     const storedSessionId =
-      targetSessionId ??
-      created?.stored_session_id ??
-      created?.session_id;
+      targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
     const sessionDisplayTitle = sessionTitle ?? titleFromPrompt(content);
     if (sessionTitle) {
@@ -693,6 +733,13 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         [storedSessionId]: sessionTitle,
       };
     }
+    await withTimeout(
+      ensureHermesBridgeSession({
+        sessionId: storedSessionId,
+        title: sessionDisplayTitle,
+      }),
+      2500,
+    ).catch(() => undefined);
     const runtimeSessionId =
       created?.session_id ??
       runtimeSessionIds[storedSessionId] ??
@@ -728,18 +775,23 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         ...current,
       ];
     });
-    setPendingHermesMessages((current) => ({
-      ...current,
-      [storedSessionId]: [
-        ...(current[storedSessionId] ?? []),
-        {
-          id: `pending:user:${Date.now()}`,
-          role: "user",
-          content,
-          timestamp: createdAt,
-        },
-      ],
-    }));
+    const pendingUserMessage: HermesSessionMessage = {
+      id: `pending:user:${Date.now()}`,
+      role: "user",
+      content,
+      timestamp: createdAt,
+    };
+    setPendingHermesMessages((current) => {
+      const next = {
+        ...current,
+        [storedSessionId]: [
+          ...(current[storedSessionId] ?? []),
+          pendingUserMessage,
+        ],
+      };
+      pendingHermesMessagesRef.current = next;
+      return next;
+    });
     setSessionWorking(storedSessionId, true);
     setSessionWaiting(storedSessionId, false);
     dispatchAgentSessionStatus({
@@ -911,19 +963,26 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   async function refreshHermesSession(sessionId: string) {
     try {
       const messages = await listHermesSessionMessages(sessionId);
+      const retainedPending = retainUnpersistedPendingMessages(
+        pendingHermesMessagesRef.current[sessionId] ?? [],
+        messages,
+      );
       setHermesSessionMessages((current) => ({
         ...current,
         [sessionId]: messages,
       }));
-      setPendingHermesMessages((current) => ({
-        ...current,
-        [sessionId]: retainUnpersistedPendingMessages(
-          current[sessionId] ?? [],
-          messages,
-        ),
-      }));
+      setPendingHermesMessages((current) => {
+        const next = {
+          ...current,
+          [sessionId]: retainedPending,
+        };
+        pendingHermesMessagesRef.current = next;
+        return next;
+      });
       void suggestTitleForUntitledSession(sessionId, messages);
-      if (sessionHasAssistantAfterLatestUser(messages)) {
+      if (
+        sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])
+      ) {
         setSessionWorking(sessionId, false);
         setSessionWaiting(sessionId, false);
         liveEventsRef.current = { ...liveEventsRef.current, [sessionId]: [] };
@@ -3305,6 +3364,48 @@ function isPreviewableImagePath(path: string) {
 
 function includesQuery(value: unknown, query: string) {
   return safeText(value).toLowerCase().includes(query);
+}
+
+function mergeActiveHermesSessions(
+  fresh: HermesSessionInfo[],
+  current: HermesSessionInfo[],
+  options: {
+    selectedSessionId?: string;
+    workingSessionIds: Set<string>;
+    waitingSessionIds: Set<string>;
+    pendingMessages: Record<string, HermesSessionMessage[]>;
+  },
+) {
+  const seen = new Set(fresh.map((session) => session.id));
+  const retained = current.filter(
+    (session) =>
+      !seen.has(session.id) && shouldRetainHermesSessionId(session.id, options),
+  );
+  return [...fresh, ...retained].sort((a, b) =>
+    sessionTimestamp(b).localeCompare(sessionTimestamp(a)),
+  );
+}
+
+function shouldRetainHermesSessionId(
+  sessionId: string,
+  {
+    pendingMessages,
+    selectedSessionId,
+    waitingSessionIds,
+    workingSessionIds,
+  }: {
+    selectedSessionId?: string;
+    workingSessionIds: Set<string>;
+    waitingSessionIds: Set<string>;
+    pendingMessages: Record<string, HermesSessionMessage[]>;
+  },
+) {
+  return (
+    sessionId === selectedSessionId ||
+    workingSessionIds.has(sessionId) ||
+    waitingSessionIds.has(sessionId) ||
+    (pendingMessages[sessionId]?.length ?? 0) > 0
+  );
 }
 
 function retainUnpersistedPendingMessages(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -175,6 +175,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const [selectedHermesSessionId, setSelectedHermesSessionId] = useState<
     string | undefined
   >(initialSessionId);
+  const selectedHermesSessionIdRef = useRef<string | undefined>(
+    initialSessionId,
+  );
   const [newSessionMode, setNewSessionMode] = useState(false);
   const [hermesSessionMessages, setHermesSessionMessages] = useState<
     Record<string, HermesSessionMessage[]>
@@ -195,9 +198,11 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const [workingSessionIds, setWorkingSessionIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const workingSessionIdsRef = useRef<Set<string>>(new Set());
   const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
     () => new Set(),
   );
+  const waitingSessionIdsRef = useRef<Set<string>>(new Set());
   const [runtimeSessionIds, setRuntimeSessionIds] = useState<
     Record<string, string>
   >({});
@@ -232,8 +237,16 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
   const listRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    selectedHermesSessionIdRef.current = selectedHermesSessionId;
+    workingSessionIdsRef.current = workingSessionIds;
+    waitingSessionIdsRef.current = waitingSessionIds;
     pendingHermesMessagesRef.current = pendingHermesMessages;
-  }, [pendingHermesMessages]);
+  }, [
+    pendingHermesMessages,
+    selectedHermesSessionId,
+    waitingSessionIds,
+    workingSessionIds,
+  ]);
 
   const setTaskWorking = useCallback((taskId: string, working: boolean) => {
     setWorkingTaskIds((current) => {
@@ -256,6 +269,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         } else {
           next.delete(sessionId);
         }
+        workingSessionIdsRef.current = next;
         return next;
       });
     },
@@ -271,6 +285,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         } else {
           next.delete(sessionId);
         }
+        waitingSessionIdsRef.current = next;
         return next;
       });
     },
@@ -333,26 +348,33 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     try {
       const sessions = applySessionTitleOverrides(await listHermesSessions());
       const pendingMessages = pendingHermesMessagesRef.current;
+      const selectedSessionId = selectedHermesSessionIdRef.current;
+      const workingSessions = workingSessionIdsRef.current;
+      const waitingSessions = waitingSessionIdsRef.current;
       setHermesSessionItems((current) =>
         mergeActiveHermesSessions(sessions, current, {
-          selectedSessionId: selectedHermesSessionId,
-          workingSessionIds,
-          waitingSessionIds,
+          selectedSessionId,
+          workingSessionIds: workingSessions,
+          waitingSessionIds: waitingSessions,
           pendingMessages,
         }),
       );
       setSelectedHermesSessionId((current) => {
-        if (newSessionModeRef.current) return undefined;
+        if (newSessionModeRef.current) {
+          selectedHermesSessionIdRef.current = undefined;
+          return undefined;
+        }
         if (
           current &&
           (sessions.some((session) => session.id === current) ||
             shouldRetainHermesSessionId(current, {
               selectedSessionId: current,
-              workingSessionIds,
-              waitingSessionIds,
+              workingSessionIds: workingSessions,
+              waitingSessionIds: waitingSessions,
               pendingMessages,
             }))
         ) {
+          selectedHermesSessionIdRef.current = current;
           return current;
         }
         const taskSession = selectedTask?.hermesSessionId;
@@ -360,9 +382,12 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
           taskSession &&
           sessions.some((session) => session.id === taskSession)
         ) {
+          selectedHermesSessionIdRef.current = taskSession;
           return taskSession;
         }
-        return sessions[0]?.id;
+        const nextSessionId = sessions[0]?.id;
+        selectedHermesSessionIdRef.current = nextSessionId;
+        return nextSessionId;
       });
       setError(null);
     } catch (err) {
@@ -370,13 +395,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     } finally {
       setHermesSessionsLoading(false);
     }
-  }, [
-    bridge.running,
-    selectedHermesSessionId,
-    selectedTask?.hermesSessionId,
-    waitingSessionIds,
-    workingSessionIds,
-  ]);
+  }, [bridge.running, selectedTask?.hermesSessionId]);
 
   useEffect(() => {
     void loadTasks();
@@ -392,6 +411,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     newSessionModeRef.current = false;
     setNewSessionMode(false);
     setActivePanel("chat");
+    selectedHermesSessionIdRef.current = initialSessionId;
     setSelectedHermesSessionId(initialSessionId);
     setSelectedTaskId(undefined);
     if (initialSession) {
@@ -436,9 +456,11 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       const { sessionId } = detail;
       setHermesSessionItems((current) => {
         const next = current.filter((session) => session.id !== sessionId);
-        setSelectedHermesSessionId((selected) =>
-          selected === sessionId ? next[0]?.id : selected,
-        );
+        setSelectedHermesSessionId((selected) => {
+          const nextSelected = selected === sessionId ? next[0]?.id : selected;
+          selectedHermesSessionIdRef.current = nextSelected;
+          return nextSelected;
+        });
         return next;
       });
       setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
@@ -450,11 +472,13 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       setWorkingSessionIds((current) => {
         const next = new Set(current);
         next.delete(sessionId);
+        workingSessionIdsRef.current = next;
         return next;
       });
       setWaitingSessionIds((current) => {
         const next = new Set(current);
         next.delete(sessionId);
+        waitingSessionIdsRef.current = next;
         return next;
       });
       liveEventsRef.current = omitRecordKey(liveEventsRef.current, sessionId);
@@ -758,6 +782,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       ...current,
       [storedSessionId]: runtimeSessionId,
     }));
+    selectedHermesSessionIdRef.current = storedSessionId;
     setSelectedHermesSessionId(storedSessionId);
     setSelectedTaskId(undefined);
     setHermesSessionItems((current) => {
@@ -1017,7 +1042,9 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       const message = messageFromError(err);
       if (message.toLowerCase().includes("session not found")) {
         setWorkingTaskIds(new Set());
-        setWorkingSessionIds(new Set());
+        const emptyWorkingSessions = new Set<string>();
+        workingSessionIdsRef.current = emptyWorkingSessions;
+        setWorkingSessionIds(emptyWorkingSessions);
         liveEventsRef.current = {};
         setLiveEvents({});
         void loadHermesSessions();
@@ -1078,6 +1105,7 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     setNewSessionMode(true);
     setActivePanel("chat");
     setSelectedTaskId(undefined);
+    selectedHermesSessionIdRef.current = undefined;
     setSelectedHermesSessionId(undefined);
     const initialPrompt = prompt?.trim() ?? "";
     setDraft(initialPrompt);

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -137,8 +137,8 @@ export function DictationHistoryView({
 
   const groups = useMemo(() => groupHistoryItems(filtered), [filtered]);
 
-  const pushToTalk = settings?.pushToTalkShortcut.label ?? "Fn";
-  const toggle = settings?.toggleShortcut.label ?? "Ctrl+Opt+Space";
+  const pushToTalk = settings?.pushToTalkShortcut.label ?? "Ctrl+Opt+D";
+  const toggle = settings?.toggleShortcut.label ?? "Ctrl+Opt+T";
 
   // Show each optional feature only while it's still unconfigured, and only
   // once we know its state (avoids the card flashing in then vanishing). The

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -98,17 +98,18 @@ const EMPTY_MODIFIERS: DictationShortcutModifiers = {
 
 const DEFAULT_SETTINGS: DictationSettingsDto = {
   pushToTalkShortcut: {
-    code: "Fn",
-    label: "Fn",
+    code: "KeyD",
+    label: "Ctrl+Opt+D",
     pressCount: 1,
     modifiers: {
       ...EMPTY_MODIFIERS,
-      function: true,
+      control: true,
+      option: true,
     },
   },
   toggleShortcut: {
-    code: "Space",
-    label: "Ctrl+Opt+Space",
+    code: "KeyT",
+    label: "Ctrl+Opt+T",
     pressCount: 1,
     modifiers: {
       ...EMPTY_MODIFIERS,
@@ -308,7 +309,8 @@ export function AppSettings({
     }
     if (helperEvent.type === "fn_monitor_unavailable") {
       setStatus(
-        helperEvent.payload?.message ?? "Fn/Globe shortcut is unavailable.",
+        helperEvent.payload?.message ??
+          "Global shortcut monitoring is unavailable.",
       );
       return;
     }

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -16,6 +16,7 @@ import {
   dictationSettings,
   listVeniceModels,
   providerModelSettings,
+  setDictationLanguage,
   setDictationMicrophone,
   setDictationShortcut,
   setVeniceModel,
@@ -118,7 +119,22 @@ const DEFAULT_SETTINGS: DictationSettingsDto = {
   },
   microphone: {},
   style: "standard",
+  language: undefined,
 };
+
+const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "Auto-detect" },
+  { value: "en", label: "English" },
+  { value: "es", label: "Spanish" },
+  { value: "fr", label: "French" },
+  { value: "de", label: "German" },
+  { value: "it", label: "Italian" },
+  { value: "pt", label: "Portuguese" },
+  { value: "nl", label: "Dutch" },
+  { value: "ja", label: "Japanese" },
+  { value: "ko", label: "Korean" },
+  { value: "zh", label: "Chinese" },
+];
 
 const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionProvider: "venice",
@@ -420,6 +436,20 @@ export function AppSettings({
     }
   }
 
+  async function selectLanguage(language: string) {
+    try {
+      const next = await setDictationLanguage(language || undefined);
+      setSettings(next);
+      setStatus(
+        language
+          ? `Default transcription language set to ${languageLabel(language)}.`
+          : "Default transcription language set to auto-detect.",
+      );
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
+
   const microphoneName = settings.microphone.name ?? "Auto-detect";
   const microphoneOptions = [
     { id: undefined, name: "Auto-detect" },
@@ -579,6 +609,35 @@ export function AppSettings({
                     onChange={() => void startShortcutCapture("toggle")}
                     onCancel={() => void cancelShortcutCapture()}
                   />
+
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Language</h3>
+                      <p className="settings-row-description">
+                        Default language hint for note transcription and
+                        dictation.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <select
+                        className="select-trigger settings-language-select"
+                        aria-label="Default transcription language"
+                        value={settings.language ?? ""}
+                        onChange={(event) =>
+                          void selectLanguage(event.currentTarget.value)
+                        }
+                      >
+                        {LANGUAGE_OPTIONS.map((option) => (
+                          <option
+                            key={option.value || "auto"}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
                 </div>
               </div>
             </section>
@@ -1311,6 +1370,12 @@ function shortcutForKind(
   return kind === "toggle"
     ? settings.toggleShortcut
     : settings.pushToTalkShortcut;
+}
+
+function languageLabel(value: string) {
+  return (
+    LANGUAGE_OPTIONS.find((option) => option.value === value)?.label ?? value
+  );
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -799,6 +799,16 @@ export async function deleteHermesBridgeSession(sessionId: string) {
   });
 }
 
+export async function ensureHermesBridgeSession(input: {
+  sessionId: string;
+  title?: string;
+  model?: string;
+}) {
+  return invoke<unknown>("ensure_hermes_bridge_session", {
+    request: input,
+  });
+}
+
 export async function updateHermesBridgeMessagingPlatform(input: {
   platformId: string;
   enabled?: boolean;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -102,6 +102,7 @@ export type DictationSettingsDto = {
   toggleShortcut: DictationShortcutSetting;
   microphone: DictationMicrophoneSetting;
   style: DictationStyle;
+  language?: string;
 };
 
 export type DictationSettingsResponse = {
@@ -1005,6 +1006,12 @@ export async function setDictationMicrophone(id?: string, name?: string) {
 
 export async function setDictationStyle(style: DictationStyle) {
   return invoke<DictationSettingsDto>("set_dictation_style", { style });
+}
+
+export async function setDictationLanguage(language?: string) {
+  return invoke<DictationSettingsDto>("set_dictation_language", {
+    language: language || undefined,
+  });
 }
 
 export async function dictationHelperCommand(command: Record<string, unknown>) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -301,26 +301,60 @@ describe("AgentWorkspace", () => {
       }
       return Promise.resolve({});
     });
+    let resolveEnsureSession: (value: unknown) => void = () => {};
+    mocks.ensureHermesBridgeSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveEnsureSession = resolve;
+        }),
+    );
 
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("previous answer")).toBeInTheDocument();
+    const initialSessionListCalls = mocks.listHermesSessions.mock.calls.length;
 
     await user.type(screen.getByRole("textbox"), "follow up while pending");
     await user.click(screen.getByRole("button", { name: "Send" }));
-
     await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "session-1",
+        }),
+      ),
+    );
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        resolveEnsureSession({});
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
         session_id: "runtime-session-1",
         text: "follow up while pending",
-      }),
-    );
-    expect(await screen.findByText("Working now.")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Working now.")).toBeInTheDocument();
+      expect(mocks.listHermesSessions).toHaveBeenCalledTimes(
+        initialSessionListCalls + 1,
+      );
+      const sessionListCallsAfterSubmit =
+        mocks.listHermesSessions.mock.calls.length;
 
-    await new Promise((resolve) => window.setTimeout(resolve, 2700));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
 
-    expect(screen.getByText("follow up while pending")).toBeInTheDocument();
-    expect(screen.getByText("Working now.")).toBeInTheDocument();
+      expect(screen.getByText("follow up while pending")).toBeInTheDocument();
+      expect(screen.getByText("Working now.")).toBeInTheDocument();
+      expect(mocks.listHermesSessions).toHaveBeenCalledTimes(
+        sessionListCallsAfterSubmit + 1,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders generated workspace files mentioned by Hermes as downloadable artifacts", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -10,6 +10,7 @@ import {
 const mocks = vi.hoisted(() => ({
   cancelAgentTask: vi.fn(),
   createAgentTask: vi.fn(),
+  ensureHermesBridgeSession: vi.fn(),
   getAgentTask: vi.fn(),
   hermesBridgeFilesystemSnapshot: vi.fn(),
   hermesBridgeFilePreview: vi.fn(),
@@ -50,6 +51,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../lib/tauri", () => ({
   cancelAgentTask: mocks.cancelAgentTask,
   createAgentTask: mocks.createAgentTask,
+  ensureHermesBridgeSession: mocks.ensureHermesBridgeSession,
   getAgentTask: mocks.getAgentTask,
   hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
   hermesBridgeFilePreview: mocks.hermesBridgeFilePreview,
@@ -142,6 +144,7 @@ describe("AgentWorkspace", () => {
     mocks.downloadHermesBridgeFile.mockResolvedValue(
       "/Users/junho/Downloads/sample.pdf",
     );
+    mocks.ensureHermesBridgeSession.mockResolvedValue({});
     mocks.suggestAgentSessionTitle.mockResolvedValue({
       title: "Summarize Current Page",
     });
@@ -214,6 +217,10 @@ describe("AgentWorkspace", () => {
       title: "Summarize Current Page",
       cols: 96,
     });
+    expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+      sessionId: "session-2",
+      title: "Summarize Current Page",
+    });
     expect(
       await screen.findByText("Summarize Current Page"),
     ).toBeInTheDocument();
@@ -248,6 +255,72 @@ describe("AgentWorkspace", () => {
       session_id: "runtime-session-1",
       text: "write a project update",
     });
+  });
+
+  it("keeps an optimistic Hermes session visible while the persisted list lags", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ prompt: "open the release notes" }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([existingSession]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "open the release notes",
+      }),
+    );
+
+    expect(
+      await screen.findByText("Summarize Current Page"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("open the release notes")).toBeInTheDocument();
+  });
+
+  it("keeps polling when a follow-up user message is still only pending locally", async () => {
+    const user = userEvent.setup();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "previous request",
+        timestamp: "2026-06-04T12:00:00.000Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "previous answer",
+        timestamp: "2026-06-04T12:00:01.000Z",
+      },
+    ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      return Promise.resolve({});
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("previous answer")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox"), "follow up while pending");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "follow up while pending",
+      }),
+    );
+    expect(await screen.findByText("Working now.")).toBeInTheDocument();
+
+    await new Promise((resolve) => window.setTimeout(resolve, 2700));
+
+    expect(screen.getByText("follow up while pending")).toBeInTheDocument();
+    expect(screen.getByText("Working now.")).toBeInTheDocument();
   });
 
   it("renders generated workspace files mentioned by Hermes as downloadable artifacts", async () => {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -58,20 +58,20 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const baseSettings: DictationSettingsDto = {
   pushToTalkShortcut: {
-    code: "Space",
-    label: "Fn+Space",
+    code: "KeyD",
+    label: "Ctrl+Opt+D",
     pressCount: 1,
     modifiers: {
       command: false,
-      control: false,
-      option: false,
+      control: true,
+      option: true,
       shift: false,
-      function: true,
+      function: false,
     },
   },
   toggleShortcut: {
-    code: "Space",
-    label: "Ctrl+Opt+Space",
+    code: "KeyT",
+    label: "Ctrl+Opt+T",
     pressCount: 1,
     modifiers: {
       command: false,
@@ -451,14 +451,14 @@ describe("AppSettings", () => {
         type: "shortcut_captured",
         payload: {
           shortcut: {
-            code: "Fn",
-            label: "Fn",
+            code: "KeyT",
+            label: "Ctrl+T",
             modifiers: {
               command: false,
-              control: false,
+              control: true,
               option: false,
               shift: false,
-              function: true,
+              function: false,
             },
             pressCount: 1,
           },
@@ -468,14 +468,14 @@ describe("AppSettings", () => {
 
     await waitFor(() =>
       expect(mocks.setDictationShortcut).toHaveBeenCalledWith("push_to_talk", {
-        code: "Fn",
-        label: "Fn",
+        code: "KeyT",
+        label: "Ctrl+T",
         modifiers: {
           command: false,
-          control: false,
+          control: true,
           option: false,
           shift: false,
-          function: true,
+          function: false,
         },
         pressCount: 1,
       }),
@@ -495,12 +495,12 @@ describe("AppSettings", () => {
         type: "shortcut_captured",
         payload: {
           shortcut: {
-            code: "Space",
-            label: "Ctrl+Opt+Space",
+            code: "Digit1",
+            label: "Ctrl+1",
             modifiers: {
               command: false,
               control: true,
-              option: true,
+              option: false,
               shift: false,
               function: false,
             },
@@ -512,12 +512,12 @@ describe("AppSettings", () => {
 
     await waitFor(() =>
       expect(mocks.setDictationShortcut).toHaveBeenCalledWith("toggle", {
-        code: "Space",
-        label: "Ctrl+Opt+Space",
+        code: "Digit1",
+        label: "Ctrl+1",
         modifiers: {
           command: false,
           control: true,
-          option: true,
+          option: false,
           shift: false,
           function: false,
         },

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   openPrivacySettings: vi.fn(),
   setDictationShortcut: vi.fn(),
   setDictationMicrophone: vi.fn(),
+  setDictationLanguage: vi.fn(),
   osAccountsLogin: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
@@ -25,6 +26,10 @@ const mocks = vi.hoisted(() => ({
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
   updateHermesBridgeMessagingPlatform: vi.fn(),
+  listDictionaryEntries: vi.fn(),
+  createDictionaryEntry: vi.fn(),
+  updateDictionaryEntry: vi.fn(),
+  deleteDictionaryEntry: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
@@ -38,6 +43,7 @@ vi.mock("../lib/tauri", () => ({
   openPrivacySettings: mocks.openPrivacySettings,
   setDictationShortcut: mocks.setDictationShortcut,
   setDictationMicrophone: mocks.setDictationMicrophone,
+  setDictationLanguage: mocks.setDictationLanguage,
   osAccountsLogin: mocks.osAccountsLogin,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
@@ -50,6 +56,10 @@ vi.mock("../lib/tauri", () => ({
   toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform:
     mocks.updateHermesBridgeMessagingPlatform,
+  listDictionaryEntries: mocks.listDictionaryEntries,
+  createDictionaryEntry: mocks.createDictionaryEntry,
+  updateDictionaryEntry: mocks.updateDictionaryEntry,
+  deleteDictionaryEntry: mocks.deleteDictionaryEntry,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -83,6 +93,7 @@ const baseSettings: DictationSettingsDto = {
   },
   microphone: {},
   style: "standard",
+  language: undefined,
 };
 
 const signedInAccount = {
@@ -102,6 +113,11 @@ describe("AppSettings", () => {
     vi.clearAllMocks();
     mocks.eventHandler = undefined;
     mocks.dictationSettings.mockResolvedValue({ settings: baseSettings });
+    mocks.setDictationLanguage.mockImplementation(async (language) => ({
+      ...baseSettings,
+      language,
+    }));
+    mocks.listDictionaryEntries.mockResolvedValue([]);
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
         transcriptionProvider: "venice",
@@ -319,6 +335,32 @@ describe("AppSettings", () => {
       screen.getByRole("switch", { name: "Capture system audio for notes" }),
     );
     expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+  });
+
+  it("saves the default transcription language", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Dictation" }));
+    const language = await screen.findByRole("combobox", {
+      name: "Default transcription language",
+    });
+
+    await user.selectOptions(language, "es");
+
+    expect(mocks.setDictationLanguage).toHaveBeenCalledWith("es");
+    await waitFor(() => expect(language).toHaveValue("es"));
   });
 
   it("lists system permissions with status and manage actions", async () => {

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -34,20 +34,20 @@ describe("DictationHistoryView", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {
             command: false,
-            control: false,
-            option: false,
+            control: true,
+            option: true,
             shift: false,
-            function: true,
+            function: false,
           },
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {
             command: false,
@@ -92,9 +92,7 @@ describe("DictationHistoryView", () => {
     );
     expect(screen.getByText("Push to talk")).toBeInTheDocument();
     expect(screen.getByText("Hands-free")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("Shortcut Ctrl+Opt+Space"),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Shortcut Ctrl+Opt+T")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Copy" }));
     await waitFor(() =>
@@ -132,14 +130,14 @@ describe("DictationHistoryView", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {},
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {},
         },
@@ -165,14 +163,14 @@ describe("DictationHistoryView", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {},
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {},
         },

--- a/src/test/style-settings.test.tsx
+++ b/src/test/style-settings.test.tsx
@@ -19,20 +19,20 @@ describe("StyleSettingsSection", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {
             command: false,
-            control: false,
-            option: false,
+            control: true,
+            option: true,
             shift: false,
-            function: true,
+            function: false,
           },
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {
             command: false,


### PR DESCRIPTION
## Summary

Fixes Scribe-side Hermes history reconciliation so active sessions and pending user messages do not disappear while Hermes persistence lags.

## Root cause

The UI decided a session had finished by checking only persisted Hermes messages. If Hermes still showed the previous assistant reply while a new follow-up user message existed only in Scribe's optimistic pending state, Scribe could clear the working state and stop polling before the new message was persisted. The session list also replaced local active sessions with the latest Hermes API list, so active optimistic sessions could vanish when the persisted list lagged.

## Changes

- Reconcile pending local Hermes messages with persisted messages before deciding whether a session is complete.
- Keep selected, working, waiting, or pending Hermes sessions visible when the persisted session list is stale.
- Add a best-effort Tauri command to ensure a Hermes API session shell exists before resume/submit.
- Add AgentWorkspace regression tests for lagging session lists and follow-up messages that are still only pending locally.

## Validation

- `pnpm vitest run src/test/agent-workspace.test.tsx src/test/hermes-adapter.test.ts src/test/agent-chat-runtime.test.ts`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm run lint`
- `git diff --check --cached`