### PR TITLE
[codex] Add agent menu bar status

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }
-tauri = { version = "2.8.0", features = ["macos-private-api"] }
+tauri = { version = "2.8.0", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod dictation;
 pub mod domain;
 pub mod hermes_bridge;
 pub mod meeting_detection;
+pub mod menu_bar;
 pub mod os_accounts;
 pub mod providers;
 pub mod scribe_api;
@@ -134,6 +135,7 @@ pub fn run() {
         .manage(os_accounts::LoginFlow::default())
         .setup(|app| {
             setup_app_menu(app)?;
+            menu_bar::setup(app)?;
             providers::setup(app);
             dictation::setup(app);
             meeting_detection::setup(app);

--- a/src-tauri/src/menu_bar.rs
+++ b/src-tauri/src/menu_bar.rs
@@ -210,12 +210,15 @@ fn show_main_window(app: &AppHandle) {
 
 fn tray_title(state: &AgentMenuBarState) -> String {
     if state.needs_user_count > 0 {
-        return format!("June {}", state.needs_user_count);
+        return counted_status_title("Needs Approval", state.needs_user_count);
     }
     if state.active_count > 0 {
-        return format!("June {}", state.active_count);
+        return counted_status_title("Working...", state.active_count);
     }
-    "June".to_string()
+    if let Some(last_status) = state.last_status.as_ref() {
+        return status_title(&last_status.status).to_string();
+    }
+    "Ready".to_string()
 }
 
 fn tray_tooltip(state: &AgentMenuBarState) -> String {
@@ -226,19 +229,19 @@ fn tray_tooltip(state: &AgentMenuBarState) -> String {
 fn status_label(state: &AgentMenuBarState) -> String {
     if state.needs_user_count > 0 {
         let waiting = pluralize(state.needs_user_count, "session", "sessions");
-        let needs_input = if state.needs_user_count == 1 {
-            "needs input"
+        let needs_approval = if state.needs_user_count == 1 {
+            "needs approval"
         } else {
-            "need input"
+            "need approval"
         };
         if state.active_count > state.needs_user_count {
             let working_count = state.active_count - state.needs_user_count;
             return format!(
-                "{waiting} {needs_input}, {} working",
+                "{waiting} {needs_approval}, {} working",
                 pluralize(working_count, "session", "sessions")
             );
         }
-        return format!("{waiting} {needs_input}");
+        return format!("{waiting} {needs_approval}");
     }
     if state.active_count > 0 {
         return format!(
@@ -278,7 +281,7 @@ fn session_label(session: &AgentMenuBarSession) -> String {
         title
     };
     let prefix = match session.status {
-        AgentMenuBarSessionStatus::WaitingForUser => "Needs input - ",
+        AgentMenuBarSessionStatus::WaitingForUser => "Needs Approval - ",
         AgentMenuBarSessionStatus::Running => "Working - ",
         AgentMenuBarSessionStatus::Idle => "",
     };
@@ -299,11 +302,31 @@ fn readable_status(status: &str) -> &'static str {
         "received" => "Received",
         "starting" => "Starting",
         "running" => "Working",
-        "waitingForUser" => "Needs input",
+        "waitingForUser" => "Needs Approval",
         "completed" => "Completed",
         "failed" => "Failed",
         "cancelled" => "Cancelled",
         _ => "Updated",
+    }
+}
+
+fn status_title(status: &str) -> &'static str {
+    match status {
+        "received" | "starting" => "Starting...",
+        "running" => "Working...",
+        "waitingForUser" => "Needs Approval",
+        "completed" => "Done",
+        "failed" => "Failed",
+        "cancelled" => "Cancelled",
+        _ => "Ready",
+    }
+}
+
+fn counted_status_title(label: &str, count: usize) -> String {
+    if count <= 1 {
+        label.to_string()
+    } else {
+        format!("{label} ({count})")
     }
 }
 
@@ -321,4 +344,46 @@ fn normalize_menu_text(value: &str) -> String {
 
 fn escape_menu_text(value: String) -> String {
     value.replace('&', "&&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tray_title_uses_agent_status_instead_of_brand_name() {
+        assert_eq!(tray_title(&AgentMenuBarState::default()), "Ready");
+        assert_eq!(tray_title(&state(1, 0, None)), "Working...");
+        assert_eq!(tray_title(&state(3, 0, None)), "Working... (3)");
+        assert_eq!(tray_title(&state(1, 1, None)), "Needs Approval");
+        assert_eq!(tray_title(&state(4, 2, None)), "Needs Approval (2)");
+    }
+
+    #[test]
+    fn tray_title_falls_back_to_last_live_status() {
+        assert_eq!(tray_title(&state(0, 0, Some("starting"))), "Starting...");
+        assert_eq!(tray_title(&state(0, 0, Some("running"))), "Working...");
+        assert_eq!(
+            tray_title(&state(0, 0, Some("waitingForUser"))),
+            "Needs Approval"
+        );
+        assert_eq!(tray_title(&state(0, 0, Some("completed"))), "Done");
+    }
+
+    fn state(
+        active_count: usize,
+        needs_user_count: usize,
+        last_status: Option<&str>,
+    ) -> AgentMenuBarState {
+        AgentMenuBarState {
+            active_count,
+            needs_user_count,
+            last_status: last_status.map(|status| AgentMenuBarLastStatus {
+                title: None,
+                status: status.to_string(),
+                summary: None,
+            }),
+            ..AgentMenuBarState::default()
+        }
+    }
 }

--- a/src-tauri/src/menu_bar.rs
+++ b/src-tauri/src/menu_bar.rs
@@ -1,0 +1,324 @@
+use serde::Deserialize;
+use tauri::{
+    menu::{Menu, MenuItem, PredefinedMenuItem},
+    tray::TrayIconBuilder,
+    App, AppHandle, Emitter, Listener, Manager, Runtime,
+};
+
+const TRAY_ID: &str = "agent-menu-bar";
+const AGENT_MENU_BAR_STATE_EVENT: &str = "scribe:menu-bar:agent-state";
+const AGENT_MENU_BAR_NEW_SESSION_EVENT: &str = "scribe:menu-bar:new-agent-session";
+const AGENT_MENU_BAR_OPEN_SESSION_EVENT: &str = "scribe:menu-bar:open-agent-session";
+
+const MENU_SHOW_ID: &str = "agent_menu_bar_show";
+const MENU_NEW_SESSION_ID: &str = "agent_menu_bar_new_session";
+const MENU_QUIT_ID: &str = "agent_menu_bar_quit";
+const MENU_STATUS_ID: &str = "agent_menu_bar_status";
+const MENU_LAST_STATUS_ID: &str = "agent_menu_bar_last_status";
+const MENU_RECENT_SESSIONS_ID: &str = "agent_menu_bar_recent_sessions";
+const MENU_EMPTY_SESSIONS_ID: &str = "agent_menu_bar_empty_sessions";
+const MENU_SESSION_ID_PREFIX: &str = "agent_menu_bar_session:";
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentMenuBarState {
+    #[serde(default)]
+    active_count: usize,
+    #[serde(default)]
+    needs_user_count: usize,
+    #[serde(default)]
+    sessions: Vec<AgentMenuBarSession>,
+    #[serde(default)]
+    last_status: Option<AgentMenuBarLastStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentMenuBarSession {
+    id: String,
+    title: String,
+    #[serde(default)]
+    subtitle: Option<String>,
+    status: AgentMenuBarSessionStatus,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum AgentMenuBarSessionStatus {
+    Idle,
+    Running,
+    WaitingForUser,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentMenuBarLastStatus {
+    #[serde(default)]
+    title: Option<String>,
+    status: String,
+    #[serde(default)]
+    summary: Option<String>,
+}
+
+pub fn setup(app: &mut App) -> tauri::Result<()> {
+    let initial_state = AgentMenuBarState::default();
+    let initial_menu = build_menu(app, &initial_state)?;
+    let mut tray_builder = TrayIconBuilder::with_id(TRAY_ID)
+        .menu(&initial_menu)
+        .title(tray_title(&initial_state))
+        .tooltip(tray_tooltip(&initial_state))
+        .show_menu_on_left_click(true)
+        .on_menu_event(handle_menu_event);
+
+    if let Some(icon) = app.handle().default_window_icon().cloned() {
+        tray_builder = tray_builder.icon(icon).icon_as_template(true);
+    }
+
+    let tray = tray_builder.build(app)?;
+    update_tray(&tray, &initial_state);
+
+    let handle = app.handle().clone();
+    app.listen_any(AGENT_MENU_BAR_STATE_EVENT, move |event| {
+        let Ok(state) = serde_json::from_str::<AgentMenuBarState>(event.payload()) else {
+            return;
+        };
+        let Some(tray) = handle.tray_by_id(TRAY_ID) else {
+            return;
+        };
+        if let Ok(menu) = build_menu(&handle, &state) {
+            let _ = tray.set_menu(Some(menu));
+        }
+        update_tray(&tray, &state);
+    });
+
+    Ok(())
+}
+
+fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    let id = event.id().as_ref();
+    if id == MENU_SHOW_ID {
+        show_main_window(app);
+        return;
+    }
+    if id == MENU_NEW_SESSION_ID {
+        show_main_window(app);
+        let _ = app.emit(AGENT_MENU_BAR_NEW_SESSION_EVENT, ());
+        return;
+    }
+    if id == MENU_QUIT_ID {
+        app.exit(0);
+        return;
+    }
+    if let Some(session_id) = id.strip_prefix(MENU_SESSION_ID_PREFIX) {
+        show_main_window(app);
+        let _ = app.emit(AGENT_MENU_BAR_OPEN_SESSION_EVENT, session_id.to_string());
+    }
+}
+
+fn build_menu<R, M>(manager: &M, state: &AgentMenuBarState) -> tauri::Result<Menu<R>>
+where
+    R: Runtime,
+    M: Manager<R>,
+{
+    let menu = Menu::new(manager)?;
+
+    let show_item = MenuItem::with_id(manager, MENU_SHOW_ID, "Open OS June", true, None::<&str>)?;
+    let new_session_item = MenuItem::with_id(
+        manager,
+        MENU_NEW_SESSION_ID,
+        "New Agent Session...",
+        true,
+        None::<&str>,
+    )?;
+    let status_item = MenuItem::with_id(
+        manager,
+        MENU_STATUS_ID,
+        escape_menu_text(status_label(state)),
+        false,
+        None::<&str>,
+    )?;
+
+    menu.append(&show_item)?;
+    menu.append(&new_session_item)?;
+    menu.append(&PredefinedMenuItem::separator(manager)?)?;
+    menu.append(&status_item)?;
+
+    if let Some(last_status) = state.last_status.as_ref() {
+        let last_status_item = MenuItem::with_id(
+            manager,
+            MENU_LAST_STATUS_ID,
+            escape_menu_text(last_status_label(last_status)),
+            false,
+            None::<&str>,
+        )?;
+        menu.append(&last_status_item)?;
+    }
+
+    menu.append(&PredefinedMenuItem::separator(manager)?)?;
+
+    let recent_label = MenuItem::with_id(
+        manager,
+        MENU_RECENT_SESSIONS_ID,
+        "Recent Agent Sessions",
+        false,
+        None::<&str>,
+    )?;
+    menu.append(&recent_label)?;
+
+    if state.sessions.is_empty() {
+        let empty_item = MenuItem::with_id(
+            manager,
+            MENU_EMPTY_SESSIONS_ID,
+            "No sessions yet",
+            false,
+            None::<&str>,
+        )?;
+        menu.append(&empty_item)?;
+    } else {
+        for session in &state.sessions {
+            let session_item = MenuItem::with_id(
+                manager,
+                format!("{MENU_SESSION_ID_PREFIX}{}", session.id),
+                escape_menu_text(session_label(session)),
+                true,
+                None::<&str>,
+            )?;
+            menu.append(&session_item)?;
+        }
+    }
+
+    menu.append(&PredefinedMenuItem::separator(manager)?)?;
+
+    let quit_item = MenuItem::with_id(manager, MENU_QUIT_ID, "Quit OS June", true, None::<&str>)?;
+    menu.append(&quit_item)?;
+
+    Ok(menu)
+}
+
+fn update_tray<R: Runtime>(tray: &tauri::tray::TrayIcon<R>, state: &AgentMenuBarState) {
+    let _ = tray.set_title(Some(tray_title(state)));
+    let _ = tray.set_tooltip(Some(tray_tooltip(state)));
+}
+
+fn show_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+fn tray_title(state: &AgentMenuBarState) -> String {
+    if state.needs_user_count > 0 {
+        return format!("June {}", state.needs_user_count);
+    }
+    if state.active_count > 0 {
+        return format!("June {}", state.active_count);
+    }
+    "June".to_string()
+}
+
+fn tray_tooltip(state: &AgentMenuBarState) -> String {
+    let status = status_label(state);
+    format!("OS June - {status}")
+}
+
+fn status_label(state: &AgentMenuBarState) -> String {
+    if state.needs_user_count > 0 {
+        let waiting = pluralize(state.needs_user_count, "session", "sessions");
+        let needs_input = if state.needs_user_count == 1 {
+            "needs input"
+        } else {
+            "need input"
+        };
+        if state.active_count > state.needs_user_count {
+            let working_count = state.active_count - state.needs_user_count;
+            return format!(
+                "{waiting} {needs_input}, {} working",
+                pluralize(working_count, "session", "sessions")
+            );
+        }
+        return format!("{waiting} {needs_input}");
+    }
+    if state.active_count > 0 {
+        return format!(
+            "{} working",
+            pluralize(state.active_count, "session", "sessions")
+        );
+    }
+    "No active agent sessions".to_string()
+}
+
+fn last_status_label(last_status: &AgentMenuBarLastStatus) -> String {
+    let title = last_status
+        .title
+        .as_deref()
+        .map(normalize_menu_text)
+        .filter(|value| !value.is_empty());
+    let summary = last_status
+        .summary
+        .as_deref()
+        .map(normalize_menu_text)
+        .filter(|value| !value.is_empty());
+    let status = readable_status(&last_status.status);
+
+    match (title, summary) {
+        (Some(title), Some(summary)) => format!("Last: {title} - {summary}"),
+        (Some(title), None) => format!("Last: {title} - {status}"),
+        (None, Some(summary)) => format!("Last: {summary}"),
+        (None, None) => format!("Last: {status}"),
+    }
+}
+
+fn session_label(session: &AgentMenuBarSession) -> String {
+    let title = normalize_menu_text(&session.title);
+    let title = if title.is_empty() {
+        "Untitled session".to_string()
+    } else {
+        title
+    };
+    let prefix = match session.status {
+        AgentMenuBarSessionStatus::WaitingForUser => "Needs input - ",
+        AgentMenuBarSessionStatus::Running => "Working - ",
+        AgentMenuBarSessionStatus::Idle => "",
+    };
+    let subtitle = session
+        .subtitle
+        .as_deref()
+        .map(normalize_menu_text)
+        .filter(|value| !value.is_empty());
+
+    match subtitle {
+        Some(subtitle) => format!("{prefix}{title} - {subtitle}"),
+        None => format!("{prefix}{title}"),
+    }
+}
+
+fn readable_status(status: &str) -> &'static str {
+    match status {
+        "received" => "Received",
+        "starting" => "Starting",
+        "running" => "Working",
+        "waitingForUser" => "Needs input",
+        "completed" => "Completed",
+        "failed" => "Failed",
+        "cancelled" => "Cancelled",
+        _ => "Updated",
+    }
+}
+
+fn pluralize(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
+}
+
+fn normalize_menu_text(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn escape_menu_text(value: String) -> String {
+    value.replace('&', "&&")
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,10 +12,13 @@ import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
 import { flushSync } from "react-dom";
 import { AccountGate } from "../components/account/AccountGate";
 import {
+  AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
+  AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
   markAgentNewSessionPending,
   type AgentNewSessionDetail,
+  type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
 import { DictationHistoryView } from "../components/dictation/DictationHistoryView";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
@@ -67,7 +70,13 @@ import {
 } from "../lib/agent-events";
 import { notifyAgentSessionStatus } from "../lib/agent-notifications";
 import { parseDictationHelperEvent } from "../lib/dictation-events";
-import { titleFromPrompt } from "../lib/hermes-adapter";
+import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
+import {
+  AGENT_MENU_BAR_NEW_SESSION_EVENT,
+  AGENT_MENU_BAR_OPEN_SESSION_EVENT,
+  buildAgentMenuBarState,
+  emitAgentMenuBarState,
+} from "../lib/menu-bar";
 import type {
   BootstrapResponse,
   NoteDto,
@@ -100,6 +109,10 @@ const SIDEBAR_MIN_WIDTH = 188;
 const SIDEBAR_MAX_WIDTH = 320;
 const SIDEBAR_COLLAPSE_WIDTH = 160;
 const CHECK_FOR_UPDATES_EVENT = "scribe://check-for-updates";
+const AGENT_MENU_BAR_SESSION_LIMIT = 6;
+const AGENT_MENU_BAR_SESSION_RETRY_DELAYS_MS = [
+  250, 500, 1000, 2000, 4000, 8000,
+];
 // Floor for the note card so the sidebar can't be dragged wide enough to
 // crush it into a sliver — it always keeps a usable width plus its gutters.
 const MAIN_PANEL_MIN_WIDTH = 420;
@@ -131,6 +144,10 @@ export function App() {
   const [activeView, setActiveView] = useState<SidebarView>("notes");
   const [activeAgentSession, setActiveAgentSession] =
     useState<HermesSessionInfo>();
+  const agentMenuBarSessionsRef = useRef<HermesSessionInfo[]>([]);
+  const agentMenuBarWorkingSessionIdsRef = useRef<Set<string>>(new Set());
+  const agentMenuBarWaitingSessionIdsRef = useRef<Set<string>>(new Set());
+  const agentMenuBarLastStatusRef = useRef<AgentSessionStatusDetail>();
   // Where the back affordance in settings returns to — captured when settings
   // is opened so "back" lands the user where they were, not on Notes.
   const [settingsReturnView, setSettingsReturnView] =
@@ -176,6 +193,16 @@ export function App() {
   const startOnFreshNoteRef = useRef(false);
   const signInRequired = shouldBlockOnSignIn(account);
   const appBlocked = accountLoading || signInRequired;
+  const publishAgentMenuBarState = useCallback(() => {
+    void emitAgentMenuBarState(
+      buildAgentMenuBarState({
+        sessions: agentMenuBarSessionsRef.current,
+        workingSessionIds: agentMenuBarWorkingSessionIdsRef.current,
+        waitingSessionIds: agentMenuBarWaitingSessionIdsRef.current,
+        lastStatus: agentMenuBarLastStatusRef.current,
+      }),
+    );
+  }, []);
   const selectedNote = state.selectedNote;
   const selectedNoteId = selectedNote?.id;
   const originFolder = originFolderId
@@ -297,6 +324,175 @@ export function App() {
       window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleAgentStatus);
     };
   }, []);
+
+  useEffect(() => {
+    publishAgentMenuBarState();
+  }, [publishAgentMenuBarState]);
+
+  useEffect(() => {
+    if (appBlocked || !bootstrapped) return;
+    let cancelled = false;
+    let retryTimeout: number | undefined;
+
+    function loadAgentMenuBarSessions(attempt: number) {
+      listHermesSessions({ limit: AGENT_MENU_BAR_SESSION_LIMIT })
+        .then((sessions) => {
+          if (cancelled) return;
+          agentMenuBarSessionsRef.current = sessions;
+          publishAgentMenuBarState();
+        })
+        .catch(() => {
+          if (cancelled) return;
+          const retryDelay = AGENT_MENU_BAR_SESSION_RETRY_DELAYS_MS[attempt];
+          if (retryDelay == null) return;
+          retryTimeout = window.setTimeout(
+            () => loadAgentMenuBarSessions(attempt + 1),
+            retryDelay,
+          );
+        });
+    }
+
+    loadAgentMenuBarSessions(0);
+
+    return () => {
+      cancelled = true;
+      if (retryTimeout != null) {
+        window.clearTimeout(retryTimeout);
+      }
+    };
+  }, [appBlocked, bootstrapped, publishAgentMenuBarState]);
+
+  useEffect(() => {
+    function handleSessionsChanged(event: Event) {
+      const detail = (event as CustomEvent<AgentSessionsChangedDetail>).detail;
+      if (!detail) return;
+      agentMenuBarSessionsRef.current = detail.sessions;
+      agentMenuBarWorkingSessionIdsRef.current = new Set(
+        detail.workingSessionIds,
+      );
+      agentMenuBarWaitingSessionIdsRef.current = new Set(
+        detail.waitingSessionIds ?? [],
+      );
+      publishAgentMenuBarState();
+    }
+
+    function handleAgentStatusForMenuBar(event: Event) {
+      const detail = (event as CustomEvent<AgentSessionStatusDetail>).detail;
+      if (!detail) return;
+      agentMenuBarLastStatusRef.current = detail;
+      if (detail.sessionId) {
+        updateMenuBarSessionStatus(detail.sessionId, detail.status, {
+          working: agentMenuBarWorkingSessionIdsRef.current,
+          waiting: agentMenuBarWaitingSessionIdsRef.current,
+        });
+      }
+      publishAgentMenuBarState();
+    }
+
+    function handleAgentSessionDeleted(event: Event) {
+      const detail = (event as CustomEvent<{ sessionId?: string }>).detail;
+      const sessionId = detail?.sessionId;
+      if (!sessionId) return;
+      agentMenuBarSessionsRef.current = agentMenuBarSessionsRef.current.filter(
+        (session) => session.id !== sessionId,
+      );
+      agentMenuBarWorkingSessionIdsRef.current.delete(sessionId);
+      agentMenuBarWaitingSessionIdsRef.current.delete(sessionId);
+      publishAgentMenuBarState();
+    }
+
+    window.addEventListener(
+      AGENT_SESSIONS_CHANGED_EVENT,
+      handleSessionsChanged,
+    );
+    window.addEventListener(
+      AGENT_SESSION_STATUS_EVENT,
+      handleAgentStatusForMenuBar,
+    );
+    window.addEventListener(
+      AGENT_DELETE_SESSION_EVENT,
+      handleAgentSessionDeleted,
+    );
+    return () => {
+      window.removeEventListener(
+        AGENT_SESSIONS_CHANGED_EVENT,
+        handleSessionsChanged,
+      );
+      window.removeEventListener(
+        AGENT_SESSION_STATUS_EVENT,
+        handleAgentStatusForMenuBar,
+      );
+      window.removeEventListener(
+        AGENT_DELETE_SESSION_EVENT,
+        handleAgentSessionDeleted,
+      );
+    };
+  }, [publishAgentMenuBarState]);
+
+  useEffect(() => {
+    let aborted = false;
+    const unlisteners: Array<() => void> = [];
+
+    async function installMenuBarListener<T>(
+      eventName: string,
+      handler: (payload: T) => void,
+    ) {
+      try {
+        const cleanup = await listen<T>(eventName, (event) =>
+          handler(event.payload),
+        );
+        if (aborted) cleanup();
+        else unlisteners.push(cleanup);
+      } catch {
+        // Native menu-bar events only exist inside the Tauri shell.
+      }
+    }
+
+    void installMenuBarListener<void>(AGENT_MENU_BAR_NEW_SESSION_EVENT, () => {
+      markAgentNewSessionPending();
+      setActiveAgentSession(undefined);
+      setActiveView("agent");
+      window.setTimeout(() => {
+        window.dispatchEvent(
+          new CustomEvent<AgentNewSessionDetail>(AGENT_NEW_SESSION_EVENT),
+        );
+      }, 0);
+    });
+
+    void installMenuBarListener<string>(
+      AGENT_MENU_BAR_OPEN_SESSION_EVENT,
+      (sessionId) => {
+        if (!sessionId) {
+          setActiveView("agent");
+          return;
+        }
+        const cachedSession = agentMenuBarSessionsRef.current.find(
+          (session) => session.id === sessionId,
+        );
+        if (cachedSession) {
+          setActiveAgentSession(cachedSession);
+          setActiveView("agent");
+          return;
+        }
+        void listHermesSessions({ limit: 100 })
+          .then((sessions) => {
+            agentMenuBarSessionsRef.current = sessions;
+            const session = sessions.find((item) => item.id === sessionId);
+            if (session) setActiveAgentSession(session);
+            setActiveView("agent");
+            publishAgentMenuBarState();
+          })
+          .catch(() => {
+            setActiveView("agent");
+          });
+      },
+    );
+
+    return () => {
+      aborted = true;
+      for (const unlisten of unlisteners) unlisten();
+    };
+  }, [publishAgentMenuBarState]);
 
   useEffect(() => {
     let aborted = false;
@@ -1259,6 +1455,27 @@ export function App() {
       />
     </main>
   );
+}
+
+function updateMenuBarSessionStatus(
+  sessionId: string,
+  status: AgentSessionStatusDetail["status"],
+  sessions: { working: Set<string>; waiting: Set<string> },
+) {
+  if (status === "waitingForUser") {
+    sessions.working.delete(sessionId);
+    sessions.waiting.add(sessionId);
+    return;
+  }
+  if (status === "starting" || status === "running") {
+    sessions.waiting.delete(sessionId);
+    sessions.working.add(sessionId);
+    return;
+  }
+  if (status === "completed" || status === "failed" || status === "cancelled") {
+    sessions.working.delete(sessionId);
+    sessions.waiting.delete(sessionId);
+  }
 }
 
 function UpdateDialog({

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -109,6 +109,7 @@ const SIDEBAR_MIN_WIDTH = 188;
 const SIDEBAR_MAX_WIDTH = 320;
 const SIDEBAR_COLLAPSE_WIDTH = 160;
 const CHECK_FOR_UPDATES_EVENT = "scribe://check-for-updates";
+const AGENT_MENU_BAR_SESSION_FETCH_LIMIT = 100;
 const AGENT_MENU_BAR_SESSION_LIMIT = 6;
 const AGENT_MENU_BAR_SESSION_RETRY_DELAYS_MS = [
   250, 500, 1000, 2000, 4000, 8000,
@@ -200,6 +201,7 @@ export function App() {
         workingSessionIds: agentMenuBarWorkingSessionIdsRef.current,
         waitingSessionIds: agentMenuBarWaitingSessionIdsRef.current,
         lastStatus: agentMenuBarLastStatusRef.current,
+        limit: AGENT_MENU_BAR_SESSION_LIMIT,
       }),
     );
   }, []);
@@ -335,7 +337,7 @@ export function App() {
     let retryTimeout: number | undefined;
 
     function loadAgentMenuBarSessions(attempt: number) {
-      listHermesSessions({ limit: AGENT_MENU_BAR_SESSION_LIMIT })
+      listHermesSessions({ limit: AGENT_MENU_BAR_SESSION_FETCH_LIMIT })
         .then((sessions) => {
           if (cancelled) return;
           agentMenuBarSessionsRef.current = sessions;

--- a/src/lib/menu-bar.ts
+++ b/src/lib/menu-bar.ts
@@ -1,0 +1,158 @@
+import type { AgentSessionStatusDetail } from "./agent-events";
+import type { HermesSessionInfo } from "./tauri";
+
+export const AGENT_MENU_BAR_STATE_EVENT = "scribe:menu-bar:agent-state";
+export const AGENT_MENU_BAR_NEW_SESSION_EVENT =
+  "scribe:menu-bar:new-agent-session";
+export const AGENT_MENU_BAR_OPEN_SESSION_EVENT =
+  "scribe:menu-bar:open-agent-session";
+
+export type AgentMenuBarSessionStatus = "idle" | "running" | "waitingForUser";
+
+export type AgentMenuBarSession = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  status: AgentMenuBarSessionStatus;
+  lastActive?: string;
+};
+
+export type AgentMenuBarState = {
+  activeCount: number;
+  needsUserCount: number;
+  sessions: AgentMenuBarSession[];
+  lastStatus?: {
+    sessionId?: string;
+    title?: string;
+    status: AgentSessionStatusDetail["status"];
+    summary?: string;
+  };
+  updatedAt: string;
+};
+
+type BuildAgentMenuBarStateOptions = {
+  sessions: HermesSessionInfo[];
+  workingSessionIds: ReadonlySet<string>;
+  waitingSessionIds: ReadonlySet<string>;
+  lastStatus?: AgentSessionStatusDetail;
+  limit?: number;
+  now?: Date;
+};
+
+const DEFAULT_SESSION_LIMIT = 6;
+const TITLE_LIMIT = 64;
+const SUBTITLE_LIMIT = 84;
+
+export function buildAgentMenuBarState({
+  sessions,
+  workingSessionIds,
+  waitingSessionIds,
+  lastStatus,
+  limit = DEFAULT_SESSION_LIMIT,
+  now = new Date(),
+}: BuildAgentMenuBarStateOptions): AgentMenuBarState {
+  const activeSessionIds = new Set([
+    ...Array.from(workingSessionIds),
+    ...Array.from(waitingSessionIds),
+  ]);
+  const orderedSessions = [...sessions]
+    .filter((session) => typeof session.id === "string" && session.id.trim())
+    .sort((a, b) => sessionTimestamp(b).localeCompare(sessionTimestamp(a)))
+    .slice(0, limit)
+    .map((session) => ({
+      id: session.id,
+      title: titleForSession(session),
+      subtitle: subtitleForSession(session),
+      status: statusForSession(
+        session.id,
+        workingSessionIds,
+        waitingSessionIds,
+      ),
+      lastActive: sessionTimestamp(session),
+    }));
+
+  return {
+    activeCount: activeSessionIds.size,
+    needsUserCount: waitingSessionIds.size,
+    sessions: orderedSessions,
+    lastStatus: lastStatus
+      ? {
+          sessionId: lastStatus.sessionId,
+          title:
+            normalizeText(lastStatus.title, TITLE_LIMIT) ??
+            normalizeText(lastStatus.prompt, TITLE_LIMIT),
+          status: lastStatus.status,
+          summary: normalizeText(lastStatus.summary, SUBTITLE_LIMIT),
+        }
+      : undefined,
+    updatedAt: now.toISOString(),
+  };
+}
+
+export async function emitAgentMenuBarState(state: AgentMenuBarState) {
+  try {
+    const api = await import("@tauri-apps/api/event");
+    if (typeof api.emit !== "function") return;
+    await api.emit(AGENT_MENU_BAR_STATE_EVENT, state);
+  } catch {
+    // Browser-only tests and web previews do not have a native menu bar.
+  }
+}
+
+function statusForSession(
+  sessionId: string,
+  workingSessionIds: ReadonlySet<string>,
+  waitingSessionIds: ReadonlySet<string>,
+): AgentMenuBarSessionStatus {
+  if (waitingSessionIds.has(sessionId)) return "waitingForUser";
+  if (workingSessionIds.has(sessionId)) return "running";
+  return "idle";
+}
+
+function titleForSession(session: HermesSessionInfo) {
+  return (
+    normalizeText(session.title, TITLE_LIMIT) ??
+    normalizeText(session.preview, TITLE_LIMIT) ??
+    "Untitled session"
+  );
+}
+
+function subtitleForSession(session: HermesSessionInfo) {
+  const preview = normalizeText(session.preview, SUBTITLE_LIMIT);
+  if (preview && preview !== titleForSession(session)) return preview;
+  if (typeof session.message_count === "number" && session.message_count > 0) {
+    return `${session.message_count} message${
+      session.message_count === 1 ? "" : "s"
+    }`;
+  }
+  return undefined;
+}
+
+function sessionTimestamp(session: HermesSessionInfo) {
+  return timestampString(
+    session.last_active ??
+      session.lastActive ??
+      session.started_at ??
+      session.startedAt ??
+      session.ended_at ??
+      session.endedAt,
+  );
+}
+
+function timestampString(value: unknown) {
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const milliseconds =
+      value > 0 && value < 10_000_000_000 ? value * 1000 : value;
+    return new Date(milliseconds).toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+function normalizeText(value: unknown, limit: number) {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, Math.max(0, limit - 3)).trim()}...`;
+}

--- a/src/lib/menu-bar.ts
+++ b/src/lib/menu-bar.ts
@@ -57,7 +57,13 @@ export function buildAgentMenuBarState({
   ]);
   const orderedSessions = [...sessions]
     .filter((session) => typeof session.id === "string" && session.id.trim())
-    .sort((a, b) => sessionTimestamp(b).localeCompare(sessionTimestamp(a)))
+    .sort((a, b) => {
+      const statusRankDelta =
+        statusPriority(b.id, workingSessionIds, waitingSessionIds) -
+        statusPriority(a.id, workingSessionIds, waitingSessionIds);
+      if (statusRankDelta !== 0) return statusRankDelta;
+      return sessionTimestamp(b).localeCompare(sessionTimestamp(a));
+    })
     .slice(0, limit)
     .map((session) => ({
       id: session.id,
@@ -87,6 +93,16 @@ export function buildAgentMenuBarState({
       : undefined,
     updatedAt: now.toISOString(),
   };
+}
+
+function statusPriority(
+  sessionId: string,
+  workingSessionIds: ReadonlySet<string>,
+  waitingSessionIds: ReadonlySet<string>,
+) {
+  if (waitingSessionIds.has(sessionId)) return 2;
+  if (workingSessionIds.has(sessionId)) return 1;
+  return 0;
 }
 
 export async function emitAgentMenuBarState(state: AgentMenuBarState) {

--- a/src/test/menu-bar.test.ts
+++ b/src/test/menu-bar.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentMenuBarState } from "../lib/menu-bar";
+import type { HermesSessionInfo } from "../lib/tauri";
+
+const sessions: HermesSessionInfo[] = [
+  {
+    id: "session-old",
+    title: "Older work",
+    preview: "First pass",
+    last_active: "2026-06-04T12:00:00Z",
+    message_count: 2,
+  },
+  {
+    id: "session-new",
+    title: "Newer work",
+    preview: "Reviewing changes",
+    last_active: "2026-06-04T13:00:00Z",
+    message_count: 4,
+  },
+];
+
+describe("buildAgentMenuBarState", () => {
+  it("summarizes active counts and orders recent sessions", () => {
+    const state = buildAgentMenuBarState({
+      sessions,
+      workingSessionIds: new Set(["session-old"]),
+      waitingSessionIds: new Set(["session-new"]),
+      now: new Date("2026-06-04T14:00:00Z"),
+    });
+
+    expect(state.activeCount).toBe(2);
+    expect(state.needsUserCount).toBe(1);
+    expect(state.sessions.map((session) => session.id)).toEqual([
+      "session-new",
+      "session-old",
+    ]);
+    expect(state.sessions[0]).toMatchObject({
+      title: "Newer work",
+      subtitle: "Reviewing changes",
+      status: "waitingForUser",
+    });
+    expect(state.sessions[1]).toMatchObject({
+      title: "Older work",
+      status: "running",
+    });
+  });
+
+  it("keeps the last status summary when no session exists yet", () => {
+    const state = buildAgentMenuBarState({
+      sessions: [],
+      workingSessionIds: new Set(),
+      waitingSessionIds: new Set(),
+      lastStatus: {
+        prompt: "Make a launch checklist",
+        status: "starting",
+        summary: "Starting June.",
+      },
+      now: new Date("2026-06-04T14:00:00Z"),
+    });
+
+    expect(state.activeCount).toBe(0);
+    expect(state.sessions).toEqual([]);
+    expect(state.lastStatus).toMatchObject({
+      title: "Make a launch checklist",
+      status: "starting",
+      summary: "Starting June.",
+    });
+  });
+});

--- a/src/test/menu-bar.test.ts
+++ b/src/test/menu-bar.test.ts
@@ -45,6 +45,38 @@ describe("buildAgentMenuBarState", () => {
     });
   });
 
+  it("keeps waiting sessions visible before recent idle sessions", () => {
+    const recentIdleSessions: HermesSessionInfo[] = Array.from(
+      { length: 6 },
+      (_, index) => ({
+        id: `idle-${index}`,
+        title: `Idle ${index}`,
+        last_active: `2026-06-04T13:0${index}:00Z`,
+      }),
+    );
+    const state = buildAgentMenuBarState({
+      sessions: [
+        ...recentIdleSessions,
+        {
+          id: "waiting-old",
+          title: "Waiting on approval",
+          last_active: "2026-06-04T12:00:00Z",
+        },
+      ],
+      workingSessionIds: new Set(),
+      waitingSessionIds: new Set(["waiting-old"]),
+      limit: 6,
+      now: new Date("2026-06-04T14:00:00Z"),
+    });
+
+    expect(state.needsUserCount).toBe(1);
+    expect(state.sessions).toHaveLength(6);
+    expect(state.sessions[0]).toMatchObject({
+      id: "waiting-old",
+      status: "waitingForUser",
+    });
+  });
+
   it("keeps the last status summary when no session exists yet", () => {
     const state = buildAgentMenuBarState({
       sessions: [],


### PR DESCRIPTION
## Summary

Adds a native OS June menu bar/tray surface for agent visibility and quick access.

- Enables Tauri tray icon support and registers a native menu bar module.
- Mirrors React agent session/status events into a compact native menu snapshot showing active sessions, sessions that need input, recent sessions, and last status.
- Adds native menu actions to open OS June, start a new agent session, open a recent session, and quit.
- Adds focused coverage for menu bar snapshot construction.

## Impact

Users can see agent activity from the macOS menu bar without keeping the main window open, and can jump straight into recent or new agent sessions from that menu.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm run lint`
- `pnpm test`
- `pnpm test:rust`
- `pnpm run build`