### PR TITLE
[codex] Fix source transcript session ordering

### DIFF
--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1604,12 +1604,18 @@ impl Repositories {
 
     async fn source_transcripts(&self, note_id: &str) -> Result<Vec<TranscriptDto>, sqlx::Error> {
         let rows = sqlx::query(
-            "SELECT id, text, source_mode, source, start_ms, end_ms, turn_index, language, status, last_error
-             FROM transcripts
-             WHERE note_id = ?
-               AND recording_session_id IS NOT NULL
-               AND turn_index IS NOT NULL
-             ORDER BY COALESCE(turn_index, 999999), COALESCE(start_ms, 999999999), created_at ASC",
+            "SELECT t.id, t.text, t.source_mode, t.source, t.start_ms, t.end_ms, t.turn_index, t.language, t.status, t.last_error
+             FROM transcripts t
+             LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
+             WHERE t.note_id = ?
+               AND t.recording_session_id IS NOT NULL
+               AND t.turn_index IS NOT NULL
+             ORDER BY COALESCE(rs.started_at, t.created_at) ASC,
+                      COALESCE(rs.rowid, 9223372036854775807) ASC,
+                      COALESCE(t.turn_index, 999999),
+                      COALESCE(t.start_ms, 999999999),
+                      t.created_at ASC,
+                      t.rowid ASC",
         )
         .bind(note_id)
         .fetch_all(&self.pool)

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -157,3 +157,130 @@ async fn upserts_source_turn_transcripts_for_retry() {
     assert_eq!(transcripts[0].text, "Recovered transcript");
     assert_eq!(transcripts[0].status, "succeeded");
 }
+
+#[tokio::test]
+async fn note_source_transcripts_are_ordered_by_session_then_turn() {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note should exist");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            "/tmp/session-1-mic.partial.wav",
+            "/tmp/session-1-mic.wav",
+            None,
+        )
+        .await
+        .expect("first session should be created");
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-2",
+            RecordingSourceMode::MicrophonePlusSystem,
+            "/tmp/session-2-mic.partial.wav",
+            "/tmp/session-2-mic.wav",
+            None,
+        )
+        .await
+        .expect("second session should be created");
+    sqlx::query("UPDATE recording_sessions SET started_at = ? WHERE id = ?")
+        .bind("2026-05-20T10:00:00.000Z")
+        .bind("session-1")
+        .execute(&repos.pool)
+        .await
+        .expect("first session timestamp");
+    sqlx::query("UPDATE recording_sessions SET started_at = ? WHERE id = ?")
+        .bind("2026-05-20T10:05:00.000Z")
+        .bind("session-2")
+        .execute(&repos.pool)
+        .await
+        .expect("second session timestamp");
+
+    let first_artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            "/tmp/session-1-mic.partial.wav",
+            "/tmp/session-1-mic.wav",
+        )
+        .await
+        .expect("first artifact should be created");
+    let second_artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-2",
+            "microphone",
+            "/tmp/session-2-mic.partial.wav",
+            "/tmp/session-2-mic.wav",
+        )
+        .await
+        .expect("second artifact should be created");
+
+    repos
+        .upsert_successful_source_turn_transcript(
+            &note.id,
+            "session-1",
+            &first_artifact.id,
+            RecordingSourceMode::MicrophonePlusSystem,
+            "microphone",
+            "First recording, first turn",
+            Some("en".to_string()),
+            "test",
+            0,
+            1_000,
+            0,
+        )
+        .await
+        .expect("first turn should be stored");
+    repos
+        .upsert_successful_source_turn_transcript(
+            &note.id,
+            "session-1",
+            &first_artifact.id,
+            RecordingSourceMode::MicrophonePlusSystem,
+            "microphone",
+            "First recording, second turn",
+            Some("en".to_string()),
+            "test",
+            2_000,
+            3_000,
+            1,
+        )
+        .await
+        .expect("second turn should be stored");
+    repos
+        .upsert_successful_source_turn_transcript(
+            &note.id,
+            "session-2",
+            &second_artifact.id,
+            RecordingSourceMode::MicrophonePlusSystem,
+            "microphone",
+            "Second recording, first turn",
+            Some("en".to_string()),
+            "test",
+            0,
+            1_000,
+            0,
+        )
+        .await
+        .expect("third turn should be stored");
+
+    let note = repos.get_note(&note.id).await.expect("note should load");
+    let texts = note
+        .source_transcripts
+        .iter()
+        .map(|transcript| transcript.text.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        texts,
+        vec![
+            "First recording, first turn",
+            "First recording, second turn",
+            "Second recording, first turn",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- Order note source transcripts by recording session before per-session turn index.
- Add a regression test for multiple recordings on the same note where each session starts turn numbering at 0.

## Root cause
`source_transcripts` sorted every timed transcript for a note by `turn_index` first, but `turn_index` is scoped to one recording session. A later recording's turn 0 could appear before an earlier recording's turn 1 in the Transcription tab.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml --test source_modes note_source_transcripts_are_ordered_by_session_then_turn`
- `cargo test --manifest-path src-tauri/Cargo.toml --test source_modes`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `rustfmt --edition 2021 --check src-tauri/src/db/repositories.rs src-tauri/tests/source_modes.rs`

## Note
`cargo fmt --manifest-path src-tauri/Cargo.toml --check` still reports a pre-existing line-wrap diff in `src-tauri/src/dictation.rs`, which this PR intentionally does not touch.