### PR TITLE
Fix agent task status lifecycle races and premature completion

### DIFF
--- a/src-tauri/migrations/008_agent_message_identity.sql
+++ b/src-tauri/migrations/008_agent_message_identity.sql
@@ -1,0 +1,10 @@
+DELETE FROM agent_messages
+WHERE rowid NOT IN (
+  SELECT MIN(rowid)
+  FROM agent_messages
+  GROUP BY task_id, role, content, created_at
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_messages_task_external_id
+ON agent_messages (task_id, external_id)
+WHERE external_id IS NOT NULL;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -38,16 +38,25 @@ use crate::{
 };
 use chrono::{TimeZone, Utc};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::Row;
+use sqlx::{Row, SqlitePool};
+use std::collections::HashSet;
 use std::str::FromStr;
-use std::{path::PathBuf, time::Instant};
+use std::sync::{Mutex, OnceLock};
+use std::{
+    path::{Path, PathBuf},
+    time::Instant,
+};
 use tauri::{AppHandle, Manager};
+use tokio::sync::OnceCell;
 
 #[tauri::command]
 pub async fn bootstrap_app(app: AppHandle) -> Result<BootstrapResponse, AppError> {
     let repos = repositories(&app).await?;
-    repos.pause_running_agent_tasks_on_launch().await?;
+    // Complete stale tasks that already received their assistant reply
+    // before pausing the rest: the repair only considers queued/running
+    // tasks, so it must run before they are flipped to paused.
     repos.complete_agent_tasks_with_assistant_messages().await?;
+    repos.pause_running_agent_tasks_on_launch().await?;
     let active_recoveries = scan_recoverable_recordings(&repos.pool)
         .await
         .map_err(|error| AppError::new("recovery_scan_failed", error.to_string()))?;
@@ -1146,54 +1155,87 @@ fn recovery_source_path(
     None
 }
 
+static AGENT_PLACEHOLDER_TASKS_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn agent_placeholder_tasks_in_flight() -> &'static Mutex<HashSet<String>> {
+    AGENT_PLACEHOLDER_TASKS_IN_FLIGHT.get_or_init(Mutex::default)
+}
+
 fn schedule_agent_runtime_placeholder(repos: Repositories, task_id: String) {
+    // Two concurrent placeholder runs for the same task (e.g. a rapid
+    // double retry) would double-insert tool events and messages, so only
+    // one in-flight run per task is allowed.
+    {
+        let mut in_flight = agent_placeholder_tasks_in_flight()
+            .lock()
+            .expect("agent placeholder in-flight set is poisoned");
+        if !in_flight.insert(task_id.clone()) {
+            return;
+        }
+    }
     tokio::spawn(async move {
-        let _ = repos
-            .update_agent_task_status(
-                &task_id,
-                AgentTaskStatus::Running,
-                Some("Preparing local privacy and tool policy."),
-                None,
-            )
-            .await;
-        let _ = repos
-            .add_agent_tool_event(
-                &task_id,
-                "local_tool_policy",
-                AgentToolEventStatus::Completed,
-                "Autonomous private mode is active. Sensitive actions will be blocked or escalated.",
-                Some(r#"{"profile":"autonomous_private"}"#),
-                Some(r#"{"localToolsReady":true,"rawOutputShared":false}"#),
-                true,
-            )
-            .await;
-        let _ = repos
-            .add_agent_tool_event(
-                &task_id,
-                "backend_agent_runtime",
-                AgentToolEventStatus::Blocked,
-                "Backend agent orchestration is not configured in this build.",
-                Some(r#"{"endpoint":"/v1/agent/tasks"}"#),
-                Some(r#"{"reason":"agent_backend_unavailable"}"#),
-                true,
-            )
-            .await;
-        let _ = repos
-            .add_agent_message(
-                &task_id,
-                AgentMessageRole::Assistant,
-                "I created the task and set up the local privacy/tool policy. The backend agent runtime endpoint is not configured yet, so I paused execution before taking desktop actions.",
-            )
-            .await;
-        let _ = repos
-            .update_agent_task_status(
-                &task_id,
-                AgentTaskStatus::Paused,
-                Some("Paused until the backend agent runtime is configured."),
-                Some("Backend agent orchestration is not configured in this build."),
-            )
-            .await;
+        run_agent_runtime_placeholder(&repos, &task_id).await;
+        agent_placeholder_tasks_in_flight()
+            .lock()
+            .expect("agent placeholder in-flight set is poisoned")
+            .remove(&task_id);
     });
+}
+
+async fn run_agent_runtime_placeholder(repos: &Repositories, task_id: &str) {
+    // Only move a still-queued task to running. If the user cancelled the
+    // task (or it otherwise changed state) since this run was scheduled,
+    // the placeholder must not resurrect it.
+    let started = repos
+        .update_agent_task_status_if_in(
+            task_id,
+            AgentTaskStatus::Running,
+            Some("Preparing local privacy and tool policy."),
+            None,
+            &[AgentTaskStatus::Queued],
+        )
+        .await;
+    if !matches!(started, Ok(true)) {
+        return;
+    }
+    let _ = repos
+        .add_agent_tool_event(
+            task_id,
+            "local_tool_policy",
+            AgentToolEventStatus::Completed,
+            "Autonomous private mode is active. Sensitive actions will be blocked or escalated.",
+            Some(r#"{"profile":"autonomous_private"}"#),
+            Some(r#"{"localToolsReady":true,"rawOutputShared":false}"#),
+            true,
+        )
+        .await;
+    let _ = repos
+        .add_agent_tool_event(
+            task_id,
+            "backend_agent_runtime",
+            AgentToolEventStatus::Blocked,
+            "Backend agent orchestration is not configured in this build.",
+            Some(r#"{"endpoint":"/v1/agent/tasks"}"#),
+            Some(r#"{"reason":"agent_backend_unavailable"}"#),
+            true,
+        )
+        .await;
+    let _ = repos
+        .add_agent_message(
+            task_id,
+            AgentMessageRole::Assistant,
+            "I created the task and set up the local privacy/tool policy. The backend agent runtime endpoint is not configured yet, so I paused execution before taking desktop actions.",
+        )
+        .await;
+    let _ = repos
+        .update_agent_task_status_if_in(
+            task_id,
+            AgentTaskStatus::Paused,
+            Some("Paused until the backend agent runtime is configured."),
+            Some("Backend agent orchestration is not configured in this build."),
+            &[AgentTaskStatus::Running],
+        )
+        .await;
 }
 
 async fn hydrate_agent_task_from_hermes(
@@ -1202,51 +1244,16 @@ async fn hydrate_agent_task_from_hermes(
     task_id: &str,
 ) -> Result<(), AppError> {
     let task = repos.get_agent_task(task_id).await?;
-    let already_has_assistant_message = task
-        .messages
-        .iter()
-        .any(|message| message.role == AgentMessageRole::Assistant);
     let paths = app_paths(app)?;
     let hermes_db_path = paths.data_dir.join("hermes").join("state.db");
     if !hermes_db_path.exists() {
         return Ok(());
     }
-
-    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", hermes_db_path.display()))
-        .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?
-        .create_if_missing(false);
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect_with(options)
-        .await
-        .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?;
+    let pool = hermes_state_pool(&hermes_db_path).await?;
 
     let session_id = match task.hermes_session_id.clone() {
         Some(session_id) if !session_id.trim().is_empty() => Some(session_id),
-        _ => {
-            let task_started_at = chrono::DateTime::parse_from_rfc3339(&task.created_at)
-                .map(|value| value.timestamp_millis() as f64 / 1000.0)
-                .unwrap_or(0.0);
-            let row = sqlx::query(
-                "SELECT id
-                 FROM sessions
-                 WHERE title = ?
-                 ORDER BY ABS(started_at - ?) ASC
-                 LIMIT 1",
-            )
-            .bind(&task.title)
-            .bind(task_started_at)
-            .fetch_optional(&pool)
-            .await
-            .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?;
-            let session_id = row.map(|row| row.get::<String, _>("id"));
-            if let Some(session_id) = &session_id {
-                repos
-                    .set_agent_task_hermes_session(task_id, session_id)
-                    .await?;
-            }
-            session_id
-        }
+        _ => match_hermes_session_for_task(repos, &pool, &task).await?,
     };
 
     let Some(session_id) = session_id else {
@@ -1254,7 +1261,7 @@ async fn hydrate_agent_task_from_hermes(
     };
 
     let rows = sqlx::query(
-        "SELECT content, timestamp
+        "SELECT CAST(id AS TEXT) AS id, content, timestamp
          FROM messages
          WHERE session_id = ?
            AND role = 'assistant'
@@ -1263,41 +1270,137 @@ async fn hydrate_agent_task_from_hermes(
            AND trim(content) != ''
          ORDER BY timestamp ASC, id ASC",
     )
-    .bind(session_id)
+    .bind(&session_id)
     .fetch_all(&pool)
     .await
     .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?;
-    let found_hermes_assistant_messages = !rows.is_empty();
+
+    // A task only counts as answered when the assistant replied AFTER the
+    // latest user message. Assistant messages from earlier turns must not
+    // complete a task that was re-queued by a newer user message.
+    let latest_user_message_at = task
+        .messages
+        .iter()
+        .filter(|message| message.role == AgentMessageRole::User)
+        .map(|message| message.created_at.clone())
+        .max();
+    let mut assistant_replied_to_latest_turn = false;
 
     for row in rows {
+        let hermes_message_id: String = row.get("id");
         let content: String = row.get("content");
         let timestamp: f64 = row.get("timestamp");
         let created_at = unix_timestamp_to_rfc3339(timestamp);
+        // Both timestamps are RFC3339 UTC with millisecond precision, so
+        // string ordering matches chronological ordering.
+        if latest_user_message_at
+            .as_deref()
+            .map(|user_at| created_at.as_str() > user_at)
+            .unwrap_or(true)
+        {
+            assistant_replied_to_latest_turn = true;
+        }
+        let external_id = format!("hermes:{session_id}:{hermes_message_id}");
         repos
             .add_agent_message_if_absent(
                 task_id,
                 AgentMessageRole::Assistant,
                 content.trim(),
                 &created_at,
+                &external_id,
             )
             .await?;
     }
-    if (already_has_assistant_message || found_hermes_assistant_messages)
+    if assistant_replied_to_latest_turn
         && matches!(
             task.status,
             AgentTaskStatus::Queued | AgentTaskStatus::Running
         )
     {
         repos
-            .update_agent_task_status(
+            .update_agent_task_status_if_in(
                 task_id,
                 AgentTaskStatus::Completed,
                 Some("Completed."),
                 None,
+                &[AgentTaskStatus::Queued, AgentTaskStatus::Running],
             )
             .await?;
     }
     Ok(())
+}
+
+/// How close (in seconds) a Hermes session's `started_at` must be to the
+/// task's creation time for heuristic title matching to bind them.
+const HERMES_SESSION_MATCH_WINDOW_SECONDS: f64 = 300.0;
+
+/// Heuristically binds a Hermes session to a task by title. Titles are
+/// derived from the first 64 characters of the prompt, so identical prompts
+/// collide; only bind when exactly one session with this title started near
+/// the task's creation time and it is not already bound to another task.
+/// When the match is ambiguous, skip hydration for this poll instead of
+/// persisting a guess.
+async fn match_hermes_session_for_task(
+    repos: &Repositories,
+    pool: &SqlitePool,
+    task: &AgentTaskDto,
+) -> Result<Option<String>, AppError> {
+    let Ok(task_started_at) = chrono::DateTime::parse_from_rfc3339(&task.created_at)
+        .map(|value| value.timestamp_millis() as f64 / 1000.0)
+    else {
+        return Ok(None);
+    };
+    let rows = sqlx::query(
+        "SELECT id
+         FROM sessions
+         WHERE title = ?
+           AND ABS(started_at - ?) <= ?
+         LIMIT 2",
+    )
+    .bind(&task.title)
+    .bind(task_started_at)
+    .bind(HERMES_SESSION_MATCH_WINDOW_SECONDS)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?;
+    if rows.len() != 1 {
+        return Ok(None);
+    }
+    let session_id: String = rows[0].get("id");
+    if repos
+        .hermes_session_bound_to_other_task(&task.id, &session_id)
+        .await?
+    {
+        return Ok(None);
+    }
+    repos
+        .set_agent_task_hermes_session(&task.id, &session_id)
+        .await?;
+    Ok(Some(session_id))
+}
+
+/// Cached read pool for the Hermes `state.db`, re-opened only if the path
+/// changes, so per-task polling does not open a fresh pool every second.
+static HERMES_STATE_POOL: tokio::sync::Mutex<Option<(PathBuf, SqlitePool)>> =
+    tokio::sync::Mutex::const_new(None);
+
+async fn hermes_state_pool(path: &Path) -> Result<SqlitePool, AppError> {
+    let mut cached = HERMES_STATE_POOL.lock().await;
+    if let Some((cached_path, pool)) = cached.as_ref() {
+        if cached_path == path && !pool.is_closed() {
+            return Ok(pool.clone());
+        }
+    }
+    let options = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))
+        .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?
+        .create_if_missing(false);
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+        .map_err(|error| AppError::new("hermes_state_unavailable", error.to_string()))?;
+    *cached = Some((path.to_path_buf(), pool.clone()));
+    Ok(pool)
 }
 
 fn unix_timestamp_to_rfc3339(timestamp: f64) -> String {
@@ -1309,21 +1412,33 @@ fn unix_timestamp_to_rfc3339(timestamp: f64) -> String {
         .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
+/// Cached app repositories pool. The database path is derived from the app
+/// data dir and never changes within a process, so the pool (and its
+/// migrations) are initialized once instead of on every Tauri command.
+static REPOSITORIES: OnceCell<Repositories> = OnceCell::const_new();
+
 pub(crate) async fn repositories(app: &AppHandle) -> Result<Repositories, AppError> {
     let paths = app_paths(app)?;
-    let options =
-        SqliteConnectOptions::from_str(&format!("sqlite://{}", paths.database_path.display()))
+    REPOSITORIES
+        .get_or_try_init(|| async {
+            let options = SqliteConnectOptions::from_str(&format!(
+                "sqlite://{}",
+                paths.database_path.display()
+            ))
             .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?
             .create_if_missing(true);
-    let pool = SqlitePoolOptions::new()
-        .max_connections(5)
-        .connect_with(options)
+            let pool = SqlitePoolOptions::new()
+                .max_connections(5)
+                .connect_with(options)
+                .await
+                .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?;
+            run_migrations(&pool)
+                .await
+                .map_err(|error| AppError::new("migration_failed", error.to_string()))?;
+            Ok(Repositories::new(pool))
+        })
         .await
-        .map_err(|error| AppError::new("storage_unavailable", error.to_string()))?;
-    run_migrations(&pool)
-        .await
-        .map_err(|error| AppError::new("migration_failed", error.to_string()))?;
-    Ok(Repositories::new(pool))
+        .cloned()
 }
 
 fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -123,6 +123,24 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
         }
     }
     ensure_column(_pool, "agent_tasks", "hermes_session_id", "TEXT").await?;
+    // `external_id` records the Hermes-side identity of hydrated agent
+    // messages so concurrent hydrations cannot double-insert the same
+    // message. The dedupe DELETE in this migration scans `agent_messages`,
+    // so only run it until the unique index exists (matching the pattern
+    // used for migration 006 above).
+    ensure_column(_pool, "agent_messages", "external_id", "TEXT").await?;
+    if !index_exists(_pool, "idx_agent_messages_task_external_id").await? {
+        for statement in include_str!("../../migrations/008_agent_message_identity.sql").split(';')
+        {
+            let statement = statement.trim();
+            if !statement.is_empty() {
+                sqlx::query(statement)
+                    .execute(_pool)
+                    .await
+                    .map_err(sqlx::migrate::MigrateError::Execute)?;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -354,6 +354,10 @@ impl Repositories {
         Ok(())
     }
 
+    /// Repairs genuinely stale `queued`/`running` tasks whose latest message
+    /// is already an assistant reply. `paused` and `waiting_for_user` are
+    /// deliberate resting states (placeholder pauses, clarify exchanges) and
+    /// must never be force-completed by this repair.
     pub async fn complete_agent_tasks_with_assistant_messages(&self) -> Result<(), sqlx::Error> {
         sqlx::query(
             "UPDATE agent_tasks
@@ -372,12 +376,12 @@ impl Repositories {
                       WHERE task_id = agent_tasks.id AND role = 'assistant'),
                      updated_at
                  )
-             WHERE status IN ('queued', 'running', 'paused', 'waiting_for_user')
-               AND EXISTS (
-                   SELECT 1
-                   FROM agent_messages
-                   WHERE task_id = agent_tasks.id AND role = 'assistant'
-               )",
+             WHERE status IN ('queued', 'running')
+               AND (SELECT role
+                    FROM agent_messages
+                    WHERE task_id = agent_tasks.id
+                    ORDER BY created_at DESC, rowid DESC
+                    LIMIT 1) = 'assistant'",
         )
         .execute(&self.pool)
         .await?;
@@ -506,38 +510,49 @@ impl Repositories {
         Ok(agent_message_from_row(row))
     }
 
+    /// Inserts a hydrated message exactly once. `external_id` carries the
+    /// source-side identity (e.g. a Hermes message id); the unique index on
+    /// `(task_id, external_id)` plus `INSERT OR IGNORE` makes concurrent
+    /// hydrations race-safe. Rows hydrated before external ids existed are
+    /// matched by content so they are not duplicated either.
     pub async fn add_agent_message_if_absent(
         &self,
         task_id: &str,
         role: AgentMessageRole,
         content: &str,
         created_at: &str,
+        external_id: &str,
     ) -> Result<bool, sqlx::Error> {
         let existing = sqlx::query(
             "SELECT 1 FROM agent_messages
-             WHERE task_id = ? AND role = ? AND content = ?
+             WHERE task_id = ?
+               AND role = ?
+               AND (external_id = ? OR (external_id IS NULL AND content = ?))
              LIMIT 1",
         )
         .bind(task_id)
         .bind(role.as_db())
+        .bind(external_id)
         .bind(content)
         .fetch_optional(&self.pool)
         .await?;
         if existing.is_some() {
             return Ok(false);
         }
-        sqlx::query(
-            "INSERT INTO agent_messages (id, task_id, role, content, created_at)
-             VALUES (?, ?, ?, ?, ?)",
+        let result = sqlx::query(
+            "INSERT OR IGNORE INTO agent_messages
+             (id, task_id, role, content, created_at, external_id)
+             VALUES (?, ?, ?, ?, ?, ?)",
         )
         .bind(Uuid::new_v4().to_string())
         .bind(task_id)
         .bind(role.as_db())
         .bind(content)
         .bind(created_at)
+        .bind(external_id)
         .execute(&self.pool)
         .await?;
-        Ok(true)
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn update_agent_task_status(
@@ -567,6 +582,66 @@ impl Repositories {
         .execute(&self.pool)
         .await?;
         self.get_agent_task(task_id).await
+    }
+
+    /// Updates a task's status only when its current status is in
+    /// `allowed_current`. Returns whether the transition was applied. This
+    /// lets background work (e.g. the runtime placeholder) avoid clobbering
+    /// states the user reached concurrently, such as resurrecting a
+    /// cancelled task.
+    pub async fn update_agent_task_status_if_in(
+        &self,
+        task_id: &str,
+        status: AgentTaskStatus,
+        progress_summary: Option<&str>,
+        last_error: Option<&str>,
+        allowed_current: &[AgentTaskStatus],
+    ) -> Result<bool, sqlx::Error> {
+        if allowed_current.is_empty() {
+            return Ok(false);
+        }
+        let now = timestamp();
+        let completed_at = match status {
+            AgentTaskStatus::Completed | AgentTaskStatus::Cancelled => Some(now.clone()),
+            _ => None,
+        };
+        let placeholders = vec!["?"; allowed_current.len()].join(", ");
+        let sql = format!(
+            "UPDATE agent_tasks
+             SET status = ?, progress_summary = ?, last_error = ?, updated_at = ?,
+                 completed_at = COALESCE(?, completed_at)
+             WHERE id = ? AND status IN ({placeholders})"
+        );
+        let mut query = sqlx::query(&sql)
+            .bind(status.as_db())
+            .bind(progress_summary)
+            .bind(last_error)
+            .bind(&now)
+            .bind(completed_at)
+            .bind(task_id);
+        for current in allowed_current {
+            query = query.bind(current.as_db());
+        }
+        let result = query.execute(&self.pool).await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Returns whether a Hermes session is already bound to a different
+    /// task, so heuristic session matching never steals another task's
+    /// conversation.
+    pub async fn hermes_session_bound_to_other_task(
+        &self,
+        task_id: &str,
+        hermes_session_id: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let row = sqlx::query(
+            "SELECT 1 FROM agent_tasks WHERE hermes_session_id = ? AND id != ? LIMIT 1",
+        )
+        .bind(hermes_session_id)
+        .bind(task_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.is_some())
     }
 
     pub async fn add_agent_tool_event(

--- a/src-tauri/tests/agent.rs
+++ b/src-tauri/tests/agent.rs
@@ -1,6 +1,6 @@
 use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
-    domain::types::{AgentSafetyProfile, AgentTaskStatus, AgentToolEventStatus},
+    domain::types::{AgentMessageRole, AgentSafetyProfile, AgentTaskStatus, AgentToolEventStatus},
 };
 use sqlx::sqlite::SqlitePoolOptions;
 
@@ -85,4 +85,275 @@ async fn pauses_active_agent_tasks_on_launch() {
         loaded.progress_summary.as_deref(),
         Some("Paused when OS Scribe restarted.")
     );
+}
+
+#[tokio::test]
+async fn repair_completes_stale_running_task_with_assistant_reply() {
+    let repos = test_repositories().await;
+    let task = repos
+        .create_agent_task("Collect release notes", None, AgentSafetyProfile::default())
+        .await
+        .expect("task should be created");
+    repos
+        .update_agent_task_status(&task.id, AgentTaskStatus::Running, Some("Working"), None)
+        .await
+        .expect("task should run");
+    repos
+        .add_agent_message(&task.id, AgentMessageRole::Assistant, "Here are the notes.")
+        .await
+        .expect("assistant message should be added");
+
+    repos
+        .complete_agent_tasks_with_assistant_messages()
+        .await
+        .expect("repair should succeed");
+
+    let loaded = repos
+        .get_agent_task(&task.id)
+        .await
+        .expect("task should load");
+    assert_eq!(loaded.status, AgentTaskStatus::Completed);
+}
+
+#[tokio::test]
+async fn repair_skips_requeued_task_whose_latest_message_is_from_the_user() {
+    let repos = test_repositories().await;
+    let task = repos
+        .create_agent_task("Plan the offsite", None, AgentSafetyProfile::default())
+        .await
+        .expect("task should be created");
+    // First turn answered, then the user sent a follow-up that re-queued
+    // the task. The stale assistant reply must not complete the new turn.
+    repos
+        .add_agent_message(&task.id, AgentMessageRole::Assistant, "Draft agenda done.")
+        .await
+        .expect("assistant message should be added");
+    repos
+        .add_agent_message(&task.id, AgentMessageRole::User, "Add a dinner slot too.")
+        .await
+        .expect("user message should be added");
+
+    repos
+        .complete_agent_tasks_with_assistant_messages()
+        .await
+        .expect("repair should succeed");
+
+    let loaded = repos
+        .get_agent_task(&task.id)
+        .await
+        .expect("task should load");
+    assert_eq!(loaded.status, AgentTaskStatus::Queued);
+}
+
+#[tokio::test]
+async fn repair_leaves_paused_and_waiting_tasks_alone() {
+    let repos = test_repositories().await;
+    for status in [AgentTaskStatus::Paused, AgentTaskStatus::WaitingForUser] {
+        let task = repos
+            .create_agent_task("Review the design", None, AgentSafetyProfile::default())
+            .await
+            .expect("task should be created");
+        repos
+            .add_agent_message(
+                &task.id,
+                AgentMessageRole::Assistant,
+                "Paused before taking desktop actions.",
+            )
+            .await
+            .expect("assistant message should be added");
+        repos
+            .update_agent_task_status(&task.id, status, Some("Resting state"), None)
+            .await
+            .expect("status should update");
+
+        repos
+            .complete_agent_tasks_with_assistant_messages()
+            .await
+            .expect("repair should succeed");
+
+        let loaded = repos
+            .get_agent_task(&task.id)
+            .await
+            .expect("task should load");
+        assert_eq!(loaded.status, status);
+    }
+}
+
+#[tokio::test]
+async fn guarded_status_update_does_not_resurrect_cancelled_tasks() {
+    let repos = test_repositories().await;
+    let task = repos
+        .create_agent_task("Clean up downloads", None, AgentSafetyProfile::default())
+        .await
+        .expect("task should be created");
+    repos
+        .update_agent_task_status(
+            &task.id,
+            AgentTaskStatus::Cancelled,
+            Some("Cancelled by the user."),
+            None,
+        )
+        .await
+        .expect("task should cancel");
+
+    let started = repos
+        .update_agent_task_status_if_in(
+            &task.id,
+            AgentTaskStatus::Running,
+            Some("Preparing"),
+            None,
+            &[AgentTaskStatus::Queued],
+        )
+        .await
+        .expect("guarded update should succeed");
+    assert!(!started);
+    let paused = repos
+        .update_agent_task_status_if_in(
+            &task.id,
+            AgentTaskStatus::Paused,
+            Some("Paused"),
+            None,
+            &[AgentTaskStatus::Running],
+        )
+        .await
+        .expect("guarded update should succeed");
+    assert!(!paused);
+
+    let loaded = repos
+        .get_agent_task(&task.id)
+        .await
+        .expect("task should load");
+    assert_eq!(loaded.status, AgentTaskStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn guarded_status_update_applies_allowed_transitions() {
+    let repos = test_repositories().await;
+    let task = repos
+        .create_agent_task("Summarize inbox", None, AgentSafetyProfile::default())
+        .await
+        .expect("task should be created");
+
+    let started = repos
+        .update_agent_task_status_if_in(
+            &task.id,
+            AgentTaskStatus::Running,
+            Some("Preparing"),
+            None,
+            &[AgentTaskStatus::Queued],
+        )
+        .await
+        .expect("guarded update should succeed");
+    assert!(started);
+
+    let loaded = repos
+        .get_agent_task(&task.id)
+        .await
+        .expect("task should load");
+    assert_eq!(loaded.status, AgentTaskStatus::Running);
+}
+
+#[tokio::test]
+async fn hydrated_messages_dedupe_by_external_id_and_legacy_content() {
+    let repos = test_repositories().await;
+    let task = repos
+        .create_agent_task(
+            "Find the meeting notes",
+            None,
+            AgentSafetyProfile::default(),
+        )
+        .await
+        .expect("task should be created");
+
+    let inserted = repos
+        .add_agent_message_if_absent(
+            &task.id,
+            AgentMessageRole::Assistant,
+            "Found three matching notes.",
+            "2026-06-09T10:00:00.000Z",
+            "hermes:session-1:42",
+        )
+        .await
+        .expect("first insert should succeed");
+    assert!(inserted);
+
+    // Same Hermes message hydrated again (e.g. by a concurrent poll).
+    let duplicate = repos
+        .add_agent_message_if_absent(
+            &task.id,
+            AgentMessageRole::Assistant,
+            "Found three matching notes.",
+            "2026-06-09T10:00:00.000Z",
+            "hermes:session-1:42",
+        )
+        .await
+        .expect("second insert should succeed");
+    assert!(!duplicate);
+
+    // A different Hermes message with identical content is a new message.
+    let distinct = repos
+        .add_agent_message_if_absent(
+            &task.id,
+            AgentMessageRole::Assistant,
+            "Found three matching notes.",
+            "2026-06-09T10:05:00.000Z",
+            "hermes:session-1:43",
+        )
+        .await
+        .expect("third insert should succeed");
+    assert!(distinct);
+
+    // Rows hydrated before external ids existed are matched by content.
+    repos
+        .add_agent_message(&task.id, AgentMessageRole::Assistant, "Legacy reply.")
+        .await
+        .expect("legacy message should be added");
+    let legacy_duplicate = repos
+        .add_agent_message_if_absent(
+            &task.id,
+            AgentMessageRole::Assistant,
+            "Legacy reply.",
+            "2026-06-09T10:10:00.000Z",
+            "hermes:session-1:44",
+        )
+        .await
+        .expect("legacy-matching insert should succeed");
+    assert!(!legacy_duplicate);
+
+    let loaded = repos
+        .get_agent_task(&task.id)
+        .await
+        .expect("task should load");
+    let assistant_messages = loaded
+        .messages
+        .iter()
+        .filter(|message| message.role == AgentMessageRole::Assistant)
+        .count();
+    assert_eq!(assistant_messages, 3);
+}
+
+#[tokio::test]
+async fn detects_hermes_sessions_bound_to_other_tasks() {
+    let repos = test_repositories().await;
+    let first = repos
+        .create_agent_task("Same prompt", None, AgentSafetyProfile::default())
+        .await
+        .expect("task should be created");
+    let second = repos
+        .create_agent_task("Same prompt", None, AgentSafetyProfile::default())
+        .await
+        .expect("task should be created");
+    repos
+        .set_agent_task_hermes_session(&first.id, "session-1")
+        .await
+        .expect("session should bind");
+
+    assert!(repos
+        .hermes_session_bound_to_other_task(&second.id, "session-1")
+        .await
+        .expect("check should succeed"));
+    assert!(!repos
+        .hermes_session_bound_to_other_task(&first.id, "session-1")
+        .await
+        .expect("check should succeed"));
 }


### PR DESCRIPTION
## Bugs fixed

1. **`src-tauri/src/commands.rs` (`hydrate_agent_task_from_hermes`) — queued/running tasks prematurely flipped to completed by hydration.** The function completed a task when *any* assistant message existed (`already_has_assistant_message || found_hermes_assistant_messages`), so after `send_agent_message` re-queued a task, the next poll completed it using a reply from an earlier turn. Now a task only completes when a Hermes assistant message is **newer than the latest user message** (both timestamps are RFC3339 UTC millis, so ordering is exact), and the completion itself is a guarded `queued/running -> completed` transition. Single-turn completion still works: the first reply is always newer than the prompt.

2. **`src-tauri/src/commands.rs` (`schedule_agent_runtime_placeholder`) — placeholder resurrected cancelled tasks and double-retry duplicated messages.** The fire-and-forget placeholder drove `running -> paused` unconditionally via an unguarded `UPDATE ... WHERE id = ?`. Fixes: (a) new repository method `update_agent_task_status_if_in` (`WHERE id = ? AND status IN (...)`) — the placeholder only starts from `queued` and only pauses from `running`, so it aborts instead of clobbering a concurrent cancel; (b) a process-wide in-flight task-id set (`OnceLock<Mutex<HashSet<String>>>`) ensures only one placeholder run per task, preventing double-inserted tool events/messages on rapid double retry.

3. **`src-tauri/src/db/repositories.rs` (`complete_agent_tasks_with_assistant_messages`) — repair force-completed `paused`/`waiting_for_user` tasks.** The repair now only touches `queued`/`running` tasks **and** only when the latest message is from the assistant, so placeholder pauses and clarify exchanges survive, and a re-queued task whose latest message is from the user is left alone. `bootstrap_app` now runs the repair *before* `pause_running_agent_tasks_on_launch` so genuinely finished tasks still complete across restarts.

4. **`src-tauri/src/db/repositories.rs` (`add_agent_message_if_absent`) — TOCTOU duplicated hydrated messages.** Hydrated messages now record their Hermes-side identity (`hermes:<session>:<message id>`) in a new `agent_messages.external_id` column. Migration `008_agent_message_identity.sql` (gated on `index_exists`, same pattern as migration 006) first deletes pre-existing duplicate rows (`GROUP BY task_id, role, content, created_at`, keeping the lowest rowid) and then creates a partial unique index on `(task_id, external_id) WHERE external_id IS NOT NULL`, and the insert is `INSERT OR IGNORE`. Legacy rows hydrated before external ids are still matched by content so they are not re-inserted; distinct Hermes messages with identical content are no longer wrongly collapsed.

5. **`src-tauri/src/commands.rs` — heuristic Hermes session matching could bind the wrong session permanently.** Title matching (titles are the first 64 chars of the prompt, so identical prompts collide) now only binds when **exactly one** session with the title started within 5 minutes of the task's creation **and** that session is not already bound to another task (`hermes_session_bound_to_other_task`). Ambiguous matches skip hydration for that poll instead of persisting a guess.

6. **Pool churn.** `repositories()` now initializes the app pool (and runs migrations) once per process via `tokio::sync::OnceCell` — the database path is derived from the app data dir and cannot change within a process. The Hermes `state.db` read pool is cached in a `tokio::sync::Mutex<Option<(PathBuf, SqlitePool)>>` and only re-opened if the path changes or the pool is closed, instead of one fresh pool per task per poll.

## Skipped / known limits

- A sub-millisecond race remains where the list-poll repair can complete a task between the placeholder's assistant-message insert and its paused transition (two consecutive DB writes); fixing it would require transactional message+status writes and was out of scope.
- Pre-existing clippy warnings in untouched code (`add_agent_tool_event` arg count, `scribe_api.rs`, `hermes_bridge.rs`, `domain/processing.rs`) were left as-is; the `-D warnings` clippy gate in CI applies only to the separate `scribe-api` service, not `src-tauri`.

## Verification

- `cargo check` — clean.
- `cargo clippy --all-targets` — no new warnings (the 5 remaining warnings are pre-existing and in untouched code; `-D warnings` fails on those pre-existing items on `main` too).
- `cargo fmt --check` — clean.
- `cargo test` — 173 tests pass, including 7 new integration tests in `src-tauri/tests/agent.rs` covering: repair completing a stale running task, repair skipping a re-queued task whose latest message is from the user, repair leaving `paused`/`waiting_for_user` alone, guarded transitions refusing to resurrect a cancelled task and applying allowed ones, external-id/legacy-content message dedupe, and detection of Hermes sessions already bound to another task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)