### PR TITLE
Fix agent chat stream rendering corruption and notification bugs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2.9.0",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/plugin-notification": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@tiptap/extension-placeholder": "^3.23.5",
@@ -238,6 +240,10 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
 
     "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
+
+    "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ=="],
+
+    "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
 
     "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -101,6 +101,7 @@ import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   completedHermesMessageText as completedHermesRuntimeMessageText,
+  toolEventKey,
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
@@ -3800,17 +3801,6 @@ function appendLogText(current: string, next: string) {
       ? ""
       : "\n";
   return `${current}${separator}${next}`;
-}
-
-function toolEventKey(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
-  return (
-    stringValue(payload?.id) ??
-    stringValue(payload?.call_id) ??
-    stringValue(payload?.tool_call_id) ??
-    stringValue(payload?.name) ??
-    `tool:${event.type}:${(event as LiveHermesEvent).receivedAt}`
-  );
 }
 
 function stringValue(value: unknown, preserveWhitespace = false) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -166,7 +166,7 @@ export function buildHermesSessionChatTurns(
       if (content) {
         turn.parts.push({
           type: "text",
-          text: collapseRepeatedMessageText(content),
+          text: content,
           status: "complete",
         });
       }
@@ -194,9 +194,7 @@ export function completedHermesMessageText(events: LiveHermesEvent[]) {
     .map((part) => part.text)
     .join("")
     .trim();
-  return turn?.status === "complete"
-    ? collapseRepeatedMessageText(text ?? "")
-    : "";
+  return turn?.status === "complete" ? (text ?? "") : "";
 }
 
 function messageToTurn(message: AgentMessageDto): AgentChatTurn {
@@ -218,16 +216,47 @@ function appendPersistedToolEvents(
   turns: AgentChatTurn[],
   toolEvents: AgentToolEventDto[],
 ) {
+  // A single synthetic turn that collects events newer than every persisted
+  // assistant message (an in-flight turn that has not been persisted yet).
+  let trailingTurn: AgentChatTurn | undefined;
   for (const event of toolEvents) {
-    const turn =
-      lastAssistantTurn(turns) ?? createAssistantTurn(turns, event.createdAt);
+    const status = toolStatus(event.status);
+    let turn: AgentChatTurn | undefined;
+    if (event.createdAt) {
+      turn = assistantTurnForTimestamp(turns, event.createdAt);
+      if (!turn) {
+        trailingTurn ??= createAssistantTurn(turns, event.createdAt);
+        turn = trailingTurn;
+      }
+    } else {
+      turn = lastAssistantTurn(turns);
+      if (!turn) {
+        trailingTurn ??= createAssistantTurn(turns, event.createdAt);
+        turn = trailingTurn;
+      }
+    }
     upsertToolPart(turn.parts, {
       id: event.id,
       name: event.toolName,
       text: event.summary,
-      status: toolStatus(event.status),
+      status,
     });
+    if (turn === trailingTurn) {
+      turn.status = status === "running" ? "running" : "complete";
+    }
   }
+}
+
+function assistantTurnForTimestamp(
+  turns: AgentChatTurn[],
+  createdAt: string | undefined,
+) {
+  if (!createdAt) return undefined;
+  for (const turn of turns) {
+    if (turn.role !== "assistant") continue;
+    if (turn.createdAt >= createdAt) return turn;
+  }
+  return undefined;
 }
 
 function appendLiveHermesEvents(
@@ -235,6 +264,7 @@ function appendLiveHermesEvents(
   events: LiveHermesEvent[],
 ) {
   let currentAssistant: AgentChatTurn | null = null;
+  const toolCreatedTurns = new Set<AgentChatTurn>();
 
   for (const event of events) {
     const text = eventText(event);
@@ -247,7 +277,11 @@ function appendLiveHermesEvents(
     if (event.type === "message.delta") {
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
       currentAssistant.status = "running";
-      appendAssistantTextPart(currentAssistant.parts, text, "running");
+      appendAssistantTextPart(
+        currentAssistant.parts,
+        deltaEventText(event),
+        "running",
+      );
       continue;
     }
 
@@ -265,7 +299,7 @@ function appendLiveHermesEvents(
     if (event.type === "thinking.delta" || event.type === "reasoning.delta") {
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
       currentAssistant.status = "running";
-      appendReasoningPart(currentAssistant.parts, text);
+      appendReasoningPart(currentAssistant.parts, deltaEventText(event));
       continue;
     }
 
@@ -278,11 +312,18 @@ function appendLiveHermesEvents(
         }
         continue;
       }
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status =
-        toolEventStatus(event) === "running"
-          ? "running"
-          : currentAssistant.status;
+      if (!currentAssistant) {
+        currentAssistant = createAssistantTurn(turns, event.receivedAt);
+        toolCreatedTurns.add(currentAssistant);
+      }
+      const status = toolEventStatus(event);
+      if (status === "running") {
+        currentAssistant.status = "running";
+      } else if (toolCreatedTurns.has(currentAssistant)) {
+        // A turn that exists only because of tool events has nothing left to
+        // stream once its tool reaches a terminal state.
+        currentAssistant.status = "complete";
+      }
       const payload = event.payload as Record<string, unknown> | undefined;
       upsertToolPart(currentAssistant.parts, {
         id: toolEventKey(event),
@@ -293,7 +334,7 @@ function appendLiveHermesEvents(
             "tool",
         ),
         text,
-        status: toolEventStatus(event),
+        status,
       });
       continue;
     }
@@ -376,12 +417,12 @@ function appendLiveHermesEvents(
       continue;
     }
 
-    if (event.type === "error" && text) {
+    if (event.type === "error") {
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
       upsertToolPart(currentAssistant.parts, {
         id: `error:${event.receivedAt}`,
         name: "Error",
-        text,
+        text: text || "The agent reported an error.",
         status: "failed",
       });
       currentAssistant.status = "complete";
@@ -392,8 +433,11 @@ function appendLiveHermesEvents(
 }
 
 function createAssistantTurn(turns: AgentChatTurn[], createdAt: string) {
+  // The `turns.length` suffix keeps ids unique when several turns are created
+  // within the same millisecond, while staying deterministic across rebuilds
+  // of the same event list (these ids are used as React keys).
   const turn: AgentChatTurn = {
-    id: `assistant:${createdAt}`,
+    id: `assistant:${createdAt}:${turns.length}`,
     role: "assistant",
     createdAt,
     status: "running",
@@ -415,45 +459,56 @@ function appendAssistantTextPart(
   delta: string,
   status: "running" | "complete",
 ) {
-  if (!delta.trim()) return;
+  if (!delta) return;
   const last = parts.at(-1);
   if (last?.type === "text") {
-    last.text = appendMessageText(last.text, delta);
+    last.text += delta;
     last.status = status;
     return;
   }
   parts.push({ type: "text", text: delta, status });
 }
 
+// `message.complete` carries the authoritative full text for the turn, so we
+// reconcile it against the concatenation of every streamed text part rather
+// than only the last one (a turn can interleave text -> tool -> text).
 function completeAssistantTextPart(parts: AgentChatPart[], text: string) {
   if (!text.trim()) return;
-  const lastText = [...parts]
-    .reverse()
-    .find((part): part is AgentChatTextPart => part.type === "text");
-  if (lastText) {
-    lastText.text = collapseRepeatedMessageText(
-      completeMessageText(lastText.text, text),
-    );
-    lastText.status = "complete";
+  const textParts = parts.filter(
+    (part): part is AgentChatTextPart => part.type === "text",
+  );
+  if (textParts.length === 0) {
+    parts.push({ type: "text", text, status: "complete" });
+    return;
+  }
+  const last = textParts[textParts.length - 1] as AgentChatTextPart;
+  const earlier = textParts.slice(0, -1);
+  const earlierText = earlier.map((part) => part.text).join("");
+  if (!earlier.length) {
+    last.text = text;
+  } else if (text.startsWith(earlierText)) {
+    last.text = text.slice(earlierText.length);
   } else {
-    parts.push({
-      type: "text",
-      text: collapseRepeatedMessageText(text),
-      status: "complete",
-    });
+    // The streamed parts cannot be reconciled with the complete text; replace
+    // the text parts wholesale, keeping tool parts in position.
+    for (const part of earlier) {
+      const index = parts.indexOf(part);
+      if (index >= 0) parts.splice(index, 1);
+    }
+    last.text = text;
+  }
+  last.status = "complete";
+  for (const part of earlier) {
+    part.status = "complete";
   }
 }
 
 function appendReasoningPart(parts: AgentChatPart[], delta: string) {
-  if (
-    !delta.trim() ||
-    delta === "thinking.delta" ||
-    delta === "reasoning.delta"
-  )
+  if (!delta || delta === "thinking.delta" || delta === "reasoning.delta")
     return;
   const last = parts.at(-1);
   if (last?.type === "reasoning") {
-    last.text = appendMessageText(last.text, delta);
+    last.text += delta;
     last.status = "running";
     return;
   }
@@ -583,6 +638,18 @@ function eventText(event: HermesGatewayEvent) {
         key === "content",
     );
     if (value) return value;
+  }
+  return "";
+}
+
+// Streaming deltas must be appended verbatim — including whitespace-only
+// chunks — so this intentionally bypasses the trimming in `stringValue`.
+function deltaEventText(event: HermesGatewayEvent) {
+  const payload = event.payload as Record<string, unknown> | undefined;
+  if (!payload) return "";
+  for (const key of ["text", "delta", "message", "content"]) {
+    const value = payload[key];
+    if (typeof value === "string" && value) return value;
   }
   return "";
 }
@@ -731,9 +798,10 @@ function stringifyObject(value: unknown) {
   }
 }
 
-function toolEventKey(event: HermesGatewayEvent) {
+export function toolEventKey(event: HermesGatewayEvent) {
   const payload = event.payload as Record<string, unknown> | undefined;
   return (
+    stringValue(payload?.tool_id) ??
     stringValue(payload?.id) ??
     stringValue(payload?.call_id) ??
     stringValue(payload?.tool_call_id) ??
@@ -795,59 +863,6 @@ function approvalChoiceValue(value: unknown): AgentApprovalChoice | undefined {
     return value;
   }
   return undefined;
-}
-
-function appendMessageText(current: string, next: string) {
-  if (!next.trim()) return current;
-  if (!current) return next;
-  if (next.startsWith(current)) return next;
-  if (current.endsWith(next)) return current;
-  return `${current}${next}`;
-}
-
-function completeMessageText(current: string, complete: string) {
-  if (!complete.trim()) return current;
-  if (!current.trim()) return complete;
-  if (complete.trim() === current.trim()) return current;
-  if (complete.includes(current.trim()) || complete.length >= current.length)
-    return complete;
-  return appendMessageText(current, complete);
-}
-
-function collapseRepeatedMessageText(value: string) {
-  let text = value.trim();
-  if (!text) return "";
-
-  for (;;) {
-    const match = text.match(/^([\s\S]+?)\s+\1$/);
-    if (!match?.[1]) break;
-    text = match[1].trim();
-  }
-
-  const paragraphs = text.split(/\n{2,}/);
-  const dedupedParagraphs = paragraphs.filter((paragraph, index) => {
-    if (index === 0) return true;
-    return !sameMessageText(paragraph, paragraphs[index - 1] ?? "");
-  });
-  text = dedupedParagraphs.join("\n\n").trim();
-
-  const lines = text.split("\n");
-  const dedupedLines = lines.filter((line, index) => {
-    if (index === 0) return true;
-    return !sameMessageText(line, lines[index - 1] ?? "");
-  });
-  text = dedupedLines.join("\n").trim();
-
-  const half = Math.floor(text.length / 2);
-  const left = text.slice(0, half).trim();
-  const right = text.slice(half).trim();
-  if (left && sameMessageText(left, right)) return left;
-
-  return text;
-}
-
-function sameMessageText(left: string, right: string) {
-  return left.replace(/\s+/g, " ").trim() === right.replace(/\s+/g, " ").trim();
 }
 
 function appendLogText(current: string, next: string) {

--- a/src/lib/agent-notifications.ts
+++ b/src/lib/agent-notifications.ts
@@ -27,10 +27,14 @@ type AgentNotificationGlobal = typeof globalThis & {
   __scribeAgentNotificationTimes?: Map<string, number>;
 };
 
-function recentNotificationTimes() {
+function recentNotificationTimes(now: number) {
   const target = globalThis as AgentNotificationGlobal;
   target.__scribeAgentNotificationTimes ??= new Map<string, number>();
-  return target.__scribeAgentNotificationTimes;
+  const recent = target.__scribeAgentNotificationTimes;
+  for (const [key, timestamp] of recent) {
+    if (now - timestamp >= DEDUPE_WINDOW_MS) recent.delete(key);
+  }
+  return recent;
 }
 
 export async function notifyAgentSessionStatus(
@@ -42,10 +46,9 @@ export async function notifyAgentSessionStatus(
   const group = agentNotificationGroup(detail);
   const dedupeKey = `${group}:${copy.title}:${copy.body}`;
   const now = Date.now();
-  const recent = recentNotificationTimes();
+  const recent = recentNotificationTimes(now);
   const previous = recent.get(dedupeKey);
   if (previous && now - previous < DEDUPE_WINDOW_MS) return false;
-  recent.set(dedupeKey, now);
 
   let granted = await isPermissionGranted().catch(() => false);
   if (!granted) {
@@ -53,6 +56,10 @@ export async function notifyAgentSessionStatus(
     granted = permission === "granted";
   }
   if (!granted) return false;
+
+  // Record the dedupe slot only once we know the notification will be shown,
+  // so a permission denial does not swallow the next legitimate notification.
+  recent.set(dedupeKey, now);
 
   sendNotification({
     title: copy.title,
@@ -125,7 +132,20 @@ function playAgentNotificationTone(status: AgentSessionStatusKind) {
     gain.connect(context.destination);
     oscillator.start(now);
     oscillator.stop(now + 0.24);
-    oscillator.addEventListener("ended", () => void context.close());
+    let closed = false;
+    const closeContext = () => {
+      if (closed) return;
+      closed = true;
+      void context.close().catch(() => {});
+    };
+    oscillator.addEventListener("ended", closeContext);
+    // WKWebView can keep the context suspended (no user gesture), in which
+    // case "ended" never fires; resume it and close on a fallback timer so
+    // contexts cannot accumulate.
+    if (context.state === "suspended") {
+      void context.resume().catch(() => {});
+    }
+    window.setTimeout(closeContext, 2_000);
   } catch {
     // Native notifications remain authoritative; the local tone is a fallback.
   }

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
+  completedHermesMessageText,
+  toolEventKey,
 } from "../lib/agent-chat-runtime";
-import type { HermesSessionMessage } from "../lib/tauri";
+import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
 
 describe("Agent chat runtime", () => {
   it("renders persisted Hermes user and assistant messages", () => {
@@ -242,5 +244,431 @@ describe("Agent chat runtime", () => {
         status: "resolved",
       },
     ]);
+  });
+
+  it("preserves whitespace-only message deltas", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {},
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: { text: "Hello" },
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.200Z",
+          payload: { text: "\n\n" },
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.300Z",
+          payload: { text: "World" },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: "Hello\n\nWorld", status: "running" },
+    ]);
+  });
+
+  it("appends repeated deltas verbatim instead of dropping them", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {},
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: { text: "no" },
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.200Z",
+          payload: { text: "no" },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: "nono", status: "running" },
+    ]);
+  });
+
+  it("keeps legitimate repeated lines and paragraphs in persisted messages", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "assistant",
+        content: "Run:\n\nfoo();\nfoo();\nbar();",
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "2",
+        role: "assistant",
+        content: "Yes.\n\nYes.",
+        timestamp: "2026-06-04T10:00:01.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Run:\n\nfoo();\nfoo();\nbar();",
+        status: "complete",
+      },
+    ]);
+    expect(turns[1]?.parts).toEqual([
+      { type: "text", text: "Yes.\n\nYes.", status: "complete" },
+    ]);
+  });
+
+  it("returns the raw completed message text for persistence", () => {
+    const text = completedHermesMessageText([
+      {
+        type: "message.start",
+        receivedAt: "2026-06-04T10:00:00.000Z",
+        payload: {},
+      },
+      {
+        type: "message.delta",
+        receivedAt: "2026-06-04T10:00:00.100Z",
+        payload: { text: "Yes.\n\nYes." },
+      },
+      {
+        type: "message.complete",
+        receivedAt: "2026-06-04T10:00:01.000Z",
+        payload: { text: "Yes.\n\nYes." },
+      },
+    ]);
+
+    expect(text).toBe("Yes.\n\nYes.");
+  });
+
+  it("does not duplicate the opening text on interleaved text/tool turns", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {},
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: { text: "Let me check." },
+        },
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.200Z",
+          payload: { tool_id: "tool-1", name: "search" },
+        },
+        {
+          type: "tool.complete",
+          receivedAt: "2026-06-04T10:00:00.300Z",
+          payload: { tool_id: "tool-1", name: "search" },
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.400Z",
+          payload: { text: "Here is the answer." },
+        },
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { text: "Let me check.Here is the answer." },
+        },
+      ],
+    );
+
+    expect(turns[0]?.status).toBe("complete");
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["Let me check.", "tool", "Here is the answer."]);
+  });
+
+  it("replaces streamed text wholesale when the complete text disagrees", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { text: "Partial garble" },
+        },
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: { tool_id: "tool-1", name: "search" },
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.200Z",
+          payload: { text: "more" },
+        },
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { text: "The authoritative answer." },
+        },
+      ],
+    );
+
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["tool", "The authoritative answer."]);
+  });
+
+  it("assigns unique turn ids to turns created in the same millisecond", () => {
+    const receivedAt = "2026-06-04T10:00:00.000Z";
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        { type: "message.start", receivedAt, payload: {} },
+        { type: "message.complete", receivedAt, payload: { text: "One" } },
+        { type: "message.start", receivedAt, payload: {} },
+        { type: "message.complete", receivedAt, payload: { text: "Two" } },
+      ],
+    );
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0]?.id).not.toBe(turns[1]?.id);
+  });
+
+  it("keys tool events by tool_id so terminal events update the same part", () => {
+    expect(
+      toolEventKey({ type: "tool.start", payload: { tool_id: "tool-9" } }),
+    ).toBe("tool-9");
+
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { tool_id: "tool-9", name: "search", text: "Searching" },
+        },
+        {
+          type: "tool.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { tool_id: "tool-9" },
+        },
+      ],
+    );
+
+    const toolParts = turns[0]?.parts.filter((part) => part.type === "tool");
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts?.[0]?.status).toBe("complete");
+  });
+
+  it("does not merge same-name tool calls with distinct tool ids", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { tool_id: "tool-a", name: "search", text: "First" },
+        },
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { tool_id: "tool-b", name: "search", text: "Second" },
+        },
+      ],
+    );
+
+    const toolParts = turns[0]?.parts.filter((part) => part.type === "tool");
+    expect(toolParts?.map((part) => part.id)).toEqual(["tool-a", "tool-b"]);
+  });
+
+  it("attributes persisted tool events to the assistant turn they belong to", () => {
+    const messages: AgentMessageDto[] = [
+      {
+        id: "m1",
+        taskId: "task-1",
+        role: "user",
+        content: "First question",
+        createdAt: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "m2",
+        taskId: "task-1",
+        role: "assistant",
+        content: "First answer",
+        createdAt: "2026-06-04T10:00:10.000Z",
+      },
+      {
+        id: "m3",
+        taskId: "task-1",
+        role: "user",
+        content: "Second question",
+        createdAt: "2026-06-04T10:01:00.000Z",
+      },
+      {
+        id: "m4",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Second answer",
+        createdAt: "2026-06-04T10:01:10.000Z",
+      },
+    ];
+    const turns = buildAgentChatTurns(messages, [
+      {
+        id: "evt-1",
+        taskId: "task-1",
+        toolName: "Search",
+        status: "completed",
+        summary: "Searched the web",
+        redacted: false,
+        createdAt: "2026-06-04T10:00:05.000Z",
+      },
+      {
+        id: "evt-2",
+        taskId: "task-1",
+        toolName: "Fetch",
+        status: "completed",
+        summary: "Fetched a page",
+        redacted: false,
+        createdAt: "2026-06-04T10:01:05.000Z",
+      },
+    ]);
+
+    const firstAssistant = turns.find((turn) => turn.id === "m2");
+    const secondAssistant = turns.find((turn) => turn.id === "m4");
+    expect(
+      firstAssistant?.parts.filter((part) => part.type === "tool"),
+    ).toEqual([
+      {
+        type: "tool",
+        id: "evt-1",
+        name: "Search",
+        text: "Searched the web",
+        status: "complete",
+      },
+    ]);
+    expect(
+      secondAssistant?.parts.filter((part) => part.type === "tool"),
+    ).toEqual([
+      {
+        type: "tool",
+        id: "evt-2",
+        name: "Fetch",
+        text: "Fetched a page",
+        status: "complete",
+      },
+    ]);
+  });
+
+  it("groups trailing persisted tool events into one in-flight turn", () => {
+    const messages: AgentMessageDto[] = [
+      {
+        id: "m1",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Earlier answer",
+        createdAt: "2026-06-04T10:00:00.000Z",
+      },
+    ];
+    const turns = buildAgentChatTurns(messages, [
+      {
+        id: "evt-1",
+        taskId: "task-1",
+        toolName: "Search",
+        status: "completed",
+        summary: "Searched the web",
+        redacted: false,
+        createdAt: "2026-06-04T10:01:00.000Z",
+      },
+      {
+        id: "evt-2",
+        taskId: "task-1",
+        toolName: "Fetch",
+        status: "completed",
+        summary: "Fetched a page",
+        redacted: false,
+        createdAt: "2026-06-04T10:01:05.000Z",
+      },
+    ]);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: "Earlier answer", status: "complete" },
+    ]);
+    expect(turns[1]?.parts.filter((part) => part.type === "tool")).toHaveLength(
+      2,
+    );
+    expect(turns[1]?.status).toBe("complete");
+  });
+
+  it("does not leave a turn created by a terminal tool event running", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "tool.complete",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { tool_id: "tool-1", name: "search", text: "Done" },
+        },
+      ],
+    );
+
+    expect(turns[0]?.status).toBe("complete");
+  });
+
+  it("marks the in-flight turn errored even when the error has no text", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {},
+        },
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: { text: "Working on it" },
+        },
+        {
+          type: "error",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: {},
+        },
+      ],
+    );
+
+    expect(turns[0]?.status).toBe("complete");
+    expect(turns[0]?.parts).toContainEqual({
+      type: "tool",
+      id: "error:2026-06-04T10:00:01.000Z",
+      name: "Error",
+      text: "The agent reported an error.",
+      status: "failed",
+    });
   });
 });

--- a/src/test/agent-notifications.test.ts
+++ b/src/test/agent-notifications.test.ts
@@ -113,4 +113,120 @@ describe("agent notifications", () => {
 
     expect(notificationMocks.sendNotification).toHaveBeenCalledOnce();
   });
+
+  it("does not consume the dedupe slot when permission is not granted", async () => {
+    notificationMocks.isPermissionGranted.mockResolvedValue(false);
+    notificationMocks.requestPermission.mockResolvedValue("denied");
+
+    await expect(
+      notifyAgentSessionStatus({
+        sessionId: "session-4",
+        status: "completed",
+        title: "Make a PDF",
+      }),
+    ).resolves.toBe(false);
+    expect(notificationMocks.sendNotification).not.toHaveBeenCalled();
+
+    notificationMocks.isPermissionGranted.mockResolvedValue(true);
+
+    await expect(
+      notifyAgentSessionStatus({
+        sessionId: "session-4",
+        status: "completed",
+        title: "Make a PDF",
+      }),
+    ).resolves.toBe(true);
+    expect(notificationMocks.sendNotification).toHaveBeenCalledOnce();
+  });
+
+  it("prunes dedupe entries older than the window", async () => {
+    vi.useFakeTimers();
+    try {
+      notificationMocks.isPermissionGranted.mockResolvedValue(true);
+
+      await notifyAgentSessionStatus({
+        sessionId: "session-5",
+        status: "completed",
+        title: "First",
+      });
+      vi.advanceTimersByTime(20_000);
+      await notifyAgentSessionStatus({
+        sessionId: "session-6",
+        status: "completed",
+        title: "Second",
+      });
+
+      expect(notificationMocks.sendNotification).toHaveBeenCalledTimes(2);
+      const recent = (
+        globalThis as typeof globalThis & {
+          __scribeAgentNotificationTimes?: Map<string, number>;
+        }
+      ).__scribeAgentNotificationTimes;
+      expect(recent?.size).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes suspended audio contexts and closes them exactly once", async () => {
+    vi.useFakeTimers();
+    const contexts: FakeAudioContext[] = [];
+    const endedListeners: Array<() => void> = [];
+
+    class FakeAudioContext {
+      state = "suspended";
+      currentTime = 0;
+      destination = {};
+      resume = vi.fn().mockResolvedValue(undefined);
+      close = vi.fn().mockResolvedValue(undefined);
+      constructor() {
+        contexts.push(this);
+      }
+      createOscillator() {
+        return {
+          type: "",
+          frequency: { setValueAtTime: vi.fn() },
+          connect: vi.fn(),
+          start: vi.fn(),
+          stop: vi.fn(),
+          addEventListener: (_name: string, listener: () => void) => {
+            endedListeners.push(listener);
+          },
+        };
+      }
+      createGain() {
+        return {
+          gain: {
+            setValueAtTime: vi.fn(),
+            exponentialRampToValueAtTime: vi.fn(),
+          },
+          connect: vi.fn(),
+        };
+      }
+    }
+
+    const target = window as unknown as { AudioContext?: unknown };
+    const originalAudioContext = target.AudioContext;
+    target.AudioContext = FakeAudioContext;
+    try {
+      notificationMocks.isPermissionGranted.mockResolvedValue(true);
+
+      await notifyAgentSessionStatus({
+        sessionId: "session-7",
+        status: "completed",
+        title: "Tone",
+      });
+
+      expect(contexts).toHaveLength(1);
+      expect(contexts[0]?.resume).toHaveBeenCalledOnce();
+
+      // "ended" fires, then the fallback timer fires; close runs only once.
+      for (const listener of endedListeners) listener();
+      vi.advanceTimersByTime(5_000);
+      expect(contexts[0]?.close).toHaveBeenCalledOnce();
+    } finally {
+      target.AudioContext = originalAudioContext;
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
Fixes nine empirically verified bugs in the agent chat runtime and agent notifications. The runtime's dedupe heuristics were written to paper over a duplicated-stream pathology but corrupted legitimate content — and the corruption was persisted.

## Bugs fixed

1. **`src/lib/agent-chat-runtime.ts:817-847` — `collapseRepeatedMessageText` deleted legitimate content and the corruption was persisted.** Consecutive duplicate lines ("Run:\n\nfoo();\nfoo();\nbar();" → "Run:\n\nfoo();\nbar();"), duplicate paragraphs, and half-matching messages ("Yes.\n\nYes." → "Yes.") were collapsed on every persisted assistant message and every completed stream, and the transformed text was persisted. **Fix:** removed the collapsing (and its O(n²)-ish backreference regex) entirely; `completedHermesMessageText` now returns the raw completed text so persistence is never transformed.

2. **`agent-chat-runtime.ts:418,800-806,871` — delta handling dropped whitespace-only deltas and mangled legitimate repeats.** "Hello" + "\n\n" + "World" rendered "HelloWorld"; "no" + "no" rendered "no"; a delta starting with the current text was treated as a snapshot replacement. **Fix:** deltas are appended verbatim via a new `deltaEventText` helper that bypasses the trimming in `stringValue`; snapshot detection was removed (no test pinned cumulative-snapshot behavior).

3. **`agent-chat-runtime.ts:428-445` — `completeAssistantTextPart` duplicated the opening text on interleaved text→tool→text turns** (parts came out as `["Let me check.", tool, "Let me check.Here is the answer."]`). **Fix:** `message.complete` is treated as authoritative for the whole turn — it is reconciled against the concatenation of all text parts (prefix match sets the last part to the remainder; otherwise text parts are replaced wholesale with tool parts kept in position).

4. **`agent-chat-runtime.ts:396` — turn ids collided within the same millisecond** (`assistant:${receivedAt}`, used as React keys). **Fix:** ids get a `turns.length` suffix — unique within a build yet deterministic across rebuilds of the same event list so React keys stay stable.

5. **`agent-chat-runtime.ts:734-743` — `toolEventKey` never read `tool_id`**, the field the gateway actually sends, so same-name calls merged, statuses flipped back to running, and complete events without a name never matched. **Fix:** `tool_id` is checked alongside `id`/`call_id`/`tool_call_id`; the helper is now exported and `AgentWorkspace.tsx` uses the shared one instead of its local copy with the same gap (surgical edit: import + delete the duplicate).

6. **`agent-chat-runtime.ts:217-231` — persisted tool events all attached to the LAST assistant turn.** **Fix:** each event is attributed to the first assistant turn whose `createdAt` is at/after the event's `createdAt` (assistant messages are persisted at turn completion, so they timestamp the end of their turn); events newer than every persisted turn group into a single in-flight turn; events without timestamps fall back to the last turn.

7. **`agent-chat-runtime.ts:281-285,394-404` — turns stuck "running" forever.** A turn created by a terminal tool event stayed "running"; an error event with no extractable text was skipped entirely. **Fix:** turns that exist only because of tool events adopt a terminal status when their tool reaches one, and error events always mark the turn errored, with the generic text "The agent reported an error." when no text can be extracted.

8. **`src/lib/agent-notifications.ts:30-55` — dedupe map never pruned, and the dedupe slot was consumed before the permission check**, so the first real notification after the user granted permission within the 15s window was swallowed. **Fix:** the dedupe timestamp is recorded only after the notification will actually be shown, and entries older than the window are pruned on each call.

9. **`agent-notifications.ts:97-128` — AudioContext leak in WKWebView.** A new context per tone was closed only in the oscillator "ended" handler; a suspended context (no user gesture) never fires "ended" and never plays. **Fix:** suspended contexts are resumed, and a guarded fallback timer closes the context exactly once even if "ended" also fires.

## Tests

- **Updated deliberately:** none of the existing tests pinned the buggy heuristics directly, so all 12 prior tests in `agent-chat-runtime.test.ts` / `agent-notifications.test.ts` pass unchanged.
- **Added regression tests** (16 new): whitespace-only deltas preserved; repeated deltas appended verbatim; repeated lines/paragraphs surviving in persisted messages; raw completed text returned for persistence; interleaved text/tool completion without duplication; wholesale replacement when complete text disagrees; unique same-millisecond turn ids; `tool_id` keying (terminal events update the same part; same-name tools with distinct ids do not merge); multi-turn persisted tool event attribution; trailing events grouping into one in-flight turn; terminal-tool-created turns not stuck running; textless error events marking the turn errored; notification dedupe slot not consumed on permission denial; dedupe map pruning; suspended AudioContext resume + single guarded close.

## Notes

- `bun.lock` is synced with `package.json`: `@tauri-apps/plugin-notification` and `@tauri-apps/plugin-dialog` were already declared in `package.json` on main but missing from the lockfile (`agent-notifications.ts` imports the former); `bun install` regenerated the entries.
- Nothing was skipped.

## Verification

- `npx vitest run`: 29 files, 193 tests — all pass.
- `npx tsc --noEmit`: clean.
- `prettier --check` on all touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)