### PR TITLE
Fix dictation shortcut defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,21 @@ The selected transcription and cleanup models are executed server-side through
 Scribe API, so missing provider keys surface in the Scribe API logs rather than
 the desktop process.
 
-The default shortcut is bare `Fn`/Globe and the default activation mode is `Push-to-talk`. If macOS opens emoji, input-source, or system dictation UI when pressing Fn, set System Settings > Keyboard > "Press Fn key to" or "Press Globe key to" to `Do Nothing`. Settings records the shortcut you press, including bare `Fn`/Globe, `Fn+Space`, or another shortcut with Cmd, Ctrl, Opt, Shift, or Fn plus one supported non-modifier key. Push-to-talk for custom shortcuts depends on macOS exposing both key-down and key-up events for that shortcut.
+The default push-to-talk shortcut is `Ctrl+Opt+D`; toggle dictation defaults to `Ctrl+Opt+T`. Settings records shortcuts with Cmd, Ctrl, Opt, Shift, or Fn plus one supported non-modifier key. Modifier-only shortcuts such as bare Fn/Globe or Ctrl+Opt are rejected because macOS does not expose them as reliable global key chords for all keyboards.
 
 Manual validation:
 
 1. Launch Scribe API with OS Accounts, OpenAI, and Venice env configured.
 2. Grant microphone and Accessibility permissions.
 3. Focus a text field in TextEdit, VS Code, or a browser.
-4. In Settings, press Change, record `Fn`/Globe, and choose `Push-to-talk`.
-5. Hold Fn/Globe to start dictation.
+4. In Settings, confirm push-to-talk shows `Ctrl+Opt+D`.
+5. Hold `Ctrl+Opt+D` to start dictation.
 6. Speak a short sentence.
-7. Release Fn/Globe to stop, transcribe, and paste.
-8. Switch activation mode to `Toggle`.
-9. Press Fn/Globe once to start dictation, then press it again to stop.
-10. Confirm the HUD transitions through listening, transcribing, pasting, and success.
-11. Confirm the transcript appears in the original focused text field.
-12. Select a microphone in Settings, restart, and confirm the selection persists.
+7. Release `Ctrl+Opt+D` to stop, transcribe, and paste.
+8. Press `Ctrl+Opt+T` once to start toggle dictation, then press it again to stop.
+9. Confirm the HUD transitions through listening, transcribing, pasting, and success.
+10. Confirm the transcript appears in the original focused text field.
+11. Select a microphone in Settings, restart, and confirm the selection persists.
 
 ## macOS Audio Permission Debugging
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -228,11 +228,11 @@ struct MonitoredShortcut {
     let modifiers: ShortcutModifiers
     let pressCount: Int
 
-    static let bareFn = MonitoredShortcut(
-        keyCode: 0,
-        code: "Fn",
-        label: "Fn",
-        modifiers: ShortcutModifiers(function: true),
+    static let defaultPushToTalk = MonitoredShortcut(
+        keyCode: 0x02,
+        code: "KeyD",
+        label: "Ctrl+Opt+D",
+        modifiers: ShortcutModifiers(control: true, option: true),
         pressCount: 1
     )
 
@@ -335,11 +335,11 @@ final class ShortcutKeyMonitor {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var shortcuts: [ShortcutKind: MonitoredShortcut] = [
-        .pushToTalk: .bareFn,
+        .pushToTalk: .defaultPushToTalk,
         .toggle: MonitoredShortcut(
-            keyCode: 0x31,
-            code: "Space",
-            label: "Ctrl+Opt+Space",
+            keyCode: 0x11,
+            code: "KeyT",
+            label: "Ctrl+Opt+T",
             modifiers: ShortcutModifiers(control: true, option: true),
             pressCount: 1
         ),
@@ -367,7 +367,7 @@ final class ShortcutKeyMonitor {
 
         if globalMonitor == nil, eventTap == nil {
             emit("fn_monitor_unavailable", [
-                "message": "Could not monitor Fn/Globe key events.",
+                "message": "Could not monitor global shortcut key events.",
             ])
         }
     }
@@ -391,7 +391,12 @@ final class ShortcutKeyMonitor {
         }
 
         let isDown = flags.contains(.maskSecondaryFn)
-        let identity = ShortcutIdentity(MonitoredShortcut.bareFn)
+        let identity = ShortcutIdentity(MonitoredShortcut(
+            keyCode: 0,
+            code: "Fn",
+            label: "Fn",
+            modifiers: ShortcutModifiers(function: true)
+        ))
         if isDown {
             handlePhysicalDown(identity: identity)
         } else {
@@ -501,7 +506,12 @@ final class ShortcutKeyMonitor {
             handlePhysicalUp(identity: identity)
         case .flagsChanged:
             if hasBareFnShortcut {
-                let identity = ShortcutIdentity(MonitoredShortcut.bareFn)
+                let identity = ShortcutIdentity(MonitoredShortcut(
+                    keyCode: 0,
+                    code: "Fn",
+                    label: "Fn",
+                    modifiers: ShortcutModifiers(function: true)
+                ))
                 if event.modifierFlags.contains(.function) {
                     handlePhysicalDown(identity: identity)
                 } else {
@@ -589,15 +599,10 @@ final class ShortcutKeyMonitor {
             guard let self else {
                 return
             }
-            self.finishCapture(
-                MonitoredShortcut(
-                    keyCode: 0,
-                    code: "Fn",
-                    label: "Fn",
-                    modifiers: ShortcutModifiers(function: true),
-                    pressCount: self.capturePressCount
-                )
-            )
+            self.pendingBareFnCapture = nil
+            emit("shortcut_capture_error", [
+                "message": "Shortcut must include a supported non-modifier key.",
+            ])
         }
         pendingBareFnCapture = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -91,8 +91,8 @@ pub struct DictationSettings {
 impl Default for DictationSettings {
     fn default() -> Self {
         Self {
-            push_to_talk_shortcut: DictationShortcutSetting::bare_fn(),
-            toggle_shortcut: DictationShortcutSetting::control_option_space(),
+            push_to_talk_shortcut: DictationShortcutSetting::control_option_d(),
+            toggle_shortcut: DictationShortcutSetting::control_option_t(),
             microphone: DictationMicrophoneSetting::default(),
             style: DictationStyle::Standard,
         }
@@ -133,10 +133,12 @@ impl<'de> Deserialize<'de> for DictationSettings {
         Ok(Self {
             push_to_talk_shortcut: settings
                 .push_to_talk_shortcut
-                .unwrap_or_else(DictationShortcutSetting::bare_fn),
+                .map(|shortcut| shortcut.normalized_or_default(DictationShortcutKind::PushToTalk))
+                .unwrap_or_else(DictationShortcutSetting::control_option_d),
             toggle_shortcut: settings
                 .toggle_shortcut
-                .unwrap_or_else(DictationShortcutSetting::control_option_space),
+                .map(|shortcut| shortcut.normalized_or_default(DictationShortcutKind::Toggle))
+                .unwrap_or_else(DictationShortcutSetting::control_option_t),
             microphone: settings.microphone.unwrap_or(microphone),
             style: settings.style.unwrap_or_default(),
         })
@@ -213,15 +215,16 @@ impl<'de> Deserialize<'de> for DictationShortcutSetting {
 }
 
 impl DictationShortcutSetting {
-    fn bare_fn() -> Self {
+    fn control_option_d() -> Self {
         Self {
-            key_code: 0,
-            code: "Fn".to_string(),
+            key_code: 0x02,
+            code: "KeyD".to_string(),
             modifiers: DictationShortcutModifiers {
-                function: true,
+                control: true,
+                option: true,
                 ..DictationShortcutModifiers::default()
             },
-            label: "Fn".to_string(),
+            label: "Ctrl+Opt+D".to_string(),
             press_count: 1,
         }
     }
@@ -240,11 +243,46 @@ impl DictationShortcutSetting {
         }
     }
 
+    fn control_option_t() -> Self {
+        Self {
+            key_code: 0x11,
+            code: "KeyT".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                option: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+Opt+T".to_string(),
+            press_count: 1,
+        }
+    }
+
     fn same_trigger_as(&self, other: &Self) -> bool {
         self.key_code == other.key_code
             && self.code == other.code
             && self.modifiers == other.modifiers
             && self.press_count == other.press_count
+    }
+
+    fn normalized_or_default(mut self, kind: DictationShortcutKind) -> Self {
+        let Some(key_code) = key_code_for_code(&self.code) else {
+            return default_shortcut_for_kind(kind);
+        };
+        if !self.modifiers.has_any() || self.is_bare_fn() {
+            return default_shortcut_for_kind(kind);
+        }
+        self.key_code = key_code;
+        if kind == DictationShortcutKind::Toggle
+            && self.same_trigger_as(&DictationShortcutSetting::control_option_space())
+        {
+            return DictationShortcutSetting::control_option_t();
+        }
+        self.press_count = if self.press_count == 2 { 2 } else { 1 };
+        self
+    }
+
+    fn is_bare_fn(&self) -> bool {
+        is_bare_fn_input(&self.code, &self.modifiers)
     }
 }
 
@@ -256,6 +294,12 @@ pub struct DictationShortcutModifiers {
     pub option: bool,
     pub shift: bool,
     pub function: bool,
+}
+
+impl DictationShortcutModifiers {
+    fn has_any(&self) -> bool {
+        self.command || self.control || self.option || self.shift || self.function
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -378,27 +422,14 @@ impl DictationShortcutInput {
 
         let press_count = 1;
 
-        if is_bare_fn_input(&self.code, &self.modifiers) {
-            return Ok(DictationShortcutSetting {
-                press_count,
-                label: "Fn".to_string(),
-                ..DictationShortcutSetting::bare_fn()
-            });
-        }
-
         let key_code = key_code_for_code(&self.code).ok_or_else(|| {
             AppError::new(
                 "dictation_shortcut_unsupported",
-                "Shortcut key is not supported.",
+                "Shortcut must include a supported non-modifier key.",
             )
         })?;
 
-        let has_modifier = self.modifiers.command
-            || self.modifiers.control
-            || self.modifiers.option
-            || self.modifiers.shift
-            || self.modifiers.function;
-        if !has_modifier {
+        if !self.modifiers.has_any() {
             return Err(AppError::new(
                 "dictation_shortcut_modifier_required",
                 "Shortcut must include at least one modifier key.",
@@ -421,7 +452,7 @@ fn is_bare_fn_input(code: &str, modifiers: &DictationShortcutModifiers) -> bool 
 
 fn legacy_shortcut_setting(id: &str) -> Option<DictationShortcutSetting> {
     match id {
-        "bare_fn" | "fn" => Some(DictationShortcutSetting::bare_fn()),
+        "bare_fn" | "fn" => Some(DictationShortcutSetting::control_option_d()),
         "fn_space" => Some(DictationShortcutSetting {
             key_code: 0x31,
             code: "Space".to_string(),
@@ -432,23 +463,20 @@ fn legacy_shortcut_setting(id: &str) -> Option<DictationShortcutSetting> {
             label: "Fn+Space".to_string(),
             press_count: 1,
         }),
-        "control_option_space" => Some(DictationShortcutSetting {
-            key_code: 0x31,
-            code: "Space".to_string(),
-            modifiers: DictationShortcutModifiers {
-                control: true,
-                option: true,
-                ..DictationShortcutModifiers::default()
-            },
-            label: "Ctrl+Opt+Space".to_string(),
-            press_count: 1,
-        }),
+        "control_option_space" => Some(DictationShortcutSetting::control_option_t()),
         _ => None,
     }
 }
 
 fn no_standard_modifiers(modifiers: &DictationShortcutModifiers) -> bool {
     !modifiers.command && !modifiers.control && !modifiers.option && !modifiers.shift
+}
+
+fn default_shortcut_for_kind(kind: DictationShortcutKind) -> DictationShortcutSetting {
+    match kind {
+        DictationShortcutKind::PushToTalk => DictationShortcutSetting::control_option_d(),
+        DictationShortcutKind::Toggle => DictationShortcutSetting::control_option_t(),
+    }
 }
 
 pub fn setup(app: &mut tauri::App) {
@@ -2192,16 +2220,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_settings_use_fn_and_double_fn() {
+    fn default_settings_use_keyboard_shortcuts_without_bare_fn() {
         let settings = DictationSettings::default();
 
         assert_eq!(
             settings.push_to_talk_shortcut,
-            DictationShortcutSetting::bare_fn()
+            DictationShortcutSetting::control_option_d()
         );
         assert_eq!(
             settings.toggle_shortcut,
-            DictationShortcutSetting::control_option_space()
+            DictationShortcutSetting::control_option_t()
         );
         assert_eq!(settings.style, DictationStyle::Standard);
     }
@@ -2215,11 +2243,11 @@ mod tests {
 
         assert_eq!(
             settings.push_to_talk_shortcut,
-            DictationShortcutSetting::bare_fn()
+            DictationShortcutSetting::control_option_d()
         );
         assert_eq!(
             settings.toggle_shortcut,
-            DictationShortcutSetting::control_option_space()
+            DictationShortcutSetting::control_option_t()
         );
         assert_eq!(settings.microphone.id.as_deref(), Some("usb"));
         assert_eq!(settings.microphone.name.as_deref(), Some("USB Mic"));
@@ -2227,28 +2255,54 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_new_shortcut_settings() {
+    fn deserializes_new_shortcut_settings_and_migrates_bare_fn_push_to_talk() {
         let settings: DictationSettings = serde_json::from_str(
             r#"{"pushToTalkShortcut":{"keyCode":0,"code":"Fn","modifiers":{"command":false,"control":false,"option":false,"shift":false,"function":true},"label":"Fn","pressCount":1},"toggleShortcut":{"keyCode":49,"code":"Space","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt+Space","pressCount":1},"microphone":{"id":null,"name":null}}"#,
         )
         .expect("new settings should deserialize");
 
+        assert_eq!(
+            settings.push_to_talk_shortcut,
+            DictationShortcutSetting::control_option_d()
+        );
         assert_eq!(settings.push_to_talk_shortcut.press_count, 1);
         assert_eq!(settings.toggle_shortcut.press_count, 1);
         assert_eq!(settings.style, DictationStyle::Standard);
         assert!(settings
             .toggle_shortcut
-            .same_trigger_as(&DictationShortcutSetting {
-                key_code: 0x31,
-                code: "Space".to_string(),
-                modifiers: DictationShortcutModifiers {
-                    control: true,
-                    option: true,
-                    ..DictationShortcutModifiers::default()
-                },
-                label: "Ctrl+Opt+Space".to_string(),
-                press_count: 1,
-            }));
+            .same_trigger_as(&DictationShortcutSetting::control_option_t()));
+    }
+
+    #[test]
+    fn deserializes_control_letter_and_digit_shortcuts() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"pushToTalkShortcut":{"keyCode":999,"code":"KeyT","modifiers":{"command":false,"control":true,"option":false,"shift":false,"function":false},"label":"Ctrl+T","pressCount":1},"toggleShortcut":{"keyCode":999,"code":"Digit1","modifiers":{"command":false,"control":true,"option":false,"shift":false,"function":false},"label":"Ctrl+1","pressCount":1},"microphone":{"id":null,"name":null}}"#,
+        )
+        .expect("control shortcuts should deserialize");
+
+        assert_eq!(settings.push_to_talk_shortcut.key_code, 0x11);
+        assert_eq!(settings.push_to_talk_shortcut.code, "KeyT");
+        assert_eq!(settings.push_to_talk_shortcut.label, "Ctrl+T");
+        assert_eq!(settings.toggle_shortcut.key_code, 0x12);
+        assert_eq!(settings.toggle_shortcut.code, "Digit1");
+        assert_eq!(settings.toggle_shortcut.label, "Ctrl+1");
+    }
+
+    #[test]
+    fn deserializes_unsupported_modifier_only_shortcuts_to_defaults() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"pushToTalkShortcut":{"keyCode":59,"code":"ControlLeft","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt","pressCount":1},"toggleShortcut":{"keyCode":0,"code":"Fn","modifiers":{"command":false,"control":false,"option":false,"shift":false,"function":true},"label":"Fn","pressCount":1},"microphone":{"id":null,"name":null}}"#,
+        )
+        .expect("settings should deserialize");
+
+        assert_eq!(
+            settings.push_to_talk_shortcut,
+            DictationShortcutSetting::control_option_d()
+        );
+        assert_eq!(
+            settings.toggle_shortcut,
+            DictationShortcutSetting::control_option_t()
+        );
     }
 
     #[test]
@@ -2262,8 +2316,8 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_input_accepts_bare_fn() {
-        let shortcut = DictationShortcutInput {
+    fn shortcut_input_rejects_bare_fn() {
+        let err = DictationShortcutInput {
             code: "Fn".to_string(),
             modifiers: DictationShortcutModifiers {
                 function: true,
@@ -2273,26 +2327,48 @@ mod tests {
             press_count: None,
         }
         .into_setting()
-        .expect("bare Fn should be accepted");
+        .expect_err("bare Fn should be rejected");
 
-        assert_eq!(shortcut, DictationShortcutSetting::bare_fn());
+        assert_eq!(err.code, "dictation_shortcut_unsupported");
     }
 
     #[test]
-    fn shortcut_input_normalizes_double_press_to_single_press() {
+    fn shortcut_input_accepts_control_letter_and_normalizes_press_count() {
         let shortcut = DictationShortcutInput {
-            code: "Fn".to_string(),
+            code: "KeyT".to_string(),
             modifiers: DictationShortcutModifiers {
-                function: true,
+                control: true,
                 ..DictationShortcutModifiers::default()
             },
-            label: "Fn".to_string(),
+            label: "Ctrl+T".to_string(),
             press_count: Some(2),
         }
         .into_setting()
-        .expect("bare Fn should be accepted");
+        .expect("control letter should be accepted");
 
-        assert_eq!(shortcut, DictationShortcutSetting::bare_fn());
+        assert_eq!(shortcut.key_code, 0x11);
+        assert_eq!(shortcut.code, "KeyT");
+        assert!(shortcut.modifiers.control);
+        assert_eq!(shortcut.press_count, 1);
+    }
+
+    #[test]
+    fn shortcut_input_accepts_control_digit() {
+        let shortcut = DictationShortcutInput {
+            code: "Digit1".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+1".to_string(),
+            press_count: Some(1),
+        }
+        .into_setting()
+        .expect("control digit should be accepted");
+
+        assert_eq!(shortcut.key_code, 0x12);
+        assert_eq!(shortcut.code, "Digit1");
+        assert!(shortcut.modifiers.control);
     }
 
     #[test]

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -137,8 +137,8 @@ export function DictationHistoryView({
 
   const groups = useMemo(() => groupHistoryItems(filtered), [filtered]);
 
-  const pushToTalk = settings?.pushToTalkShortcut.label ?? "Fn";
-  const toggle = settings?.toggleShortcut.label ?? "Ctrl+Opt+Space";
+  const pushToTalk = settings?.pushToTalkShortcut.label ?? "Ctrl+Opt+D";
+  const toggle = settings?.toggleShortcut.label ?? "Ctrl+Opt+T";
 
   // Show each optional feature only while it's still unconfigured, and only
   // once we know its state (avoids the card flashing in then vanishing). The

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -98,17 +98,18 @@ const EMPTY_MODIFIERS: DictationShortcutModifiers = {
 
 const DEFAULT_SETTINGS: DictationSettingsDto = {
   pushToTalkShortcut: {
-    code: "Fn",
-    label: "Fn",
+    code: "KeyD",
+    label: "Ctrl+Opt+D",
     pressCount: 1,
     modifiers: {
       ...EMPTY_MODIFIERS,
-      function: true,
+      control: true,
+      option: true,
     },
   },
   toggleShortcut: {
-    code: "Space",
-    label: "Ctrl+Opt+Space",
+    code: "KeyT",
+    label: "Ctrl+Opt+T",
     pressCount: 1,
     modifiers: {
       ...EMPTY_MODIFIERS,
@@ -308,7 +309,8 @@ export function AppSettings({
     }
     if (helperEvent.type === "fn_monitor_unavailable") {
       setStatus(
-        helperEvent.payload?.message ?? "Fn/Globe shortcut is unavailable.",
+        helperEvent.payload?.message ??
+          "Global shortcut monitoring is unavailable.",
       );
       return;
     }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -58,20 +58,20 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const baseSettings: DictationSettingsDto = {
   pushToTalkShortcut: {
-    code: "Space",
-    label: "Fn+Space",
+    code: "KeyD",
+    label: "Ctrl+Opt+D",
     pressCount: 1,
     modifiers: {
       command: false,
-      control: false,
-      option: false,
+      control: true,
+      option: true,
       shift: false,
-      function: true,
+      function: false,
     },
   },
   toggleShortcut: {
-    code: "Space",
-    label: "Ctrl+Opt+Space",
+    code: "KeyT",
+    label: "Ctrl+Opt+T",
     pressCount: 1,
     modifiers: {
       command: false,
@@ -451,14 +451,14 @@ describe("AppSettings", () => {
         type: "shortcut_captured",
         payload: {
           shortcut: {
-            code: "Fn",
-            label: "Fn",
+            code: "KeyT",
+            label: "Ctrl+T",
             modifiers: {
               command: false,
-              control: false,
+              control: true,
               option: false,
               shift: false,
-              function: true,
+              function: false,
             },
             pressCount: 1,
           },
@@ -468,14 +468,14 @@ describe("AppSettings", () => {
 
     await waitFor(() =>
       expect(mocks.setDictationShortcut).toHaveBeenCalledWith("push_to_talk", {
-        code: "Fn",
-        label: "Fn",
+        code: "KeyT",
+        label: "Ctrl+T",
         modifiers: {
           command: false,
-          control: false,
+          control: true,
           option: false,
           shift: false,
-          function: true,
+          function: false,
         },
         pressCount: 1,
       }),
@@ -495,12 +495,12 @@ describe("AppSettings", () => {
         type: "shortcut_captured",
         payload: {
           shortcut: {
-            code: "Space",
-            label: "Ctrl+Opt+Space",
+            code: "Digit1",
+            label: "Ctrl+1",
             modifiers: {
               command: false,
               control: true,
-              option: true,
+              option: false,
               shift: false,
               function: false,
             },
@@ -512,12 +512,12 @@ describe("AppSettings", () => {
 
     await waitFor(() =>
       expect(mocks.setDictationShortcut).toHaveBeenCalledWith("toggle", {
-        code: "Space",
-        label: "Ctrl+Opt+Space",
+        code: "Digit1",
+        label: "Ctrl+1",
         modifiers: {
           command: false,
           control: true,
-          option: true,
+          option: false,
           shift: false,
           function: false,
         },

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -34,20 +34,20 @@ describe("DictationHistoryView", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {
             command: false,
-            control: false,
-            option: false,
+            control: true,
+            option: true,
             shift: false,
-            function: true,
+            function: false,
           },
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {
             command: false,
@@ -92,9 +92,7 @@ describe("DictationHistoryView", () => {
     );
     expect(screen.getByText("Push to talk")).toBeInTheDocument();
     expect(screen.getByText("Hands-free")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("Shortcut Ctrl+Opt+Space"),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Shortcut Ctrl+Opt+T")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Copy" }));
     await waitFor(() =>
@@ -132,14 +130,14 @@ describe("DictationHistoryView", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {},
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {},
         },
@@ -165,14 +163,14 @@ describe("DictationHistoryView", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {},
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {},
         },

--- a/src/test/style-settings.test.tsx
+++ b/src/test/style-settings.test.tsx
@@ -19,20 +19,20 @@ describe("StyleSettingsSection", () => {
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {
-          code: "Fn",
-          label: "Fn",
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
           pressCount: 1,
           modifiers: {
             command: false,
-            control: false,
-            option: false,
+            control: true,
+            option: true,
             shift: false,
-            function: true,
+            function: false,
           },
         },
         toggleShortcut: {
-          code: "Space",
-          label: "Ctrl+Opt+Space",
+          code: "KeyT",
+          label: "Ctrl+Opt+T",
           pressCount: 1,
           modifiers: {
             command: false,


### PR DESCRIPTION
## Summary
- Change dictation defaults to real Control+Option letter chords: push-to-talk `Ctrl+Opt+D`, toggle `Ctrl+Opt+T`.
- Reject modifier-only/bare Fn shortcut capture and backend customization, while keeping supported non-modifier chords such as Control+letters/numbers.
- Normalize legacy broken saved defaults (`Fn`, modifier-only, old `Ctrl+Opt+Space` toggle) to usable defaults and update UI/docs/tests.

## Checks
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml dictation::tests:: --lib`
- `pnpm run lint`
- `pnpm exec vitest run src/test/app-settings.test.tsx src/test/dictation-history.test.tsx src/test/style-settings.test.tsx`
- `pnpm exec prettier --check README.md src/components/settings/AppSettings.tsx src/components/dictation/DictationHistoryView.tsx src/test/app-settings.test.tsx src/test/dictation-history.test.tsx src/test/style-settings.test.tsx`
- `swiftc -framework Foundation -framework AppKit -framework AVFoundation -framework Carbon -framework CoreMedia -framework CoreGraphics src-tauri/native/mac-dictation-helper/main.swift -o /tmp/os-scribe-dictation-helper-test`