### PR TITLE
[codex] Guard scribe-api model kinds

### DIFF
--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -8,7 +8,7 @@ use axum::{
     http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
 };
-use scribe_domain::ModelId;
+use scribe_domain::{ModelId, ModelKind};
 use scribe_services::AgentChatParams;
 
 pub(crate) async fn chat_completions(
@@ -26,7 +26,7 @@ pub(crate) async fn chat_completions(
         .to_string();
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
     validation::validate_agent_chat_body(&body)?;
-    require_priced_model(&state, &model_id)?;
+    require_priced_model(&state, &model_id, ModelKind::Text)?;
     if let Some(object) = body.as_object_mut() {
         object.insert(
             "model".to_string(),

--- a/scribe-api/crates/api/src/handlers/dictate.rs
+++ b/scribe-api/crates/api/src/handlers/dictate.rs
@@ -13,7 +13,7 @@ use axum::{
     extract::{Multipart, State},
     http::HeaderMap,
 };
-use scribe_domain::ModelId;
+use scribe_domain::{ModelId, ModelKind};
 use scribe_services::{
     DictateCleanupOutput, DictateCleanupParams, DictateTranscribeOutput, DictateTranscribeParams,
 };
@@ -31,7 +31,7 @@ pub(crate) async fn transcribe(
     validate_audio(&audio)?;
     let model_id = form.required_text("model")?;
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
-    require_priced_model(&state, &model_id)?;
+    require_priced_model(&state, &model_id, ModelKind::Asr)?;
     let session_id = form.required_text("sessionId")?;
     validation::validate_text_len("session_id", &session_id, validation::MAX_ID_CHARS)?;
     let utterance_id = form.required_text("utteranceId")?;
@@ -78,7 +78,7 @@ pub(crate) async fn cleanup(
     request.validate()?;
     let model_id = required(request.model, "model_required")?;
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
-    require_priced_model(&state, &model_id)?;
+    require_priced_model(&state, &model_id, ModelKind::Text)?;
     let output = state
         .dictate()
         .cleanup(DictateCleanupParams {

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -7,9 +7,10 @@ use axum::{
     extract::{Multipart, State},
     http::HeaderMap,
 };
-use scribe_domain::ModelId;
+use scribe_domain::{ModelId, ModelKind};
 use scribe_services::{
     NoteGenerateOutput, NoteGenerateParams, NoteTranscribeOutput, NoteTranscribeParams,
+    PricingError, PricingTable,
 };
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +26,7 @@ pub(crate) async fn transcribe(
     validate_audio(&audio)?;
     let model_id = form.required_text("model")?;
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
-    require_priced_model(&state, &model_id)?;
+    require_priced_model(&state, &model_id, ModelKind::Asr)?;
     let title = form.required_text("title")?;
     validation::validate_text_len("title", &title, validation::MAX_TITLE_CHARS)?;
     let context = form.optional_text("context");
@@ -70,7 +71,7 @@ pub(crate) async fn generate(
     request.validate()?;
     let model_id = required(request.model, "model_required")?;
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
-    require_priced_model(&state, &model_id)?;
+    require_priced_model(&state, &model_id, ModelKind::Text)?;
     let output = state
         .note_generate()
         .generate(NoteGenerateParams {
@@ -193,10 +194,110 @@ pub(crate) fn required(value: Option<String>, message: &str) -> Result<String, A
         .ok_or_else(|| ApiError::bad_request(message))
 }
 
-pub(crate) fn require_priced_model(state: &ApiState, model_id: &str) -> Result<(), ApiError> {
-    if state.pricing().has_model(model_id) {
-        Ok(())
-    } else {
-        Err(ApiError::unprocessable("model_not_priced"))
+pub(crate) fn require_priced_model(
+    state: &ApiState,
+    model_id: &str,
+    kind: ModelKind,
+) -> Result<(), ApiError> {
+    require_priced_model_kind(state.pricing(), model_id, kind)
+}
+
+fn require_priced_model_kind(
+    pricing: &PricingTable,
+    model_id: &str,
+    kind: ModelKind,
+) -> Result<(), ApiError> {
+    match pricing.ensure_model_kind(model_id, kind) {
+        Ok(()) => Ok(()),
+        Err(PricingError::WrongUnit) => Err(ApiError::unprocessable("model_type_invalid")),
+        Err(PricingError::NotPriced | PricingError::MissingRate) => {
+            Err(ApiError::unprocessable("model_not_priced"))
+        }
+        Err(PricingError::Overflow) => Err(ApiError::unprocessable("price_overflow")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_priced_model_kind;
+    use crate::ApiError;
+    use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
+    use scribe_domain::ModelKind;
+    use scribe_services::PricingTable;
+    use std::collections::BTreeMap;
+
+    fn pricing_table() -> PricingTable {
+        let mut models = BTreeMap::new();
+        models.insert(
+            "asr-model".to_string(),
+            ModelPriceConfig {
+                unit: PriceUnit::Seconds,
+                credits_per_million_seconds: Some(1),
+                input_credits_per_million_tokens: None,
+                output_credits_per_million_tokens: None,
+                provider: ModelProvider::Openai,
+                model_type: ModelType::Asr,
+                display_name: "ASR".to_string(),
+                description: None,
+                privacy: None,
+                pricing: None,
+                context_tokens: None,
+                traits: Vec::new(),
+                capabilities: Vec::new(),
+            },
+        );
+        models.insert(
+            "text-model".to_string(),
+            ModelPriceConfig {
+                unit: PriceUnit::Tokens,
+                credits_per_million_seconds: None,
+                input_credits_per_million_tokens: Some(1),
+                output_credits_per_million_tokens: Some(1),
+                provider: ModelProvider::Venice,
+                model_type: ModelType::Text,
+                display_name: "Text".to_string(),
+                description: None,
+                privacy: None,
+                pricing: None,
+                context_tokens: None,
+                traits: Vec::new(),
+                capabilities: Vec::new(),
+            },
+        );
+        PricingTable::new(models)
+    }
+
+    #[test]
+    fn require_priced_model_kind_accepts_matching_model_type() {
+        let pricing = pricing_table();
+
+        assert!(require_priced_model_kind(&pricing, "asr-model", ModelKind::Asr).is_ok());
+        assert!(require_priced_model_kind(&pricing, "text-model", ModelKind::Text).is_ok());
+    }
+
+    #[test]
+    fn require_priced_model_kind_rejects_wrong_endpoint_model_type() {
+        let pricing = pricing_table();
+
+        let error = require_priced_model_kind(&pricing, "asr-model", ModelKind::Text)
+            .expect_err("ASR model must not be accepted for text generation");
+
+        assert!(matches!(
+            error,
+            ApiError::Unprocessable { message, .. } if message == "model_type_invalid"
+        ));
+    }
+
+    #[test]
+    fn require_priced_model_kind_keeps_missing_model_error() {
+        let pricing = pricing_table();
+
+        let error = require_priced_model_kind(&pricing, "missing", ModelKind::Text)
+            .expect_err("missing model should be rejected");
+
+        assert!(matches!(
+            error,
+            ApiError::Unprocessable { message, .. } if message == "model_not_priced"
+        ));
     }
 }

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use scribe_domain::{
     ActionSlug, AgentChatCompleter, AgentChatCompletion, AgentChatRequest, Credits, ModelId,
-    OsAccountsClient, Receipt, UserId,
+    ModelKind, OsAccountsClient, Receipt, UserId,
 };
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -40,6 +40,8 @@ impl AgentChatService {
     }
 
     pub async fn complete(&self, params: AgentChatParams) -> Result<AgentChatOutput, ServiceError> {
+        self.pricing
+            .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
         let estimate = Credits(self.flat_estimate_credits);
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),

--- a/scribe-api/crates/services/src/dictate.rs
+++ b/scribe-api/crates/services/src/dictate.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use scribe_domain::{
     ActionSlug, AudioDurationProbe, CleanedText, Cleaner, CleanupRequest, Credits, ModelId,
-    OsAccountsClient, Receipt, Transcriber, Transcript, TranscriptionRequest, UserId,
+    ModelKind, OsAccountsClient, Receipt, Transcriber, Transcript, TranscriptionRequest, UserId,
 };
 use std::sync::Arc;
 
@@ -106,6 +106,8 @@ impl DictateService {
         &self,
         params: DictateCleanupParams,
     ) -> Result<DictateCleanupOutput, ServiceError> {
+        self.pricing
+            .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -229,6 +229,68 @@ mod tests {
         assert!(prompt.contains("Do not add wrapper headings"));
     }
 
+    #[tokio::test]
+    async fn note_generate_rejects_asr_model_before_authorize() {
+        // Regression: generation accepted any priced model id. Passing an ASR
+        // model could take a wallet hold and call the text upstream before the
+        // token-pricing unit mismatch was discovered.
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteGenerateService::new(NoteGenerateServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            generator: Arc::new(FixedGenerator),
+            hold_ttl_seconds: 300,
+            flat_estimate_credits: 1024,
+        });
+        let mut params = note_generate_params();
+        params.model_id = ModelId("audio-model".to_string());
+
+        let result = service.generate(params).await;
+
+        assert_eq!(result.map(|_| ()), Err(ServiceError::ModelNotPriced));
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn dictate_cleanup_rejects_asr_model_before_authorize() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = DictateService::new(DictateServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            cleaner: Arc::new(FixedCleaner),
+            duration_probe: Arc::new(FixedDurationProbe),
+            transcribe_hold_ttl_seconds: 30,
+            cleanup_hold_ttl_seconds: 30,
+            flat_estimate_credits: 1024,
+        });
+
+        let result = service
+            .cleanup(DictateCleanupParams {
+                user_id: UserId("usr_123".to_string()),
+                session_id: "session_1".to_string(),
+                utterance_id: "utt_2".to_string(),
+                text: "hello".to_string(),
+                dictionary_context: None,
+                style: "plain".to_string(),
+                model_id: ModelId("audio-model".to_string()),
+            })
+            .await;
+
+        assert_eq!(result.map(|_| ()), Err(ServiceError::ModelNotPriced));
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
     fn note_generate_service(os_accounts: Arc<RecordingOsAccounts>) -> NoteGenerateService {
         NoteGenerateService::new(NoteGenerateServiceDeps {
             pricing: Arc::new(PricingTable::new(models([(

--- a/scribe-api/crates/services/src/note_generate.rs
+++ b/scribe-api/crates/services/src/note_generate.rs
@@ -7,8 +7,8 @@ use crate::{
     prompts,
 };
 use scribe_domain::{
-    ActionSlug, Credits, GeneratedNote, GenerationRequest, Generator, ModelId, OsAccountsClient,
-    Receipt, UserId,
+    ActionSlug, Credits, GeneratedNote, GenerationRequest, Generator, ModelId, ModelKind,
+    OsAccountsClient, Receipt, UserId,
 };
 use std::sync::Arc;
 
@@ -43,6 +43,8 @@ impl NoteGenerateService {
         &self,
         params: NoteGenerateParams,
     ) -> Result<NoteGenerateOutput, ServiceError> {
+        self.pricing
+            .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
         // Flat-estimate mode — see note_transcribe.rs. The actual charge below
         // is still computed from real token usage; only the Hold size changes.
         let estimate = Credits(self.flat_estimate_credits);

--- a/scribe-api/crates/services/src/pricing.rs
+++ b/scribe-api/crates/services/src/pricing.rs
@@ -55,6 +55,35 @@ impl PricingTable {
         self.models.contains_key(model_id)
     }
 
+    pub fn ensure_model_kind(&self, model_id: &str, kind: ModelKind) -> Result<(), PricingError> {
+        let model = self.models.get(model_id).ok_or(PricingError::NotPriced)?;
+        if !model_type_matches_kind(model.model_type, kind) {
+            return Err(PricingError::WrongUnit);
+        }
+        match kind {
+            ModelKind::Asr => {
+                if model.unit != PriceUnit::Seconds {
+                    return Err(PricingError::WrongUnit);
+                }
+                model
+                    .credits_per_million_seconds
+                    .ok_or(PricingError::MissingRate)?;
+            }
+            ModelKind::Text => {
+                if model.unit != PriceUnit::Tokens {
+                    return Err(PricingError::WrongUnit);
+                }
+                model
+                    .input_credits_per_million_tokens
+                    .ok_or(PricingError::MissingRate)?;
+                model
+                    .output_credits_per_million_tokens
+                    .ok_or(PricingError::MissingRate)?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (&String, &ModelPriceConfig)> {
         self.models.iter()
     }
@@ -111,7 +140,7 @@ mod tests {
     use super::{PricingError, PricingTable};
     use pretty_assertions::assert_eq;
     use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
-    use scribe_domain::TokenUsage;
+    use scribe_domain::{ModelKind, TokenUsage};
     use std::collections::BTreeMap;
 
     fn models<const N: usize>(
@@ -235,6 +264,28 @@ mod tests {
                 },
             ),
             Err(PricingError::WrongUnit)
+        );
+    }
+
+    #[test]
+    fn ensures_model_kind_matches_pricing_metadata() {
+        let table = PricingTable::new(models([
+            ("asr-model", PriceUnit::Seconds, 1, 0, ModelType::Asr),
+            ("text-model", PriceUnit::Tokens, 1, 1, ModelType::Text),
+        ]));
+
+        assert_eq!(table.ensure_model_kind("asr-model", ModelKind::Asr), Ok(()));
+        assert_eq!(
+            table.ensure_model_kind("text-model", ModelKind::Text),
+            Ok(())
+        );
+        assert_eq!(
+            table.ensure_model_kind("asr-model", ModelKind::Text),
+            Err(PricingError::WrongUnit)
+        );
+        assert_eq!(
+            table.ensure_model_kind("missing", ModelKind::Text),
+            Err(PricingError::NotPriced)
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a backend model-validation bug in `scribe-api`: endpoints only checked that a model id was priced, not that it matched the expected endpoint kind. Text paths could accept an ASR model, take an OS Accounts hold, and call the wrong upstream before discovering the token-pricing mismatch.

## What changed

- Added `PricingTable::ensure_model_kind` to validate model kind and pricing unit/rates together.
- Updated note transcription/dictation transcription to require ASR models and note generation/dictation cleanup/agent chat to require text models at the API boundary.
- Added service-side text-model preflights before authorization for note generation, dictation cleanup, and agent chat.
- Added focused regression tests for API error mapping and for avoiding OS Accounts authorization when an ASR model is passed to text operations.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
