### PR TITLE
[codex] Trigger staging DMG for all HTML entrypoints

### DIFF
--- a/.github/workflows/staging-desktop-dmg.yml
+++ b/.github/workflows/staging-desktop-dmg.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/staging-desktop-dmg.yml"
       - "hud.html"
       - "index.html"
+      - "mascot.html"
+      - "meeting-hud.html"
       - "package.json"
       - "pnpm-lock.yaml"
       - "public/**"


### PR DESCRIPTION
## Summary
- Add `mascot.html` and `meeting-hud.html` to the staging desktop DMG workflow path filters.
- Keep staging DMG builds running when a push only changes secondary Tauri window entrypoints.

## Root Cause
`vite.config.ts` and `src-tauri/tauri.conf.json` package four root HTML entrypoints, but `staging-desktop-dmg.yml` only watched `index.html` and `hud.html`. Changes isolated to the mascot or meeting HUD entrypoint could merge to `main` without producing a new staging DMG.

## Validation
- `node - <<'NODE' ...` targeted check that every Vite HTML entrypoint appears in the staging workflow paths.
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `pnpm build`