### PR TITLE
Composer polish: smooth expansion, attachment chip fit, working drag-and-drop

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -761,6 +761,80 @@ pub async fn import_hermes_bridge_file(
     })
 }
 
+/// Imports a dropped file from its raw bytes. DOM drops in WKWebView never
+/// expose a filesystem path (and Tauri's own drag-drop interception is
+/// disabled so notes can use HTML5 drag), so the frontend reads the dropped
+/// blob and sends its contents as the raw invoke payload, with the filename
+/// in a header.
+#[tauri::command]
+pub fn import_hermes_bridge_file_bytes(
+    app: AppHandle,
+    request: tauri::ipc::Request<'_>,
+) -> Result<ImportedHermesFile, AppError> {
+    let tauri::ipc::InvokeBody::Raw(bytes) = request.body() else {
+        return Err(AppError::new(
+            "hermes_file_import_failed",
+            "Expected the dropped file's contents as a binary payload.",
+        ));
+    };
+    if bytes.len() as u64 > HERMES_IMPORT_MAX_BYTES {
+        return Err(AppError::new(
+            "hermes_file_import_denied",
+            "Dropped files must be 50 MB or smaller.",
+        ));
+    }
+    let raw_name = request
+        .headers()
+        .get("x-file-name")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| urlencoding::decode(value).ok())
+        .map(|value| value.into_owned())
+        .unwrap_or_default();
+    let file_name = validate_dropped_file_name(&raw_name)?;
+    let hermes_home = resolve_scribe_hermes_home(&app)?;
+    let upload_dir = hermes_home.join("workspace").join("uploads");
+    fs::create_dir_all(&upload_dir)
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?;
+    let destination = unique_upload_path(&upload_dir, Path::new(&file_name))?;
+    fs::write(&destination, bytes)
+        .map_err(|error| AppError::new("hermes_file_import_failed", error.to_string()))?;
+    let name = destination
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("attachment")
+        .to_string();
+    Ok(ImportedHermesFile {
+        name,
+        path: destination.to_string_lossy().into_owned(),
+        root_label: "Workspace".to_string(),
+        size: bytes.len() as u64,
+        preview_data_url: image_preview_data_url(&destination)?,
+    })
+}
+
+/// Reduces a browser-supplied filename to a safe bare name, mirroring the
+/// checks `validate_dropped_file_path` applies to native paths.
+fn validate_dropped_file_name(raw: &str) -> Result<String, AppError> {
+    let name = Path::new(raw.trim())
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_string();
+    if name.is_empty() {
+        return Err(AppError::new(
+            "hermes_file_import_failed",
+            "The dropped file does not have a usable filename.",
+        ));
+    }
+    if is_hidden_secret_path(Path::new(&name)) {
+        return Err(AppError::new(
+            "hermes_file_import_denied",
+            "Hidden or sensitive files cannot be attached.",
+        ));
+    }
+    Ok(name)
+}
+
 fn validate_hermes_file_path(app: &AppHandle, path: &str) -> Result<PathBuf, AppError> {
     let hermes_home = resolve_scribe_hermes_home(&app)?;
     let requested = PathBuf::from(path)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ pub fn run() {
             hermes_bridge::download_hermes_bridge_file,
             hermes_bridge::hermes_bridge_file_preview,
             hermes_bridge::import_hermes_bridge_file,
+            hermes_bridge::import_hermes_bridge_file_bytes,
             hermes_bridge::hermes_bridge_sessions,
             hermes_bridge::ensure_hermes_bridge_session,
             hermes_bridge::hermes_bridge_session_messages,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -32,6 +32,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -300,6 +301,7 @@ export function AgentWorkspace({
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
+  const composerBoxRef = useRef<HTMLDivElement | null>(null);
   const [composerMultiline, setComposerMultiline] = useState(false);
 
   useEffect(() => {
@@ -726,10 +728,15 @@ export function AgentWorkspace({
 
   // Auto-grow the composer with its content (capped), since WKWebView has no
   // CSS field-sizing. Recomputing on `draft` also collapses it back after a
-  // submit clears the value.
-  useEffect(() => {
+  // submit clears the value. Runs pre-paint (layout effect) so the FLIP
+  // measurements below straddle the reflow without a visible jump.
+  useLayoutEffect(() => {
     const el = composerRef.current;
     if (!el) return;
+    const box = composerBoxRef.current;
+    // FLIP "first": where things sit before this growth step reflows them.
+    const prevBoxHeight = box?.offsetHeight ?? 0;
+    const prevRect = el.getBoundingClientRect();
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
     // Once the input wraps to a second line, the toolbar drops below it.
@@ -738,8 +745,48 @@ export function AgentWorkspace({
     const padding =
       parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
     const lines = Math.round((el.scrollHeight - padding) / lineHeight);
-    setComposerMultiline(lines >= 2);
-  }, [draft]);
+    const multiline = lines >= 2;
+    setComposerMultiline(multiline);
+    if (!box) return;
+    // Flip the layout attribute now rather than waiting for the re-render so
+    // the FLIP "last" measurement sees the final layout in this same effect.
+    box.dataset.multiline = multiline ? "true" : "false";
+    const nextBoxHeight = box.offsetHeight;
+    if (nextBoxHeight === prevBoxHeight) return;
+    if (
+      typeof box.animate !== "function" ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return;
+    }
+    // Animate the box open/closed. Its content is bottom-anchored
+    // (justify-content: flex-end) and clipped (overflow: hidden), so the
+    // toolbar stays pinned to the bottom edge while the top edge glides up to
+    // reveal the new line.
+    const grow = {
+      duration: 160,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)", // --ease-out
+    };
+    box.animate(
+      [{ height: `${prevBoxHeight}px` }, { height: `${nextBoxHeight}px` }],
+      grow,
+    );
+    // Glide the textarea from its old spot, bottom-left anchored so the line
+    // being typed stays put while space opens above it (most visible on the
+    // one→two line hop, where it leaves the slot between the +/mic buttons).
+    const nextRect = el.getBoundingClientRect();
+    const dx = prevRect.left - nextRect.left;
+    const dy = prevRect.bottom - nextRect.bottom;
+    if (dx || dy) {
+      el.animate(
+        [
+          { transform: `translate(${dx}px, ${dy}px)` },
+          { transform: "translate(0, 0)" },
+        ],
+        grow,
+      );
+    }
+  }, [draft, attachments.length]);
 
   useEffect(() => {
     let disposed = false;
@@ -1819,6 +1866,7 @@ export function AgentWorkspace({
             onDrop={handleComposerDrop}
           >
             <div
+              ref={composerBoxRef}
               className="agent-composer-box"
               data-dirty={draft.trim() || attachments.length ? "true" : "false"}
               data-multiline={composerMultiline ? "true" : "false"}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -52,6 +52,7 @@ import {
   hermesBridgeStatus,
   hermesBridgeToolsets,
   importHermesBridgeFile,
+  importHermesBridgeFileBytes,
   listAgentTasks,
   downloadHermesBridgeFile,
   retryAgentTask,
@@ -912,26 +913,22 @@ export function AgentWorkspace({
   function handleComposerDrop(event: DragEvent<HTMLFormElement>) {
     event.preventDefault();
     setDropActive(false);
-    const paths = Array.from(event.dataTransfer.files)
-      .map((file) => (file as File & { path?: string }).path)
-      .filter((path): path is string => Boolean(path));
-    if (!paths.length) {
+    const files = Array.from(event.dataTransfer.files);
+    if (!files.length) {
       setError("Drop files from Finder to attach them to the agent.");
       return;
     }
-    void importDroppedFilePaths(paths);
+    void importDroppedFiles(files);
   }
 
-  async function importDroppedFilePaths(paths: string[]) {
-    const uniquePaths = Array.from(new Set(paths.map((path) => path.trim())))
-      .filter(Boolean)
-      .slice(0, 8);
-    if (!uniquePaths.length) return;
+  async function importAttachments<T>(
+    items: T[],
+    importItem: (item: T) => Promise<ImportedHermesFile>,
+  ) {
+    if (!items.length) return;
     setImportingFiles(true);
     try {
-      const imported = await Promise.all(
-        uniquePaths.map((path) => importHermesBridgeFile(path)),
-      );
+      const imported = await Promise.all(items.map((item) => importItem(item)));
       setAttachments((current) => [
         ...current,
         ...imported.map((file) => ({
@@ -946,6 +943,33 @@ export function AgentWorkspace({
     } finally {
       setImportingFiles(false);
     }
+  }
+
+  // Native paths come from the file picker and Tauri drag-drop events.
+  async function importDroppedFilePaths(paths: string[]) {
+    const uniquePaths = Array.from(new Set(paths.map((path) => path.trim())))
+      .filter(Boolean)
+      .slice(0, 8);
+    await importAttachments(uniquePaths, importHermesBridgeFile);
+  }
+
+  // DOM drops are how Finder files actually arrive: Tauri's drag-drop
+  // interception is disabled (it has to be, so notes can use HTML5 drag into
+  // folders) and WKWebView never exposes filesystem paths on dropped Files —
+  // so read each blob and import its bytes.
+  async function importDroppedFiles(files: File[]) {
+    await importAttachments(files.slice(0, 8), async (file) => {
+      if (file.size > 50 * 1024 * 1024) {
+        throw new Error("Dropped files must be 50 MB or smaller.");
+      }
+      const bytes = await readFileBytes(file).catch(() => {
+        // Reading fails for directories, which Finder happily lets you drop.
+        throw new Error(
+          `Could not read "${file.name}" — folders can't be attached.`,
+        );
+      });
+      return importHermesBridgeFileBytes(file.name, bytes);
+    });
   }
 
   function removeAttachment(id: string) {
@@ -4637,6 +4661,18 @@ function messageFromError(err: unknown) {
     return String((err as { message: unknown }).message);
   }
   return String(err);
+}
+
+// FileReader instead of Blob.arrayBuffer(): same everywhere a drop can land
+// (WKWebView and jsdom included).
+function readFileBytes(file: File) {
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Could not read the dropped file."));
+    reader.readAsArrayBuffer(file);
+  });
 }
 
 function omitRecordKey<T>(record: Record<string, T>, key: string) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -732,14 +732,18 @@ export function AgentWorkspace({
   // measurements below straddle the reflow without a visible jump.
   useLayoutEffect(() => {
     const el = composerRef.current;
-    if (!el) return;
     const box = composerBoxRef.current;
+    if (!el || !box) return;
     // FLIP "first": where things sit before this growth step reflows them.
-    const prevBoxHeight = box?.offsetHeight ?? 0;
+    const prevBoxHeight = box.offsetHeight;
     const prevRect = el.getBoundingClientRect();
+    // The toolbar drops below the input once the text can't fit on one line
+    // beside the buttons — so probe that at the narrow single-line width.
+    // Deciding at the *current* width feeds back into itself: text that
+    // overflows the narrow slot can fit on one full-width line, so the modes
+    // would flip-flop on every keystroke right at the wrap boundary.
+    box.dataset.multiline = "false";
     el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-    // Once the input wraps to a second line, the toolbar drops below it.
     const styles = getComputedStyle(el);
     const lineHeight = parseFloat(styles.lineHeight) || 20;
     const padding =
@@ -747,10 +751,14 @@ export function AgentWorkspace({
     const lines = Math.round((el.scrollHeight - padding) / lineHeight);
     const multiline = lines >= 2;
     setComposerMultiline(multiline);
-    if (!box) return;
     // Flip the layout attribute now rather than waiting for the re-render so
-    // the FLIP "last" measurement sees the final layout in this same effect.
+    // the height below and the FLIP "last" measurement both see the final
+    // layout in this same effect (none of the probe states ever paint).
     box.dataset.multiline = multiline ? "true" : "false";
+    // Size to the content at the final width, never the probe width — a
+    // narrow-width height on a full-width textarea leaves a phantom line.
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
     const nextBoxHeight = box.offsetHeight;
     if (nextBoxHeight === prevBoxHeight) return;
     if (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -736,8 +736,18 @@ export function AgentWorkspace({
     const box = composerBoxRef.current;
     if (!el || !box) return;
     // FLIP "first": where things sit before this growth step reflows them.
+    // On rapid typing a previous step's 160ms animation may still be in
+    // flight, so these reads are mid-animation values — where the element
+    // visually is right now. Cancel the stale animations afterwards so the
+    // "last" measurement below is pure layout: the delta between the two then
+    // starts the new glide exactly where the old one left off, instead of
+    // double-applying a residual offset (jitter).
     const prevBoxHeight = box.offsetHeight;
     const prevRect = el.getBoundingClientRect();
+    if (typeof el.getAnimations === "function") {
+      for (const animation of el.getAnimations()) animation.cancel();
+      for (const animation of box.getAnimations()) animation.cancel();
+    }
     // The toolbar drops below the input once the text can't fit on one line
     // beside the buttons — so probe that at the narrow single-line width.
     // Deciding at the *current* width feeds back into itself: text that
@@ -928,7 +938,13 @@ export function AgentWorkspace({
     if (!items.length) return;
     setImportingFiles(true);
     try {
-      const imported = await Promise.all(items.map((item) => importItem(item)));
+      // One at a time on purpose: a dropped file's bytes can be 50 MB, so
+      // interleave read and upload to keep at most one buffer alive instead
+      // of staging the whole batch (up to ~400 MB) in memory at once.
+      const imported: ImportedHermesFile[] = [];
+      for (const item of items) {
+        imported.push(await importItem(item));
+      }
       setAttachments((current) => [
         ...current,
         ...imported.map((file) => ({

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -793,6 +793,18 @@ export async function importHermesBridgeFile(path: string) {
   });
 }
 
+// DOM drops in WKWebView carry no filesystem path, so the file's contents go
+// over as the raw invoke payload with the name in a header (URI-encoded:
+// header values must be ASCII).
+export async function importHermesBridgeFileBytes(
+  name: string,
+  bytes: Uint8Array,
+) {
+  return invoke<ImportedHermesFile>("import_hermes_bridge_file_bytes", bytes, {
+    headers: { "x-file-name": encodeURIComponent(name) },
+  });
+}
+
 export async function hermesBridgeSessions(
   input: {
     limit?: number;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2092,6 +2092,10 @@ input:focus-visible,
   height: 20px;
   border-radius: var(--r-xs);
   object-fit: cover;
+  /* Hairline just inside the thumb so light image edges don't melt into the
+   * chip. Mixed from --foreground so it flips with the theme. */
+  outline: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
+  outline-offset: -1px;
 }
 
 .agent-attachment-chip > svg {
@@ -2106,20 +2110,42 @@ input:focus-visible,
 }
 
 .agent-attachment-chip button {
+  position: relative;
   display: inline-grid;
   place-items: center;
   flex: 0 0 auto;
-  width: 18px;
-  height: 18px;
+  /* The same square as the image thumb, so it sits flush with the chip's 2px
+   * padding on all three sides — at 18px it floated 3px off the top/bottom
+   * but only 2px off the right edge, reading as off-center. */
+  width: 20px;
+  height: 20px;
   border: 0;
+  /* Concentric with the chip: r-sm (6px) minus the 2px padding. */
   border-radius: var(--r-xs);
   background: transparent;
   color: var(--muted-foreground);
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out),
+    scale var(--t-fast) var(--ease-out);
+}
+
+/* The visible square is small; quietly widen the hit target around it
+ * (stops 1px shy of the textarea below, and the chip body to its left is
+ * inert, so nothing overlaps). */
+.agent-attachment-chip button::after {
+  content: "";
+  position: absolute;
+  inset: -5px;
 }
 
 .agent-attachment-chip button:hover {
   background: color-mix(in oklch, var(--muted-foreground) 16%, transparent);
   color: var(--foreground);
+}
+
+.agent-attachment-chip button:active {
+  scale: 0.96;
 }
 
 .agent-composer-box:focus-within {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2086,6 +2086,12 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
+/* When the chip leads with an image thumb, drop the text-oriented left
+ * padding so the thumb sits flush at 2px on all sides, like the button. */
+.agent-attachment-chip:has(> img) {
+  padding-left: 2px;
+}
+
 .agent-attachment-chip > img {
   flex: 0 0 auto;
   width: 20px;
@@ -2119,6 +2125,11 @@ input:focus-visible,
    * but only 2px off the right edge, reading as off-center. */
   width: 20px;
   height: 20px;
+  /* The app never resets UA button padding globally — WebKit's default
+   * (2px 6px 3px) squeezes the content box to 8px, and the overflowing 12px
+   * icon gets safe-aligned to the start instead of centered: the x sat 2px
+   * right and 0.5px high of true center. */
+  padding: 0;
   border: 0;
   /* Concentric with the chip: r-sm (6px) minus the 2px padding. */
   border-radius: var(--r-xs);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1989,6 +1989,10 @@ input:focus-visible,
   pointer-events: auto;
   display: flex;
   flex-direction: column;
+  /* Bottom-anchored so that while the JS FLIP animates the box height, the
+   * toolbar stays pinned to the bottom edge and new lines reveal from the
+   * rising top edge. */
+  justify-content: flex-end;
   gap: var(--sp-1);
   width: 100%;
   max-width: var(--content-max);
@@ -2008,7 +2012,11 @@ input:focus-visible,
 .agent-composer-row {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  /* The single-line textarea (33px) runs 1px taller than the 32px controls;
+   * centering splits the difference so the send button sits evenly inset
+   * instead of flush-bottom with a fatter top gap. On the multiline toolbar
+   * row every control is the same height, so centering is a no-op there. */
+  align-items: center;
   gap: var(--sp-1);
 }
 
@@ -2134,8 +2142,9 @@ input:focus-visible,
   font-size: var(--fs-lg);
   line-height: 1.5;
   outline: none;
-  /* Smooths the upward growth as lines wrap (height is set in JS). */
-  transition: height var(--t-fast) var(--ease-out);
+  /* Growth is animated by the JS FLIP in AgentWorkspace (box height +
+   * textarea transform together) — a CSS height transition here would fight
+   * those measurements. */
 }
 
 .agent-composer textarea::placeholder {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1,4 +1,10 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -21,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeStatus: vi.fn(),
   hermesBridgeToolsets: vi.fn(),
   importHermesBridgeFile: vi.fn(),
+  importHermesBridgeFileBytes: vi.fn(),
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
   retryAgentTask: vi.fn(),
@@ -63,6 +70,7 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeStatus: mocks.hermesBridgeStatus,
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
   importHermesBridgeFile: mocks.importHermesBridgeFile,
+  importHermesBridgeFileBytes: mocks.importHermesBridgeFileBytes,
   listAgentTasks: mocks.listAgentTasks,
   downloadHermesBridgeFile: mocks.downloadHermesBridgeFile,
   retryAgentTask: mocks.retryAgentTask,
@@ -146,6 +154,15 @@ describe("AgentWorkspace", () => {
         ? "data:image/png;base64,preview"
         : null,
     }));
+    mocks.importHermesBridgeFileBytes.mockImplementation(
+      async (name: string) => ({
+        name,
+        path: `/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/${name}`,
+        rootLabel: "Workspace",
+        size: 5,
+        previewDataUrl: null,
+      }),
+    );
     mocks.downloadHermesBridgeFile.mockResolvedValue(
       "/Users/junho/Downloads/sample.pdf",
     );
@@ -494,6 +511,29 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("imports DOM-dropped files by uploading their bytes", async () => {
+    // WKWebView never exposes filesystem paths on dropped Files, and Tauri's
+    // drag-drop interception is disabled — DOM drops must go through the
+    // bytes-based import.
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    const form = document.querySelector(".agent-composer");
+    expect(form).not.toBeNull();
+    fireEvent.drop(form as HTMLFormElement, {
+      dataTransfer: {
+        files: [new File(["hello"], "notes.txt", { type: "text/plain" })],
+      },
+    });
+
+    expect(await screen.findByText("notes.txt")).toBeInTheDocument();
+    expect(mocks.importHermesBridgeFileBytes).toHaveBeenCalledWith(
+      "notes.txt",
+      expect.any(Uint8Array),
+    );
+    expect(mocks.importHermesBridgeFile).not.toHaveBeenCalled();
+  });
+
   it("keeps a re-sent duplicate message and the running state against older identical history", async () => {
     const user = userEvent.setup();
     mocks.listHermesSessionMessages.mockResolvedValue([
@@ -626,15 +666,11 @@ describe("AgentWorkspace", () => {
       await user.type(screen.getByRole("textbox"), "do something long");
       await user.click(screen.getByRole("button", { name: "Send message" }));
       await waitFor(() =>
-        expect(sessionDetails.at(-1)?.workingSessionIds).toContain(
-          "session-1",
-        ),
+        expect(sessionDetails.at(-1)?.workingSessionIds).toContain("session-1"),
       );
 
       mocks.listHermesSessions.mockResolvedValue([]);
-      await user.click(
-        screen.getByRole("button", { name: "Session actions" }),
-      );
+      await user.click(screen.getByRole("button", { name: "Session actions" }));
       await user.click(
         screen.getByRole("menuitem", { name: "Delete session" }),
       );


### PR DESCRIPTION
## Summary

A round of agent-composer fixes, from animation feel down to a broken feature:

- **Smooth one→two line expansion.** The toolbar dropping below the textarea was an instant flex reflow. Now a pre-paint FLIP animates the box height (content bottom-anchored so the toolbar stays pinned while the top edge glides up) and slides the textarea out of its slot between the buttons. Respects `prefers-reduced-motion`.
- **No more layout flip-flop at the wrap boundary.** The multiline decision was measured at whatever width the textarea currently had — but the decision changes that width, so it oscillated every keystroke right at the boundary (two squeezed lines beside inline buttons / phantom empty line at full width). The line count is now probed at the narrow single-line width, so the decision no longer feeds back into itself; height is then sized at the final width.
- **Send button & attachment chip evenly inset.** Single-line row centers instead of flex-end (the 33px textarea ran 1px taller than the 32px controls). The chip's x button is now the same 20px square as the image thumb — flush 2px inset on all sides.
- **Attachment chip x truly centered.** The global stylesheet never resets UA button padding; WebKit's default (`2px 6px 3px`) squeezed the 20px button's content box to 8px and the overflowing 12px icon got safe-aligned to the start — 2px right, 0.5px high. Verified the root cause and the fix in a real WKWebView harness. Plus: hover wash transitions, 0.96 press scale, wider invisible hit target, hairline outline on image thumbs, and image chips drop the text-oriented left padding (`:has(> img)`) so the thumb sits flush at 2px all around.
- **Drag-and-drop files into the chat actually works now.** The drop handler read `File.path` — an Electron-only API that doesn't exist in WKWebView — and the `tauri://drag-drop` fallback never fires because `dragDropEnabled` is (and must stay) false for note→folder HTML5 drag. Every drop errored. New `import_hermes_bridge_file_bytes` command takes the file's contents as a raw IPC payload (filename in a header) with the same 50 MB cap and sensitive-filename screening as the path-based import; the drop handler reads blobs via `FileReader` and routes through it. Picker and Tauri-event paths still use the path import; all three share the attach/preview plumbing.

## Test plan

- [ ] Type until the composer wraps to two lines — toolbar reveal animates smoothly, no flicker at the wrap boundary while typing/deleting around it
- [ ] Send/clear collapses smoothly back to one line; send button sits evenly inset at one line
- [ ] Attach an image and a non-image file — chip x is dead-centered (incl. hover), image thumb flush at 2px on all sides
- [ ] Drag files from Finder onto the composer — chips appear, agent receives workspace paths; >50 MB files and folders show friendly errors
- [ ] Drag a note into a folder still works (HTML5 drag unaffected)
- [x] `pnpm test` — 214 passing (new coverage: DOM-drop bytes import, blank-composer regression intact)
- [x] `cargo check`, `tsc --noEmit`, prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)