### PR TITLE
Add post-validation FLAC compression for saved recordings

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -387,6 +387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +570,12 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
 ]
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "combine"
@@ -1246,6 +1258,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flacenc"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c892c2b5fa08f967e8b5ad29121570b4762202f2402033ce08479ec65eccd0"
+dependencies = [
+ "built",
+ "crc",
+ "heapless",
+ "md-5",
+ "num-traits",
+ "rustversion",
+ "seq-macro",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1785,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2988,8 +3034,10 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "claxon",
  "cpal",
  "dotenvy",
+ "flacenc",
  "hound",
  "keyring",
  "objc2",
@@ -3994,6 +4042,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,8 @@ tracing = "0.1"
 urlencoding = "2"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 zeroize = { version = "1", features = ["derive"] }
+flacenc = { version = "0.5.1", default-features = false }
+claxon = "0.4.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/src-tauri/src/audio/compression.rs
+++ b/src-tauri/src/audio/compression.rs
@@ -1,0 +1,440 @@
+//! Post-validation FLAC compression for saved recording artifacts.
+//!
+//! Compression is archival only: capture always records WAV, and a FLAC copy
+//! is produced after the WAV has been finalized and validated. FLAC is
+//! lossless, so validation can require the decoded samples to match the WAV
+//! source exactly before the original is ever eligible for deletion.
+
+use crate::domain::types::AppError;
+use flacenc::component::BitRepr;
+use flacenc::error::Verify;
+use flacenc::source::{Fill, Source};
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+pub const FLAC_FORMAT: &str = "flac";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompressionOutcome {
+    pub output_path: PathBuf,
+    pub format: String,
+    pub original_size_bytes: i64,
+    pub compressed_size_bytes: i64,
+    pub compressed_checksum: String,
+    pub duration_ms: i64,
+}
+
+/// Streams 16-bit PCM WAV samples into the FLAC encoder without loading the
+/// whole recording into memory (long meetings can be hundreds of MB).
+struct WavSource {
+    reader: WavReader<BufReader<std::fs::File>>,
+    spec: WavSpec,
+    buffer: Vec<i32>,
+    failed: bool,
+}
+
+impl WavSource {
+    fn open(path: &Path) -> Result<Self, AppError> {
+        let reader = WavReader::open(path)
+            .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+        let spec = reader.spec();
+        ensure_compressible_spec(spec)?;
+        Ok(Self {
+            reader,
+            spec,
+            buffer: Vec::new(),
+            failed: false,
+        })
+    }
+}
+
+impl Source for WavSource {
+    fn channels(&self) -> usize {
+        self.spec.channels.max(1) as usize
+    }
+
+    fn bits_per_sample(&self) -> usize {
+        16
+    }
+
+    fn sample_rate(&self) -> usize {
+        self.spec.sample_rate as usize
+    }
+
+    fn read_samples<F: Fill>(
+        &mut self,
+        block_size: usize,
+        dest: &mut F,
+    ) -> Result<usize, flacenc::error::SourceError> {
+        let channels = self.channels();
+        self.buffer.clear();
+        for sample in self
+            .reader
+            .samples::<i16>()
+            .take(block_size.saturating_mul(channels))
+        {
+            match sample {
+                Ok(sample) => self.buffer.push(sample as i32),
+                Err(_) => {
+                    // A torn trailing frame in an otherwise-finalized WAV
+                    // would corrupt the archive; surface it instead.
+                    self.failed = true;
+                    return Err(flacenc::error::SourceError::from_unknown());
+                }
+            }
+        }
+        // The encoder expects whole frames; drop a torn trailing frame.
+        self.buffer
+            .truncate((self.buffer.len() / channels) * channels);
+        dest.fill_interleaved(&self.buffer)?;
+        Ok(self.buffer.len() / channels)
+    }
+}
+
+/// Encodes a finalized 16-bit PCM WAV into a FLAC archive copy.
+pub fn compress_wav_to_flac(
+    input_path: &Path,
+    output_path: &Path,
+) -> Result<CompressionOutcome, AppError> {
+    let original_size_bytes = file_size(input_path)?;
+    let mut source = WavSource::open(input_path)?;
+    let config = flacenc::config::Encoder::default()
+        .into_verified()
+        .map_err(|(_, error)| AppError::new("audio_compression_failed", error.to_string()))?;
+    let stream = flacenc::encode_with_fixed_block_size(&config, &mut source, config.block_size)
+        .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+    if source.failed {
+        return Err(AppError::new(
+            "audio_compression_failed",
+            "Source WAV could not be fully read while encoding.",
+        ));
+    }
+    let mut sink = flacenc::bitsink::ByteSink::new();
+    stream
+        .write(&mut sink)
+        .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+    }
+    std::fs::write(output_path, sink.as_slice())
+        .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+    let compressed_size_bytes = file_size(output_path)?;
+    let compressed_checksum = crate::audio::validation::checksum_file(output_path)
+        .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+    Ok(CompressionOutcome {
+        output_path: output_path.to_path_buf(),
+        format: FLAC_FORMAT.to_string(),
+        original_size_bytes,
+        compressed_size_bytes,
+        compressed_checksum,
+        duration_ms: flac_duration_ms(output_path)?,
+    })
+}
+
+/// Verifies a FLAC archive decodes to exactly the samples of its WAV source.
+/// FLAC is lossless, so anything short of an exact match (spec, length, every
+/// sample) means the archive cannot replace the original.
+pub fn validate_flac_matches_wav(flac_path: &Path, wav_path: &Path) -> Result<(), AppError> {
+    let size = file_size(flac_path)?;
+    if size == 0 {
+        return Err(AppError::new(
+            "audio_compression_invalid",
+            "Compressed audio file is empty.",
+        ));
+    }
+    let mut flac = claxon::FlacReader::open(flac_path)
+        .map_err(|error| AppError::new("audio_compression_invalid", error.to_string()))?;
+    let info = flac.streaminfo();
+    let mut wav = WavReader::open(wav_path)
+        .map_err(|error| AppError::new("audio_compression_invalid", error.to_string()))?;
+    let spec = wav.spec();
+    ensure_compressible_spec(spec)?;
+    if info.sample_rate != spec.sample_rate
+        || info.channels != spec.channels as u32
+        || info.bits_per_sample != 16
+    {
+        return Err(AppError::new(
+            "audio_compression_invalid",
+            "Compressed audio format does not match the WAV source.",
+        ));
+    }
+    let mut wav_samples = wav.samples::<i16>();
+    let mut compared = 0_u64;
+    let mut non_silent_preserved = false;
+    for flac_sample in flac.samples() {
+        let flac_sample = flac_sample
+            .map_err(|error| AppError::new("audio_compression_invalid", error.to_string()))?;
+        let Some(wav_sample) = wav_samples.next() else {
+            return Err(AppError::new(
+                "audio_compression_invalid",
+                "Compressed audio is longer than the WAV source.",
+            ));
+        };
+        let wav_sample = wav_sample
+            .map_err(|error| AppError::new("audio_compression_invalid", error.to_string()))?;
+        if flac_sample != wav_sample as i32 {
+            return Err(AppError::new(
+                "audio_compression_invalid",
+                "Compressed audio does not match the WAV source signal.",
+            ));
+        }
+        if wav_sample != 0 {
+            non_silent_preserved = true;
+        }
+        compared += 1;
+    }
+    if wav_samples.next().is_some() {
+        return Err(AppError::new(
+            "audio_compression_invalid",
+            "Compressed audio is shorter than the WAV source.",
+        ));
+    }
+    if compared == 0 {
+        return Err(AppError::new(
+            "audio_compression_invalid",
+            "Compressed audio contains no samples.",
+        ));
+    }
+    // A WAV that carried signal must still carry it after compression. A
+    // fully-silent source stays valid: silence compresses to silence.
+    let _ = non_silent_preserved;
+    Ok(())
+}
+
+/// Decodes a FLAC archive back into a 16-bit PCM WAV, used to restore the
+/// processing source of truth when the original WAV was deleted by policy.
+pub fn decode_flac_to_wav(flac_path: &Path, output_path: &Path) -> Result<PathBuf, AppError> {
+    let mut flac = claxon::FlacReader::open(flac_path)
+        .map_err(|error| AppError::new("audio_decompression_failed", error.to_string()))?;
+    let info = flac.streaminfo();
+    if info.bits_per_sample != 16 {
+        return Err(AppError::new(
+            "audio_decompression_failed",
+            "Only 16-bit FLAC archives are supported.",
+        ));
+    }
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| AppError::new("audio_decompression_failed", error.to_string()))?;
+    }
+    let spec = WavSpec {
+        channels: info.channels as u16,
+        sample_rate: info.sample_rate,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(output_path, spec)
+        .map_err(|error| AppError::new("audio_decompression_failed", error.to_string()))?;
+    for sample in flac.samples() {
+        let sample = sample
+            .map_err(|error| AppError::new("audio_decompression_failed", error.to_string()))?;
+        writer
+            .write_sample(sample.clamp(i16::MIN as i32, i16::MAX as i32) as i16)
+            .map_err(|error| AppError::new("audio_decompression_failed", error.to_string()))?;
+    }
+    writer
+        .finalize()
+        .map_err(|error| AppError::new("audio_decompression_failed", error.to_string()))?;
+    Ok(output_path.to_path_buf())
+}
+
+pub fn flac_duration_ms(flac_path: &Path) -> Result<i64, AppError> {
+    let flac = claxon::FlacReader::open(flac_path)
+        .map_err(|error| AppError::new("audio_compression_invalid", error.to_string()))?;
+    let info = flac.streaminfo();
+    let Some(samples) = info.samples else {
+        return Err(AppError::new(
+            "audio_compression_invalid",
+            "Compressed audio does not declare its length.",
+        ));
+    };
+    Ok(((samples as i128 * 1000) / info.sample_rate.max(1) as i128) as i64)
+}
+
+pub fn compression_ratio(original_bytes: i64, compressed_bytes: i64) -> Option<f64> {
+    if original_bytes <= 0 || compressed_bytes <= 0 {
+        return None;
+    }
+    Some(compressed_bytes as f64 / original_bytes as f64)
+}
+
+fn ensure_compressible_spec(spec: WavSpec) -> Result<(), AppError> {
+    if spec.sample_format == SampleFormat::Int && spec.bits_per_sample == 16 {
+        return Ok(());
+    }
+    Err(AppError::new(
+        "audio_compression_failed",
+        "Only 16-bit PCM WAV compression is supported.",
+    ))
+}
+
+fn file_size(path: &Path) -> Result<i64, AppError> {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len() as i64)
+        .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("os-scribe-{label}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_wav(path: &Path, channels: u16, sample_rate: u32, samples: &[i16]) {
+        let spec = WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        for sample in samples {
+            writer.write_sample(*sample).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn speech_like_samples(frames: usize) -> Vec<i16> {
+        (0..frames)
+            .map(|index| {
+                let phase = index as f32 / 48.0;
+                ((phase * 2.0 * std::f32::consts::PI).sin() * 9_000.0) as i16
+            })
+            .collect()
+    }
+
+    #[test]
+    fn round_trips_wav_through_flac_losslessly() {
+        let dir = temp_dir("flac-roundtrip");
+        let wav = dir.join("source.wav");
+        let flac = dir.join("source.flac");
+        let restored = dir.join("restored.wav");
+        let samples = speech_like_samples(48_000);
+        write_wav(&wav, 1, 48_000, &samples);
+
+        let outcome = compress_wav_to_flac(&wav, &flac).expect("compression succeeds");
+        assert_eq!(outcome.format, FLAC_FORMAT);
+        assert!(outcome.compressed_size_bytes > 0);
+        assert!(
+            outcome.compressed_size_bytes < outcome.original_size_bytes,
+            "FLAC ({}) should be smaller than WAV ({})",
+            outcome.compressed_size_bytes,
+            outcome.original_size_bytes
+        );
+        assert_eq!(outcome.duration_ms, 1_000);
+        assert!(!outcome.compressed_checksum.is_empty());
+
+        validate_flac_matches_wav(&flac, &wav).expect("lossless validation succeeds");
+
+        decode_flac_to_wav(&flac, &restored).expect("decode succeeds");
+        let mut reader = WavReader::open(&restored).unwrap();
+        assert_eq!(reader.spec().sample_rate, 48_000);
+        assert_eq!(reader.spec().channels, 1);
+        let restored_samples = reader
+            .samples::<i16>()
+            .map(|sample| sample.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(restored_samples, samples);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn round_trips_stereo_wav() {
+        let dir = temp_dir("flac-stereo");
+        let wav = dir.join("source.wav");
+        let flac = dir.join("source.flac");
+        let frames = speech_like_samples(8_000);
+        let samples = frames
+            .iter()
+            .flat_map(|sample| [*sample, sample / 2])
+            .collect::<Vec<_>>();
+        write_wav(&wav, 2, 16_000, &samples);
+
+        compress_wav_to_flac(&wav, &flac).expect("stereo compression succeeds");
+        validate_flac_matches_wav(&flac, &wav).expect("stereo validation succeeds");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn validation_rejects_mismatched_audio() {
+        let dir = temp_dir("flac-mismatch");
+        let wav = dir.join("source.wav");
+        let other_wav = dir.join("other.wav");
+        let flac = dir.join("source.flac");
+        write_wav(&wav, 1, 16_000, &speech_like_samples(4_000));
+        write_wav(&other_wav, 1, 16_000, &speech_like_samples(3_000));
+        compress_wav_to_flac(&wav, &flac).unwrap();
+
+        let error = validate_flac_matches_wav(&flac, &other_wav).expect_err("must not validate");
+        assert_eq!(error.code, "audio_compression_invalid");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn validation_rejects_corrupt_flac() {
+        let dir = temp_dir("flac-corrupt");
+        let wav = dir.join("source.wav");
+        let flac = dir.join("source.flac");
+        write_wav(&wav, 1, 16_000, &speech_like_samples(4_000));
+        compress_wav_to_flac(&wav, &flac).unwrap();
+        let mut bytes = std::fs::read(&flac).unwrap();
+        let truncated = bytes.len() / 2;
+        bytes.truncate(truncated);
+        std::fs::write(&flac, bytes).unwrap();
+
+        assert!(validate_flac_matches_wav(&flac, &wav).is_err());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn validation_rejects_empty_file() {
+        let dir = temp_dir("flac-empty");
+        let wav = dir.join("source.wav");
+        let flac = dir.join("empty.flac");
+        write_wav(&wav, 1, 16_000, &speech_like_samples(1_000));
+        std::fs::write(&flac, []).unwrap();
+
+        let error = validate_flac_matches_wav(&flac, &wav).expect_err("must not validate");
+        assert_eq!(error.code, "audio_compression_invalid");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rejects_non_16_bit_wav() {
+        let dir = temp_dir("flac-spec");
+        let wav = dir.join("source.wav");
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 32,
+            sample_format: SampleFormat::Float,
+        };
+        let mut writer = WavWriter::create(&wav, spec).unwrap();
+        writer.write_sample(0.25_f32).unwrap();
+        writer.finalize().unwrap();
+
+        let error =
+            compress_wav_to_flac(&wav, &dir.join("out.flac")).expect_err("must reject spec");
+        assert_eq!(error.code, "audio_compression_failed");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn compression_ratio_is_fraction_of_original() {
+        assert_eq!(compression_ratio(1_000, 400), Some(0.4));
+        assert_eq!(compression_ratio(0, 400), None);
+        assert_eq!(compression_ratio(1_000, 0), None);
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
+pub mod compression;
 pub mod recovery;
 pub mod system_macos;
 pub mod turns;

--- a/src-tauri/src/audio_storage.rs
+++ b/src-tauri/src/audio_storage.rs
@@ -1,0 +1,374 @@
+//! Audio storage policy: optional FLAC compression of saved recordings.
+//!
+//! Capture always records WAV; the storage mode only decides what happens to
+//! validated artifacts afterwards. Compression runs on the per-note processing
+//! queue so it never competes with — or deletes audio out from under — the
+//! transcription job for the same recording, and a compression failure never
+//! affects the note's processing status.
+
+use crate::{
+    app_paths::AppPaths,
+    audio::compression::{
+        compress_wav_to_flac, compression_ratio, validate_flac_matches_wav, CompressionOutcome,
+        FLAC_FORMAT,
+    },
+    db::repositories::{CompressibleArtifact, Repositories},
+    domain::{processing_queue, types::AppError},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Mutex, OnceLock},
+    time::Instant,
+};
+use tauri::{AppHandle, Manager, State};
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AudioStorageMode {
+    /// Keep recordings as WAV only (no compression).
+    #[default]
+    WavOnly,
+    /// Create a FLAC archive copy after a recording validates.
+    CompressedAfterValidation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AudioStorageSettings {
+    pub mode: AudioStorageMode,
+    /// When compressing, keep the WAV original alongside the FLAC archive.
+    /// When false, the WAV is deleted only after the FLAC copy passes
+    /// lossless validation.
+    pub keep_wav_after_compression: bool,
+}
+
+impl Default for AudioStorageSettings {
+    fn default() -> Self {
+        Self {
+            mode: AudioStorageMode::WavOnly,
+            keep_wav_after_compression: true,
+        }
+    }
+}
+
+pub struct AudioStorageSettingsState {
+    path: PathBuf,
+    settings: Mutex<AudioStorageSettings>,
+}
+
+static SETTINGS_CACHE: OnceLock<Mutex<AudioStorageSettings>> = OnceLock::new();
+
+fn settings_cache() -> &'static Mutex<AudioStorageSettings> {
+    SETTINGS_CACHE.get_or_init(|| Mutex::new(AudioStorageSettings::default()))
+}
+
+fn replace_cached_settings(settings: AudioStorageSettings) {
+    if let Ok(mut cached) = settings_cache().lock() {
+        *cached = settings;
+    }
+}
+
+/// Storage settings readable from backend code without an [`AppHandle`]
+/// (mirrors `dictation::configured_transcription_language`).
+pub fn configured_audio_storage_settings() -> AudioStorageSettings {
+    settings_cache()
+        .lock()
+        .map(|settings| settings.clone())
+        .unwrap_or_default()
+}
+
+fn settings_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|directory| directory.join("audio-storage-settings.json"))
+}
+
+fn load_settings(app: &AppHandle) -> AudioStorageSettings {
+    let Some(path) = settings_path(app) else {
+        return AudioStorageSettings::default();
+    };
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|settings| serde_json::from_str::<AudioStorageSettings>(&settings).ok())
+        .unwrap_or_default()
+}
+
+pub fn setup(app: &AppHandle) {
+    let path = settings_path(app).unwrap_or_else(|| PathBuf::from("audio-storage-settings.json"));
+    let settings = load_settings(app);
+    replace_cached_settings(settings.clone());
+    app.manage(AudioStorageSettingsState {
+        path,
+        settings: Mutex::new(settings),
+    });
+}
+
+fn save_settings(
+    state: &AudioStorageSettingsState,
+    settings: &AudioStorageSettings,
+) -> Result<(), AppError> {
+    if let Some(parent) = state.path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AppError::new("audio_storage_settings_save_failed", error.to_string())
+        })?;
+    }
+    let serialized = serde_json::to_string_pretty(settings)
+        .map_err(|error| AppError::new("audio_storage_settings_save_failed", error.to_string()))?;
+    fs::write(&state.path, serialized)
+        .map_err(|error| AppError::new("audio_storage_settings_save_failed", error.to_string()))
+}
+
+#[tauri::command]
+pub fn audio_storage_settings(
+    state: State<'_, AudioStorageSettingsState>,
+) -> Result<AudioStorageSettings, AppError> {
+    state
+        .settings
+        .lock()
+        .map(|settings| settings.clone())
+        .map_err(|_| {
+            AppError::new(
+                "audio_storage_settings_unavailable",
+                "Audio storage settings lock failed.",
+            )
+        })
+}
+
+#[tauri::command]
+pub fn set_audio_storage_settings(
+    state: State<'_, AudioStorageSettingsState>,
+    settings: AudioStorageSettings,
+) -> Result<AudioStorageSettings, AppError> {
+    save_settings(&state, &settings)?;
+    let mut current = state.settings.lock().map_err(|_| {
+        AppError::new(
+            "audio_storage_settings_unavailable",
+            "Audio storage settings lock failed.",
+        )
+    })?;
+    *current = settings.clone();
+    replace_cached_settings(settings.clone());
+    Ok(settings)
+}
+
+/// Queues archival compression for a validated session behind any processing
+/// already running for the note. No-op unless compression is enabled.
+pub fn schedule_session_compression(
+    repos: Repositories,
+    paths: AppPaths,
+    note_id: String,
+    session_id: String,
+) {
+    let settings = configured_audio_storage_settings();
+    if settings.mode != AudioStorageMode::CompressedAfterValidation {
+        return;
+    }
+    tokio::spawn(async move {
+        let (ticket, _depth) = processing_queue::enqueue(&note_id);
+        let queue_lock = ticket.lock();
+        let _guard = queue_lock.lock().await;
+        compress_session_artifacts(
+            &repos,
+            &paths,
+            &session_id,
+            settings.keep_wav_after_compression,
+        )
+        .await;
+        ticket.finish();
+    });
+}
+
+/// Compresses every validated, not-yet-compressed artifact of a session.
+/// Failures are recorded per artifact and never propagate to the note.
+pub async fn compress_session_artifacts(
+    repos: &Repositories,
+    paths: &AppPaths,
+    session_id: &str,
+    keep_wav: bool,
+) {
+    let artifacts = match repos.compressible_artifacts_for_session(session_id).await {
+        Ok(artifacts) => artifacts,
+        Err(error) => {
+            tracing::warn!(%session_id, %error, "could not list artifacts for compression");
+            return;
+        }
+    };
+    for artifact in artifacts {
+        let started = Instant::now();
+        let result = compress_one_artifact(paths, &artifact).await;
+        let duration_ms = started.elapsed().as_millis().min(i64::MAX as u128) as i64;
+        match result {
+            Ok(outcome) => {
+                let ratio =
+                    compression_ratio(outcome.original_size_bytes, outcome.compressed_size_bytes);
+                if let Err(error) = repos
+                    .record_artifact_compression(
+                        &artifact.id,
+                        FLAC_FORMAT,
+                        &outcome.output_path.to_string_lossy(),
+                        outcome.compressed_size_bytes,
+                        &outcome.compressed_checksum,
+                        "succeeded",
+                        None,
+                    )
+                    .await
+                {
+                    tracing::warn!(%session_id, artifact_id = %artifact.id, %error, "could not record compression result");
+                    // Without the metadata row the FLAC copy is unreachable,
+                    // so the WAV original must survive regardless of policy.
+                    continue;
+                }
+                tracing::info!(
+                    %session_id,
+                    artifact_id = %artifact.id,
+                    source = %artifact.source,
+                    original_bytes = outcome.original_size_bytes,
+                    compressed_bytes = outcome.compressed_size_bytes,
+                    compression_ratio = ratio.unwrap_or_default(),
+                    "compressed recording artifact"
+                );
+                let _ = repos
+                    .add_source_checkpoint(
+                        session_id,
+                        Some(&artifact.id),
+                        Some(&artifact.source),
+                        "audio_compression",
+                        Some(
+                            serde_json::json!({
+                                "durationMs": duration_ms,
+                                "status": "succeeded",
+                                "format": FLAC_FORMAT,
+                                "originalBytes": outcome.original_size_bytes,
+                                "compressedBytes": outcome.compressed_size_bytes,
+                                "compressionRatio": ratio,
+                            })
+                            .to_string(),
+                        ),
+                    )
+                    .await;
+                if !keep_wav {
+                    remove_original_wav(repos, paths, &artifact).await;
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %session_id,
+                    artifact_id = %artifact.id,
+                    code = %error.code,
+                    message = %error.message,
+                    "artifact compression failed; keeping WAV original"
+                );
+                let _ = repos
+                    .record_artifact_compression(
+                        &artifact.id,
+                        FLAC_FORMAT,
+                        "",
+                        0,
+                        "",
+                        "failed",
+                        Some(&error.message),
+                    )
+                    .await;
+                let _ = repos
+                    .add_source_checkpoint(
+                        session_id,
+                        Some(&artifact.id),
+                        Some(&artifact.source),
+                        "audio_compression",
+                        Some(
+                            serde_json::json!({
+                                "durationMs": duration_ms,
+                                "status": "failed",
+                                "error": error.code,
+                            })
+                            .to_string(),
+                        ),
+                    )
+                    .await;
+            }
+        }
+    }
+}
+
+async fn compress_one_artifact(
+    paths: &AppPaths,
+    artifact: &CompressibleArtifact,
+) -> Result<CompressionOutcome, AppError> {
+    let wav_path = paths
+        .contained_recording_file(&artifact.path)
+        .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?;
+    if !wav_path.exists() {
+        return Err(AppError::new(
+            "audio_compression_failed",
+            "Source WAV is no longer available.",
+        ));
+    }
+    let flac_path = wav_path.with_extension("flac");
+    tokio::task::spawn_blocking(move || {
+        let outcome = compress_wav_to_flac(&wav_path, &flac_path)?;
+        if let Err(error) = validate_flac_matches_wav(&flac_path, &wav_path) {
+            // Never leave an unvalidated archive behind: a later retry could
+            // mistake it for a usable copy of the recording.
+            let _ = std::fs::remove_file(&flac_path);
+            return Err(error);
+        }
+        Ok(outcome)
+    })
+    .await
+    .map_err(|error| AppError::new("audio_compression_failed", error.to_string()))?
+}
+
+async fn remove_original_wav(
+    repos: &Repositories,
+    paths: &AppPaths,
+    artifact: &CompressibleArtifact,
+) {
+    if let Err(error) = paths.remove_recording_file(&artifact.path) {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(artifact_id = %artifact.id, %error, "could not remove WAV original after compression");
+            return;
+        }
+    }
+    if let Err(error) = repos.mark_artifact_original_removed(&artifact.id).await {
+        tracing::warn!(artifact_id = %artifact.id, %error, "could not mark WAV original as removed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_default_to_wav_only_with_originals_kept() {
+        let settings = AudioStorageSettings::default();
+        assert_eq!(settings.mode, AudioStorageMode::WavOnly);
+        assert!(settings.keep_wav_after_compression);
+    }
+
+    #[test]
+    fn settings_deserialize_with_missing_fields() {
+        let settings: AudioStorageSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(settings, AudioStorageSettings::default());
+
+        let settings: AudioStorageSettings =
+            serde_json::from_str(r#"{"mode":"compressedAfterValidation"}"#).unwrap();
+        assert_eq!(settings.mode, AudioStorageMode::CompressedAfterValidation);
+        assert!(settings.keep_wav_after_compression);
+    }
+
+    #[test]
+    fn settings_round_trip_camel_case() {
+        let settings = AudioStorageSettings {
+            mode: AudioStorageMode::CompressedAfterValidation,
+            keep_wav_after_compression: false,
+        };
+        let serialized = serde_json::to_string(&settings).unwrap();
+        assert!(serialized.contains("compressedAfterValidation"));
+        assert!(serialized.contains("keepWavAfterCompression"));
+        let parsed: AudioStorageSettings = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(parsed, settings);
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -537,7 +537,7 @@ pub async fn start_recording(
             .unwrap_or_else(|| "The selected recording sources are not ready.".to_string());
         return Err(AppError::new("source_not_ready", message));
     }
-    finish_active_capture_before_start(&repos).await?;
+    finish_active_capture_before_start(&repos, &paths).await?;
     let capture_paths = paths.clone();
     let capture_note_id = note.id.clone();
     let started = tokio::task::spawn_blocking(move || {
@@ -600,22 +600,27 @@ pub async fn finish_recording(
     app: AppHandle,
     request: SessionRequest,
 ) -> Result<FinishRecordingResponse, AppError> {
+    let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
     let finalization_started = Instant::now();
     let finished = finish_capture(&request.session_id)?;
-    finish_recording_session(&repos, finished, finalization_started).await
+    finish_recording_session(&repos, &paths, finished, finalization_started).await
 }
 
-async fn finish_active_capture_before_start(repos: &Repositories) -> Result<(), AppError> {
+async fn finish_active_capture_before_start(
+    repos: &Repositories,
+    paths: &AppPaths,
+) -> Result<(), AppError> {
     let finalization_started = Instant::now();
     if let Some(finished) = finish_active_capture()? {
-        finish_recording_session(repos, finished, finalization_started).await?;
+        finish_recording_session(repos, paths, finished, finalization_started).await?;
     }
     Ok(())
 }
 
 async fn finish_recording_session(
     repos: &Repositories,
+    paths: &AppPaths,
     finished: crate::audio::capture::FinishedRecording,
     finalization_started: Instant,
 ) -> Result<FinishRecordingResponse, AppError> {
@@ -875,6 +880,15 @@ async fn finish_recording_session(
         }
         ticket.finish();
     });
+    // Archival compression (when enabled) queues behind the processing job we
+    // just registered, so it runs only after transcription has finished with
+    // the WAV originals.
+    crate::audio_storage::schedule_session_compression(
+        (*repos).clone(),
+        paths.clone(),
+        finished.note_id.clone(),
+        finished.session_id.clone(),
+    );
     Ok(FinishRecordingResponse {
         note,
         recording: finished.recording,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -42,6 +42,13 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
     .await?;
     ensure_column(_pool, "audio_artifacts", "validation_summary", "TEXT").await?;
     ensure_column(_pool, "audio_artifacts", "last_error", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "compressed_path", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "compressed_format", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "compressed_size_bytes", "INTEGER").await?;
+    ensure_column(_pool, "audio_artifacts", "compressed_checksum", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "compression_status", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "compression_error", "TEXT").await?;
+    ensure_column(_pool, "audio_artifacts", "original_removed_at", "TEXT").await?;
     ensure_column(_pool, "transcripts", "recording_session_id", "TEXT").await?;
     ensure_column(_pool, "transcripts", "source_artifact_id", "TEXT").await?;
     ensure_column(_pool, "transcripts", "source", "TEXT").await?;

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -843,11 +843,23 @@ impl Repositories {
         &self,
         note_id: &str,
     ) -> Result<Vec<String>, sqlx::Error> {
-        let rows = sqlx::query("SELECT path FROM audio_artifacts WHERE note_id = ?")
-            .bind(note_id)
-            .fetch_all(&self.pool)
-            .await?;
-        Ok(rows.into_iter().map(|row| row.get("path")).collect())
+        let rows = sqlx::query(
+            "SELECT path, partial_path, compressed_path FROM audio_artifacts WHERE note_id = ?",
+        )
+        .bind(note_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .flat_map(|row| {
+                [
+                    row.get::<Option<String>, _>("path"),
+                    row.get::<Option<String>, _>("partial_path"),
+                    row.get::<Option<String>, _>("compressed_path"),
+                ]
+            })
+            .flatten()
+            .collect())
     }
 
     pub async fn delete_note(&self, note_id: &str) -> Result<(), sqlx::Error> {
@@ -1331,6 +1343,9 @@ impl Repositories {
             size_bytes: 0,
             checksum: String::new(),
             created_at: timestamp(),
+            compressed_format: None,
+            compressed_size_bytes: None,
+            compression_ratio: None,
         };
         sqlx::query(
             "INSERT INTO audio_artifacts
@@ -1354,7 +1369,8 @@ impl Repositories {
         session_id: &str,
     ) -> Result<Vec<AudioArtifactDto>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at,
+                    compressed_format, compressed_size_bytes, compression_status
              FROM audio_artifacts
              WHERE recording_session_id = ?
              ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
@@ -1362,18 +1378,7 @@ impl Repositories {
         .bind(session_id)
         .fetch_all(&self.pool)
         .await?;
-        Ok(rows
-            .into_iter()
-            .map(|row| AudioArtifactDto {
-                id: row.get("id"),
-                source: row.get("source"),
-                format: row.get("format"),
-                duration_ms: row.get("duration_ms"),
-                size_bytes: row.get("size_bytes"),
-                checksum: row.get("checksum"),
-                created_at: row.get("created_at"),
-            })
-            .collect())
+        Ok(rows.into_iter().map(audio_artifact_from_row).collect())
     }
 
     pub async fn source_artifact_paths_for_session(
@@ -1450,6 +1455,9 @@ impl Repositories {
             size_bytes,
             checksum: checksum.to_string(),
             created_at: timestamp(),
+            compressed_format: None,
+            compressed_size_bytes: None,
+            compression_ratio: None,
         };
         sqlx::query(
             "INSERT INTO audio_artifacts (id, note_id, recording_session_id, source, path, format, duration_ms, size_bytes, checksum, status, expected_duration_ms, created_at)
@@ -1487,7 +1495,8 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Option<AudioArtifactDto>, sqlx::Error> {
         let row = sqlx::query(
-            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at,
+                    compressed_format, compressed_size_bytes, compression_status
              FROM audio_artifacts
              WHERE note_id = ? AND status = 'valid'
              ORDER BY created_at DESC
@@ -1496,21 +1505,13 @@ impl Repositories {
         .bind(note_id)
         .fetch_optional(&self.pool)
         .await?;
-        Ok(row.map(|row| AudioArtifactDto {
-            id: row.get("id"),
-            source: row.get("source"),
-            format: row.get("format"),
-            duration_ms: row.get("duration_ms"),
-            size_bytes: row.get("size_bytes"),
-            checksum: row.get("checksum"),
-            created_at: row.get("created_at"),
-        }))
+        Ok(row.map(audio_artifact_from_row))
     }
 
     pub async fn latest_valid_audio_artifact_paths(
         &self,
         note_id: &str,
-    ) -> Result<Vec<(String, String, String, String)>, sqlx::Error> {
+    ) -> Result<Vec<RetryAudioSource>, sqlx::Error> {
         let session = sqlx::query(
             "SELECT recording_session_id
              FROM audio_artifacts
@@ -1526,7 +1527,7 @@ impl Repositories {
         };
         let session_id: String = session.get("recording_session_id");
         let rows = sqlx::query(
-            "SELECT id, source, path, recording_session_id
+            "SELECT id, source, path, recording_session_id, compressed_path, compression_status
              FROM audio_artifacts
              WHERE note_id = ? AND recording_session_id = ? AND status = 'valid'
              ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
@@ -1537,15 +1538,83 @@ impl Repositories {
         .await?;
         Ok(rows
             .into_iter()
-            .map(|row| {
-                (
-                    row.get("id"),
-                    row.get("source"),
-                    row.get("path"),
-                    row.get("recording_session_id"),
-                )
+            .map(|row| RetryAudioSource {
+                artifact_id: row.get("id"),
+                source: row.get("source"),
+                path: row.get("path"),
+                session_id: row.get("recording_session_id"),
+                compressed_path: row.get("compressed_path"),
+                compression_status: row.get("compression_status"),
             })
             .collect())
+    }
+
+    /// Validated artifacts of a session that have no archival copy yet.
+    pub async fn compressible_artifacts_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<CompressibleArtifact>, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, source, path
+             FROM audio_artifacts
+             WHERE recording_session_id = ?
+               AND status = 'valid'
+               AND compression_status IS NULL
+               AND path IS NOT NULL
+             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| CompressibleArtifact {
+                id: row.get("id"),
+                source: row.get("source"),
+                path: row.get("path"),
+            })
+            .collect())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_artifact_compression(
+        &self,
+        artifact_id: &str,
+        format: &str,
+        compressed_path: &str,
+        compressed_size_bytes: i64,
+        compressed_checksum: &str,
+        status: &str,
+        error: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE audio_artifacts
+             SET compressed_format = ?, compressed_path = ?, compressed_size_bytes = ?,
+                 compressed_checksum = ?, compression_status = ?, compression_error = ?
+             WHERE id = ?",
+        )
+        .bind(format)
+        .bind(compressed_path)
+        .bind(compressed_size_bytes)
+        .bind(compressed_checksum)
+        .bind(status)
+        .bind(error)
+        .bind(artifact_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_artifact_original_removed(
+        &self,
+        artifact_id: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE audio_artifacts SET original_removed_at = ? WHERE id = ?")
+            .bind(timestamp())
+            .bind(artifact_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     async fn latest_audio_sources(
@@ -1553,7 +1622,8 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Vec<AudioArtifactDto>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at,
+                    compressed_format, compressed_size_bytes, compression_status
              FROM audio_artifacts
              WHERE note_id = ? AND status = 'valid'
              ORDER BY created_at DESC",
@@ -1561,18 +1631,7 @@ impl Repositories {
         .bind(note_id)
         .fetch_all(&self.pool)
         .await?;
-        Ok(rows
-            .into_iter()
-            .map(|row| AudioArtifactDto {
-                id: row.get("id"),
-                source: row.get("source"),
-                format: row.get("format"),
-                duration_ms: row.get("duration_ms"),
-                size_bytes: row.get("size_bytes"),
-                checksum: row.get("checksum"),
-                created_at: row.get("created_at"),
-            })
-            .collect())
+        Ok(rows.into_iter().map(audio_artifact_from_row).collect())
     }
 
     async fn latest_transcript(&self, note_id: &str) -> Result<Option<TranscriptDto>, sqlx::Error> {
@@ -2314,6 +2373,56 @@ pub struct SourceArtifactPath {
     pub partial_path: Option<String>,
     pub final_path: Option<String>,
     pub expected_duration_ms: i64,
+}
+
+/// Validated artifact eligible for archival compression.
+#[derive(Debug, Clone)]
+pub struct CompressibleArtifact {
+    pub id: String,
+    pub source: String,
+    pub path: String,
+}
+
+/// Saved audio available for retry: the WAV path plus the compressed archive
+/// (when one was created) so retry can restore a deleted WAV original.
+#[derive(Debug, Clone)]
+pub struct RetryAudioSource {
+    pub artifact_id: String,
+    pub source: String,
+    pub path: String,
+    pub session_id: String,
+    pub compressed_path: Option<String>,
+    pub compression_status: Option<String>,
+}
+
+fn audio_artifact_from_row(row: sqlx::sqlite::SqliteRow) -> AudioArtifactDto {
+    let size_bytes: i64 = row.get("size_bytes");
+    let compression_succeeded = row
+        .get::<Option<String>, _>("compression_status")
+        .as_deref()
+        == Some("succeeded");
+    let compressed_format: Option<String> = compression_succeeded
+        .then(|| row.get::<Option<String>, _>("compressed_format"))
+        .flatten();
+    let compressed_size_bytes: Option<i64> = compression_succeeded
+        .then(|| row.get::<Option<i64>, _>("compressed_size_bytes"))
+        .flatten()
+        .filter(|size| *size > 0);
+    let compression_ratio = compressed_size_bytes
+        .filter(|_| size_bytes > 0)
+        .map(|compressed| compressed as f64 / size_bytes as f64);
+    AudioArtifactDto {
+        id: row.get("id"),
+        source: row.get("source"),
+        format: row.get("format"),
+        duration_ms: row.get("duration_ms"),
+        size_bytes,
+        checksum: row.get("checksum"),
+        created_at: row.get("created_at"),
+        compressed_format,
+        compressed_size_bytes,
+        compression_ratio,
+    }
 }
 
 pub fn timestamp() -> String {

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -729,17 +729,18 @@ pub async fn retry_from_saved_audio(
     paths: &AppPaths,
     note_id: &str,
 ) -> Result<NoteDto, AppError> {
-    let sources = repos
-        .latest_valid_audio_artifact_paths(note_id)
-        .await?
-        .into_iter()
-        .filter_map(|(id, source, path, session_id)| {
-            paths
-                .contained_recording_file(path)
-                .ok()
-                .map(|path| (id, source, path, session_id))
-        })
-        .collect::<Vec<_>>();
+    let mut sources = Vec::new();
+    for retry_source in repos.latest_valid_audio_artifact_paths(note_id).await? {
+        let Some(path) = materialize_retry_audio(paths, &retry_source).await else {
+            continue;
+        };
+        sources.push((
+            retry_source.artifact_id,
+            retry_source.source,
+            path,
+            retry_source.session_id,
+        ));
+    }
     if sources.is_empty() {
         return Err(AppError::new(
             "audio_artifact_missing",
@@ -780,6 +781,69 @@ pub async fn retry_from_saved_audio(
         manual_notes,
     )
     .await
+}
+
+/// Resolves a recording path inside the recordings directory even when the
+/// file itself no longer exists (containment is then checked on its parent
+/// directory, since `canonicalize` needs an existing path).
+pub fn expected_recording_path(paths: &AppPaths, raw: &str) -> Option<PathBuf> {
+    match paths.contained_recording_file(raw) {
+        Ok(path) => Some(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let raw_path = std::path::Path::new(raw);
+            let parent = paths.contained_recording_file(raw_path.parent()?).ok()?;
+            Some(parent.join(raw_path.file_name()?))
+        }
+        Err(_) => None,
+    }
+}
+
+/// Resolves the WAV for a retry source, restoring it from the FLAC archive
+/// when the original was deleted by storage policy.
+pub async fn materialize_retry_audio(
+    paths: &AppPaths,
+    source: &crate::db::repositories::RetryAudioSource,
+) -> Option<PathBuf> {
+    let wav_path = expected_recording_path(paths, &source.path)?;
+    if wav_path.exists() {
+        return Some(wav_path);
+    }
+    if source.compression_status.as_deref() != Some("succeeded") {
+        return None;
+    }
+    let compressed = source.compressed_path.as_deref()?;
+    let flac_path = paths.contained_recording_file(compressed).ok()?;
+    if !flac_path.exists() {
+        return None;
+    }
+    let restored = wav_path.clone();
+    match tokio::task::spawn_blocking(move || {
+        crate::audio::compression::decode_flac_to_wav(&flac_path, &restored)
+    })
+    .await
+    {
+        Ok(Ok(path)) => {
+            tracing::info!(
+                artifact_id = %source.artifact_id,
+                path = %path.display(),
+                "restored WAV from FLAC archive for retry"
+            );
+            Some(path)
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(
+                artifact_id = %source.artifact_id,
+                code = %error.code,
+                message = %error.message,
+                "could not restore WAV from FLAC archive"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(artifact_id = %source.artifact_id, %error, "FLAC restore task failed");
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -353,6 +353,14 @@ pub struct AudioArtifactDto {
     pub size_bytes: i64,
     pub checksum: String,
     pub created_at: String,
+    /// Format of the archival compressed copy ("flac"), when one exists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compressed_format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compressed_size_bytes: Option<i64>,
+    /// Compressed size as a fraction of the original WAV size (0–1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compression_ratio: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app_paths;
 pub mod audio;
+pub mod audio_storage;
 pub mod commands;
 pub mod db;
 pub mod dictation;
@@ -111,6 +112,8 @@ pub fn run() {
             commands::finish_recording,
             commands::retry_processing,
             commands::recover_recording,
+            audio_storage::audio_storage_settings,
+            audio_storage::set_audio_storage_settings,
             dictation::dictation_settings,
             dictation::list_dictation_history,
             dictation::delete_dictation_history_item,
@@ -143,6 +146,7 @@ pub fn run() {
             menu_bar::setup(app)?;
             providers::setup(app);
             dictation::setup(app);
+            audio_storage::setup(app.handle());
             mascot::setup(app);
             meeting_detection::setup(app);
             repair_agent_task_statuses_on_app_start(app);

--- a/src-tauri/tests/compression.rs
+++ b/src-tauri/tests/compression.rs
@@ -1,0 +1,256 @@
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+use os_scribe_lib::app_paths::AppPaths;
+use os_scribe_lib::audio_storage::compress_session_artifacts;
+use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
+use os_scribe_lib::domain::processing::materialize_retry_audio;
+use os_scribe_lib::domain::types::{NoteDto, ProcessingStatus, RecordingSourceMode};
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::Row;
+use std::path::{Path, PathBuf};
+
+async fn test_repositories() -> Repositories {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite should open");
+    run_migrations(&pool).await.expect("migrations should run");
+    Repositories::new(pool)
+}
+
+fn write_speech_wav(path: &Path, frames: usize) {
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec).unwrap();
+    for index in 0..frames {
+        let phase = index as f32 / 16.0;
+        writer
+            .write_sample(((phase * 2.0 * std::f32::consts::PI).sin() * 9_000.0) as i16)
+            .unwrap();
+    }
+    writer.finalize().unwrap();
+}
+
+struct CompressedSession {
+    repos: Repositories,
+    paths: AppPaths,
+    note: NoteDto,
+    session_id: String,
+    artifact_id: String,
+    wav_path: PathBuf,
+    _data_dir: tempfile::TempDir,
+}
+
+async fn validated_session() -> CompressedSession {
+    let repos = test_repositories().await;
+    let data_dir = tempfile::tempdir().expect("tempdir");
+    let paths = AppPaths::from_data_dir(data_dir.path().join("data")).expect("paths");
+    let note = repos.create_note(None).await.expect("note");
+    let session_id = "session-compression".to_string();
+    let session_dir = paths
+        .recording_session_dir(&note.id, &session_id)
+        .expect("session dir");
+    std::fs::create_dir_all(&session_dir).expect("session dir create");
+    let wav_path = session_dir.join("microphone.wav");
+    write_speech_wav(&wav_path, 32_000);
+    let partial_path = session_dir.join("microphone.partial.wav");
+    repos
+        .create_recording_session(
+            &note.id,
+            &session_id,
+            RecordingSourceMode::MicrophoneOnly,
+            &partial_path.to_string_lossy(),
+            &wav_path.to_string_lossy(),
+            None,
+        )
+        .await
+        .expect("recording session");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            &session_id,
+            "microphone",
+            &partial_path.to_string_lossy(),
+            &wav_path.to_string_lossy(),
+        )
+        .await
+        .expect("artifact");
+    let size_bytes = std::fs::metadata(&wav_path).unwrap().len() as i64;
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "valid",
+            2_000,
+            size_bytes,
+            "checksum",
+            2_000,
+            None,
+            None,
+        )
+        .await
+        .expect("finalize artifact");
+    CompressedSession {
+        repos,
+        paths,
+        note,
+        session_id,
+        artifact_id: artifact.id,
+        wav_path,
+        _data_dir: data_dir,
+    }
+}
+
+#[tokio::test]
+async fn compresses_validated_artifact_and_keeps_wav_by_default_policy() {
+    let session = validated_session().await;
+
+    compress_session_artifacts(&session.repos, &session.paths, &session.session_id, true).await;
+
+    let flac_path = session.wav_path.with_extension("flac");
+    assert!(flac_path.exists(), "FLAC archive should exist");
+    assert!(session.wav_path.exists(), "WAV original should be kept");
+
+    let artifacts = session
+        .repos
+        .source_artifacts_for_session(&session.session_id)
+        .await
+        .expect("artifacts");
+    assert_eq!(artifacts.len(), 1);
+    let artifact = &artifacts[0];
+    assert_eq!(artifact.compressed_format.as_deref(), Some("flac"));
+    let compressed_size = artifact.compressed_size_bytes.expect("compressed size");
+    assert!(compressed_size > 0);
+    assert!(
+        compressed_size < artifact.size_bytes,
+        "FLAC ({compressed_size}) should be smaller than WAV ({})",
+        artifact.size_bytes
+    );
+    let ratio = artifact.compression_ratio.expect("ratio");
+    assert!(ratio > 0.0 && ratio < 1.0);
+
+    let checkpoint = sqlx::query(
+        "SELECT details FROM recording_checkpoints WHERE recording_session_id = ? AND kind = 'audio_compression'",
+    )
+    .bind(&session.session_id)
+    .fetch_one(&session.repos.pool)
+    .await
+    .expect("compression checkpoint recorded");
+    let detail: String = checkpoint.get("details");
+    assert!(detail.contains("\"status\":\"succeeded\""));
+    assert!(detail.contains("originalBytes"));
+    assert!(detail.contains("compressedBytes"));
+    assert!(detail.contains("compressionRatio"));
+}
+
+#[tokio::test]
+async fn deletes_wav_only_after_validated_compression_when_policy_allows() {
+    let session = validated_session().await;
+
+    compress_session_artifacts(&session.repos, &session.paths, &session.session_id, false).await;
+
+    let flac_path = session.wav_path.with_extension("flac");
+    assert!(flac_path.exists(), "FLAC archive should exist");
+    assert!(
+        !session.wav_path.exists(),
+        "WAV original should be deleted once the archive validated"
+    );
+
+    let row = sqlx::query(
+        "SELECT original_removed_at, compression_status FROM audio_artifacts WHERE id = ?",
+    )
+    .bind(&session.artifact_id)
+    .fetch_one(&session.repos.pool)
+    .await
+    .expect("artifact row");
+    assert_eq!(
+        row.get::<Option<String>, _>("compression_status")
+            .as_deref(),
+        Some("succeeded")
+    );
+    assert!(row
+        .get::<Option<String>, _>("original_removed_at")
+        .is_some());
+}
+
+#[tokio::test]
+async fn retry_restores_wav_from_flac_archive() {
+    let session = validated_session().await;
+    let original_samples = WavReader::open(&session.wav_path)
+        .unwrap()
+        .samples::<i16>()
+        .map(|sample| sample.unwrap())
+        .collect::<Vec<_>>();
+
+    compress_session_artifacts(&session.repos, &session.paths, &session.session_id, false).await;
+    assert!(!session.wav_path.exists());
+
+    let sources = session
+        .repos
+        .latest_valid_audio_artifact_paths(&session.note.id)
+        .await
+        .expect("retry sources");
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].compression_status.as_deref(), Some("succeeded"));
+
+    let restored = materialize_retry_audio(&session.paths, &sources[0])
+        .await
+        .expect("WAV should be restored from the FLAC archive");
+    assert!(restored.exists());
+    let restored_samples = WavReader::open(&restored)
+        .unwrap()
+        .samples::<i16>()
+        .map(|sample| sample.unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(restored_samples, original_samples);
+}
+
+#[tokio::test]
+async fn compression_failure_keeps_wav_and_does_not_fail_the_note() {
+    let session = validated_session().await;
+    std::fs::remove_file(&session.wav_path).expect("simulate missing source");
+
+    compress_session_artifacts(&session.repos, &session.paths, &session.session_id, false).await;
+
+    let row = sqlx::query(
+        "SELECT compression_status, compression_error FROM audio_artifacts WHERE id = ?",
+    )
+    .bind(&session.artifact_id)
+    .fetch_one(&session.repos.pool)
+    .await
+    .expect("artifact row");
+    assert_eq!(
+        row.get::<Option<String>, _>("compression_status")
+            .as_deref(),
+        Some("failed")
+    );
+    assert!(row.get::<Option<String>, _>("compression_error").is_some());
+
+    let note = session
+        .repos
+        .get_note(&session.note.id)
+        .await
+        .expect("note");
+    assert!(
+        !matches!(note.processing_status, ProcessingStatus::Failed),
+        "compression failure must not fail the note"
+    );
+}
+
+#[tokio::test]
+async fn already_compressed_artifacts_are_not_recompressed() {
+    let session = validated_session().await;
+    compress_session_artifacts(&session.repos, &session.paths, &session.session_id, true).await;
+    let compressible = session
+        .repos
+        .compressible_artifacts_for_session(&session.session_id)
+        .await
+        .expect("compressible artifacts");
+    assert!(
+        compressible.is_empty(),
+        "compressed artifacts must not be queued again"
+    );
+}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -16,10 +16,12 @@ import { IconTelevision } from "central-icons/IconTelevision";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import {
+  audioStorageSettings,
   dictationHelperCommand,
   dictationSettings,
   listVeniceModels,
   providerModelSettings,
+  setAudioStorageSettings,
   setDictationLanguage,
   setDictationMicrophone,
   setDictationShortcut,
@@ -27,6 +29,7 @@ import {
 } from "../../lib/tauri";
 import type {
   AccountStatus,
+  AudioStorageSettingsDto,
   DictationHelperEvent,
   DictationMicrophoneDeviceDto,
   DictationShortcutKind,
@@ -251,6 +254,8 @@ export function AppSettings({
   const [languageOpen, setLanguageOpen] = useState(false);
   const [languagePopoverPlacement, setLanguagePopoverPlacement] =
     useState<SelectPopoverPlacement>("align-selected");
+  const [audioStorage, setAudioStorage] =
+    useState<AudioStorageSettingsDto | null>(null);
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
   const activeTab = controlled ? controlledTab : internalTab;
   const setActiveTab = (tab: SettingsTab) => {
@@ -281,6 +286,29 @@ export function AppSettings({
     setMicOpen(false);
     setLanguageOpen(false);
   }, [activeTab]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void audioStorageSettings()
+      .then((storage) => {
+        if (!cancelled) setAudioStorage(storage);
+      })
+      .catch(() => {
+        // Leave the storage rows disabled when settings can't be loaded.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const updateAudioStorage = (next: AudioStorageSettingsDto) => {
+    const previous = audioStorage;
+    setAudioStorage(next);
+    void setAudioStorageSettings(next).catch((error) => {
+      setAudioStorage(previous);
+      setStatus(messageFromError(error));
+    });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -927,6 +955,58 @@ export function AppSettings({
                     </div>
                   </div>
                 )}
+
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">
+                      Compress saved recordings
+                    </h3>
+                    <p className="settings-row-description">
+                      Create a smaller lossless FLAC copy after a recording is
+                      saved and validated.
+                    </p>
+                  </div>
+                  <div className="settings-row-control">
+                    <Switch
+                      checked={
+                        audioStorage?.mode === "compressedAfterValidation"
+                      }
+                      disabled={!audioStorage}
+                      aria-label="Compress saved recordings"
+                      onCheckedChange={(next) =>
+                        updateAudioStorage({
+                          mode: next ? "compressedAfterValidation" : "wavOnly",
+                          keepWavAfterCompression:
+                            audioStorage?.keepWavAfterCompression ?? true,
+                        })
+                      }
+                    />
+                  </div>
+                </div>
+
+                {audioStorage?.mode === "compressedAfterValidation" ? (
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Keep WAV originals</h3>
+                      <p className="settings-row-description">
+                        Keep the original WAV next to the compressed copy. Turn
+                        off to free space once a copy is verified.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <Switch
+                        checked={audioStorage.keepWavAfterCompression}
+                        aria-label="Keep WAV originals after compression"
+                        onCheckedChange={(next) =>
+                          updateAudioStorage({
+                            mode: audioStorage.mode,
+                            keepWavAfterCompression: next,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </div>
           </section>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -240,6 +240,17 @@ export type AudioArtifactDto = {
   sizeBytes: number;
   checksum: string;
   createdAt: string;
+  compressedFormat?: "flac";
+  compressedSizeBytes?: number;
+  /** Compressed size as a fraction of the original WAV size (0–1). */
+  compressionRatio?: number;
+};
+
+export type AudioStorageMode = "wavOnly" | "compressedAfterValidation";
+
+export type AudioStorageSettingsDto = {
+  mode: AudioStorageMode;
+  keepWavAfterCompression: boolean;
 };
 
 export type NoteDto = NoteListItemDto & {
@@ -974,6 +985,18 @@ export async function osAccountsLogout() {
 
 export async function osAccountsTopUp() {
   return invoke<void>("os_accounts_top_up");
+}
+
+export async function audioStorageSettings() {
+  return invoke<AudioStorageSettingsDto>("audio_storage_settings");
+}
+
+export async function setAudioStorageSettings(
+  settings: AudioStorageSettingsDto,
+) {
+  return invoke<AudioStorageSettingsDto>("set_audio_storage_settings", {
+    settings,
+  });
 }
 
 export async function dictationSettings() {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -7,6 +7,8 @@ import { APP_COMMIT_HASH, APP_VERSION } from "../app/build-info";
 import { MASCOT_ENABLED_KEY } from "../lib/mascot-settings";
 
 const mocks = vi.hoisted(() => ({
+  audioStorageSettings: vi.fn(),
+  setAudioStorageSettings: vi.fn(),
   dictationSettings: vi.fn(),
   dictationHelperCommand: vi.fn(),
   providerModelSettings: vi.fn(),
@@ -38,6 +40,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/tauri", () => ({
+  audioStorageSettings: mocks.audioStorageSettings,
+  setAudioStorageSettings: mocks.setAudioStorageSettings,
   dictationSettings: mocks.dictationSettings,
   dictationHelperCommand: mocks.dictationHelperCommand,
   providerModelSettings: mocks.providerModelSettings,
@@ -119,6 +123,13 @@ describe("AppSettings", () => {
     localStorage.clear();
     mocks.eventHandler = undefined;
     mocks.dictationSettings.mockResolvedValue({ settings: baseSettings });
+    mocks.audioStorageSettings.mockResolvedValue({
+      mode: "wavOnly",
+      keepWavAfterCompression: true,
+    });
+    mocks.setAudioStorageSettings.mockImplementation((settings) =>
+      Promise.resolve(settings),
+    );
     mocks.setDictationLanguage.mockImplementation(async (language) => ({
       ...baseSettings,
       language,
@@ -341,6 +352,50 @@ describe("AppSettings", () => {
       screen.getByRole("switch", { name: "Capture system audio for notes" }),
     );
     expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+  });
+
+  it("saves audio storage compression settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
+
+    const compressSwitch = await screen.findByRole("switch", {
+      name: "Compress saved recordings",
+    });
+    expect(compressSwitch).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.queryByRole("switch", {
+        name: "Keep WAV originals after compression",
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.click(compressSwitch);
+    expect(mocks.setAudioStorageSettings).toHaveBeenCalledWith({
+      mode: "compressedAfterValidation",
+      keepWavAfterCompression: true,
+    });
+
+    const keepWavSwitch = await screen.findByRole("switch", {
+      name: "Keep WAV originals after compression",
+    });
+    expect(keepWavSwitch).toHaveAttribute("aria-checked", "true");
+    await user.click(keepWavSwitch);
+    expect(mocks.setAudioStorageSettings).toHaveBeenLastCalledWith({
+      mode: "compressedAfterValidation",
+      keepWavAfterCompression: false,
+    });
   });
 
   it("saves the default transcription language", async () => {


### PR DESCRIPTION
Closes #7

## What

Implements the MVP-safe storage strategy from the issue: capture keeps recording plain WAV, and compression happens **after** finalization + validation, never on the live capture path.

- **Settings (default unchanged):** new audio storage preference persisted in `audio-storage-settings.json`, default `WAV only`. Settings → Audio gains two rows: "Compress saved recordings" and, when enabled, "Keep WAV originals".
- **FLAC backend (Option A from the issue):** streaming encode via `flacenc` (no full-file memory load for long meetings), decode via `claxon`.
- **Validation before anything else:** the archive must exist, be non-empty, decode fully, and match the WAV source **sample-for-sample** (FLAC is lossless, so exact equality is required, which subsumes the duration/non-silence checks). An archive that fails validation is deleted on the spot.
- **Storage policy:** the WAV original is deleted only when the user disabled "Keep WAV originals" *and* the archive passed validation. Deletion is recorded (`original_removed_at`).
- **Metadata in SQLite:** `compressed_path/format/size/checksum`, `compression_status`, `compression_error` on `audio_artifacts`; original size, compressed size, and compression ratio are exposed on `AudioArtifactDto` and recorded in an `audio_compression` checkpoint per source.
- **Retry still works after compression:** `materialize_retry_audio` restores the WAV from the FLAC archive into its original location before reprocessing.
- **Failure isolation:** compression errors are recorded per artifact and never mark the recording or note as failed.

## How it sequences

Compression is enqueued on the existing per-note processing queue right after `finish_recording` schedules transcription, so it only runs once transcription/generation for that recording has finished with the WAV files, and it never competes for CPU during processing.

## Tests

- `src-tauri/src/audio/compression.rs`: round-trip (mono + stereo), corrupted/truncated/empty/mismatched archive rejection, non-16-bit-PCM rejection, ratio math.
- `src-tauri/tests/compression.rs`: end-to-end against a real SQLite + recordings dir — compress-and-keep policy, delete-after-validation policy, retry restore from FLAC (sample-exact), failure keeps WAV + note status untouched, no re-compression of already-archived artifacts.
- `src/test/app-settings.test.tsx`: settings rows render, toggle, and persist through the new commands.
- Full gate: `cargo test` (118), `pnpm test` (211), `pnpm lint`, `pnpm build` all green; `cargo clippy` introduces no new warnings; prettier failures on main are pre-existing and untouched.

## Notes / follow-ups

- Sizes and ratio are surfaced via DTO + checkpoint; a small UI affordance showing "12.3 MB → 4.1 MB" on the note could be layered on top later.
- A concurrent manual retry during the archive-deletion window is self-healing (the next retry restores from FLAC), mirroring the existing retry semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)