### PR TITLE
[codex] add indonesian transcription language

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -129,6 +129,7 @@ const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
   { value: "es", label: "Spanish" },
   { value: "fr", label: "French" },
   { value: "de", label: "German" },
+  { value: "id", label: "Indonesian" },
   { value: "it", label: "Italian" },
   { value: "pt", label: "Portuguese" },
   { value: "nl", label: "Dutch" },

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -357,10 +357,10 @@ describe("AppSettings", () => {
       name: "Default transcription language",
     });
 
-    await user.selectOptions(language, "es");
+    await user.selectOptions(language, "id");
 
-    expect(mocks.setDictationLanguage).toHaveBeenCalledWith("es");
-    await waitFor(() => expect(language).toHaveValue("es"));
+    expect(mocks.setDictationLanguage).toHaveBeenCalledWith("id");
+    await waitFor(() => expect(language).toHaveValue("id"));
   });
 
   it("lists system permissions with status and manage actions", async () => {


### PR DESCRIPTION
## Summary
- Add Indonesian (`id`) to the default transcription language selector.
- Update the settings test to verify saving the Indonesian language option.

## Impact
Users can now choose Indonesian as the language hint for note transcription and dictation.

## Validation
- `pnpm test src/test/app-settings.test.tsx`