### PR TITLE
Fix notes frontend reliability races and dead-end states

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -197,6 +197,13 @@ export function App() {
     setAccount,
   } = useAccountStatus();
   const startOnFreshNoteRef = useRef(false);
+  // The note the active recording session belongs to. recordingStatus carries
+  // no noteId, so without this the finish flow could only guess from the
+  // currently selected note — wrong whenever the user browsed away while
+  // recording.
+  const recordingNoteIdRef = useRef<string | undefined>(undefined);
+  // Sessions with a finishRecording call in flight; guards stop double-clicks.
+  const finishingSessionsRef = useRef<Set<string>>(new Set());
   const signInRequired = shouldBlockOnSignIn(account);
   const appBlocked = accountLoading || signInRequired;
   const publishAgentMenuBarState = useCallback(() => {
@@ -235,7 +242,7 @@ export function App() {
   function handleRecovery(sessionId: string, action: "validate" | "discard") {
     void recoverRecording(sessionId, action)
       .then((note) => {
-        dispatch({ type: "noteUpdated", note });
+        dispatch({ type: "noteProcessingUpdated", note });
         dispatch({ type: "recoveryRemoved", sessionId });
       })
       .catch((err: unknown) => setError(messageFromError(err)));
@@ -740,6 +747,12 @@ export function App() {
       return;
     }
     const sessionId = state.recordingStatus.sessionId;
+    // Drops in-flight responses once this effect is torn down. Without it, a
+    // poll that was already in flight when the user hit stop resolves after
+    // recordingStatusCleared and resurrects the recorder bar with a stale
+    // status — and since polling for that state never restarts, the bar would
+    // be stuck on screen indefinitely.
+    let cancelled = false;
     // ~20Hz so the waveform tracks speech as snappily as the dictation HUD
     // (which is event-driven at ~25Hz). The polled equivalent for the recorder;
     // each poll coalesces the peaks since the last one (see Waveform.tsx). Audio
@@ -747,14 +760,25 @@ export function App() {
     // 100ms left the bars a beat behind the voice.
     const interval = window.setInterval(() => {
       getRecordingStatus(sessionId)
-        .then((status) => dispatch({ type: "recordingStatusChanged", status }))
+        .then((status) => {
+          if (!cancelled) dispatch({ type: "recordingStatusChanged", status });
+        })
         .catch((err: unknown) => {
-          if (!isAppErrorCode(err, "recording_not_found")) {
-            setError(messageFromError(err));
+          if (cancelled) return;
+          if (isAppErrorCode(err, "recording_not_found")) {
+            // The backend no longer tracks this session — clear the bar
+            // instead of polling a dead session forever. The reducer ignores
+            // this if a newer session already replaced it.
+            dispatch({ type: "recordingSessionLost", sessionId });
+            return;
           }
+          setError(messageFromError(err));
         });
     }, 50);
-    return () => window.clearInterval(interval);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
   }, [state.recordingStatus?.sessionId, state.recordingStatus?.state]);
 
   useEffect(() => {
@@ -766,9 +790,14 @@ export function App() {
     }
     const noteId = selectedNote.id;
     const startedAt = performance.now();
+    // Drops in-flight responses once this effect is torn down (note switched,
+    // status moved on, note deleted) so a late resolution can't apply a stale
+    // snapshot — or surface a spurious "note not found" error after a delete.
+    let cancelled = false;
     const interval = window.setInterval(() => {
       getNote(noteId)
         .then((note) => {
+          if (cancelled) return;
           if (
             import.meta.env.DEV &&
             !shouldPollProcessingStatus(note.processingStatus)
@@ -781,9 +810,14 @@ export function App() {
           }
           dispatch({ type: "noteUpdated", note });
         })
-        .catch((err: unknown) => setError(messageFromError(err)));
+        .catch((err: unknown) => {
+          if (!cancelled) setError(messageFromError(err));
+        });
     }, 1000);
-    return () => window.clearInterval(interval);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
   }, [selectedNote?.id, selectedNote?.processingStatus]);
 
   const handleCreateNote = useCallback(
@@ -1007,6 +1041,7 @@ export function App() {
 
   const handleStartRecording = useCallback(async () => {
     if (!selectedNoteId) return;
+    recordingNoteIdRef.current = selectedNoteId;
     dispatch({
       type: "recordingStatusChanged",
       status: startingRecordingStatus(sourceMode),
@@ -1069,6 +1104,12 @@ export function App() {
   }, [appBlocked, bootstrapped, handleStartRecording]);
 
   async function handleFinishRecording(sessionId: string) {
+    // The recorder bar stays mounted (and clickable) for the duration of its
+    // exit animation after the first stop click, so a fast double-click would
+    // fire finishRecording twice — the second call fails with a scary
+    // "recording not found" error. Gate per session until the call settles.
+    if (finishingSessionsRef.current.has(sessionId)) return;
+    finishingSessionsRef.current.add(sessionId);
     // Collapse the shell back to idle the instant stop is pressed so it
     // never lingers wide while the (potentially long) transcribe +
     // generate pipeline runs. Processing is queued per note, so the record
@@ -1077,17 +1118,23 @@ export function App() {
     // notes…") plus a queued count tell the user work is still in flight.
     dispatch({ type: "recordingStatusCleared" });
     playRecordingSound("stop");
-    if (selectedNote) {
+    // Optimistically flip the note that owns this recording to transcribing.
+    // The selected note isn't necessarily that note — the user may have
+    // browsed elsewhere while recording — and stamping the wrong note as
+    // transcribing would lock its record button and shimmer forever.
+    if (selectedNote && selectedNote.id === recordingNoteIdRef.current) {
       dispatch({
-        type: "noteUpdated",
+        type: "noteProcessingUpdated",
         note: { ...selectedNote, processingStatus: "transcribing" },
       });
     }
     try {
       const result = await finishRecording(sessionId);
-      dispatch({ type: "noteUpdated", note: result.note });
+      dispatch({ type: "noteProcessingUpdated", note: result.note });
     } catch (err) {
       setError(messageFromError(err));
+    } finally {
+      finishingSessionsRef.current.delete(sessionId);
     }
   }
 
@@ -1442,8 +1489,15 @@ export function App() {
                   }
                   onRetry={async () => {
                     if (!selectedNote) return;
-                    const note = await retryProcessing(selectedNote.id);
-                    dispatch({ type: "noteUpdated", note });
+                    try {
+                      const note = await retryProcessing(selectedNote.id);
+                      dispatch({ type: "noteProcessingUpdated", note });
+                    } catch (err) {
+                      // Surface the failure (the banner only releases its
+                      // busy gate on rejection — it expects us to report).
+                      setError(messageFromError(err));
+                      throw err;
+                    }
                   }}
                   onTopUp={() =>
                     void osAccountsTopUp().catch((err: unknown) =>

--- a/src/app/state/app-state.ts
+++ b/src/app/state/app-state.ts
@@ -23,8 +23,10 @@ export type NotesAction =
   | { type: "bootstrapLoaded"; payload: BootstrapResponse }
   | { type: "noteLoaded"; note: NoteDto }
   | { type: "noteUpdated"; note: NoteDto }
+  | { type: "noteProcessingUpdated"; note: NoteDto }
   | { type: "recordingStatusChanged"; status: RecordingStatusDto }
   | { type: "recordingStatusCleared" }
+  | { type: "recordingSessionLost"; sessionId: string }
   | { type: "folderCreated"; folder: FolderDto }
   | { type: "folderRenamed"; folder: FolderDto }
   | { type: "folderDeleted"; folderId: string }
@@ -66,14 +68,19 @@ export function notesReducer(
         selectedNoteId: action.note.id,
         selectedNote: action.note,
       };
-    case "noteUpdated": {
-      const note = mergeNoteUpdate(state, action.note);
-      return {
-        ...upsertNote(state, note),
-        selectedNote:
-          state.selectedNoteId === note.id ? note : state.selectedNote,
-      };
-    }
+    // Incidental updates (autosave, folder moves, polls): the snapshot may
+    // carry stale DB state, so the processing status is merged to never
+    // regress an in-flight pipeline or reopen a terminal one.
+    case "noteUpdated":
+      return applyNoteUpdate(state, mergeNoteUpdate(state, action.note));
+    // Authoritative results of commands whose purpose is to change the
+    // processing status (retry, recover, finish recording). Applied as-is so
+    // they can restart processing on a note that already sits in a terminal
+    // status — failed → transcribing on retry, ready → transcribing when
+    // stacking another take — which the merge would otherwise swallow,
+    // leaving the note stuck stale with no shimmer and no polling.
+    case "noteProcessingUpdated":
+      return applyNoteUpdate(state, action.note);
     case "recordingStatusChanged":
       return {
         ...state,
@@ -84,6 +91,13 @@ export function notesReducer(
         ...state,
         recordingStatus: undefined,
       };
+    // The backend no longer knows this session (e.g. it was finalized or the
+    // capture process restarted). Only clear if the UI still shows that exact
+    // session so a fresh recording started in the meantime is untouched.
+    case "recordingSessionLost":
+      return state.recordingStatus?.sessionId === action.sessionId
+        ? { ...state, recordingStatus: undefined }
+        : state;
     case "folderCreated":
       return {
         ...state,
@@ -153,6 +167,13 @@ export function notesReducer(
     default:
       return state;
   }
+}
+
+function applyNoteUpdate(state: NotesState, note: NoteDto): NotesState {
+  return {
+    ...upsertNote(state, note),
+    selectedNote: state.selectedNoteId === note.id ? note : state.selectedNote,
+  };
 }
 
 function mergeNoteUpdate(state: NotesState, note: NoteDto): NoteDto {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -1,0 +1,314 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "../app/App";
+import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
+import type {
+  AccountStatus,
+  BootstrapResponse,
+  NoteDto,
+  RecordingSessionDto,
+} from "../lib/tauri";
+
+type TauriListener = (event: { payload: unknown }) => unknown;
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, TauriListener>(),
+  listen: vi.fn((event: string, listener: TauriListener) => {
+    mocks.listeners.set(event, listener);
+    return Promise.resolve(vi.fn());
+  }),
+  getCurrentWindow: vi.fn(),
+  bootstrapApp: vi.fn(),
+  createNote: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFolder: vi.fn(),
+  renameFolder: vi.fn(),
+  assignNoteToFolder: vi.fn(),
+  removeNoteFromFolder: vi.fn(),
+  listNotes: vi.fn(),
+  getNote: vi.fn(),
+  deleteNote: vi.fn(),
+  updateNote: vi.fn(),
+  checkRecordingSourceReadiness: vi.fn(),
+  openPrivacySettings: vi.fn(),
+  startRecording: vi.fn(),
+  pauseRecording: vi.fn(),
+  resumeRecording: vi.fn(),
+  getRecordingStatus: vi.fn(),
+  finishRecording: vi.fn(),
+  retryProcessing: vi.fn(),
+  recoverRecording: vi.fn(),
+  dictationHelperCommand: vi.fn(),
+  listDictationHistory: vi.fn(),
+  osAccountsStatus: vi.fn(),
+  osAccountsLogin: vi.fn(),
+  osAccountsCancelLogin: vi.fn(),
+  osAccountsLogout: vi.fn(),
+  osAccountsTopUp: vi.fn(),
+  mascotShow: vi.fn(),
+  mascotHide: vi.fn(),
+  playRecordingSound: vi.fn(),
+  preloadRecordingSounds: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: mocks.getCurrentWindow,
+}));
+
+vi.mock("../lib/recording-sounds", () => ({
+  playRecordingSound: mocks.playRecordingSound,
+  preloadRecordingSounds: mocks.preloadRecordingSounds,
+}));
+
+vi.mock("../lib/tauri", () => ({
+  bootstrapApp: mocks.bootstrapApp,
+  createNote: mocks.createNote,
+  createFolder: mocks.createFolder,
+  deleteFolder: mocks.deleteFolder,
+  renameFolder: mocks.renameFolder,
+  assignNoteToFolder: mocks.assignNoteToFolder,
+  removeNoteFromFolder: mocks.removeNoteFromFolder,
+  listNotes: mocks.listNotes,
+  getNote: mocks.getNote,
+  deleteNote: mocks.deleteNote,
+  updateNote: mocks.updateNote,
+  checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
+  openPrivacySettings: mocks.openPrivacySettings,
+  startRecording: mocks.startRecording,
+  pauseRecording: mocks.pauseRecording,
+  resumeRecording: mocks.resumeRecording,
+  getRecordingStatus: mocks.getRecordingStatus,
+  finishRecording: mocks.finishRecording,
+  retryProcessing: mocks.retryProcessing,
+  recoverRecording: mocks.recoverRecording,
+  dictationHelperCommand: mocks.dictationHelperCommand,
+  listDictationHistory: mocks.listDictationHistory,
+  osAccountsStatus: mocks.osAccountsStatus,
+  osAccountsLogin: mocks.osAccountsLogin,
+  osAccountsCancelLogin: mocks.osAccountsCancelLogin,
+  osAccountsLogout: mocks.osAccountsLogout,
+  osAccountsTopUp: mocks.osAccountsTopUp,
+  mascotShow: mocks.mascotShow,
+  mascotHide: mocks.mascotHide,
+}));
+
+const now = "2026-05-19T10:00:00Z";
+
+function note(overrides: Partial<NoteDto> = {}): NoteDto {
+  return {
+    id: "note-1",
+    title: "First note",
+    preview: "Preview",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    generatedContent: "Existing note",
+    activeTab: "notes",
+    ...overrides,
+  };
+}
+
+function recording(overrides: Partial<RecordingSessionDto> = {}) {
+  return {
+    id: "rec-1",
+    noteId: "note-1",
+    sourceMode: "microphonePlusSystem" as const,
+    state: "recording" as const,
+    startedAt: now,
+    elapsedMs: 0,
+    level: { peak: 0, rms: 0, recentPeaks: [] },
+    sources: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("notes recording reliability", () => {
+  const first = note();
+  // Draft on purpose: drafts were the worst case for the wrong-note
+  // optimistic update — a falsely stamped "transcribing" draft locks its
+  // record button and shimmers forever.
+  const second = note({
+    id: "note-2",
+    title: "Second note",
+    processingStatus: "draft",
+    generatedContent: undefined,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listeners.clear();
+
+    const payload: BootstrapResponse = {
+      folders: [],
+      notes: [first, second],
+      activeRecoveries: [],
+      providerConfigured: true,
+    };
+    const account: AccountStatus = {
+      signedIn: true,
+      configured: true,
+      user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
+      balance: { usdMillis: 1200 },
+    };
+
+    mocks.getCurrentWindow.mockReturnValue({
+      startDragging: vi.fn().mockResolvedValue(undefined),
+    });
+    mocks.bootstrapApp.mockResolvedValue(payload);
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2" ? second : first,
+    );
+    mocks.checkRecordingSourceReadiness.mockResolvedValue({
+      sourceMode: "microphonePlusSystem",
+      sources: [
+        { source: "microphone", ready: true },
+        { source: "system", ready: true },
+      ],
+    });
+    mocks.startRecording.mockResolvedValue(recording());
+    mocks.getRecordingStatus.mockResolvedValue({
+      sessionId: "rec-1",
+      state: "recording",
+      elapsedMs: 500,
+      level: { peak: 0.2, rms: 0.1, recentPeaks: [0.2] },
+      silenceWarning: false,
+      bytesWritten: 2048,
+    });
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.listDictationHistory.mockResolvedValue({
+      items: [],
+      retentionDays: 7,
+    });
+    mocks.osAccountsStatus.mockResolvedValue(account);
+    mocks.osAccountsLogin.mockResolvedValue(account);
+    mocks.osAccountsLogout.mockResolvedValue(undefined);
+    mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
+    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.updateNote.mockImplementation(async (input) => ({
+      ...first,
+      ...input,
+    }));
+  });
+
+  async function startRecordingOnFirstNote() {
+    render(<App />);
+    await waitFor(() =>
+      expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await act(async () => {
+      await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+        payload: undefined,
+      });
+    });
+    await waitFor(() =>
+      expect(mocks.startRecording).toHaveBeenCalledWith(
+        "note-1",
+        "microphonePlusSystem",
+      ),
+    );
+  }
+
+  it("does not mark a different note transcribing when finishing a recording started elsewhere", async () => {
+    mocks.finishRecording.mockResolvedValue({
+      note: { ...first, processingStatus: "transcribing" },
+      recording: recording({ state: "ready" }),
+      validation: {},
+      processingStarted: true,
+    });
+
+    await startRecordingOnFirstNote();
+
+    // Browse to another note while the recording keeps running on note-1.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Notes", current: "page" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /Second note Preview/ }),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-2"));
+
+    // The recorder bar is global, so Done is still reachable from note-2.
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    await waitFor(() =>
+      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1"),
+    );
+
+    // note-2 must not pick up note-1's optimistic "transcribing" lock.
+    expect(screen.queryByText(/Transcribing audio/)).not.toBeInTheDocument();
+  });
+
+  it("applies the finish result even when the note already sat in a terminal status", async () => {
+    mocks.finishRecording.mockResolvedValue({
+      note: { ...first, processingStatus: "transcribing" },
+      recording: recording({ state: "ready" }),
+      validation: {},
+      processingStarted: true,
+    });
+
+    await startRecordingOnFirstNote();
+
+    // note-1 is "ready" (terminal); stacking another take must still flip it
+    // back to transcribing so the shimmer shows and polling resumes.
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    await waitFor(() =>
+      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1"),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/Transcribing audio/)).toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces retry failures instead of dead-ending silently", async () => {
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2"
+        ? second
+        : {
+            ...first,
+            processingStatus: "failed",
+            lastError: "Network unreachable",
+            audio: {
+              id: "audio-1",
+              format: "wav",
+              durationMs: 1000,
+              sizeBytes: 2048,
+              checksum: "abc",
+              createdAt: now,
+            },
+          },
+    );
+    mocks.retryProcessing.mockRejectedValue({
+      code: "audio_artifact_missing",
+      message: "No saved audio is available for retry.",
+    });
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    // Open the note from the All notes list so the editor (and its failure
+    // banner) is on screen.
+    await userEvent.click(
+      screen.getByRole("button", { name: /First note Preview/ }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Retry/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No saved audio is available for retry."),
+      ).toBeInTheDocument(),
+    );
+    // The banner releases its busy gate so the user can try again.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Retry/ })).toBeEnabled(),
+    );
+  });
+});

--- a/src/test/app-state.test.ts
+++ b/src/test/app-state.test.ts
@@ -132,6 +132,56 @@ describe("notesReducer", () => {
     expect(state.selectedNote?.lastError).toBe("Transcription failed");
   });
 
+  it("lets an authoritative command restart processing on a failed note", () => {
+    // Retry returns the note in an active status; without the bypass the
+    // terminal guard would swallow it and the failure banner would never
+    // clear even though the backend is reprocessing.
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        processingStatus: "failed",
+        lastError: "Transcription failed",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteProcessingUpdated",
+      note: note({
+        id: "note-1",
+        processingStatus: "transcribing",
+      }),
+    });
+
+    expect(state.selectedNote?.processingStatus).toBe("transcribing");
+    expect(state.notes[0].processingStatus).toBe("transcribing");
+  });
+
+  it("lets a new take restart processing on a ready note", () => {
+    // Stacking another recording on an already-ready note: the finish flow
+    // marks it transcribing again so the shimmer shows and polling resumes.
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        processingStatus: "ready",
+        generatedContent: "Finished notes",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteProcessingUpdated",
+      note: note({
+        id: "note-1",
+        processingStatus: "transcribing",
+        generatedContent: "Finished notes",
+      }),
+    });
+
+    expect(state.selectedNote?.processingStatus).toBe("transcribing");
+    expect(state.notes[0].processingStatus).toBe("transcribing");
+  });
+
   it("does not move a terminal note backward after stale active polling", () => {
     const initial = notesReducer(createInitialState(), {
       type: "noteLoaded",
@@ -246,5 +296,51 @@ describe("notesReducer", () => {
     const cleared = notesReducer(recording, { type: "recordingStatusCleared" });
 
     expect(cleared.recordingStatus).toBeUndefined();
+  });
+
+  it("clears the recorder when the backend lost the polled session", () => {
+    const status: RecordingStatusDto = {
+      sessionId: "session-1",
+      state: "recording",
+      elapsedMs: 1250,
+      level: { peak: 0.4, rms: 0.2, recentPeaks: [0.1, 0.4] },
+      silenceWarning: false,
+      bytesWritten: 4096,
+    };
+    const recording = notesReducer(createInitialState(), {
+      type: "recordingStatusChanged",
+      status,
+    });
+
+    const lost = notesReducer(recording, {
+      type: "recordingSessionLost",
+      sessionId: "session-1",
+    });
+
+    expect(lost.recordingStatus).toBeUndefined();
+  });
+
+  it("ignores a lost-session signal for a superseded recording", () => {
+    const status: RecordingStatusDto = {
+      sessionId: "session-2",
+      state: "recording",
+      elapsedMs: 200,
+      level: { peak: 0.4, rms: 0.2, recentPeaks: [0.1, 0.4] },
+      silenceWarning: false,
+      bytesWritten: 1024,
+    };
+    const recording = notesReducer(createInitialState(), {
+      type: "recordingStatusChanged",
+      status,
+    });
+
+    // A stale poll for the previous session must not tear down the bar for
+    // the recording that replaced it.
+    const state = notesReducer(recording, {
+      type: "recordingSessionLost",
+      sessionId: "session-1",
+    });
+
+    expect(state.recordingStatus).toEqual(status);
   });
 });


### PR DESCRIPTION
Frontend-only reliability pass over the notes feature (state reducer, polling effects, recorder flow). No src-tauri or scribe-api changes.

## Findings

### Fixed

1. **Terminal-status merge guard swallowed legitimate processing restarts** — `src/app/state/app-state.ts:177-197` (`mergeProcessingStatus`), dispatched from retry/recover/finish in `src/app/App.tsx`.
   *Symptom:* recording a second take on a `ready` note never showed the "Transcribing audio…" shimmer and never started polling — the note silently went stale until reselected. Retry/recover results from terminal statuses (`failed`/`recoverable`) were similarly suppressed.
   *Root cause:* every `noteUpdated` ran through the anti-regression merge, which keeps the current status whenever it is terminal. Correct for stale polls, wrong for commands whose purpose is to restart processing (backend confirms `finish_recording` and `retry_processing` set the note to `Transcribing`).
   *Fix:* split actions — `noteUpdated` (autosave, folder moves, polls) keeps the merge; new `noteProcessingUpdated` (retry, recover, finish optimistic + result) applies the note as-is.

2. **In-flight recording-status poll could resurrect the recorder bar after stop** — `src/app/App.tsx` (~50 ms poll effect).
   *Symptom:* intermittently after pressing Done, the recorder bar reappeared with a stale status and stayed stuck (polling never restarts for non-recording states; subsequent polls fail `recording_not_found` and were swallowed).
   *Root cause:* a `getRecordingStatus` call already in flight when `recordingStatusCleared` fired resolved afterwards and re-dispatched `recordingStatusChanged`.
   *Fix:* `cancelled` flag set in the effect cleanup; late resolutions/rejections are dropped.

3. **Lost backend session left the recorder bar polling a dead session forever** — same effect.
   *Symptom:* if the backend stopped tracking the session, the UI kept the bar and polled at 20 Hz indefinitely with every error silently ignored.
   *Fix:* `recording_not_found` (when not caused by our own teardown, see fix 2) now dispatches `recordingSessionLost`, which clears the bar only if that exact session is still displayed — a newer recording is never torn down by a stale signal.

4. **Finishing a recording stamped the wrong note "transcribing"** — `src/app/App.tsx` `handleFinishRecording`.
   *Symptom:* start recording on note A, browse to draft note B, press Done (the recorder bar is global): note B was optimistically marked `transcribing`, locking its record button behind the processing shimmer *permanently* — the poll merge then refused to regress it back to `draft`.
   *Root cause:* the optimistic update targeted `selectedNote`, but `RecordingStatusDto` carries no `noteId`, so the selected note isn't necessarily the recording's note.
   *Fix:* track the owning note id in a ref at `handleStartRecording`; the optimistic update only applies when it matches the selected note. The authoritative `result.note` still updates the real note.

5. **Double-click on stop fired `finishRecording` twice** — `src/app/App.tsx` `handleFinishRecording` + `RecorderBar`.
   *Symptom:* the bar stays mounted (and clickable) through its ~120 ms exit animation after the first click; a second click re-invoked `finishRecording`, which fails with a scary "recording not found" error banner.
   *Fix:* per-session in-flight guard (`finishingSessionsRef`).

6. **Deleting/switching away from a processing note could flash a spurious error** — `src/app/App.tsx` (~1 s processing poll).
   *Symptom:* an in-flight `getNote` for a just-deleted note rejected after teardown and hit `setError` ("note not found"); a late response could also apply a stale snapshot.
   *Fix:* `cancelled` flag in the processing-poll effect; late responses and errors are dropped.

7. **Retry failures were completely silent** — `src/app/App.tsx` `onRetry`.
   *Symptom:* clicking Retry when `retryProcessing` rejects (e.g. `audio_artifact_missing`) showed nothing — `NoteFailureBanner` explicitly assumes "Parent already surfaces errors", but the parent never caught the rejection.
   *Fix:* catch, surface via the error banner, and rethrow so the banner releases its busy gate.

### Investigated and ruled out

- **`classifyFailure` string matching** (`NoteFailureBanner.tsx`): verified against the backend — `scribe_api.rs:648-651` produces code `insufficient_credits` / message "Your balance is too low. Add funds to continue.", both matched by the regex; multi-source errors are joined with `" | "` exactly as `userFacingFailureMessage` splits them. No current misclassification (structured codes would still be sturdier long-term — see backend comment in the file).
- **`NotePreview` stale-blur clobbering**: already guarded — blur callbacks are tagged with the note id the editor was created under and dropped on mismatch.
- **`NoteFailureBanner` double-retry**: already guarded by its local `retrying` flag.
- **Interval leaks in the polling effects**: both effects clear their intervals correctly; the bugs were in-flight-promise races, not leaks (fixes 2 and 6).

### Not fixed (out of scope / too risky)

- **No timeout/backoff on the processing poll**: if the backend wedges in `transcribing`, the shimmer spins forever with no user-visible failure. A frontend-imposed timeout risks declaring failure while the backend is legitimately still working (long recordings); needs a backend heartbeat or queue-state signal to do safely.
- **Polled `getNote` can clobber concurrent local edits**: the merge protects only `processingStatus`; a title typed between a poll fetch and the autosave round-trip can briefly revert. Pre-existing; fixing properly needs dirty-field tracking.
- **Capture-level terminal states (`failed`, `invalid`) freeze the recorder bar** with disabled controls and no affordance; crash recovery handles the next-launch case via `activeRecoveries`, but an in-session affordance is a product/UX decision.
- **The recorder bar is global** and doesn't indicate which note owns the recording when you browse elsewhere (UX, not a correctness issue after fix 4).

## Tests

- `src/test/app-state.test.ts`: new cases for authoritative restarts from `failed`/`ready` and for session-scoped `recordingSessionLost`.
- `src/test/app-notes-reliability.test.tsx` (new): App-level regressions for the wrong-note optimistic stamp, finish-on-terminal-note restart, and silent-retry-failure surfacing. All three fail on `main`.
- Full suite: 31 files, 210 tests passing; `tsc --noEmit` and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)