### PR TITLE
Fix agent workspace session-state and gateway connection reliability

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -52,8 +52,6 @@ import {
   listAgentTasks,
   downloadHermesBridgeFile,
   retryAgentTask,
-  saveAgentAssistantMessage,
-  saveAgentHermesSession,
   sendAgentMessage,
   startHermesBridge,
   suggestAgentSessionTitle,
@@ -100,7 +98,6 @@ import {
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
-  completedHermesMessageText as completedHermesRuntimeMessageText,
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
@@ -183,9 +180,6 @@ export function AgentWorkspace({
     running: false,
   });
   const [bridgeStarting, setBridgeStarting] = useState(false);
-  const [hermesSessions, setHermesSessions] = useState<Record<string, string>>(
-    {},
-  );
   const [hermesSessionItems, setHermesSessionItems] = useState<
     HermesSessionInfo[]
   >(() => (initialSession ? [initialSession] : []));
@@ -246,6 +240,11 @@ export function AgentWorkspace({
     Record<string, string>
   >({});
   const gatewayRef = useRef<HermesGatewayClient | null>(null);
+  // The gateway's close listener is registered once per client instance, so
+  // it routes through this ref to always run the latest render's recovery
+  // closure (see recoverFromGatewayClose).
+  const gatewayCloseHandlerRef = useRef(() => {});
+  const gatewayRecoveringRef = useRef(false);
   // One live gateway subscription per Hermes session. A follow-up send while
   // the previous turn is still streaming must replace the old handler, not
   // stack a second one — otherwise every event lands twice in liveEvents.
@@ -270,18 +269,6 @@ export function AgentWorkspace({
     waitingSessionIds,
     workingSessionIds,
   ]);
-
-  const setTaskWorking = useCallback((taskId: string, working: boolean) => {
-    setWorkingTaskIds((current) => {
-      const next = new Set(current);
-      if (working) {
-        next.add(taskId);
-      } else {
-        next.delete(taskId);
-      }
-      return next;
-    });
-  }, []);
 
   const setSessionWorking = useCallback(
     (sessionId: string, working: boolean) => {
@@ -332,6 +319,26 @@ export function AgentWorkspace({
     };
   }, []);
 
+  // Shared teardown for a session that is going away: its messages, pending
+  // sends, working/waiting flags, live gateway listener, and buffered live
+  // events. Both delete paths (sidebar event and session-bar menu) run this so
+  // neither leaves a phantom "working" session with a leaked listener behind.
+  const scrubHermesSessionState = useCallback(
+    (sessionId: string) => {
+      setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
+      setPendingHermesMessages((current) => {
+        const next = omitRecordKey(current, sessionId);
+        pendingHermesMessagesRef.current = next;
+        return next;
+      });
+      clearSessionActivity(sessionId);
+      sessionGatewayUnlistenRef.current.get(sessionId)?.();
+      liveEventsRef.current = omitRecordKey(liveEventsRef.current, sessionId);
+      setLiveEvents(liveEventsRef.current);
+    },
+    [clearSessionActivity],
+  );
+
   const selectedTask = useMemo(
     () => tasks.find((task) => task.id === selectedTaskId),
     [selectedTaskId, tasks],
@@ -355,6 +362,9 @@ export function AgentWorkspace({
     [filesystemSnapshot],
   );
 
+  // Updates the task list without touching the selection — a late poll
+  // response must not re-select a task the user already navigated away from.
+  // Selection changes only where user intent exists (load, explicit click).
   const upsertTask = useCallback((task: AgentTaskDto) => {
     setTasks((prev) => {
       const rest = prev.filter((item) => item.id !== task.id);
@@ -362,7 +372,6 @@ export function AgentWorkspace({
         b.updatedAt.localeCompare(a.updatedAt),
       );
     });
-    setSelectedTaskId(task.id);
   }, []);
 
   const loadTasks = useCallback(async () => {
@@ -484,50 +493,41 @@ export function AgentWorkspace({
     workingSessionIds,
   ]);
 
+  // Latest-instance handlers for the mount-scoped window listeners below. The
+  // empty-deps effect would otherwise freeze first-render closures — where
+  // bridge is still { running: false }, so a post-submit loadHermesSessions
+  // silently no-ops and the sidebar never refreshes after event-driven runs.
+  const windowEventHandlersRef = useRef({
+    startNewTask,
+    removeHermesSessionLocally,
+  });
+  useEffect(() => {
+    windowEventHandlersRef.current = {
+      startNewTask,
+      removeHermesSessionLocally,
+    };
+    gatewayCloseHandlerRef.current = () => {
+      void recoverFromGatewayClose();
+    };
+  });
+
   useEffect(() => {
     function handleNewSession(event: Event) {
       const detail = (event as CustomEvent<AgentNewSessionDetail>).detail;
-      void startNewTask(detail?.prompt);
+      void windowEventHandlersRef.current.startNewTask(detail?.prompt);
     }
 
     function handleDeleteSession(event: Event) {
       const detail = (event as CustomEvent<AgentDeleteSessionDetail>).detail;
       if (!detail?.sessionId) return;
-      const { sessionId } = detail;
-      setHermesSessionItems((current) => {
-        const next = current.filter((session) => session.id !== sessionId);
-        setSelectedHermesSessionId((selected) => {
-          const nextSelected = selected === sessionId ? next[0]?.id : selected;
-          selectedHermesSessionIdRef.current = nextSelected;
-          return nextSelected;
-        });
-        return next;
-      });
-      setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
-      setPendingHermesMessages((current) => {
-        const next = omitRecordKey(current, sessionId);
-        pendingHermesMessagesRef.current = next;
-        return next;
-      });
-      setWorkingSessionIds((current) => {
-        const next = new Set(current);
-        next.delete(sessionId);
-        workingSessionIdsRef.current = next;
-        return next;
-      });
-      setWaitingSessionIds((current) => {
-        const next = new Set(current);
-        next.delete(sessionId);
-        waitingSessionIdsRef.current = next;
-        return next;
-      });
-      liveEventsRef.current = omitRecordKey(liveEventsRef.current, sessionId);
-      setLiveEvents(liveEventsRef.current);
+      windowEventHandlersRef.current.removeHermesSessionLocally(
+        detail.sessionId,
+      );
     }
 
     const pending = pendingNewSessionRequest();
     if (pending) {
-      void startNewTask(pending.prompt);
+      void windowEventHandlersRef.current.startNewTask(pending.prompt);
     }
 
     window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
@@ -564,9 +564,18 @@ export function AgentWorkspace({
           return next;
         });
         void suggestTitleForUntitledSession(selectedHermesSessionId, messages);
+        const combined = [...messages, ...retainedPending];
         if (
-          sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])
+          shouldResumeSessionActivity(combined) &&
+          !waitingSessionIdsRef.current.has(selectedHermesSessionId)
         ) {
+          // An in-flight run from before a remount or gateway drop: the
+          // latest message is the user's, so re-arm working state — the
+          // working-gated poll below picks the session back up and
+          // reconciles it from persisted messages.
+          setSessionWorking(selectedHermesSessionId, true);
+        }
+        if (sessionHasAssistantAfterLatestUser(combined)) {
           const wasActive = sessionHasActiveWork(
             selectedHermesSessionId,
             workingSessionIdsRef.current,
@@ -657,32 +666,19 @@ export function AgentWorkspace({
     return () => window.clearInterval(interval);
   }, [selectedTask?.id, selectedTask?.status, upsertTask]);
 
+  // Poll every working session — not just the selected one — so a run whose
+  // live gateway stream died (disconnect, navigation) still reconciles from
+  // persisted messages instead of staying "working" forever.
   useEffect(() => {
-    if (
-      !bridge.running ||
-      !selectedHermesSessionId ||
-      !workingSessionIds.has(selectedHermesSessionId)
-    )
-      return;
-    const sessionId = selectedHermesSessionId;
+    if (!bridge.running || workingSessionIds.size === 0) return;
+    const sessionIds = Array.from(workingSessionIds);
     const interval = window.setInterval(() => {
-      void refreshHermesSession(sessionId);
+      for (const sessionId of sessionIds) {
+        void refreshHermesSession(sessionId);
+      }
     }, 2500);
     return () => window.clearInterval(interval);
-  }, [bridge.running, selectedHermesSessionId, workingSessionIds]);
-
-  useEffect(() => {
-    // The conversation scrolls in the main card (.main-panel-body), not an
-    // inner pane — so drive that scroller to the bottom as turns arrive.
-    const scroller = listRef.current?.closest(".main-panel-body");
-    if (!(scroller instanceof HTMLElement)) return;
-    scroller.scrollTo({ top: scroller.scrollHeight, behavior: "smooth" });
-  }, [
-    selectedTask?.messages.length,
-    selectedTask?.toolEvents.length,
-    selectedHermesMessages.length,
-    selectedHermesSessionId,
-  ]);
+  }, [bridge.running, workingSessionIds]);
 
   // Auto-grow the composer with its content (capped), since WKWebView has no
   // CSS field-sizing. Recomputing on `draft` also collapses it back after a
@@ -758,10 +754,11 @@ export function AgentWorkspace({
       await submitHermesSession(content);
       setError(null);
     } catch (err) {
-      // Restore the composer so a failed send doesn't eat the message or
-      // its attachments.
-      setDraft(message);
-      setAttachments(attachments);
+      // Restore the composer so a failed send doesn't eat the message or its
+      // attachments — but only where the user hasn't typed or attached
+      // something new during the in-flight send.
+      setDraft((current) => (current.trim() ? current : message));
+      setAttachments((current) => (current.length ? current : attachments));
       setError(messageFromError(err));
     } finally {
       setSubmitting(false);
@@ -798,7 +795,9 @@ export function AgentWorkspace({
       await submitHermesSession(message, targetSession);
       setError(null);
     } catch (err) {
-      setDraft(message);
+      // Same merge-restore as submit(): don't clobber a draft the user
+      // started typing while the reply was in flight.
+      setDraft((current) => (current.trim() ? current : message));
       setError(messageFromError(err));
     } finally {
       setSubmitting(false);
@@ -1067,10 +1066,62 @@ export function AgentWorkspace({
     const current = bridge.running ? bridge : await startBridge();
     const wsUrl = current.connection?.wsUrl;
     if (!wsUrl) throw new Error("Hermes bridge did not return a gateway URL.");
-    const gateway = gatewayRef.current ?? new HermesGatewayClient();
-    gatewayRef.current = gateway;
+    let gateway = gatewayRef.current;
+    if (!gateway) {
+      gateway = new HermesGatewayClient();
+      gatewayRef.current = gateway;
+      // Fires only on unexpected drops — the unmount close() detaches the
+      // socket first, and a superseded socket never notifies.
+      gateway.onClose(() => gatewayCloseHandlerRef.current());
+    }
     await gateway.connect(wsUrl);
     return gateway;
+  }
+
+  // prompt.submit is ack-style: once acked there are no pending RPCs, so a
+  // socket drop mid-run rejects nothing and no event will ever arrive — the
+  // session would otherwise stay "working" (and broadcast "June is working.")
+  // forever. Try to reconnect and resubscribe the active runtime sessions;
+  // either way, refresh them immediately so the working-gated poll reconciles
+  // their true state from persisted messages.
+  async function recoverFromGatewayClose() {
+    if (gatewayRecoveringRef.current) return;
+    const activeSessionIds = new Set([
+      ...workingSessionIdsRef.current,
+      ...waitingSessionIdsRef.current,
+    ]);
+    if (!activeSessionIds.size) return;
+    gatewayRecoveringRef.current = true;
+    try {
+      const gateway = await ensureHermesGateway();
+      await Promise.all(
+        Array.from(activeSessionIds).map(async (sessionId) => {
+          try {
+            const resumed =
+              await gateway.request<HermesRuntimeSessionResponse>(
+                "session.resume",
+                { session_id: sessionId, cols: 96 },
+              );
+            const runtimeSessionId = resumed.session_id;
+            if (runtimeSessionId) {
+              setRuntimeSessionIds((current) => ({
+                ...current,
+                [sessionId]: runtimeSessionId,
+              }));
+            }
+          } catch {
+            // The runtime session may be gone; the poll reconciles it.
+          }
+        }),
+      );
+    } catch {
+      // Reconnect failed — fall back to the persisted-message poll.
+    } finally {
+      gatewayRecoveringRef.current = false;
+    }
+    for (const sessionId of activeSessionIds) {
+      void refreshHermesSession(sessionId);
+    }
   }
 
   async function startBridge() {
@@ -1086,78 +1137,6 @@ export function AgentWorkspace({
       throw err;
     } finally {
       setBridgeStarting(false);
-    }
-  }
-
-  async function submitToHermes(task: AgentTaskDto, content: string) {
-    try {
-      const gateway = await ensureHermesGateway();
-      const existingSessionId = task.hermesSessionId ?? hermesSessions[task.id];
-      const sessionId =
-        existingSessionId ??
-        (
-          await gateway.request<HermesRuntimeSessionResponse>(
-            "session.create",
-            {
-              title: task.title,
-              cols: 100,
-            },
-          )
-        ).session_id;
-      if (!sessionId) throw new Error("Hermes did not create a session.");
-      setHermesSessions((prev) => ({ ...prev, [task.id]: sessionId }));
-      setTaskWorking(task.id, true);
-      if (sessionId !== task.hermesSessionId) {
-        saveAgentHermesSession({
-          taskId: task.id,
-          hermesSessionId: sessionId,
-        })
-          .then(upsertTask)
-          .catch((err: unknown) => setError(messageFromError(err)));
-      }
-      const unlisten = gateway.onEvent((event) => {
-        if (event.session_id !== sessionId) return;
-        const liveEvent = { ...event, receivedAt: new Date().toISOString() };
-        const nextTaskEvents = [
-          ...(liveEventsRef.current[task.id] ?? []),
-          liveEvent,
-        ].slice(-200);
-        liveEventsRef.current = {
-          ...liveEventsRef.current,
-          [task.id]: nextTaskEvents,
-        };
-        setLiveEvents(liveEventsRef.current);
-        if (isTerminalHermesEvent(event.type)) {
-          unlisten();
-          setTaskWorking(task.id, false);
-          const completedText =
-            completedHermesRuntimeMessageText(nextTaskEvents);
-          if (completedText) {
-            void persistHermesAssistantMessage(task.id, completedText);
-          }
-        }
-      });
-      await gateway.request("prompt.submit", {
-        session_id: sessionId,
-        text: content,
-      });
-    } catch (err) {
-      setTaskWorking(task.id, false);
-      setError(messageFromError(err));
-    }
-  }
-
-  async function persistHermesAssistantMessage(
-    taskId: string,
-    content: string,
-  ) {
-    try {
-      const savedTask = await saveAgentAssistantMessage({ taskId, content });
-      liveEventsRef.current = { ...liveEventsRef.current, [taskId]: [] };
-      setLiveEvents(liveEventsRef.current);
-      upsertTask(savedTask);
-    } catch (err) {
-      setError(messageFromError(err));
     }
   }
 
@@ -1233,12 +1212,25 @@ export function AgentWorkspace({
     } catch (err) {
       const message = messageFromError(err);
       if (message.toLowerCase().includes("session not found")) {
-        setWorkingTaskIds(new Set());
-        const emptyWorkingSessions = new Set<string>();
-        workingSessionIdsRef.current = emptyWorkingSessions;
-        setWorkingSessionIds(emptyWorkingSessions);
-        liveEventsRef.current = {};
-        setLiveEvents({});
+        // The runtime session is gone. Scrub only the affected session/task —
+        // including its waiting flag, so the "Needs you" badge clears —
+        // without clobbering other healthy sessions' working state or live
+        // event streams.
+        setWorkingTaskIds((current) => {
+          if (!current.has(liveEventKey)) return current;
+          const next = new Set(current);
+          next.delete(liveEventKey);
+          return next;
+        });
+        for (const key of new Set([liveEventKey, sessionId])) {
+          sessionGatewayUnlistenRef.current.get(key)?.();
+          clearSessionActivity(key);
+        }
+        liveEventsRef.current = omitRecordKey(
+          liveEventsRef.current,
+          liveEventKey,
+        );
+        setLiveEvents(liveEventsRef.current);
         void loadHermesSessions();
       }
       setError(message);
@@ -1410,17 +1402,33 @@ export function AgentWorkspace({
     );
   }
 
+  // Drops a deleted session from local state. Removing it from items fires
+  // the sessions-changed effect, which syncs the sidebar; the shared scrub
+  // clears messages, pending sends, working/waiting flags, and live events so
+  // a running session doesn't linger as phantom "working" work.
+  function removeHermesSessionLocally(sessionId: string, selectNext = true) {
+    setHermesSessionItems((current) => {
+      const next = current.filter((session) => session.id !== sessionId);
+      setSelectedHermesSessionId((selected) => {
+        const nextSelected =
+          selected === sessionId
+            ? selectNext
+              ? next[0]?.id
+              : undefined
+            : selected;
+        selectedHermesSessionIdRef.current = nextSelected;
+        return nextSelected;
+      });
+      return next;
+    });
+    scrubHermesSessionState(sessionId);
+  }
+
   async function deleteSelectedHermesSession(sessionId: string) {
     try {
       await deleteHermesSession(sessionId);
-      // Dropping it from items fires the sessions-changed effect, which syncs
-      // the sidebar; clearing the selection falls the workspace back to empty.
-      setHermesSessionItems((current) =>
-        current.filter((item) => item.id !== sessionId),
-      );
-      setSelectedHermesSessionId((current) =>
-        current === sessionId ? undefined : current,
-      );
+      // Clearing the selection falls the workspace back to empty.
+      removeHermesSessionLocally(sessionId, false);
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -1573,6 +1581,21 @@ export function AgentWorkspace({
       )
     : [];
 
+  // Aggregate size of the rendered conversation so streaming deltas — which
+  // grow text inside an existing turn without changing any count — still keep
+  // the scroller pinned to the bottom.
+  const renderedTurnsSignature = chatTurnsSignature(
+    selectedHermesSessionId ? hermesTurns : taskTurns,
+  );
+
+  useEffect(() => {
+    // The conversation scrolls in the main card (.main-panel-body), not an
+    // inner pane — so drive that scroller to the bottom as turns arrive.
+    const scroller = listRef.current?.closest(".main-panel-body");
+    if (!(scroller instanceof HTMLElement)) return;
+    scroller.scrollTo({ top: scroller.scrollHeight, behavior: "smooth" });
+  }, [renderedTurnsSignature, selectedHermesSessionId, selectedTaskId]);
+
   return (
     <section className="agent-workspace" aria-label="Agent">
       {!newSessionMode && !selectedHermesSessionId && selectedTask ? null : (
@@ -1687,9 +1710,7 @@ export function AgentWorkspace({
                   }
                   onApproval={(part, choice) => {
                     const sessionId =
-                      part.sessionId ??
-                      selectedTask.hermesSessionId ??
-                      hermesSessions[selectedTask.id];
+                      part.sessionId ?? selectedTask.hermesSessionId;
                     if (!sessionId) return;
                     void respondToApproval(
                       selectedTask.id,
@@ -2896,6 +2917,26 @@ function CapabilityRow({
   );
 }
 
+// Sums turn/part counts plus streamed text lengths so the auto-scroll effect
+// re-fires as streamed output grows, not only when a whole turn is added.
+function chatTurnsSignature(turns: AgentChatTurn[]) {
+  return turns.reduce(
+    (total, turn) =>
+      total +
+      1 +
+      turn.parts.reduce(
+        (size, part) =>
+          size +
+          1 +
+          ("text" in part && typeof part.text === "string"
+            ? part.text.length
+            : 0),
+        0,
+      ),
+    0,
+  );
+}
+
 // Collapse runs of "thinking-only" assistant turns (reasoning/tool, no answer
 // text) into the next answer turn, so a back-to-back chain of thoughts shows as
 // a single "Thought" disclosure rather than several stacked in a row.
@@ -3991,21 +4032,49 @@ function shouldRetainHermesSessionId(
   );
 }
 
+// Hermes may persist timestamps with second precision while pending entries
+// carry millisecond ISO strings, so allow a little backward skew when deciding
+// whether a persisted message is the stored copy of a pending one.
+const PENDING_MATCH_SKEW_MS = 1500;
+
 function retainUnpersistedPendingMessages(
   pending: HermesSessionMessage[],
   persisted: HermesSessionMessage[],
 ) {
-  return pending.filter(
-    (pendingMessage) =>
-      !persisted.some(
-        (message) =>
-          message.role === pendingMessage.role &&
-          sameVisibleMessageText(
-            visibleHermesMessageText(message),
-            visibleHermesMessageText(pendingMessage),
-          ),
-      ),
-  );
+  return pending.filter((pendingMessage) => {
+    const pendingAt = hermesMessageTimestampMs(pendingMessage);
+    return !persisted.some((message) => {
+      if (message.role !== pendingMessage.role) return false;
+      if (
+        !sameVisibleMessageText(
+          visibleHermesMessageText(message),
+          visibleHermesMessageText(pendingMessage),
+        )
+      ) {
+        return false;
+      }
+      if (pendingAt === undefined) return true;
+      // Only a message persisted at/after the pending send can be its stored
+      // copy — an older identical message (e.g. a re-sent "continue") must
+      // not swallow the new pending entry and fake a completed turn.
+      const persistedAt = hermesMessageTimestampMs(message);
+      return (
+        persistedAt === undefined ||
+        persistedAt >= pendingAt - PENDING_MATCH_SKEW_MS
+      );
+    });
+  });
+}
+
+function hermesMessageTimestampMs(message: HermesSessionMessage) {
+  const raw = message.timestamp ?? message.created_at;
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw === "number") {
+    // Hermes sometimes reports epoch seconds rather than milliseconds.
+    return raw > 1e12 ? raw : raw * 1000;
+  }
+  const parsed = Date.parse(String(raw));
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 function sessionHasAssistantAfterLatestUser(messages: HermesSessionMessage[]) {
@@ -4021,6 +4090,25 @@ function sessionHasAssistantAfterLatestUser(messages: HermesSessionMessage[]) {
   if (latestAssistantIndex < 0) return false;
   if (latestUserIndex < 0) return true;
   return latestAssistantIndex > latestUserIndex;
+}
+
+// A session whose latest message is a recent user prompt with no assistant
+// reply yet is treated as an in-flight run — e.g. the workspace was unmounted
+// mid-run (navigation) or the gateway dropped — so working state and the poll
+// are re-armed to catch the conversation up. The recency window keeps long-
+// abandoned sessions (a trailing "thanks" from days ago) from spinning.
+const RESUME_ACTIVITY_WINDOW_MS = 15 * 60 * 1000;
+
+function shouldResumeSessionActivity(messages: HermesSessionMessage[]) {
+  if (sessionHasAssistantAfterLatestUser(messages)) return false;
+  const latestUser = [...messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  if (!latestUser) return false;
+  const sentAt = hermesMessageTimestampMs(latestUser);
+  return (
+    sentAt !== undefined && Date.now() - sentAt < RESUME_ACTIVITY_WINDOW_MS
+  );
 }
 
 function sessionHasActiveWork(

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -41,10 +41,16 @@ export class HermesGatewayClient {
   private nextId = 0;
   private pending = new Map<string | number, PendingCall>();
   private socket?: WebSocket;
+  private connectPromise?: Promise<void>;
   private handlers = new Set<(event: HermesGatewayEvent) => void>();
+  private closeHandlers = new Set<() => void>();
 
   async connect(wsUrl: string) {
     if (this.socket?.readyState === WebSocket.OPEN) return;
+    // Coalesce concurrent connects: a second caller arriving while the
+    // handshake is in flight must not kill the first caller's socket — it
+    // just awaits the same connection attempt.
+    if (this.connectPromise) return this.connectPromise;
     this.close();
     const socket = new WebSocket(wsUrl);
     this.socket = socket;
@@ -52,10 +58,14 @@ export class HermesGatewayClient {
       this.handleMessage(event.data),
     );
     socket.addEventListener("close", () => {
-      if (this.socket === socket) this.socket = undefined;
+      // A stale socket's close event must not reject requests pending on
+      // the socket that replaced it, nor notify close listeners.
+      if (this.socket !== socket) return;
+      this.socket = undefined;
       this.rejectAll(new Error("Hermes gateway connection closed."));
+      for (const handler of [...this.closeHandlers]) handler();
     });
-    await new Promise<void>((resolve, reject) => {
+    const connectPromise = new Promise<void>((resolve, reject) => {
       const timer = window.setTimeout(() => {
         reject(new Error("Hermes gateway connection timed out."));
         socket.close();
@@ -76,17 +86,35 @@ export class HermesGatewayClient {
         },
         { once: true },
       );
+    }).finally(() => {
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = undefined;
+      }
     });
+    this.connectPromise = connectPromise;
+    return connectPromise;
   }
 
   close() {
-    this.socket?.close();
+    // Detach before closing so the close event reads as intentional — the
+    // identity guard in the close handler then skips rejectAll/onClose.
+    const socket = this.socket;
     this.socket = undefined;
+    socket?.close();
   }
 
   onEvent(handler: (event: HermesGatewayEvent) => void) {
     this.handlers.add(handler);
     return () => this.handlers.delete(handler);
+  }
+
+  // Fires only for unexpected disconnects of the current socket — an explicit
+  // close() or a superseded (stale) socket does not notify.
+  onClose(handler: () => void) {
+    this.closeHandlers.add(handler);
+    return () => {
+      this.closeHandlers.delete(handler);
+    };
   }
 
   request<T>(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AGENT_NEW_SESSION_EVENT,
   AGENT_NEW_SESSION_PENDING_KEY,
+  AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
+  type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
 
 const mocks = vi.hoisted(() => ({
@@ -30,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
   updateHermesBridgeMessagingPlatform: vi.fn(),
+  deleteHermesSession: vi.fn(),
   listHermesSessionMessages: vi.fn(),
   listHermesSessions: vi.fn(),
   gatewayRequest: vi.fn(),
@@ -79,6 +82,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 vi.mock("../lib/hermes-adapter", () => ({
+  deleteHermesSession: mocks.deleteHermesSession,
   listHermesSessionMessages: mocks.listHermesSessionMessages,
   listHermesSessions: mocks.listHermesSessions,
   sessionTimestamp: (session: { last_active?: string; started_at?: string }) =>
@@ -91,6 +95,7 @@ vi.mock("../lib/hermes-gateway", () => ({
     connect = vi.fn();
     close = vi.fn();
     onEvent = vi.fn(() => vi.fn());
+    onClose = vi.fn(() => vi.fn());
     request = mocks.gatewayRequest;
   },
 }));
@@ -145,6 +150,7 @@ describe("AgentWorkspace", () => {
       "/Users/junho/Downloads/sample.pdf",
     );
     mocks.ensureHermesBridgeSession.mockResolvedValue({});
+    mocks.deleteHermesSession.mockResolvedValue(undefined);
     mocks.suggestAgentSessionTitle.mockResolvedValue({
       title: "Summarize Current Page",
     });
@@ -486,5 +492,168 @@ describe("AgentWorkspace", () => {
     expect(mocks.importHermesBridgeFile).toHaveBeenCalledWith(
       "/Users/junho/Library/Application Support/CleanShot/media/screenshot.png",
     );
+  });
+
+  it("keeps a re-sent duplicate message and the running state against older identical history", async () => {
+    const user = userEvent.setup();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "continue",
+        timestamp: "2026-06-04T12:00:00.000Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "older answer",
+        timestamp: "2026-06-04T12:00:01.000Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("older answer")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox"), "continue");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "continue",
+      }),
+    );
+
+    // The just-sent message must not be swallowed by the older identical one.
+    expect(screen.getAllByText("continue")).toHaveLength(2);
+    expect(screen.getByText("Thinking…")).toBeInTheDocument();
+
+    // Let the working-gated poll (2.5s) refresh against the same old
+    // history: the new pending "continue" must survive and the run must not
+    // be marked finished against the old answer.
+    const refreshCallsBefore =
+      mocks.listHermesSessionMessages.mock.calls.length;
+    await waitFor(
+      () =>
+        expect(
+          mocks.listHermesSessionMessages.mock.calls.length,
+        ).toBeGreaterThan(refreshCallsBefore),
+      { timeout: 4000 },
+    );
+    // Give the refresh's state updates time to land before asserting.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+    expect(screen.getAllByText("continue")).toHaveLength(2);
+    expect(screen.getByText("Thinking…")).toBeInTheDocument();
+  });
+
+  it("resumes working state when the latest persisted message is a recent user prompt", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "long running task",
+        timestamp: new Date(Date.now() - 60_000).toISOString(),
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    // A remount mid-run (navigation away and back) re-arms the working state
+    // and poll instead of leaving the conversation frozen.
+    expect(await screen.findByText("long running task")).toBeInTheDocument();
+    expect(await screen.findByText("Thinking…")).toBeInTheDocument();
+  });
+
+  it("does not resume working state for a stale session that ended on a user message", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "thanks!",
+        timestamp: "2026-06-01T12:00:00.000Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("thanks!")).toBeInTheDocument();
+    expect(screen.queryByText("Thinking…")).toBeNull();
+  });
+
+  it("refreshes the session list after an event-driven new session run", async () => {
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    const callsBefore = mocks.listHermesSessions.mock.calls.length;
+
+    window.dispatchEvent(
+      new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+        detail: { prompt: "write a project update" },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "write a project update",
+      }),
+    );
+    // The mount-time listener must call through to the latest handlers — a
+    // first-render closure would no-op loadHermesSessions (bridge not yet
+    // running) and the sidebar would never refresh.
+    await waitFor(() =>
+      expect(mocks.listHermesSessions.mock.calls.length).toBeGreaterThan(
+        callsBefore,
+      ),
+    );
+  });
+
+  it("scrubs working state when deleting the selected session from the session bar", async () => {
+    const user = userEvent.setup();
+    const sessionDetails: AgentSessionsChangedDetail[] = [];
+    const onSessionsChanged = (event: Event) =>
+      sessionDetails.push(
+        (event as CustomEvent<AgentSessionsChangedDetail>).detail,
+      );
+    window.addEventListener(AGENT_SESSIONS_CHANGED_EVENT, onSessionsChanged);
+
+    try {
+      render(<AgentWorkspace />);
+      expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+      await user.type(screen.getByRole("textbox"), "do something long");
+      await user.click(screen.getByRole("button", { name: "Send message" }));
+      await waitFor(() =>
+        expect(sessionDetails.at(-1)?.workingSessionIds).toContain(
+          "session-1",
+        ),
+      );
+
+      mocks.listHermesSessions.mockResolvedValue([]);
+      await user.click(
+        screen.getByRole("button", { name: "Session actions" }),
+      );
+      await user.click(
+        screen.getByRole("menuitem", { name: "Delete session" }),
+      );
+
+      await waitFor(() =>
+        expect(mocks.deleteHermesSession).toHaveBeenCalledWith("session-1"),
+      );
+      await waitFor(() => {
+        const last = sessionDetails.at(-1);
+        expect(last?.workingSessionIds).toEqual([]);
+        expect(last?.sessions.map((session) => session.id)).not.toContain(
+          "session-1",
+        );
+      });
+    } finally {
+      window.removeEventListener(
+        AGENT_SESSIONS_CHANGED_EVENT,
+        onSessionsChanged,
+      );
+    }
   });
 });

--- a/src/test/hermes-gateway.test.ts
+++ b/src/test/hermes-gateway.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HermesGatewayClient } from "../lib/hermes-gateway";
+
+type Listener = (event: unknown) => void;
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  private listeners = new Map<string, Listener[]>();
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(
+    type: string,
+    listener: Listener,
+    options?: { once?: boolean },
+  ) {
+    const wrapped: Listener = options?.once
+      ? (event) => {
+          this.removeEventListener(type, wrapped);
+          listener(event);
+        }
+      : listener;
+    const list = this.listeners.get(type) ?? [];
+    list.push(wrapped);
+    this.listeners.set(type, list);
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    const list = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      list.filter((item) => item !== listener),
+    );
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", {});
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit("open", {});
+  }
+
+  message(frame: unknown) {
+    this.emit("message", { data: JSON.stringify(frame) });
+  }
+
+  emit(type: string, event: unknown) {
+    for (const listener of [...(this.listeners.get(type) ?? [])]) {
+      listener(event);
+    }
+  }
+}
+
+describe("HermesGatewayClient", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("coalesces concurrent connect calls onto a single socket", async () => {
+    const client = new HermesGatewayClient();
+    const first = client.connect("ws://gateway");
+    const second = client.connect("ws://gateway");
+
+    // The second caller must not kill the in-flight socket.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    FakeWebSocket.instances[0].open();
+    await expect(first).resolves.toBeUndefined();
+    await expect(second).resolves.toBeUndefined();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(FakeWebSocket.instances[0].readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  it("short-circuits connect when the socket is already open", async () => {
+    const client = new HermesGatewayClient();
+    const first = client.connect("ws://gateway");
+    FakeWebSocket.instances[0].open();
+    await first;
+
+    await client.connect("ws://gateway");
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it("ignores a stale socket's close event for requests pending on the new socket", async () => {
+    const client = new HermesGatewayClient();
+    const first = client.connect("ws://gateway");
+    const stale = FakeWebSocket.instances[0];
+    stale.open();
+    await first;
+
+    client.close();
+    const second = client.connect("ws://gateway");
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    const fresh = FakeWebSocket.instances[1];
+    fresh.open();
+    await second;
+
+    const pending = client.request<{ ok: boolean }>("ping");
+    // A late close event from the replaced socket must not reject requests
+    // pending on the socket that superseded it.
+    stale.emit("close", {});
+
+    const frame = JSON.parse(fresh.sent[0]) as { id: number };
+    fresh.message({ id: frame.id, result: { ok: true } });
+    await expect(pending).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects requests pending on the current socket when it closes", async () => {
+    const client = new HermesGatewayClient();
+    const connecting = client.connect("ws://gateway");
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    await connecting;
+
+    const pending = client.request("ping");
+    socket.close();
+
+    await expect(pending).rejects.toThrow(
+      "Hermes gateway connection closed.",
+    );
+  });
+
+  it("notifies close listeners on unexpected drops but not on explicit close", async () => {
+    const client = new HermesGatewayClient();
+    const onClose = vi.fn();
+    client.onClose(onClose);
+
+    const first = client.connect("ws://gateway");
+    FakeWebSocket.instances[0].open();
+    await first;
+
+    // Server-side drop → listeners fire.
+    FakeWebSocket.instances[0].close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const second = client.connect("ws://gateway");
+    FakeWebSocket.instances[1].open();
+    await second;
+
+    // Intentional teardown → listeners stay quiet.
+    client.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes eleven verified bugs from code review in `src/lib/hermes-gateway.ts` and `src/components/agent/AgentWorkspace.tsx`. Does not touch `agent-chat-runtime.ts` internals or the `toolEventKey` copy in AgentWorkspace (being fixed on a separate branch).

## Bugs fixed

1. **hermes-gateway.ts:46-57 — concurrent connect() calls killed each other's socket; rejectAll fired for stale sockets.** A second `connect()` during CONNECTING closed the in-flight socket, and any socket's close event unconditionally rejected pending requests. Fix: concurrent connects coalesce onto a single in-flight connect promise, and the close handler is guarded by socket identity — a stale socket's close no longer rejects requests pending on the new socket.

2. **Disconnect mid-run left sessions stuck "working" forever (HIGH).** `prompt.submit` is ack-style, so a socket drop mid-run rejected nothing and the per-session listener leaked. Fix: (a) `HermesGatewayClient.onClose()` fires only for unexpected drops of the current socket (explicit `close()` detaches first, so unmount doesn't trigger it); (b) AgentWorkspace registers a close listener (routed through a latest-closure ref) that reconnects, re-issues `session.resume` for each working/waiting session, and refreshes them immediately; (c) the working-gated poll (AgentWorkspace.tsx:669) now polls **all** working sessions instead of only the selected one, so `refreshHermesSession` reconciles every stuck run from persisted messages even if reconnect fails. A re-entry guard prevents recovery loops when the reconnect itself fails.

3. **AgentWorkspace.tsx:3994-4009 + 550-594 + 1167-1207 — optimistic-message dedup matched the entire history.** Re-sending "continue" matched the *old* persisted "continue", the pending entry vanished, and `sessionHasAssistantAfterLatestUser` saw the old answer as latest → working state cleared, live events wiped, false "June finished." dispatched mid-run. Fix: pending entries (which already carry a `timestamp`) only match persisted messages created at/after the pending send, with a 1.5s skew allowance for second-precision Hermes timestamps (`retainUnpersistedPendingMessages` + `hermesMessageTimestampMs`).

4. **AgentWorkspace.tsx:1233-1244 — "session not found" recovery left a permanent "Needs you" badge and clobbered global state.** The catch in `respondToApproval` now scrubs only the affected session/task: its working-task entry, working **and waiting** flags (via `clearSessionActivity`), its per-session gateway listener, and only its live-event key — other healthy sessions' streams are untouched.

5. **AgentWorkspace.tsx:643-647 + 544 — navigating away mid-run severed the stream.** On mount/session-select, if the latest persisted message is a *recent* (≤15 min) user prompt with no assistant reply and the session isn't waiting on the user, working state is re-armed so the existing poll/refresh machinery catches the conversation up (`shouldResumeSessionActivity`). The recency window keeps long-abandoned sessions that end on a user message from spinning forever.

6. **AgentWorkspace.tsx:1413-1427 vs 493-526 — session-bar delete didn't scrub state.** Extracted `scrubHermesSessionState` (messages, pending, working/waiting, live listener, live events) and `removeHermesSessionLocally`; both the `AGENT_DELETE_SESSION_EVENT` path and the session-bar menu now use them. The scrub also detaches the session's live gateway listener, which neither path did before.

7. **AgentWorkspace.tsx:358-366 — upsertTask unconditionally re-selected the task.** `upsertTask` now only updates the list; selection is set only where user intent exists (initial load fallback in `loadTasks` is unchanged; cancel/retry act on the already-selected task).

8. **AgentWorkspace.tsx:487-542 — empty-deps listener effect froze first-render closures.** The `AGENT_NEW_SESSION_EVENT` / `AGENT_DELETE_SESSION_EVENT` handlers (and the pending-new-session mount check) now call through `windowEventHandlersRef`, which an every-render effect keeps pointed at the latest `startNewTask` / `removeHermesSessionLocally`, so post-submit `loadHermesSessions` sees the live `bridge.running` and the sidebar refreshes.

9. **AgentWorkspace.tsx:674-685 — scroll effect didn't follow streaming output or task switches.** The effect now keys on `chatTurnsSignature` (turn/part counts **plus** streamed text lengths of the rendered turns), `selectedHermesSessionId`, and `selectedTaskId`. The effect moved below the turns computation so it can read the rendered turns.

10. **AgentWorkspace.tsx:748-769 — failed-send restore clobbered concurrent edits.** Restores now use functional updates that keep whatever the user typed/attached during the in-flight send and only restore when the composer is still empty. Applied the same merge-restore to `submitMascotReply`'s catch, which had the identical race.

11. **AgentWorkspace.tsx:1092 — submitToHermes dead code.** Verified zero call sites and deleted it, plus its now-dead dependencies: `persistHermesAssistantMessage`, `setTaskWorking`, the `hermesSessions` state (its only remaining read could never produce a value), and the `saveAgentAssistantMessage` / `saveAgentHermesSession` / `completedHermesMessageText` imports.

## Tests

New `src/test/hermes-gateway.test.ts` (FakeWebSocket-based unit tests):
- concurrent `connect()` calls coalesce onto a single socket
- already-open short-circuit
- stale socket's close event doesn't reject requests pending on the new socket
- current socket's close still rejects its pending requests
- `onClose` fires on unexpected drops but not on explicit `close()`

Extended `src/test/agent-workspace.test.tsx`:
- re-sent duplicate message survives a poll against older identical history and the run stays "working" (#3 — exercises the real 2.5s poll)
- working state resumes on mount when the latest persisted message is a recent user prompt (#5), and does **not** resume for a stale one
- session list refreshes after an event-driven new-session run (#8)
- session-bar delete scrubs working state and the session from the broadcast detail (#6)

I verified the new tests are discriminating by temporarily reverting the corresponding fixes: the dedup test and three of the gateway tests fail against the old code.

`npx tsc --noEmit` clean; `npx vitest run` — 30 files, 187 tests, all passing.

## Not covered by automated tests (verified by reading/reasoning)

- **#2 reconnect-on-close and #1's 15s timeout path**: the component harness mocks `HermesGatewayClient` wholesale, so socket drops mid-run can't be simulated through the component; the gateway-side behavior (`onClose` semantics, identity guards) is unit-tested, and the component fallback (the all-working-sessions poll) is the same code path the resume test (#5) exercises.
- **#4, #7, #9, #10**: jsdom can't observe real scrolling, and the approval/`upsertTask`/concurrent-typing races need mid-flight interleavings the harness can't schedule deterministically; each fix is a state-scoping or functional-update change reviewed at the call sites listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)