### PR TITLE
Fix breadcrumb scrollbar overlap

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -108,6 +108,7 @@ import {
   type ScribeUpdate,
 } from "../lib/updater";
 import { shouldPollProcessingStatus } from "./processing-polling";
+import { attachScrollThumbFade } from "../lib/scroll-thumb-fade";
 import { createInitialState, notesReducer } from "./state/app-state";
 import {
   checkForScribeUpdate,
@@ -184,6 +185,7 @@ export function App() {
   const agentMenuBarWorkingSessionIdsRef = useRef<Set<string>>(new Set());
   const agentMenuBarWaitingSessionIdsRef = useRef<Set<string>>(new Set());
   const agentMenuBarLastStatusRef = useRef<AgentSessionStatusDetail>();
+  const mainPanelBodyRef = useRef<HTMLDivElement | null>(null);
   // Where the back affordance in settings returns to — captured when settings
   // is opened so "back" lands the user where they were, not on Notes.
   const [settingsReturnView, setSettingsReturnView] =
@@ -304,6 +306,15 @@ export function App() {
 
   useEffect(() => {
     preloadRecordingSounds();
+  }, []);
+
+  // The card scroller's thumb fades in with scroll activity and back out when
+  // idle (native-overlay feel; the CSS only listens on breadcrumb views —
+  // see scroll-thumb-fade.ts).
+  useEffect(() => {
+    const el = mainPanelBodyRef.current;
+    if (!el) return;
+    return attachScrollThumbFade(el);
   }, []);
 
   // installingUpdate is read through a ref so runUpdateCheck keeps a stable
@@ -1545,7 +1556,11 @@ export function App() {
       />
       <section className="main-panel">
         {accessibilityBlocked ? <PermissionBanner /> : null}
-        <div className="main-panel-body" data-active-view={activeView}>
+        <div
+          ref={mainPanelBodyRef}
+          className="main-panel-body"
+          data-active-view={activeView}
+        >
           {error ? <p className="error-banner">{error}</p> : null}
           <div className="workspace">
             {activeView === "settings" ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -126,6 +126,7 @@ import {
   buildAgentChatGallery,
   type AgentChatGallerySection,
 } from "../../lib/agent-chat-gallery";
+import { attachScrollThumbFade } from "../../lib/scroll-thumb-fade";
 
 const POLLED_STATUSES = new Set<AgentTaskStatus>([
   "queued",
@@ -429,9 +430,18 @@ export function AgentWorkspace({
   const sessionTitleOverridesRef = useRef<Record<string, string>>({});
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
+  const agentScrollRef = useRef<HTMLDivElement | null>(null);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const composerBoxRef = useRef<HTMLDivElement | null>(null);
   const [composerMultiline, setComposerMultiline] = useState(false);
+
+  // The conversation scroller's thumb fades in with scroll activity and back
+  // out when idle (native-overlay feel; see scroll-thumb-fade.ts).
+  useEffect(() => {
+    const el = agentScrollRef.current;
+    if (!el) return;
+    return attachScrollThumbFade(el);
+  }, []);
 
   useEffect(() => {
     selectedHermesSessionIdRef.current = selectedHermesSessionId;
@@ -1925,7 +1935,7 @@ export function AgentWorkspace({
           }
         />
       )}
-      <div className="agent-scroll">
+      <div ref={agentScrollRef} className="agent-scroll">
         <section className="agent-main" aria-label="Agent task details">
           {error ? <p className="error-banner">{error}</p> : null}
           {gallerySections ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1894,10 +1894,12 @@ export function AgentWorkspace({
   );
 
   useEffect(() => {
-    // The conversation scrolls in the main card (.main-panel-body), not an
-    // inner pane — so drive that scroller to the bottom as turns arrive.
-    const scroller = listRef.current?.closest(".main-panel-body");
+    // The conversation scrolls in .agent-scroll, which sits below the sticky
+    // breadcrumb so the scrollbar can't ride up over the bar — drive that
+    // scroller to the bottom as turns arrive.
+    const scroller = listRef.current?.closest(".agent-scroll");
     if (!(scroller instanceof HTMLElement)) return;
+    if (typeof scroller.scrollTo !== "function") return; // jsdom has no scrollTo
     scroller.scrollTo({ top: scroller.scrollHeight, behavior: "smooth" });
   }, [renderedTurnsSignature, selectedHermesSessionId, selectedTaskId]);
 
@@ -1923,276 +1925,280 @@ export function AgentWorkspace({
           }
         />
       )}
-      <section className="agent-main" aria-label="Agent task details">
-        {error ? <p className="error-banner">{error}</p> : null}
-        {gallerySections ? (
-          <AgentResponseGallery
-            sections={gallerySections}
-            onClose={() => setGalleryDesired(false)}
-          />
-        ) : !newSessionMode && selectedHermesSessionId ? (
-          <>
-            <div ref={listRef} className="agent-timeline">
-              {hermesTurns.map((turn) => (
-                <AgentChatTurnRow
-                  key={turn.id}
-                  turn={turn}
-                  artifacts={chatArtifacts}
-                  approvalSubmitting={approvalSubmitting}
-                  clarifySubmitting={clarifySubmitting}
-                  onDownloadArtifact={(artifact) =>
-                    void downloadHermesBridgeFile(artifact.path).catch(
-                      (err: unknown) => setError(messageFromError(err)),
-                    )
-                  }
-                  onApproval={(part, choice) =>
-                    void respondToApproval(
-                      selectedHermesSessionId,
-                      part.sessionId ?? selectedHermesSessionId,
-                      part.id,
-                      choice,
-                    )
-                  }
-                  onClarify={(part, answer) =>
-                    void respondToClarify(
-                      selectedHermesSessionId,
-                      part.id,
-                      answer,
-                    )
-                  }
-                />
-              ))}
-              {workingSessionIds.has(selectedHermesSessionId) &&
-              hermesTurns.at(-1)?.role === "user" ? (
-                <AgentThinking />
-              ) : null}
-            </div>
-          </>
-        ) : !newSessionMode && selectedTask ? (
-          <>
-            <header className="agent-detail-header">
-              <div className="agent-detail-title">
-                <ActivityIndicator
-                  active={workingTaskIds.has(selectedTask.id)}
-                  large
-                />
-                <div className="agent-detail-heading">
-                  <h2>{selectedTask.title}</h2>
-                  <SafetyBadge />
-                </div>
-              </div>
-              <div className="agent-actions">
-                {selectedTask.status !== "cancelled" &&
-                selectedTask.status !== "completed" ? (
-                  <button
-                    type="button"
-                    className="agent-icon-button"
-                    aria-label="Cancel task"
-                    onClick={() => void cancelTask(selectedTask.id)}
-                  >
-                    <CircleStopIcon size={15} />
-                  </button>
-                ) : null}
-                {selectedTask.status === "failed" ||
-                selectedTask.status === "paused" ? (
-                  <button
-                    type="button"
-                    className="agent-icon-button"
-                    aria-label="Retry task"
-                    onClick={() => void retryTask(selectedTask.id)}
-                  >
-                    <RotateCwIcon size={15} />
-                  </button>
-                ) : null}
-              </div>
-            </header>
-            <div ref={listRef} className="agent-timeline">
-              {taskTurns.map((turn) => (
-                <AgentChatTurnRow
-                  key={turn.id}
-                  turn={turn}
-                  artifacts={chatArtifacts}
-                  approvalSubmitting={approvalSubmitting}
-                  clarifySubmitting={clarifySubmitting}
-                  onDownloadArtifact={(artifact) =>
-                    void downloadHermesBridgeFile(artifact.path).catch(
-                      (err: unknown) => setError(messageFromError(err)),
-                    )
-                  }
-                  onApproval={(part, choice) => {
-                    const sessionId =
-                      part.sessionId ?? selectedTask.hermesSessionId;
-                    if (!sessionId) return;
-                    void respondToApproval(
-                      selectedTask.id,
-                      sessionId,
-                      part.id,
-                      choice,
-                    );
-                  }}
-                  onClarify={(part, answer) =>
-                    void respondToClarify(selectedTask.id, part.id, answer)
-                  }
-                />
-              ))}
-              {workingTaskIds.has(selectedTask.id) &&
-              taskTurns.at(-1)?.role === "user" ? (
-                <AgentThinking />
-              ) : null}
-            </div>
-          </>
-        ) : (
-          <div className="agent-empty-view">
-            <EmptyState
-              icon={<IconPangolin size={24} />}
-              title="Start an agent session"
-              description={
-                bridgeStarting
-                  ? "Getting the agent ready…"
-                  : "Pick a shortcut, or describe any desktop task in the box below. It runs privately on your machine."
-              }
-              label="Start an agent session"
-              footer={
-                <div className="agent-shortcut-grid">
-                  {AGENT_SHORTCUTS.map((shortcut) => (
-                    <button
-                      key={shortcut.key}
-                      type="button"
-                      className="agent-shortcut"
-                      disabled={submitting}
-                      onClick={() => runShortcut(shortcut)}
-                    >
-                      <span className="agent-shortcut-icon" aria-hidden>
-                        {shortcut.icon}
-                      </span>
-                      <span className="agent-shortcut-text">
-                        <span className="agent-shortcut-title">
-                          {shortcut.title}
-                        </span>
-                        <span className="agent-shortcut-description">
-                          {shortcut.description}
-                        </span>
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              }
+      <div className="agent-scroll">
+        <section className="agent-main" aria-label="Agent task details">
+          {error ? <p className="error-banner">{error}</p> : null}
+          {gallerySections ? (
+            <AgentResponseGallery
+              sections={gallerySections}
+              onClose={() => setGalleryDesired(false)}
             />
-          </div>
-        )}
-
-        {activePanel === "chat" ? (
-          <form
-            className="agent-composer"
-            data-drop-active={dropActive ? "true" : undefined}
-            onSubmit={(event) => void submit(event)}
-            onDragOver={handleComposerDragOver}
-            onDragEnter={() => setDropActive(true)}
-            onDragLeave={() => setDropActive(false)}
-            onDrop={handleComposerDrop}
-          >
-            <div
-              ref={composerBoxRef}
-              className="agent-composer-box"
-              data-dirty={draft.trim() || attachments.length ? "true" : "false"}
-              data-multiline={composerMultiline ? "true" : "false"}
-            >
-              {attachments.length ? (
-                <div className="agent-composer-attachments">
-                  {attachments.map((attachment) => (
-                    <span
-                      key={attachment.id}
-                      className="agent-attachment-chip"
-                      title={attachment.name}
-                    >
-                      {attachment.previewDataUrl ? (
-                        <img
-                          src={attachment.previewDataUrl}
-                          alt=""
-                          aria-hidden="true"
-                        />
-                      ) : (
-                        <FileIcon size={14} />
-                      )}
-                      <span className="agent-attachment-name">
-                        {attachment.name}
-                      </span>
-                      <button
-                        type="button"
-                        aria-label={`Remove ${attachment.name}`}
-                        onClick={() => removeAttachment(attachment.id)}
-                      >
-                        <XIcon size={12} />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-              <div className="agent-composer-row">
-                <button
-                  type="button"
-                  className="agent-composer-attach"
-                  aria-label="Attach files"
-                  title="Attach files"
-                  onClick={() => void pickAttachments()}
-                >
-                  <IconPlusMedium size={18} />
-                </button>
-                <textarea
-                  ref={composerRef}
-                  value={draft}
-                  onChange={(event) => setDraft(event.currentTarget.value)}
-                  placeholder={
-                    importingFiles ? "Attaching file…" : "Send a message"
-                  }
-                  rows={1}
-                  onKeyDown={(event) => {
-                    // Ignore the Enter that commits an IME composition
-                    // (Japanese/Chinese/Korean input) — only a real Enter
-                    // press should send the message.
-                    if (event.nativeEvent.isComposing) return;
-                    if (event.key === "Enter" && !event.shiftKey) {
-                      event.preventDefault();
-                      event.currentTarget.form?.requestSubmit();
+          ) : !newSessionMode && selectedHermesSessionId ? (
+            <>
+              <div ref={listRef} className="agent-timeline">
+                {hermesTurns.map((turn) => (
+                  <AgentChatTurnRow
+                    key={turn.id}
+                    turn={turn}
+                    artifacts={chatArtifacts}
+                    approvalSubmitting={approvalSubmitting}
+                    clarifySubmitting={clarifySubmitting}
+                    onDownloadArtifact={(artifact) =>
+                      void downloadHermesBridgeFile(artifact.path).catch(
+                        (err: unknown) => setError(messageFromError(err)),
+                      )
                     }
-                  }}
-                />
-                <div className="agent-composer-actions">
+                    onApproval={(part, choice) =>
+                      void respondToApproval(
+                        selectedHermesSessionId,
+                        part.sessionId ?? selectedHermesSessionId,
+                        part.id,
+                        choice,
+                      )
+                    }
+                    onClarify={(part, answer) =>
+                      void respondToClarify(
+                        selectedHermesSessionId,
+                        part.id,
+                        answer,
+                      )
+                    }
+                  />
+                ))}
+                {workingSessionIds.has(selectedHermesSessionId) &&
+                hermesTurns.at(-1)?.role === "user" ? (
+                  <AgentThinking />
+                ) : null}
+              </div>
+            </>
+          ) : !newSessionMode && selectedTask ? (
+            <>
+              <header className="agent-detail-header">
+                <div className="agent-detail-title">
+                  <ActivityIndicator
+                    active={workingTaskIds.has(selectedTask.id)}
+                    large
+                  />
+                  <div className="agent-detail-heading">
+                    <h2>{selectedTask.title}</h2>
+                    <SafetyBadge />
+                  </div>
+                </div>
+                <div className="agent-actions">
+                  {selectedTask.status !== "cancelled" &&
+                  selectedTask.status !== "completed" ? (
+                    <button
+                      type="button"
+                      className="agent-icon-button"
+                      aria-label="Cancel task"
+                      onClick={() => void cancelTask(selectedTask.id)}
+                    >
+                      <CircleStopIcon size={15} />
+                    </button>
+                  ) : null}
+                  {selectedTask.status === "failed" ||
+                  selectedTask.status === "paused" ? (
+                    <button
+                      type="button"
+                      className="agent-icon-button"
+                      aria-label="Retry task"
+                      onClick={() => void retryTask(selectedTask.id)}
+                    >
+                      <RotateCwIcon size={15} />
+                    </button>
+                  ) : null}
+                </div>
+              </header>
+              <div ref={listRef} className="agent-timeline">
+                {taskTurns.map((turn) => (
+                  <AgentChatTurnRow
+                    key={turn.id}
+                    turn={turn}
+                    artifacts={chatArtifacts}
+                    approvalSubmitting={approvalSubmitting}
+                    clarifySubmitting={clarifySubmitting}
+                    onDownloadArtifact={(artifact) =>
+                      void downloadHermesBridgeFile(artifact.path).catch(
+                        (err: unknown) => setError(messageFromError(err)),
+                      )
+                    }
+                    onApproval={(part, choice) => {
+                      const sessionId =
+                        part.sessionId ?? selectedTask.hermesSessionId;
+                      if (!sessionId) return;
+                      void respondToApproval(
+                        selectedTask.id,
+                        sessionId,
+                        part.id,
+                        choice,
+                      );
+                    }}
+                    onClarify={(part, answer) =>
+                      void respondToClarify(selectedTask.id, part.id, answer)
+                    }
+                  />
+                ))}
+                {workingTaskIds.has(selectedTask.id) &&
+                taskTurns.at(-1)?.role === "user" ? (
+                  <AgentThinking />
+                ) : null}
+              </div>
+            </>
+          ) : (
+            <div className="agent-empty-view">
+              <EmptyState
+                icon={<IconPangolin size={24} />}
+                title="Start an agent session"
+                description={
+                  bridgeStarting
+                    ? "Getting the agent ready…"
+                    : "Pick a shortcut, or describe any desktop task in the box below. It runs privately on your machine."
+                }
+                label="Start an agent session"
+                footer={
+                  <div className="agent-shortcut-grid">
+                    {AGENT_SHORTCUTS.map((shortcut) => (
+                      <button
+                        key={shortcut.key}
+                        type="button"
+                        className="agent-shortcut"
+                        disabled={submitting}
+                        onClick={() => runShortcut(shortcut)}
+                      >
+                        <span className="agent-shortcut-icon" aria-hidden>
+                          {shortcut.icon}
+                        </span>
+                        <span className="agent-shortcut-text">
+                          <span className="agent-shortcut-title">
+                            {shortcut.title}
+                          </span>
+                          <span className="agent-shortcut-description">
+                            {shortcut.description}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                }
+              />
+            </div>
+          )}
+
+          {activePanel === "chat" ? (
+            <form
+              className="agent-composer"
+              data-drop-active={dropActive ? "true" : undefined}
+              onSubmit={(event) => void submit(event)}
+              onDragOver={handleComposerDragOver}
+              onDragEnter={() => setDropActive(true)}
+              onDragLeave={() => setDropActive(false)}
+              onDrop={handleComposerDrop}
+            >
+              <div
+                ref={composerBoxRef}
+                className="agent-composer-box"
+                data-dirty={
+                  draft.trim() || attachments.length ? "true" : "false"
+                }
+                data-multiline={composerMultiline ? "true" : "false"}
+              >
+                {attachments.length ? (
+                  <div className="agent-composer-attachments">
+                    {attachments.map((attachment) => (
+                      <span
+                        key={attachment.id}
+                        className="agent-attachment-chip"
+                        title={attachment.name}
+                      >
+                        {attachment.previewDataUrl ? (
+                          <img
+                            src={attachment.previewDataUrl}
+                            alt=""
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <FileIcon size={14} />
+                        )}
+                        <span className="agent-attachment-name">
+                          {attachment.name}
+                        </span>
+                        <button
+                          type="button"
+                          aria-label={`Remove ${attachment.name}`}
+                          onClick={() => removeAttachment(attachment.id)}
+                        >
+                          <XIcon size={12} />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+                <div className="agent-composer-row">
                   <button
                     type="button"
-                    className="agent-composer-mic"
-                    aria-label="Dictate"
-                    title="Start dictation"
-                    onClick={() => void startDictation()}
+                    className="agent-composer-attach"
+                    aria-label="Attach files"
+                    title="Attach files"
+                    onClick={() => void pickAttachments()}
                   >
-                    <IconMicrophone size={18} />
+                    <IconPlusMedium size={18} />
                   </button>
-                  <button
-                    type="submit"
-                    className="agent-composer-send"
-                    disabled={
-                      submitting ||
-                      importingFiles ||
-                      (!draft.trim() && !attachments.length)
+                  <textarea
+                    ref={composerRef}
+                    value={draft}
+                    onChange={(event) => setDraft(event.currentTarget.value)}
+                    placeholder={
+                      importingFiles ? "Attaching file…" : "Send a message"
                     }
-                    tabIndex={draft.trim() || attachments.length ? 0 : -1}
-                    aria-hidden={
-                      draft.trim() || attachments.length ? undefined : true
-                    }
-                    aria-label={
-                      selectedHermesSessionId || selectedTask
-                        ? "Send message"
-                        : "Start session"
-                    }
-                  >
-                    {submitting ? <Spinner /> : <IconArrowUp size={16} />}
-                  </button>
+                    rows={1}
+                    onKeyDown={(event) => {
+                      // Ignore the Enter that commits an IME composition
+                      // (Japanese/Chinese/Korean input) — only a real Enter
+                      // press should send the message.
+                      if (event.nativeEvent.isComposing) return;
+                      if (event.key === "Enter" && !event.shiftKey) {
+                        event.preventDefault();
+                        event.currentTarget.form?.requestSubmit();
+                      }
+                    }}
+                  />
+                  <div className="agent-composer-actions">
+                    <button
+                      type="button"
+                      className="agent-composer-mic"
+                      aria-label="Dictate"
+                      title="Start dictation"
+                      onClick={() => void startDictation()}
+                    >
+                      <IconMicrophone size={18} />
+                    </button>
+                    <button
+                      type="submit"
+                      className="agent-composer-send"
+                      disabled={
+                        submitting ||
+                        importingFiles ||
+                        (!draft.trim() && !attachments.length)
+                      }
+                      tabIndex={draft.trim() || attachments.length ? 0 : -1}
+                      aria-hidden={
+                        draft.trim() || attachments.length ? undefined : true
+                      }
+                      aria-label={
+                        selectedHermesSessionId || selectedTask
+                          ? "Send message"
+                          : "Start session"
+                      }
+                    >
+                      {submitting ? <Spinner /> : <IconArrowUp size={16} />}
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
-        ) : null}
-      </section>
+            </form>
+          ) : null}
+        </section>
+      </div>
     </section>
   );
 }

--- a/src/lib/scroll-thumb-fade.ts
+++ b/src/lib/scroll-thumb-fade.ts
@@ -1,0 +1,64 @@
+/**
+ * Recreates the native overlay scrollbar's show-while-scrolling behavior for
+ * the custom webkit scrollbars on breadcrumb views (see the --thumb-alpha
+ * rules in app.css). Scrollbar parts ignore CSS transitions, so the fade is
+ * driven by stepping the --thumb-alpha custom property each frame — engines
+ * repaint the thumb on custom-property changes.
+ */
+
+/** Thumb opacity while scrolling, in color-mix percent of muted-foreground. */
+const VISIBLE_ALPHA = 30;
+/** Fade-in duration — quick, so the thumb tracks the first scroll tick. */
+const SHOW_MS = 100;
+/** Fade-out duration — a softer dissolve, like the native overlay. */
+const HIDE_MS = 450;
+/** How long after the last scroll event the thumb starts fading out. */
+const IDLE_MS = 800;
+
+/**
+ * Fade `el`'s scrollbar thumb in on scroll activity and back out after a beat
+ * of idleness. Returns a cleanup function.
+ */
+export function attachScrollThumbFade(el: HTMLElement): () => void {
+  let alpha = 0;
+  let target = 0;
+  let rate = 0; // alpha units per ms
+  let frame = 0;
+  let idleTimer = 0;
+  let lastTick = 0;
+
+  const step = (now: number) => {
+    frame = 0;
+    const elapsed = Math.max(now - lastTick, 1);
+    lastTick = now;
+    alpha =
+      target > alpha
+        ? Math.min(target, alpha + rate * elapsed)
+        : Math.max(target, alpha - rate * elapsed);
+    el.style.setProperty("--thumb-alpha", alpha.toFixed(1));
+    if (alpha !== target) frame = requestAnimationFrame(step);
+  };
+
+  const animateTo = (next: number, durationMs: number) => {
+    target = next;
+    rate = VISIBLE_ALPHA / durationMs;
+    if (!frame && alpha !== target) {
+      lastTick = performance.now();
+      frame = requestAnimationFrame(step);
+    }
+  };
+
+  const onScroll = () => {
+    animateTo(VISIBLE_ALPHA, SHOW_MS);
+    window.clearTimeout(idleTimer);
+    idleTimer = window.setTimeout(() => animateTo(0, HIDE_MS), IDLE_MS);
+  };
+
+  el.addEventListener("scroll", onScroll, { passive: true });
+  return () => {
+    el.removeEventListener("scroll", onScroll);
+    window.clearTimeout(idleTimer);
+    if (frame) cancelAnimationFrame(frame);
+    el.style.removeProperty("--thumb-alpha");
+  };
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -405,14 +405,16 @@ input:focus-visible,
 
 /* The conversation scroller, below the breadcrumb. Full-bleed (cancelling the
  * card body's gutter, then re-adding it inside) so its scrollbar hugs the card
- * edge like the shared scroller did — only now it starts beneath the bar. */
+ * edge like the shared scroller did — only now it starts beneath the bar.
+ * No explicit width: the stretched flex item grows by the negative margins
+ * (like .detail-bar does); width:100% would resolve to the container width and
+ * leave the right edge — and the scrollbar — a gutter short of the card edge. */
 .agent-scroll {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-width: 0;
   min-height: 0;
-  width: 100%;
   overflow-y: auto;
   overscroll-behavior: contain;
   margin: 0 calc(-1 * var(--sp-8));

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -225,21 +225,40 @@ input:focus-visible,
 
 /* Agent ------------------------------------------------------------- */
 
-/* The conversation flows in the main card scroller (like a note's body), so the
- * agent surface grows with its content rather than owning an inner scrollbar.
- * min-height keeps a short/empty session filling the card so the pinned
- * composer still lands at the bottom. */
+/* The breadcrumb is a fixed header and the conversation scrolls in .agent-scroll
+ * below it, so the scrollbar starts under the bar instead of riding up over it
+ * (the shared .main-panel-body scrollbar sits in the gutter past the bar's edge,
+ * so the bar can't cover it). This means filling the card exactly — not growing
+ * past it — so .agent-scroll has a bounded height to scroll within. */
 .agent-workspace {
   display: flex;
   flex-direction: column;
   width: 100%;
-  /* align-self:start stops the fixed-height .workspace grid from stretching us
-   * to exactly one viewport — that capped the sticky breadcrumb's range so it
-   * scrolled away after a screenful. Growing with content keeps it pinned. */
-  align-self: start;
-  min-height: 100%;
+  align-self: stretch;
+  height: 100%;
+  min-height: 0;
   margin: 0 auto;
 }
+
+/* Agent view: stop the card body from scrolling (the breadcrumb would scroll
+ * with it) and give the grid row a definite height so .agent-workspace fills
+ * the card exactly. Scoped so every other view keeps the shared scroller. */
+.main-panel-body[data-active-view="agent"] {
+  overflow: hidden;
+  padding-bottom: 0;
+}
+
+.main-panel-body[data-active-view="agent"] .workspace {
+  grid-template-rows: minmax(0, 1fr);
+}
+
+/* The card-edge fades animate off .main-panel-body's scroll; with that frozen in
+ * the agent view, switch them off so the bottom fade doesn't stick on. */
+.main-panel:has(> .main-panel-body[data-active-view="agent"])::before,
+.main-panel:has(> .main-panel-body[data-active-view="agent"])::after {
+  content: none;
+}
+
 /* The agent already lives inside the floating .main-panel card, so it draws
  * no card of its own — that card-in-a-card read busier than any Notes view.
  * The rail surface (kept for any rail-mode reuse) is the only bordered box. */
@@ -384,13 +403,27 @@ input:focus-visible,
   -webkit-line-clamp: 2;
 }
 
+/* The conversation scroller, below the breadcrumb. Full-bleed (cancelling the
+ * card body's gutter, then re-adding it inside) so its scrollbar hugs the card
+ * edge like the shared scroller did — only now it starts beneath the bar. */
+.agent-scroll {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  margin: 0 calc(-1 * var(--sp-8));
+  padding: 0 var(--sp-8) var(--sp-5);
+}
+
 .agent-main {
   display: flex;
   flex-direction: column;
-  /* flex:1 with the default (auto) min-height fills the space under the sticky
-   * breadcrumb when the conversation is short, AND grows with the content when
-   * it's long — so the whole .agent-workspace (and thus the breadcrumb's sticky
-   * range) spans the full scroll height and the bar persists the entire way. */
+  /* flex:1 fills the scroller when the conversation is short and grows with it
+   * when long; max-width keeps the column centred inside the full-bleed scroller. */
   flex: 1;
   width: 100%;
   max-width: var(--content-max);
@@ -6048,32 +6081,6 @@ input:focus-visible,
   background: color-mix(in oklch, var(--card) 78%, transparent);
   backdrop-filter: saturate(140%) blur(14px);
   -webkit-backdrop-filter: saturate(140%) blur(14px);
-}
-
-/* The card's scroll lives in .main-panel-body, and this full-bleed bar overlaps
- * the gutter where that scroller's thin scrollbar sits. The sticky bar paints
- * over the scrollbar, but its translucent frost lets the thumb show through at
- * the top — so it reads as a sliver poking above the bar while you scroll.
- * Opaque chips at the scrollbar gutters clip the thumb to start below the bar.
- * They sit at the very edges, well inside the sp-8 (24px) content inset, so
- * they never touch the crumb or actions, and the frosted middle is untouched. */
-.detail-bar::before,
-.detail-bar::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 8px;
-  background: var(--card);
-  pointer-events: none;
-}
-
-.detail-bar::before {
-  left: 0;
-}
-
-.detail-bar::after {
-  right: 0;
 }
 
 .detail-breadcrumb {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6110,16 +6110,17 @@ input:focus-visible,
 /* The opt-out also moves the thumb off scrollbar-color (which is what painted
  * it) onto the webkit pseudo path, whose base style is transparent-until-hover
  * — and WKWebView doesn't repaint scrollbar parts on hover, so the thumb would
- * never show. Paint these scrollers' thumb statically in the same quiet color,
- * with the usual brighten-on-hover where the engine supports it. */
+ * never show. Scrollbar parts can't be transitioned either, so the native
+ * show-while-scrolling fade is recreated by stepping --thumb-alpha from JS
+ * (attachScrollThumbFade in src/lib/scroll-thumb-fade.ts) — engines DO repaint
+ * the thumb when a custom property changes. */
 .agent-scroll::-webkit-scrollbar-thumb,
 .main-panel-body:has(.detail-bar)::-webkit-scrollbar-thumb {
-  background: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
-}
-
-.agent-scroll::-webkit-scrollbar-thumb:hover,
-.main-panel-body:has(.detail-bar)::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  background: color-mix(
+    in oklch,
+    var(--muted-foreground) calc(var(--thumb-alpha, 0) * 1%),
+    transparent
+  );
 }
 
 .detail-bar {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6114,13 +6114,25 @@ input:focus-visible,
  * show-while-scrolling fade is recreated by stepping --thumb-alpha from JS
  * (attachScrollThumbFade in src/lib/scroll-thumb-fade.ts) — engines DO repaint
  * the thumb when a custom property changes. */
+/* Native overlay thumbs float a couple px off the window edge; match that on
+ * the custom scrollbar so breadcrumb views don't read flush against the card
+ * edge next to the bar-less views' native thumb. The region widens to 8px and
+ * transparent borders clip the painted pill back to the usual 4px, inset 2px
+ * from the card edge and the content alike. */
+.agent-scroll::-webkit-scrollbar,
+.main-panel-body:has(.detail-bar)::-webkit-scrollbar {
+  width: 8px;
+}
+
 .agent-scroll::-webkit-scrollbar-thumb,
 .main-panel-body:has(.detail-bar)::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
   background: color-mix(
     in oklch,
     var(--muted-foreground) calc(var(--thumb-alpha, 0) * 1%),
     transparent
   );
+  background-clip: padding-box;
 }
 
 .detail-bar {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6107,6 +6107,21 @@ input:focus-visible,
   margin-top: var(--detail-bar-h);
 }
 
+/* The opt-out also moves the thumb off scrollbar-color (which is what painted
+ * it) onto the webkit pseudo path, whose base style is transparent-until-hover
+ * — and WKWebView doesn't repaint scrollbar parts on hover, so the thumb would
+ * never show. Paint these scrollers' thumb statically in the same quiet color,
+ * with the usual brighten-on-hover where the engine supports it. */
+.agent-scroll::-webkit-scrollbar-thumb,
+.main-panel-body:has(.detail-bar)::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
+}
+
+.agent-scroll::-webkit-scrollbar-thumb:hover,
+.main-panel-body:has(.detail-bar)::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+}
+
 .detail-bar {
   position: sticky;
   top: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -252,11 +252,27 @@ input:focus-visible,
   grid-template-rows: minmax(0, 1fr);
 }
 
-/* The card-edge fades animate off .main-panel-body's scroll; with that frozen in
- * the agent view, switch them off so the bottom fade doesn't stick on. */
-.main-panel:has(> .main-panel-body[data-active-view="agent"])::before,
-.main-panel:has(> .main-panel-body[data-active-view="agent"])::after {
-  content: none;
+/* The card-edge fades animate off .main-panel-body's scroll, but in the agent
+ * view that body is frozen and the conversation scrolls in .agent-scroll. Drive
+ * the named timeline off that inner scroller instead so the bottom fade still
+ * dissolves the conversation into the fixed composer (and reads at the top edge
+ * under the breadcrumb), rather than sticking on. */
+@supports (animation-timeline: scroll()) {
+  .main-panel-body[data-active-view="agent"] {
+    scroll-timeline: none;
+  }
+  .main-panel-body[data-active-view="agent"] .agent-scroll {
+    scroll-timeline: --main-panel-scroll block;
+  }
+}
+
+/* The conversation scrolls in a pane below the breadcrumb (not behind it), so
+ * the frosted bar has nothing passing under it to blur. Drop the top fade to
+ * the bar's bottom edge (its 46px min-height) so the conversation softly
+ * dissolves into the breadcrumb as it scrolls up — the seam the frost used to
+ * read from content moving behind it. */
+.main-panel:has(> .main-panel-body[data-active-view="agent"])::before {
+  top: 46px;
 }
 
 /* The agent already lives inside the floating .main-panel card, so it draws

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -225,11 +225,11 @@ input:focus-visible,
 
 /* Agent ------------------------------------------------------------- */
 
-/* The breadcrumb is a fixed header and the conversation scrolls in .agent-scroll
- * below it, so the scrollbar starts under the bar instead of riding up over it
- * (the shared .main-panel-body scrollbar sits in the gutter past the bar's edge,
- * so the bar can't cover it). This means filling the card exactly — not growing
- * past it — so .agent-scroll has a bounded height to scroll within. */
+/* The breadcrumb is a fixed header and the conversation scrolls in .agent-scroll,
+ * whose box reaches up behind the bar (so the frost blurs passing content) while
+ * its scrollbar track is inset below the bar (so the thumb can't ride over it) —
+ * see .agent-scroll. This means filling the card exactly — not growing past it —
+ * so .agent-scroll has a bounded height to scroll within. */
 .agent-workspace {
   display: flex;
   flex-direction: column;
@@ -255,8 +255,7 @@ input:focus-visible,
 /* The card-edge fades animate off .main-panel-body's scroll, but in the agent
  * view that body is frozen and the conversation scrolls in .agent-scroll. Drive
  * the named timeline off that inner scroller instead so the bottom fade still
- * dissolves the conversation into the fixed composer (and reads at the top edge
- * under the breadcrumb), rather than sticking on. */
+ * dissolves the conversation into the fixed composer, rather than sticking on. */
 @supports (animation-timeline: scroll()) {
   .main-panel-body[data-active-view="agent"] {
     scroll-timeline: none;
@@ -264,15 +263,6 @@ input:focus-visible,
   .main-panel-body[data-active-view="agent"] .agent-scroll {
     scroll-timeline: --main-panel-scroll block;
   }
-}
-
-/* The conversation scrolls in a pane below the breadcrumb (not behind it), so
- * the frosted bar has nothing passing under it to blur. Drop the top fade to
- * the bar's bottom edge (its 46px min-height) so the conversation softly
- * dissolves into the breadcrumb as it scrolls up — the seam the frost used to
- * read from content moving behind it. */
-.main-panel:has(> .main-panel-body[data-active-view="agent"])::before {
-  top: 46px;
 }
 
 /* The agent already lives inside the floating .main-panel card, so it draws
@@ -419,12 +409,19 @@ input:focus-visible,
   -webkit-line-clamp: 2;
 }
 
-/* The conversation scroller, below the breadcrumb. Full-bleed (cancelling the
- * card body's gutter, then re-adding it inside) so its scrollbar hugs the card
- * edge like the shared scroller did — only now it starts beneath the bar.
- * No explicit width: the stretched flex item grows by the negative margins
- * (like .detail-bar does); width:100% would resolve to the container width and
- * leave the right edge — and the scrollbar — a gutter short of the card edge. */
+/* The conversation scroller. Full-bleed (cancelling the card body's gutter,
+ * then re-adding it inside) so its scrollbar hugs the card edge like the
+ * shared scroller did. No explicit width: the stretched flex item grows by
+ * the negative margins (like .detail-bar does); width:100% would resolve to
+ * the container width and leave the right edge — and the scrollbar — a
+ * gutter short of the card edge.
+ *
+ * The negative top margin slides the scroller's box up BEHIND the frosted
+ * breadcrumb (the matching top padding keeps the conversation itself starting
+ * below it), so scrolling content passes under the bar's backdrop blur — the
+ * frost actually frosts. The scrollbar would then span that band too, so the
+ * track is inset by the same height below: the thumb physically can't ride up
+ * over the breadcrumb. */
 .agent-scroll {
   display: flex;
   flex-direction: column;
@@ -433,8 +430,19 @@ input:focus-visible,
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  margin: 0 calc(-1 * var(--sp-8));
-  padding: 0 var(--sp-8) var(--sp-5);
+  margin: calc(-1 * var(--detail-bar-h)) calc(-1 * var(--sp-8)) 0;
+  padding: var(--detail-bar-h) var(--sp-8) var(--sp-5);
+  /* The global standard props (scrollbar-width/color, top of file) make the
+   * engine IGNORE all ::-webkit-scrollbar styling and draw a native overlay
+   * scrollbar instead — which offers no way to start the track below the bar.
+   * Opt this scroller out so the app's quiet 4px webkit scrollbar rules
+   * actually engage here, including the track inset below. */
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}
+
+.agent-scroll::-webkit-scrollbar-track {
+  margin-top: var(--detail-bar-h);
 }
 
 .agent-main {
@@ -6090,7 +6098,7 @@ input:focus-visible,
   display: flex;
   align-items: center;
   gap: var(--sp-3);
-  min-height: 46px;
+  min-height: var(--detail-bar-h);
   margin: 0 calc(-1 * var(--sp-8));
   /* Full-bleed bar, but the crumb lines up with the content gutter (sp-8)
    * rather than hugging the sidebar edge. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6091,6 +6091,22 @@ input:focus-visible,
 
 /* Sticky detail bar — quiet back affordance on folder and note detail */
 
+/* When a breadcrumb is present, the card scroller's content passes behind the
+ * translucent bar — but so would the scrollbar thumb, showing through the
+ * frost. Same treatment as .agent-scroll: the standard scrollbar props (set
+ * globally) make engines ignore ::-webkit-scrollbar styling, so opt the
+ * scroller out to re-engage the quiet 4px webkit scrollbar, then inset its
+ * track below the bar so the thumb can't ride up over it. Scoped with :has()
+ * so bar-less views keep the native overlay scrollbar. */
+.main-panel-body:has(.detail-bar) {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}
+
+.main-panel-body:has(.detail-bar)::-webkit-scrollbar-track {
+  margin-top: var(--detail-bar-h);
+}
+
 .detail-bar {
   position: sticky;
   top: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6050,6 +6050,32 @@ input:focus-visible,
   -webkit-backdrop-filter: saturate(140%) blur(14px);
 }
 
+/* The card's scroll lives in .main-panel-body, and this full-bleed bar overlaps
+ * the gutter where that scroller's thin scrollbar sits. The sticky bar paints
+ * over the scrollbar, but its translucent frost lets the thumb show through at
+ * the top — so it reads as a sliver poking above the bar while you scroll.
+ * Opaque chips at the scrollbar gutters clip the thumb to start below the bar.
+ * They sit at the very edges, well inside the sp-8 (24px) content inset, so
+ * they never touch the crumb or actions, and the frosted middle is untouched. */
+.detail-bar::before,
+.detail-bar::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  background: var(--card);
+  pointer-events: none;
+}
+
+.detail-bar::before {
+  left: 0;
+}
+
+.detail-bar::after {
+  right: 0;
+}
+
 .detail-breadcrumb {
   min-width: 0;
   color: var(--muted-foreground);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -60,6 +60,10 @@
   --control-md: 28px;
   --control-lg: 32px;
   --control-xl: 36px;
+  /* Breadcrumb (.detail-bar) height — its min-height, and what content fits
+   * inside it resolves to. Shared with the rules that tuck scrollers behind
+   * the bar and inset their scrollbar tracks below it. */
+  --detail-bar-h: 46px;
 
   /* Sidebar dimensions ---------------------------------------------- */
   --sidebar-w: 240px;

--- a/src/test/scroll-thumb-fade.test.ts
+++ b/src/test/scroll-thumb-fade.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { attachScrollThumbFade } from "../lib/scroll-thumb-fade";
+
+/** Manually driven rAF so each frame's timestamp is under test control. */
+function stubRaf() {
+  let pending: FrameRequestCallback[] = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    pending.push(cb);
+    return pending.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {
+    pending = [];
+  });
+  return (timestamp: number) => {
+    const cbs = pending;
+    pending = [];
+    for (const cb of cbs) cb(timestamp);
+    return pending.length > 0;
+  };
+}
+
+describe("attachScrollThumbFade", () => {
+  let el: HTMLElement;
+  let frame: (timestamp: number) => boolean;
+  let detach: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    frame = stubRaf();
+    el = document.createElement("div");
+    detach = undefined;
+  });
+
+  afterEach(() => {
+    detach?.();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const alpha = () => Number(el.style.getPropertyValue("--thumb-alpha"));
+
+  it("fades the thumb in on scroll and back out after the idle delay", () => {
+    detach = attachScrollThumbFade(el);
+
+    el.dispatchEvent(new Event("scroll"));
+    frame(50); // halfway through the 100ms fade-in
+    expect(alpha()).toBeGreaterThan(0);
+    expect(alpha()).toBeLessThan(30);
+    while (frame(200)); // run the animation to rest
+    expect(alpha()).toBe(30);
+
+    vi.advanceTimersByTime(800); // idle delay elapses → fade-out starts
+    frame(400);
+    while (frame(2000));
+    expect(alpha()).toBe(0);
+  });
+
+  it("keeps the thumb visible while scrolling continues", () => {
+    detach = attachScrollThumbFade(el);
+
+    el.dispatchEvent(new Event("scroll"));
+    while (frame(200));
+    expect(alpha()).toBe(30);
+
+    vi.advanceTimersByTime(500); // more scrolling before the idle delay ends
+    el.dispatchEvent(new Event("scroll"));
+    vi.advanceTimersByTime(500); // old timer would have fired by now
+    expect(alpha()).toBe(30);
+
+    vi.advanceTimersByTime(300); // full idle delay after the second scroll
+    while (frame(5000));
+    expect(alpha()).toBe(0);
+  });
+
+  it("cleans up the listener, timers, and property on detach", () => {
+    const cleanup = attachScrollThumbFade(el);
+
+    el.dispatchEvent(new Event("scroll"));
+    while (frame(200));
+    expect(alpha()).toBe(30);
+
+    cleanup();
+    expect(el.style.getPropertyValue("--thumb-alpha")).toBe("");
+
+    el.dispatchEvent(new Event("scroll")); // detached — no longer reacts
+    expect(el.style.getPropertyValue("--thumb-alpha")).toBe("");
+  });
+});


### PR DESCRIPTION
Fixes breadcrumb scrollbar overlap by moving the agent conversation into its own bounded scroller and clipping scrollbar tracks below sticky detail bars. Adds a shared scroll-thumb fade helper so custom breadcrumb scrollbars keep the native show-while-scrolling feel. Updates the detail bar height token and related CSS so agent and non-agent breadcrumb views use the same geometry. Validated with pnpm test and pnpm run lint.