### PR TITLE
[codex] Add default transcription language setting

### DIFF
--- a/scribe-api/crates/api/src/handlers/dictate.rs
+++ b/scribe-api/crates/api/src/handlers/dictate.rs
@@ -42,6 +42,12 @@ pub(crate) async fn transcribe(
         context.as_deref(),
         validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
     )?;
+    let language = form.optional_text("language");
+    validation::validate_optional_text_len(
+        "language",
+        language.as_deref(),
+        validation::MAX_LANGUAGE_CHARS,
+    )?;
     let filename = form
         .take_filename()
         .unwrap_or_else(|| "dictation.wav".to_string());
@@ -54,6 +60,7 @@ pub(crate) async fn transcribe(
             audio,
             filename,
             context,
+            language,
             model_id: ModelId(model_id),
         })
         .await?;

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -34,6 +34,12 @@ pub(crate) async fn transcribe(
         context.as_deref(),
         validation::MAX_TRANSCRIPTION_CONTEXT_CHARS,
     )?;
+    let language = form.optional_text("language");
+    validation::validate_optional_text_len(
+        "language",
+        language.as_deref(),
+        validation::MAX_LANGUAGE_CHARS,
+    )?;
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;
     let filename = form
@@ -48,6 +54,7 @@ pub(crate) async fn transcribe(
             filename,
             title,
             context,
+            language,
             model_id: ModelId(model_id),
         })
         .await?;

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -116,6 +116,7 @@ pub struct TranscriptionRequest {
     pub filename: String,
     pub title: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub model: ModelId,
 }
 

--- a/scribe-api/crates/providers/src/openai.rs
+++ b/scribe-api/crates/providers/src/openai.rs
@@ -46,6 +46,14 @@ impl Transcriber for OpenAiTranscriber {
         {
             form = form.text("prompt", prompt.to_string());
         }
+        if let Some(language) = request
+            .language
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            form = form.text("language", language.to_string());
+        }
         let response = self
             .http
             .post(&url)

--- a/scribe-api/crates/providers/src/routing.rs
+++ b/scribe-api/crates/providers/src/routing.rs
@@ -45,7 +45,7 @@ mod tests {
     use serde_json::json;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{header, method, path},
+        matchers::{body_string_contains, header, method, path},
     };
 
     #[tokio::test]
@@ -54,6 +54,8 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/audio/transcriptions"))
             .and(header("authorization", "Bearer openai_key"))
+            .and(body_string_contains(r#"name="language""#))
+            .and(body_string_contains("es"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "text": "Transcribed text"
             })))
@@ -80,6 +82,7 @@ mod tests {
                 filename: "recording.wav".to_string(),
                 title: "Title".to_string(),
                 context: Some("Prompt context".to_string()),
+                language: Some("es".to_string()),
                 model: ModelId("gpt-4o-mini-transcribe".to_string()),
             })
             .await;

--- a/scribe-api/crates/services/src/dictate.rs
+++ b/scribe-api/crates/services/src/dictate.rs
@@ -77,6 +77,7 @@ impl DictateService {
                 filename: params.filename,
                 title: "Dictation".to_string(),
                 context: params.context,
+                language: params.language,
                 model: params.model_id.clone(),
             })
             .await?;
@@ -158,6 +159,7 @@ pub struct DictateTranscribeParams {
     pub audio: Vec<u8>,
     pub filename: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub model_id: ModelId,
 }
 

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -179,6 +179,7 @@ mod tests {
                 audio: vec![1, 2, 3],
                 filename: "dictation.wav".to_string(),
                 context: Some("Writing style: formal.".to_string()),
+                language: Some("es".to_string()),
                 model_id: ModelId("audio-model".to_string()),
             })
             .await
@@ -193,6 +194,7 @@ mod tests {
             transcriber.last_context(),
             Some("Writing style: formal.".to_string())
         );
+        assert_eq!(transcriber.last_language(), Some("es".to_string()));
         assert_eq!(
             wait_for_charge_idempotency_key(&os_accounts).await,
             Some("dictate_transcribe:usr_123:session_1:utt_2".to_string())
@@ -497,11 +499,19 @@ mod tests {
     #[derive(Default)]
     struct RecordingTranscriber {
         last_context: Mutex<Option<String>>,
+        last_language: Mutex<Option<String>>,
     }
 
     impl RecordingTranscriber {
         fn last_context(&self) -> Option<String> {
             self.last_context
+                .lock()
+                .ok()
+                .and_then(|value| value.clone())
+        }
+
+        fn last_language(&self) -> Option<String> {
+            self.last_language
                 .lock()
                 .ok()
                 .and_then(|value| value.clone())
@@ -516,6 +526,9 @@ mod tests {
         ) -> Result<Transcript, DomainError> {
             if let Ok(mut last_context) = self.last_context.lock() {
                 *last_context = request.context;
+            }
+            if let Ok(mut last_language) = self.last_language.lock() {
+                *last_language = request.language;
             }
             Ok(Transcript {
                 text: "Transcript".to_string(),

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -91,6 +91,7 @@ impl NoteTranscribeService {
                 filename: params.filename,
                 title: params.title,
                 context: params.context,
+                language: params.language,
                 model: params.model_id.clone(),
             })
             .await?;
@@ -131,6 +132,7 @@ pub struct NoteTranscribeParams {
     pub filename: String,
     pub title: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub model_id: ModelId,
 }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -14,7 +14,7 @@ use std::{
     io::{BufRead, BufReader, Write},
     path::PathBuf,
     process::{Child, ChildStdin, Command, Stdio},
-    sync::Mutex,
+    sync::{Mutex, OnceLock},
     thread,
     time::Duration,
 };
@@ -26,6 +26,8 @@ const DICTATION_TRANSCRIPTION_CONTEXT: &str = "Transcribe this as clean hands-fr
 const DICTATION_CLEANUP_TIMEOUT_MS: u64 = 15_000;
 const DICTATION_AUDIO_ACTIVITY_THRESHOLD: f32 = 0.04;
 const DICTATION_EVENT_LOG: &str = "dictation-events.log";
+
+static SETTINGS_CACHE: OnceLock<Mutex<DictationSettings>> = OnceLock::new();
 
 pub struct HelperProcess {
     child: Child,
@@ -79,6 +81,13 @@ pub struct HudHoverState {
     last_passthrough: std::sync::atomic::AtomicBool,
 }
 
+pub fn configured_transcription_language() -> Option<String> {
+    settings_store()
+        .lock()
+        .ok()
+        .and_then(|settings| settings.language.clone())
+}
+
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DictationSettings {
@@ -86,6 +95,7 @@ pub struct DictationSettings {
     pub toggle_shortcut: DictationShortcutSetting,
     pub microphone: DictationMicrophoneSetting,
     pub style: DictationStyle,
+    pub language: Option<String>,
 }
 
 impl Default for DictationSettings {
@@ -95,6 +105,7 @@ impl Default for DictationSettings {
             toggle_shortcut: DictationShortcutSetting::control_option_space(),
             microphone: DictationMicrophoneSetting::default(),
             style: DictationStyle::Standard,
+            language: None,
         }
     }
 }
@@ -111,6 +122,7 @@ impl<'de> Deserialize<'de> for DictationSettings {
             toggle_shortcut: Option<DictationShortcutSetting>,
             microphone: Option<DictationMicrophoneSetting>,
             style: Option<DictationStyle>,
+            language: Option<String>,
         }
 
         let value = serde_json::Value::deserialize(deserializer)?;
@@ -139,6 +151,7 @@ impl<'de> Deserialize<'de> for DictationSettings {
                 .unwrap_or_else(DictationShortcutSetting::control_option_space),
             microphone: settings.microphone.unwrap_or(microphone),
             style: settings.style.unwrap_or_default(),
+            language: normalize_language(settings.language),
         })
     }
 }
@@ -607,6 +620,17 @@ pub fn set_dictation_style(
 }
 
 #[tauri::command]
+pub fn set_dictation_language(
+    state: State<'_, DictationSettingsState>,
+    language: Option<String>,
+) -> Result<DictationSettings, AppError> {
+    let language = normalize_language(language);
+    update_settings(&state, |settings| {
+        settings.language = language;
+    })
+}
+
+#[tauri::command]
 pub fn dictation_helper_command(
     state: State<'_, HelperState>,
     command: serde_json::Value,
@@ -1025,6 +1049,7 @@ fn settings_path(app: &AppHandle) -> Option<PathBuf> {
 fn manage_settings(app: &AppHandle) {
     let path = settings_path(app).unwrap_or_else(|| PathBuf::from("dictation-settings.json"));
     let settings = load_settings(app);
+    replace_current_settings(settings.clone());
     app.manage(DictationSettingsState {
         path,
         settings: Mutex::new(settings),
@@ -1042,6 +1067,27 @@ fn load_settings(app: &AppHandle) -> DictationSettings {
         .unwrap_or_default()
 }
 
+fn normalize_language(language: Option<String>) -> Option<String> {
+    language
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| {
+            value.len() == 2
+                && value
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase())
+        })
+}
+
+fn settings_store() -> &'static Mutex<DictationSettings> {
+    SETTINGS_CACHE.get_or_init(|| Mutex::new(DictationSettings::default()))
+}
+
+fn replace_current_settings(settings: DictationSettings) {
+    if let Ok(mut current) = settings_store().lock() {
+        *current = settings;
+    }
+}
+
 fn update_settings(
     state: &DictationSettingsState,
     update: impl FnOnce(&mut DictationSettings),
@@ -1052,6 +1098,7 @@ fn update_settings(
         .map_err(|_| AppError::new("dictation_settings_unavailable", "Settings lock failed."))?;
     update(&mut settings);
     save_settings(state, &settings)?;
+    replace_current_settings(settings.clone());
     Ok(settings.clone())
 }
 
@@ -1243,9 +1290,9 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
         }
     };
     let provider_for_cleanup = provider.clone();
-    let style = current_dictation_settings(&app)
-        .map(|settings| settings.style)
-        .unwrap_or_default();
+    let current_settings = current_dictation_settings(&app).unwrap_or_default();
+    let style = current_settings.style;
+    let language = current_settings.language;
     let dictionary_context = dictionary_context_for_app(&app).await;
     let session_id = dictation_session_id();
     let utterance_id = uuid::Uuid::new_v4().to_string();
@@ -1256,6 +1303,7 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     let result = dictate_transcribe(DictateTranscribeRequest {
         audio_path: recording.audio_path,
         context: transcription_context,
+        language,
         session_id: session_id.clone(),
         utterance_id: utterance_id.clone(),
     })
@@ -2204,6 +2252,7 @@ mod tests {
             DictationShortcutSetting::control_option_space()
         );
         assert_eq!(settings.style, DictationStyle::Standard);
+        assert_eq!(settings.language, None);
     }
 
     #[test]
@@ -2224,6 +2273,7 @@ mod tests {
         assert_eq!(settings.microphone.id.as_deref(), Some("usb"));
         assert_eq!(settings.microphone.name.as_deref(), Some("USB Mic"));
         assert_eq!(settings.style, DictationStyle::Standard);
+        assert_eq!(settings.language, None);
     }
 
     #[test]
@@ -2236,6 +2286,7 @@ mod tests {
         assert_eq!(settings.push_to_talk_shortcut.press_count, 1);
         assert_eq!(settings.toggle_shortcut.press_count, 1);
         assert_eq!(settings.style, DictationStyle::Standard);
+        assert_eq!(settings.language, None);
         assert!(settings
             .toggle_shortcut
             .same_trigger_as(&DictationShortcutSetting {
@@ -2259,6 +2310,26 @@ mod tests {
         .expect("style settings should deserialize");
 
         assert_eq!(settings.style, DictationStyle::CasualLowercase);
+    }
+
+    #[test]
+    fn deserializes_default_transcription_language() {
+        let settings: DictationSettings = serde_json::from_str(
+            r#"{"pushToTalkShortcut":{"keyCode":0,"code":"Fn","modifiers":{"command":false,"control":false,"option":false,"shift":false,"function":true},"label":"Fn","pressCount":1},"toggleShortcut":{"keyCode":49,"code":"Space","modifiers":{"command":false,"control":true,"option":true,"shift":false,"function":false},"label":"Ctrl+Opt+Space","pressCount":1},"microphone":{"id":null,"name":null},"language":"ES"}"#,
+        )
+        .expect("language settings should deserialize");
+
+        assert_eq!(settings.language.as_deref(), Some("es"));
+    }
+
+    #[test]
+    fn ignores_invalid_default_transcription_language() {
+        assert_eq!(normalize_language(Some("english".to_string())), None);
+        assert_eq!(normalize_language(Some(" e ".to_string())), None);
+        assert_eq!(
+            normalize_language(Some(" en ".to_string())).as_deref(),
+            Some("en")
+        );
     }
 
     #[test]
@@ -2351,6 +2422,7 @@ mod tests {
             },
             microphone: DictationMicrophoneSetting::default(),
             style: DictationStyle::Standard,
+            language: None,
         };
 
         assert!(validate_shortcut_update(

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -856,6 +856,7 @@ async fn transcribe_prepared_audio(
     transcriber: TurnTranscriber,
     request: TranscribePreparedAudioRequest,
 ) -> Result<TranscriptionProviderResult, AppError> {
+    let request_language = crate::dictation::configured_transcription_language();
     let chunk_dir = request.temp_dir.join("chunks");
     let audio_paths = if request.audio_path.exists() {
         split_wav_for_transcription(&request.audio_path, &chunk_dir, &request.chunk_stem)?
@@ -868,6 +869,7 @@ async fn transcribe_prepared_audio(
             audio_path: audio_paths.into_iter().next().unwrap_or(request.audio_path),
             title: request.title,
             context: request.base_context,
+            language: request_language,
             operation_id: Some(request.operation_id),
         })
         .await;
@@ -887,6 +889,7 @@ async fn transcribe_prepared_audio(
             audio_path,
             title: request.title.clone(),
             context,
+            language: request_language.clone(),
             operation_id: Some(format!("{}-chunk-{index}", request.operation_id)),
         })
         .await?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
             dictation::set_dictation_shortcut,
             dictation::set_dictation_microphone,
             dictation::set_dictation_style,
+            dictation::set_dictation_language,
             dictation::dictation_helper_command,
             dictation::dictation_hud_set_stop_bounds,
             dictation::dictation_hud_set_pill_bounds,

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -29,6 +29,7 @@ pub struct TranscriptionRequest {
     pub audio_path: PathBuf,
     pub title: String,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub operation_id: Option<String>,
 }
 
@@ -84,6 +85,7 @@ pub struct GenerationProviderResult {
 pub struct DictateTranscribeRequest {
     pub audio_path: PathBuf,
     pub context: Option<String>,
+    pub language: Option<String>,
     pub session_id: String,
     pub utterance_id: String,
 }
@@ -196,6 +198,9 @@ pub async fn transcribe_saved_audio(
     {
         form = form.text("context", context.to_string());
     }
+    if let Some(language) = normalized_language(request.language.as_deref()) {
+        form = form.text("language", language.to_string());
+    }
     let response: TranscribeResponse = post_multipart("/v1/notes/transcribe", form).await?;
     Ok(TranscriptionProviderResult {
         text: response.text,
@@ -252,11 +257,23 @@ pub async fn dictate_transcribe(
     {
         form = form.text("context", context.to_string());
     }
+    if let Some(language) = normalized_language(request.language.as_deref()) {
+        form = form.text("language", language.to_string());
+    }
     let response: TranscribeResponse = post_multipart("/v1/dictate", form).await?;
     Ok(TranscriptionProviderResult {
         text: response.text,
         language: response.language,
         provider: response.provider,
+    })
+}
+
+fn normalized_language(language: Option<&str>) -> Option<&str> {
+    language.map(str::trim).filter(|value| {
+        value.len() == 2
+            && value
+                .chars()
+                .all(|character| character.is_ascii_lowercase())
     })
 }
 

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -16,6 +16,7 @@ import {
   dictationSettings,
   listVeniceModels,
   providerModelSettings,
+  setDictationLanguage,
   setDictationMicrophone,
   setDictationShortcut,
   setVeniceModel,
@@ -118,7 +119,22 @@ const DEFAULT_SETTINGS: DictationSettingsDto = {
   },
   microphone: {},
   style: "standard",
+  language: undefined,
 };
+
+const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
+  { value: "", label: "Auto-detect" },
+  { value: "en", label: "English" },
+  { value: "es", label: "Spanish" },
+  { value: "fr", label: "French" },
+  { value: "de", label: "German" },
+  { value: "it", label: "Italian" },
+  { value: "pt", label: "Portuguese" },
+  { value: "nl", label: "Dutch" },
+  { value: "ja", label: "Japanese" },
+  { value: "ko", label: "Korean" },
+  { value: "zh", label: "Chinese" },
+];
 
 const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionProvider: "venice",
@@ -420,6 +436,20 @@ export function AppSettings({
     }
   }
 
+  async function selectLanguage(language: string) {
+    try {
+      const next = await setDictationLanguage(language || undefined);
+      setSettings(next);
+      setStatus(
+        language
+          ? `Default transcription language set to ${languageLabel(language)}.`
+          : "Default transcription language set to auto-detect.",
+      );
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
+
   const microphoneName = settings.microphone.name ?? "Auto-detect";
   const microphoneOptions = [
     { id: undefined, name: "Auto-detect" },
@@ -579,6 +609,35 @@ export function AppSettings({
                     onChange={() => void startShortcutCapture("toggle")}
                     onCancel={() => void cancelShortcutCapture()}
                   />
+
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Language</h3>
+                      <p className="settings-row-description">
+                        Default language hint for note transcription and
+                        dictation.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <select
+                        className="select-trigger settings-language-select"
+                        aria-label="Default transcription language"
+                        value={settings.language ?? ""}
+                        onChange={(event) =>
+                          void selectLanguage(event.currentTarget.value)
+                        }
+                      >
+                        {LANGUAGE_OPTIONS.map((option) => (
+                          <option
+                            key={option.value || "auto"}
+                            value={option.value}
+                          >
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
                 </div>
               </div>
             </section>
@@ -1311,6 +1370,12 @@ function shortcutForKind(
   return kind === "toggle"
     ? settings.toggleShortcut
     : settings.pushToTalkShortcut;
+}
+
+function languageLabel(value: string) {
+  return (
+    LANGUAGE_OPTIONS.find((option) => option.value === value)?.label ?? value
+  );
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -102,6 +102,7 @@ export type DictationSettingsDto = {
   toggleShortcut: DictationShortcutSetting;
   microphone: DictationMicrophoneSetting;
   style: DictationStyle;
+  language?: string;
 };
 
 export type DictationSettingsResponse = {
@@ -1005,6 +1006,12 @@ export async function setDictationMicrophone(id?: string, name?: string) {
 
 export async function setDictationStyle(style: DictationStyle) {
   return invoke<DictationSettingsDto>("set_dictation_style", { style });
+}
+
+export async function setDictationLanguage(language?: string) {
+  return invoke<DictationSettingsDto>("set_dictation_language", {
+    language: language || undefined,
+  });
 }
 
 export async function dictationHelperCommand(command: Record<string, unknown>) {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   openPrivacySettings: vi.fn(),
   setDictationShortcut: vi.fn(),
   setDictationMicrophone: vi.fn(),
+  setDictationLanguage: vi.fn(),
   osAccountsLogin: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
@@ -25,6 +26,10 @@ const mocks = vi.hoisted(() => ({
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
   updateHermesBridgeMessagingPlatform: vi.fn(),
+  listDictionaryEntries: vi.fn(),
+  createDictionaryEntry: vi.fn(),
+  updateDictionaryEntry: vi.fn(),
+  deleteDictionaryEntry: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
@@ -38,6 +43,7 @@ vi.mock("../lib/tauri", () => ({
   openPrivacySettings: mocks.openPrivacySettings,
   setDictationShortcut: mocks.setDictationShortcut,
   setDictationMicrophone: mocks.setDictationMicrophone,
+  setDictationLanguage: mocks.setDictationLanguage,
   osAccountsLogin: mocks.osAccountsLogin,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
@@ -50,6 +56,10 @@ vi.mock("../lib/tauri", () => ({
   toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform:
     mocks.updateHermesBridgeMessagingPlatform,
+  listDictionaryEntries: mocks.listDictionaryEntries,
+  createDictionaryEntry: mocks.createDictionaryEntry,
+  updateDictionaryEntry: mocks.updateDictionaryEntry,
+  deleteDictionaryEntry: mocks.deleteDictionaryEntry,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -83,6 +93,7 @@ const baseSettings: DictationSettingsDto = {
   },
   microphone: {},
   style: "standard",
+  language: undefined,
 };
 
 const signedInAccount = {
@@ -102,6 +113,11 @@ describe("AppSettings", () => {
     vi.clearAllMocks();
     mocks.eventHandler = undefined;
     mocks.dictationSettings.mockResolvedValue({ settings: baseSettings });
+    mocks.setDictationLanguage.mockImplementation(async (language) => ({
+      ...baseSettings,
+      language,
+    }));
+    mocks.listDictionaryEntries.mockResolvedValue([]);
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
         transcriptionProvider: "venice",
@@ -319,6 +335,32 @@ describe("AppSettings", () => {
       screen.getByRole("switch", { name: "Capture system audio for notes" }),
     );
     expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+  });
+
+  it("saves the default transcription language", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Dictation" }));
+    const language = await screen.findByRole("combobox", {
+      name: "Default transcription language",
+    });
+
+    await user.selectOptions(language, "es");
+
+    expect(mocks.setDictationLanguage).toHaveBeenCalledWith("es");
+    await waitFor(() => expect(language).toHaveValue("es"));
   });
 
   it("lists system permissions with status and manage actions", async () => {


### PR DESCRIPTION
## Summary
- Add a persisted default transcription language setting in Dictation settings, with auto-detect as the default.
- Forward the selected language through note and dictation transcription requests.
- Pass the language form field to OpenAI transcription providers where language hints are supported.

## Validation
- `pnpm test`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec prettier --check src/components/settings/AppSettings.tsx src/lib/tauri.ts src/test/app-settings.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo +1.95.0 test --manifest-path scribe-api/Cargo.toml`

Note: full `pnpm run format` currently reports pre-existing formatting issues in `src/lib/hermes-adapter.ts` and `src/test/app-meeting-start.test.tsx`; those files are unrelated to this change and were left untouched.