### PR TITLE
[codex] Render Hermes compaction as context

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2449,11 +2449,36 @@ function AgentChatTurnRow({
     (part): part is Extract<AgentChatPart, { type: "text" }> =>
       part.type === "text",
   );
+  const contextParts = turn.parts.filter(
+    (part): part is Extract<AgentChatPart, { type: "context" }> =>
+      part.type === "context",
+  );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
   const mentionedArtifacts = artifactsMentionedInText(
     artifacts ?? [],
-    turn.parts.map((part) => ("text" in part ? part.text : "")).join("\n"),
+    turn.parts
+      .map((part) =>
+        part.type !== "context" && "text" in part ? part.text : "",
+      )
+      .join("\n"),
   );
+
+  if (
+    contextParts.length &&
+    turn.parts.every((part) => part.type === "context")
+  ) {
+    return (
+      <>
+        {contextParts.map((part, index) => (
+          <ContextCompactionPart
+            key={`${turn.id}:context:${index}`}
+            createdAt={turn.createdAt}
+            part={part}
+          />
+        ))}
+      </>
+    );
+  }
 
   if (turn.role === "user") {
     return (
@@ -2486,6 +2511,12 @@ function AgentChatTurnRow({
             </div>
           ) : part.type === "reasoning" ? (
             <ReasoningPart key={`${turn.id}:reasoning:${index}`} part={part} />
+          ) : part.type === "context" ? (
+            <ContextCompactionPart
+              key={`${turn.id}:context:${index}`}
+              createdAt={turn.createdAt}
+              part={part}
+            />
           ) : part.type === "approval" ? (
             <ApprovalPart
               key={`${turn.id}:approval:${part.id}`}
@@ -2513,6 +2544,26 @@ function AgentChatTurnRow({
         ) : null}
       </div>
     </article>
+  );
+}
+
+function ContextCompactionPart({
+  createdAt,
+  part,
+}: {
+  createdAt: string;
+  part: Extract<AgentChatPart, { type: "context" }>;
+}) {
+  return (
+    <details className="agent-context-summary">
+      <summary>
+        <BotIcon size={14} />
+        <span>Context compacted</span>
+        <p>{part.preview}</p>
+        <time>{relativeDate(createdAt)}</time>
+      </summary>
+      <MarkdownContent markdown={part.text} />
+    </details>
   );
 }
 

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -22,6 +22,13 @@ export type AgentChatReasoningPart = {
   status: "running" | "complete";
 };
 
+export type AgentChatContextPart = {
+  type: "context";
+  text: string;
+  preview: string;
+  status: "complete";
+};
+
 export type AgentChatToolPart = {
   type: "tool";
   id: string;
@@ -56,6 +63,7 @@ export type AgentChatClarifyPart = {
 export type AgentChatPart =
   | AgentChatTextPart
   | AgentChatReasoningPart
+  | AgentChatContextPart
   | AgentChatToolPart
   | AgentChatApprovalPart
   | AgentChatClarifyPart;
@@ -107,10 +115,16 @@ export function buildHermesSessionChatTurns(
       continue;
     }
 
+    const content = displayContentForHermesMessage(message);
+    const contextPart = content
+      ? contextCompactionPartForHermesContent(content)
+      : undefined;
+
     const turn: AgentChatTurn = {
       id: message.id,
-      role:
-        message.role === "assistant"
+      role: contextPart
+        ? "system"
+        : message.role === "assistant"
           ? "assistant"
           : message.role === "system"
             ? "system"
@@ -120,39 +134,42 @@ export function buildHermesSessionChatTurns(
       parts: [],
     };
 
-    const reasoning =
-      stringValue(message.reasoning, true) ??
-      stringValue(message.reasoning_content, true) ??
-      textFromHermesContent(message.reasoning_details);
-    if (reasoning) {
-      turn.parts.push({
-        type: "reasoning",
-        text: reasoning,
-        status: "complete",
-      });
-    }
+    if (contextPart) {
+      turn.parts.push(contextPart);
+    } else {
+      const reasoning =
+        stringValue(message.reasoning, true) ??
+        stringValue(message.reasoning_content, true) ??
+        textFromHermesContent(message.reasoning_details);
+      if (reasoning) {
+        turn.parts.push({
+          type: "reasoning",
+          text: reasoning,
+          status: "complete",
+        });
+      }
 
-    for (const call of parseToolCalls(message.tool_calls)) {
-      const result = toolResults.get(call.id);
-      turn.parts.push({
-        type: "tool",
-        id: call.id,
-        name: humanizeToolName(call.name),
-        text:
-          textFromHermesContent(result?.content) ??
-          stringifyObject(call.arguments) ??
-          "",
-        status: "complete",
-      });
-    }
+      for (const call of parseToolCalls(message.tool_calls)) {
+        const result = toolResults.get(call.id);
+        turn.parts.push({
+          type: "tool",
+          id: call.id,
+          name: humanizeToolName(call.name),
+          text:
+            textFromHermesContent(result?.content) ??
+            stringifyObject(call.arguments) ??
+            "",
+          status: "complete",
+        });
+      }
 
-    const content = displayContentForHermesMessage(message);
-    if (content) {
-      turn.parts.push({
-        type: "text",
-        text: collapseRepeatedMessageText(content),
-        status: "complete",
-      });
+      if (content) {
+        turn.parts.push({
+          type: "text",
+          text: collapseRepeatedMessageText(content),
+          status: "complete",
+        });
+      }
     }
 
     if (turn.parts.length) {
@@ -618,6 +635,38 @@ function displayContentForHermesMessage(message: HermesSessionMessage) {
   return stripHermesContextMarkers(content);
 }
 
+function contextCompactionPartForHermesContent(
+  content: string,
+): AgentChatContextPart | undefined {
+  const text = content.trim();
+  if (!isHermesContextCompactionSummary(text)) return undefined;
+  const detail = stripContextSummaryEndMarker(text);
+  return {
+    type: "context",
+    text: detail,
+    preview: contextCompactionPreview(detail),
+    status: "complete",
+  };
+}
+
+function isHermesContextCompactionSummary(value: string) {
+  const text = value.trimStart();
+  return (
+    text.startsWith("[CONTEXT COMPACTION") ||
+    text.startsWith("[CONTEXT SUMMARY]:")
+  );
+}
+
+function stripContextSummaryEndMarker(value: string) {
+  return value.replace(/\n*--- END OF CONTEXT SUMMARY[\s\S]*$/m, "").trim();
+}
+
+function contextCompactionPreview(value: string) {
+  return value.toLowerCase().includes("deterministic fallback")
+    ? "Earlier turns were compacted; fallback summary generated without the LLM summarizer."
+    : "Earlier turns were compacted into a reference summary.";
+}
+
 function textFromHermesContent(value: unknown, depth = 0): string | undefined {
   if (value === null || value === undefined || depth > 4) return undefined;
   if (typeof value === "string") {
@@ -732,6 +781,7 @@ function partText(part: AgentChatPart) {
   if (part.type === "approval") return part.command || part.description;
   if (part.type === "clarify")
     return [part.question, part.answer ?? ""].join(" ");
+  if (part.type === "context") return part.preview || part.text;
   return part.text;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1259,6 +1259,64 @@ input:focus-visible,
   text-decoration: none;
 }
 
+.agent-context-summary {
+  width: min(760px, 100%);
+  padding: 0 var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.agent-context-summary summary {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: var(--sp-2);
+  cursor: pointer;
+  list-style: none;
+}
+
+.agent-context-summary summary::-webkit-details-marker {
+  display: none;
+}
+
+.agent-context-summary svg {
+  align-self: center;
+  color: var(--muted-foreground);
+}
+
+.agent-context-summary span {
+  font-weight: 650;
+}
+
+.agent-context-summary p {
+  overflow: hidden;
+  margin: 0;
+  color: var(--muted-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-context-summary time {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.agent-context-summary > .agent-markdown {
+  overflow: auto;
+  max-height: 320px;
+  margin: var(--sp-2) 0 0 calc(var(--control-sm) + var(--sp-2));
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.agent-context-summary:not([open]) > .agent-markdown {
+  display: none;
+}
+
+.agent-context-summary[open] summary p {
+  display: none;
+}
+
 .agent-hermes-note {
   width: min(760px, 100%);
   padding: 0 var(--sp-2);

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -71,6 +71,34 @@ describe("Agent chat runtime", () => {
     expect(textParts).toEqual(["Say hello", "Hello there", "Nested reply"]);
   });
 
+  it("classifies Hermes context compaction summaries as system context", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "compact-1",
+        role: "assistant",
+        content:
+          "[CONTEXT COMPACTION - REFERENCE ONLY] Earlier turns were compacted.\n\n" +
+          "## Active Task\nRecovered from a deterministic fallback.\n\n" +
+          "--- END OF CONTEXT SUMMARY - respond to the message below, not the summary above ---",
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.role).toBe("system");
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "context",
+        text:
+          "[CONTEXT COMPACTION - REFERENCE ONLY] Earlier turns were compacted.\n\n" +
+          "## Active Task\nRecovered from a deterministic fallback.",
+        preview:
+          "Earlier turns were compacted; fallback summary generated without the LLM summarizer.",
+        status: "complete",
+      },
+    ]);
+  });
+
   it("appends live reasoning deltas without inserting log line breaks", () => {
     const turns = buildAgentChatTurns(
       [],


### PR DESCRIPTION
## Summary

- Detect Hermes context compaction summaries in persisted session messages and classify them as system context instead of normal assistant output.
- Render compaction summaries as collapsed, muted `Context compacted` rows with an expandable full summary.
- Avoid treating paths inside compacted historical context as current downloadable artifacts.
- Add runtime coverage for assistant-role compaction summaries.

## Why

Hermes can persist context compaction handoff summaries as ordinary assistant/user messages to preserve model continuity. OS Scribe was rendering assistant-role summaries as normal Agent replies, which made internal reference context look like active output.

## Validation

- `pnpm lint`
- `pnpm test`