### PR TITLE
[codex] Fix manual note context extraction

### DIFF
--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -236,11 +236,14 @@ pub fn manual_notes_for_generation(note: &NoteDto) -> Option<String> {
         };
     }
     edited.find(generated).and_then(|index| {
-        let rest = edited[index + generated.len()..].trim();
-        if rest.is_empty() {
-            None
+        let before = edited[..index].trim();
+        let after = edited[index + generated.len()..].trim();
+        if !after.is_empty() {
+            Some(after.to_string())
+        } else if !before.is_empty() {
+            Some(before.to_string())
         } else {
-            Some(rest.to_string())
+            None
         }
     })
 }

--- a/src-tauri/tests/processing.rs
+++ b/src-tauri/tests/processing.rs
@@ -67,6 +67,20 @@ fn manual_notes_for_generation_uses_new_tail_after_manual_preface() {
     );
 }
 
+#[test]
+fn manual_notes_for_generation_uses_preface_when_generated_note_was_appended_below_it() {
+    let note = note(|note| {
+        note.generated_content = Some("Generated note body".to_string());
+        note.edited_content =
+            Some("Manual notes from recording\n\nGenerated note body".to_string());
+    });
+
+    assert_eq!(
+        manual_notes_for_generation(&note).as_deref(),
+        Some("Manual notes from recording")
+    );
+}
+
 #[tokio::test]
 async fn generation_rejects_empty_transcript() {
     let err = os_scribe_lib::scribe_api::generate_note_from_transcript(


### PR DESCRIPTION
## Summary

Fixes manual-note context extraction when generated content has been appended below user-written notes. In that persisted shape, `manual_notes_for_generation` found the generated block but only considered text after it, so retry/recovery or preface-style manual notes could be sent to generation with no manual context.

The helper now keeps the existing tail-after-generated behavior, and falls back to the text before the generated block when there is no tail. A regression test covers the appended-below-preface shape.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --test notes --test processing`
- `rustfmt --edition 2021 --check src-tauri/src/domain/processing.rs src-tauri/tests/processing.rs`
- `git diff --check`

Note: full `cargo fmt --manifest-path src-tauri/Cargo.toml --check` on clean `main` currently reports an unrelated pre-existing wrap in `src-tauri/src/dictation.rs`, so this PR keeps formatting scoped to the changed files.