### PR TITLE
Review fixes: frontend

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -50,7 +50,7 @@
         >Meeting detected</span
       >
       <button id="hud-meeting-start" class="hud-meeting-start" type="button">
-        Start Transcription
+        Start transcription
       </button>
       <button
         id="hud-stop"

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -239,6 +239,10 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     Record<string, string>
   >({});
   const gatewayRef = useRef<HermesGatewayClient | null>(null);
+  // One live gateway subscription per Hermes session. A follow-up send while
+  // the previous turn is still streaming must replace the old handler, not
+  // stack a second one — otherwise every event lands twice in liveEvents.
+  const sessionGatewayUnlistenRef = useRef<Map<string, () => void>>(new Map());
   const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>({});
   const hydratedTaskIdsRef = useRef<Set<string>>(new Set());
   const newSessionModeRef = useRef(false);
@@ -711,10 +715,12 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
     setAttachments([]);
     try {
       await submitHermesSession(content);
-      setAttachments([]);
       setError(null);
     } catch (err) {
+      // Restore the composer so a failed send doesn't eat the message or
+      // its attachments.
       setDraft(message);
+      setAttachments(attachments);
       setError(messageFromError(err));
     } finally {
       setSubmitting(false);
@@ -895,7 +901,8 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
       status: "running",
       summary: "June is working.",
     });
-    const unlisten = gateway.onEvent((event) => {
+    sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
+    const removeListener = gateway.onEvent((event) => {
       if (
         event.session_id !== runtimeSessionId &&
         event.session_id !== storedSessionId
@@ -936,6 +943,13 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
         }, 300);
       }
     });
+    const unlisten = () => {
+      removeListener();
+      if (sessionGatewayUnlistenRef.current.get(storedSessionId) === unlisten) {
+        sessionGatewayUnlistenRef.current.delete(storedSessionId);
+      }
+    };
+    sessionGatewayUnlistenRef.current.set(storedSessionId, unlisten);
     try {
       await gateway.request("prompt.submit", {
         session_id: runtimeSessionId,
@@ -1669,6 +1683,10 @@ export function AgentWorkspace({ initialSession }: AgentWorkspaceProps = {}) {
                   }
                   rows={1}
                   onKeyDown={(event) => {
+                    // Ignore the Enter that commits an IME composition
+                    // (Japanese/Chinese/Korean input) — only a real Enter
+                    // press should send the message.
+                    if (event.nativeEvent.isComposing) return;
                     if (event.key === "Enter" && !event.shiftKey) {
                       event.preventDefault();
                       event.currentTarget.form?.requestSubmit();

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -113,6 +113,7 @@ export function DictationHistoryView({
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
     let unlisten: (() => void) | undefined;
     void listen<string>("dictation-event", (event) => {
       const payload = parseDictationHelperEvent(event.payload);
@@ -120,9 +121,15 @@ export function DictationHistoryView({
         void loadHistory();
       }
     }).then((cleanup) => {
-      unlisten = cleanup;
+      // Unmount can race the listen() promise — unsubscribe immediately
+      // instead of leaking the listener.
+      if (cancelled) cleanup();
+      else unlisten = cleanup;
     });
-    return () => unlisten?.();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   }, [loadHistory]);
 
   const filtered = useMemo(() => {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -308,7 +308,10 @@ export function AppSettings({
       const helperEvent = parseDictationHelperEvent(event.payload);
       if (helperEvent) handleHelperEvent(helperEvent);
     }).then((cleanup) => {
-      unlisten = cleanup;
+      // Unmount can race the listen() promise — unsubscribe immediately
+      // instead of leaking the listener.
+      if (cancelled) cleanup();
+      else unlisten = cleanup;
     });
     void boot();
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -398,7 +398,7 @@ export function Sidebar({
               <span className="sidebar-nav-icon">
                 <IconPlusMedium size={15} />
               </span>
-              <span className="sidebar-nav-label">New Session</span>
+              <span className="sidebar-nav-label">New session</span>
             </button>
             <button
               type="button"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -601,7 +601,6 @@ input:focus-visible,
   font-size: var(--fs-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .agent-capability-group h3 span {
@@ -924,7 +923,6 @@ input:focus-visible,
   font-size: var(--fs-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .agent-advanced-toggle {

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -77,7 +77,7 @@ describe("folders UI", () => {
     expect(screen.getByRole("button", { name: "Agent" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Notes" }));
-    await user.click(screen.getByRole("button", { name: "New Session" }));
+    await user.click(screen.getByRole("button", { name: "New session" }));
 
     expect(onChangeView).toHaveBeenCalledWith("notes");
     expect(onChangeView).toHaveBeenCalledWith("agent");

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -58,7 +58,7 @@ describe("meeting detection HUD", () => {
       "Meeting detected",
     );
     expect(document.querySelector("#hud-meeting-start")).toHaveTextContent(
-      "Start Transcription",
+      "Start transcription",
     );
     expect(mocks.show).toHaveBeenCalledOnce();
     expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_stop_bounds", {
@@ -273,7 +273,7 @@ function hudMarkup() {
       <span id="hud-error-text" class="hud-error-text" aria-hidden="true"></span>
       <span id="hud-agent-label" class="hud-agent-label" aria-hidden="true"></span>
       <span id="hud-meeting-label" class="hud-meeting-label">Meeting detected</span>
-      <button id="hud-meeting-start" class="hud-meeting-start" type="button">Start Transcription</button>
+      <button id="hud-meeting-start" class="hud-meeting-start" type="button">Start transcription</button>
       <button id="hud-stop" class="hud-stop" type="button" aria-label="Stop dictation">
         <span class="hud-stop-glyph" aria-hidden="true"></span>
       </button>


### PR DESCRIPTION
## Summary

Code review of the frontend TypeScript/React code: `src/` (app shell, components, lib, styles, `hud.ts`, `main.tsx`), plus `index.html`, `hud.html`, and `vite.config.ts`. Focus was correctness: Tauri event listener lifecycle, race conditions, state handling, error swallowing, accessibility, and the UI conventions in CLAUDE.md. `src-tauri/` and `scribe-api/` were out of scope.

## Issues found and fixed

- **Tauri listener leak in settings** (`src/components/settings/AppSettings.tsx`): the `listen("dictation-event")` cleanup was only stored after the promise resolved, so unmounting before resolution leaked the listener. Now follows the same `cancelled` guard pattern used in `App.tsx`.
- **Tauri listener leak in dictation history** (`src/components/dictation/DictationHistoryView.tsx`): same unmount-vs-`listen()` race; the view mounts/unmounts on every sidebar navigation, so the leak was easy to accumulate. Same guard applied.
- **Duplicate gateway subscriptions per agent session** (`src/components/agent/AgentWorkspace.tsx`): sending a follow-up message while the previous turn was still streaming registered a second `gateway.onEvent` handler for the same session — every subsequent event was appended twice to the live-event log and session status was dispatched twice. A per-session unlisten registry now replaces the old handler on resubmit.
- **Attachments lost on failed send** (`src/components/agent/AgentWorkspace.tsx`): `submit()` restored the draft text when `submitHermesSession` threw, but the already-cleared attachments were dropped. Both are now restored together.
- **IME Enter submitted mid-composition** (`src/components/agent/AgentWorkspace.tsx`): the composer's Enter-to-send fired on the Enter that commits a Japanese/Chinese/Korean IME composition. Now ignored via `event.nativeEvent.isComposing`.
- **Sentence-case violations** (CLAUDE.md convention): sidebar "New Session" → "New session" (`src/components/sidebar/Sidebar.tsx`), HUD "Start Transcription" → "Start transcription" (`hud.html`), and removed `text-transform: uppercase` from agent section titles in `src/styles/app.css`. Matching test strings updated (`src/test/folders.test.tsx`, `src/test/hud-meeting.test.ts`).

## Notable issues found but NOT fixed

- **Stale-closure pattern in `AgentWorkspace` new-session handling**: the mount-only `AGENT_NEW_SESSION_EVENT` effect captures first-render `startNewTask`/`submitHermesSession`. It works today because the critical state goes through refs (`newSessionModeRef`, `selectedHermesSessionIdRef`), but the stale `bridge` causes a redundant `startHermesBridge()` call. Restructuring would be a large refactor with regression risk, so left as-is.
- **Dead code**: `submitToHermes`, `mergeTimeline`/`normalizeHermesEvents` and several row components in `AgentWorkspace.tsx`, plus `NoteRow`/`openMenuForNote`/`filteredNotes` in `Sidebar.tsx` are unreferenced. Removal would be churn unrelated to correctness; flagging for a dedicated cleanup.
- **`AccountGate` cancel-on-busy-change** (`src/components/account/AccountGate.tsx`): the unmount-cancel effect's cleanup also runs whenever `busy` flips false, sending a redundant `osAccountsCancelLogin` after every settled login. Benign (backend no-ops when nothing is pending), so not worth the rework.
- **Pre-existing Prettier violations** in `AgentWorkspace.tsx` on origin/main (3 spots untouched by this review) were deliberately left unformatted to avoid formatting-only churn.

## Verification

- `pnpm install`, then `pnpm lint` (`tsc --noEmit`): clean.
- `pnpm test` (vitest): 28 files, 169 tests, all passing — verified green on origin/main first, then again with the fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)