### PR TITLE
Reveal mascot card actions on hover and add Hide pet context menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
             if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
                 let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());
             }
+            mascot::handle_menu_event(app, &event);
         })
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap_app,
@@ -127,6 +128,7 @@ pub fn run() {
             mascot::mascot_hide,
             mascot::mascot_set_layout,
             mascot::mascot_open_agent,
+            mascot::mascot_show_context_menu,
             providers::provider_model_settings,
             providers::list_venice_models,
             providers::set_venice_model,

--- a/src-tauri/src/mascot.rs
+++ b/src-tauri/src/mascot.rs
@@ -1,12 +1,23 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::time::Duration;
 use tauri::{
+    menu::{Menu, MenuEvent, MenuItem},
     AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, PhysicalSize, Size, WebviewWindow,
 };
 
 const MASCOT_WINDOW_LABEL: &str = "mascot";
 const MAIN_WINDOW_LABEL: &str = "main";
 const AGENT_OPEN_EVENT: &str = "scribe:agent:open";
+const MASCOT_CURSOR_EVENT: &str = "scribe:mascot:cursor";
+const MASCOT_HIDE_PET_EVENT: &str = "scribe:mascot:hide-pet";
+const MASCOT_HIDE_PET_MENU_ID: &str = "mascot_hide_pet";
+// macOS only delivers mouse-moved events to the key window, so the mascot
+// webview never sees hover until it is clicked. The tracker polls the global
+// cursor instead and streams window-relative positions to the webview, which
+// applies hover styling itself.
+const CURSOR_POLL_INSIDE: Duration = Duration::from_millis(66);
+const CURSOR_POLL_OUTSIDE: Duration = Duration::from_millis(150);
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -19,6 +30,13 @@ pub struct MascotLayoutRequest {
 pub fn setup(app: &mut tauri::App) {
     if let Err(error) = configure_mascot_window(app.handle()) {
         tracing::warn!(%error, "failed to configure desktop mascot");
+    }
+    spawn_cursor_tracker(app.handle().clone());
+}
+
+pub fn handle_menu_event(app: &AppHandle, event: &MenuEvent) {
+    if event.id().as_ref() == MASCOT_HIDE_PET_MENU_ID {
+        let _ = app.emit_to(MASCOT_WINDOW_LABEL, MASCOT_HIDE_PET_EVENT, ());
     }
 }
 
@@ -58,6 +76,23 @@ pub fn mascot_set_layout(app: AppHandle, request: MascotLayoutRequest) -> Result
     let scale = window.scale_factor().map_err(|error| error.to_string())?;
     let size = LogicalSize::new(width, height).to_physical::<u32>(scale);
     position_mascot_window_with_size(&window, size)
+}
+
+#[tauri::command]
+pub fn mascot_show_context_menu(app: AppHandle) -> Result<(), String> {
+    let Some(window) = app.get_webview_window(MASCOT_WINDOW_LABEL) else {
+        return Ok(());
+    };
+    let hide_pet = MenuItem::with_id(
+        &app,
+        MASCOT_HIDE_PET_MENU_ID,
+        "Hide pet",
+        true,
+        None::<&str>,
+    )
+    .map_err(|error| error.to_string())?;
+    let menu = Menu::with_items(&app, &[&hide_pet]).map_err(|error| error.to_string())?;
+    window.popup_menu(&menu).map_err(|error| error.to_string())
 }
 
 #[tauri::command]
@@ -144,6 +179,69 @@ fn position_mascot_window_with_size(
     window
         .set_position(PhysicalPosition::new(x, y))
         .map_err(|error| error.to_string())
+}
+
+#[derive(Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MascotCursorPayload {
+    inside: bool,
+    x: f64,
+    y: f64,
+}
+
+const CURSOR_OUTSIDE: MascotCursorPayload = MascotCursorPayload {
+    inside: false,
+    x: 0.0,
+    y: 0.0,
+};
+
+fn spawn_cursor_tracker(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut last = CURSOR_OUTSIDE;
+        loop {
+            let delay = if last.inside {
+                CURSOR_POLL_INSIDE
+            } else {
+                CURSOR_POLL_OUTSIDE
+            };
+            tokio::time::sleep(delay).await;
+            let next = sample_cursor(&app);
+            if next == last {
+                continue;
+            }
+            last = next;
+            let _ = app.emit_to(MASCOT_WINDOW_LABEL, MASCOT_CURSOR_EVENT, next);
+        }
+    });
+}
+
+fn sample_cursor(app: &AppHandle) -> MascotCursorPayload {
+    let Some(window) = app.get_webview_window(MASCOT_WINDOW_LABEL) else {
+        return CURSOR_OUTSIDE;
+    };
+    if !window.is_visible().unwrap_or(false) {
+        return CURSOR_OUTSIDE;
+    }
+    let (Ok(cursor), Ok(position), Ok(size)) = (
+        app.cursor_position(),
+        window.outer_position(),
+        window.outer_size(),
+    ) else {
+        return CURSOR_OUTSIDE;
+    };
+    let x = cursor.x - position.x as f64;
+    let y = cursor.y - position.y as f64;
+    if x < 0.0 || y < 0.0 || x >= size.width as f64 || y >= size.height as f64 {
+        return CURSOR_OUTSIDE;
+    }
+    let scale = window.scale_factor().unwrap_or(1.0).max(0.1);
+    MascotCursorPayload {
+        inside: true,
+        // Rounded CSS pixels: precise enough for elementFromPoint hit-testing
+        // while letting sub-pixel jitter dedupe against the previous sample.
+        x: (x / scale).round(),
+        y: (y / scale).round(),
+    }
 }
 
 fn show_main_window(app: &AppHandle) {

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { listen } from "@tauri-apps/api/event";
 import { useEffect, useState } from "react";
 import {
   FilesystemPanel,
@@ -71,11 +72,20 @@ export function AgentSettingsSection() {
       MASCOT_VISIBILITY_CHANGED_EVENT,
       handleVisibilityChanged,
     );
+    // Cross-window changes (e.g. "Hide pet" in the mascot's context menu)
+    // arrive as a Tauri event rather than a DOM event on this window.
+    const unlisten = listen<MascotVisibilityChangedDetail>(
+      MASCOT_VISIBILITY_CHANGED_EVENT,
+      (event) => {
+        if (event.payload) setMascotEnabledState(event.payload.enabled);
+      },
+    ).catch(() => undefined);
     return () => {
       window.removeEventListener(
         MASCOT_VISIBILITY_CHANGED_EVENT,
         handleVisibilityChanged,
       );
+      void unlisten.then((fn) => fn?.());
     };
   }, []);
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -672,6 +672,10 @@ export async function mascotOpenAgent(session?: HermesSessionInfo) {
   return invoke<void>("mascot_open_agent", { session });
 }
 
+export async function mascotShowContextMenu() {
+  return invoke<void>("mascot_show_context_menu");
+}
+
 export async function createAgentTask(input: {
   prompt: string;
   title?: string;

--- a/src/mascot.ts
+++ b/src/mascot.ts
@@ -14,6 +14,7 @@ import {
   getMascotEnabled,
   MASCOT_ENABLED_KEY,
   MASCOT_VISIBILITY_CHANGED_EVENT,
+  setMascotEnabled,
   type MascotVisibilityChangedDetail,
 } from "./lib/mascot-settings";
 import {
@@ -21,6 +22,7 @@ import {
   mascotOpenAgent,
   mascotSetLayout,
   mascotShow,
+  mascotShowContextMenu,
 } from "./lib/tauri";
 import type { HermesSessionInfo } from "./lib/tauri";
 import "./styles/mascot.css";
@@ -41,7 +43,19 @@ type MascotEntry = {
 };
 
 const EXPANDED_KEY = "scribe:mascot:expanded";
+// macOS only delivers mouse-moved events to the key window, so CSS :hover is
+// dead in this webview until it is clicked. The Rust side polls the global
+// cursor and streams window-relative positions over this event; hover styling
+// is applied here via the `mascot-card--hover` class instead.
+const MASCOT_CURSOR_EVENT = "scribe:mascot:cursor";
+const MASCOT_HIDE_PET_EVENT = "scribe:mascot:hide-pet";
 const MAX_VISIBLE_CARDS = 3;
+
+type MascotCursorDetail = {
+  inside: boolean;
+  x: number;
+  y: number;
+};
 const COMPLETED_STATUS_TTL_MS = 12 * 1000;
 const FAILED_STATUS_TTL_MS = 8 * 1000;
 
@@ -68,6 +82,17 @@ const state = {
 let lastLayoutKey = "";
 let lastStackKey = "";
 let pruneTimer: number | undefined;
+let lastCursor: MascotCursorDetail | undefined;
+
+function applyCursor(detail?: MascotCursorDetail) {
+  lastCursor = detail;
+  const hovered = detail?.inside
+    ? document.elementFromPoint(detail.x, detail.y)?.closest(".mascot-card")
+    : null;
+  for (const card of document.querySelectorAll(".mascot-card")) {
+    card.classList.toggle("mascot-card--hover", card === hovered);
+  }
+}
 
 function applySessionsChanged(detail?: AgentSessionsChangedDetail) {
   if (!detail) return;
@@ -202,6 +227,9 @@ function render() {
     if (expanded) {
       for (const entry of entries) stack.appendChild(renderCard(entry));
     }
+    // Rebuilding drops the hover class from the previous nodes; restore it
+    // from the last cursor sample instead of waiting for the next poll tick.
+    applyCursor(lastCursor);
   }
   stack.setAttribute("aria-hidden", expanded ? "false" : "true");
   toggle.hidden = !hasEntries;
@@ -668,6 +696,14 @@ avatar?.addEventListener("click", () => {
   void openAgent(entry?.session);
 });
 
+document.addEventListener("contextmenu", (event) => {
+  const target = event.target as HTMLElement | null;
+  // Keep the native menu on the reply input (cut/copy/paste).
+  if (target?.closest(".mascot-reply-input")) return;
+  event.preventDefault();
+  void mascotShowContextMenu().catch(() => {});
+});
+
 window.addEventListener(MASCOT_VISIBILITY_CHANGED_EVENT, (event) => {
   const detail = (event as CustomEvent<MascotVisibilityChangedDetail>).detail;
   if (detail) applyVisibility(detail.enabled);
@@ -701,6 +737,14 @@ void listen<MascotVisibilityChangedDetail>(
   MASCOT_VISIBILITY_CHANGED_EVENT,
   (event) => applyVisibility(event.payload.enabled),
 ).catch(() => {});
+
+void listen<MascotCursorDetail>(MASCOT_CURSOR_EVENT, (event) =>
+  applyCursor(event.payload),
+).catch(() => {});
+
+void listen(MASCOT_HIDE_PET_EVENT, () => setMascotEnabled(false)).catch(
+  () => {},
+);
 
 render();
 applyVisibility(state.enabled);

--- a/src/styles/mascot.css
+++ b/src/styles/mascot.css
@@ -174,7 +174,11 @@ body {
   transition: opacity 120ms var(--ease-out);
 }
 
+/* `mascot-card--hover` mirrors :hover. macOS delivers mouse-moved events only
+   to the key window, so :hover alone stays dead until the mascot is clicked;
+   the Rust cursor tracker drives this class instead (see mascot.ts). */
 .mascot-card:hover .mascot-status,
+.mascot-card--hover .mascot-status,
 .mascot-card:focus-within .mascot-status {
   opacity: 0;
 }
@@ -209,6 +213,7 @@ body {
 }
 
 .mascot-card:hover .mascot-reply,
+.mascot-card--hover .mascot-reply,
 .mascot-card:focus-within .mascot-reply {
   opacity: 1;
   pointer-events: auto;
@@ -298,6 +303,7 @@ body {
 }
 
 .mascot-card:not([data-status="waitingForUser"]):hover .mascot-dismiss,
+.mascot-card--hover:not([data-status="waitingForUser"]) .mascot-dismiss,
 .mascot-card:not([data-status="waitingForUser"]) .mascot-dismiss:focus-visible {
   opacity: 1;
   pointer-events: auto;

--- a/src/test/mascot.test.ts
+++ b/src/test/mascot.test.ts
@@ -185,6 +185,51 @@ describe("desktop mascot", () => {
     expect(stackElement()).toBeEmptyDOMElement();
   });
 
+  it("reveals card actions from tracked cursor positions without a click", async () => {
+    await loadMascot();
+
+    emitStatus({
+      status: "waitingForUser",
+      title: "Need approval",
+      summary: "Review this step.",
+    });
+    await flushPromises();
+
+    const card = document.querySelector<HTMLElement>(".mascot-card");
+    expect(card).toBeTruthy();
+    document.elementFromPoint = vi.fn(() => card);
+
+    emitCursor({ inside: true, x: 40, y: 20 });
+    expect(card?.classList.contains("mascot-card--hover")).toBe(true);
+
+    emitCursor({ inside: false, x: 0, y: 0 });
+    expect(card?.classList.contains("mascot-card--hover")).toBe(false);
+  });
+
+  it("shows the native context menu on right click", async () => {
+    await loadMascot();
+
+    const avatar = document.querySelector<HTMLButtonElement>("#mascot-avatar");
+    const event = new Event("contextmenu", { bubbles: true, cancelable: true });
+    avatar?.dispatchEvent(event);
+    await flushPromises();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.invoke).toHaveBeenCalledWith("mascot_show_context_menu");
+  });
+
+  it("disables and hides the pet when the context menu requests it", async () => {
+    await loadMascot();
+
+    const hide = mocks.listeners.get("scribe:mascot:hide-pet");
+    expect(hide).toBeTruthy();
+    hide?.({ payload: null });
+    await flushPromises();
+
+    expect(localStorage.getItem("scribe:mascot:enabled")).toBe("false");
+    expect(mocks.invoke).toHaveBeenCalledWith("mascot_hide");
+  });
+
   it("opens a compact reply form and requests the taller reply layout", async () => {
     await loadMascot();
 
@@ -217,9 +262,7 @@ function emitStatus(detail: {
   title: string;
   summary: string;
 }) {
-  window.dispatchEvent(
-    new CustomEvent(AGENT_SESSION_STATUS_EVENT, { detail }),
-  );
+  window.dispatchEvent(new CustomEvent(AGENT_SESSION_STATUS_EVENT, { detail }));
 }
 
 function emitSessionsChanged(detail: {
@@ -237,6 +280,12 @@ function emitSessionsChanged(detail: {
   window.dispatchEvent(
     new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, { detail }),
   );
+}
+
+function emitCursor(detail: { inside: boolean; x: number; y: number }) {
+  const listener = mocks.listeners.get("scribe:mascot:cursor");
+  expect(listener).toBeTruthy();
+  listener?.({ payload: detail });
 }
 
 async function flushPromises() {


### PR DESCRIPTION
## Summary
- **Hover-reveal without a click.** The reply and dismiss (x) buttons on the mascot's chat bubbles already had `:hover` CSS, but it never fired until you clicked the bubble: macOS delivers mouse-moved events only to the key window, so the mascot webview (a non-activating panel) is blind to the cursor. A Rust-side tracker now polls the global cursor (`AppHandle::cursor_position()`, 66ms inside / 150ms outside, only while the window is visible) and streams window-relative positions to the mascot webview, which hit-tests cards via `elementFromPoint` and applies a `mascot-card--hover` class that mirrors `:hover`. Hover state is restored after card rebuilds so it doesn't flicker during status bursts.
- **Right-click → Hide pet.** Right-clicking the pet (or a bubble) pops a native context menu with a "Hide pet" item — native because the 72px mascot window can't fit a DOM menu. The menu event routes back to the mascot webview, which calls the existing `setMascotEnabled(false)` path, so the choice persists and the pet hides immediately. The reply input keeps its native cut/copy/paste menu. The agent settings toggle in the main window now also listens for the cross-window Tauri event so it reflects a hide triggered from the pet.

## Test plan
- [x] `pnpm vitest run` — 213 tests pass, including 3 new ones: cursor-driven hover class application/removal, context-menu invoke on right-click, and hide-pet event disabling + hiding the pet
- [x] `cargo check` / `cargo clippy` / `cargo fmt --check` clean
- [ ] Manual: with the app unfocused, hover a chat bubble — Reply and x should appear without clicking; right-click the pet → "Hide pet" → pet hides and the settings toggle flips off

🤖 Generated with [Claude Code](https://claude.com/claude-code)