### PR TITLE
Transcribe dual-source recordings incrementally while still recording

### DIFF
--- a/src-tauri/src/audio/live.rs
+++ b/src-tauri/src/audio/live.rs
@@ -163,17 +163,65 @@ pub fn rms_windows_from_partial(path: &Path) -> Result<(PartialWavInfo, Vec<f32>
     Ok((info, windows))
 }
 
+/// RMS windows accumulated across live ticks so each tick only reads the
+/// audio appended since the previous one, instead of re-reading the whole
+/// in-progress file (which grows without bound during long meetings).
+#[derive(Debug, Default)]
+pub struct RmsWindowCache {
+    windows: Vec<f32>,
+    frames_consumed: u64,
+}
+
+/// Extends the cache with complete RMS windows from frames appended since the
+/// last tick. Only whole windows are cached: the trailing partial window
+/// changes as the file grows, and the live-edge padding keeps anything that
+/// close to the edge out of transcription anyway.
+fn extend_window_cache(
+    path: &Path,
+    info: &PartialWavInfo,
+    cache: &mut RmsWindowCache,
+) -> Result<(), AppError> {
+    let channels = info.channels.max(1) as u64;
+    let frames_per_window =
+        ((info.sample_rate.max(1) as i64 * turns::WINDOW_MS) / 1000).max(1) as u64;
+    if info.frame_count < cache.frames_consumed {
+        // The file shrank (recreated source); start over from scratch.
+        cache.windows.clear();
+        cache.frames_consumed = 0;
+    }
+    let new_windows = (info.frame_count - cache.frames_consumed) / frames_per_window;
+    if new_windows == 0 {
+        return Ok(());
+    }
+    let new_frames = new_windows * frames_per_window;
+    let samples = open_samples(path, info, cache.frames_consumed, new_frames)?;
+    let mut windows = turns::rms_windows_from_samples(
+        samples,
+        channels as usize,
+        info.sample_rate.max(1) as usize,
+    );
+    // A short read (torn tail) would yield a partial final window that the
+    // next tick must recompute; keep only the complete ones.
+    windows.truncate(new_windows as usize);
+    cache.frames_consumed += windows.len() as u64 * frames_per_window;
+    cache.windows.append(&mut windows);
+    Ok(())
+}
+
 /// Detects speech turns in an in-progress source recording using the same
-/// per-source thresholds as finalized detection. Returned turns carry the
-/// partial file as their source path; `turn_index` is left at 0.
+/// per-source thresholds as finalized detection, reading only the audio
+/// appended since the previous call with the same cache. Returned turns carry
+/// the partial file as their source path; `turn_index` is left at 0.
 pub fn detect_partial_turns(
     artifact_id: &str,
     source: &str,
     path: &Path,
+    cache: &mut RmsWindowCache,
 ) -> Result<(PartialWavInfo, Vec<AudioTurn>), AppError> {
-    let (info, windows) = rms_windows_from_partial(path)?;
+    let info = read_partial_wav_info(path)?;
+    extend_window_cache(path, &info, cache)?;
     let intervals =
-        turns::active_intervals_from_windows(&windows, turns::config_for_source(source));
+        turns::active_intervals_from_windows(&cache.windows, turns::config_for_source(source));
     let turns = intervals
         .into_iter()
         .map(|(start_ms, end_ms)| AudioTurn {
@@ -366,13 +414,64 @@ mod tests {
         write_wav(&partial, 1, 16_000, &samples);
         zero_header_sizes(&partial);
 
-        let (info, turns) =
-            detect_partial_turns("artifact", "microphone", &partial).expect("detection");
+        let (info, turns) = detect_partial_turns(
+            "artifact",
+            "microphone",
+            &partial,
+            &mut RmsWindowCache::default(),
+        )
+        .expect("detection");
         assert_eq!(info.duration_ms(), 6_000);
         assert_eq!(turns.len(), 2, "expected two distinct turns: {turns:?}");
         assert!(turns[0].start_ms < 500);
         assert!((1_000..=2_500).contains(&turns[0].end_ms));
         assert!((4_000..=5_100).contains(&turns[1].start_ms));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn cached_detection_across_ticks_matches_detection_from_scratch() {
+        let dir = temp_dir("live-cache");
+        let partial = dir.join("partial.wav");
+        // First tick sees speech then silence; the file then grows by another
+        // silence + speech stretch before the second tick.
+        let first = tone(24_000, 12_000.0)
+            .into_iter()
+            .chain(std::iter::repeat(0).take(48_000))
+            .collect::<Vec<_>>();
+        let mut full = first.clone();
+        full.extend(std::iter::repeat(0).take(8_000));
+        full.extend(tone(24_000, 12_000.0));
+
+        write_wav(&partial, 1, 16_000, &first);
+        zero_header_sizes(&partial);
+        let mut cache = RmsWindowCache::default();
+        let (_, first_turns) = detect_partial_turns("artifact", "microphone", &partial, &mut cache)
+            .expect("first tick");
+        assert_eq!(first_turns.len(), 1);
+
+        write_wav(&partial, 1, 16_000, &full);
+        zero_header_sizes(&partial);
+        let (_, cached_turns) =
+            detect_partial_turns("artifact", "microphone", &partial, &mut cache)
+                .expect("second tick");
+        let (_, fresh_turns) = detect_partial_turns(
+            "artifact",
+            "microphone",
+            &partial,
+            &mut RmsWindowCache::default(),
+        )
+        .expect("from scratch");
+
+        let ranges = |turns: &[AudioTurn]| {
+            turns
+                .iter()
+                .map(|turn| (turn.start_ms, turn.end_ms))
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ranges(&cached_turns), ranges(&fresh_turns));
+        assert_eq!(cached_turns.len(), 2);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/audio/live.rs
+++ b/src-tauri/src/audio/live.rs
@@ -1,0 +1,390 @@
+//! Reading in-progress (`.partial.wav`) recordings while capture is running.
+//!
+//! A live WAV's header still carries placeholder sizes (writers only patch
+//! them on finalize), so these readers walk the RIFF chunks and size the data
+//! section from the bytes actually on disk. Live turn detection and extraction
+//! share the same window math as finalized-audio detection in
+//! [`crate::audio::turns`], so both see the same boundaries.
+
+use crate::audio::turns::{self, AudioTurn};
+use crate::domain::types::AppError;
+use hound::{SampleFormat, WavSpec, WavWriter};
+use std::{
+    fs::File,
+    io::{BufReader, Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartialWavInfo {
+    pub channels: u16,
+    pub sample_rate: u32,
+    pub data_offset: u64,
+    /// Whole frames currently available on disk.
+    pub frame_count: u64,
+}
+
+impl PartialWavInfo {
+    pub fn duration_ms(&self) -> i64 {
+        ((self.frame_count as i128 * 1000) / self.sample_rate.max(1) as i128) as i64
+    }
+
+    fn bytes_per_frame(&self) -> u64 {
+        self.channels.max(1) as u64 * 2
+    }
+}
+
+fn read_error(error: impl ToString) -> AppError {
+    AppError::new("audio_live_read_failed", error.to_string())
+}
+
+/// Parses the RIFF layout of a possibly still-growing 16-bit PCM WAV. The
+/// data section length is derived from the file size on disk, not from the
+/// (placeholder) chunk size in the header.
+pub fn read_partial_wav_info(path: &Path) -> Result<PartialWavInfo, AppError> {
+    let file = File::open(path).map_err(read_error)?;
+    let file_len = file.metadata().map_err(read_error)?.len();
+    let mut reader = BufReader::new(file);
+    let mut riff = [0_u8; 12];
+    reader.read_exact(&mut riff).map_err(read_error)?;
+    if &riff[0..4] != b"RIFF" || &riff[8..12] != b"WAVE" {
+        return Err(read_error("Recording is not a RIFF WAVE file."));
+    }
+
+    let mut position = 12_u64;
+    let mut format: Option<(u16, u32, u16)> = None;
+    loop {
+        let mut header = [0_u8; 8];
+        if reader.read_exact(&mut header).is_err() {
+            return Err(read_error("Recording has no audio data yet."));
+        }
+        position += 8;
+        let chunk_id = &header[0..4];
+        let stated_size = u32::from_le_bytes([header[4], header[5], header[6], header[7]]) as u64;
+        if chunk_id == b"fmt " {
+            let mut body = vec![0_u8; stated_size.min(64) as usize];
+            reader.read_exact(&mut body).map_err(read_error)?;
+            if body.len() < 16 {
+                return Err(read_error("Recording fmt chunk is too short."));
+            }
+            let audio_format = u16::from_le_bytes([body[0], body[1]]);
+            let channels = u16::from_le_bytes([body[2], body[3]]);
+            let sample_rate = u32::from_le_bytes([body[4], body[5], body[6], body[7]]);
+            let bits_per_sample = u16::from_le_bytes([body[14], body[15]]);
+            if audio_format != 1 || bits_per_sample != 16 {
+                return Err(read_error(
+                    "Only 16-bit PCM recordings support live reading.",
+                ));
+            }
+            format = Some((channels, sample_rate, bits_per_sample));
+            let skip = stated_size.saturating_sub(body.len() as u64) + (stated_size & 1);
+            if skip > 0 {
+                reader
+                    .seek(SeekFrom::Current(skip as i64))
+                    .map_err(read_error)?;
+            }
+            position += stated_size + (stated_size & 1);
+        } else if chunk_id == b"data" {
+            let Some((channels, sample_rate, _bits)) = format else {
+                return Err(read_error("Recording data chunk precedes fmt chunk."));
+            };
+            let data_offset = position;
+            // The stated size is a placeholder until finalize; the bytes on
+            // disk are the truth for a live file (data is the last chunk in
+            // recordings we write).
+            let available = file_len.saturating_sub(data_offset);
+            let bytes_per_frame = channels.max(1) as u64 * 2;
+            let frame_count = available / bytes_per_frame;
+            return Ok(PartialWavInfo {
+                channels,
+                sample_rate,
+                data_offset,
+                frame_count,
+            });
+        } else {
+            let skip = stated_size + (stated_size & 1);
+            reader
+                .seek(SeekFrom::Current(skip as i64))
+                .map_err(read_error)?;
+            position += skip;
+        }
+        if position >= file_len {
+            return Err(read_error("Recording has no audio data yet."));
+        }
+    }
+}
+
+struct I16LeSamples<R: Read> {
+    reader: R,
+    remaining_bytes: u64,
+}
+
+impl<R: Read> Iterator for I16LeSamples<R> {
+    type Item = i16;
+
+    fn next(&mut self) -> Option<i16> {
+        if self.remaining_bytes < 2 {
+            return None;
+        }
+        let mut buffer = [0_u8; 2];
+        self.reader.read_exact(&mut buffer).ok()?;
+        self.remaining_bytes -= 2;
+        Some(i16::from_le_bytes(buffer))
+    }
+}
+
+fn open_samples(
+    path: &Path,
+    info: &PartialWavInfo,
+    start_frame: u64,
+    frame_count: u64,
+) -> Result<I16LeSamples<BufReader<File>>, AppError> {
+    let mut file = File::open(path).map_err(read_error)?;
+    file.seek(SeekFrom::Start(
+        info.data_offset + start_frame * info.bytes_per_frame(),
+    ))
+    .map_err(read_error)?;
+    Ok(I16LeSamples {
+        reader: BufReader::new(file),
+        remaining_bytes: frame_count * info.bytes_per_frame(),
+    })
+}
+
+/// RMS windows over the audio currently on disk, identical to the windows
+/// finalized-audio detection computes for the same samples.
+pub fn rms_windows_from_partial(path: &Path) -> Result<(PartialWavInfo, Vec<f32>), AppError> {
+    let info = read_partial_wav_info(path)?;
+    let samples = open_samples(path, &info, 0, info.frame_count)?;
+    let windows = turns::rms_windows_from_samples(
+        samples,
+        info.channels.max(1) as usize,
+        info.sample_rate.max(1) as usize,
+    );
+    Ok((info, windows))
+}
+
+/// Detects speech turns in an in-progress source recording using the same
+/// per-source thresholds as finalized detection. Returned turns carry the
+/// partial file as their source path; `turn_index` is left at 0.
+pub fn detect_partial_turns(
+    artifact_id: &str,
+    source: &str,
+    path: &Path,
+) -> Result<(PartialWavInfo, Vec<AudioTurn>), AppError> {
+    let (info, windows) = rms_windows_from_partial(path)?;
+    let intervals =
+        turns::active_intervals_from_windows(&windows, turns::config_for_source(source));
+    let turns = intervals
+        .into_iter()
+        .map(|(start_ms, end_ms)| AudioTurn {
+            artifact_id: artifact_id.to_string(),
+            source: source.to_string(),
+            source_path: path.to_path_buf(),
+            start_ms,
+            end_ms,
+            turn_index: 0,
+        })
+        .collect();
+    Ok((info, turns))
+}
+
+/// Writes a finalized, valid-header WAV for a turn of an in-progress
+/// recording, so the segment can be uploaded to a provider while capture is
+/// still running.
+pub fn extract_partial_turn_wav(
+    source_path: &Path,
+    start_ms: i64,
+    end_ms: i64,
+    output_path: &Path,
+) -> Result<PathBuf, AppError> {
+    let info = read_partial_wav_info(source_path)?;
+    let sample_rate = info.sample_rate.max(1) as i64;
+    let start_frame = ((start_ms.max(0) * sample_rate) / 1000) as u64;
+    let end_frame = ((end_ms.max(start_ms) * sample_rate) / 1000) as u64;
+    let start_frame = start_frame.min(info.frame_count);
+    let end_frame = end_frame.min(info.frame_count);
+    let samples = open_samples(source_path, &info, start_frame, end_frame - start_frame)?;
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent).map_err(read_error)?;
+    }
+    let mut writer = WavWriter::create(
+        output_path,
+        WavSpec {
+            channels: info.channels.max(1),
+            sample_rate: info.sample_rate,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        },
+    )
+    .map_err(read_error)?;
+    for sample in samples {
+        writer.write_sample(sample).map_err(read_error)?;
+    }
+    writer.finalize().map_err(read_error)?;
+    Ok(output_path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::WavReader;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("os-scribe-{label}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_wav(path: &Path, channels: u16, sample_rate: u32, samples: &[i16]) {
+        let spec = WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        for sample in samples {
+            writer.write_sample(*sample).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    /// Simulates an in-progress recording: a valid data section but the RIFF
+    /// and data chunk sizes still hold the writer's placeholder zeros.
+    fn zero_header_sizes(path: &Path) {
+        let mut bytes = std::fs::read(path).unwrap();
+        bytes[4..8].fill(0);
+        let data_pos = bytes
+            .windows(4)
+            .position(|window| window == b"data")
+            .expect("data chunk");
+        bytes[data_pos + 4..data_pos + 8].fill(0);
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    fn tone(frames: usize, amplitude: f32) -> Vec<i16> {
+        (0..frames)
+            .map(|index| {
+                let phase = index as f32 / 32.0;
+                ((phase * 2.0 * std::f32::consts::PI).sin() * amplitude) as i16
+            })
+            .collect()
+    }
+
+    #[test]
+    fn reads_partial_wav_with_placeholder_sizes() {
+        let dir = temp_dir("live-info");
+        let path = dir.join("microphone.partial.wav");
+        write_wav(&path, 2, 48_000, &tone(9_600, 9_000.0));
+        zero_header_sizes(&path);
+
+        let info = read_partial_wav_info(&path).expect("partial info");
+        assert_eq!(info.channels, 2);
+        assert_eq!(info.sample_rate, 48_000);
+        assert_eq!(info.frame_count, 4_800);
+        assert_eq!(info.duration_ms(), 100);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn partial_windows_match_finalized_windows() {
+        let dir = temp_dir("live-windows");
+        let finalized = dir.join("final.wav");
+        let partial = dir.join("partial.wav");
+        let samples = tone(48_000, 9_000.0)
+            .into_iter()
+            .chain(std::iter::repeat(0).take(24_000))
+            .collect::<Vec<_>>();
+        write_wav(&finalized, 1, 16_000, &samples);
+        write_wav(&partial, 1, 16_000, &samples);
+        zero_header_sizes(&partial);
+
+        let (_, partial_windows) = rms_windows_from_partial(&partial).expect("partial windows");
+        let finalized_windows = turns::rms_windows_from_samples(
+            WavReader::open(&finalized)
+                .unwrap()
+                .samples::<i16>()
+                .map(|sample| sample.unwrap()),
+            1,
+            16_000,
+        );
+        assert_eq!(partial_windows, finalized_windows);
+        assert!(!partial_windows.is_empty());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn extracts_turn_segment_with_valid_header() {
+        let dir = temp_dir("live-extract");
+        let partial = dir.join("partial.wav");
+        let samples = (0..32_000)
+            .map(|index| (index % 1_000) as i16)
+            .collect::<Vec<_>>();
+        write_wav(&partial, 1, 16_000, &samples);
+        zero_header_sizes(&partial);
+
+        let output = dir.join("turn.wav");
+        extract_partial_turn_wav(&partial, 500, 1_000, &output).expect("extract turn");
+
+        let mut reader = WavReader::open(&output).expect("turn must have a valid header");
+        assert_eq!(reader.spec().sample_rate, 16_000);
+        let extracted = reader
+            .samples::<i16>()
+            .map(|sample| sample.unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(extracted.len(), 8_000);
+        assert_eq!(extracted[..10], samples[8_000..8_010]);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn extraction_clamps_to_available_audio() {
+        let dir = temp_dir("live-clamp");
+        let partial = dir.join("partial.wav");
+        write_wav(&partial, 1, 16_000, &tone(8_000, 9_000.0));
+        zero_header_sizes(&partial);
+
+        let output = dir.join("turn.wav");
+        extract_partial_turn_wav(&partial, 0, 10_000, &output).expect("extract clamps");
+        let reader = WavReader::open(&output).unwrap();
+        assert_eq!(reader.duration(), 8_000);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn detects_turns_in_partial_audio() {
+        let dir = temp_dir("live-detect");
+        let partial = dir.join("partial.wav");
+        // 1.5s speech, 3s silence, 1.5s speech at 16kHz.
+        let mut samples = tone(24_000, 12_000.0);
+        samples.extend(std::iter::repeat(0).take(48_000));
+        samples.extend(tone(24_000, 12_000.0));
+        write_wav(&partial, 1, 16_000, &samples);
+        zero_header_sizes(&partial);
+
+        let (info, turns) =
+            detect_partial_turns("artifact", "microphone", &partial).expect("detection");
+        assert_eq!(info.duration_ms(), 6_000);
+        assert_eq!(turns.len(), 2, "expected two distinct turns: {turns:?}");
+        assert!(turns[0].start_ms < 500);
+        assert!((1_000..=2_500).contains(&turns[0].end_ms));
+        assert!((4_000..=5_100).contains(&turns[1].start_ms));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rejects_non_wav_files() {
+        let dir = temp_dir("live-reject");
+        let path = dir.join("not-audio.partial.wav");
+        std::fs::write(&path, b"definitely not a riff file").unwrap();
+
+        assert!(read_partial_wav_info(&path).is_err());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
+pub mod live;
 pub mod recovery;
 pub mod system_macos;
 pub mod turns;

--- a/src-tauri/src/audio/turns.rs
+++ b/src-tauri/src/audio/turns.rs
@@ -42,6 +42,16 @@ pub(crate) struct SourceDetectionConfig {
     noise_multiplier: f32,
 }
 
+impl SourceDetectionConfig {
+    /// Same-source turns closer than this are coalesced into one, so two
+    /// distinct final turns of a source are always at least this far apart.
+    /// Transcript-reuse tolerances must stay below it to never admit a row
+    /// that overlaps a neighboring turn's speech.
+    pub(crate) fn merge_gap_ms(&self) -> i64 {
+        self.merge_gap_ms
+    }
+}
+
 pub fn detect_turns(sources: &[DetectionSource]) -> Result<Vec<AudioTurn>, AppError> {
     let mut turns = Vec::new();
     for source in sources {

--- a/src-tauri/src/audio/turns.rs
+++ b/src-tauri/src/audio/turns.rs
@@ -2,7 +2,7 @@ use crate::domain::types::AppError;
 use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
 use std::path::{Path, PathBuf};
 
-const WINDOW_MS: i64 = 30;
+pub(crate) const WINDOW_MS: i64 = 30;
 const TRANSCRIPTION_COHERENCE_GAP_MS: i64 = 2_500;
 const NORMALIZE_TARGET_PEAK: f32 = 0.75;
 const NORMALIZE_MIN_GAIN: f32 = 1.25;
@@ -33,7 +33,7 @@ pub struct AudioTurn {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct SourceDetectionConfig {
+pub(crate) struct SourceDetectionConfig {
     start_active_ms: i64,
     end_silence_ms: i64,
     min_turn_ms: i64,
@@ -308,13 +308,33 @@ fn detect_source_turns(
     config: SourceDetectionConfig,
 ) -> Result<Vec<AudioTurn>, AppError> {
     let windows = read_rms_windows(&source.path)?;
+    Ok(active_intervals_from_windows(&windows, config)
+        .into_iter()
+        .map(|(start_ms, end_ms)| AudioTurn {
+            artifact_id: source.artifact_id.clone(),
+            source: source.source.clone(),
+            source_path: source.path.clone(),
+            start_ms,
+            end_ms,
+            turn_index: 0,
+        })
+        .collect())
+}
+
+/// Detects active speech intervals from a sequence of [`WINDOW_MS`] RMS
+/// windows. Shared between finalized-WAV turn detection and live detection on
+/// in-progress recordings so both produce the same boundaries.
+pub(crate) fn active_intervals_from_windows(
+    windows: &[f32],
+    config: SourceDetectionConfig,
+) -> Vec<(i64, i64)> {
     if windows.is_empty() {
-        return Ok(Vec::new());
+        return Vec::new();
     }
-    let threshold = activity_threshold(&windows, config);
+    let threshold = activity_threshold(windows, config);
     let start_windows = windows_for_ms(config.start_active_ms);
     let silence_windows = windows_for_ms(config.end_silence_ms);
-    let mut turns = Vec::new();
+    let mut intervals = Vec::new();
     let mut active_run = 0_i64;
     let mut silence_run = 0_i64;
     let mut current_start: Option<i64> = None;
@@ -333,9 +353,8 @@ fn detect_source_turns(
                 silence_run += 1;
                 if silence_run >= silence_windows {
                     let end_ms = window_start - ((silence_windows - 1) * WINDOW_MS);
-                    push_turn_if_long_enough(
-                        &mut turns,
-                        source,
+                    push_interval_if_long_enough(
+                        &mut intervals,
                         current_start.take().unwrap(),
                         end_ms,
                         config,
@@ -347,15 +366,14 @@ fn detect_source_turns(
     }
 
     if let Some(start_ms) = current_start {
-        push_turn_if_long_enough(
-            &mut turns,
-            source,
+        push_interval_if_long_enough(
+            &mut intervals,
             start_ms,
             windows.len() as i64 * WINDOW_MS,
             config,
         );
     }
-    Ok(merge_close_turns(turns, config.merge_gap_ms))
+    merge_close_intervals(intervals, config.merge_gap_ms)
 }
 
 fn read_rms_windows(path: &Path) -> Result<Vec<f32>, AppError> {
@@ -368,15 +386,29 @@ fn read_rms_windows(path: &Path) -> Result<Vec<f32>, AppError> {
             "Only 16-bit PCM WAV turn detection is supported.",
         ));
     }
-    let channels = spec.channels.max(1) as usize;
-    let sample_rate = spec.sample_rate.max(1) as usize;
+    Ok(rms_windows_from_samples(
+        reader.samples::<i16>().map(|sample| sample.unwrap_or(0)),
+        spec.channels.max(1) as usize,
+        spec.sample_rate.max(1) as usize,
+    ))
+}
+
+/// Computes [`WINDOW_MS`] RMS windows from interleaved 16-bit samples. Shared
+/// with live detection so partial recordings produce identical windows.
+pub(crate) fn rms_windows_from_samples(
+    samples: impl Iterator<Item = i16>,
+    channels: usize,
+    sample_rate: usize,
+) -> Vec<f32> {
+    let channels = channels.max(1);
+    let sample_rate = sample_rate.max(1);
     let frames_per_window = ((sample_rate as i64 * WINDOW_MS) / 1000).max(1) as usize;
     let mut windows = Vec::new();
     let mut sum_square = 0.0_f64;
     let mut frames = 0_usize;
     let mut channel_index = 0_usize;
-    for sample in reader.samples::<i16>() {
-        let normalized = sample.unwrap_or(0) as f32 / i16::MAX as f32;
+    for sample in samples {
+        let normalized = sample as f32 / i16::MAX as f32;
         sum_square += (normalized as f64).powi(2);
         channel_index += 1;
         if channel_index == channels {
@@ -392,7 +424,7 @@ fn read_rms_windows(path: &Path) -> Result<Vec<f32>, AppError> {
     if frames > 0 {
         windows.push((sum_square / (frames * channels) as f64).sqrt() as f32);
     }
-    Ok(windows)
+    windows
 }
 
 fn activity_threshold(windows: &[f32], config: SourceDetectionConfig) -> f32 {
@@ -405,9 +437,8 @@ fn activity_threshold(windows: &[f32], config: SourceDetectionConfig) -> f32 {
         .max(config.min_rms)
 }
 
-fn push_turn_if_long_enough(
-    turns: &mut Vec<AudioTurn>,
-    source: &DetectionSource,
+fn push_interval_if_long_enough(
+    intervals: &mut Vec<(i64, i64)>,
     start_ms: i64,
     end_ms: i64,
     config: SourceDetectionConfig,
@@ -415,26 +446,19 @@ fn push_turn_if_long_enough(
     if end_ms - start_ms < config.min_turn_ms {
         return;
     }
-    turns.push(AudioTurn {
-        artifact_id: source.artifact_id.clone(),
-        source: source.source.clone(),
-        source_path: source.path.clone(),
-        start_ms: start_ms.max(0),
-        end_ms: end_ms.max(start_ms),
-        turn_index: 0,
-    });
+    intervals.push((start_ms.max(0), end_ms.max(start_ms)));
 }
 
-fn merge_close_turns(turns: Vec<AudioTurn>, merge_gap_ms: i64) -> Vec<AudioTurn> {
-    let mut merged: Vec<AudioTurn> = Vec::new();
-    for turn in turns {
-        if let Some(last) = merged.last_mut() {
-            if turn.start_ms - last.end_ms <= merge_gap_ms {
-                last.end_ms = last.end_ms.max(turn.end_ms);
+fn merge_close_intervals(intervals: Vec<(i64, i64)>, merge_gap_ms: i64) -> Vec<(i64, i64)> {
+    let mut merged: Vec<(i64, i64)> = Vec::new();
+    for (start_ms, end_ms) in intervals {
+        if let Some((_, last_end)) = merged.last_mut() {
+            if start_ms - *last_end <= merge_gap_ms {
+                *last_end = (*last_end).max(end_ms);
                 continue;
             }
         }
-        merged.push(turn);
+        merged.push((start_ms, end_ms));
     }
     merged
 }
@@ -443,7 +467,7 @@ fn windows_for_ms(duration_ms: i64) -> i64 {
     ((duration_ms + WINDOW_MS - 1) / WINDOW_MS).max(1)
 }
 
-fn config_for_source(source: &str) -> SourceDetectionConfig {
+pub(crate) fn config_for_source(source: &str) -> SourceDetectionConfig {
     if source == "system" {
         SourceDetectionConfig {
             start_active_ms: 180,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -617,7 +617,16 @@ pub async fn finish_recording(
 ) -> Result<FinishRecordingResponse, AppError> {
     let repos = repositories(&app).await?;
     let finalization_started = Instant::now();
-    let finished = finish_capture(&request.session_id)?;
+    let finished = match finish_capture(&request.session_id) {
+        Ok(finished) => finished,
+        Err(error) => {
+            // Capture failed to finalize, so finish_recording_session (which
+            // normally stops the live loop) never runs; stop the loop here or
+            // it would keep scanning the abandoned partial files forever.
+            let _ = crate::domain::live_transcription::signal_stop(&request.session_id);
+            return Err(error);
+        }
+    };
     finish_recording_session(&repos, finished, finalization_started).await
 }
 
@@ -1016,6 +1025,9 @@ pub async fn recover_recording(
         ));
     };
     if request.action == "discard" {
+        // Normally a no-op (recovery implies a fresh app start), but never
+        // delete recording files out from under a still-running live loop.
+        crate::domain::live_transcription::stop_and_drain(&request.session_id).await;
         for artifact in repos
             .source_artifact_paths_for_session(&request.session_id)
             .await?

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -555,8 +555,9 @@ pub async fn start_recording(
             started.device_label.clone(),
         )
         .await?;
+    let mut live_sources = Vec::new();
     for source in &started.sources {
-        repos
+        let artifact = repos
             .create_pending_source_artifact(
                 &note.id,
                 &started.session_id,
@@ -565,7 +566,21 @@ pub async fn start_recording(
                 &source.final_path.to_string_lossy(),
             )
             .await?;
+        live_sources.push(crate::domain::live_transcription::LiveSourceInput {
+            artifact_id: artifact.id,
+            source: source.source.as_db().to_string(),
+            partial_path: source.partial_path.clone(),
+        });
     }
+    // Dual-source recordings start transcribing completed turns while the
+    // recording is still running; failures there never affect capture.
+    crate::domain::live_transcription::start_live_transcription(
+        repos.clone(),
+        note.id.clone(),
+        started.session_id.clone(),
+        source_mode,
+        live_sources,
+    );
     Ok(RecordingSessionDto {
         id: started.session_id,
         note_id: note.id,
@@ -619,6 +634,10 @@ async fn finish_recording_session(
     finished: crate::audio::capture::FinishedRecording,
     finalization_started: Instant,
 ) -> Result<FinishRecordingResponse, AppError> {
+    // Stop the live transcription loop now that the partial files are being
+    // finalized; its in-flight work is drained before final processing reads
+    // the session's persisted turn transcripts.
+    let live_handle = crate::domain::live_transcription::signal_stop(&finished.session_id);
     let finalization_ms = finalization_started
         .elapsed()
         .as_millis()
@@ -761,6 +780,11 @@ async fn finish_recording_session(
         .await?;
 
     if valid_sources.is_empty() {
+        if let Some(handle) = live_handle {
+            tokio::spawn(async move {
+                crate::domain::live_transcription::drain(handle).await;
+            });
+        }
         repos
             .set_note_status(
                 &finished.note_id,
@@ -819,6 +843,11 @@ async fn finish_recording_session(
     let task_session_id = finished.session_id.clone();
     let task_source_mode = finished.source_mode;
     tokio::spawn(async move {
+        // Wait for any in-flight live turn transcription to land before the
+        // final pass reads the session's persisted turn transcripts.
+        if let Some(handle) = live_handle {
+            crate::domain::live_transcription::drain(handle).await;
+        }
         let queue_lock = ticket.lock();
         let _guard = queue_lock.lock().await;
         // Now that earlier jobs on this note are done, read the latest note so
@@ -925,6 +954,39 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
 
 fn should_probe_system_audio_permission(system_ready: bool, capture_active: bool) -> bool {
     system_ready && !capture_active
+}
+
+/// Frontend-observed processing checkpoints (e.g. when polling first sees a
+/// terminal status). Whitelisted so arbitrary kinds can't pollute the
+/// development latency timeline.
+const UI_CHECKPOINT_KINDS: [&str; 1] = ["ui_polling_complete"];
+
+#[tauri::command]
+pub async fn record_ui_checkpoint(
+    app: AppHandle,
+    request: crate::domain::types::RecordUiCheckpointRequest,
+) -> Result<(), AppError> {
+    if !UI_CHECKPOINT_KINDS.contains(&request.kind.as_str()) {
+        return Err(AppError::new(
+            "invalid_checkpoint_kind",
+            format!("Unknown UI checkpoint kind: {}", request.kind),
+        ));
+    }
+    repositories(&app)
+        .await?
+        .add_checkpoint(
+            &request.session_id,
+            &request.kind,
+            Some(
+                serde_json::json!({
+                    "durationMs": request.duration_ms,
+                    "status": request.status,
+                })
+                .to_string(),
+            ),
+        )
+        .await?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1652,6 +1652,9 @@ impl Repositories {
             .iter()
             .map(|(source, turn_index)| (source.as_str(), *turn_index))
             .collect();
+        // All-or-nothing: a partially pruned session would let the surviving
+        // provisional rows be re-matched differently on retry.
+        let mut tx = self.pool.begin().await?;
         let mut pruned = 0_u64;
         for row in rows {
             let source: Option<String> = row.get("source");
@@ -1666,10 +1669,11 @@ impl Repositories {
             let id: String = row.get("id");
             sqlx::query("DELETE FROM transcripts WHERE id = ?")
                 .bind(&id)
-                .execute(&self.pool)
+                .execute(&mut *tx)
                 .await?;
             pruned += 1;
         }
+        tx.commit().await?;
         Ok(pruned)
     }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1633,6 +1633,46 @@ impl Repositories {
             .collect())
     }
 
+    /// Deletes a session's turn-transcript rows whose (source, turn_index)
+    /// is not in `keep`. Used after final turn detection to drop provisional
+    /// rows persisted during live transcription that matched no final turn.
+    pub async fn prune_source_turn_transcripts(
+        &self,
+        session_id: &str,
+        keep: &[(String, i64)],
+    ) -> Result<u64, sqlx::Error> {
+        let rows = sqlx::query(
+            "SELECT id, source, turn_index FROM transcripts
+             WHERE recording_session_id = ? AND turn_index IS NOT NULL",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let keep: std::collections::HashSet<(&str, i64)> = keep
+            .iter()
+            .map(|(source, turn_index)| (source.as_str(), *turn_index))
+            .collect();
+        let mut pruned = 0_u64;
+        for row in rows {
+            let source: Option<String> = row.get("source");
+            let turn_index: Option<i64> = row.get("turn_index");
+            let kept = match (source.as_deref(), turn_index) {
+                (Some(source), Some(turn_index)) => keep.contains(&(source, turn_index)),
+                _ => true,
+            };
+            if kept {
+                continue;
+            }
+            let id: String = row.get("id");
+            sqlx::query("DELETE FROM transcripts WHERE id = ?")
+                .bind(&id)
+                .execute(&self.pool)
+                .await?;
+            pruned += 1;
+        }
+        Ok(pruned)
+    }
+
     pub async fn successful_source_turn_transcripts_for_session(
         &self,
         session_id: &str,

--- a/src-tauri/src/domain/live_transcription.rs
+++ b/src-tauri/src/domain/live_transcription.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     audio::{
-        live::detect_partial_turns,
+        live::{detect_partial_turns, RmsWindowCache},
         turns::{coalesce_turns_for_transcription, normalize_wav_for_transcription, AudioTurn},
     },
     db::repositories::Repositories,
@@ -41,6 +41,7 @@ use std::{
 
 /// Set to `0`, `false`, or `off` to disable live transcription.
 const LIVE_TRANSCRIPTION_ENV: &str = "OS_SCRIBE_LIVE_TRANSCRIPTION";
+const LIVE_TEMP_PREFIX: &str = "os-scribe-live";
 const LIVE_TICK_INTERVAL: Duration = Duration::from_secs(15);
 const STOP_POLL_INTERVAL: Duration = Duration::from_millis(250);
 /// A live turn is only transcribed once this much audio exists after it.
@@ -50,6 +51,10 @@ const LIVE_EDGE_PADDING_MS: i64 = 4_000;
 /// Overlap (relative to the shorter interval) above which a detected turn is
 /// considered already attempted in an earlier tick.
 const ATTEMPTED_OVERLAP: f64 = 0.6;
+/// How long [`drain`] waits for a signalled loop to finish its in-flight turn
+/// before aborting it. Final processing re-transcribes whatever the aborted
+/// turn would have produced, so waiting longer only delays the note.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct LiveSourceInput {
@@ -59,6 +64,7 @@ pub struct LiveSourceInput {
 }
 
 pub struct LiveSessionHandle {
+    session_id: String,
     stop: Arc<AtomicBool>,
     task: tokio::task::JoinHandle<()>,
 }
@@ -109,7 +115,20 @@ pub fn start_live_transcription(
     let mut sessions = LIVE_SESSIONS
         .lock()
         .expect("live transcription registry poisoned");
-    sessions.insert(session_id, LiveSessionHandle { stop, task });
+    if let Some(previous) = sessions.insert(
+        session_id.clone(),
+        LiveSessionHandle {
+            session_id,
+            stop,
+            task,
+        },
+    ) {
+        // Should be unreachable (capture is single-instance and session ids
+        // are fresh UUIDs), but never leave a loop without a reachable stop
+        // flag: a dropped handle would detach the task and let it tick
+        // forever.
+        previous.stop.store(true, Ordering::Release);
+    }
 }
 
 /// Signals the session's live loop to stop and removes it from the registry.
@@ -124,9 +143,25 @@ pub fn signal_stop(session_id: &str) -> Option<LiveSessionHandle> {
     Some(handle)
 }
 
-/// Waits for a signalled live loop to finish its in-flight work.
-pub async fn drain(handle: LiveSessionHandle) {
-    let _ = handle.task.await;
+/// Waits for a signalled live loop to finish its in-flight work, aborting it
+/// after [`DRAIN_TIMEOUT`] so one hung provider request can never hold up the
+/// final pass indefinitely. The loop must be fully terminated when this
+/// returns: a still-running task could persist a provisional row *after*
+/// reconciliation pruned the session, leaving a stale row behind.
+pub async fn drain(mut handle: LiveSessionHandle) {
+    if tokio::time::timeout(DRAIN_TIMEOUT, &mut handle.task)
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            session_id = %handle.session_id,
+            "live transcription did not stop in time; aborting it"
+        );
+        handle.task.abort();
+        let _ = handle.task.await;
+        // The aborted loop never reached its own cleanup.
+        let _ = std::fs::remove_dir_all(session_temp_dir(LIVE_TEMP_PREFIX, &handle.session_id));
+    }
 }
 
 pub async fn stop_and_drain(session_id: &str) {
@@ -140,6 +175,9 @@ pub(crate) struct LiveSessionState {
     attempted: Vec<(String, i64, i64)>,
     /// Successful transcripts in completion order, used as rolling context.
     completed: Vec<SourceTranscriptInput>,
+    /// Per-source RMS windows accumulated across ticks, so each tick reads
+    /// only the audio appended since the previous one.
+    rms_caches: HashMap<String, RmsWindowCache>,
     transcribed_turns: usize,
     failed_turns: usize,
 }
@@ -149,6 +187,7 @@ impl LiveSessionState {
         Self {
             attempted: Vec::new(),
             completed: Vec::new(),
+            rms_caches: HashMap::new(),
             transcribed_turns: 0,
             failed_turns: 0,
         }
@@ -193,7 +232,7 @@ async fn run_live_session(
     sources: Vec<LiveSourceInput>,
     stop: Arc<AtomicBool>,
 ) {
-    let temp_dir = session_temp_dir("os-scribe-live", &session_id);
+    let temp_dir = session_temp_dir(LIVE_TEMP_PREFIX, &session_id);
     let _ = std::fs::remove_dir_all(&temp_dir);
     if std::fs::create_dir_all(&temp_dir).is_err() {
         return;
@@ -262,7 +301,7 @@ pub(crate) async fn run_live_tick(
     context: &LiveTickContext,
     state: &mut LiveSessionState,
     transcriber: &TurnTranscriber,
-    stop: &AtomicBool,
+    stop: &Arc<AtomicBool>,
 ) -> Result<(), AppError> {
     let mut detected = Vec::new();
     let mut source_durations: HashMap<String, i64> = HashMap::new();
@@ -270,11 +309,14 @@ pub(crate) async fn run_live_tick(
         let artifact_id = source.artifact_id.clone();
         let source_name = source.source.clone();
         let path = source.partial_path.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            detect_partial_turns(&artifact_id, &source_name, &path)
+        let mut cache = state.rms_caches.remove(&source.source).unwrap_or_default();
+        let (result, cache) = tokio::task::spawn_blocking(move || {
+            let result = detect_partial_turns(&artifact_id, &source_name, &path, &mut cache);
+            (result, cache)
         })
         .await
         .map_err(|error| AppError::new("audio_live_read_failed", error.to_string()))?;
+        state.rms_caches.insert(source.source.clone(), cache);
         match result {
             Ok((info, mut turns)) => {
                 source_durations.insert(source.source.clone(), info.duration_ms());
@@ -311,7 +353,7 @@ pub(crate) async fn run_live_tick(
             continue;
         }
         state.mark_attempted(&turn);
-        transcribe_live_turn(repos, context, state, transcriber, &turn).await;
+        transcribe_live_turn(repos, context, state, transcriber, &turn, stop).await;
     }
     Ok(())
 }
@@ -322,9 +364,10 @@ async fn transcribe_live_turn(
     state: &mut LiveSessionState,
     transcriber: &TurnTranscriber,
     turn: &AudioTurn,
+    stop: &Arc<AtomicBool>,
 ) {
     let started = Instant::now();
-    let result = prepare_and_transcribe_live_turn(context, state, transcriber, turn).await;
+    let result = prepare_and_transcribe_live_turn(context, state, transcriber, turn, stop).await;
     let status = if result.is_ok() {
         "succeeded"
     } else {
@@ -422,6 +465,7 @@ async fn prepare_and_transcribe_live_turn(
     state: &LiveSessionState,
     transcriber: &TurnTranscriber,
     turn: &AudioTurn,
+    stop: &Arc<AtomicBool>,
 ) -> Result<crate::scribe_api::TranscriptionProviderResult, AppError> {
     let segment_path = context.temp_dir.join(format!(
         "live-{}-{}-{}.wav",
@@ -431,9 +475,54 @@ async fn prepare_and_transcribe_live_turn(
         "live-{}-{}-{}-normalized.wav",
         turn.source, turn.start_ms, turn.end_ms
     ));
+    let chunk_stem = format!("live-{}-{}", turn.source, turn.start_ms);
+    let result = transcribe_extracted_live_turn(
+        context,
+        state,
+        transcriber,
+        turn,
+        stop,
+        &segment_path,
+        &normalized_path,
+        &chunk_stem,
+    )
+    .await;
+    // The session temp dir is only removed when the loop ends; clean this
+    // turn's files (on success *and* failure) so they don't pile up over a
+    // long recording.
+    let _ = std::fs::remove_file(&segment_path);
+    let _ = std::fs::remove_file(&normalized_path);
+    remove_turn_chunks(&context.temp_dir.join("chunks"), &chunk_stem);
+    result
+}
+
+/// Removes the split-chunk WAVs a long turn may have produced.
+fn remove_turn_chunks(chunk_dir: &std::path::Path, chunk_stem: &str) {
+    let Ok(entries) = std::fs::read_dir(chunk_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name().to_string_lossy().starts_with(chunk_stem) {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn transcribe_extracted_live_turn(
+    context: &LiveTickContext,
+    state: &LiveSessionState,
+    transcriber: &TurnTranscriber,
+    turn: &AudioTurn,
+    stop: &Arc<AtomicBool>,
+    segment_path: &std::path::Path,
+    normalized_path: &std::path::Path,
+    chunk_stem: &str,
+) -> Result<crate::scribe_api::TranscriptionProviderResult, AppError> {
     let source_path = turn.source_path.clone();
     let (start_ms, end_ms) = (turn.start_ms, turn.end_ms);
-    let extract_segment = segment_path.clone();
+    let extract_segment = segment_path.to_path_buf();
+    let normalize_target = normalized_path.to_path_buf();
     let audio_path = tokio::task::spawn_blocking(move || {
         crate::audio::live::extract_partial_turn_wav(
             &source_path,
@@ -441,7 +530,7 @@ async fn prepare_and_transcribe_live_turn(
             end_ms,
             &extract_segment,
         )?;
-        normalize_wav_for_transcription(&extract_segment, &normalized_path)
+        normalize_wav_for_transcription(&extract_segment, &normalize_target)
     })
     .await
     .map_err(|error| AppError::new("audio_live_read_failed", error.to_string()))??;
@@ -456,7 +545,7 @@ async fn prepare_and_transcribe_live_turn(
             provider: context.provider.clone(),
             audio_path,
             temp_dir: context.temp_dir.clone(),
-            chunk_stem: format!("live-{}-{}", turn.source, turn.start_ms),
+            chunk_stem: chunk_stem.to_string(),
             title: context.title.clone(),
             base_context: base_context.clone(),
             operation_id: format!(
@@ -467,10 +556,10 @@ async fn prepare_and_transcribe_live_turn(
             start_ms: Some(turn.start_ms),
             end_ms: Some(turn.end_ms),
             turn_index: None,
+            stop: Some(Arc::clone(stop)),
         },
     )
     .await?;
-    let _ = std::fs::remove_file(&segment_path);
     Ok(
         maybe_post_process_note_transcript(&context.provider, transcript, base_context.as_deref())
             .await,
@@ -607,7 +696,7 @@ mod tests {
         let (context, mut state) = tick_fixture(&repos, dir.path(), &eligible_turn_samples()).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let transcriber = counting_transcriber(Arc::clone(&calls));
-        let stop = AtomicBool::new(false);
+        let stop = Arc::new(AtomicBool::new(false));
 
         run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
             .await
@@ -651,7 +740,7 @@ mod tests {
         let (context, mut state) = tick_fixture(&repos, dir.path(), &samples).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let transcriber = counting_transcriber(Arc::clone(&calls));
-        let stop = AtomicBool::new(false);
+        let stop = Arc::new(AtomicBool::new(false));
 
         run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
             .await
@@ -682,7 +771,7 @@ mod tests {
                 }) as TranscriptionFuture
             })
         };
-        let stop = AtomicBool::new(false);
+        let stop = Arc::new(AtomicBool::new(false));
 
         run_live_tick(&repos, &context, &mut state, &failing, &stop)
             .await
@@ -711,7 +800,7 @@ mod tests {
         let (context, mut state) = tick_fixture(&repos, dir.path(), &eligible_turn_samples()).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let transcriber = counting_transcriber(Arc::clone(&calls));
-        let stop = AtomicBool::new(true);
+        let stop = Arc::new(AtomicBool::new(true));
 
         run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
             .await

--- a/src-tauri/src/domain/live_transcription.rs
+++ b/src-tauri/src/domain/live_transcription.rs
@@ -1,0 +1,722 @@
+//! Rolling-chunk transcription while a dual-source recording is in progress.
+//!
+//! Every tick, the in-progress source WAVs are scanned with the same turn
+//! detection used after finalization. Turns that ended comfortably before the
+//! live edge are extracted as valid standalone WAVs, transcribed, and
+//! persisted as provisional turn transcripts so most of the transcription work
+//! is already done when the user stops the recording. Final processing then
+//! reuses those transcripts by time-range matching (see
+//! `processing::reuse_persisted_transcript_text`).
+//!
+//! Reliability rules: the saved full WAVs stay the source of truth, every
+//! failure here is logged-and-dropped (the final pass redoes the turn), and
+//! nothing in this module can touch the note's processing status or the
+//! capture path.
+
+use crate::{
+    audio::{
+        live::detect_partial_turns,
+        turns::{coalesce_turns_for_transcription, normalize_wav_for_transcription, AudioTurn},
+    },
+    db::repositories::Repositories,
+    domain::{
+        processing::{
+            build_dictionary_context, build_transcription_context, default_turn_transcriber,
+            elapsed_ms, maybe_post_process_note_transcript, merge_transcription_context,
+            session_temp_dir, transcribe_prepared_audio, SourceTranscriptInput,
+            TranscribePreparedAudioRequest, TurnTranscriber,
+        },
+        types::{AppError, RecordingSourceMode},
+    },
+};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, LazyLock, Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+/// Set to `0`, `false`, or `off` to disable live transcription.
+const LIVE_TRANSCRIPTION_ENV: &str = "OS_SCRIBE_LIVE_TRANSCRIPTION";
+const LIVE_TICK_INTERVAL: Duration = Duration::from_secs(15);
+const STOP_POLL_INTERVAL: Duration = Duration::from_millis(250);
+/// A live turn is only transcribed once this much audio exists after it.
+/// Must exceed the transcription coalesce gap (2.5s) so a turn that already
+/// ended can never later merge with speech that starts after the live edge.
+const LIVE_EDGE_PADDING_MS: i64 = 4_000;
+/// Overlap (relative to the shorter interval) above which a detected turn is
+/// considered already attempted in an earlier tick.
+const ATTEMPTED_OVERLAP: f64 = 0.6;
+
+#[derive(Debug, Clone)]
+pub struct LiveSourceInput {
+    pub artifact_id: String,
+    pub source: String,
+    pub partial_path: PathBuf,
+}
+
+pub struct LiveSessionHandle {
+    stop: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+static LIVE_SESSIONS: LazyLock<Mutex<HashMap<String, LiveSessionHandle>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn live_transcription_enabled() -> bool {
+    match std::env::var(LIVE_TRANSCRIPTION_ENV) {
+        Ok(value) => {
+            let value = value.trim().to_ascii_lowercase();
+            !(value == "0" || value == "false" || value == "off")
+        }
+        Err(_) => true,
+    }
+}
+
+/// Starts the live transcription loop for a dual-source recording session.
+/// No-op for microphone-only recordings (their final processing transcribes
+/// the whole file, so there are no turn transcripts to reuse).
+pub fn start_live_transcription(
+    repos: Repositories,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    sources: Vec<LiveSourceInput>,
+) {
+    if source_mode != RecordingSourceMode::MicrophonePlusSystem || !live_transcription_enabled() {
+        return;
+    }
+    if sources.is_empty() {
+        return;
+    }
+    let stop = Arc::new(AtomicBool::new(false));
+    let task_stop = Arc::clone(&stop);
+    let task_session_id = session_id.clone();
+    let task = tokio::spawn(async move {
+        run_live_session(
+            repos,
+            note_id,
+            task_session_id,
+            source_mode,
+            sources,
+            task_stop,
+        )
+        .await;
+    });
+    let mut sessions = LIVE_SESSIONS
+        .lock()
+        .expect("live transcription registry poisoned");
+    sessions.insert(session_id, LiveSessionHandle { stop, task });
+}
+
+/// Signals the session's live loop to stop and removes it from the registry.
+/// Returns the handle so the caller can [`drain`] it when it needs the loop to
+/// have fully finished (e.g. before final processing).
+pub fn signal_stop(session_id: &str) -> Option<LiveSessionHandle> {
+    let handle = LIVE_SESSIONS
+        .lock()
+        .expect("live transcription registry poisoned")
+        .remove(session_id)?;
+    handle.stop.store(true, Ordering::Release);
+    Some(handle)
+}
+
+/// Waits for a signalled live loop to finish its in-flight work.
+pub async fn drain(handle: LiveSessionHandle) {
+    let _ = handle.task.await;
+}
+
+pub async fn stop_and_drain(session_id: &str) {
+    if let Some(handle) = signal_stop(session_id) {
+        drain(handle).await;
+    }
+}
+
+pub(crate) struct LiveSessionState {
+    /// Turns already attempted (successfully or not), as (source, start, end).
+    attempted: Vec<(String, i64, i64)>,
+    /// Successful transcripts in completion order, used as rolling context.
+    completed: Vec<SourceTranscriptInput>,
+    transcribed_turns: usize,
+    failed_turns: usize,
+}
+
+impl LiveSessionState {
+    pub(crate) fn new() -> Self {
+        Self {
+            attempted: Vec::new(),
+            completed: Vec::new(),
+            transcribed_turns: 0,
+            failed_turns: 0,
+        }
+    }
+
+    fn already_attempted(&self, turn: &AudioTurn) -> bool {
+        self.attempted.iter().any(|(source, start_ms, end_ms)| {
+            if source != &turn.source {
+                return false;
+            }
+            let overlap = turn
+                .end_ms
+                .min(*end_ms)
+                .saturating_sub(turn.start_ms.max(*start_ms)) as f64;
+            let shorter = (turn.end_ms - turn.start_ms).min(end_ms - start_ms).max(1) as f64;
+            overlap / shorter >= ATTEMPTED_OVERLAP
+        })
+    }
+
+    fn mark_attempted(&mut self, turn: &AudioTurn) {
+        self.attempted
+            .push((turn.source.clone(), turn.start_ms, turn.end_ms));
+    }
+}
+
+pub(crate) struct LiveTickContext {
+    pub(crate) note_id: String,
+    pub(crate) session_id: String,
+    pub(crate) source_mode: RecordingSourceMode,
+    pub(crate) title: String,
+    pub(crate) provider: String,
+    pub(crate) dictionary_context: Option<String>,
+    pub(crate) temp_dir: PathBuf,
+    pub(crate) sources: Vec<LiveSourceInput>,
+}
+
+async fn run_live_session(
+    repos: Repositories,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    sources: Vec<LiveSourceInput>,
+    stop: Arc<AtomicBool>,
+) {
+    let temp_dir = session_temp_dir("os-scribe-live", &session_id);
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    if std::fs::create_dir_all(&temp_dir).is_err() {
+        return;
+    }
+    let title = repos
+        .get_note(&note_id)
+        .await
+        .map(|note| note.title)
+        .unwrap_or_default();
+    let dictionary_context = match repos.list_dictionary_entries().await {
+        Ok(entries) => build_dictionary_context(&entries),
+        Err(_) => None,
+    };
+    let context = LiveTickContext {
+        note_id,
+        session_id: session_id.clone(),
+        source_mode,
+        title,
+        provider: crate::providers::configured_transcription_provider(),
+        dictionary_context,
+        temp_dir: temp_dir.clone(),
+        sources,
+    };
+    let transcriber = default_turn_transcriber();
+    let mut state = LiveSessionState::new();
+
+    let mut last_tick = Instant::now();
+    loop {
+        if stop.load(Ordering::Acquire) {
+            break;
+        }
+        if last_tick.elapsed() < LIVE_TICK_INTERVAL {
+            tokio::time::sleep(STOP_POLL_INTERVAL).await;
+            continue;
+        }
+        last_tick = Instant::now();
+        if let Err(error) = run_live_tick(&repos, &context, &mut state, &transcriber, &stop).await {
+            tracing::debug!(
+                %session_id,
+                code = %error.code,
+                message = %error.message,
+                "live transcription tick skipped"
+            );
+        }
+    }
+
+    let _ = repos
+        .add_checkpoint(
+            &session_id,
+            "live_transcription",
+            Some(
+                serde_json::json!({
+                    "turnsTranscribed": state.transcribed_turns,
+                    "turnsFailed": state.failed_turns,
+                })
+                .to_string(),
+            ),
+        )
+        .await;
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+/// One detection + transcription pass over the in-progress source files.
+pub(crate) async fn run_live_tick(
+    repos: &Repositories,
+    context: &LiveTickContext,
+    state: &mut LiveSessionState,
+    transcriber: &TurnTranscriber,
+    stop: &AtomicBool,
+) -> Result<(), AppError> {
+    let mut detected = Vec::new();
+    let mut source_durations: HashMap<String, i64> = HashMap::new();
+    for source in &context.sources {
+        let artifact_id = source.artifact_id.clone();
+        let source_name = source.source.clone();
+        let path = source.partial_path.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            detect_partial_turns(&artifact_id, &source_name, &path)
+        })
+        .await
+        .map_err(|error| AppError::new("audio_live_read_failed", error.to_string()))?;
+        match result {
+            Ok((info, mut turns)) => {
+                source_durations.insert(source.source.clone(), info.duration_ms());
+                detected.append(&mut turns);
+            }
+            Err(error) => {
+                // The partial file may not exist yet (or was just finalized);
+                // skip the source this tick.
+                tracing::debug!(
+                    source = %source.source,
+                    code = %error.code,
+                    "live detection skipped for source"
+                );
+            }
+        }
+    }
+    if detected.is_empty() {
+        return Ok(());
+    }
+
+    let turns = coalesce_turns_for_transcription(detected);
+    for turn in turns {
+        if stop.load(Ordering::Acquire) {
+            break;
+        }
+        let source_duration = source_durations
+            .get(&turn.source)
+            .copied()
+            .unwrap_or_default();
+        if turn.end_ms + LIVE_EDGE_PADDING_MS > source_duration {
+            continue;
+        }
+        if state.already_attempted(&turn) {
+            continue;
+        }
+        state.mark_attempted(&turn);
+        transcribe_live_turn(repos, context, state, transcriber, &turn).await;
+    }
+    Ok(())
+}
+
+async fn transcribe_live_turn(
+    repos: &Repositories,
+    context: &LiveTickContext,
+    state: &mut LiveSessionState,
+    transcriber: &TurnTranscriber,
+    turn: &AudioTurn,
+) {
+    let started = Instant::now();
+    let result = prepare_and_transcribe_live_turn(context, state, transcriber, turn).await;
+    let status = if result.is_ok() {
+        "succeeded"
+    } else {
+        "failed"
+    };
+    let _ = repos
+        .add_source_checkpoint(
+            &context.session_id,
+            Some(&turn.artifact_id),
+            Some(&turn.source),
+            "live_transcription_request",
+            Some(
+                serde_json::json!({
+                    "durationMs": elapsed_ms(started),
+                    "status": status,
+                    "startMs": turn.start_ms,
+                    "endMs": turn.end_ms,
+                })
+                .to_string(),
+            ),
+        )
+        .await;
+    match result {
+        Ok(transcript) => {
+            let text = transcript.text.trim().to_string();
+            if text.is_empty() {
+                state.failed_turns += 1;
+                return;
+            }
+            // Provisional rows are keyed by start time: chronologically
+            // ordered for display, collision-free per source, and replaced by
+            // final-index rows during reconciliation after the recording ends.
+            let provisional_index = turn.start_ms;
+            match repos
+                .upsert_successful_source_turn_transcript(
+                    &context.note_id,
+                    &context.session_id,
+                    &turn.artifact_id,
+                    context.source_mode,
+                    &turn.source,
+                    &text,
+                    transcript.language.clone(),
+                    &transcript.provider,
+                    turn.start_ms,
+                    turn.end_ms,
+                    provisional_index,
+                )
+                .await
+            {
+                Ok(row) => {
+                    tracing::info!(
+                        session_id = %context.session_id,
+                        source = %turn.source,
+                        start_ms = turn.start_ms,
+                        end_ms = turn.end_ms,
+                        transcript_id = %row.id,
+                        "persisted live turn transcript"
+                    );
+                    state.transcribed_turns += 1;
+                    state.completed.push(SourceTranscriptInput {
+                        source: turn.source.clone(),
+                        text,
+                        valid: true,
+                        warning: None,
+                        start_ms: Some(turn.start_ms),
+                        end_ms: Some(turn.end_ms),
+                        turn_index: Some(provisional_index),
+                    });
+                }
+                Err(error) => {
+                    state.failed_turns += 1;
+                    tracing::warn!(
+                        session_id = %context.session_id,
+                        %error,
+                        "could not persist live turn transcript"
+                    );
+                }
+            }
+        }
+        Err(error) => {
+            state.failed_turns += 1;
+            tracing::debug!(
+                session_id = %context.session_id,
+                source = %turn.source,
+                start_ms = turn.start_ms,
+                code = %error.code,
+                "live turn transcription failed; final processing will retry it"
+            );
+        }
+    }
+}
+
+async fn prepare_and_transcribe_live_turn(
+    context: &LiveTickContext,
+    state: &LiveSessionState,
+    transcriber: &TurnTranscriber,
+    turn: &AudioTurn,
+) -> Result<crate::scribe_api::TranscriptionProviderResult, AppError> {
+    let segment_path = context.temp_dir.join(format!(
+        "live-{}-{}-{}.wav",
+        turn.source, turn.start_ms, turn.end_ms
+    ));
+    let normalized_path = context.temp_dir.join(format!(
+        "live-{}-{}-{}-normalized.wav",
+        turn.source, turn.start_ms, turn.end_ms
+    ));
+    let source_path = turn.source_path.clone();
+    let (start_ms, end_ms) = (turn.start_ms, turn.end_ms);
+    let extract_segment = segment_path.clone();
+    let audio_path = tokio::task::spawn_blocking(move || {
+        crate::audio::live::extract_partial_turn_wav(
+            &source_path,
+            start_ms,
+            end_ms,
+            &extract_segment,
+        )?;
+        normalize_wav_for_transcription(&extract_segment, &normalized_path)
+    })
+    .await
+    .map_err(|error| AppError::new("audio_live_read_failed", error.to_string()))??;
+
+    let base_context = merge_transcription_context(
+        context.dictionary_context.as_deref(),
+        build_transcription_context(&state.completed).as_deref(),
+    );
+    let transcript = transcribe_prepared_audio(
+        Arc::clone(transcriber),
+        TranscribePreparedAudioRequest {
+            provider: context.provider.clone(),
+            audio_path,
+            temp_dir: context.temp_dir.clone(),
+            chunk_stem: format!("live-{}-{}", turn.source, turn.start_ms),
+            title: context.title.clone(),
+            base_context: base_context.clone(),
+            operation_id: format!(
+                "{}-{}-live-{}",
+                turn.artifact_id, turn.source, turn.start_ms
+            ),
+            source: turn.source.clone(),
+            start_ms: Some(turn.start_ms),
+            end_ms: Some(turn.end_ms),
+            turn_index: None,
+        },
+    )
+    .await?;
+    let _ = std::fs::remove_file(&segment_path);
+    Ok(
+        maybe_post_process_note_transcript(&context.provider, transcript, base_context.as_deref())
+            .await,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{migrations::run_migrations, repositories::Repositories};
+    use crate::domain::processing::TranscriptionFuture;
+    use crate::scribe_api::{TranscriptionProviderResult, TranscriptionRequest};
+    use hound::{SampleFormat, WavSpec, WavWriter};
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::path::Path;
+    use std::sync::atomic::AtomicUsize;
+
+    async fn test_repositories() -> Repositories {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite should open");
+        run_migrations(&pool).await.expect("migrations should run");
+        Repositories::new(pool)
+    }
+
+    fn write_partial_wav(path: &Path, samples: &[i16]) {
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        for sample in samples {
+            writer.write_sample(*sample).unwrap();
+        }
+        writer.finalize().unwrap();
+        // Simulate an in-progress file: zero out the header sizes the writer
+        // only patches on finalize.
+        let mut bytes = std::fs::read(path).unwrap();
+        bytes[4..8].fill(0);
+        let data_pos = bytes
+            .windows(4)
+            .position(|window| window == b"data")
+            .unwrap();
+        bytes[data_pos + 4..data_pos + 8].fill(0);
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    fn tone(frames: usize) -> Vec<i16> {
+        (0..frames)
+            .map(|index| {
+                let phase = index as f32 / 32.0;
+                ((phase * 2.0 * std::f32::consts::PI).sin() * 12_000.0) as i16
+            })
+            .collect()
+    }
+
+    fn counting_transcriber(counter: Arc<AtomicUsize>) -> TurnTranscriber {
+        Arc::new(move |request: TranscriptionRequest| {
+            let counter = Arc::clone(&counter);
+            Box::pin(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(TranscriptionProviderResult {
+                    text: format!("transcript for {}", request.operation_id()),
+                    language: Some("en".to_string()),
+                    provider: "test".to_string(),
+                }) as Result<TranscriptionProviderResult, AppError>
+            }) as TranscriptionFuture
+        }) as TurnTranscriber
+    }
+
+    async fn tick_fixture(
+        repos: &Repositories,
+        dir: &Path,
+        samples: &[i16],
+    ) -> (LiveTickContext, LiveSessionState) {
+        let note = repos.create_note(None).await.expect("note");
+        let session_id = "live-session".to_string();
+        let partial_path = dir.join("microphone.partial.wav");
+        write_partial_wav(&partial_path, samples);
+        repos
+            .create_recording_session(
+                &note.id,
+                &session_id,
+                RecordingSourceMode::MicrophonePlusSystem,
+                &partial_path.to_string_lossy(),
+                &dir.join("microphone.wav").to_string_lossy(),
+                None,
+            )
+            .await
+            .expect("session");
+        let artifact = repos
+            .create_pending_source_artifact(
+                &note.id,
+                &session_id,
+                "microphone",
+                &partial_path.to_string_lossy(),
+                &dir.join("microphone.wav").to_string_lossy(),
+            )
+            .await
+            .expect("artifact");
+        let context = LiveTickContext {
+            note_id: note.id,
+            session_id,
+            source_mode: RecordingSourceMode::MicrophonePlusSystem,
+            title: "Meeting".to_string(),
+            provider: crate::providers::OPENAI_PROVIDER.to_string(),
+            dictionary_context: None,
+            temp_dir: dir.join("temp"),
+            sources: vec![LiveSourceInput {
+                artifact_id: artifact.id,
+                source: "microphone".to_string(),
+                partial_path,
+            }],
+        };
+        std::fs::create_dir_all(&context.temp_dir).unwrap();
+        (context, LiveSessionState::new())
+    }
+
+    /// 2s speech, 8s silence: one turn ending 8s before the live edge.
+    fn eligible_turn_samples() -> Vec<i16> {
+        let mut samples = tone(32_000);
+        samples.extend(std::iter::repeat(0).take(128_000));
+        samples
+    }
+
+    #[tokio::test]
+    async fn tick_transcribes_eligible_turn_and_persists_provisional_row() {
+        let repos = test_repositories().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (context, mut state) = tick_fixture(&repos, dir.path(), &eligible_turn_samples()).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let transcriber = counting_transcriber(Arc::clone(&calls));
+        let stop = AtomicBool::new(false);
+
+        run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
+            .await
+            .expect("tick");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(state.transcribed_turns, 1);
+        let rows = repos
+            .successful_source_turn_transcripts_for_session(&context.session_id)
+            .await
+            .expect("rows");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.source.as_deref(), Some("microphone"));
+        let start_ms = row.start_ms.expect("start");
+        assert_eq!(
+            row.turn_index,
+            Some(start_ms),
+            "provisional index is the start time"
+        );
+        assert!(row.text.starts_with("transcript for"));
+
+        // Same audio on the next tick: nothing new to transcribe.
+        run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
+            .await
+            .expect("second tick");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "turn must not be re-transcribed"
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_skips_turns_near_the_live_edge() {
+        let repos = test_repositories().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        // 2s speech then only 1s silence: too close to the live edge.
+        let mut samples = tone(32_000);
+        samples.extend(std::iter::repeat(0).take(16_000));
+        let (context, mut state) = tick_fixture(&repos, dir.path(), &samples).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let transcriber = counting_transcriber(Arc::clone(&calls));
+        let stop = AtomicBool::new(false);
+
+        run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
+            .await
+            .expect("tick");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(state.transcribed_turns, 0);
+        let rows = repos
+            .successful_source_turn_transcripts_for_session(&context.session_id)
+            .await
+            .expect("rows");
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_live_turn_is_not_persisted_and_not_retried_live() {
+        let repos = test_repositories().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (context, mut state) = tick_fixture(&repos, dir.path(), &eligible_turn_samples()).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let failing: TurnTranscriber = {
+            let calls = Arc::clone(&calls);
+            Arc::new(move |_request: TranscriptionRequest| {
+                let calls = Arc::clone(&calls);
+                Box::pin(async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Err(AppError::new("transcription_failed", "provider offline"))
+                }) as TranscriptionFuture
+            })
+        };
+        let stop = AtomicBool::new(false);
+
+        run_live_tick(&repos, &context, &mut state, &failing, &stop)
+            .await
+            .expect("tick");
+        run_live_tick(&repos, &context, &mut state, &failing, &stop)
+            .await
+            .expect("second tick");
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "a failed live turn is left for final processing, not hammered"
+        );
+        assert_eq!(state.failed_turns, 1);
+        let rows = repos
+            .successful_source_turn_transcripts_for_session(&context.session_id)
+            .await
+            .expect("rows");
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stop_flag_prevents_new_turn_transcriptions() {
+        let repos = test_repositories().await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (context, mut state) = tick_fixture(&repos, dir.path(), &eligible_turn_samples()).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let transcriber = counting_transcriber(Arc::clone(&calls));
+        let stop = AtomicBool::new(true);
+
+        run_live_tick(&repos, &context, &mut state, &transcriber, &stop)
+            .await
+            .expect("tick");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+}

--- a/src-tauri/src/domain/mod.rs
+++ b/src-tauri/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod live_transcription;
 pub mod processing;
 pub mod processing_queue;
 pub mod types;

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -69,13 +69,25 @@ fn source_transcript_input_from_row(row: &TranscriptDto) -> SourceTranscriptInpu
 /// Tolerances for reusing a transcript persisted during the live recording
 /// (or a previous retry) for a final-detection turn. Live boundaries can
 /// drift slightly from final ones because the dynamic noise floor is computed
-/// over a shorter prefix of the audio.
+/// over a shorter prefix of the audio. Both are clamped per source to the
+/// detection merge gap: two final turns of one source are always at least
+/// that far apart, so a clamped tolerance can never admit a row that overlaps
+/// a neighboring turn's speech.
 const REUSE_START_TOLERANCE_MS: i64 = 1_200;
 const REUSE_END_TOLERANCE_MS: i64 = 1_500;
 /// Persisted rows must cover at least this share of the final turn's range;
 /// anything less means part of the turn was never transcribed, so it is
 /// transcribed fresh from the saved audio.
 const REUSE_MIN_COVERAGE: f64 = 0.8;
+/// ...and regardless of share, they may leave at most this much of the turn
+/// uncovered. The relative threshold alone would let a long turn silently
+/// drop many seconds of speech that no one ever transcribed.
+const REUSE_MAX_UNCOVERED_MS: i64 = 2_000;
+/// A row whose effective start lies this far (or more) behind the join cursor
+/// mostly repeats audio an earlier row already covered; joining its text
+/// would duplicate that speech, so the row is skipped instead (dropping
+/// coverage and, if that matters, falling back to fresh transcription).
+const REUSE_JOIN_MAX_OVERLAP_MS: i64 = 500;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ReusedTranscript {
@@ -110,6 +122,9 @@ pub(crate) fn reuse_persisted_transcript_text(
                 language: row.language.clone(),
             });
     }
+    let merge_gap_ms = crate::audio::turns::config_for_source(source).merge_gap_ms();
+    let start_tolerance = REUSE_START_TOLERANCE_MS.min(merge_gap_ms);
+    let end_tolerance = REUSE_END_TOLERANCE_MS.min(merge_gap_ms);
     let mut candidates = existing
         .iter()
         .filter_map(|row| {
@@ -119,8 +134,8 @@ pub(crate) fn reuse_persisted_transcript_text(
             let row_start = row.start_ms?;
             let row_end = row.end_ms?;
             (row_end > row_start
-                && row_start >= start_ms - REUSE_START_TOLERANCE_MS
-                && row_end <= end_ms + REUSE_END_TOLERANCE_MS)
+                && row_start >= start_ms - start_tolerance
+                && row_end <= end_ms + end_tolerance)
                 .then_some((row_start, row_end, row))
         })
         .collect::<Vec<_>>();
@@ -130,30 +145,36 @@ pub(crate) fn reuse_persisted_transcript_text(
     candidates.sort_by_key(|(row_start, row_end, _)| (*row_start, *row_end));
     let mut covered = 0_i64;
     let mut cursor = start_ms;
-    for (row_start, row_end, _) in &candidates {
-        let overlap_start = (*row_start).max(cursor);
+    let mut language = None;
+    let mut parts: Vec<&str> = Vec::new();
+    for (row_start, row_end, row) in &candidates {
+        let overlap_start = (*row_start).max(start_ms);
         let overlap_end = (*row_end).min(end_ms);
-        if overlap_end > overlap_start {
-            covered += overlap_end - overlap_start;
-            cursor = cursor.max(overlap_end);
+        if overlap_end <= overlap_start || overlap_start + REUSE_JOIN_MAX_OVERLAP_MS <= cursor {
+            // The row adds nothing, or mostly repeats audio already covered
+            // by an earlier row; its text would duplicate that speech.
+            continue;
+        }
+        covered += overlap_end.max(cursor) - overlap_start.max(cursor);
+        cursor = cursor.max(overlap_end);
+        let text = row.text.trim();
+        if !text.is_empty() {
+            parts.push(text);
+        }
+        if language.is_none() {
+            language = row.language.clone();
         }
     }
-    if (covered as f64) < (turn_len as f64) * REUSE_MIN_COVERAGE {
+    if (covered as f64) < (turn_len as f64) * REUSE_MIN_COVERAGE
+        || turn_len - covered > REUSE_MAX_UNCOVERED_MS
+    {
         return None;
     }
-    let text = candidates
-        .iter()
-        .map(|(_, _, row)| row.text.trim())
-        .filter(|text| !text.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let text = parts.join(" ");
     if text.is_empty() {
         return None;
     }
-    Some(ReusedTranscript {
-        text,
-        language: candidates[0].2.language.clone(),
-    })
+    Some(ReusedTranscript { text, language })
 }
 
 pub(crate) fn elapsed_ms(started: Instant) -> i64 {
@@ -370,6 +391,7 @@ pub async fn process_saved_audio(
             start_ms: None,
             end_ms: None,
             turn_index: None,
+            stop: None,
         },
     )
     .await
@@ -959,6 +981,11 @@ pub(crate) struct TranscribePreparedAudioRequest {
     pub(crate) start_ms: Option<i64>,
     pub(crate) end_ms: Option<i64>,
     pub(crate) turn_index: Option<i64>,
+    /// When set (live transcription), checked between chunk requests so a
+    /// stopped recording abandons the remaining chunks instead of holding up
+    /// the final pass; the final pass re-transcribes the turn from the saved
+    /// audio. `None` for final processing, which must always run to the end.
+    pub(crate) stop: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 pub(crate) async fn transcribe_prepared_audio(
@@ -989,6 +1016,16 @@ pub(crate) async fn transcribe_prepared_audio(
     let mut language = None;
     let mut provider_name = request.provider.clone();
     for (index, audio_path) in audio_paths.into_iter().enumerate() {
+        if request
+            .stop
+            .as_ref()
+            .is_some_and(|stop| stop.load(std::sync::atomic::Ordering::Acquire))
+        {
+            return Err(AppError::new(
+                "live_transcription_stopped",
+                "Recording stopped; remaining live chunks are left for final processing.",
+            ));
+        }
         let context = merge_transcription_context(
             request.base_context.as_deref(),
             build_transcription_context(&previous).as_deref(),
@@ -1243,6 +1280,7 @@ async fn transcribe_one_turn_job(
             start_ms: Some(job.start_ms),
             end_ms: Some(job.end_ms),
             turn_index: Some(job.turn_index),
+            stop: None,
         },
     )
     .await
@@ -2124,6 +2162,48 @@ mod tests {
         let reused = reuse_persisted_transcript_text(&existing, "microphone", 1_000, 8_000)
             .expect("covering rows should be joined");
         assert_eq!(reused.text, "First part. second part.");
+    }
+
+    #[test]
+    fn does_not_reuse_when_the_uncovered_span_is_long_even_at_high_relative_coverage() {
+        // 50s of a 60s turn is 83% — above the relative threshold — but the
+        // missing 10s were never transcribed by anyone; reusing would
+        // silently drop that speech from the note.
+        let existing = vec![persisted_row(
+            "microphone",
+            0,
+            50_000,
+            "first fifty seconds",
+        )];
+        assert!(reuse_persisted_transcript_text(&existing, "microphone", 0, 60_000).is_none());
+    }
+
+    #[test]
+    fn does_not_join_rows_that_mostly_repeat_already_covered_audio() {
+        // The second row re-covers the tail of the first (boundary drift
+        // across ticks); joining both texts would duplicate that speech, and
+        // skipping the second row leaves a 3s hole — so no reuse at all.
+        let existing = vec![
+            persisted_row("microphone", 0, 60_000, "long first row."),
+            persisted_row("microphone", 58_000, 63_000, "drifted overlap."),
+        ];
+        assert!(reuse_persisted_transcript_text(&existing, "microphone", 0, 63_000).is_none());
+    }
+
+    #[test]
+    fn start_tolerance_is_clamped_to_the_source_merge_gap() {
+        // Two uncoalesced microphone turns can be as little as ~900ms apart
+        // (the mic merge gap), so a row starting 1s early may contain the
+        // previous turn's tail. The clamped tolerance must reject it for the
+        // microphone source while the wider system gap still admits it.
+        let row = |source: &str| vec![persisted_row(source, 9_000, 15_000, "early start")];
+        assert!(
+            reuse_persisted_transcript_text(&row("microphone"), "microphone", 10_000, 15_000)
+                .is_none()
+        );
+        assert!(
+            reuse_persisted_transcript_text(&row("system"), "system", 10_000, 15_000).is_some()
+        );
     }
 
     #[test]

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -66,15 +66,101 @@ fn source_transcript_input_from_row(row: &TranscriptDto) -> SourceTranscriptInpu
     }
 }
 
-fn turn_cache_key(source: &str, turn_index: i64) -> String {
-    format!("{source}:{turn_index}")
+/// Tolerances for reusing a transcript persisted during the live recording
+/// (or a previous retry) for a final-detection turn. Live boundaries can
+/// drift slightly from final ones because the dynamic noise floor is computed
+/// over a shorter prefix of the audio.
+const REUSE_START_TOLERANCE_MS: i64 = 1_200;
+const REUSE_END_TOLERANCE_MS: i64 = 1_500;
+/// Persisted rows must cover at least this share of the final turn's range;
+/// anything less means part of the turn was never transcribed, so it is
+/// transcribed fresh from the saved audio.
+const REUSE_MIN_COVERAGE: f64 = 0.8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReusedTranscript {
+    pub(crate) text: String,
+    pub(crate) language: Option<String>,
 }
 
-fn elapsed_ms(started: Instant) -> i64 {
+/// Matches already-persisted successful turn transcripts to a final turn by
+/// time range: rows of the same source contained within the turn (with small
+/// boundary tolerances) are joined in chronological order when they cover
+/// enough of the turn. Exact matches (retry of the same audio) are the
+/// trivial single-row case.
+pub(crate) fn reuse_persisted_transcript_text(
+    existing: &[TranscriptDto],
+    source: &str,
+    start_ms: i64,
+    end_ms: i64,
+) -> Option<ReusedTranscript> {
+    let turn_len = end_ms - start_ms;
+    if turn_len <= 0 {
+        // Whole-source fallback turns carry no real range; only a row with
+        // the identical degenerate range can stand in for them.
+        return existing
+            .iter()
+            .find(|row| {
+                row.source.as_deref() == Some(source)
+                    && row.start_ms == Some(start_ms)
+                    && row.end_ms == Some(end_ms)
+            })
+            .map(|row| ReusedTranscript {
+                text: row.text.trim().to_string(),
+                language: row.language.clone(),
+            });
+    }
+    let mut candidates = existing
+        .iter()
+        .filter_map(|row| {
+            if row.source.as_deref() != Some(source) {
+                return None;
+            }
+            let row_start = row.start_ms?;
+            let row_end = row.end_ms?;
+            (row_end > row_start
+                && row_start >= start_ms - REUSE_START_TOLERANCE_MS
+                && row_end <= end_ms + REUSE_END_TOLERANCE_MS)
+                .then_some((row_start, row_end, row))
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return None;
+    }
+    candidates.sort_by_key(|(row_start, row_end, _)| (*row_start, *row_end));
+    let mut covered = 0_i64;
+    let mut cursor = start_ms;
+    for (row_start, row_end, _) in &candidates {
+        let overlap_start = (*row_start).max(cursor);
+        let overlap_end = (*row_end).min(end_ms);
+        if overlap_end > overlap_start {
+            covered += overlap_end - overlap_start;
+            cursor = cursor.max(overlap_end);
+        }
+    }
+    if (covered as f64) < (turn_len as f64) * REUSE_MIN_COVERAGE {
+        return None;
+    }
+    let text = candidates
+        .iter()
+        .map(|(_, _, row)| row.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if text.is_empty() {
+        return None;
+    }
+    Some(ReusedTranscript {
+        text,
+        language: candidates[0].2.language.clone(),
+    })
+}
+
+pub(crate) fn elapsed_ms(started: Instant) -> i64 {
     started.elapsed().as_millis().min(i64::MAX as u128) as i64
 }
 
-fn session_temp_dir(prefix: &str, session_id: &str) -> PathBuf {
+pub(crate) fn session_temp_dir(prefix: &str, session_id: &str) -> PathBuf {
     let safe_session_id = safe_temp_path_segment(session_id);
     std::env::temp_dir().join(format!("{prefix}-{safe_session_id}"))
 }
@@ -438,35 +524,51 @@ pub async fn process_saved_source_audio(
     let existing_transcripts = repos
         .successful_source_turn_transcripts_for_session(session_id)
         .await?;
-    let existing_by_turn = existing_transcripts
-        .into_iter()
-        .filter_map(|transcript| {
-            Some((
-                turn_cache_key(transcript.source.as_deref()?, transcript.turn_index?),
-                transcript,
-            ))
-        })
-        .collect::<HashMap<_, _>>();
+    // Final detection's turn keys; provisional rows persisted during the live
+    // recording that match none of them are pruned after reconciliation.
+    let final_turn_keys = turns
+        .iter()
+        .map(|turn| (turn.source.clone(), turn.turn_index))
+        .collect::<Vec<_>>();
     let mut transcription_jobs = Vec::new();
     let mut cached_candidates = Vec::new();
     for turn in turns {
-        if let Some(existing) = existing_by_turn.get(&turn_cache_key(&turn.source, turn.turn_index))
-        {
+        if let Some(reused) = reuse_persisted_transcript_text(
+            &existing_transcripts,
+            &turn.source,
+            turn.start_ms,
+            turn.end_ms,
+        ) {
+            // Re-persist under the final boundaries and index so live
+            // (provisional) rows and retry caches converge on final
+            // detection for display, assembly, and future reuse.
+            repos
+                .upsert_successful_source_turn_transcript(
+                    note_id,
+                    session_id,
+                    &turn.artifact_id,
+                    source_mode,
+                    &turn.source,
+                    &reused.text,
+                    reused.language.clone(),
+                    &transcription_provider,
+                    turn.start_ms,
+                    turn.end_ms,
+                    turn.turn_index,
+                )
+                .await?;
             cached_candidates.push(TranscriptCandidate {
                 artifact_id: turn.artifact_id,
-                language: existing.language.clone(),
+                language: reused.language,
                 provider: transcription_provider.clone(),
                 input: SourceTranscriptInput {
-                    source: existing
-                        .source
-                        .clone()
-                        .unwrap_or_else(|| turn.source.clone()),
-                    text: existing.text.clone(),
-                    valid: existing.status == "succeeded" && !existing.text.trim().is_empty(),
+                    source: turn.source.clone(),
+                    text: reused.text,
+                    valid: true,
                     warning: None,
-                    start_ms: existing.start_ms.or(Some(turn.start_ms)),
-                    end_ms: existing.end_ms.or(Some(turn.end_ms)),
-                    turn_index: existing.turn_index.or(Some(turn.turn_index)),
+                    start_ms: Some(turn.start_ms),
+                    end_ms: Some(turn.end_ms),
+                    turn_index: Some(turn.turn_index),
                 },
             });
             continue;
@@ -609,6 +711,12 @@ pub async fn process_saved_source_audio(
             )
             .await?;
     }
+
+    // Reconciliation is done: drop provisional live-transcription rows that
+    // matched no final turn so the session's rows mirror final detection.
+    repos
+        .prune_source_turn_transcripts(session_id, &final_turn_keys)
+        .await?;
 
     let persisted_transcripts = repos
         .successful_source_turn_transcripts_for_session(session_id)
@@ -828,31 +936,32 @@ struct TurnTranscriptionJob {
     turn_index: i64,
 }
 
-type TranscriptionFuture =
+pub(crate) type TranscriptionFuture =
     Pin<Box<dyn Future<Output = Result<TranscriptionProviderResult, AppError>> + Send>>;
-type TurnTranscriber = Arc<dyn Fn(TranscriptionRequest) -> TranscriptionFuture + Send + Sync>;
+pub(crate) type TurnTranscriber =
+    Arc<dyn Fn(TranscriptionRequest) -> TranscriptionFuture + Send + Sync>;
 type TurnResultFuture = Pin<Box<dyn Future<Output = Result<(), AppError>> + Send>>;
 type TurnResultSink = Arc<dyn Fn(CompletedTurnTranscription) -> TurnResultFuture + Send + Sync>;
 
-fn default_turn_transcriber() -> TurnTranscriber {
+pub(crate) fn default_turn_transcriber() -> TurnTranscriber {
     Arc::new(|request| Box::pin(transcribe_saved_audio(request)))
 }
 
-struct TranscribePreparedAudioRequest {
-    provider: String,
-    audio_path: PathBuf,
-    temp_dir: PathBuf,
-    chunk_stem: String,
-    title: String,
-    base_context: Option<String>,
-    operation_id: String,
-    source: String,
-    start_ms: Option<i64>,
-    end_ms: Option<i64>,
-    turn_index: Option<i64>,
+pub(crate) struct TranscribePreparedAudioRequest {
+    pub(crate) provider: String,
+    pub(crate) audio_path: PathBuf,
+    pub(crate) temp_dir: PathBuf,
+    pub(crate) chunk_stem: String,
+    pub(crate) title: String,
+    pub(crate) base_context: Option<String>,
+    pub(crate) operation_id: String,
+    pub(crate) source: String,
+    pub(crate) start_ms: Option<i64>,
+    pub(crate) end_ms: Option<i64>,
+    pub(crate) turn_index: Option<i64>,
 }
 
-async fn transcribe_prepared_audio(
+pub(crate) async fn transcribe_prepared_audio(
     transcriber: TurnTranscriber,
     request: TranscribePreparedAudioRequest,
 ) -> Result<TranscriptionProviderResult, AppError> {
@@ -1449,7 +1558,7 @@ fn join_transcript_text(left: &str, right: &str) -> String {
     format!("{left} {right}")
 }
 
-async fn maybe_post_process_note_transcript(
+pub(crate) async fn maybe_post_process_note_transcript(
     provider: &str,
     mut transcript: TranscriptionProviderResult,
     context: Option<&str>,
@@ -1963,6 +2072,89 @@ mod tests {
             covers_full_source: false,
             ..test_job(path, source, turn_index)
         }
+    }
+
+    fn persisted_row(
+        source: &str,
+        start_ms: i64,
+        end_ms: i64,
+        text: &str,
+    ) -> crate::domain::types::TranscriptDto {
+        crate::domain::types::TranscriptDto {
+            id: uuid::Uuid::new_v4().to_string(),
+            text: text.to_string(),
+            source_mode: None,
+            source: Some(source.to_string()),
+            start_ms: Some(start_ms),
+            end_ms: Some(end_ms),
+            turn_index: Some(start_ms),
+            language: Some("en".to_string()),
+            status: "succeeded".to_string(),
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn reuses_exactly_matching_persisted_transcript() {
+        let existing = vec![persisted_row("microphone", 1_000, 5_000, "hello world")];
+        let reused = reuse_persisted_transcript_text(&existing, "microphone", 1_000, 5_000)
+            .expect("exact match should be reused");
+        assert_eq!(reused.text, "hello world");
+        assert_eq!(reused.language.as_deref(), Some("en"));
+    }
+
+    #[test]
+    fn reuses_persisted_transcript_with_small_boundary_drift() {
+        // Live detection ran on a prefix of the audio, so the noise floor —
+        // and with it the boundaries — drifted slightly from final detection.
+        let existing = vec![persisted_row("microphone", 1_400, 4_800, "drifted")];
+        let reused = reuse_persisted_transcript_text(&existing, "microphone", 1_000, 5_000)
+            .expect("drift within tolerance should be reused");
+        assert_eq!(reused.text, "drifted");
+    }
+
+    #[test]
+    fn joins_live_rows_covered_by_a_coalesced_final_turn() {
+        // Final detection coalesced two live turns (gap below the coherence
+        // threshold) into one; their texts are joined in order.
+        let existing = vec![
+            persisted_row("microphone", 6_000, 8_000, "second part."),
+            persisted_row("microphone", 1_000, 5_800, "First part."),
+        ];
+        let reused = reuse_persisted_transcript_text(&existing, "microphone", 1_000, 8_000)
+            .expect("covering rows should be joined");
+        assert_eq!(reused.text, "First part. second part.");
+    }
+
+    #[test]
+    fn does_not_reuse_rows_that_cover_too_little_of_the_turn() {
+        // The live row only saw the first third of the final turn; reusing it
+        // would silently drop the rest of the speech.
+        let existing = vec![persisted_row("microphone", 0, 3_000, "early fragment")];
+        assert!(reuse_persisted_transcript_text(&existing, "microphone", 0, 12_000).is_none());
+    }
+
+    #[test]
+    fn does_not_reuse_rows_from_another_source() {
+        let existing = vec![persisted_row("system", 1_000, 5_000, "system speech")];
+        assert!(reuse_persisted_transcript_text(&existing, "microphone", 1_000, 5_000).is_none());
+    }
+
+    #[test]
+    fn does_not_reuse_rows_extending_outside_the_turn() {
+        // A row reaching well past the turn end belongs to different
+        // boundaries; mixing it in would duplicate text across turns.
+        let existing = vec![persisted_row("microphone", 1_000, 9_000, "overlapping")];
+        assert!(reuse_persisted_transcript_text(&existing, "microphone", 1_000, 5_000).is_none());
+    }
+
+    #[test]
+    fn degenerate_turns_only_match_identical_rows() {
+        let existing = vec![persisted_row("microphone", 0, 0, "full source")];
+        let reused = reuse_persisted_transcript_text(&existing, "microphone", 0, 0)
+            .expect("identical degenerate row matches");
+        assert_eq!(reused.text, "full source");
+        assert!(reuse_persisted_transcript_text(&existing, "microphone", 0, 1_000).is_none());
     }
 
     #[test]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -242,6 +242,16 @@ pub struct FinishRecordingResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RecordUiCheckpointRequest {
+    pub session_id: String,
+    pub kind: String,
+    pub duration_ms: i64,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RetryProcessingRequest {
     pub note_id: String,
     pub step: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ pub fn run() {
             commands::finish_recording,
             commands::retry_processing,
             commands::recover_recording,
+            commands::record_ui_checkpoint,
             dictation::dictation_settings,
             dictation::list_dictation_history,
             dictation::delete_dictation_history_item,

--- a/src-tauri/tests/live_reconciliation.rs
+++ b/src-tauri/tests/live_reconciliation.rs
@@ -1,0 +1,150 @@
+use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
+use os_scribe_lib::domain::types::RecordingSourceMode;
+use sqlx::sqlite::SqlitePoolOptions;
+
+async fn test_repositories() -> Repositories {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite should open");
+    run_migrations(&pool).await.expect("migrations should run");
+    Repositories::new(pool)
+}
+
+struct SessionFixture {
+    repos: Repositories,
+    note_id: String,
+    session_id: String,
+    artifact_id: String,
+}
+
+async fn session_fixture() -> SessionFixture {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note");
+    let session_id = "live-session".to_string();
+    repos
+        .create_recording_session(
+            &note.id,
+            &session_id,
+            RecordingSourceMode::MicrophonePlusSystem,
+            "partial.wav",
+            "final.wav",
+            None,
+        )
+        .await
+        .expect("session");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            &session_id,
+            "microphone",
+            "partial.wav",
+            "final.wav",
+        )
+        .await
+        .expect("artifact");
+    SessionFixture {
+        repos,
+        note_id: note.id,
+        session_id,
+        artifact_id: artifact.id,
+    }
+}
+
+async fn upsert_turn(
+    fixture: &SessionFixture,
+    source: &str,
+    text: &str,
+    start_ms: i64,
+    end_ms: i64,
+    turn_index: i64,
+) {
+    fixture
+        .repos
+        .upsert_successful_source_turn_transcript(
+            &fixture.note_id,
+            &fixture.session_id,
+            &fixture.artifact_id,
+            RecordingSourceMode::MicrophonePlusSystem,
+            source,
+            text,
+            Some("en".to_string()),
+            "test",
+            start_ms,
+            end_ms,
+            turn_index,
+        )
+        .await
+        .expect("upsert turn transcript");
+}
+
+#[tokio::test]
+async fn prune_removes_provisional_rows_that_match_no_final_turn() {
+    let fixture = session_fixture().await;
+    // Two provisional live rows (keyed by start time) and one already-final row.
+    upsert_turn(&fixture, "microphone", "live one", 1_000, 4_000, 1_000).await;
+    upsert_turn(&fixture, "system", "live two", 5_000, 8_000, 5_000).await;
+    upsert_turn(&fixture, "microphone", "final zero", 1_000, 4_000, 0).await;
+
+    let pruned = fixture
+        .repos
+        .prune_source_turn_transcripts(
+            &fixture.session_id,
+            &[("microphone".to_string(), 0), ("system".to_string(), 1)],
+        )
+        .await
+        .expect("prune");
+
+    assert_eq!(pruned, 2, "both provisional rows are removed");
+    let rows = fixture
+        .repos
+        .successful_source_turn_transcripts_for_session(&fixture.session_id)
+        .await
+        .expect("rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].text, "final zero");
+    assert_eq!(rows[0].turn_index, Some(0));
+}
+
+#[tokio::test]
+async fn prune_keeps_all_rows_matching_final_turns() {
+    let fixture = session_fixture().await;
+    upsert_turn(&fixture, "microphone", "turn zero", 0, 2_000, 0).await;
+    upsert_turn(&fixture, "system", "turn one", 2_500, 5_000, 1).await;
+
+    let pruned = fixture
+        .repos
+        .prune_source_turn_transcripts(
+            &fixture.session_id,
+            &[("microphone".to_string(), 0), ("system".to_string(), 1)],
+        )
+        .await
+        .expect("prune");
+
+    assert_eq!(pruned, 0);
+    let rows = fixture
+        .repos
+        .successful_source_turn_transcripts_for_session(&fixture.session_id)
+        .await
+        .expect("rows");
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn reconciliation_upsert_replaces_provisional_row_sharing_the_final_key() {
+    let fixture = session_fixture().await;
+    // A live turn that started at 0ms gets provisional index 0 — the same key
+    // a final turn 0 would use. Reconciliation upserts over it in place.
+    upsert_turn(&fixture, "microphone", "provisional", 0, 2_000, 0).await;
+    upsert_turn(&fixture, "microphone", "reconciled", 0, 2_100, 0).await;
+
+    let rows = fixture
+        .repos
+        .successful_source_turn_transcripts_for_session(&fixture.session_id)
+        .await
+        .expect("rows");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].text, "reconciled");
+    assert_eq!(rows[0].end_ms, Some(2_100));
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -50,6 +50,7 @@ import {
   osAccountsLogout,
   osAccountsTopUp,
   pauseRecording,
+  recordUiCheckpoint,
   removeNoteFromFolder,
   recoverRecording,
   renameFolder,
@@ -798,15 +799,25 @@ export function App() {
       getNote(noteId)
         .then((note) => {
           if (cancelled) return;
-          if (
-            import.meta.env.DEV &&
-            !shouldPollProcessingStatus(note.processingStatus)
-          ) {
-            console.debug("[processing] polling complete", {
-              noteId,
-              status: note.processingStatus,
-              durationMs: Math.round(performance.now() - startedAt),
-            });
+          if (!shouldPollProcessingStatus(note.processingStatus)) {
+            const durationMs = Math.round(performance.now() - startedAt);
+            if (import.meta.env.DEV) {
+              console.debug("[processing] polling complete", {
+                noteId,
+                status: note.processingStatus,
+                durationMs,
+              });
+            }
+            const sessionId = note.recording?.id;
+            if (sessionId) {
+              // Dev-latency checkpoint only; failures are ignored.
+              recordUiCheckpoint(
+                sessionId,
+                "ui_polling_complete",
+                durationMs,
+                note.processingStatus,
+              ).catch(() => {});
+            }
           }
           dispatch({ type: "noteUpdated", note });
         })

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -859,6 +859,18 @@ export async function getNote(noteId: string) {
   return invoke<NoteDto>("get_note", { request: { noteId } });
 }
 
+/** Records a frontend-observed processing checkpoint (dev latency timeline). */
+export async function recordUiCheckpoint(
+  sessionId: string,
+  kind: "ui_polling_complete",
+  durationMs: number,
+  status?: string,
+) {
+  return invoke<void>("record_ui_checkpoint", {
+    request: { sessionId, kind, durationMs, status },
+  });
+}
+
 export async function deleteNote(noteId: string) {
   return invoke<void>("delete_note", { request: { noteId } });
 }

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -137,6 +137,45 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Microphone response")).toBeInTheDocument();
   });
 
+  it("shows partial turn transcripts while the note is still transcribing", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          activeTab: "transcription",
+          processingStatus: "transcribing",
+          generatedContent: undefined,
+          sourceTranscripts: [
+            {
+              id: "turn-1",
+              text: "First turn arrived early",
+              source: "microphone",
+              startMs: 0,
+              endMs: 2000,
+              turnIndex: 0,
+              status: "succeeded",
+            },
+            {
+              id: "turn-2",
+              text: "Second turn while later ones still run",
+              source: "system",
+              startMs: 2500,
+              endMs: 5000,
+              turnIndex: 5000,
+              status: "succeeded",
+            },
+          ],
+        })}
+      />,
+    );
+
+    // Partial rows render before processing finishes, in order.
+    expect(screen.getByText("First turn arrived early")).toBeInTheDocument();
+    expect(
+      screen.getByText("Second turn while later ones still run"),
+    ).toBeInTheDocument();
+  });
+
   it("shows friendly source transcript failure reasons", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
Closes #6

## Context

Phases 1–3 of the issue (latency checkpoints, partial turn persistence shown live in the UI, bounded turn concurrency of 4) already landed in #60. What remained was the substantive Phase 4 — starting transcription **before the recording ends** — plus two small Phase 1/2 gaps (a UI polling completion checkpoint and test coverage for partial rows during processing). This PR implements those.

## How it works

**Live loop (dual-source recordings only).** When a microphone+system recording starts, a per-session background loop ticks every 15s:

1. `audio/live.rs` reads the in-progress `.partial.wav` files — their RIFF headers still hold placeholder sizes, so it walks the chunks and sizes the data section from the bytes actually on disk. RMS windows and interval detection are the *same code paths* as finalized-audio detection (`turns.rs` was refactored to share them), so live and final boundaries agree.
2. Turns from both sources are sorted and coalesced exactly like the final pipeline, then only turns that ended **at least 4s before the live edge** are transcribed. 4s deliberately exceeds the 2.5s transcription coalesce gap: a turn that ended that long ago can never later merge with speech arriving after the edge, which is what guarantees no clipped words at chunk boundaries.
3. Successful transcripts are persisted as provisional rows keyed by start time (chronological, collision-free per source), so the Transcription tab shows them in order while later turns are still running.

**Reconciliation at Done.** `finish_recording` signals the loop synchronously; the background processing task drains it, then final detection runs on the saved full WAVs (still the source of truth). The old exact `(source, turn_index)` transcript cache is replaced by time-range matching: persisted rows contained in a final turn (±1.2s/±1.5s boundary tolerance) are joined in order and reused when they cover ≥80% of it — anything less is re-transcribed from the saved audio. Reused text is re-persisted under final boundaries/indices and unmatched provisional rows are pruned, so the session's stored rows converge on final detection. Retry reuse (identical boundaries) matches exactly, as before.

## Reliability constraints from the issue

- Audio validation is untouched; capture never depends on the provider. Live failures are logged, counted in a `live_transcription` checkpoint, and left for the final pass (no hot-loop retries).
- Saved full audio remains available for retry; successful turn transcripts are never discarded because a later turn fails (failed live turns simply aren't persisted; reconciliation only *replaces* provisional rows with their final-keyed equivalents).
- `Microphone`/`System` labels and chronological ordering preserved; the upsert key + prune prevent duplicate or stale rows.
- Kill switch: `OS_SCRIBE_LIVE_TRANSCRIPTION=0` disables the loop entirely.

## Instrumentation

- Per-turn `live_transcription_request` source checkpoints and a session-level `live_transcription` summary.
- New `ui_polling_complete` checkpoint recorded by the frontend when polling first observes a terminal status (kind whitelist on the command).

## Tests

- `audio/live.rs`: placeholder-header parsing, partial-vs-finalized RMS window equality, segment extraction with valid headers, clamping, detection on partial audio, non-WAV rejection.
- `domain/live_transcription.rs` (fake transcriber + real SQLite): eligible turn transcribed once and persisted provisionally, near-edge turns skipped, failed turns not persisted and not re-hammered, stop flag honored.
- `domain/processing.rs`: reuse matcher — exact, drifted, coalesced-join, insufficient coverage, wrong source, out-of-range, degenerate full-source turns.
- `tests/live_reconciliation.rs`: prune removes only unmatched provisional rows; reconciliation upsert replaces same-key rows.
- Frontend: partial turn rows render while the note is `transcribing`.
- Full gate: `cargo test` (195), `pnpm test` (211), `pnpm lint`, `pnpm build` green; no new clippy warnings; prettier failures on main are pre-existing.

## Notes

- Mic-only recordings keep the existing whole-file pipeline (no turn transcripts to reuse there); scoping live work to dual-source matches the issue's 30-minute dual-source acceptance scenario.
- During the few seconds of reconciliation, the UI can briefly show final-keyed rows alongside not-yet-pruned provisional rows; prune at the end of the pass settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)