### PR TITLE
Add Routines view for managing Hermes scheduled automations

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,6 +22,7 @@ import {
 } from "../components/agent/AgentWorkspace";
 import { DictationHistoryView } from "../components/dictation/DictationHistoryView";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
+import { RoutinesView } from "../components/routines/RoutinesView";
 import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDialog";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { NotesList } from "../components/notes-list/NotesList";
@@ -1339,6 +1340,17 @@ export function App() {
                       .getElementById(headingId)
                       ?.scrollIntoView({ behavior: "smooth", block: "start" });
                   }, 80);
+                }}
+              />
+            ) : activeView === "routines" ? (
+              <RoutinesView
+                onCreateRoutine={(prompt) => {
+                  // The agent workspace is unmounted while Routines is shown,
+                  // so the pending marker alone is consumed on mount — no
+                  // window event needed (it could double-submit the session).
+                  markAgentNewSessionPending(prompt);
+                  setActiveAgentSession(undefined);
+                  setActiveView("agent");
                 }}
               />
             ) : activeView === "agent" ? (

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -1,0 +1,376 @@
+import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
+import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
+import { IconArrowsRepeat as IconArrowsRepeatFilled } from "central-icons-filled/IconArrowsRepeat";
+import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { IconPause } from "central-icons/IconPause";
+import { IconPlay } from "central-icons/IconPlay";
+import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { IconTrashCanSimple } from "central-icons/IconTrashCanSimple";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  listRoutines,
+  pauseRoutine,
+  removeRoutine,
+  resumeRoutine,
+  routineCreationPrompt,
+  type RoutineJob,
+} from "../../lib/hermes-routines";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { Dialog } from "../ui/Dialog";
+import { EmptyState } from "../ui/EmptyState";
+
+type RoutinesViewProps = {
+  /** Hands off a composed agent prompt; the app opens a new June session with
+   * it so the agent does the actual cron-job creation. */
+  onCreateRoutine: (prompt: string) => void;
+};
+
+export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
+  const [routines, setRoutines] = useState<RoutineJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
+  const [pendingDelete, setPendingDelete] = useState<RoutineJob | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  const loadRoutines = useCallback(async () => {
+    try {
+      const jobs = await listRoutines();
+      setRoutines(sortRoutines(jobs));
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRoutines();
+  }, [loadRoutines]);
+
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return routines;
+    return routines.filter((routine) =>
+      `${routine.name} ${routine.prompt_preview} ${routine.schedule}`
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [routines, query]);
+
+  function markBusy(jobId: string, busy: boolean) {
+    setBusyIds((current) => {
+      const next = new Set(current);
+      if (busy) next.add(jobId);
+      else next.delete(jobId);
+      return next;
+    });
+  }
+
+  async function togglePaused(routine: RoutineJob) {
+    markBusy(routine.job_id, true);
+    try {
+      if (routine.state === "paused") await resumeRoutine(routine.job_id);
+      else await pauseRoutine(routine.job_id);
+      await loadRoutines();
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      markBusy(routine.job_id, false);
+    }
+  }
+
+  async function confirmDelete() {
+    const routine = pendingDelete;
+    if (!routine) return;
+    // Let errors propagate so ConfirmDialog keeps itself open on failure.
+    await removeRoutine(routine.job_id);
+    setRoutines((prev) =>
+      prev.filter((entry) => entry.job_id !== routine.job_id),
+    );
+  }
+
+  function openCreate() {
+    setDraft("");
+    setCreateOpen(true);
+  }
+
+  function submitCreate() {
+    const description = draft.trim();
+    if (!description) return;
+    setCreateOpen(false);
+    onCreateRoutine(routineCreationPrompt(description));
+  }
+
+  return (
+    <section className="routines-workspace" aria-label="Routines">
+      <header className="folders-header">
+        <div className="folders-heading">
+          <h1>
+            Routines
+            {routines.length > 0 ? (
+              <span className="folders-count">{routines.length}</span>
+            ) : null}
+          </h1>
+          <p className="folders-subtitle">
+            Automations June runs for you on a schedule.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="primary-action primary-solid"
+          onClick={openCreate}
+        >
+          <IconPlusMedium size={13} />
+          New routine
+        </button>
+      </header>
+
+      {routines.length > 0 ? (
+        <div className="folders-controls">
+          <label className="folders-search">
+            <IconMagnifyingGlass size={14} />
+            <input
+              type="search"
+              placeholder="Search"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+            />
+          </label>
+          <button
+            type="button"
+            className="routines-refresh"
+            aria-label="Refresh"
+            onClick={() => void loadRoutines()}
+          >
+            <IconArrowRotateClockwise size={14} />
+          </button>
+        </div>
+      ) : null}
+
+      {error ? <p className="error-banner">{error}</p> : null}
+
+      {loading ? (
+        <div className="folders-empty">
+          <p>Loading routines…</p>
+        </div>
+      ) : routines.length === 0 ? (
+        <EmptyState
+          label="Create your first routine"
+          icon={<IconArrowsRepeatFilled size={28} />}
+          title="Put June on a schedule"
+          description="Describe something June should do every morning, every hour, or at a specific time — a routine runs it for you automatically."
+          footer={
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              onClick={openCreate}
+            >
+              <IconPlusMedium size={13} />
+              New routine
+            </button>
+          }
+        />
+      ) : filtered.length === 0 ? (
+        <div className="folders-empty">
+          <p>No routines match “{query.trim()}”.</p>
+        </div>
+      ) : (
+        <ul className="routines-list" role="list">
+          {filtered.map((routine) => (
+            <RoutineRow
+              key={routine.job_id}
+              routine={routine}
+              busy={busyIds.has(routine.job_id)}
+              onTogglePaused={() => void togglePaused(routine)}
+              onDelete={() => setPendingDelete(routine)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <Dialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        leading={<IconArrowsRepeat size={15} />}
+        title="New routine"
+        description="Tell June what to do and when. It opens a new session to set the routine up — you can fine-tune the schedule there."
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setCreateOpen(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              disabled={!draft.trim()}
+              onClick={submitCreate}
+            >
+              Ask June to set it up
+            </button>
+          </>
+        }
+      >
+        <textarea
+          className="routines-create-input"
+          rows={4}
+          placeholder="Every weekday at 9am, summarize my unread notes…"
+          value={draft}
+          onChange={(event) => setDraft(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              submitCreate();
+            }
+          }}
+        />
+      </Dialog>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={confirmDelete}
+        title={`Delete “${pendingDelete?.name ?? ""}”?`}
+        description="June will stop running this routine. This can’t be undone."
+        confirmLabel="Delete"
+        destructive
+      />
+    </section>
+  );
+}
+
+function RoutineRow({
+  routine,
+  busy,
+  onTogglePaused,
+  onDelete,
+}: {
+  routine: RoutineJob;
+  busy: boolean;
+  onTogglePaused: () => void;
+  onDelete: () => void;
+}) {
+  const paused = routine.state === "paused";
+  const completed = routine.state === "completed";
+  const meta = [
+    routine.schedule,
+    completed
+      ? routine.last_run_at
+        ? `Last ran ${formatRunTime(routine.last_run_at)}`
+        : null
+      : routine.next_run_at
+        ? `Next ${formatRunTime(routine.next_run_at)}`
+        : null,
+  ].filter(Boolean);
+
+  return (
+    <li className="routines-item" data-state={routine.state}>
+      <span className="routines-item-icon" aria-hidden>
+        <IconArrowsRepeat size={14} />
+      </span>
+      <div className="routines-item-body">
+        <span className="routines-item-title">
+          <span className="routines-item-name">{routine.name}</span>
+          {paused ? <span className="routines-item-badge">Paused</span> : null}
+          {completed ? (
+            <span className="routines-item-badge">Completed</span>
+          ) : null}
+          {routine.last_status === "error" ? (
+            <span className="routines-item-badge routines-item-badge-error">
+              Last run failed
+            </span>
+          ) : null}
+        </span>
+        {routine.prompt_preview ? (
+          <p className="routines-item-prompt">{routine.prompt_preview}</p>
+        ) : null}
+      </div>
+      <span className="routines-item-meta">{meta.join(" · ")}</span>
+      <span className="routines-item-actions">
+        {!completed ? (
+          <button
+            type="button"
+            className="dictation-row-act"
+            aria-label={paused ? "Resume" : "Pause"}
+            disabled={busy}
+            onClick={onTogglePaused}
+          >
+            {paused ? <IconPlay size={14} /> : <IconPause size={14} />}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="dictation-row-act dictation-row-act-danger"
+          aria-label="Delete"
+          disabled={busy}
+          onClick={onDelete}
+        >
+          <IconTrashCanSimple size={14} />
+        </button>
+      </span>
+    </li>
+  );
+}
+
+/** Active routines first (soonest run on top), then paused, then completed. */
+function sortRoutines(jobs: RoutineJob[]) {
+  const rank = { scheduled: 0, paused: 1, completed: 2 } as const;
+  return [...jobs].sort((left, right) => {
+    const byState = (rank[left.state] ?? 0) - (rank[right.state] ?? 0);
+    if (byState !== 0) return byState;
+    return timeValue(left.next_run_at) - timeValue(right.next_run_at);
+  });
+}
+
+function timeValue(iso: string | null | undefined) {
+  if (!iso) return Number.MAX_SAFE_INTEGER;
+  const time = new Date(iso).getTime();
+  return Number.isNaN(time) ? Number.MAX_SAFE_INTEGER : time;
+}
+
+function formatRunTime(iso: string) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const now = new Date();
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  if (isSameDate(date, now)) return `today ${time}`;
+  const tomorrow = new Date(now);
+  tomorrow.setDate(now.getDate() + 1);
+  if (isSameDate(date, tomorrow)) return `tomorrow ${time}`;
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (isSameDate(date, yesterday)) return `yesterday ${time}`;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function isSameDate(left: Date, right: Date) {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+function messageFromError(err: unknown) {
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
+  }
+  return "Routines are unavailable. Is June's agent running?";
+}

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -1,6 +1,5 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
-import { IconArrowsRepeat as IconArrowsRepeatFilled } from "central-icons-filled/IconArrowsRepeat";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconPause } from "central-icons/IconPause";
 import { IconPlay } from "central-icons/IconPlay";
@@ -28,6 +27,7 @@ type RoutinesViewProps = {
 export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
   const [routines, setRoutines] = useState<RoutineJob[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
@@ -35,7 +35,11 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [draft, setDraft] = useState("");
 
+  // `loading` gates the whole list and only covers the first fetch;
+  // `refreshing` covers every fetch so reloads keep the list visible while
+  // still signalling progress on the refresh control.
   const loadRoutines = useCallback(async () => {
+    setRefreshing(true);
     try {
       const jobs = await listRoutines();
       setRoutines(sortRoutines(jobs));
@@ -44,6 +48,7 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
       setError(messageFromError(err));
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
   }, []);
 
@@ -75,8 +80,9 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
     try {
       if (routine.state === "paused") await resumeRoutine(routine.job_id);
       else await pauseRoutine(routine.job_id);
+      // loadRoutines manages the error banner itself (clears on success,
+      // sets on failure) — clearing here would mask a failed reload.
       await loadRoutines();
-      setError(null);
     } catch (err) {
       setError(messageFromError(err));
     } finally {
@@ -87,11 +93,17 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
   async function confirmDelete() {
     const routine = pendingDelete;
     if (!routine) return;
-    // Let errors propagate so ConfirmDialog keeps itself open on failure.
-    await removeRoutine(routine.job_id);
-    setRoutines((prev) =>
-      prev.filter((entry) => entry.job_id !== routine.job_id),
-    );
+    // ConfirmDialog swallows a thrown error (it only keeps itself open), so
+    // route failures to the banner like togglePaused does instead.
+    try {
+      await removeRoutine(routine.job_id);
+      setRoutines((prev) =>
+        prev.filter((entry) => entry.job_id !== routine.job_id),
+      );
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    }
   }
 
   function openCreate() {
@@ -145,6 +157,9 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
             type="button"
             className="routines-refresh"
             aria-label="Refresh"
+            aria-busy={refreshing}
+            data-busy={refreshing || undefined}
+            disabled={refreshing}
             onClick={() => void loadRoutines()}
           >
             <IconArrowRotateClockwise size={14} />
@@ -161,7 +176,7 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
       ) : routines.length === 0 ? (
         <EmptyState
           label="Create your first routine"
-          icon={<IconArrowsRepeatFilled size={28} />}
+          icon={<IconArrowsRepeat size={28} />}
           title="Put June on a schedule"
           description="Describe something June should do every morning, every hour, or at a specific time — a routine runs it for you automatically."
           footer={

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { IconArrowBoxRight } from "central-icons/IconArrowBoxRight";
+import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
 import { IconAudio } from "central-icons/IconAudio";
 import { IconBrain2 } from "central-icons/IconBrain2";
@@ -58,6 +59,7 @@ export type SidebarView =
   | "settings"
   | "folders"
   | "dictation"
+  | "routines"
   | "agent";
 
 type SidebarProps = {
@@ -437,6 +439,18 @@ export function Sidebar({
                 <IconMicrophone size={16} />
               </span>
               <span className="sidebar-nav-label">Dictation</span>
+            </button>
+            <button
+              type="button"
+              className="sidebar-nav-item"
+              data-active={activeView === "routines"}
+              aria-current={activeView === "routines" ? "page" : undefined}
+              onClick={() => onChangeView("routines")}
+            >
+              <span className="sidebar-nav-icon">
+                <IconArrowsRepeat size={16} />
+              </span>
+              <span className="sidebar-nav-label">Routines</span>
             </button>
           </nav>
 

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -70,7 +70,10 @@ export async function listRoutines(): Promise<RoutineJob[]> {
   return response.jobs ?? [];
 }
 
-/** The gateway's `cron.manage` reads the job reference from `name`. */
+/** The gateway's `cron.manage` reads the job reference from the wire param
+ * `name` and resolves it as ID-or-name with exact ID match winning (Hermes
+ * `resolve_job_ref`). Send the unique `job_id`, never the display name — two
+ * routines can share a name, which Hermes rejects as ambiguous. */
 export function pauseRoutine(jobId: string) {
   return manageRoutines({ action: "pause", name: jobId });
 }

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -1,0 +1,94 @@
+import { HermesGatewayClient } from "./hermes-gateway";
+import { hermesBridgeStatus, startHermesBridge } from "./tauri";
+
+/** A Hermes cron job as returned by the gateway's `cron.manage` method
+ * (Hermes formats jobs via `_format_job`, so field names are snake_case). */
+export type RoutineJob = {
+  job_id: string;
+  name: string;
+  prompt_preview: string;
+  schedule: string;
+  repeat: string;
+  deliver: string;
+  next_run_at: string | null;
+  last_run_at: string | null;
+  last_status: "ok" | "error" | null;
+  last_delivery_error?: string | null;
+  enabled: boolean;
+  state: "scheduled" | "paused" | "completed";
+  paused_at?: string | null;
+  paused_reason?: string | null;
+};
+
+type CronManageResponse = {
+  success?: boolean;
+  error?: string;
+  count?: number;
+  jobs?: RoutineJob[];
+  job?: RoutineJob;
+};
+
+// One gateway socket for the Routines view, lazily connected and reused across
+// calls. AgentWorkspace keeps its own client; sharing would couple this view's
+// lifecycle to the agent chat's reconnect logic for no benefit — the gateway
+// accepts multiple sockets.
+let client: HermesGatewayClient | undefined;
+
+async function gatewayRequest<T>(
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const status = await hermesBridgeStatus();
+  const bridge = status.running ? status : await startHermesBridge();
+  const wsUrl = bridge.connection?.wsUrl;
+  if (!wsUrl) throw new Error("Hermes did not return a gateway URL.");
+  if (!client) client = new HermesGatewayClient();
+  await client.connect(wsUrl);
+  return client.request<T>(method, params);
+}
+
+// Hermes reports cron tool failures two ways: a JSON-RPC error (the request
+// rejects) or an `{ success: false, error }` payload passed through from the
+// cronjob tool. Normalize the latter into a throw so callers handle one shape.
+async function manageRoutines(
+  params: Record<string, unknown>,
+): Promise<CronManageResponse> {
+  const response = await gatewayRequest<CronManageResponse | undefined>(
+    "cron.manage",
+    params,
+  );
+  if (response?.success === false) {
+    throw new Error(
+      response.error || "Hermes could not complete the routine action.",
+    );
+  }
+  return response ?? {};
+}
+
+export async function listRoutines(): Promise<RoutineJob[]> {
+  const response = await manageRoutines({ action: "list" });
+  return response.jobs ?? [];
+}
+
+/** The gateway's `cron.manage` reads the job reference from `name`. */
+export function pauseRoutine(jobId: string) {
+  return manageRoutines({ action: "pause", name: jobId });
+}
+
+export function resumeRoutine(jobId: string) {
+  return manageRoutines({ action: "resume", name: jobId });
+}
+
+export function removeRoutine(jobId: string) {
+  return manageRoutines({ action: "remove", name: jobId });
+}
+
+/** Builds the agent prompt for "create a routine": June owns naming and
+ * scheduling via its cronjob tool, so the user only describes the outcome. */
+export function routineCreationPrompt(description: string) {
+  return [
+    "Set up a new routine (a scheduled cron job) for me using your cronjob tool.",
+    `Here is what it should do: ${description.trim()}`,
+    "Pick a short descriptive name and an appropriate schedule (ask me if the timing is unclear), create the job, then confirm what you created and when it will first run.",
+  ].join("\n\n");
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5883,6 +5883,192 @@ input:focus-visible,
   margin-bottom: var(--sp-3);
 }
 
+/* Routines — Hermes scheduled automations. Shares the Dictation page chrome
+ * (.folders-* header/search) and the dictation row action buttons. */
+.routines-workspace {
+  width: 100%;
+  max-width: var(--content-max);
+  margin: 0 auto;
+  padding: var(--sp-10) 0 var(--sp-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+}
+
+.routines-workspace .folders-controls {
+  margin-top: var(--sp-2);
+  margin-bottom: var(--sp-3);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.routines-refresh {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.routines-refresh:hover {
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--foreground);
+}
+
+.routines-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.routines-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--sp-3);
+  margin: 0 calc(-1 * var(--sp-4));
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--r-md);
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.routines-item:hover,
+.routines-item:focus-within {
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.routines-item-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+}
+
+.routines-item[data-state="paused"] .routines-item-name,
+.routines-item[data-state="completed"] .routines-item-name {
+  color: var(--muted-foreground);
+}
+
+.routines-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.routines-item-title {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.routines-item-name {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: 500;
+  line-height: 1.45;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.routines-item-badge {
+  flex-shrink: 0;
+  padding: 1px var(--sp-2);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+}
+
+.routines-item-badge-error {
+  background: color-mix(in oklch, var(--destructive) 14%, transparent);
+  color: var(--destructive);
+}
+
+.routines-item-prompt {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+.routines-item-meta {
+  padding-top: 3px;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  white-space: nowrap;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.routines-item:hover .routines-item-meta,
+.routines-item:focus-within .routines-item-meta {
+  opacity: 0;
+}
+
+.routines-item-actions {
+  position: absolute;
+  z-index: 2;
+  top: var(--sp-3);
+  right: var(--sp-4);
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  min-height: 28px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.routines-item:hover .routines-item-actions,
+.routines-item:focus-within .routines-item-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.routines-create-input {
+  width: 100%;
+  min-height: 96px;
+  padding: var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--fs-md);
+  line-height: 1.45;
+  resize: vertical;
+}
+
+.routines-create-input:focus {
+  outline: none;
+  border-color: var(--ring);
+}
+
 .folders-header {
   display: flex;
   align-items: flex-start;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5924,6 +5924,16 @@ input:focus-visible,
   color: var(--foreground);
 }
 
+.routines-refresh[data-busy] svg {
+  animation: spinner-spin 0.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .routines-refresh[data-busy] svg {
+    animation: none;
+  }
+}
+
 .routines-list {
   display: flex;
   flex-direction: column;

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RoutinesView } from "../components/routines/RoutinesView";
+import type { RoutineJob } from "../lib/hermes-routines";
+
+const mocks = vi.hoisted(() => ({
+  listRoutines: vi.fn<() => Promise<RoutineJob[]>>(),
+  pauseRoutine: vi.fn(),
+  resumeRoutine: vi.fn(),
+  removeRoutine: vi.fn(),
+}));
+
+vi.mock("../lib/hermes-routines", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/hermes-routines")>()),
+  ...mocks,
+}));
+
+function job(overrides: Partial<RoutineJob> = {}): RoutineJob {
+  return {
+    job_id: "abc123",
+    name: "Morning summary",
+    prompt_preview: "Summarize my unread notes",
+    schedule: "every day at 9:00",
+    repeat: "forever",
+    deliver: "local",
+    next_run_at: "2026-06-10T09:00:00",
+    last_run_at: null,
+    last_status: null,
+    enabled: true,
+    state: "scheduled",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.pauseRoutine.mockResolvedValue({ success: true });
+  mocks.resumeRoutine.mockResolvedValue({ success: true });
+  mocks.removeRoutine.mockResolvedValue({ success: true });
+});
+
+describe("RoutinesView", () => {
+  it("lists routines with schedule and state", async () => {
+    mocks.listRoutines.mockResolvedValue([
+      job(),
+      job({
+        job_id: "def456",
+        name: "Weekly digest",
+        prompt_preview: "Compile a digest of the week",
+        state: "paused",
+        last_status: "error",
+      }),
+    ]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+
+    expect(await screen.findByText("Morning summary")).toBeInTheDocument();
+    expect(screen.getByText("Weekly digest")).toBeInTheDocument();
+    expect(screen.getByText("Paused")).toBeInTheDocument();
+    expect(screen.getByText("Last run failed")).toBeInTheDocument();
+    expect(screen.getByText("Summarize my unread notes")).toBeInTheDocument();
+  });
+
+  it("shows the empty state and routes creation through the agent prompt", async () => {
+    mocks.listRoutines.mockResolvedValue([]);
+    const onCreateRoutine = vi.fn();
+    render(<RoutinesView onCreateRoutine={onCreateRoutine} />);
+
+    expect(await screen.findByText("Put June on a schedule")).toBeVisible();
+    await userEvent.click(
+      screen.getAllByRole("button", { name: /new routine/i })[0],
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.type(
+      within(dialog).getByRole("textbox"),
+      "every morning, email me a digest",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Ask June to set it up" }),
+    );
+
+    expect(onCreateRoutine).toHaveBeenCalledTimes(1);
+    const prompt = onCreateRoutine.mock.calls[0][0] as string;
+    expect(prompt).toContain("every morning, email me a digest");
+    expect(prompt).toContain("cronjob tool");
+  });
+
+  it("pauses a scheduled routine and reloads the list", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    await screen.findByText("Morning summary");
+
+    mocks.listRoutines.mockResolvedValue([job({ state: "paused" })]);
+    await userEvent.click(screen.getByRole("button", { name: "Pause" }));
+
+    await waitFor(() =>
+      expect(mocks.pauseRoutine).toHaveBeenCalledWith("abc123"),
+    );
+    expect(await screen.findByText("Paused")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument();
+  });
+
+  it("resumes a paused routine", async () => {
+    mocks.listRoutines.mockResolvedValue([job({ state: "paused" })]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    await screen.findByText("Morning summary");
+
+    await userEvent.click(screen.getByRole("button", { name: "Resume" }));
+    await waitFor(() =>
+      expect(mocks.resumeRoutine).toHaveBeenCalledWith("abc123"),
+    );
+  });
+
+  it("deletes a routine after confirmation", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    await screen.findByText("Morning summary");
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.removeRoutine).toHaveBeenCalledWith("abc123"),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Morning summary")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces a load error", async () => {
+    mocks.listRoutines.mockRejectedValue(new Error("gateway down"));
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    expect(await screen.findByText("gateway down")).toBeInTheDocument();
+  });
+});

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -131,6 +131,34 @@ describe("RoutinesView", () => {
     );
   });
 
+  it("surfaces a failed reload after a successful pause", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    await screen.findByText("Morning summary");
+
+    mocks.listRoutines.mockRejectedValue(new Error("reload failed"));
+    await userEvent.click(screen.getByRole("button", { name: "Pause" }));
+
+    expect(await screen.findByText("reload failed")).toBeInTheDocument();
+  });
+
+  it("surfaces a failed delete in the error banner", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    mocks.removeRoutine.mockRejectedValue(new Error("remove failed"));
+    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    await screen.findByText("Morning summary");
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Delete" }),
+    );
+
+    expect(await screen.findByText("remove failed")).toBeInTheDocument();
+    // The routine stays listed — only a successful delete removes the row.
+    expect(screen.getByText("Morning summary")).toBeInTheDocument();
+  });
+
   it("surfaces a load error", async () => {
     mocks.listRoutines.mockRejectedValue(new Error("gateway down"));
     render(<RoutinesView onCreateRoutine={vi.fn()} />);


### PR DESCRIPTION
## Summary

Adds a **Routines** view — a home for all of June's Hermes automations (cron jobs), reachable from the sidebar directly under Dictation.

- **List & manage**: fetches jobs over the Hermes gateway (`cron.manage` → list) and shows each routine's name, prompt preview, schedule, next/last run, and state. Rows support pause/resume and delete (with confirmation), plus search and refresh. Active routines sort first by soonest run, then paused, then completed.
- **Create via the agent**: "New routine" opens a small dialog where the user describes what June should do and when. Submitting composes a prompt (`routineCreationPrompt`) and opens a fresh agent session via the existing pending-new-session mechanism, so June itself creates the job with its `cronjob` tool — no bespoke schedule-builder UI.
- **Plumbing**: new `src/lib/hermes-routines.ts` adapter keeps its own lazily-connected gateway socket (starting the bridge if needed) and normalizes both Hermes error shapes (JSON-RPC errors and `{ success: false, error }` tool payloads) into throws.

The view reuses the Dictation page chrome (`.folders-*` header/search, `.dictation-row-act` hover actions) and follows the sentence-case label convention.

## Notes for review

- From the Routines view the Agent workspace is always unmounted, so creation relies on the pending marker alone (consumed on mount) rather than also dispatching `AGENT_NEW_SESSION_EVENT` — dispatching both could double-submit the session.
- The gateway's `cron.manage` only exposes list/add/pause/resume/remove; editing an existing routine's schedule goes through the agent instead.

## Testing

- `pnpm test` — 216 tests pass, including 6 new RoutinesView tests (list render, empty-state → create prompt flow, pause/resume, delete confirmation, load error).
- `pnpm lint` (tsc) and `pnpm build` pass; changed files are Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)