### PR TITLE
[codex] Retry sidebar agent session hydration

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -58,6 +58,9 @@ type MenuState = {
 };
 
 const AGENT_SIDEBAR_SESSION_LIMIT = 12;
+const AGENT_SIDEBAR_SESSION_RETRY_DELAYS_MS = [
+  250, 500, 1000, 2000, 4000, 8000, 16000, 32000,
+];
 
 export function Sidebar({
   notes,
@@ -136,21 +139,38 @@ export function Sidebar({
 
   useEffect(() => {
     let cancelled = false;
-    listHermesSessions({ limit: AGENT_SIDEBAR_SESSION_LIMIT })
-      .then((sessions) => {
-        if (!cancelled) {
-          setAgentSessions((current) =>
-            current.length > 0 ? current : sessions,
-          );
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
+    let retryTimeout: number | undefined;
+
+    function loadAgentSessions(attempt: number) {
+      listHermesSessions({ limit: AGENT_SIDEBAR_SESSION_LIMIT })
+        .then((sessions) => {
+          if (!cancelled) {
+            setAgentSessions((current) =>
+              current.length > 0 ? current : sessions,
+            );
+          }
+        })
+        .catch(() => {
+          if (cancelled) return;
+          const retryDelay = AGENT_SIDEBAR_SESSION_RETRY_DELAYS_MS[attempt];
+          if (retryDelay != null) {
+            retryTimeout = window.setTimeout(
+              () => loadAgentSessions(attempt + 1),
+              retryDelay,
+            );
+            return;
+          }
           setAgentSessions((current) => (current.length > 0 ? current : []));
-        }
-      });
+        });
+    }
+
+    loadAgentSessions(0);
+
     return () => {
       cancelled = true;
+      if (retryTimeout != null) {
+        window.clearTimeout(retryTimeout);
+      }
     };
   }, []);
 

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -136,6 +136,56 @@ describe("folders UI", () => {
     );
   });
 
+  it("retries initial agent session hydration when the bridge is still starting", async () => {
+    vi.useFakeTimers();
+    try {
+      hermesMocks.listHermesSessions
+        .mockRejectedValueOnce({
+          code: "hermes_bridge_not_running",
+          message: "Hermes bridge is not running.",
+        })
+        .mockResolvedValueOnce([
+          {
+            id: "session-1",
+            title: "Existing session",
+            preview: "Previous work",
+            last_active: "2026-06-04T19:00:00Z",
+          },
+        ]);
+
+      render(
+        <Sidebar
+          notes={notes}
+          activeView="notes"
+          onChangeView={vi.fn()}
+          onSelectNote={vi.fn()}
+          onDeleteNote={vi.fn()}
+          onOpenMoveDialog={vi.fn()}
+          onRemoveNoteFromFolder={vi.fn()}
+          onNewAgentSession={vi.fn()}
+          onSelectAgentSession={vi.fn()}
+        />,
+      );
+
+      expect(hermesMocks.listHermesSessions).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("No sessions yet")).toBeInTheDocument();
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+        await Promise.resolve();
+      });
+
+      expect(hermesMocks.listHermesSessions).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Existing session")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("marks agent sessions that need input", async () => {
     render(
       <Sidebar


### PR DESCRIPTION
## Summary

Fixes the agent sidebar session list staying empty when the initial session fetch races Hermes bridge startup. The sidebar now retries the initial hydration with bounded backoff while preserving live workspace session updates when they arrive first.

## Root Cause

On app launch, Hermes is started asynchronously. The sidebar also tries to load sessions immediately. If that first list request happens before the bridge is ready, the sidebar catches the error, leaves the list empty, and never retries until another action such as New Session causes the Agent workspace to publish session state.

## Validation

- `pnpm exec vitest run src/test/folders.test.tsx`
- `pnpm test`
- `pnpm run lint`
- `pnpm run build`