### PR TITLE
[codex] Improve mascot hover and hide menu

### DIFF
--- a/mascot.html
+++ b/mascot.html
@@ -29,6 +29,17 @@
       >
         <img id="mascot-image" alt="" />
       </button>
+      <div
+        id="mascot-context-menu"
+        class="mascot-context-menu"
+        role="menu"
+        aria-hidden="true"
+        hidden
+      >
+        <button id="mascot-hide-pet" type="button" role="menuitem">
+          Hide pet
+        </button>
+      </div>
     </main>
     <script type="module" src="/src/mascot.ts"></script>
   </body>

--- a/src-tauri/src/mascot.rs
+++ b/src-tauri/src/mascot.rs
@@ -14,6 +14,7 @@ pub struct MascotLayoutRequest {
     expanded: bool,
     card_count: Option<u32>,
     replying: Option<bool>,
+    context_menu_open: Option<bool>,
 }
 
 pub fn setup(app: &mut tauri::App) {
@@ -48,6 +49,7 @@ pub fn mascot_set_layout(app: AppHandle, request: MascotLayoutRequest) -> Result
         request.expanded,
         request.card_count.unwrap_or(0),
         request.replying.unwrap_or(false),
+        request.context_menu_open.unwrap_or(false),
     );
     window
         .set_size(Size::Logical(LogicalSize::new(width, height)))
@@ -70,18 +72,29 @@ pub fn mascot_open_agent(app: AppHandle, session: Option<serde_json::Value>) -> 
         .map_err(|error| error.to_string())
 }
 
-fn mascot_window_size(expanded: bool, card_count: u32, replying: bool) -> (f64, f64) {
-    if !expanded || card_count == 0 {
-        return (72.0, 72.0);
-    }
-
-    let base_height = match card_count.min(3) {
-        0 | 1 => 106.0,
-        2 => 158.0,
-        _ => 210.0,
+fn mascot_window_size(
+    expanded: bool,
+    card_count: u32,
+    replying: bool,
+    context_menu_open: bool,
+) -> (f64, f64) {
+    let (width, height): (f64, f64) = if !expanded || card_count == 0 {
+        (72.0, 72.0)
+    } else {
+        let base_height = match card_count.min(3) {
+            0 | 1 => 106.0,
+            2 => 158.0,
+            _ => 210.0,
+        };
+        let reply_height = if replying { 36.0 } else { 0.0 };
+        (328.0, base_height + reply_height)
     };
-    let reply_height = if replying { 36.0 } else { 0.0 };
-    (328.0, base_height + reply_height)
+
+    if context_menu_open {
+        (width.max(180.0), height.max(122.0))
+    } else {
+        (width, height)
+    }
 }
 
 fn configure_mascot_window(app: &AppHandle) -> Result<(), String> {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -664,6 +664,7 @@ export async function mascotSetLayout(input: {
   expanded: boolean;
   cardCount?: number;
   replying?: boolean;
+  contextMenuOpen?: boolean;
 }) {
   return invoke<void>("mascot_set_layout", { request: input });
 }

--- a/src/mascot.ts
+++ b/src/mascot.ts
@@ -14,6 +14,7 @@ import {
   getMascotEnabled,
   MASCOT_ENABLED_KEY,
   MASCOT_VISIBILITY_CHANGED_EVENT,
+  setMascotEnabled,
   type MascotVisibilityChangedDetail,
 } from "./lib/mascot-settings";
 import {
@@ -50,12 +51,17 @@ const stack = document.querySelector<HTMLElement>("#mascot-stack");
 const toggle = document.querySelector<HTMLButtonElement>("#mascot-toggle");
 const avatar = document.querySelector<HTMLButtonElement>("#mascot-avatar");
 const image = document.querySelector<HTMLImageElement>("#mascot-image");
+const contextMenu = document.querySelector<HTMLElement>("#mascot-context-menu");
+const hidePet = document.querySelector<HTMLButtonElement>("#mascot-hide-pet");
 
 if (image) image.src = mascotUrl;
 
 const state = {
   enabled: getMascotEnabled(),
   expanded: localStorage.getItem(EXPANDED_KEY) === "true",
+  hovered: false,
+  focused: false,
+  contextMenuOpen: false,
   sessions: [] as HermesSessionInfo[],
   selectedSessionId: undefined as string | undefined,
   workingSessionIds: new Set<string>(),
@@ -158,6 +164,12 @@ function applyStatus(detail?: AgentSessionStatusDetail) {
 
 function applyVisibility(enabled: boolean) {
   state.enabled = enabled;
+  if (!enabled) {
+    state.hovered = false;
+    state.focused = false;
+    state.contextMenuOpen = false;
+    state.replyingEntryId = undefined;
+  }
   render();
   if (enabled) {
     void mascotShow().catch(() => {});
@@ -173,12 +185,19 @@ function render() {
   const realEntries = buildEntries(false);
   const entries = state.expanded ? buildEntries(true) : realEntries;
   const hasEntries = realEntries.length > 0;
-  const expanded = state.enabled && state.expanded && realEntries.length > 0;
+  const expanded =
+    state.enabled &&
+    (state.expanded ||
+      state.hovered ||
+      state.focused ||
+      Boolean(state.replyingEntryId)) &&
+    realEntries.length > 0;
   const active = realEntries.some((entry) => isActiveStatus(entry.status));
 
   mascot.dataset.expanded = expanded ? "true" : "false";
   mascot.dataset.active = active ? "true" : "false";
   mascot.dataset.hasEntries = hasEntries ? "true" : "false";
+  mascot.dataset.contextMenuOpen = state.contextMenuOpen ? "true" : "false";
   // Only rebuild the cards when their visible content changes. Status events
   // arrive in bursts while a session works; recreating identical nodes on
   // each one restarts CSS animations (the status spinner) and reads as
@@ -211,6 +230,13 @@ function render() {
     "aria-label",
     expanded ? "Collapse June mascot" : "Expand June mascot",
   );
+  if (contextMenu) {
+    contextMenu.hidden = !state.contextMenuOpen;
+    contextMenu.setAttribute(
+      "aria-hidden",
+      state.contextMenuOpen ? "false" : "true",
+    );
+  }
 
   void syncWindowLayout(expanded, expanded ? entries.length : 0);
   scheduleStatusPrune();
@@ -602,19 +628,28 @@ function statusSubject(record: StatusRecord) {
 
 async function syncWindowLayout(expanded: boolean, cardCount: number) {
   const replying = Boolean(state.replyingEntryId);
-  const key = `${state.enabled}:${expanded}:${cardCount}:${replying}`;
+  const contextMenuOpen = state.contextMenuOpen;
+  const key = `${state.enabled}:${expanded}:${cardCount}:${replying}:${contextMenuOpen}`;
   if (key === lastLayoutKey) return;
   lastLayoutKey = key;
   if (!state.enabled) {
     await mascotHide().catch(() => {});
     return;
   }
-  await mascotSetLayout({ expanded, cardCount, replying }).catch(() => {});
+  await mascotSetLayout({
+    expanded,
+    cardCount,
+    replying,
+    ...(contextMenuOpen ? { contextMenuOpen } : {}),
+  }).catch(() => {});
   await mascotShow().catch(() => {});
 }
 
 function setExpanded(expanded: boolean) {
   if (!expanded) {
+    state.hovered = false;
+    state.focused = false;
+    state.contextMenuOpen = false;
     state.replyingEntryId = undefined;
   }
   state.expanded = expanded;
@@ -651,6 +686,63 @@ function toggleExpanded() {
   setExpanded(!renderedExpanded);
 }
 
+function setHoverExpanded(hovered: boolean) {
+  const changed = state.hovered !== hovered;
+  state.hovered = hovered;
+  let contextMenuClosed = false;
+  if (!hovered && state.contextMenuOpen) {
+    state.contextMenuOpen = false;
+    contextMenuClosed = true;
+  }
+  if (changed || contextMenuClosed) render();
+}
+
+function setFocusExpanded(focused: boolean) {
+  const changed = state.focused !== focused;
+  state.focused = focused;
+  let contextMenuClosed = false;
+  if (!focused && state.contextMenuOpen) {
+    state.contextMenuOpen = false;
+    contextMenuClosed = true;
+  }
+  if (changed || contextMenuClosed) render();
+}
+
+function openContextMenu() {
+  state.contextMenuOpen = true;
+  render();
+  window.setTimeout(() => hidePet?.focus(), 0);
+}
+
+function closeContextMenu() {
+  if (!state.contextMenuOpen) return;
+  state.contextMenuOpen = false;
+  render();
+}
+
+function hidePetFromContextMenu() {
+  closeContextMenu();
+  setMascotEnabled(false);
+}
+
+mascot?.addEventListener("pointerenter", () => {
+  setHoverExpanded(true);
+});
+
+mascot?.addEventListener("pointerleave", () => {
+  setHoverExpanded(false);
+});
+
+mascot?.addEventListener("focusin", () => {
+  setFocusExpanded(true);
+});
+
+mascot?.addEventListener("focusout", (event) => {
+  const next = event.relatedTarget;
+  if (next instanceof Node && mascot.contains(next)) return;
+  setFocusExpanded(false);
+});
+
 toggle?.addEventListener("pointerdown", (event) => {
   event.preventDefault();
   event.stopPropagation();
@@ -666,6 +758,33 @@ toggle?.addEventListener("keydown", (event) => {
 avatar?.addEventListener("click", () => {
   const [entry] = buildEntries(false);
   void openAgent(entry?.session);
+});
+
+avatar?.addEventListener("contextmenu", (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  openContextMenu();
+});
+
+contextMenu?.addEventListener("pointerdown", (event) => {
+  event.stopPropagation();
+});
+
+hidePet?.addEventListener("click", (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  hidePetFromContextMenu();
+});
+
+window.addEventListener("pointerdown", (event) => {
+  if (!state.contextMenuOpen) return;
+  const target = event.target;
+  if (target instanceof Node && contextMenu?.contains(target)) return;
+  closeContextMenu();
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") closeContextMenu();
 });
 
 window.addEventListener(MASCOT_VISIBILITY_CHANGED_EVENT, (event) => {

--- a/src/styles/mascot.css
+++ b/src/styles/mascot.css
@@ -372,12 +372,56 @@ body {
   transform-origin: 50% 72%;
 }
 
+.mascot-context-menu {
+  position: absolute;
+  z-index: 4;
+  right: 0;
+  bottom: 68px;
+  min-width: 132px;
+  padding: 5px;
+  border: 1px solid color-mix(in oklch, white 14%, transparent);
+  border-radius: 8px;
+  background: color-mix(in oklch, black 90%, transparent);
+  box-shadow:
+    0 14px 30px oklch(0% 0 none / 34%),
+    inset 0 1px 0 color-mix(in oklch, white 13%, transparent);
+  backdrop-filter: blur(12px) saturate(1.2);
+  pointer-events: auto;
+}
+
+.mascot-context-menu[hidden] {
+  display: none;
+}
+
+.mascot-context-menu button {
+  width: 100%;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: white;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 560;
+  letter-spacing: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mascot-context-menu button:hover,
+.mascot-context-menu button:focus-visible {
+  background: color-mix(in oklch, white 13%, transparent);
+  outline: none;
+}
+
 .mascot-avatar:focus-visible,
 .mascot-toggle:focus-visible,
 .mascot-reply:focus-visible,
 .mascot-reply-input:focus-visible,
 .mascot-reply-send:focus-visible,
-.mascot-dismiss:focus-visible {
+.mascot-dismiss:focus-visible,
+.mascot-context-menu button:focus-visible {
   outline: 2px solid oklch(0.72 0.18 250);
   outline-offset: 2px;
 }

--- a/src/test/mascot.test.ts
+++ b/src/test/mascot.test.ts
@@ -73,6 +73,67 @@ describe("desktop mascot", () => {
     expect(mascotElement().dataset.hasEntries).toBe("false");
   });
 
+  it("temporarily expands a collapsed active bubble on mascot hover", async () => {
+    await loadMascot();
+
+    emitStatus({
+      status: "running",
+      title: "Review the branch.",
+      summary: "Working.",
+    });
+    await flushPromises();
+
+    toggleElement().dispatchEvent(
+      new Event("pointerdown", { bubbles: true, cancelable: true }),
+    );
+    await flushPromises();
+
+    expect(mascotElement().dataset.expanded).toBe("false");
+    expect(stackElement()).toBeEmptyDOMElement();
+
+    mascotElement().dispatchEvent(new Event("pointerenter"));
+    await flushPromises();
+
+    expect(mascotElement().dataset.expanded).toBe("true");
+    expect(stackElement()).toHaveTextContent("Review the branch.");
+    expect(document.querySelector(".mascot-dismiss")).toBeTruthy();
+    expect(document.querySelector(".mascot-reply")).toBeTruthy();
+    expect(localStorage.getItem("scribe:mascot:expanded")).toBe("false");
+
+    mascotElement().dispatchEvent(new Event("pointerleave"));
+    await flushPromises();
+
+    expect(mascotElement().dataset.expanded).toBe("false");
+    expect(stackElement()).toBeEmptyDOMElement();
+  });
+
+  it("shows a hide pet option from the avatar context menu", async () => {
+    await loadMascot();
+
+    avatarElement().dispatchEvent(
+      new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+    );
+    await flushPromises();
+
+    expect(contextMenuElement().hidden).toBe(false);
+    expect(contextMenuElement()).toHaveAttribute("aria-hidden", "false");
+    expect(hidePetButton()).toHaveTextContent("Hide pet");
+    expect(mocks.invoke).toHaveBeenCalledWith("mascot_set_layout", {
+      request: {
+        expanded: false,
+        cardCount: 0,
+        replying: false,
+        contextMenuOpen: true,
+      },
+    });
+
+    hidePetButton().click();
+    await flushPromises();
+
+    expect(localStorage.getItem("scribe:mascot:enabled")).toBe("false");
+    expect(mocks.invoke).toHaveBeenCalledWith("mascot_hide");
+  });
+
   it("briefly shows Done before removing the bubble when the agent completes", async () => {
     vi.useFakeTimers();
     await loadMascot();
@@ -217,9 +278,7 @@ function emitStatus(detail: {
   title: string;
   summary: string;
 }) {
-  window.dispatchEvent(
-    new CustomEvent(AGENT_SESSION_STATUS_EVENT, { detail }),
-  );
+  window.dispatchEvent(new CustomEvent(AGENT_SESSION_STATUS_EVENT, { detail }));
 }
 
 function emitSessionsChanged(detail: {
@@ -262,10 +321,30 @@ function toggleElement() {
   return toggle as HTMLButtonElement;
 }
 
+function avatarElement() {
+  const avatar = document.querySelector<HTMLButtonElement>("#mascot-avatar");
+  expect(avatar).toBeTruthy();
+  return avatar as HTMLButtonElement;
+}
+
 function replyButton() {
   const reply = document.querySelector<HTMLButtonElement>(".mascot-reply");
   expect(reply).toBeTruthy();
   return reply as HTMLButtonElement;
+}
+
+function contextMenuElement() {
+  const contextMenu = document.querySelector<HTMLElement>(
+    "#mascot-context-menu",
+  );
+  expect(contextMenu).toBeTruthy();
+  return contextMenu as HTMLElement;
+}
+
+function hidePetButton() {
+  const hidePet = document.querySelector<HTMLButtonElement>("#mascot-hide-pet");
+  expect(hidePet).toBeTruthy();
+  return hidePet as HTMLButtonElement;
 }
 
 function mascotMarkup() {
@@ -293,6 +372,17 @@ function mascotMarkup() {
       >
         <img id="mascot-image" alt="" />
       </button>
+      <div
+        id="mascot-context-menu"
+        class="mascot-context-menu"
+        role="menu"
+        aria-hidden="true"
+        hidden
+      >
+        <button id="mascot-hide-pet" type="button" role="menuitem">
+          Hide pet
+        </button>
+      </div>
     </main>
   `;
 }


### PR DESCRIPTION
## Summary
- Expand collapsed mascot notification bubbles while the pet window is hovered or focused, so the card controls are reachable without clicking the bubble first.
- Add a right-click context menu on the pet avatar with a Hide pet action that disables the desktop mascot.
- Resize the mascot overlay while the context menu is open and cover the new interactions with mascot tests.

## Validation
- pnpm exec prettier --check src/mascot.ts src/test/mascot.test.ts src/styles/mascot.css src/lib/tauri.ts mascot.html
- pnpm run lint
- pnpm test
- pnpm test:rust

## Note
- pnpm run format still reports pre-existing formatting drift in five unrelated files not touched by this PR.