### PR TITLE
Review fixes: Tauri shell

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -394,24 +394,31 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
     } = recording;
     paused_flag.store(true, Ordering::Release);
     drop(_stream);
-    if let Some(writer) = writer
-        .lock()
-        .map_err(|_| AppError::new("audio_finalization_failed", "Audio writer lock failed."))?
-        .take()
-    {
-        writer
-            .finalize()
-            .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
-    }
-    std::fs::rename(&partial_path, &final_path)
-        .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+    let microphone_finalized = (|| -> Result<(), AppError> {
+        if let Some(writer) = writer
+            .lock()
+            .map_err(|_| AppError::new("audio_finalization_failed", "Audio writer lock failed."))?
+            .take()
+        {
+            writer
+                .finalize()
+                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        }
+        std::fs::rename(&partial_path, &final_path)
+            .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))
+    })();
+    // Stop the system-audio helper even when microphone finalization failed:
+    // dropping `SystemAudioCapture` without `stop()` would leave the helper
+    // process recording in the background.
+    let system_stopped = system_capture.map(SystemAudioCapture::stop);
+    microphone_finalized?;
     let mut sources = vec![FinishedSource {
         source: RecordingSource::Microphone,
         final_path: final_path.clone(),
         elapsed_ms: recording_dto.elapsed_ms,
     }];
-    if let Some(system_capture) = system_capture {
-        let system_path = system_capture.stop()?;
+    if let Some(system_path) = system_stopped {
+        let system_path = system_path?;
         sources.push(FinishedSource {
             source: RecordingSource::System,
             final_path: system_final_path.unwrap_or(system_path.clone()),

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -71,14 +71,21 @@ impl SystemAudioCapture {
         dev_log(format!("open returned status={open_status}"));
 
         let stats = Arc::new(Mutex::new(SystemAudioStats::default()));
-        let ready = wait_for_status(
+        let ready = match wait_for_status(
             &status_path,
             Some(&log_path),
             Duration::from_secs(30),
             &["ready", "level", "error"],
             "System audio helper did not become ready. See the terminal helper log for the last CoreAudio step.",
-        )?;
+        ) {
+            Ok(ready) => ready,
+            Err(error) => {
+                abort_failed_helper_start(&partial_path, &status_path, &pid_path);
+                return Err(error);
+            }
+        };
         if ready.event == "error" {
+            abort_failed_helper_start(&partial_path, &status_path, &pid_path);
             return Err(AppError::new(
                 "system_audio_permission_denied",
                 ready
@@ -86,12 +93,13 @@ impl SystemAudioCapture {
                     .unwrap_or_else(|| "System audio capture failed.".to_string()),
             ));
         }
-        let pid = read_pid(&pid_path).ok_or_else(|| {
-            AppError::new(
+        let Some(pid) = read_pid(&pid_path) else {
+            abort_failed_helper_start(&partial_path, &status_path, &pid_path);
+            return Err(AppError::new(
                 "system_audio_unavailable",
                 "System audio helper PID was not written.",
-            )
-        })?;
+            ));
+        };
         dev_log(format!("helper ready event={} pid={pid}", ready.event));
         Ok(Self {
             pid,
@@ -355,6 +363,21 @@ pub fn helper_app_path() -> PathBuf {
         }
     }
     dev_path
+}
+
+/// Kill a helper that launched but never became usable, so a failed start
+/// doesn't leave a stray process recording in the background. The probe in
+/// `helper_permission_check` already does this; `start` must too.
+fn abort_failed_helper_start(partial_path: &Path, status_path: &Path, pid_path: &Path) {
+    if let Some(pid) = read_pid(pid_path) {
+        send_signal(pid, "-TERM");
+        if wait_for_stopped(status_path, Duration::from_secs(2)).is_err() {
+            send_signal(pid, "-KILL");
+        }
+    }
+    let _ = std::fs::remove_file(partial_path);
+    let _ = std::fs::remove_file(status_path);
+    let _ = std::fs::remove_file(pid_path);
 }
 
 fn send_signal(pid: u32, signal: &str) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -458,7 +458,12 @@ pub async fn get_microphone_permission_state() -> Result<MicrophonePermissionRes
 pub async fn check_recording_source_readiness(
     request: CheckRecordingSourceReadinessRequest,
 ) -> Result<RecordingSourceReadinessDto, AppError> {
-    Ok(recording_source_readiness(request.source_mode))
+    // The system-audio permission probe can block for over a minute while the
+    // helper waits on a CoreAudio permission grant; keep that work off the
+    // async runtime so other commands stay responsive.
+    tokio::task::spawn_blocking(move || recording_source_readiness(request.source_mode))
+        .await
+        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
 }
 
 #[tauri::command]
@@ -509,7 +514,11 @@ pub async fn start_recording(
     let repos = repositories(&app).await?;
     let note = repos.get_note(&request.note_id).await?;
     let source_mode = request.source_mode.unwrap_or_default();
-    let readiness = recording_source_readiness(source_mode);
+    // Readiness probing and capture startup both wait on the system-audio
+    // helper (up to tens of seconds); run them off the async runtime.
+    let readiness = tokio::task::spawn_blocking(move || recording_source_readiness(source_mode))
+        .await
+        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))?;
     if !readiness.ready {
         let message = readiness
             .sources
@@ -520,7 +529,13 @@ pub async fn start_recording(
         return Err(AppError::new("source_not_ready", message));
     }
     finish_active_capture_before_start(&repos).await?;
-    let started = start_capture(&paths, note.id.clone(), source_mode)?;
+    let capture_paths = paths.clone();
+    let capture_note_id = note.id.clone();
+    let started = tokio::task::spawn_blocking(move || {
+        start_capture(&capture_paths, capture_note_id, source_mode)
+    })
+    .await
+    .map_err(|error| AppError::new("recording_start_failed", error.to_string()))??;
     repos
         .create_recording_session(
             &note.id,

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -341,7 +341,7 @@ async fn start_hermes_bridge_inner(
     apply_isolated_hermes_env(&mut cmd, &hermes_home, &token);
     cmd.current_dir(cwd);
 
-    let child = cmd.spawn().map_err(|error| {
+    let mut child = cmd.spawn().map_err(|error| {
         AppError::new(
             "hermes_bridge_start_failed",
             format!("Could not start the Scribe-managed Hermes runtime. {error}"),
@@ -364,6 +364,23 @@ async fn start_hermes_bridge_inner(
         let mut guard = bridge.process.lock().map_err(|_| {
             AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
         })?;
+        // A concurrent start may have won the race while we were spawning
+        // (the early `existing_running_status` check runs before any await).
+        // Keep the established process and tear down the redundant one we
+        // just launched instead of leaking it.
+        if let Some(existing) = guard.as_mut() {
+            if matches!(existing.child.try_wait(), Ok(None)) {
+                let existing_connection = existing.connection.clone();
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = provider_proxy.shutdown.send(());
+                return Ok(HermesBridgeStatus {
+                    running: true,
+                    connection: Some(existing_connection),
+                    message: None,
+                });
+            }
+        }
         *guard = Some(HermesProcess {
             child,
             connection: connection.clone(),
@@ -1136,28 +1153,39 @@ async fn install_managed_hermes_runtime(
         .try_clone()
         .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
 
-    let status = Command::new("/bin/bash")
-        .arg("-c")
-        .arg(MANAGED_HERMES_INSTALL_SCRIPT)
-        .env("SCRIBE_HERMES_RUNTIME_DIR", &runtime_dir)
-        .env("SCRIBE_HERMES_INSTALL_DIR", &install_dir)
-        .env("SCRIBE_HERMES_HOME", hermes_home)
-        .env("SCRIBE_HERMES_INSTALL_COMMIT", HERMES_AGENT_INSTALL_COMMIT)
-        .env(
-            "SCRIBE_HERMES_SOURCE_TARBALL_URL",
-            HERMES_SOURCE_TARBALL_URL,
-        )
-        .env(
-            "SCRIBE_HERMES_SOURCE_TARBALL_SHA256",
-            HERMES_SOURCE_TARBALL_SHA256,
-        )
-        .env("HERMES_HOME", hermes_home)
-        .env("HERMES_INSTALL_DIR", &install_dir)
-        .env("UV_NO_CONFIG", "1")
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(log_file))
-        .stderr(Stdio::from(log_file_for_stderr))
-        .status()
+    // The installer downloads the Hermes source and builds a venv — it can run
+    // for minutes. Run it on a blocking thread so it doesn't pin an async
+    // runtime worker for the whole install.
+    let status = {
+        let runtime_dir = runtime_dir.clone();
+        let install_dir = install_dir.clone();
+        let hermes_home = hermes_home.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            Command::new("/bin/bash")
+                .arg("-c")
+                .arg(MANAGED_HERMES_INSTALL_SCRIPT)
+                .env("SCRIBE_HERMES_RUNTIME_DIR", &runtime_dir)
+                .env("SCRIBE_HERMES_INSTALL_DIR", &install_dir)
+                .env("SCRIBE_HERMES_HOME", &hermes_home)
+                .env("SCRIBE_HERMES_INSTALL_COMMIT", HERMES_AGENT_INSTALL_COMMIT)
+                .env(
+                    "SCRIBE_HERMES_SOURCE_TARBALL_URL",
+                    HERMES_SOURCE_TARBALL_URL,
+                )
+                .env(
+                    "SCRIBE_HERMES_SOURCE_TARBALL_SHA256",
+                    HERMES_SOURCE_TARBALL_SHA256,
+                )
+                .env("HERMES_HOME", &hermes_home)
+                .env("HERMES_INSTALL_DIR", &install_dir)
+                .env("UV_NO_CONFIG", "1")
+                .stdin(Stdio::null())
+                .stdout(Stdio::from(log_file))
+                .stderr(Stdio::from(log_file_for_stderr))
+                .status()
+        })
+        .await
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?
         .map_err(|error| {
             AppError::new(
                 "hermes_runtime_install_failed",
@@ -1166,7 +1194,8 @@ async fn install_managed_hermes_runtime(
                     install_log.display()
                 ),
             )
-        })?;
+        })?
+    };
 
     if !status.success() {
         return Err(AppError::new(

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -916,9 +916,14 @@ fn random_b64url(bytes: usize) -> String {
 }
 
 fn open_in_browser(url: &str) -> Result<(), AppError> {
-    std::process::Command::new("open")
+    let mut child = std::process::Command::new("open")
         .arg(url)
         .spawn()
-        .map(|_| ())
-        .map_err(|e| AppError::new("browser_open_failed", e.to_string()))
+        .map_err(|e| AppError::new("browser_open_failed", e.to_string()))?;
+    // Reap the short-lived `open` process off-thread so it doesn't linger as
+    // a zombie until the app exits.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Code review of the Tauri Rust shell (`src-tauri/`) covering audio capture (`audio/capture.rs`, `audio/system_macos.rs`, `audio/turns.rs`, `audio/validation.rs`, `audio/recovery.rs`), the db layer (`db/migrations.rs`, `db/repositories.rs`), domain logic (`domain/processing.rs`, `domain/processing_queue.rs`, `domain/types.rs`), `providers/`, `commands.rs`, `dictation.rs`, `meeting_detection.rs`, `menu_bar.rs`, `hermes_bridge.rs`, `os_accounts.rs`, `scribe_api.rs`, and `app_paths.rs`. The review prioritized panics in runtime paths, race conditions and lock handling across await points, unhandled errors, resource leaks (audio streams, helper processes, file handles, threads), Tauri command error handling, SQL issues, unsafe blocks, and logic bugs.

## Issues found and fixed

- **System-audio helper leaked when microphone finalization fails** (`src-tauri/src/audio/capture.rs`, `finalize_recording`): if the mic WAV `finalize()` or the partial-to-final rename failed, the function returned early and dropped `SystemAudioCapture` without `stop()`, leaving the helper process recording in the background indefinitely. The helper is now stopped on both the success and failure paths.
- **System-audio helper leaked on every failed start** (`src-tauri/src/audio/system_macos.rs`, `SystemAudioCapture::start`): on readiness timeout, a helper `error` event, or a missing PID file, the launched helper kept running. All failure paths now terminate the helper (TERM, then KILL) and remove its partial/status/pid files, matching what `helper_permission_check` already did on its failure path.
- **Async commands blocked the tokio runtime for up to 75 s** (`src-tauri/src/commands.rs`): `check_recording_source_readiness` and `start_recording` called `recording_source_readiness` (which runs the CoreAudio permission probe, blocking up to ~75 s with `thread::sleep`) and `start_capture` (blocking up to ~30 s on helper readiness) directly on async worker threads. Repeated readiness checks could starve the whole async runtime and hang all other commands. Both are now wrapped in `tokio::task::spawn_blocking`.
- **Concurrent `start_hermes_bridge` leaked a Hermes child process** (`src-tauri/src/hermes_bridge.rs`, `start_hermes_bridge_inner`): the auto-start at app launch and a frontend `start_hermes_bridge` call could both pass the early running check (it runs before any await) and both spawn `hermes dashboard`; the second overwrote the first in the state mutex, leaking an unkilled, unreaped process plus its provider proxy. The losing child is now killed/reaped and its proxy shut down, returning the established connection instead.
- **Hermes runtime installer blocked an async worker for minutes** (`src-tauri/src/hermes_bridge.rs`, `install_managed_hermes_runtime`): the bash installer (tarball download + venv + dependency install) ran via a synchronous `Command::status()` inside async context. It now runs on `tokio::task::spawn_blocking`.
- **Zombie `open` processes from the login flow** (`src-tauri/src/os_accounts.rs`, `open_in_browser`): the spawned `/usr/bin/open` child was never waited on, leaving one zombie per login/top-up until app exit. The child is now reaped on a detached thread.

## Notable issues found but NOT fixed

- **A new SQLite pool is created and migrations re-run on every Tauri command** (`src-tauri/src/commands.rs`, `repositories()`): functionally correct but wasteful; moving to a shared managed pool would touch every command and is too broad for this review.
- **`hydrate_agent_task_from_hermes` opens a fresh pool to the Hermes `state.db` per task in `list_agent_tasks`** and drops it without `.close()` (`src-tauri/src/commands.rs`): mild connection churn; same shared-pool refactor as above.
- **`unsafe impl Send for ActiveRecording`** (`src-tauri/src/audio/capture.rs:84`): carries a documented justification tied to the single-recording lifecycle on macOS; left as is.
- **`delete_folder(delete_notes: true)` deletes note rows but not their audio files on disk** (`src-tauri/src/db/repositories.rs`), unlike `delete_note` which removes them. A fix needs a new repo query plus path cleanup in the command layer; flagged rather than fixed to keep this change set low-risk.
- **`ProcessingTicket` pending count leaks if a processing task panics before `finish()`** (`src-tauri/src/domain/processing_queue.rs`): would only mis-report the queued-recordings UI count; a Drop-guard redesign was judged out of scope.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `cargo test --manifest-path src-tauri/Cargo.toml` — 145 tests passing (100 lib + 45 integration/unit across `migrations`, `turn_detection`, and module test suites), 0 failed.
- Baseline `cargo check` on `origin/main` was run first and passes, so no pre-existing failures were masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)