### PR TITLE
[codex] Polish settings navigation

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -135,7 +135,7 @@ export function App() {
   // is opened so "back" lands the user where they were, not on Notes.
   const [settingsReturnView, setSettingsReturnView] =
     useState<SidebarView>("notes");
-  const [settingsTab, setSettingsTab] = useState<SettingsTab>("account");
+  const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
   // note shows the same back-arrow + breadcrumb chrome folders use. Cleared

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -37,6 +37,12 @@ export function AccountSettings({
         onAccountChanged={onAccountChanged}
         onRefresh={onRefresh}
       />
+      <BillingSettingsSection
+        account={account}
+        loading={loading}
+        onAccountChanged={onAccountChanged}
+        onRefresh={onRefresh}
+      />
     </div>
   );
 }
@@ -45,13 +51,9 @@ export function AccountSettingsSection({
   account,
   loading,
   onAccountChanged,
-  onRefresh,
 }: Props) {
-  const [refreshing, setRefreshing] = useState(false);
   const [busy, setBusy] = useState(false);
   const [accountStatus, setAccountStatus] = useState<string>();
-  const [billingStatus, setBillingStatus] = useState<string>();
-  const [spins, setSpins] = useState(0);
 
   async function handleSignIn() {
     setBusy(true);
@@ -85,13 +87,81 @@ export function AccountSettingsSection({
       await osAccountsLogout();
       onAccountChanged({ signedIn: false, configured: account.configured });
       setAccountStatus("Signed out.");
-      setBillingStatus(undefined);
     } catch (error) {
       setAccountStatus(messageFromError(error));
     } finally {
       setBusy(false);
     }
   }
+
+  return (
+    <section className="settings-group" aria-labelledby="account-heading">
+      <h2 id="account-heading" className="settings-group-heading">
+        Account
+      </h2>
+      {accountStatus ? (
+        <p className="settings-status">{accountStatus}</p>
+      ) : null}
+      <div className="settings-card">
+        <div className="settings-rows">
+          <div className="settings-row">
+            <div className="settings-row-info">
+              <h3 className="settings-row-title">
+                {loading
+                  ? "Checking sign-in..."
+                  : account.signedIn
+                    ? displayName(account)
+                    : "Not signed in"}
+              </h3>
+              <p className="settings-row-description">
+                {account.signedIn
+                  ? (account.user?.email ??
+                    `@${account.user?.handle ?? "account"}`)
+                  : account.configured
+                    ? "Your login is managed by OpenSoftware."
+                    : "OpenSoftware sign-in is not configured for this build."}
+              </p>
+            </div>
+            <div className="settings-row-control">
+              {account.signedIn ? (
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={busy}
+                  onClick={() => void handleSignOut()}
+                >
+                  Sign out
+                </button>
+              ) : busy ? (
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => void handleCancel()}
+                >
+                  Cancel
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={loading || !account.configured}
+                  onClick={() => void handleSignIn()}
+                >
+                  Sign in with OpenSoftware
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function BillingSettingsSection({ account, onRefresh }: Props) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [billingStatus, setBillingStatus] = useState<string>();
+  const [spins, setSpins] = useState(0);
 
   async function handleTopUp() {
     try {
@@ -118,127 +188,53 @@ export function AccountSettingsSection({
   }
 
   return (
-    <>
-      <section className="settings-group" aria-labelledby="account-heading">
-        <h2 id="account-heading" className="settings-group-heading">
-          Account
-        </h2>
-        {accountStatus ? (
-          <p className="settings-status">{accountStatus}</p>
-        ) : null}
-        <div className="settings-card">
-          <div className="settings-rows">
-            <div className="settings-row">
-              <div className="settings-row-info">
-                <h3 className="settings-row-title">
-                  {loading
-                    ? "Checking sign-in…"
-                    : account.signedIn
-                      ? displayName(account)
-                      : "Not signed in"}
-                </h3>
-                <p className="settings-row-description">
-                  {account.signedIn
-                    ? (account.user?.email ??
-                      `@${account.user?.handle ?? "account"}`)
-                    : account.configured
-                      ? "Your login and balance are managed by OpenSoftware."
-                      : "OpenSoftware sign-in is not configured for this build."}
-                </p>
-              </div>
-              <div className="settings-row-control">
-                {account.signedIn ? (
-                  <>
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      disabled={busy}
-                      onClick={() => void handleTopUp()}
-                    >
-                      Manage
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      disabled={busy}
-                      onClick={() => void handleSignOut()}
-                    >
-                      Sign out
-                    </button>
-                  </>
-                ) : busy ? (
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    onClick={() => void handleCancel()}
-                  >
-                    Cancel
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    disabled={loading || !account.configured}
-                    onClick={() => void handleSignIn()}
-                  >
-                    Sign in with OpenSoftware
-                  </button>
-                )}
-              </div>
+    <section className="settings-group" aria-labelledby="billing-heading">
+      <h2 id="billing-heading" className="settings-group-heading">
+        Billing
+      </h2>
+      <p className="settings-group-description">
+        Managed by OpenSoftware. Your balance updates after checkout.
+      </p>
+      {billingStatus ? (
+        <p className="settings-status">{billingStatus}</p>
+      ) : null}
+      <div className="settings-card">
+        <div className="settings-rows">
+          <div className="settings-row">
+            <div className="settings-row-info">
+              <p className="balance-amount">
+                {formatUsd(account.balance?.usdMillis)}
+              </p>
+              <p className="settings-row-description">Available balance</p>
+            </div>
+            <div className="settings-row-control">
+              <button
+                type="button"
+                className="icon-button"
+                aria-label="Refresh balance"
+                title="Refresh balance"
+                disabled={refreshing || !account.signedIn}
+                onClick={() => void handleRefresh()}
+              >
+                <IconArrowRotateClockwise
+                  size={14}
+                  className="balance-refresh-icon"
+                  style={{ transform: `rotate(${spins * 360}deg)` }}
+                />
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                disabled={!account.signedIn}
+                onClick={() => void handleTopUp()}
+              >
+                Add funds
+              </button>
             </div>
           </div>
         </div>
-      </section>
-
-      {account.signedIn ? (
-        <section className="settings-group" aria-labelledby="billing-heading">
-          <h2 id="billing-heading" className="settings-group-heading">
-            Billing
-          </h2>
-          <p className="settings-group-description">
-            Managed by OpenSoftware. Your balance updates after checkout.
-          </p>
-          {billingStatus ? (
-            <p className="settings-status">{billingStatus}</p>
-          ) : null}
-          <div className="settings-card">
-            <div className="settings-rows">
-              <div className="settings-row">
-                <div className="settings-row-info">
-                  <p className="balance-amount">
-                    {formatUsd(account.balance?.usdMillis)}
-                  </p>
-                  <p className="settings-row-description">Available balance</p>
-                </div>
-                <div className="settings-row-control">
-                  <button
-                    type="button"
-                    className="icon-button"
-                    aria-label="Refresh balance"
-                    title="Refresh balance"
-                    disabled={refreshing}
-                    onClick={() => void handleRefresh()}
-                  >
-                    <IconArrowRotateClockwise
-                      size={14}
-                      className="balance-refresh-icon"
-                      style={{ transform: `rotate(${spins * 360}deg)` }}
-                    />
-                  </button>
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    onClick={() => void handleTopUp()}
-                  >
-                    Add funds
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-      ) : null}
-    </>
+      </div>
+    </section>
   );
 }
 

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -39,8 +39,6 @@ export function AccountSettings({
       />
       <BillingSettingsSection
         account={account}
-        loading={loading}
-        onAccountChanged={onAccountChanged}
         onRefresh={onRefresh}
       />
     </div>
@@ -158,7 +156,10 @@ export function AccountSettingsSection({
   );
 }
 
-export function BillingSettingsSection({ account, onRefresh }: Props) {
+export function BillingSettingsSection({
+  account,
+  onRefresh,
+}: Pick<Props, "account" | "onRefresh">) {
   const [refreshing, setRefreshing] = useState(false);
   const [billingStatus, setBillingStatus] = useState<string>();
   const [spins, setSpins] = useState(0);

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -278,6 +278,11 @@ export function AppSettings({
   }, [capturingShortcut]);
 
   useEffect(() => {
+    setMicOpen(false);
+    setLanguageOpen(false);
+  }, [activeTab]);
+
+  useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | undefined;
 
@@ -691,8 +696,6 @@ export function AppSettings({
         {activeTab === "billing" ? (
           <BillingSettingsSection
             account={account}
-            loading={accountLoading}
-            onAccountChanged={onAccountChanged}
             onRefresh={onAccountRefresh}
           />
         ) : null}
@@ -769,13 +772,7 @@ export function AppSettings({
                         aria-label="Default transcription language"
                         aria-haspopup="listbox"
                         aria-expanded={languageOpen}
-                        onClick={() => {
-                          setLanguageOpen((value) => {
-                            const next = !value;
-                            if (next) updateLanguagePopoverPlacement();
-                            return next;
-                          });
-                        }}
+                        onClick={() => setLanguageOpen((value) => !value)}
                       >
                         <span>{languageLabel(settings.language ?? "")}</span>
                         <IconChevronDownSmall size={14} />
@@ -846,11 +843,7 @@ export function AppSettings({
                       aria-haspopup="listbox"
                       aria-expanded={micOpen}
                       onClick={() => {
-                        setMicOpen((value) => {
-                          const next = !value;
-                          if (next) updateMicrophonePopoverPlacement();
-                          return next;
-                        });
+                        setMicOpen((value) => !value);
                         void requestMicrophones();
                       }}
                     >

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -3,6 +3,10 @@ import { IconAnonymous } from "central-icons/IconAnonymous";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconCheckmark2Small } from "central-icons/IconCheckmark2Small";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
+import { IconCircleCheck } from "central-icons/IconCircleCheck";
+import { IconCircleQuestionmark } from "central-icons/IconCircleQuestionmark";
+import { IconCircleX } from "central-icons/IconCircleX";
+import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
 import { IconFire1 } from "central-icons/IconFire1";
 import { IconGhost2 } from "central-icons/IconGhost2";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
@@ -10,7 +14,7 @@ import { IconMoonStar } from "central-icons/IconMoonStar";
 import { IconSun } from "central-icons/IconSun";
 import { IconTelevision } from "central-icons/IconTelevision";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import {
   dictationHelperCommand,
   dictationSettings,
@@ -35,7 +39,10 @@ import type {
   RecordingSourceReadinessDto,
   VeniceModelDto,
 } from "../../lib/tauri";
-import { AccountSettingsSection } from "../account/AccountSettings";
+import {
+  AccountSettingsSection,
+  BillingSettingsSection,
+} from "../account/AccountSettings";
 import { KeycapShortcut } from "../shortcuts/KeycapShortcut";
 import { Dialog } from "../ui/Dialog";
 import { SegmentedControl } from "../ui/SegmentedControl";
@@ -145,19 +152,23 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
 };
 
 export type SettingsTab =
-  | "account"
+  | "general"
+  | "billing"
+  | "shortcuts"
   | "dictation"
   | "audio"
-  | "permissions"
   | "models"
   | "agent"
   | "about";
 
+type SelectPopoverPlacement = "align-selected" | "below" | "above";
+
 export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
-  { id: "account", label: "Account" },
+  { id: "general", label: "General" },
+  { id: "billing", label: "Billing" },
+  { id: "shortcuts", label: "Shortcuts" },
   { id: "dictation", label: "Dictation" },
   { id: "audio", label: "Audio" },
-  { id: "permissions", label: "Permissions" },
   { id: "models", label: "Models" },
   { id: "agent", label: "Agent" },
   { id: "about", label: "About" },
@@ -224,7 +235,12 @@ export function AppSettings({
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [pickerMode, setPickerMode] = useState<ProviderModelMode>();
   const [modelSearch, setModelSearch] = useState("");
-  const [internalTab, setInternalTab] = useState<SettingsTab>("account");
+  const [internalTab, setInternalTab] = useState<SettingsTab>("general");
+  const [micPopoverPlacement, setMicPopoverPlacement] =
+    useState<SelectPopoverPlacement>("align-selected");
+  const [languageOpen, setLanguageOpen] = useState(false);
+  const [languagePopoverPlacement, setLanguagePopoverPlacement] =
+    useState<SelectPopoverPlacement>("align-selected");
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
   const activeTab = controlled ? controlledTab : internalTab;
   const setActiveTab = (tab: SettingsTab) => {
@@ -235,6 +251,7 @@ export function AppSettings({
     }
   };
   const micWrapRef = useRef<HTMLDivElement>(null);
+  const languageWrapRef = useRef<HTMLDivElement>(null);
   const systemOn = sourceMode === "microphonePlusSystem";
   const systemReadiness = sourceReadiness?.sources.find(
     (source) => source.source === "system",
@@ -303,6 +320,24 @@ export function AppSettings({
       window.removeEventListener("keydown", onKey);
     };
   }, [micOpen]);
+
+  useEffect(() => {
+    if (!languageOpen) return;
+    function onPointer(event: MouseEvent) {
+      if (!languageWrapRef.current?.contains(event.target as Node)) {
+        setLanguageOpen(false);
+      }
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setLanguageOpen(false);
+    }
+    window.addEventListener("mousedown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [languageOpen]);
 
   useEffect(() => {
     if (!capturingShortcut) return;
@@ -460,6 +495,7 @@ export function AppSettings({
     try {
       const next = await setDictationLanguage(language || undefined);
       setSettings(next);
+      setLanguageOpen(false);
       setStatus(
         language
           ? `Default transcription language set to ${languageLabel(language)}.`
@@ -481,6 +517,12 @@ export function AppSettings({
       (option) => (option.id ?? "") === (settings.microphone.id ?? ""),
     ),
   );
+  const selectedLanguageIndex = Math.max(
+    0,
+    LANGUAGE_OPTIONS.findIndex(
+      (option) => option.value === (settings.language ?? ""),
+    ),
+  );
   const transcriptionOptions = modelOptions(
     veniceModels.transcription,
     providerSettings.transcriptionModel,
@@ -491,6 +533,34 @@ export function AppSettings({
   );
   const pickerOptions = pickerMode ? modelOptionsForMode(pickerMode) : [];
   const pickerValue = pickerMode ? modelValueForMode(pickerMode) : "";
+
+  useEffect(() => {
+    if (micOpen) updateMicrophonePopoverPlacement();
+  }, [micOpen, microphoneOptions.length, selectedMicrophoneIndex]);
+
+  useEffect(() => {
+    if (languageOpen) updateLanguagePopoverPlacement();
+  }, [languageOpen, selectedLanguageIndex]);
+
+  function updateMicrophonePopoverPlacement() {
+    setMicPopoverPlacement(
+      selectPopoverPlacement(
+        micWrapRef.current,
+        microphoneOptions.length,
+        selectedMicrophoneIndex,
+      ),
+    );
+  }
+
+  function updateLanguagePopoverPlacement() {
+    setLanguagePopoverPlacement(
+      selectPopoverPlacement(
+        languageWrapRef.current,
+        LANGUAGE_OPTIONS.length,
+        selectedLanguageIndex,
+      ),
+    );
+  }
 
   function modelOptionsForMode(mode: ProviderModelMode) {
     return mode === "transcription" ? transcriptionOptions : generationOptions;
@@ -506,6 +576,14 @@ export function AppSettings({
     setPickerMode(mode);
     setModelSearch("");
     void requestVeniceModels(mode);
+  }
+
+  function microphonePopoverStyle(): CSSProperties {
+    return selectPopoverStyle(micPopoverPlacement, selectedMicrophoneIndex);
+  }
+
+  function languagePopoverStyle(): CSSProperties {
+    return selectPopoverStyle(languagePopoverPlacement, selectedLanguageIndex);
   }
 
   return (
@@ -547,7 +625,7 @@ export function AppSettings({
         id={`settings-panel-${activeTab}`}
         aria-labelledby={`settings-tab-${activeTab}`}
       >
-        {activeTab === "account" ? (
+        {activeTab === "general" ? (
           <>
             <AccountSettingsSection
               account={account}
@@ -587,7 +665,72 @@ export function AppSettings({
                 </div>
               </div>
             </section>
+
+            <PermissionsSettingsSection
+              microphonePermissionStatus={microphonePermissionStatus}
+              microphoneReadiness={microphoneReadiness}
+              accessibilityPermissionStatus={accessibilityPermissionStatus}
+              systemReadiness={systemReadiness}
+              onEnableMicrophone={onEnableMicrophone}
+              onEnableAccessibility={onEnableAccessibility}
+              onEnableSystemAudio={onEnableSystemAudio}
+            />
           </>
+        ) : null}
+
+        {activeTab === "billing" ? (
+          <BillingSettingsSection
+            account={account}
+            loading={accountLoading}
+            onAccountChanged={onAccountChanged}
+            onRefresh={onAccountRefresh}
+          />
+        ) : null}
+
+        {activeTab === "shortcuts" ? (
+          <section
+            className="settings-group"
+            aria-labelledby="shortcuts-heading"
+          >
+            <h2 id="shortcuts-heading" className="settings-group-heading">
+              Shortcuts
+            </h2>
+            <div className="settings-card">
+              <div className="settings-rows">
+                <ShortcutRow
+                  title="Push to talk"
+                  description="Hold this shortcut to dictate, then release to paste."
+                  shortcut={settings.pushToTalkShortcut}
+                  capturing={capturingShortcut === "push_to_talk"}
+                  disabled={
+                    !!capturingShortcut && capturingShortcut !== "push_to_talk"
+                  }
+                  error={
+                    capturingShortcut === "push_to_talk"
+                      ? shortcutError
+                      : undefined
+                  }
+                  onChange={() => void startShortcutCapture("push_to_talk")}
+                  onCancel={() => void cancelShortcutCapture()}
+                />
+
+                <ShortcutRow
+                  title="Toggle dictation"
+                  description="Press this shortcut to start or stop dictation."
+                  shortcut={settings.toggleShortcut}
+                  capturing={capturingShortcut === "toggle"}
+                  disabled={
+                    !!capturingShortcut && capturingShortcut !== "toggle"
+                  }
+                  error={
+                    capturingShortcut === "toggle" ? shortcutError : undefined
+                  }
+                  onChange={() => void startShortcutCapture("toggle")}
+                  onCancel={() => void cancelShortcutCapture()}
+                />
+              </div>
+            </div>
+          </section>
         ) : null}
 
         {activeTab === "dictation" ? (
@@ -601,39 +744,6 @@ export function AppSettings({
               </h2>
               <div className="settings-card">
                 <div className="settings-rows">
-                  <ShortcutRow
-                    title="Push to talk"
-                    description="Hold this shortcut to dictate, then release to paste."
-                    shortcut={settings.pushToTalkShortcut}
-                    capturing={capturingShortcut === "push_to_talk"}
-                    disabled={
-                      !!capturingShortcut &&
-                      capturingShortcut !== "push_to_talk"
-                    }
-                    error={
-                      capturingShortcut === "push_to_talk"
-                        ? shortcutError
-                        : undefined
-                    }
-                    onChange={() => void startShortcutCapture("push_to_talk")}
-                    onCancel={() => void cancelShortcutCapture()}
-                  />
-
-                  <ShortcutRow
-                    title="Toggle dictation"
-                    description="Press this shortcut to start or stop dictation."
-                    shortcut={settings.toggleShortcut}
-                    capturing={capturingShortcut === "toggle"}
-                    disabled={
-                      !!capturingShortcut && capturingShortcut !== "toggle"
-                    }
-                    error={
-                      capturingShortcut === "toggle" ? shortcutError : undefined
-                    }
-                    onChange={() => void startShortcutCapture("toggle")}
-                    onCancel={() => void cancelShortcutCapture()}
-                  />
-
                   <div className="settings-row">
                     <div className="settings-row-info">
                       <h3 className="settings-row-title">Language</h3>
@@ -642,24 +752,57 @@ export function AppSettings({
                         dictation.
                       </p>
                     </div>
-                    <div className="settings-row-control">
-                      <select
+                    <div className="settings-row-control" ref={languageWrapRef}>
+                      <button
+                        type="button"
                         className="select-trigger settings-language-select"
                         aria-label="Default transcription language"
-                        value={settings.language ?? ""}
-                        onChange={(event) =>
-                          void selectLanguage(event.currentTarget.value)
-                        }
+                        aria-haspopup="listbox"
+                        aria-expanded={languageOpen}
+                        onClick={() => {
+                          setLanguageOpen((value) => {
+                            const next = !value;
+                            if (next) updateLanguagePopoverPlacement();
+                            return next;
+                          });
+                        }}
                       >
-                        {LANGUAGE_OPTIONS.map((option) => (
-                          <option
-                            key={option.value || "auto"}
-                            value={option.value}
-                          >
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
+                        <span>{languageLabel(settings.language ?? "")}</span>
+                        <IconChevronDownSmall size={14} />
+                      </button>
+                      {languageOpen ? (
+                        <ul
+                          className="select-popover"
+                          role="listbox"
+                          data-placement={languagePopoverPlacement}
+                          style={languagePopoverStyle()}
+                        >
+                          {LANGUAGE_OPTIONS.map((option) => {
+                            const selected =
+                              option.value === (settings.language ?? "");
+                            return (
+                              <li key={option.value || "auto"}>
+                                <button
+                                  type="button"
+                                  role="option"
+                                  aria-selected={selected}
+                                  data-selected={selected}
+                                  onClick={() =>
+                                    void selectLanguage(option.value)
+                                  }
+                                >
+                                  <span>{option.label}</span>
+                                  <span className="select-check" aria-hidden>
+                                    {selected ? (
+                                      <IconCheckmark1Small size={14} />
+                                    ) : null}
+                                  </span>
+                                </button>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      ) : null}
                     </div>
                   </div>
                 </div>
@@ -693,7 +836,11 @@ export function AppSettings({
                       aria-haspopup="listbox"
                       aria-expanded={micOpen}
                       onClick={() => {
-                        setMicOpen((value) => !value);
+                        setMicOpen((value) => {
+                          const next = !value;
+                          if (next) updateMicrophonePopoverPlacement();
+                          return next;
+                        });
                         void requestMicrophones();
                       }}
                     >
@@ -706,7 +853,8 @@ export function AppSettings({
                       <ul
                         className="select-popover"
                         role="listbox"
-                        style={{ top: -(2 + selectedMicrophoneIndex * 28) }}
+                        data-placement={micPopoverPlacement}
+                        style={microphonePopoverStyle()}
                       >
                         {microphoneOptions.map((option) => {
                           const selected =
@@ -773,48 +921,6 @@ export function AppSettings({
                     </div>
                   </div>
                 )}
-              </div>
-            </div>
-          </section>
-        ) : null}
-
-        {activeTab === "permissions" ? (
-          <section
-            className="settings-group"
-            aria-labelledby="permissions-heading"
-          >
-            <h2 id="permissions-heading" className="settings-group-heading">
-              System permissions
-            </h2>
-            <p className="settings-group-description">
-              macOS access used for recording audio, pasting dictation, and
-              capturing system sound.
-            </p>
-            <div className="settings-card">
-              <div className="settings-rows">
-                <PermissionRow
-                  title="Microphone"
-                  description="Record dictation and note audio."
-                  status={permissionStatus(
-                    microphonePermissionStatus ??
-                      microphoneReadiness?.permissionState,
-                  )}
-                  onManage={onEnableMicrophone}
-                />
-
-                <PermissionRow
-                  title="Accessibility"
-                  description="Paste dictated text into the active app."
-                  status={permissionStatus(accessibilityPermissionStatus)}
-                  onManage={onEnableAccessibility}
-                />
-
-                <PermissionRow
-                  title="System audio"
-                  description="Record audio from other apps when system audio is enabled."
-                  status={sourcePermissionStatus(systemReadiness)}
-                  onManage={onEnableSystemAudio}
-                />
               </div>
             </div>
           </section>
@@ -919,6 +1025,63 @@ type PermissionStatusView = {
   tone: PermissionStatusTone;
 };
 
+function PermissionsSettingsSection({
+  microphonePermissionStatus,
+  microphoneReadiness,
+  accessibilityPermissionStatus,
+  systemReadiness,
+  onEnableMicrophone,
+  onEnableAccessibility,
+  onEnableSystemAudio,
+}: {
+  microphonePermissionStatus?: string;
+  microphoneReadiness?: RecordingSourceReadinessDto["sources"][number];
+  accessibilityPermissionStatus?: string;
+  systemReadiness?: RecordingSourceReadinessDto["sources"][number];
+  onEnableMicrophone?: () => void;
+  onEnableAccessibility?: () => void;
+  onEnableSystemAudio: () => void;
+}) {
+  return (
+    <section className="settings-group" aria-labelledby="permissions-heading">
+      <h2 id="permissions-heading" className="settings-group-heading">
+        System permissions
+      </h2>
+      <p className="settings-group-description">
+        macOS access used for recording audio, pasting dictation, and capturing
+        system sound.
+      </p>
+      <div className="settings-card">
+        <div className="settings-rows">
+          <PermissionRow
+            title="Microphone"
+            description="Record dictation and note audio."
+            status={permissionStatus(
+              microphonePermissionStatus ??
+                microphoneReadiness?.permissionState,
+            )}
+            onManage={onEnableMicrophone}
+          />
+
+          <PermissionRow
+            title="Accessibility"
+            description="Paste dictated text into the active app."
+            status={permissionStatus(accessibilityPermissionStatus)}
+            onManage={onEnableAccessibility}
+          />
+
+          <PermissionRow
+            title="System audio"
+            description="Record audio from other apps when system audio is enabled."
+            status={sourcePermissionStatus(systemReadiness)}
+            onManage={onEnableSystemAudio}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function PermissionRow({
   title,
   description,
@@ -938,8 +1101,14 @@ function PermissionRow({
         <p className="settings-row-description">{description}</p>
       </div>
       <div className="settings-row-control settings-permission-control">
-        <span className="settings-permission-status" data-status={status.tone}>
-          {status.label}
+        <span
+          className="settings-permission-status"
+          data-status={status.tone}
+          role="img"
+          aria-label={status.label}
+          title={status.label}
+        >
+          <PermissionStatusIcon tone={status.tone} />
         </span>
         <button
           type="button"
@@ -953,6 +1122,13 @@ function PermissionRow({
       </div>
     </div>
   );
+}
+
+function PermissionStatusIcon({ tone }: { tone: PermissionStatusTone }) {
+  if (tone === "allowed") return <IconCircleCheck size={16} />;
+  if (tone === "unknown") return <IconCircleQuestionmark size={16} />;
+  if (tone === "unsupported") return <IconCircleX size={16} />;
+  return <IconExclamationCircle size={16} />;
 }
 
 function permissionStatus(state?: string): PermissionStatusView {
@@ -1400,6 +1576,55 @@ function languageLabel(value: string) {
   return (
     LANGUAGE_OPTIONS.find((option) => option.value === value)?.label ?? value
   );
+}
+
+function selectPopoverPlacement(
+  anchor: HTMLElement | null,
+  optionCount: number,
+  selectedIndex: number,
+): SelectPopoverPlacement {
+  if (!anchor) return "align-selected";
+  const rect = anchor.getBoundingClientRect();
+
+  const viewportPadding = 12;
+  const rowHeight = 28;
+  const popoverPadding = 8;
+  const popoverHeight = optionCount * rowHeight + popoverPadding;
+  const selectedOffset = 2 + selectedIndex * rowHeight;
+  const panel = anchor.closest(".main-panel");
+  const panelRect = panel?.getBoundingClientRect();
+  const topBound = Math.max(viewportPadding, (panelRect?.top ?? 0) + 12);
+  const bottomBound = Math.min(
+    window.innerHeight - viewportPadding,
+    (panelRect?.bottom ?? window.innerHeight) - 12,
+  );
+  const alignedTop = rect.top - selectedOffset;
+  const alignedBottom = alignedTop + popoverHeight;
+  const belowBottom = rect.bottom + 4 + popoverHeight;
+  const aboveTop = rect.top - 4 - popoverHeight;
+  const spaceBelow = bottomBound - rect.bottom;
+  const spaceAbove = rect.top - topBound;
+
+  if (alignedTop >= topBound && alignedBottom <= bottomBound) {
+    return "align-selected";
+  }
+  if (belowBottom <= bottomBound || spaceBelow >= spaceAbove) {
+    return "below";
+  }
+  return aboveTop >= topBound ? "above" : "below";
+}
+
+function selectPopoverStyle(
+  placement: SelectPopoverPlacement,
+  selectedIndex: number,
+): CSSProperties {
+  if (placement === "below") {
+    return { top: "calc(100% + 4px)" };
+  }
+  if (placement === "above") {
+    return { bottom: "calc(100% + 4px)" };
+  }
+  return { top: -(2 + selectedIndex * 28) };
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,17 +1,30 @@
 import { IconArrowBoxRight } from "central-icons/IconArrowBoxRight";
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
+import { IconAudio } from "central-icons/IconAudio";
+import { IconBrain2 } from "central-icons/IconBrain2";
+import { IconCircleInfo } from "central-icons/IconCircleInfo";
+import { IconCreditCard1 } from "central-icons/IconCreditCard1";
 import { IconDotGrid1x3Vertical } from "central-icons/IconDotGrid1x3Vertical";
 import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
 import { IconFolderDelete } from "central-icons/IconFolderDelete";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophone } from "central-icons/IconMicrophone";
+import { IconMicrophoneSparkle } from "central-icons/IconMicrophoneSparkle";
 import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPeople } from "central-icons/IconPeople";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
+import { IconShortcut } from "central-icons/IconShortcut";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import { type DragEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type DragEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   markAgentNewSessionPending,
   type AgentSessionsChangedDetail,
@@ -32,7 +45,7 @@ import type {
   HermesSessionInfo,
   NoteListItemDto,
 } from "../../lib/tauri";
-import { SETTINGS_TABS, type SettingsTab } from "../settings/AppSettings";
+import { type SettingsTab } from "../settings/AppSettings";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { PangolinSpinner } from "../PangolinSpinner";
 import { IconPangolin } from "../icons/IconPangolin";
@@ -77,11 +90,61 @@ type MenuState = {
 
 const AGENT_SIDEBAR_SESSION_LIMIT = 12;
 
+const SETTINGS_SIDEBAR_GROUPS: {
+  title: string;
+  items: { id: SettingsTab; label: string; icon: ReactNode }[];
+}[] = [
+  {
+    title: "Personal",
+    items: [
+      {
+        id: "general",
+        label: "General",
+        icon: <IconSettingsGear4 size={16} />,
+      },
+      {
+        id: "billing",
+        label: "Billing",
+        icon: <IconCreditCard1 size={16} />,
+      },
+      {
+        id: "shortcuts",
+        label: "Shortcuts",
+        icon: <IconShortcut size={16} />,
+      },
+    ],
+  },
+  {
+    title: "Audio",
+    items: [
+      {
+        id: "dictation",
+        label: "Dictation",
+        icon: <IconMicrophoneSparkle size={16} />,
+      },
+      { id: "audio", label: "Audio", icon: <IconAudio size={16} /> },
+    ],
+  },
+  {
+    title: "AI",
+    items: [
+      { id: "models", label: "Models", icon: <IconBrain2 size={16} /> },
+      { id: "agent", label: "Agent", icon: <IconPangolin size={16} /> },
+    ],
+  },
+  {
+    title: "App",
+    items: [
+      { id: "about", label: "About", icon: <IconCircleInfo size={16} /> },
+    ],
+  },
+];
+
 export function Sidebar({
   notes,
   activeView,
   account = { signedIn: false, configured: false },
-  settingsTab = "account",
+  settingsTab = "general",
   onSettingsTabChange,
   onChangeView,
   onExitSettings,
@@ -263,23 +326,25 @@ export function Sidebar({
       data-collapsed={collapsed}
       data-mode={inSettings ? "settings" : "default"}
     >
-      <header className="sidebar-header">
-        <a className="sidebar-brand" href="#" aria-label="OS June">
-          <img
-            className="sidebar-brand-img light"
-            src="/os-june-light.svg"
-            alt=""
-            height={16}
-          />
-          <img
-            className="sidebar-brand-img dark"
-            src="/os-june-dark.svg"
-            alt=""
-            height={16}
-          />
-          <span style={{ position: "absolute", left: -9999 }}>OS June</span>
-        </a>
-      </header>
+      {inSettings ? null : (
+        <header className="sidebar-header">
+          <a className="sidebar-brand" href="#" aria-label="OS June">
+            <img
+              className="sidebar-brand-img light"
+              src="/os-june-light.svg"
+              alt=""
+              height={16}
+            />
+            <img
+              className="sidebar-brand-img dark"
+              src="/os-june-dark.svg"
+              alt=""
+              height={16}
+            />
+            <span style={{ position: "absolute", left: -9999 }}>OS June</span>
+          </a>
+        </header>
+      )}
 
       {inSettings ? (
         <SettingsSidebarNav
@@ -291,108 +356,110 @@ export function Sidebar({
         />
       ) : (
         <>
-      <label className="sidebar-search">
-        <IconMagnifyingGlass size={15} />
-        <input
-          value={query}
-          onChange={(event) => setQuery(event.currentTarget.value)}
-          placeholder="Search"
-        />
-      </label>
+          <label className="sidebar-search">
+            <IconMagnifyingGlass size={15} />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Search"
+            />
+          </label>
 
-      <nav className="sidebar-nav" aria-label="Primary">
-        <button
-          type="button"
-          className="sidebar-nav-item"
-          onClick={() => {
-            markAgentNewSessionPending();
-            onNewAgentSession();
-            dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
-          }}
-        >
-          <span className="sidebar-nav-icon">
-            <IconPlusMedium size={15} />
-          </span>
-          <span className="sidebar-nav-label">New Session</span>
-        </button>
-        <button
-          type="button"
-          className="sidebar-nav-item"
-          data-active={activeView === "meetings" || activeView === "notes"}
-          aria-current={
-            activeView === "meetings" || activeView === "notes"
-              ? "page"
-              : undefined
-          }
-          onClick={() => {
-            onChangeView("notes");
-          }}
-        >
-          <span className="sidebar-nav-icon">
-            <IconNoteText size={15} />
-          </span>
-          <span className="sidebar-nav-label">Notes</span>
-        </button>
-        <button
-          type="button"
-          className="sidebar-nav-item"
-          data-active={activeView === "dictation"}
-          aria-current={activeView === "dictation" ? "page" : undefined}
-          onClick={() => onChangeView("dictation")}
-        >
-          <span className="sidebar-nav-icon">
-            <IconMicrophone size={16} />
-          </span>
-          <span className="sidebar-nav-label">Dictation</span>
-        </button>
-      </nav>
+          <nav className="sidebar-nav" aria-label="Primary">
+            <button
+              type="button"
+              className="sidebar-nav-item"
+              onClick={() => {
+                markAgentNewSessionPending();
+                onNewAgentSession();
+                dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);
+              }}
+            >
+              <span className="sidebar-nav-icon">
+                <IconPlusMedium size={15} />
+              </span>
+              <span className="sidebar-nav-label">New Session</span>
+            </button>
+            <button
+              type="button"
+              className="sidebar-nav-item"
+              data-active={activeView === "meetings" || activeView === "notes"}
+              aria-current={
+                activeView === "meetings" || activeView === "notes"
+                  ? "page"
+                  : undefined
+              }
+              onClick={() => {
+                onChangeView("notes");
+              }}
+            >
+              <span className="sidebar-nav-icon">
+                <IconNoteText size={15} />
+              </span>
+              <span className="sidebar-nav-label">Notes</span>
+            </button>
+            <button
+              type="button"
+              className="sidebar-nav-item"
+              data-active={activeView === "dictation"}
+              aria-current={activeView === "dictation" ? "page" : undefined}
+              onClick={() => onChangeView("dictation")}
+            >
+              <span className="sidebar-nav-icon">
+                <IconMicrophone size={16} />
+              </span>
+              <span className="sidebar-nav-label">Dictation</span>
+            </button>
+          </nav>
 
-      <section
-        className="sidebar-section sidebar-agent-section"
-        aria-label="Agent sessions"
-        data-active={activeView === "agent"}
-      >
-        <div className="section-title section-title-with-action">
-          <button
-            type="button"
-            className="section-title-label section-title-open"
-            onClick={() => onChangeView("agent")}
+          <section
+            className="sidebar-section sidebar-agent-section"
+            aria-label="Agent sessions"
+            data-active={activeView === "agent"}
           >
-            Agent
-          </button>
-        </div>
-        <div className="notes-nav-wrap">
-          <div className="notes-nav">
-            {filteredAgentSessions.length > 0 ? (
-              filteredAgentSessions.map((session) => (
-                <AgentSessionRow
-                  key={session.id}
-                  session={session}
-                  selected={
-                    activeView === "agent" &&
-                    selectedAgentSessionId === session.id
-                  }
-                  working={workingAgentSessionIds.has(session.id)}
-                  waiting={waitingAgentSessionIds.has(session.id)}
-                  deleting={deletingAgentSessionIds.has(session.id)}
-                  onSelect={() => {
-                    setSelectedAgentSessionId(session.id);
-                    onSelectAgentSession(session);
-                  }}
-                  onDelete={() => {
-                    setAgentSessionDeleteError(null);
-                    setAgentSessionToDelete(session);
-                  }}
-                />
-              ))
-            ) : (
-              <div className="sidebar-empty">
-                {agentSessions.length === 0 ? "No sessions yet" : "No matches"}
+            <div className="section-title section-title-with-action">
+              <button
+                type="button"
+                className="section-title-label section-title-open"
+                onClick={() => onChangeView("agent")}
+              >
+                Agent
+              </button>
+            </div>
+            <div className="notes-nav-wrap">
+              <div className="notes-nav">
+                {filteredAgentSessions.length > 0 ? (
+                  filteredAgentSessions.map((session) => (
+                    <AgentSessionRow
+                      key={session.id}
+                      session={session}
+                      selected={
+                        activeView === "agent" &&
+                        selectedAgentSessionId === session.id
+                      }
+                      working={workingAgentSessionIds.has(session.id)}
+                      waiting={waitingAgentSessionIds.has(session.id)}
+                      deleting={deletingAgentSessionIds.has(session.id)}
+                      onSelect={() => {
+                        setSelectedAgentSessionId(session.id);
+                        onSelectAgentSession(session);
+                      }}
+                      onDelete={() => {
+                        setAgentSessionDeleteError(null);
+                        setAgentSessionToDelete(session);
+                      }}
+                    />
+                  ))
+                ) : (
+                  <div className="sidebar-empty">
+                    {agentSessions.length === 0
+                      ? "No sessions yet"
+                      : "No matches"}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-        </div>
-      </section>
+            </div>
+          </section>
         </>
       )}
 
@@ -400,7 +467,6 @@ export function Sidebar({
         <SidebarIdentity
           account={account}
           menuOpen={identityMenuOpen}
-          inSettings={inSettings}
           onToggleMenu={() => setIdentityMenuOpen((open) => !open)}
           onCloseMenu={() => setIdentityMenuOpen(false)}
           onOpenSettings={() => {
@@ -564,29 +630,40 @@ function SettingsSidebarNav({
       className="sidebar-section sidebar-settings-section"
       aria-label="Settings"
     >
-      <button type="button" className="sidebar-settings-back" onClick={onBack}>
+      <button
+        type="button"
+        className="sidebar-nav-item sidebar-settings-back"
+        onClick={onBack}
+      >
         <span className="sidebar-nav-icon">
           <IconChevronLeftSmall size={15} />
         </span>
-        <span className="sidebar-nav-label">Back</span>
+        <span className="sidebar-nav-label">Back to app</span>
       </button>
-      <div className="section-title">
-        <span className="section-title-label">Settings</span>
-      </div>
-      <nav className="sidebar-nav" aria-label="Settings sections">
-        {SETTINGS_TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            className="sidebar-nav-item"
-            data-active={activeTab === tab.id}
-            aria-current={activeTab === tab.id ? "page" : undefined}
-            onClick={() => onSelectTab(tab.id)}
-          >
-            <span className="sidebar-nav-label">{tab.label}</span>
-          </button>
-        ))}
-      </nav>
+      {SETTINGS_SIDEBAR_GROUPS.map((group) => (
+        <div key={group.title} className="sidebar-settings-group">
+          <div className="section-title">
+            <span className="section-title-label">{group.title}</span>
+          </div>
+          <nav className="sidebar-nav" aria-label={`${group.title} settings`}>
+            {group.items.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                className="sidebar-nav-item"
+                data-active={activeTab === tab.id}
+                aria-current={activeTab === tab.id ? "page" : undefined}
+                onClick={() => onSelectTab(tab.id)}
+              >
+                <span className="sidebar-nav-icon" aria-hidden>
+                  {tab.icon}
+                </span>
+                <span className="sidebar-nav-label">{tab.label}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
+      ))}
     </section>
   );
 }
@@ -596,7 +673,6 @@ function SettingsSidebarNav({
 function SidebarIdentity({
   account,
   menuOpen,
-  inSettings,
   onToggleMenu,
   onCloseMenu,
   onOpenSettings,
@@ -604,7 +680,6 @@ function SidebarIdentity({
 }: {
   account: AccountStatus;
   menuOpen: boolean;
-  inSettings: boolean;
   onToggleMenu: () => void;
   onCloseMenu: () => void;
   onOpenSettings: () => void;
@@ -634,7 +709,6 @@ function SidebarIdentity({
       <button
         type="button"
         className="sidebar-nav-item sidebar-identity"
-        data-active={inSettings}
         aria-haspopup="menu"
         aria-expanded={menuOpen}
         aria-label={`${name} — account menu`}
@@ -717,7 +791,7 @@ function AgentSessionRow({
               <PangolinSpinner className="agent-sidebar-spinner" />
             </span>
           ) : (
-            <IconPangolin size={15} />
+            <IconPangolin size={16} />
           )}
         </span>
         <span className="note-row-title">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2480,37 +2480,46 @@ input:focus-visible,
 /* Settings nav — replaces the main sidebar list while the settings page is
  * open, with a quiet back affordance to notes at the top. */
 .sidebar-settings-section {
-  gap: var(--sp-1);
+  flex: 1;
+  gap: var(--sp-4);
+  overflow-y: auto;
+  padding-bottom: var(--sp-3);
 }
 
 .sidebar-settings-back {
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
-  align-items: center;
-  gap: var(--sp-3);
-  width: 100%;
-  min-height: 30px;
-  padding: var(--sp-2) var(--sp-3);
-  border: 0;
-  border-radius: var(--r-md);
-  background: transparent;
   color: var(--muted-foreground);
-  font-size: var(--fs-md);
-  text-align: left;
 }
 
 .sidebar-settings-back:hover {
-  background: var(--sidebar-accent);
   color: var(--foreground);
 }
 
 .sidebar-settings-section .section-title {
-  margin-top: var(--sp-2);
+  min-height: 22px;
+  padding: 0 var(--sp-3);
+  color: color-mix(in oklch, var(--muted-foreground) 82%, transparent);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.sidebar-settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
 }
 
 .sidebar-settings-section .sidebar-nav-item {
-  grid-template-columns: minmax(0, 1fr);
-  padding-left: calc(18px + var(--sp-3) + var(--sp-3));
+  grid-template-columns: 18px minmax(0, 1fr);
+}
+
+.sidebar-settings-section .sidebar-nav-icon {
+  color: var(--muted-foreground);
+}
+
+.sidebar-settings-section
+  .sidebar-nav-item[data-active="true"]
+  .sidebar-nav-icon {
+  color: var(--muted-foreground);
 }
 
 /* Sidebar section --------------------------------------------------- */
@@ -4935,56 +4944,41 @@ input:focus-visible,
 }
 
 .settings-permission-control {
-  min-width: 225px;
+  min-width: 166px;
   justify-content: flex-end;
 }
 
 .settings-permission-status {
-  display: inline-flex;
+  display: inline-grid;
+  place-items: center;
   align-items: center;
-  min-height: 24px;
-  padding: 0 var(--sp-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-sm);
-  background: var(--surface-subtle);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: transparent;
   color: var(--muted-foreground);
-  font-size: var(--fs-sm);
-  font-weight: 500;
-  white-space: nowrap;
 }
 
 .settings-permission-status[data-status="allowed"] {
-  border-color: color-mix(in oklch, var(--success) 24%, var(--border-subtle));
-  background: color-mix(in oklch, var(--success) 10%, var(--surface-subtle));
-  color: color-mix(in oklch, var(--success) 76%, var(--foreground));
+  color: color-mix(in oklch, var(--success) 72%, var(--foreground));
 }
 
 .settings-permission-status[data-status="attention"] {
-  border-color: color-mix(
-    in oklch,
-    var(--warm-strong) 28%,
-    var(--border-subtle)
-  );
-  background: color-mix(
-    in oklch,
-    var(--warm-strong) 12%,
-    var(--surface-subtle)
-  );
-  color: color-mix(in oklch, var(--warm-strong) 76%, var(--foreground));
+  color: color-mix(in oklch, var(--warm-strong) 82%, var(--foreground));
 }
 
 .settings-permission-status[data-status="blocked"] {
-  border-color: color-mix(
-    in oklch,
-    var(--destructive) 26%,
-    var(--border-subtle)
-  );
-  background: color-mix(
-    in oklch,
-    var(--destructive) 10%,
-    var(--surface-subtle)
-  );
-  color: color-mix(in oklch, var(--destructive) 76%, var(--foreground));
+  color: var(--destructive);
+}
+
+.settings-permission-status[data-status="unsupported"] {
+  color: var(--muted-foreground);
+}
+
+.settings-permission-status svg {
+  display: block;
 }
 
 .settings-model-control {
@@ -5262,6 +5256,12 @@ input:focus-visible,
   box-shadow:
     0 12px 32px oklch(0% 0 none / 12%),
     0 2px 6px oklch(0% 0 none / 6%);
+}
+
+.select-popover[data-placement="below"],
+.select-popover[data-placement="above"] {
+  max-height: min(280px, calc(100vh - 24px));
+  overflow-y: auto;
 }
 
 .select-popover li {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -273,7 +273,7 @@ describe("AppSettings", () => {
     });
   });
 
-  it("opens OS Accounts from Manage and Add funds in account settings", async () => {
+  it("opens OS Accounts from Add funds in billing settings", async () => {
     const user = userEvent.setup();
     render(
       <AppSettings
@@ -288,11 +288,9 @@ describe("AppSettings", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Manage" }));
-    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(1);
-
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
     await user.click(screen.getByRole("button", { name: "Add funds" }));
-    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(2);
+    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(1);
   });
 
   it("updates dictation microphone and note recording source", async () => {
@@ -353,14 +351,15 @@ describe("AppSettings", () => {
     );
 
     await user.click(screen.getByRole("tab", { name: "Dictation" }));
-    const language = await screen.findByRole("combobox", {
+    const language = await screen.findByRole("button", {
       name: "Default transcription language",
     });
 
-    await user.selectOptions(language, "id");
+    await user.click(language);
+    await user.click(await screen.findByRole("option", { name: "Indonesian" }));
 
     expect(mocks.setDictationLanguage).toHaveBeenCalledWith("id");
-    await waitFor(() => expect(language).toHaveValue("id"));
+    await waitFor(() => expect(language).toHaveTextContent("Indonesian"));
   });
 
   it("lists system permissions with status and manage actions", async () => {
@@ -410,8 +409,6 @@ describe("AppSettings", () => {
       />,
     );
 
-    await user.click(screen.getByRole("tab", { name: "Permissions" }));
-
     const microphoneRow = screen
       .getByText("Microphone")
       .closest(".settings-row");
@@ -426,13 +423,13 @@ describe("AppSettings", () => {
     expect(accessibilityRow).not.toBeNull();
     expect(systemAudioRow).not.toBeNull();
     expect(
-      within(microphoneRow as HTMLElement).getByText("Blocked"),
+      within(microphoneRow as HTMLElement).getByLabelText("Blocked"),
     ).toBeInTheDocument();
     expect(
-      within(accessibilityRow as HTMLElement).getByText("Needs access"),
+      within(accessibilityRow as HTMLElement).getByLabelText("Needs access"),
     ).toBeInTheDocument();
     expect(
-      within(systemAudioRow as HTMLElement).getByText("Blocked"),
+      within(systemAudioRow as HTMLElement).getByLabelText("Blocked"),
     ).toBeInTheDocument();
 
     await user.click(
@@ -471,7 +468,7 @@ describe("AppSettings", () => {
       />,
     );
 
-    await user.click(screen.getByRole("tab", { name: "Dictation" }));
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
     expect(await screen.findByText("Push to talk")).toBeInTheDocument();
     expect(screen.getByText("Toggle dictation")).toBeInTheDocument();
     expect(

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -136,6 +136,56 @@ describe("Sidebar primary navigation", () => {
     await user.click(screen.getByRole("button", { name: "Dictation" }));
     expect(onChangeView).toHaveBeenCalledWith("dictation");
   });
+
+  it("renders grouped icon settings navigation without focusing the identity row", async () => {
+    const user = userEvent.setup();
+    const onSettingsTabChange = vi.fn();
+    const onExitSettings = vi.fn();
+    render(
+      <Sidebar
+        notes={notes}
+        activeView="settings"
+        settingsTab="billing"
+        onSettingsTabChange={onSettingsTabChange}
+        onExitSettings={onExitSettings}
+        onChangeView={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByLabelText("OS June")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back to app" }));
+    expect(onExitSettings).toHaveBeenCalledTimes(1);
+
+    expect(
+      screen.getByRole("navigation", { name: "Personal settings" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Audio settings" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "AI settings" }),
+    ).toBeInTheDocument();
+
+    const billingButton = screen.getByRole("button", { name: "Billing" });
+    expect(billingButton).toHaveAttribute("data-active", "true");
+    expect(
+      screen.getByRole("button", { name: "Shortcuts" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Permissions" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Shortcuts" }));
+    expect(onSettingsTabChange).toHaveBeenCalledWith("shortcuts");
+
+    expect(
+      screen.getByRole("button", { name: /account menu/i }),
+    ).not.toHaveAttribute("data-active");
+  });
 });
 
 describe("FoldersWorkspace — list view", () => {


### PR DESCRIPTION
Updates Settings navigation into grouped sections with icon-led items, splits Billing and Shortcuts out as first-class sections, and moves permissions into General.
Reworks dictation controls so Language and Microphone share the same adaptive popover behavior and avoid clipping near the card edge.
Simplifies permission status badges into icons, removes the Settings logo, and tunes sidebar icon alignment, color, and pangolin sizing.
Validated with `pnpm test`, `pnpm build`, `pnpm exec tsc --noEmit`, and focused settings/sidebar tests.