### PR TITLE
Agent session rows: centered spinner, trailing timestamp, unread dot

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -194,6 +194,18 @@ export function Sidebar({
   const workingAgentSessionIdsRef = useRef<Set<string>>(new Set());
   const openAgentSessionIdRef = useRef<string | undefined>(undefined);
 
+  // formatSessionTime reads the clock at render time, so re-render once a
+  // minute to keep the relative timestamps ("5m", "3h") advancing instead of
+  // waiting for an unrelated session event.
+  const [, bumpTimeClock] = useState(0);
+  useEffect(() => {
+    const interval = window.setInterval(
+      () => bumpTimeClock((tick) => tick + 1),
+      60_000,
+    );
+    return () => window.clearInterval(interval);
+  }, []);
+
   useEffect(() => {
     const openId = activeView === "agent" ? selectedAgentSessionId : undefined;
     openAgentSessionIdRef.current = openId;
@@ -309,13 +321,26 @@ export function Sidebar({
         (id) => !nextWorking.has(id) && !nextWaiting.has(id) && id !== openId,
       );
       workingAgentSessionIdsRef.current = nextWorking;
-      if (finished.length > 0) {
-        setUnreadAgentSessionIds((current) => {
-          const next = new Set(current);
-          for (const id of finished) next.add(id);
-          return next;
-        });
-      }
+      setUnreadAgentSessionIds((current) => {
+        let changed = false;
+        const next = new Set(current);
+        for (const id of finished) {
+          if (!next.has(id)) {
+            next.add(id);
+            changed = true;
+          }
+        }
+        // A session that starts a new turn (or pauses for input) before the
+        // user opened it drops its unread mark — the spinner / needs-you dot
+        // is the fresher signal, and the dot would double-signal beside it.
+        for (const id of Array.from(next)) {
+          if (nextWorking.has(id) || nextWaiting.has(id)) {
+            next.delete(id);
+            changed = true;
+          }
+        }
+        return changed ? next : current;
+      });
       setWorkingAgentSessionIds(nextWorking);
       setWaitingAgentSessionIds(nextWaiting);
     }

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -183,6 +183,29 @@ export function Sidebar({
   const [waitingAgentSessionIds, setWaitingAgentSessionIds] = useState<
     Set<string>
   >(() => new Set());
+  // Sessions that finished a turn while the user wasn't looking — shown as a
+  // terracotta dot in place of the timestamp until the session is opened.
+  const [unreadAgentSessionIds, setUnreadAgentSessionIds] = useState<
+    Set<string>
+  >(() => new Set());
+  // Refs for the mount-once sessions-changed listener: the previous working
+  // set (to spot sessions that just finished) and which session is open in
+  // front of the user (those never go unread).
+  const workingAgentSessionIdsRef = useRef<Set<string>>(new Set());
+  const openAgentSessionIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const openId = activeView === "agent" ? selectedAgentSessionId : undefined;
+    openAgentSessionIdRef.current = openId;
+    if (!openId) return;
+    // Opening a session reads it.
+    setUnreadAgentSessionIds((current) => {
+      if (!current.has(openId)) return current;
+      const next = new Set(current);
+      next.delete(openId);
+      return next;
+    });
+  }, [activeView, selectedAgentSessionId]);
   const filteredNotes = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     if (!normalized) return notes;
@@ -276,8 +299,25 @@ export function Sidebar({
       if (!detail) return;
       setAgentSessions(detail.sessions.slice(0, AGENT_SIDEBAR_SESSION_LIMIT));
       setSelectedAgentSessionId(detail.selectedSessionId);
-      setWorkingAgentSessionIds(new Set(detail.workingSessionIds));
-      setWaitingAgentSessionIds(new Set(detail.waitingSessionIds ?? []));
+      const nextWorking = new Set(detail.workingSessionIds);
+      const nextWaiting = new Set(detail.waitingSessionIds ?? []);
+      // A session that left the working set without pausing for input just
+      // finished a turn — mark it unread unless it's open in front of the
+      // user.
+      const openId = openAgentSessionIdRef.current;
+      const finished = Array.from(workingAgentSessionIdsRef.current).filter(
+        (id) => !nextWorking.has(id) && !nextWaiting.has(id) && id !== openId,
+      );
+      workingAgentSessionIdsRef.current = nextWorking;
+      if (finished.length > 0) {
+        setUnreadAgentSessionIds((current) => {
+          const next = new Set(current);
+          for (const id of finished) next.add(id);
+          return next;
+        });
+      }
+      setWorkingAgentSessionIds(nextWorking);
+      setWaitingAgentSessionIds(nextWaiting);
     }
 
     window.addEventListener(
@@ -328,6 +368,11 @@ export function Sidebar({
         return next;
       });
       setWaitingAgentSessionIds((current) => {
+        const next = new Set(current);
+        next.delete(session.id);
+        return next;
+      });
+      setUnreadAgentSessionIds((current) => {
         const next = new Set(current);
         next.delete(session.id);
         return next;
@@ -467,6 +512,7 @@ export function Sidebar({
                       }
                       working={workingAgentSessionIds.has(session.id)}
                       waiting={waitingAgentSessionIds.has(session.id)}
+                      unread={unreadAgentSessionIds.has(session.id)}
                       deleting={deletingAgentSessionIds.has(session.id)}
                       onSelect={() => {
                         setSelectedAgentSessionId(session.id);
@@ -781,6 +827,7 @@ function AgentSessionRow({
   selected,
   working,
   waiting,
+  unread,
   deleting,
   onSelect,
   onDelete,
@@ -789,6 +836,7 @@ function AgentSessionRow({
   selected: boolean;
   working: boolean;
   waiting: boolean;
+  unread: boolean;
   deleting: boolean;
   onSelect: () => void;
   onDelete: () => void;
@@ -837,6 +885,18 @@ function AgentSessionRow({
             className="agent-sidebar-working"
             data-status="waitingForUser"
             title="Needs you"
+          />
+        </span>
+      ) : unread ? (
+        <span
+          className="agent-session-meta"
+          role="status"
+          aria-label="New reply"
+        >
+          <span
+            className="agent-sidebar-working"
+            data-status="unread"
+            title="New reply"
           />
         </span>
       ) : time ? (

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -795,6 +795,7 @@ function AgentSessionRow({
 }) {
   const title = session.title || session.preview || "Untitled session";
   const status = waiting ? "waitingForUser" : working ? "running" : undefined;
+  const time = formatSessionTime(sessionTimestamp(session));
   return (
     <article
       className="note-row agent-sidebar-row"
@@ -824,16 +825,23 @@ function AgentSessionRow({
         </span>
         <span className="note-row-title">
           <span className="note-row-title-text">{title}</span>
-          {waiting ? (
-            <span
-              className="agent-sidebar-working"
-              data-status="waitingForUser"
-              aria-label="Needs you"
-              title="Needs you"
-            />
-          ) : null}
         </span>
       </div>
+      {waiting ? (
+        <span
+          className="agent-session-meta"
+          role="status"
+          aria-label="Needs you"
+        >
+          <span
+            className="agent-sidebar-working"
+            data-status="waitingForUser"
+            title="Needs you"
+          />
+        </span>
+      ) : time ? (
+        <span className="agent-session-meta agent-session-time">{time}</span>
+      ) : null}
       <button
         type="button"
         className="note-row-menu agent-session-delete"
@@ -850,6 +858,26 @@ function AgentSessionRow({
       </button>
     </article>
   );
+}
+
+// Compact trailing timestamp for agent session rows: "now", "5m", "3h", "2d"
+// while recent, then "May 2". sessionTimestamp falls back to the epoch when a
+// session has no dates at all, which we render as nothing rather than 1970.
+function formatSessionTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime()) || date.getTime() === 0) return "";
+  const diffMs = Date.now() - date.getTime();
+  if (diffMs < 60_000) return "now";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 function NoteContextMenu({

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3007,26 +3007,11 @@ input:focus-visible,
   grid-row: 1;
 }
 
-/* Fade the title's tail instead of ellipsizing so long titles tuck under the
- * timestamp / trash can. The mask only bites when text actually reaches the
- * trailing zone; short titles render untouched. Text must hit fully
- * transparent BEFORE the meta slot ("May 28" right-aligned 8px in ≈ 48px) so
- * overflowing titles never butt against the timestamp. flex: 1 makes the box
- * fill the column — without it the flex item hugs its text and the mask
- * fades the tail of every title, however short. */
-.agent-sidebar-row .note-row-title-text {
-  flex: 1;
-  text-overflow: clip;
-  -webkit-mask-image: linear-gradient(
-    to right,
-    #000 calc(100% - 84px),
-    transparent calc(100% - 40px)
-  );
-  mask-image: linear-gradient(
-    to right,
-    #000 calc(100% - 84px),
-    transparent calc(100% - 40px)
-  );
+/* Titles ellipsize short of the trailing slot so they never collide with the
+ * timestamp / dot ("May 28" right-aligned 8px into the row ≈ 48px; the title
+ * box already ends 12px in, leaving 36px to reserve). */
+.agent-sidebar-row .note-row-title {
+  padding-right: 36px;
 }
 
 /* Running agent sessions show the rolling pangolin; idle rows show nothing.
@@ -3060,7 +3045,7 @@ input:focus-visible,
 }
 
 .agent-session-time {
-  color: var(--muted-foreground);
+  color: color-mix(in oklch, var(--muted-foreground) 65%, transparent);
   font-size: var(--fs-sm);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -3101,6 +3086,12 @@ input:focus-visible,
 .agent-sidebar-working[data-status="waitingForUser"] {
   background: var(--warm-strong);
   box-shadow: 0 0 0 3px color-mix(in oklch, var(--warm-strong) 18%, transparent);
+}
+
+/* Unread variant: a finished turn the user hasn't looked at yet. Plain dot —
+ * the halo stays reserved for "needs you". */
+.agent-sidebar-working[data-status="unread"] {
+  background: var(--warm-strong);
 }
 
 /* A session awaiting your input reads a touch heavier so it stands out in the

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2992,12 +2992,32 @@ input:focus-visible,
   color: var(--destructive);
 }
 
+/* Agent rows drop the reserved menu column: the title spans (nearly) the full
+ * row and fades out under the trailing overlay — a relative timestamp (or the
+ * needs-you dot), swapped for the delete button on hover. */
+.agent-sidebar-row {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .agent-sidebar-row .note-row-main {
   grid-template-rows: auto;
 }
 
 .agent-sidebar-row .note-row-icon {
   grid-row: 1;
+}
+
+/* Fade the title's tail instead of ellipsizing so long titles tuck under the
+ * timestamp / trash can. The mask only bites when text actually reaches the
+ * trailing zone; short titles render untouched. */
+.agent-sidebar-row .note-row-title-text {
+  text-overflow: clip;
+  -webkit-mask-image: linear-gradient(
+    to right,
+    #000 calc(100% - 48px),
+    transparent
+  );
+  mask-image: linear-gradient(to right, #000 calc(100% - 48px), transparent);
 }
 
 /* Running agent sessions show the rolling pangolin; idle rows show nothing.
@@ -3016,8 +3036,51 @@ input:focus-visible,
   line-height: 0;
 }
 
-/* Needs-you dot beside the session title: terracotta, matching the live-status
- * accent used across the agent surfaces. */
+/* Trailing meta on agent rows: the relative timestamp, or the terracotta
+ * needs-you dot when the session is waiting. It sits where the delete button
+ * lands, so the hover swap reads as the trash can covering the date. */
+.agent-session-meta {
+  position: absolute;
+  top: 50%;
+  right: var(--sp-3);
+  translate: 0 -50%;
+  display: inline-flex;
+  align-items: center;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.agent-session-time {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.agent-sidebar-row:hover .agent-session-meta,
+.agent-sidebar-row:has(.agent-session-delete:focus-visible)
+  .agent-session-meta {
+  opacity: 0;
+}
+
+/* The delete button overlays the meta slot rather than holding a grid column
+ * of its own, and reveals on hover only — a selected row keeps showing its
+ * timestamp until pointed at. */
+.agent-sidebar-row .note-row-menu.agent-session-delete {
+  position: absolute;
+  top: 50%;
+  right: var(--sp-1);
+  translate: 0 -50%;
+  opacity: 0;
+}
+
+.agent-sidebar-row:hover .agent-session-delete,
+.agent-sidebar-row .agent-session-delete:focus-visible {
+  opacity: 1;
+}
+
+/* Needs-you dot: terracotta, matching the live-status accent used across the
+ * agent surfaces. */
 .agent-sidebar-working {
   display: inline-block;
   flex: 0 0 auto;
@@ -3038,7 +3101,8 @@ input:focus-visible,
 }
 
 .sidebar[data-collapsed="true"] .note-row-menu,
-.sidebar[data-collapsed="true"] .note-row-title {
+.sidebar[data-collapsed="true"] .note-row-title,
+.sidebar[data-collapsed="true"] .agent-session-meta {
   display: none;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3009,15 +3009,21 @@ input:focus-visible,
 
 /* Fade the title's tail instead of ellipsizing so long titles tuck under the
  * timestamp / trash can. The mask only bites when text actually reaches the
- * trailing zone; short titles render untouched. */
+ * trailing zone; short titles render untouched. Text must hit fully
+ * transparent BEFORE the meta slot ("May 28" right-aligned 8px in ≈ 48px) so
+ * overflowing titles never butt against the timestamp. */
 .agent-sidebar-row .note-row-title-text {
   text-overflow: clip;
   -webkit-mask-image: linear-gradient(
     to right,
-    #000 calc(100% - 48px),
-    transparent
+    #000 calc(100% - 84px),
+    transparent calc(100% - 40px)
   );
-  mask-image: linear-gradient(to right, #000 calc(100% - 48px), transparent);
+  mask-image: linear-gradient(
+    to right,
+    #000 calc(100% - 84px),
+    transparent calc(100% - 40px)
+  );
 }
 
 /* Running agent sessions show the rolling pangolin; idle rows show nothing.

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3045,7 +3045,7 @@ input:focus-visible,
 }
 
 .agent-session-time {
-  color: color-mix(in oklch, var(--muted-foreground) 65%, transparent);
+  color: var(--muted-foreground);
   font-size: var(--fs-sm);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3007,6 +3007,15 @@ input:focus-visible,
   color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
 }
 
+/* The status wrapper is inline by default, so its line box inherits the row's
+ * line-height and the dot-grid lands off-center in the icon cell. Make it a
+ * centering grid so the pangolin sits dead-center like the idle icon. */
+.agent-sidebar-row .note-row-icon > [role="status"] {
+  display: inline-grid;
+  place-items: center;
+  line-height: 0;
+}
+
 /* Needs-you dot beside the session title: terracotta, matching the live-status
  * accent used across the agent surfaces. */
 .agent-sidebar-working {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3011,8 +3011,11 @@ input:focus-visible,
  * timestamp / trash can. The mask only bites when text actually reaches the
  * trailing zone; short titles render untouched. Text must hit fully
  * transparent BEFORE the meta slot ("May 28" right-aligned 8px in ≈ 48px) so
- * overflowing titles never butt against the timestamp. */
+ * overflowing titles never butt against the timestamp. flex: 1 makes the box
+ * fill the column — without it the flex item hugs its text and the mask
+ * fades the tail of every title, however short. */
 .agent-sidebar-row .note-row-title-text {
+  flex: 1;
   text-overflow: clip;
   -webkit-mask-image: linear-gradient(
     to right,


### PR DESCRIPTION
Polishes the agent session rows in the sidebar. The pangolin spinner is now vertically centered in its icon cell, and rows drop the reserved trash-can column so titles span more width before ellipsizing short of the trailing slot. That slot shows a quiet relative timestamp (now/5m/3h/2d/May 2), swapped on hover for the delete button. When a session finishes a turn while not in front of the user, a plain terracotta unread dot replaces the timestamp until the session is opened; sessions waiting on approval/clarification keep the haloed needs-you dot in the same slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)