### PR TITLE
[codex] Fix transcript turn ordering

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -127,7 +127,7 @@ export function NoteEditor({
 }: NoteEditorProps) {
   const content = note.editedContent ?? note.generatedContent ?? "";
   const activeTab = note.activeTab ?? "notes";
-  const sourceTranscripts = visibleSourceTranscripts(note);
+  const sourceTranscripts = orderedVisibleSourceTranscripts(note);
   const recordingForNote = recordingStatus;
   const recordingActive = Boolean(recordingForNote);
   const [optionsOpen, setOptionsOpen] = useState(false);
@@ -740,18 +740,51 @@ function turnsToText(turns: TranscriptDto[]): string {
 
 function transcriptToText(note: NoteDto): string {
   if (note.sourceTranscripts?.length) {
-    return turnsToText(note.sourceTranscripts);
+    return turnsToText(orderedVisibleSourceTranscripts(note));
   }
   return note.transcript?.text ?? "";
 }
 
-function visibleSourceTranscripts(
+function orderedVisibleSourceTranscripts(
   note: NoteDto,
 ): NonNullable<NoteDto["sourceTranscripts"]> {
-  return (note.sourceTranscripts ?? []).filter((turn) => {
-    if (turn.text.trim()) return true;
-    return note.processingStatus !== "failed" && !!turn.lastError;
-  });
+  return (note.sourceTranscripts ?? [])
+    .filter((turn) => {
+      if (turn.text.trim()) return true;
+      return note.processingStatus !== "failed" && !!turn.lastError;
+    })
+    .map((turn, index) => ({ turn, index }))
+    .sort(compareSourceTranscriptOrder)
+    .map(({ turn }) => turn);
+}
+
+function compareSourceTranscriptOrder(
+  left: { turn: TranscriptDto; index: number },
+  right: { turn: TranscriptDto; index: number },
+) {
+  const turnIndexOrder = compareOptionalNumber(
+    left.turn.turnIndex,
+    right.turn.turnIndex,
+  );
+  if (turnIndexOrder !== 0) return turnIndexOrder;
+
+  const startOrder = compareOptionalNumber(
+    left.turn.startMs,
+    right.turn.startMs,
+  );
+  if (startOrder !== 0) return startOrder;
+
+  const endOrder = compareOptionalNumber(left.turn.endMs, right.turn.endMs);
+  if (endOrder !== 0) return endOrder;
+
+  return left.index - right.index;
+}
+
+function compareOptionalNumber(left?: number, right?: number) {
+  if (left === undefined && right === undefined) return 0;
+  if (left === undefined) return 1;
+  if (right === undefined) return -1;
+  return left - right;
 }
 
 /** A single conversation turn in the Transcription tab. Mirrors the dictation

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -137,6 +137,55 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Microphone response")).toBeInTheDocument();
   });
 
+  it("orders source transcript turns by persisted turn metadata", () => {
+    const { container } = render(
+      <NoteEditor
+        {...props}
+        note={note({
+          activeTab: "transcription",
+          sourceTranscripts: [
+            {
+              id: "turn-3",
+              text: "Second microphone turn",
+              source: "microphone",
+              startMs: 5000,
+              endMs: 6500,
+              turnIndex: 2,
+              status: "succeeded",
+            },
+            {
+              id: "turn-1",
+              text: "First microphone turn",
+              source: "microphone",
+              startMs: 1000,
+              endMs: 2000,
+              turnIndex: 0,
+              status: "succeeded",
+            },
+            {
+              id: "turn-2",
+              text: "System reply",
+              source: "system",
+              startMs: 3000,
+              endMs: 4000,
+              turnIndex: 1,
+              status: "succeeded",
+            },
+          ],
+        })}
+      />,
+    );
+
+    const renderedTurns = Array.from(
+      container.querySelectorAll(".transcript-turn-text"),
+    ).map((turn) => turn.textContent);
+    expect(renderedTurns).toEqual([
+      "First microphone turn",
+      "System reply",
+      "Second microphone turn",
+    ]);
+  });
+
   it("shows friendly source transcript failure reasons", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary

Fixes the Transcription tab so source transcript rows are rendered and copied in persisted conversation order instead of trusting the incoming array order.

## Root cause

The note editor filtered `sourceTranscripts` but kept the backend array order. If rows arrived out of order, the UI could show Microphone/System turns out of chronological conversation order despite each row carrying `turnIndex` and timing metadata.

## Changes

- Sort visible source transcript rows by `turnIndex`, then `startMs`, then `endMs`, preserving stable input order for legacy rows without metadata.
- Reuse the same ordered row list for transcript copy text.
- Add a regression test with out-of-order source turns.

## Validation

- `pnpm vitest run src/test/note-editor.test.tsx`
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`
- `pnpm exec prettier --check src/components/note-editor/NoteEditor.tsx src/test/note-editor.test.tsx`

Note: `pnpm run format` still reports pre-existing formatting issues in unrelated files on `main` (`src/components/account/AccountSettings.tsx`, `src/lib/hermes-adapter.ts`, `src/test/hermes-gateway.test.ts`).