### PR TITLE
Defer recording consent to a non-blocking reminder

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -184,20 +184,29 @@ export function NoteEditor({
         : recordingActive && !prev.recording;
 
     consentEdgeRef.current = { noteId: note.id, recording: recordingActive };
+    // Undo the ref mutation on cleanup so StrictMode's double-invoke replays
+    // the same edge — otherwise the second invoke sees its own write and the
+    // reminder never appears in development.
+    const restoreEdge = () => {
+      consentEdgeRef.current = prev;
+    };
 
     if (!recordingActive) {
       setConsentReminderVisible(false);
-      return;
+      return restoreEdge;
     }
 
-    if (!shouldReveal) return;
+    if (!shouldReveal) return restoreEdge;
 
     setConsentReminderVisible(false);
     const timer = window.setTimeout(
       () => setConsentReminderVisible(true),
       RECORD_CONSENT_REVEAL_DELAY_MS,
     );
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      restoreEdge();
+    };
   }, [note.id, recordingActive]);
 
   useEffect(() => {

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -3,6 +3,7 @@ import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconFolder1 } from "central-icons/IconFolder1";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophoneOff } from "central-icons/IconMicrophoneOff";
+import { IconRecord } from "central-icons/IconRecord";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconMicrophone as IconMicrophoneLine } from "central-icons/IconMicrophone";
 import { IconVolumeFull } from "central-icons/IconVolumeFull";
@@ -127,7 +128,9 @@ export function NoteEditor({
   const sourceTranscripts = visibleSourceTranscripts(note);
   const recordingForNote = recordingStatus;
   const [optionsOpen, setOptionsOpen] = useState(false);
-  const [recordConsentOpen, setRecordConsentOpen] = useState(false);
+  // Consent is a gentle, non-blocking reminder that slides in *after*
+  // recording starts — clicking record never stalls behind a dialog.
+  const [consentReminderVisible, setConsentReminderVisible] = useState(false);
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
   // The source filter is ephemeral view state — reset it when navigating
   // to a different note so it never leaks across transcripts.
@@ -171,12 +174,26 @@ export function NoteEditor({
   useEffect(() => {
     if (recordingForNote) setOptionsOpen(false);
   }, [recordingForNote]);
+  // Surface the consent reminder the moment a recording begins (or when we
+  // land on a note that's already recording), and clear it once recording
+  // ends. Tracking the idle -> recording edge keeps frequent meter-tick
+  // status updates from resurrecting a reminder the user already dismissed.
+  const consentEdgeRef = useRef({ noteId: note.id, recording: false });
   useEffect(() => {
-    if (recordingForNote) setRecordConsentOpen(false);
-  }, [recordingForNote]);
+    const isRecording = Boolean(recordingForNote);
+    const prev = consentEdgeRef.current;
+    if (prev.noteId !== note.id) setConsentReminderVisible(isRecording);
+    else if (isRecording && !prev.recording) setConsentReminderVisible(true);
+    else if (!isRecording) setConsentReminderVisible(false);
+    consentEdgeRef.current = { noteId: note.id, recording: isRecording };
+  }, [note.id, recordingForNote]);
+  // The reminder is a transient courtesy, not a gate — let it fade on its own
+  // so it never lingers over the waveform.
   useEffect(() => {
-    setRecordConsentOpen(false);
-  }, [note.id]);
+    if (!consentReminderVisible) return;
+    const timer = setTimeout(() => setConsentReminderVisible(false), 6000);
+    return () => clearTimeout(timer);
+  }, [consentReminderVisible]);
   const processingLock =
     note.processingStatus === "transcribing" ||
     note.processingStatus === "generating" ||
@@ -353,163 +370,163 @@ export function NoteEditor({
             }
           />
         ) : (
-          <div
-            className="record-shell"
-            data-state={shellState}
-            data-options-open={
-              !recordingForNote && !processingLock && optionsOpen
-            }
-          >
-            {!recordingForNote && !processingLock ? (
-              <div
-                className="record-options-panel"
-                data-open={optionsOpen}
-                aria-hidden={!optionsOpen}
+          <div className="record-dock">
+            {recordingForNote && consentReminderVisible ? (
+              <motion.div
+                className="record-consent-note"
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
-                <div className="record-options-panel-inner">
-                  {systemUnsupported ? (
-                    <p className="record-options-unsupported">
-                      System audio requires macOS 14.2 or later.
-                    </p>
-                  ) : (
-                    <div
-                      className="record-options-row"
-                      data-locked={systemDenied || undefined}
+                <InlineNotice
+                  aria-label="Recording consent reminder"
+                  icon={<IconRecord size={14} aria-hidden />}
+                  eyebrow="Now recording"
+                  body="Make sure everyone has agreed to be recorded."
+                  actions={
+                    <button
+                      type="button"
+                      className="btn btn-ghost"
+                      onClick={() => setConsentReminderVisible(false)}
                     >
-                      <Switch
-                        checked={systemOn}
-                        disabled={systemDenied}
-                        aria-labelledby="record-options-system"
-                        onCheckedChange={(next) =>
-                          onSourceModeChange(
-                            next ? "microphonePlusSystem" : "microphoneOnly",
-                          )
-                        }
-                      />
-                      <span
-                        id="record-options-system"
-                        className="record-options-label"
+                      Got it
+                    </button>
+                  }
+                />
+              </motion.div>
+            ) : null}
+            <div
+              className="record-shell"
+              data-state={shellState}
+              data-options-open={
+                !recordingForNote && !processingLock && optionsOpen
+              }
+            >
+              {!recordingForNote && !processingLock ? (
+                <div
+                  className="record-options-panel"
+                  data-open={optionsOpen}
+                  aria-hidden={!optionsOpen}
+                >
+                  <div className="record-options-panel-inner">
+                    {systemUnsupported ? (
+                      <p className="record-options-unsupported">
+                        System audio requires macOS 14.2 or later.
+                      </p>
+                    ) : (
+                      <div
+                        className="record-options-row"
+                        data-locked={systemDenied || undefined}
                       >
-                        Capture system audio
-                      </span>
-                      {systemDenied ? (
+                        <Switch
+                          checked={systemOn}
+                          disabled={systemDenied}
+                          aria-labelledby="record-options-system"
+                          onCheckedChange={(next) =>
+                            onSourceModeChange(
+                              next ? "microphonePlusSystem" : "microphoneOnly",
+                            )
+                          }
+                        />
+                        <span
+                          id="record-options-system"
+                          className="record-options-label"
+                        >
+                          Capture system audio
+                        </span>
+                        {systemDenied ? (
+                          <button
+                            type="button"
+                            className="btn btn-ghost record-options-enable"
+                            onClick={onEnableSystemAudio}
+                          >
+                            Enable
+                          </button>
+                        ) : null}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ) : null}
+              <div className="record-stage">
+                <AnimatePresence initial={false}>
+                  {recordingForNote ? (
+                    <motion.div
+                      key="recorder"
+                      className="record-state record-state-recorder"
+                      initial={{ opacity: 0 }}
+                      animate={{
+                        opacity: 1,
+                        transition: {
+                          duration: 0.22,
+                          delay: 0.14,
+                          ease: [0.22, 1, 0.36, 1],
+                        },
+                      }}
+                      exit={{
+                        opacity: 0,
+                        transition: {
+                          duration: 0.12,
+                          ease: [0.22, 1, 0.36, 1],
+                        },
+                      }}
+                    >
+                      <RecorderBar
+                        status={recordingForNote}
+                        onPause={onPauseRecording}
+                        onResume={onResumeRecording}
+                        onDone={onFinishRecording}
+                      />
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key="idle"
+                      className="record-state record-state-idle"
+                      initial={{ opacity: 0 }}
+                      animate={{
+                        opacity: 1,
+                        // Symmetric to the recorder enter — delay the reveal
+                        // so the idle pill resolves as the shell finishes
+                        // collapsing back, not while it's still wide.
+                        transition: {
+                          duration: 0.22,
+                          delay: 0.12,
+                          ease: [0.22, 1, 0.36, 1],
+                        },
+                      }}
+                      exit={{
+                        opacity: 0,
+                        transition: {
+                          duration: 0.12,
+                          ease: [0.22, 1, 0.36, 1],
+                        },
+                      }}
+                    >
+                      <div className="record-idle">
                         <button
                           type="button"
-                          className="btn btn-ghost record-options-enable"
-                          onClick={onEnableSystemAudio}
+                          className="record-button"
+                          aria-label="Record"
+                          title="Record"
+                          onClick={onStartRecording}
                         >
-                          Enable
+                          <IconMicrophone size={20} />
                         </button>
-                      ) : null}
-                    </div>
-                  )}
-                </div>
-              </div>
-            ) : null}
-            <div className="record-stage">
-              <AnimatePresence initial={false}>
-                {recordingForNote ? (
-                  <motion.div
-                    key="recorder"
-                    className="record-state record-state-recorder"
-                    initial={{ opacity: 0 }}
-                    animate={{
-                      opacity: 1,
-                      transition: {
-                        duration: 0.22,
-                        delay: 0.14,
-                        ease: [0.22, 1, 0.36, 1],
-                      },
-                    }}
-                    exit={{
-                      opacity: 0,
-                      transition: { duration: 0.12, ease: [0.22, 1, 0.36, 1] },
-                    }}
-                  >
-                    <RecorderBar
-                      status={recordingForNote}
-                      onPause={onPauseRecording}
-                      onResume={onResumeRecording}
-                      onDone={onFinishRecording}
-                    />
-                  </motion.div>
-                ) : (
-                  <motion.div
-                    key="idle"
-                    className="record-state record-state-idle"
-                    initial={{ opacity: 0 }}
-                    animate={{
-                      opacity: 1,
-                      // Symmetric to the recorder enter — delay the reveal
-                      // so the idle pill resolves as the shell finishes
-                      // collapsing back, not while it's still wide.
-                      transition: {
-                        duration: 0.22,
-                        delay: 0.12,
-                        ease: [0.22, 1, 0.36, 1],
-                      },
-                    }}
-                    exit={{
-                      opacity: 0,
-                      transition: { duration: 0.12, ease: [0.22, 1, 0.36, 1] },
-                    }}
-                  >
-                    <div className="record-idle">
-                      <button
-                        type="button"
-                        className="record-button"
-                        aria-label="Record"
-                        title="Record"
-                        aria-expanded={recordConsentOpen}
-                        onClick={() => setRecordConsentOpen(true)}
-                      >
-                        <IconMicrophone size={20} />
-                      </button>
-                      <button
-                        type="button"
-                        className="record-options-trigger"
-                        aria-label="Recording options"
-                        aria-expanded={optionsOpen}
-                        data-rotated={optionsOpen}
-                        onClick={() => setOptionsOpen((value) => !value)}
-                      >
-                        <IconChevronBottom size={16} />
-                      </button>
-                    </div>
-                    {recordConsentOpen ? (
-                      <div
-                        className="record-consent-popover"
-                        role="dialog"
-                        aria-label="Recording consent reminder"
-                      >
-                        <p>
-                          Make sure everyone has agreed to be recorded before
-                          you start.
-                        </p>
-                        <div className="record-consent-actions">
-                          <button
-                            type="button"
-                            className="btn btn-ghost"
-                            onClick={() => setRecordConsentOpen(false)}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            className="btn btn-secondary"
-                            onClick={() => {
-                              setRecordConsentOpen(false);
-                              onStartRecording();
-                            }}
-                          >
-                            Continue
-                          </button>
-                        </div>
+                        <button
+                          type="button"
+                          className="record-options-trigger"
+                          aria-label="Recording options"
+                          aria-expanded={optionsOpen}
+                          data-rotated={optionsOpen}
+                          onClick={() => setOptionsOpen((value) => !value)}
+                        >
+                          <IconChevronBottom size={16} />
+                        </button>
                       </div>
-                    ) : null}
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -385,13 +385,15 @@ export function NoteEditor({
           />
         ) : (
           <div className="record-dock">
-            {recordingForNote && consentReminderVisible ? (
-              <div className="record-consent-note">
+            <AnimatePresence>
+              {recordingForNote && consentReminderVisible ? (
                 <motion.div
-                  className="record-consent-note-anim"
-                  initial={{ opacity: 0, y: 3 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                  key="consent"
+                  className="record-consent-note"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.22, ease: "easeOut" }}
                 >
                   <InlineNotice
                     className="record-consent-note-surface"
@@ -408,8 +410,8 @@ export function NoteEditor({
                     }
                   />
                 </motion.div>
-              </div>
-            ) : null}
+              ) : null}
+            </AnimatePresence>
             <div
               className="record-shell"
               data-state={shellState}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -386,27 +386,29 @@ export function NoteEditor({
         ) : (
           <div className="record-dock">
             {recordingForNote && consentReminderVisible ? (
-              <motion.div
-                className="record-consent-note"
-                initial={{ opacity: 0, y: 3 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
-              >
-                <InlineNotice
-                  className="record-consent-note-surface"
-                  aria-label="Recording consent reminder"
-                  body="Make sure everyone has agreed to be recorded."
-                  actions={
-                    <button
-                      type="button"
-                      className="btn btn-ghost"
-                      onClick={() => setConsentReminderVisible(false)}
-                    >
-                      Dismiss
-                    </button>
-                  }
-                />
-              </motion.div>
+              <div className="record-consent-note">
+                <motion.div
+                  className="record-consent-note-anim"
+                  initial={{ opacity: 0, y: 3 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                >
+                  <InlineNotice
+                    className="record-consent-note-surface"
+                    aria-label="Recording consent reminder"
+                    body="Make sure everyone has agreed to be recorded."
+                    actions={
+                      <button
+                        type="button"
+                        className="btn btn-ghost"
+                        onClick={() => setConsentReminderVisible(false)}
+                      >
+                        Dismiss
+                      </button>
+                    }
+                  />
+                </motion.div>
+              </div>
             ) : null}
             <div
               className="record-shell"

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -3,7 +3,6 @@ import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconFolder1 } from "central-icons/IconFolder1";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophoneOff } from "central-icons/IconMicrophoneOff";
-import { IconRecord } from "central-icons/IconRecord";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconMicrophone as IconMicrophoneLine } from "central-icons/IconMicrophone";
 import { IconVolumeFull } from "central-icons/IconVolumeFull";
@@ -84,6 +83,9 @@ const SOURCE_FILTERS = [
   { value: "system", label: "System" },
 ] as const;
 
+const RECORD_CONSENT_REVEAL_DELAY_MS = 420;
+const RECORD_CONSENT_AUTO_HIDE_MS = 5000;
+
 function formatTurnTime(startMs?: number, endMs?: number) {
   if (startMs === undefined || endMs === undefined || endMs <= startMs) {
     return null;
@@ -127,9 +129,8 @@ export function NoteEditor({
   const activeTab = note.activeTab ?? "notes";
   const sourceTranscripts = visibleSourceTranscripts(note);
   const recordingForNote = recordingStatus;
+  const recordingActive = Boolean(recordingForNote);
   const [optionsOpen, setOptionsOpen] = useState(false);
-  // Consent is a gentle, non-blocking reminder that slides in *after*
-  // recording starts — clicking record never stalls behind a dialog.
   const [consentReminderVisible, setConsentReminderVisible] = useState(false);
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
   // The source filter is ephemeral view state — reset it when navigating
@@ -174,25 +175,38 @@ export function NoteEditor({
   useEffect(() => {
     if (recordingForNote) setOptionsOpen(false);
   }, [recordingForNote]);
-  // Surface the consent reminder the moment a recording begins (or when we
-  // land on a note that's already recording), and clear it once recording
-  // ends. Tracking the idle -> recording edge keeps frequent meter-tick
-  // status updates from resurrecting a reminder the user already dismissed.
   const consentEdgeRef = useRef({ noteId: note.id, recording: false });
   useEffect(() => {
-    const isRecording = Boolean(recordingForNote);
     const prev = consentEdgeRef.current;
-    if (prev.noteId !== note.id) setConsentReminderVisible(isRecording);
-    else if (isRecording && !prev.recording) setConsentReminderVisible(true);
-    else if (!isRecording) setConsentReminderVisible(false);
-    consentEdgeRef.current = { noteId: note.id, recording: isRecording };
-  }, [note.id, recordingForNote]);
-  // The reminder is a transient courtesy, not a gate — let it fade on its own
-  // so it never lingers over the waveform.
+    const shouldReveal =
+      prev.noteId !== note.id
+        ? recordingActive
+        : recordingActive && !prev.recording;
+
+    consentEdgeRef.current = { noteId: note.id, recording: recordingActive };
+
+    if (!recordingActive) {
+      setConsentReminderVisible(false);
+      return;
+    }
+
+    if (!shouldReveal) return;
+
+    setConsentReminderVisible(false);
+    const timer = window.setTimeout(
+      () => setConsentReminderVisible(true),
+      RECORD_CONSENT_REVEAL_DELAY_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [note.id, recordingActive]);
+
   useEffect(() => {
     if (!consentReminderVisible) return;
-    const timer = setTimeout(() => setConsentReminderVisible(false), 6000);
-    return () => clearTimeout(timer);
+    const timer = window.setTimeout(
+      () => setConsentReminderVisible(false),
+      RECORD_CONSENT_AUTO_HIDE_MS,
+    );
+    return () => window.clearTimeout(timer);
   }, [consentReminderVisible]);
   const processingLock =
     note.processingStatus === "transcribing" ||
@@ -374,14 +388,13 @@ export function NoteEditor({
             {recordingForNote && consentReminderVisible ? (
               <motion.div
                 className="record-consent-note"
-                initial={{ opacity: 0, y: 6 }}
+                initial={{ opacity: 0, y: 3 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+                transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
               >
                 <InlineNotice
+                  className="record-consent-note-surface"
                   aria-label="Recording consent reminder"
-                  icon={<IconRecord size={14} aria-hidden />}
-                  eyebrow="Now recording"
                   body="Make sure everyone has agreed to be recorded."
                   actions={
                     <button
@@ -389,7 +402,7 @@ export function NoteEditor({
                       className="btn btn-ghost"
                       onClick={() => setConsentReminderVisible(false)}
                     >
-                      Got it
+                      Dismiss
                     </button>
                   }
                 />

--- a/src/components/ui/InlineNotice.tsx
+++ b/src/components/ui/InlineNotice.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 export type InlineNoticeTone = "warning" | "destructive";
 
 type InlineNoticeProps = {
-  eyebrow: ReactNode;
+  eyebrow?: ReactNode;
   body: ReactNode;
   actions?: ReactNode;
   icon?: ReactNode;
@@ -32,10 +32,12 @@ export function InlineNotice({
       aria-label={ariaLabel}
     >
       <p className="inline-notice-message">
-        <span className="inline-notice-eyebrow">
-          {icon}
-          {eyebrow}
-        </span>
+        {eyebrow ? (
+          <span className="inline-notice-eyebrow">
+            {icon}
+            {eyebrow}
+          </span>
+        ) : null}
         <span className="inline-notice-body">{body}</span>
       </p>
       {actions ? <div className="inline-notice-actions">{actions}</div> : null}

--- a/src/components/ui/InlineNotice.tsx
+++ b/src/components/ui/InlineNotice.tsx
@@ -32,7 +32,7 @@ export function InlineNotice({
       aria-label={ariaLabel}
     >
       <p className="inline-notice-message">
-        {eyebrow ? (
+        {eyebrow || icon ? (
           <span className="inline-notice-eyebrow">
             {icon}
             {eyebrow}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3986,20 +3986,41 @@ input:focus-visible,
 
 /* Scoped to .record-dock to outrank the later, equal-specificity base
  * .inline-notice rule, which would otherwise win on background/border/padding. */
+/* Matches the "Generating notes…" pill's padding/height/radius/surface so the
+ * two status messages read as the same family. */
 .record-dock .record-consent-note-surface {
   gap: var(--sp-3);
-  padding: var(--sp-1) var(--sp-2) var(--sp-1) var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
   border-color: transparent;
-  border-radius: var(--r-sm);
-  background: color-mix(in oklch, var(--muted) 70%, transparent);
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--muted) 68%, var(--card));
   color: var(--muted-foreground);
   box-shadow: none;
 }
 
 .record-dock .record-consent-note-surface .inline-notice-message {
   flex-wrap: nowrap;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-md);
+  font-weight: 500;
+  line-height: 1;
   white-space: nowrap;
+}
+
+/* Dismiss reads as a quiet text link, not a button. */
+.record-dock .record-consent-note-surface .inline-notice-actions .btn {
+  height: auto;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--muted-foreground);
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.record-dock .record-consent-note-surface .inline-notice-actions .btn:hover {
+  background: none;
+  color: var(--foreground);
 }
 
 .record-options-trigger {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4235,8 +4235,11 @@ input:focus-visible,
 .record-shell[data-state="paused"],
 .record-shell[data-state="validating"] {
   /* Sized to fit: pause(40) + 16 + timer(44) + 24 + waveform(38) + 24
-   * + stop(40) + 12 shell border/padding = 238. 2px slack at 240. */
-  width: min(240px, calc(100% - var(--sp-8)));
+   * + stop(40) + 12 shell border/padding = 238. 2px slack at 240. The
+   * narrow-screen fallback is viewport-relative (not 100%) so it stays
+   * definite even when the shell sits inside the shrink-wrapped
+   * .record-dock — a percentage there collapses the pill to min-content. */
+  width: min(240px, calc(100vw - var(--sp-8)));
   overflow: hidden;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3970,25 +3970,33 @@ input:focus-visible,
   align-self: flex-end;
 }
 
+/* Centered over the recorder pill. The dock shrink-wraps the pill and the
+ * footer centers the dock in the canvas, so 50% of the dock is the pill's
+ * (and the canvas's) center. The framer-motion child owns translateY, so
+ * the centering transform lives here, not on the animated node. */
 .record-consent-note {
   position: absolute;
-  right: 0;
+  left: 50%;
   bottom: calc(100% + var(--sp-2));
   z-index: 4;
+  transform: translateX(-50%);
   width: max-content;
   max-width: calc(100vw - var(--sp-8));
 }
 
-.record-consent-note-surface {
+/* Scoped to .record-dock to outrank the later, equal-specificity base
+ * .inline-notice rule, which would otherwise win on background/border/padding. */
+.record-dock .record-consent-note-surface {
   gap: var(--sp-3);
   padding: var(--sp-1) var(--sp-2) var(--sp-1) var(--sp-3);
   border-color: transparent;
   border-radius: var(--r-sm);
   background: color-mix(in oklch, var(--muted) 70%, transparent);
   color: var(--muted-foreground);
+  box-shadow: none;
 }
 
-.record-consent-note-surface .inline-notice-message {
+.record-dock .record-consent-note-surface .inline-notice-message {
   flex-wrap: nowrap;
   font-size: var(--fs-sm);
   white-space: nowrap;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3964,36 +3964,26 @@ input:focus-visible,
   height: 40px;
 }
 
-.record-consent-popover {
+/* Wraps the recorder pill so the consent reminder can float above it
+ * without nudging the pill or fighting the shell's overflow clipping. */
+.record-dock {
+  position: relative;
+  display: inline-flex;
+  align-self: flex-end;
+}
+
+/* A gentle, non-blocking nudge that slides up once recording begins —
+ * anchored to the pill's right edge so it reads as belonging to it. */
+.record-consent-note {
   position: absolute;
   right: 0;
   bottom: calc(100% + var(--sp-2));
   z-index: 4;
-  width: min(280px, calc(100vw - var(--sp-8)));
-  padding: var(--sp-3);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  background: color-mix(in oklch, var(--card) 96%, var(--warm-soft));
+  width: min(300px, calc(100vw - var(--sp-8)));
+}
+
+.record-consent-note .inline-notice {
   box-shadow: var(--shadow-lg);
-}
-
-.record-consent-popover p {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: var(--fs-sm);
-  line-height: var(--lh-body);
-}
-
-.record-consent-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--sp-2);
-  margin-top: var(--sp-3);
-}
-
-.record-consent-actions .btn {
-  height: var(--control-sm);
-  padding-inline: var(--sp-3);
 }
 
 .record-options-trigger {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3964,26 +3964,34 @@ input:focus-visible,
   height: 40px;
 }
 
-/* Wraps the recorder pill so the consent reminder can float above it
- * without nudging the pill or fighting the shell's overflow clipping. */
 .record-dock {
   position: relative;
   display: inline-flex;
   align-self: flex-end;
 }
 
-/* A gentle, non-blocking nudge that slides up once recording begins —
- * anchored to the pill's right edge so it reads as belonging to it. */
 .record-consent-note {
   position: absolute;
   right: 0;
   bottom: calc(100% + var(--sp-2));
   z-index: 4;
-  width: min(300px, calc(100vw - var(--sp-8)));
+  width: max-content;
+  max-width: calc(100vw - var(--sp-8));
 }
 
-.record-consent-note .inline-notice {
-  box-shadow: var(--shadow-lg);
+.record-consent-note-surface {
+  gap: var(--sp-3);
+  padding: var(--sp-1) var(--sp-2) var(--sp-1) var(--sp-3);
+  border-color: transparent;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
+  color: var(--muted-foreground);
+}
+
+.record-consent-note-surface .inline-notice-message {
+  flex-wrap: nowrap;
+  font-size: var(--fs-sm);
+  white-space: nowrap;
 }
 
 .record-options-trigger {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4007,14 +4007,17 @@ input:focus-visible,
 }
 
 /* Dismiss reads as a quiet text link, not a button — no underline, just a
- * medium-weight label that darkens to full foreground on hover. */
+ * medium-weight label in the app's link color (matching .agent-markdown a)
+ * that deepens to foreground on hover. line-height matches the message so the
+ * two text runs share a baseline. */
 .record-dock .record-consent-note-surface .inline-notice-actions .btn {
   height: auto;
   padding: 0;
   border: 0;
   background: none;
-  color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
+  color: var(--primary);
   font-weight: 500;
+  line-height: 1;
 }
 
 .record-dock .record-consent-note-surface .inline-notice-actions .btn:hover {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4006,16 +4006,15 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-/* Dismiss reads as a quiet text link, not a button. */
+/* Dismiss reads as a quiet text link, not a button — no underline, just a
+ * medium-weight label that darkens to full foreground on hover. */
 .record-dock .record-consent-note-surface .inline-notice-actions .btn {
   height: auto;
   padding: 0;
   border: 0;
   background: none;
-  color: var(--muted-foreground);
+  color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
   font-weight: 500;
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 .record-dock .record-consent-note-surface .inline-notice-actions .btn:hover {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -407,6 +407,55 @@ describe("NoteEditor", () => {
     // It fades out via AnimatePresence, so it lingers for the exit animation
     // before unmounting — advance past it.
     await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    expect(
+      screen.queryByRole("status", { name: "Recording consent reminder" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("auto-hides the consent reminder after five seconds", async () => {
+    vi.useFakeTimers();
+    render(
+      <NoteEditor
+        {...props}
+        note={note()}
+        recordingStatus={{
+          sessionId: "session-1",
+          state: "recording",
+          elapsedMs: 1000,
+          level: { peak: 0.5, rms: 0.2, recentPeaks: [0.1, 0.3] },
+          silenceWarning: false,
+          bytesWritten: 2048,
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(420);
+    });
+
+    expect(
+      screen.getByRole("status", { name: "Recording consent reminder" }),
+    ).toBeInTheDocument();
+
+    // Just shy of the auto-hide window the reminder is still up.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4999);
+    });
+
+    expect(
+      screen.getByRole("status", { name: "Recording consent reminder" }),
+    ).toBeInTheDocument();
+
+    // Cross the 5s mark so the auto-hide fires...
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    // ...then advance past the AnimatePresence exit fade.
+    await act(async () => {
       await vi.advanceTimersByTimeAsync(400);
     });
 

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -404,6 +404,12 @@ describe("NoteEditor", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
+    // It fades out via AnimatePresence, so it lingers for the exit animation
+    // before unmounting — advance past it.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
     expect(
       screen.queryByRole("status", { name: "Recording consent reminder" }),
     ).not.toBeInTheDocument();

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -334,7 +334,7 @@ describe("NoteEditor", () => {
     expect(status).toHaveTextContent("+1");
   });
 
-  it("keeps recording available when the note has an interrupted recording", async () => {
+  it("starts recording immediately without a consent gate", async () => {
     const user = userEvent.setup();
     const onStartRecording = vi.fn();
     render(
@@ -346,6 +346,7 @@ describe("NoteEditor", () => {
       />,
     );
 
+    // An interrupted recording must not disable the record button.
     expect(screen.getByText("Interrupted recording")).toBeInTheDocument();
 
     const recordButton = screen.getByRole("button", { name: "Record" });
@@ -353,38 +354,39 @@ describe("NoteEditor", () => {
 
     await user.click(recordButton);
 
-    expect(onStartRecording).not.toHaveBeenCalled();
-    expect(
-      screen.getByRole("dialog", { name: "Recording consent reminder" }),
-    ).toHaveTextContent(/everyone has agreed to be recorded/i);
-
-    await user.click(screen.getByRole("button", { name: "Continue" }));
-
+    // The click records straight away — no blocking dialog in the way.
     expect(onStartRecording).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByRole("status", { name: "Recording consent reminder" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("lets users dismiss the recording consent reminder", async () => {
+  it("surfaces a dismissible consent reminder once recording starts", async () => {
     const user = userEvent.setup();
-    const onStartRecording = vi.fn();
     render(
       <NoteEditor
         {...props}
         note={note()}
-        onStartRecording={onStartRecording}
+        recordingStatus={{
+          sessionId: "session-1",
+          state: "recording",
+          elapsedMs: 1000,
+          level: { peak: 0.5, rms: 0.2, recentPeaks: [0.1, 0.3] },
+          silenceWarning: false,
+          bytesWritten: 2048,
+        }}
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Record" }));
     expect(
-      screen.getByRole("dialog", { name: "Recording consent reminder" }),
-    ).toBeInTheDocument();
+      screen.getByRole("status", { name: "Recording consent reminder" }),
+    ).toHaveTextContent(/everyone has agreed to be recorded/i);
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Got it" }));
 
     expect(
-      screen.queryByRole("dialog", { name: "Recording consent reminder" }),
+      screen.queryByRole("status", { name: "Recording consent reminder" }),
     ).not.toBeInTheDocument();
-    expect(onStartRecording).not.toHaveBeenCalled();
   });
 
   it("keeps existing notes visible while showing processing status below them", () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import type { NoteDto, RecoverableRecordingDto } from "../lib/tauri";
 
@@ -57,6 +57,10 @@ const recovery: RecoverableRecordingDto = {
 };
 
 describe("NoteEditor", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("edits title and renders the generated note as a preview", async () => {
     const user = userEvent.setup();
     const onTitleChange = vi.fn();
@@ -361,8 +365,8 @@ describe("NoteEditor", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("surfaces a dismissible consent reminder once recording starts", async () => {
-    const user = userEvent.setup();
+  it("surfaces a dismissible consent reminder after the recorder settles", async () => {
+    vi.useFakeTimers();
     render(
       <NoteEditor
         {...props}
@@ -379,10 +383,26 @@ describe("NoteEditor", () => {
     );
 
     expect(
+      screen.queryByRole("status", { name: "Recording consent reminder" }),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(419);
+    });
+
+    expect(
+      screen.queryByRole("status", { name: "Recording consent reminder" }),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(
       screen.getByRole("status", { name: "Recording consent reminder" }),
     ).toHaveTextContent(/everyone has agreed to be recorded/i);
 
-    await user.click(screen.getByRole("button", { name: "Got it" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
 
     expect(
       screen.queryByRole("status", { name: "Recording consent reminder" }),

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
+import { MotionGlobalConfig } from "framer-motion";
 import { afterEach, vi } from "vitest";
+
+// Resolve framer-motion animations instantly. Without this the frameloop
+// stalls when tests swap fake/real timers, leaving AnimatePresence exits
+// stuck in the DOM and exit-dependent assertions flaky.
+MotionGlobalConfig.skipAnimations = true;
 
 vi.mock("@tauri-apps/plugin-updater", () => ({
   check: vi.fn(async () => null),


### PR DESCRIPTION
Clicking record no longer stalls behind a blocking "Cancel / Continue" consent dialog — recording now starts immediately, and the consent message instead surfaces as a non-blocking reminder that fades in over the recorder once recording begins (auto-dismissing, with a Dismiss link). The reminder reuses the shared `InlineNotice` surface (the same component as the interrupted-recording notice), now with an optional eyebrow, and is styled to match the "Generating notes…" pill's padding, height, radius, and muted surface so the two status messages read as one family. It's centered over the recorder pill in the canvas, fades in and out via `AnimatePresence`, and uses the app's link color (`var(--primary)`) for the Dismiss action. Also fixes a recorder pill that collapsed to a thin capsule once nested in the new consent dock (a `calc(100%…)` → `calc(100vw…)` width fix). Tests in `note-editor.test.tsx` are updated to cover immediate recording start, the delayed/centered reminder, and dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)