### PR TITLE
[codex] Fix transcript status flicker

### DIFF
--- a/src/app/state/app-state.ts
+++ b/src/app/state/app-state.ts
@@ -3,6 +3,7 @@ import type {
   FolderDto,
   NoteDto,
   NoteListItemDto,
+  ProcessingStatus,
   RecoverableRecordingDto,
   RecordingStatusDto,
 } from "../../lib/tauri";
@@ -65,14 +66,14 @@ export function notesReducer(
         selectedNoteId: action.note.id,
         selectedNote: action.note,
       };
-    case "noteUpdated":
+    case "noteUpdated": {
+      const note = mergeNoteUpdate(state, action.note);
       return {
-        ...upsertNote(state, action.note),
+        ...upsertNote(state, note),
         selectedNote:
-          state.selectedNoteId === action.note.id
-            ? action.note
-            : state.selectedNote,
+          state.selectedNoteId === note.id ? note : state.selectedNote,
       };
+    }
     case "recordingStatusChanged":
       return {
         ...state,
@@ -151,6 +152,68 @@ export function notesReducer(
       };
     default:
       return state;
+  }
+}
+
+function mergeNoteUpdate(state: NotesState, note: NoteDto): NoteDto {
+  const current =
+    state.selectedNote?.id === note.id
+      ? state.selectedNote
+      : state.notes.find((item) => item.id === note.id);
+  if (!current) return note;
+
+  const processingStatus = mergeProcessingStatus(
+    current.processingStatus,
+    note.processingStatus,
+  );
+  if (processingStatus === note.processingStatus) return note;
+
+  return {
+    ...note,
+    processingStatus,
+  };
+}
+
+function mergeProcessingStatus(
+  current: ProcessingStatus,
+  incoming: ProcessingStatus,
+): ProcessingStatus {
+  if (isTerminalProcessingStatus(incoming)) {
+    return incoming;
+  }
+  if (isTerminalProcessingStatus(current)) return current;
+
+  const currentRank = activeProcessingRank(current);
+  const incomingRank = activeProcessingRank(incoming);
+  if (
+    currentRank >= activeProcessingRank("transcribing") &&
+    incomingRank >= 0 &&
+    incomingRank < currentRank
+  ) {
+    return current;
+  }
+
+  return incoming;
+}
+
+function isTerminalProcessingStatus(status: ProcessingStatus): boolean {
+  return status === "ready" || status === "failed" || status === "recoverable";
+}
+
+function activeProcessingRank(status: ProcessingStatus): number {
+  switch (status) {
+    case "draft":
+      return 0;
+    case "recording":
+      return 1;
+    case "validating":
+      return 2;
+    case "transcribing":
+      return 3;
+    case "generating":
+      return 4;
+    default:
+      return -1;
   }
 }
 

--- a/src/test/app-state.test.ts
+++ b/src/test/app-state.test.ts
@@ -66,6 +66,94 @@ describe("notesReducer", () => {
     expect(state.selectedNote?.editedContent).toBe("Clean notes");
   });
 
+  it("keeps optimistic transcribing status when a stale validating note arrives", () => {
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        processingStatus: "transcribing",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteUpdated",
+      note: note({
+        id: "note-1",
+        title: "Server title",
+        processingStatus: "validating",
+      }),
+    });
+
+    expect(state.selectedNote?.title).toBe("Server title");
+    expect(state.selectedNote?.processingStatus).toBe("transcribing");
+    expect(state.notes[0].processingStatus).toBe("transcribing");
+  });
+
+  it("does not move generating backward when polling responses finish out of order", () => {
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        processingStatus: "generating",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteUpdated",
+      note: note({
+        id: "note-1",
+        processingStatus: "transcribing",
+      }),
+    });
+
+    expect(state.selectedNote?.processingStatus).toBe("generating");
+    expect(state.notes[0].processingStatus).toBe("generating");
+  });
+
+  it("accepts terminal processing statuses after optimistic transcribing", () => {
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        processingStatus: "transcribing",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteUpdated",
+      note: note({
+        id: "note-1",
+        processingStatus: "failed",
+        lastError: "Transcription failed",
+      }),
+    });
+
+    expect(state.selectedNote?.processingStatus).toBe("failed");
+    expect(state.selectedNote?.lastError).toBe("Transcription failed");
+  });
+
+  it("does not move a terminal note backward after stale active polling", () => {
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        processingStatus: "ready",
+        generatedContent: "Finished notes",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteUpdated",
+      note: note({
+        id: "note-1",
+        processingStatus: "transcribing",
+      }),
+    });
+
+    expect(state.selectedNote?.processingStatus).toBe("ready");
+    expect(state.notes[0].processingStatus).toBe("ready");
+  });
+
   it("tracks recording status transitions without changing selected note", () => {
     const initial = notesReducer(createInitialState(), {
       type: "noteLoaded",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -23,7 +23,11 @@ if (!document.elementFromPoint) {
   document.elementFromPoint = () => document.body;
 }
 
-if (!("localStorage" in globalThis) || !globalThis.localStorage) {
+if (
+  !("localStorage" in globalThis) ||
+  !globalThis.localStorage ||
+  typeof globalThis.localStorage.clear !== "function"
+) {
   const values = new Map<string, string>();
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,


### PR DESCRIPTION
This fixes a long-recording UI race where stale note polling could replace optimistic or completed processing state with an older active status, making the processing banner flash off and back on.

The reducer now preserves forward processing progress and terminal states while still accepting terminal backend updates, with regression tests for stale validating, out-of-order polling, and stale active polls after `ready`.

The test setup also handles partial `localStorage` implementations so dictation-history tests run reliably in this environment.

Validated with `pnpm exec vitest run src/test/app-state.test.ts`, `pnpm exec vitest run src/test/dictation-history.test.tsx`, `pnpm run lint`, and an isolated `pnpm exec vitest run src/test/hud-meeting.test.ts`; full `pnpm test` previously surfaced an order-dependent HUD test failure unrelated to this diff.