### PR TITLE
Harden hermes bridge startup and stream agent completions through the provider proxy

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -7,7 +7,10 @@ use std::{
     net::TcpListener,
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
     time::{Duration, Instant},
 };
 use tauri::{AppHandle, Manager, State};
@@ -58,9 +61,21 @@ const ISOLATED_HERMES_ENV_VARS: &[&str] = &[
 #[derive(Default)]
 pub struct HermesBridge {
     process: Mutex<Option<HermesProcess>>,
+    /// Serializes the whole start sequence (config sync, runtime install,
+    /// spawn, readiness wait). Concurrent starts would otherwise write
+    /// `config.yaml` with different proxy ports/tokens and could run two
+    /// installers at once. This must be an async mutex because it is held
+    /// across awaits; the `process` mutex above is std::sync and must never
+    /// be held across an await.
+    start_lock: tokio::sync::Mutex<()>,
+    /// Monotonic id assigned to each spawned Hermes process so a start
+    /// attempt only tears down the exact process it launched (and not a
+    /// replacement that arrived after a stop/restart).
+    next_generation: AtomicU64,
 }
 
 struct HermesProcess {
+    generation: u64,
     child: Child,
     connection: HermesBridgeConnection,
     proxy: Option<ScribeProviderProxy>,
@@ -295,6 +310,12 @@ async fn start_hermes_bridge_inner(
     bridge: &HermesBridge,
     request: StartHermesBridgeRequest,
 ) -> Result<HermesBridgeStatus, AppError> {
+    // Hold the start guard for the entire start sequence so concurrent
+    // starts cannot interleave config writes, installs, or spawns. The
+    // loser of the race blocks here and then short-circuits below once it
+    // sees the winner's running process.
+    let _start_guard = bridge.start_lock.lock().await;
+
     if let Some(status) = existing_running_status(bridge)? {
         return Ok(status);
     }
@@ -360,14 +381,16 @@ async fn start_hermes_bridge_inner(
         pid,
     };
 
+    let generation = bridge.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
     {
         let mut guard = bridge.process.lock().map_err(|_| {
             AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
         })?;
-        // A concurrent start may have won the race while we were spawning
-        // (the early `existing_running_status` check runs before any await).
-        // Keep the established process and tear down the redundant one we
-        // just launched instead of leaking it.
+        // The start guard serializes starts, so no concurrent start can have
+        // populated the slot since the `existing_running_status` check above.
+        // Keep a defensive check anyway: if a live process is somehow present
+        // we keep it and tear down the redundant one we just launched instead
+        // of leaking it.
         if let Some(existing) = guard.as_mut() {
             if matches!(existing.child.try_wait(), Ok(None)) {
                 let existing_connection = existing.connection.clone();
@@ -382,6 +405,7 @@ async fn start_hermes_bridge_inner(
             }
         }
         *guard = Some(HermesProcess {
+            generation,
             child,
             connection: connection.clone(),
             proxy: Some(ScribeProviderProxy {
@@ -391,7 +415,10 @@ async fn start_hermes_bridge_inner(
     }
 
     if let Err(error) = wait_for_hermes(&base_url, &token).await {
-        let _ = stop_hermes_bridge_inner(bridge);
+        // Only tear down the exact process this start spawned. If a stop (or
+        // stop+restart) happened during the readiness wait, the slot is empty
+        // or holds a different generation and must be left alone.
+        let _ = stop_hermes_bridge_generation(bridge, generation);
         return Err(error);
     }
 
@@ -998,11 +1025,38 @@ fn existing_running_status(bridge: &HermesBridge) -> Result<Option<HermesBridgeS
 }
 
 fn stop_hermes_bridge_inner(bridge: &HermesBridge) -> Result<(), AppError> {
-    let mut process = bridge
+    let process = bridge
         .process
         .lock()
         .map_err(|_| AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed."))?
         .take();
+    shutdown_hermes_process(process);
+    Ok(())
+}
+
+/// Stops the bridge only if the slot still holds the process spawned by the
+/// start attempt identified by `generation`. A stop (or stop+restart) that
+/// raced with that start leaves a different process in the slot, which must
+/// not be killed by the stale start attempt's cleanup.
+fn stop_hermes_bridge_generation(bridge: &HermesBridge, generation: u64) -> Result<(), AppError> {
+    let process = {
+        let mut guard = bridge.process.lock().map_err(|_| {
+            AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
+        })?;
+        if guard
+            .as_ref()
+            .is_some_and(|process| process.generation == generation)
+        {
+            guard.take()
+        } else {
+            None
+        }
+    };
+    shutdown_hermes_process(process);
+    Ok(())
+}
+
+fn shutdown_hermes_process(mut process: Option<HermesProcess>) {
     if let Some(process) = process.as_mut() {
         let _ = process.child.kill();
         let _ = process.child.wait();
@@ -1012,7 +1066,6 @@ fn stop_hermes_bridge_inner(bridge: &HermesBridge) -> Result<(), AppError> {
             }
         }
     }
-    Ok(())
 }
 
 async fn resolve_hermes_command(
@@ -1488,7 +1541,14 @@ async fn run_scribe_provider_proxy(
                             let _ = handle_scribe_provider_connection(stream, token).await;
                         });
                     }
-                    Err(_) => break,
+                    Err(error) => {
+                        // Accept errors (ECONNABORTED, EMFILE, ...) are
+                        // usually transient. Keep the listener alive — the
+                        // bridge still reports running — and back off
+                        // briefly so a persistent error can't hot-loop.
+                        eprintln!("Scribe provider proxy accept failed: {error}");
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
                 }
             }
         }
@@ -1539,13 +1599,7 @@ async fn handle_scribe_provider_connection(
                 .unwrap_or_else(|_| serde_json::json!({}));
             match crate::scribe_api::proxy_agent_chat_completions(body).await {
                 Ok(response) => {
-                    write_raw_response(
-                        &mut stream,
-                        response.status,
-                        &response.content_type,
-                        &response.body,
-                    )
-                    .await?;
+                    write_streaming_response(&mut stream, response).await?;
                 }
                 Err(error) => {
                     write_json_response(
@@ -1700,21 +1754,63 @@ async fn write_raw_response(
     content_type: &str,
     body: &[u8],
 ) -> io::Result<()> {
-    let reason = match status {
-        200 => "OK",
-        400 => "Bad Request",
-        401 => "Unauthorized",
-        404 => "Not Found",
-        502 => "Bad Gateway",
-        _ => "OK",
-    };
     let headers = format!(
         "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-        body.len()
+        body.len(),
+        reason = http_status_reason(status),
     );
     stream.write_all(headers.as_bytes()).await?;
     stream.write_all(body).await?;
     stream.shutdown().await
+}
+
+/// Forwards an upstream chat-completions response to the socket chunk by
+/// chunk, so Hermes sees streamed tokens (`stream: true`) as they are
+/// generated instead of one buffered body after generation completes. The
+/// proxy already speaks `Connection: close`, so the body is delimited by
+/// closing the connection and no Content-Length is sent.
+async fn write_streaming_response(
+    stream: &mut tokio::net::TcpStream,
+    mut response: crate::scribe_api::AgentChatCompletionsResponse,
+) -> io::Result<()> {
+    let headers = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nConnection: close\r\n\r\n",
+        status = response.status,
+        reason = http_status_reason(response.status),
+        content_type = response.content_type,
+    );
+    stream.write_all(headers.as_bytes()).await?;
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => stream.write_all(&chunk).await?,
+            Ok(None) => break,
+            Err(error) => {
+                // Headers are already on the wire, so an error response is
+                // no longer possible. Close the connection to end the body;
+                // the client sees a truncated stream and surfaces the abort.
+                eprintln!(
+                    "Scribe provider proxy upstream stream failed: {}",
+                    error.message
+                );
+                break;
+            }
+        }
+    }
+    stream.shutdown().await
+}
+
+fn http_status_reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        402 => "Payment Required",
+        404 => "Not Found",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        _ => "OK",
+    }
 }
 
 fn pick_port() -> Result<u16, AppError> {
@@ -1737,7 +1833,14 @@ fn random_token() -> String {
 }
 
 async fn wait_for_hermes(base_url: &str, token: &str) -> Result<(), AppError> {
-    let client = reqwest::Client::new();
+    // `.no_proxy()` matters: the probe targets 127.0.0.1, and routing it
+    // through an HTTP(S)_PROXY would fail for the whole readiness window
+    // and kill a healthy Hermes.
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|error| AppError::new("hermes_bridge_ready_timeout", error.to_string()))?;
     let deadline = Instant::now() + READY_TIMEOUT;
     let mut last_error = "timeout".to_string();
     while Instant::now() < deadline {

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -99,11 +99,33 @@ pub struct DictateCleanupRequestParams {
     pub utterance_id: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RawScribeResponse {
+/// Response from the agent chat-completions proxy. Holds the upstream
+/// reqwest response so callers can forward body bytes as they arrive
+/// (Hermes requests `stream: true`) instead of buffering the whole
+/// generation before the first token is visible.
+pub struct AgentChatCompletionsResponse {
     pub status: u16,
     pub content_type: String,
-    pub body: Vec<u8>,
+    upstream: reqwest::Response,
+}
+
+impl AgentChatCompletionsResponse {
+    /// Next chunk of the upstream body as it arrives. Returns `Ok(None)`
+    /// once the body is complete.
+    pub async fn chunk(&mut self) -> Result<Option<Vec<u8>>, AppError> {
+        Ok(self
+            .upstream
+            .chunk()
+            .await
+            .map_err(network_error)?
+            .map(|chunk| chunk.to_vec()))
+    }
+
+    /// Buffer the entire body. For small non-streamed responses such as
+    /// session-title suggestions.
+    pub async fn collect_body(self) -> Result<Vec<u8>, AppError> {
+        Ok(self.upstream.bytes().await.map_err(network_error)?.to_vec())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -303,7 +325,7 @@ pub async fn list_models(model_type: &str) -> Result<Vec<ModelDto>, AppError> {
 
 pub async fn proxy_agent_chat_completions(
     mut body: serde_json::Value,
-) -> Result<RawScribeResponse, AppError> {
+) -> Result<AgentChatCompletionsResponse, AppError> {
     limit_agent_chat_messages_for_proxy(&mut body);
     if let Some(object) = body.as_object_mut() {
         object.insert(
@@ -332,11 +354,10 @@ pub async fn proxy_agent_chat_completions(
             .and_then(|value| value.to_str().ok())
             .unwrap_or("application/json")
             .to_string();
-        let body = response.bytes().await.map_err(network_error)?.to_vec();
-        return Ok(RawScribeResponse {
+        return Ok(AgentChatCompletionsResponse {
             status,
             content_type,
-            body,
+            upstream: response,
         });
     }
     Err(AppError::new("unauthorized", "Not signed in."))
@@ -368,16 +389,16 @@ fn limit_agent_chat_messages(body: &mut serde_json::Value, max_messages: usize) 
         .cloned()
         .collect::<Vec<_>>();
     let remaining_capacity = max_messages.saturating_sub(next_messages.len());
-    if remaining_capacity == 0 {
-        *messages = next_messages;
-        return;
-    }
 
     let tail = agent_message_chunks(&messages[instruction_count..]);
     let mut suffix = Vec::new();
     let mut suffix_len = 0usize;
     for chunk in tail.into_iter().rev() {
-        if suffix_len + chunk.len() > remaining_capacity {
+        // Always keep the most recent chunk (the latest turn plus its tool
+        // results), even when it alone exceeds the budget — otherwise the
+        // request would go out with only system/developer messages.
+        // Truncate older chunks instead.
+        if !suffix.is_empty() && suffix_len + chunk.len() > remaining_capacity {
             break;
         }
         suffix_len += chunk.len();
@@ -490,7 +511,8 @@ pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppErro
             format!("Title generation returned status {}.", response.status),
         ));
     }
-    let value: serde_json::Value = serde_json::from_slice(&response.body)
+    let body = response.collect_body().await?;
+    let value: serde_json::Value = serde_json::from_slice(&body)
         .map_err(|error| AppError::new("agent_title_invalid", error.to_string()))?;
     let text = extract_chat_completion_text(&value).ok_or_else(|| {
         AppError::new(
@@ -765,6 +787,49 @@ mod tests {
         assert_eq!(messages[1]["role"], "assistant");
         assert_eq!(messages[2]["role"], "tool");
         assert_eq!(messages[3]["content"], "next request");
+    }
+
+    #[test]
+    fn agent_proxy_keeps_latest_chunk_even_when_it_exceeds_the_budget() {
+        let tool_calls = (0..6)
+            .map(|index| {
+                serde_json::json!({
+                    "id": format!("call_{index}"),
+                    "type": "function",
+                    "function": { "name": "browser_console", "arguments": "{}" }
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut messages = vec![
+            serde_json::json!({ "role": "system", "content": "system prompt" }),
+            serde_json::json!({ "role": "user", "content": "old context" }),
+            serde_json::json!({ "role": "user", "content": "latest request" }),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": tool_calls
+            }),
+        ];
+        messages.extend((0..6).map(|index| {
+            serde_json::json!({
+                "role": "tool",
+                "tool_call_id": format!("call_{index}"),
+                "content": format!("result {index}")
+            })
+        }));
+        let mut body = serde_json::json!({ "messages": messages });
+
+        // The most recent chunk (assistant turn + 6 tool results) alone
+        // exceeds the budget; it must still be kept rather than stripping
+        // the conversation down to the system prompt.
+        limit_agent_chat_messages(&mut body, 4);
+
+        let messages = body["messages"].as_array().expect("messages array");
+        assert_eq!(messages.len(), 8);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[7]["content"], "result 5");
     }
 }
 


### PR DESCRIPTION
## Bugs fixed

1. **`src-tauri/src/hermes_bridge.rs:1740` (pre-fix) — readiness probe ignored `.no_proxy()`.** With `HTTP_PROXY`/`HTTPS_PROXY` set, `wait_for_hermes`'s probe to `http://127.0.0.1:{port}/api/status` routed through the proxy, failed for the whole 45s window, and the bridge killed the healthy hermes it just started. The probe client is now built with `.no_proxy()` (matching `hermes_connection_json`) plus a 5s per-request timeout.

2. **`src-tauri/src/hermes_bridge.rs:1491` — provider-proxy accept loop exited permanently on any accept error.** `Err(_) => break` abandoned the listener on transient errors (ECONNABORTED, EMFILE) while the bridge kept reporting running. The loop now logs the error and continues with a 100ms backoff; only the shutdown signal breaks the loop.

3. **`src-tauri/src/hermes_bridge.rs:298-391` — unguarded concurrent-start window.** Two racing starts could both run `sync_hermes_config` with different proxy ports/tokens (corrupting `config.yaml` for whichever process read it second) and both run `install_managed_hermes_runtime`. The whole start sequence (config sync, install, spawn, readiness wait) is now serialized behind a dedicated `tokio::sync::Mutex` start lock; the losing caller blocks, then short-circuits via `existing_running_status`. The std::sync `process` mutex is still never held across an await.

4. **`src-tauri/src/hermes_bridge.rs:393-396` — start-failure cleanup killed whichever process occupied the slot.** Each spawned process is now tagged with a monotonic generation, and readiness-timeout cleanup goes through `stop_hermes_bridge_generation`, which only takes/kills the slot if it still holds that exact generation. Start serialization (fix 3) prevents start/start races; the generation check explicitly handles stop(+restart)-during-the-45s-wait, where the slot may be empty or hold a newer process that must be left alone.

5. **`src-tauri/src/scribe_api.rs:335` + `src-tauri/src/hermes_bridge.rs:1537-1563` — streaming completions buffered end-to-end.** `proxy_agent_chat_completions` now returns `AgentChatCompletionsResponse`, which wraps the upstream `reqwest::Response` instead of buffering it; the provider proxy writes the status line + headers immediately and forwards body chunks as they arrive via `Response::chunk()` (avoids needing the reqwest `stream` feature). The proxy already speaks `Connection: close`, so the body is close-delimited with no Content-Length — the least-risk option for the hand-rolled proxy, and standard HTTP for hermes's OpenAI-compatible python client. Status/content-type pass-through and the 502 error mapping are unchanged; mid-stream upstream errors are logged and end the body by closing the socket. `suggest_agent_session_title` (the only other caller) buffers via `collect_body()`. Public Tauri command signatures are unchanged.

6. **`src-tauri/src/scribe_api.rs:370-392` — `limit_agent_chat_messages` could strip the entire conversation tail.** When the most recent chunk (assistant turn + its tool results) alone exceeded remaining capacity, the suffix loop broke before taking anything and the request went out with only system/developer messages. The most recent chunk is now always kept — even over budget — and older chunks are truncated instead. Covered by a new unit test (`agent_proxy_keeps_latest_chunk_even_when_it_exceeds_the_budget`).

## Notes / not changed

- `AGENT_HTTP_TIMEOUT` (600s) is still a total-request timeout on the agent client, so a single generation longer than 600s is still cut off — but tokens now stream from the start, which was the user-visible problem. Switching to a read/idle timeout would change semantics for all agent calls and felt out of scope for this fix.
- The defensive "slot already occupied" check before inserting the spawned process was kept (it is now unreachable under the start lock) as a guard against future regressions.

## Verification

- `cargo fmt` — clean.
- `cargo check` — clean.
- `cargo clippy --all-targets` — the only 5 warnings present are identical to origin/main (verified by running clippy on the stashed tree); no new warnings.
- `cargo test` — all pass: 102 lib unit tests (including the new `limit_agent_chat_messages` test and existing provider-proxy auth tests) plus store and turn-detection integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)