### PR TITLE
[codex] Accept wake name variants

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1817,10 +1817,16 @@ fn agent_session_prompt_from_dictation(text: &str) -> Option<String> {
     }
     let after_first = skip_word_separators(after_first);
     let (second, after_second) = take_ascii_word(after_first)?;
-    if !second.eq_ignore_ascii_case("june") {
+    if !is_agent_session_wake_name(second) {
         return None;
     }
     Some(skip_word_separators(after_second).trim().to_string())
+}
+
+fn is_agent_session_wake_name(word: &str) -> bool {
+    ["june", "jun", "joon"]
+        .iter()
+        .any(|variant| word.eq_ignore_ascii_case(variant))
 }
 
 fn take_ascii_word(value: &str) -> Option<(&str, &str)> {
@@ -2768,6 +2774,14 @@ mod tests {
     fn hey_june_detection_requires_first_two_words() {
         assert_eq!(
             agent_session_prompt_from_dictation("Hey June open settings").as_deref(),
+            Some("open settings")
+        );
+        assert_eq!(
+            agent_session_prompt_from_dictation("Hey Jun open settings").as_deref(),
+            Some("open settings")
+        );
+        assert_eq!(
+            agent_session_prompt_from_dictation("Hey Joon open settings").as_deref(),
             Some("open settings")
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- Accept `hey jun` and `hey joon` as agent-session wake phrase variants alongside `hey june`.
- Keep matching scoped to exact second-word wake tokens so phrases like `hey juniper` still do not trigger.
- Add unit coverage for the new variants in the existing dictation wake phrase test.

## Why

Speech transcription can render "June" as "Jun" or "Joon", causing the agent-session trigger to be missed even when the user clearly spoke the intended wake phrase.

## Impact

Users can start an agent session more reliably from dictation when ASR produces common spelling variants of the wake name.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml`