### PR TITLE
Add microphone test playback to settings

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1852,6 +1852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,6 +4746,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni 0.21.1",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }
-tauri = { version = "2.8.0", features = ["macos-private-api", "tray-icon"] }
+tauri = { version = "2.8.0", features = ["protocol-asset", "macos-private-api", "tray-icon"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -139,6 +139,16 @@ func audioInputDevices() -> [AVCaptureDevice] {
     ).devices
 }
 
+func defaultMicrophoneDevice() -> [String: String]? {
+    guard let device = AVCaptureDevice.default(for: .audio) ?? audioInputDevices().first else {
+        return nil
+    }
+    return [
+        "id": device.uniqueID,
+        "name": device.localizedName,
+    ]
+}
+
 func microphoneDevice(for id: String?) -> AVCaptureDevice? {
     guard let id, !id.isEmpty else {
         return nil
@@ -149,10 +159,14 @@ func microphoneDevice(for id: String?) -> AVCaptureDevice? {
 }
 
 func emitMicrophoneDevices(selectedID: String?) {
-    emitJSON("microphone_devices", [
+    var payload: [String: Any] = [
         "devices": microphoneDevices(),
         "selectedID": selectedID ?? "",
-    ])
+    ]
+    if let defaultDevice = defaultMicrophoneDevice() {
+        payload["defaultDevice"] = defaultDevice
+    }
+    emitJSON("microphone_devices", payload)
 }
 
 func runOnMain(_ work: @escaping () -> Void) {
@@ -1333,11 +1347,22 @@ enum DictationError: LocalizedError {
     }
 }
 
+enum RecordingPurpose {
+    case dictation
+    case micTest
+}
+
+let micTestCapturePaddingSeconds: Double = 0.35
+
 final class DictationController {
     private var audioRecorder: AVAudioRecorder?
     private var selectedDeviceRecorder: SelectedDeviceRecorder?
     private var autoDetectInputMeter: AutoDetectInputMeter?
     private var recordingURL: URL?
+    private var micTestSampleURL: URL?
+    private var micTestStopWorkItem: DispatchWorkItem?
+    private var recordingPurpose: RecordingPurpose = .dictation
+    private var recordingStartedAt: TimeInterval = 0
     private var meteringTimer: DispatchSourceTimer?
     private var preferredMicrophoneID: String?
     private var preferredMicrophoneName: String?
@@ -1384,38 +1409,43 @@ final class DictationController {
                 emit("permission_status", permissionPayload())
                 return
             }
-            self?.startRecording()
+            self?.startRecording(purpose: .dictation, durationSeconds: nil)
         }
     }
 
     func stop() {
-        guard isListening else {
+        guard isListening, recordingPurpose == .dictation else {
             emit("error", ["code": "not_listening", "message": "Dictation is not listening."])
             return
         }
 
-        isListening = false
-        isFinalizing = true
-        stopMetering()
-        RecordingCuePlayer.play(.stop)
-        emit("finalizing_transcript")
+        stopActiveRecording()
+    }
 
-        if let selectedDeviceRecorder {
-            selectedDeviceRecorder.stop { [weak self] error in
-                runOnMain {
-                    self?.selectedDeviceRecorder = nil
-                    if let error {
-                        self?.fail(error)
-                        return
-                    }
-                    self?.emitRecordingReady()
-                }
-            }
+    func startMicTest(durationSeconds: Double) {
+        guard !listening else {
+            emit("mic_test_error", ["code": "already_listening", "message": "Audio capture is already running."])
             return
         }
 
-        audioRecorder?.stop()
-        emitRecordingReady()
+        AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
+            guard microphoneAllowed else {
+                emit("mic_test_error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
+                emit("permission_status", permissionPayload())
+                return
+            }
+            self?.startRecording(
+                purpose: .micTest,
+                durationSeconds: max(1, min(15, durationSeconds))
+            )
+        }
+    }
+
+    func discardMicTest() {
+        if isListening, recordingPurpose == .micTest {
+            resetRecordingState()
+        }
+        cleanupMicTestSample()
     }
 
     func paste(text: String) {
@@ -1440,8 +1470,11 @@ final class DictationController {
         exit(0)
     }
 
-    private func startRecording() {
+    private func startRecording(purpose: RecordingPurpose, durationSeconds: Double?) {
         resetRecordingState()
+        cleanupMicTestSample()
+        recordingPurpose = purpose
+        recordingStartedAt = ProcessInfo.processInfo.systemUptime
 
         let nextRecordingURL = temporaryRecordingURL()
         // Preserve the legacy Auto-detect behavior: AVAudioRecorder delegates
@@ -1450,7 +1483,12 @@ final class DictationController {
         // (Routing Auto-detect through the capture path was reverted in #86 — it
         // caused low recorded levels / no_speech for some default-mic users.)
         if let selectedDevice = microphoneDevice(for: preferredMicrophoneID) {
-            startSelectedDeviceRecording(device: selectedDevice, url: nextRecordingURL)
+            startSelectedDeviceRecording(
+                device: selectedDevice,
+                url: nextRecordingURL,
+                purpose: purpose,
+                durationSeconds: durationSeconds
+            )
             return
         }
 
@@ -1474,20 +1512,28 @@ final class DictationController {
 
             audioRecorder = recorder
             recordingURL = nextRecordingURL
-            isListening = true
             startAutoDetectMetering()
-            RecordingCuePlayer.play(.start)
-            emit("listening_started", [
-                "recognitionMode": "venice_recording",
-                "microphone": preferredMicrophoneName ?? "Auto-detect",
-            ])
+            markRecordingStarted(
+                microphone: preferredMicrophoneName ?? "Auto-detect",
+                purpose: purpose,
+                durationSeconds: durationSeconds
+            )
         } catch {
             resetRecordingState()
-            emit("error", ["code": "audio_start_failed", "message": error.localizedDescription])
+            emitRecordingError(
+                purpose: purpose,
+                code: "audio_start_failed",
+                message: error.localizedDescription
+            )
         }
     }
 
-    private func startSelectedDeviceRecording(device: AVCaptureDevice, url: URL) {
+    private func startSelectedDeviceRecording(
+        device: AVCaptureDevice,
+        url: URL,
+        purpose: RecordingPurpose,
+        durationSeconds: Double?
+    ) {
         do {
             let recorder = try SelectedDeviceRecorder(
                 device: device,
@@ -1505,16 +1551,19 @@ final class DictationController {
             )
             selectedDeviceRecorder = recorder
             recordingURL = url
-            isListening = true
             recorder.start()
-            RecordingCuePlayer.play(.start)
-            emit("listening_started", [
-                "recognitionMode": "venice_recording",
-                "microphone": device.localizedName,
-            ])
+            markRecordingStarted(
+                microphone: device.localizedName,
+                purpose: purpose,
+                durationSeconds: durationSeconds
+            )
         } catch {
             resetRecordingState()
-            emit("error", ["code": "audio_start_failed", "message": error.localizedDescription])
+            emitRecordingError(
+                purpose: purpose,
+                code: "audio_start_failed",
+                message: error.localizedDescription
+            )
         }
     }
 
@@ -1538,10 +1587,93 @@ final class DictationController {
             return
         }
 
+        if recordingPurpose == .micTest {
+            emitMicTestReady(url: recordingURL)
+            return
+        }
+
         emit("recording_ready", [
             "path": recordingURL.path,
             "observedAudioLevel": String(format: "%.4f", maxObservedAudioLevel),
         ])
+    }
+
+    private func emitMicTestReady(url: URL) {
+        let observedAudioLevel = maxObservedAudioLevel
+        let durationMs = Int(max(0, ProcessInfo.processInfo.systemUptime - recordingStartedAt) * 1000)
+        micTestSampleURL = url
+        resetRecordingState(keepRecordingFile: true)
+        emitJSON("mic_test_ready", [
+            "path": url.path,
+            "durationMs": durationMs,
+            "observedAudioLevel": String(format: "%.4f", observedAudioLevel),
+        ])
+    }
+
+    private func markRecordingStarted(
+        microphone: String,
+        purpose: RecordingPurpose,
+        durationSeconds: Double?
+    ) {
+        isListening = true
+        RecordingCuePlayer.play(.start)
+        if purpose == .micTest {
+            scheduleMicTestStop(after: durationSeconds ?? 5)
+            emitJSON("mic_test_started", [
+                "durationMs": Int((durationSeconds ?? 5) * 1000),
+                "microphone": microphone,
+            ])
+        } else {
+            emit("listening_started", [
+                "recognitionMode": "venice_recording",
+                "microphone": microphone,
+            ])
+        }
+    }
+
+    private func stopActiveRecording() {
+        let purpose = recordingPurpose
+        isListening = false
+        isFinalizing = true
+        micTestStopWorkItem?.cancel()
+        micTestStopWorkItem = nil
+        stopMetering()
+        RecordingCuePlayer.play(.stop)
+        if purpose == .dictation {
+            emit("finalizing_transcript")
+        }
+
+        if let selectedDeviceRecorder {
+            selectedDeviceRecorder.stop { [weak self] error in
+                runOnMain {
+                    self?.selectedDeviceRecorder = nil
+                    if let error {
+                        self?.fail(error)
+                        return
+                    }
+                    self?.emitRecordingReady()
+                }
+            }
+            return
+        }
+
+        audioRecorder?.stop()
+        emitRecordingReady()
+    }
+
+    private func scheduleMicTestStop(after seconds: Double) {
+        micTestStopWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.isListening, self.recordingPurpose == .micTest else {
+                return
+            }
+            self.stopActiveRecording()
+        }
+        micTestStopWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + seconds + micTestCapturePaddingSeconds,
+            execute: workItem
+        )
     }
 
     private func temporaryRecordingURL() -> URL {
@@ -1608,7 +1740,11 @@ final class DictationController {
 
     private func observeAudioLevel(_ level: Float) {
         maxObservedAudioLevel = max(maxObservedAudioLevel, level)
-        emit("audio_level", ["level": String(format: "%.4f", level)])
+        if recordingPurpose == .micTest {
+            emit("mic_test_level", ["level": String(format: "%.4f", level)])
+        } else {
+            emit("audio_level", ["level": String(format: "%.4f", level)])
+        }
     }
 
     private func stopMetering() {
@@ -1624,11 +1760,20 @@ final class DictationController {
 
     private func fail(_ error: Error) {
         let code = (error as? DictationError)?.code ?? "dictation_failed"
-        emit("error", [
-            "code": code,
-            "message": error.localizedDescription,
-        ])
+        emitRecordingError(
+            purpose: recordingPurpose,
+            code: code,
+            message: error.localizedDescription
+        )
         resetRecordingState()
+    }
+
+    private func emitRecordingError(purpose: RecordingPurpose, code: String, message: String) {
+        if purpose == .micTest {
+            emit("mic_test_error", ["code": code, "message": message])
+        } else {
+            emit("error", ["code": code, "message": message])
+        }
     }
 
     private func cleanupRecordingFile() {
@@ -1638,17 +1783,31 @@ final class DictationController {
         try? FileManager.default.removeItem(at: recordingURL)
     }
 
-    private func resetRecordingState() {
+    private func cleanupMicTestSample() {
+        guard let micTestSampleURL else {
+            return
+        }
+        try? FileManager.default.removeItem(at: micTestSampleURL)
+        self.micTestSampleURL = nil
+    }
+
+    private func resetRecordingState(keepRecordingFile: Bool = false) {
         isListening = false
         isFinalizing = false
         maxObservedAudioLevel = 0
+        recordingStartedAt = 0
+        micTestStopWorkItem?.cancel()
+        micTestStopWorkItem = nil
         stopMetering()
         audioRecorder?.stop()
         audioRecorder = nil
         selectedDeviceRecorder?.cancel()
         selectedDeviceRecorder = nil
-        cleanupRecordingFile()
+        if !keepRecordingFile {
+            cleanupRecordingFile()
+        }
         recordingURL = nil
+        recordingPurpose = .dictation
     }
 }
 
@@ -1766,6 +1925,17 @@ func handleCommandLine(_ line: String) {
     case "stop_and_paste":
         runOnMain {
             dictation.stop()
+        }
+    case "start_mic_test":
+        let durationSeconds = command?["durationSeconds"] as? Double
+            ?? (command?["durationSeconds"] as? Int).map(Double.init)
+            ?? 5
+        runOnMain {
+            dictation.startMicTest(durationSeconds: durationSeconds)
+        }
+    case "discard_mic_test":
+        runOnMain {
+            dictation.discardMicTest()
         }
     case "set_microphone":
         let id = command?["id"] as? String

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -78,6 +78,10 @@
     ],
     "security": {
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$TEMP/os-scribe-dictation-*.m4a"]
+      },
       "capabilities": ["main", "hud", "mascot", "meeting-hud"]
     }
   },

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -19,6 +19,7 @@ import {
   dictationHelperCommand,
   dictationSettings,
   listVeniceModels,
+  localAudioFileSrc,
   providerModelSettings,
   setDictationLanguage,
   setDictationMicrophone,
@@ -57,6 +58,7 @@ import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { ProviderLogo } from "./ProviderLogo";
 import { AgentSettingsSection } from "./AgentSettingsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
+import { MicTestControl, type MicTestState } from "./MicTestControl";
 import { StyleSettingsSection } from "./StyleSettingsSection";
 
 const THEME_OPTIONS: readonly {
@@ -161,6 +163,8 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   generationModel: "zai-org-glm-5",
 };
 
+const MIC_TEST_DURATION_SECONDS = 5;
+
 export type SettingsTab =
   | "general"
   | "billing"
@@ -236,6 +240,8 @@ export function AppSettings({
   const [microphones, setMicrophones] = useState<
     DictationMicrophoneDeviceDto[]
   >([]);
+  const [defaultMicrophone, setDefaultMicrophone] =
+    useState<DictationMicrophoneDeviceDto>();
   const [capturingShortcut, setCapturingShortcut] =
     useState<DictationShortcutKind>();
   const capturingShortcutRef = useRef<DictationShortcutKind>();
@@ -251,6 +257,13 @@ export function AppSettings({
   const [languageOpen, setLanguageOpen] = useState(false);
   const [languagePopoverPlacement, setLanguagePopoverPlacement] =
     useState<SelectPopoverPlacement>("align-selected");
+  const [micTestState, setMicTestState] = useState<MicTestState>("idle");
+  const [micTestLevel, setMicTestLevel] = useState(0);
+  const [micTestStartedAt, setMicTestStartedAt] = useState<number>();
+  const [micTestElapsedMs, setMicTestElapsedMs] = useState(0);
+  const [micTestSampleSrc, setMicTestSampleSrc] = useState<string>();
+  const [micTestError, setMicTestError] = useState<string>();
+  const [micTestPlaying, setMicTestPlaying] = useState(false);
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
   const activeTab = controlled ? controlledTab : internalTab;
   const setActiveTab = (tab: SettingsTab) => {
@@ -280,6 +293,9 @@ export function AppSettings({
   useEffect(() => {
     setMicOpen(false);
     setLanguageOpen(false);
+    if (activeTab !== "audio" && micTestState !== "idle") {
+      void resetMicTestState(true);
+    }
   }, [activeTab]);
 
   useEffect(() => {
@@ -392,6 +408,47 @@ export function AppSettings({
   function handleHelperEvent(helperEvent: DictationHelperEvent) {
     if (helperEvent.type === "microphone_devices") {
       setMicrophones(helperEvent.payload?.devices ?? []);
+      setDefaultMicrophone(helperEvent.payload?.defaultDevice);
+      return;
+    }
+    if (helperEvent.type === "mic_test_started") {
+      setMicTestState("recording");
+      setMicTestError(undefined);
+      setMicTestSampleSrc(undefined);
+      setMicTestLevel(0);
+      setMicTestStartedAt(Date.now());
+      setMicTestElapsedMs(0);
+      setMicTestPlaying(false);
+      return;
+    }
+    if (helperEvent.type === "mic_test_level") {
+      setMicTestLevel(numericPayload(helperEvent.payload?.level));
+      return;
+    }
+    if (helperEvent.type === "mic_test_ready") {
+      const path = stringPayload(helperEvent.payload?.path);
+      if (!path) {
+        setMicTestState("error");
+        setMicTestError("Microphone test did not return a playable sample.");
+        return;
+      }
+      setMicTestState("ready");
+      setMicTestStartedAt(undefined);
+      setMicTestElapsedMs(0);
+      setMicTestLevel(numericPayload(helperEvent.payload?.observedAudioLevel));
+      setMicTestError(undefined);
+      setMicTestPlaying(false);
+      setMicTestSampleSrc(localAudioFileSrc(path));
+      return;
+    }
+    if (helperEvent.type === "mic_test_error") {
+      const message =
+        helperEvent.payload?.message ?? "Microphone test could not record.";
+      setMicTestState("error");
+      setMicTestStartedAt(undefined);
+      setMicTestError(message);
+      setMicTestPlaying(false);
+      setStatus(message);
       return;
     }
     if (helperEvent.type === "fn_monitor_unavailable") {
@@ -439,6 +496,9 @@ export function AppSettings({
 
   async function selectMicrophone(id?: string, name?: string) {
     try {
+      if (micTestState !== "idle") {
+        await resetMicTestState(true);
+      }
       const next = await setDictationMicrophone(id, name);
       setSettings(next);
       setMicOpen(false);
@@ -495,6 +555,49 @@ export function AppSettings({
     }
   }
 
+  async function startMicTest() {
+    setMicTestState("recording");
+    setMicTestError(undefined);
+    setMicTestSampleSrc(undefined);
+    setMicTestLevel(0);
+    setMicTestStartedAt(Date.now());
+    setMicTestElapsedMs(0);
+    setMicTestPlaying(false);
+    try {
+      await dictationHelperCommand({
+        type: "start_mic_test",
+        durationSeconds: MIC_TEST_DURATION_SECONDS,
+      });
+    } catch (error) {
+      const message = messageFromError(error);
+      setMicTestState("error");
+      setMicTestStartedAt(undefined);
+      setMicTestError(message);
+      setStatus(message);
+    }
+  }
+
+  async function startOverMicTest() {
+    await resetMicTestState(true);
+    await startMicTest();
+  }
+
+  async function resetMicTestState(discardHelper = false) {
+    setMicTestState("idle");
+    setMicTestLevel(0);
+    setMicTestStartedAt(undefined);
+    setMicTestElapsedMs(0);
+    setMicTestSampleSrc(undefined);
+    setMicTestError(undefined);
+    setMicTestPlaying(false);
+    if (!discardHelper) return;
+    try {
+      await dictationHelperCommand({ type: "discard_mic_test" });
+    } catch {
+      // Resetting the settings UI should not surface stale helper cleanup errors.
+    }
+  }
+
   async function selectVeniceModel(mode: ProviderModelMode, modelId: string) {
     try {
       const next = await setVeniceModel(mode, modelId);
@@ -525,6 +628,11 @@ export function AppSettings({
   }
 
   const microphoneName = settings.microphone.name ?? "Auto-detect";
+  const microphoneDescription = settings.microphone.id
+    ? "Input device used for dictation."
+    : defaultMicrophone?.name
+      ? `Auto-detect uses ${defaultMicrophone.name}.`
+      : "Auto-detect uses the current macOS input.";
   const microphoneOptions = [
     { id: undefined, name: "Auto-detect" },
     ...microphones,
@@ -559,6 +667,14 @@ export function AppSettings({
   useEffect(() => {
     if (languageOpen) updateLanguagePopoverPlacement();
   }, [languageOpen, selectedLanguageIndex]);
+
+  useEffect(() => {
+    if (micTestState !== "recording" || !micTestStartedAt) return;
+    const interval = window.setInterval(() => {
+      setMicTestElapsedMs(Date.now() - micTestStartedAt);
+    }, 100);
+    return () => window.clearInterval(interval);
+  }, [micTestState, micTestStartedAt]);
 
   function updateMicrophonePopoverPlacement() {
     setMicPopoverPlacement(
@@ -836,7 +952,7 @@ export function AppSettings({
                   <div className="settings-row-info">
                     <h3 className="settings-row-title">Microphone</h3>
                     <p className="settings-row-description">
-                      Input device used for dictation.
+                      {microphoneDescription}
                     </p>
                   </div>
                   <div className="settings-row-control" ref={micWrapRef}>
@@ -894,6 +1010,24 @@ export function AppSettings({
                     ) : null}
                   </div>
                 </div>
+
+                <MicTestControl
+                  state={micTestState}
+                  level={micTestLevel}
+                  elapsedMs={micTestElapsedMs}
+                  sampleSrc={micTestSampleSrc}
+                  error={micTestError}
+                  playing={micTestPlaying}
+                  durationSeconds={MIC_TEST_DURATION_SECONDS}
+                  onStart={() => void startMicTest()}
+                  onStartOver={() => void startOverMicTest()}
+                  onPlaybackError={() => {
+                    setMicTestError(
+                      "Microphone test recorded, but playback is unavailable.",
+                    );
+                  }}
+                  onPlayingChange={setMicTestPlaying}
+                />
 
                 {systemUnsupported ? null : (
                   <div className="settings-row">
@@ -1164,6 +1298,21 @@ function sourcePermissionStatus(
   if (!source) return { label: "Checking", tone: "unknown" };
   if (source.ready) return { label: "Allowed", tone: "allowed" };
   return permissionStatus(source.permissionState);
+}
+
+function stringPayload(value: unknown) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numericPayload(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.min(1, value));
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.max(0, Math.min(1, parsed));
+  }
+  return 0;
 }
 
 function ModelRow({

--- a/src/components/settings/MicTestControl.tsx
+++ b/src/components/settings/MicTestControl.tsx
@@ -1,0 +1,200 @@
+import { useRef, useState } from "react";
+
+export type MicTestState = "idle" | "recording" | "ready" | "error";
+
+type MicTestControlProps = {
+  state: MicTestState;
+  level: number;
+  elapsedMs: number;
+  sampleSrc?: string;
+  error?: string;
+  playing: boolean;
+  durationSeconds: number;
+  onStart: () => void;
+  onStartOver: () => void;
+  onPlaybackError: () => void;
+  onPlayingChange: (playing: boolean) => void;
+};
+
+export function MicTestControl({
+  state,
+  level,
+  elapsedMs,
+  sampleSrc,
+  error,
+  playing,
+  durationSeconds,
+  onStart,
+  onStartOver,
+  onPlaybackError,
+  onPlayingChange,
+}: MicTestControlProps) {
+  return (
+    <div className="settings-row settings-row-mic-test">
+      <div className="settings-row-info">
+        <h3 className="settings-row-title">Mic test</h3>
+        <p className="settings-row-description">{micTestDescription(state)}</p>
+        {error ? <p className="settings-row-error">{error}</p> : null}
+      </div>
+      <div className="settings-row-control settings-mic-test-control">
+        {state === "recording" ? (
+          <>
+            <div className="settings-mic-test-meter">
+              <div
+                className="settings-mic-test-meter-fill"
+                role="progressbar"
+                aria-label="Microphone test level"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={Math.round(level * 100)}
+                style={{
+                  transform: `scaleX(${Math.max(0, Math.min(1, level))})`,
+                }}
+              />
+            </div>
+            <span className="settings-mic-test-time">
+              {formatMicTestTime(elapsedMs, durationSeconds)} /{" "}
+              {formatMicTestDuration(durationSeconds)}
+            </span>
+          </>
+        ) : null}
+        {sampleSrc && state === "ready" ? (
+          <MicTestPlayer
+            src={sampleSrc}
+            playing={playing}
+            durationSeconds={durationSeconds}
+            onPlaybackError={onPlaybackError}
+            onPlayingChange={onPlayingChange}
+          />
+        ) : null}
+        {state === "ready" ? (
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={playing}
+            onClick={onStartOver}
+          >
+            Start over
+          </button>
+        ) : null}
+        {state !== "recording" && state !== "ready" ? (
+          <button type="button" className="btn btn-secondary" onClick={onStart}>
+            Start test
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function micTestDescription(state: MicTestState) {
+  if (state === "recording") {
+    return "Recording 5-second sample.";
+  }
+  if (state === "ready") {
+    return "Sample ready. Check volume.";
+  }
+  return "Check your microphone.";
+}
+
+function formatMicTestTime(milliseconds: number, durationSeconds: number) {
+  const seconds = Math.min(
+    durationSeconds,
+    Math.floor(Math.max(0, milliseconds) / 1000),
+  );
+  return formatMicTestDuration(seconds);
+}
+
+function formatMicTestDuration(seconds: number) {
+  return `00:${seconds.toString().padStart(2, "0")}`;
+}
+
+function MicTestPlayer({
+  src,
+  playing,
+  durationSeconds,
+  onPlaybackError,
+  onPlayingChange,
+}: {
+  src: string;
+  playing: boolean;
+  durationSeconds: number;
+  onPlaybackError: () => void;
+  onPlayingChange: (playing: boolean) => void;
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(durationSeconds);
+
+  async function playSample() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    try {
+      audio.currentTime = 0;
+      setCurrentTime(0);
+      await audio.play();
+      onPlayingChange(true);
+    } catch {
+      onPlayingChange(false);
+      onPlaybackError();
+    }
+  }
+
+  function seek(nextValue: string) {
+    const next = Number(nextValue);
+    if (!Number.isFinite(next)) return;
+    setCurrentTime(next);
+    if (audioRef.current) {
+      audioRef.current.currentTime = next;
+    }
+  }
+
+  return (
+    <>
+      <audio
+        ref={audioRef}
+        className="settings-mic-test-hidden-audio"
+        src={src}
+        preload="metadata"
+        onLoadedMetadata={(event) => {
+          const nextDuration = event.currentTarget.duration;
+          if (Number.isFinite(nextDuration) && nextDuration > 0) {
+            setDuration(nextDuration);
+          }
+        }}
+        onTimeUpdate={(event) =>
+          setCurrentTime(event.currentTarget.currentTime)
+        }
+        onPause={() => onPlayingChange(false)}
+        onPlay={() => onPlayingChange(true)}
+        onEnded={() => {
+          onPlayingChange(false);
+          setCurrentTime(0);
+          if (audioRef.current) audioRef.current.currentTime = 0;
+        }}
+        onError={onPlaybackError}
+      />
+      {playing ? (
+        <input
+          className="settings-mic-test-mini-scrubber"
+          type="range"
+          min={0}
+          max={Math.max(duration, durationSeconds)}
+          step={0.1}
+          value={Math.min(currentTime, duration)}
+          aria-label="Microphone test playback progress"
+          onChange={(event) => seek(event.currentTarget.value)}
+        />
+      ) : (
+        <button
+          type="button"
+          className="btn btn-secondary"
+          aria-label="Play microphone test sample"
+          onClick={() => void playSample()}
+        >
+          Play sample
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 
 export type ProcessingStatus =
   | "draft"
@@ -138,10 +138,15 @@ export type DictationHelperEvent = {
   type: string;
   payload?: {
     devices?: DictationMicrophoneDeviceDto[];
+    defaultDevice?: DictationMicrophoneDeviceDto;
     selectedID?: string;
     shortcut?: DictationShortcutSetting;
     message?: string;
     code?: string;
+    path?: string;
+    durationMs?: number | string;
+    observedAudioLevel?: number | string;
+    level?: number | string;
     [key: string]: unknown;
   };
 };
@@ -1078,6 +1083,10 @@ export async function setDictationLanguage(language?: string) {
 
 export async function dictationHelperCommand(command: Record<string, unknown>) {
   return invoke<void>("dictation_helper_command", { command });
+}
+
+export function localAudioFileSrc(path: string) {
+  return convertFileSrc(path);
 }
 
 export async function dictationHotkeyStatus() {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5450,6 +5450,50 @@ input:focus-visible,
   gap: var(--sp-3);
 }
 
+.settings-row-mic-test {
+  align-items: start;
+}
+
+.settings-mic-test-control {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  width: min(420px, 48vw);
+}
+
+.settings-mic-test-meter {
+  width: 150px;
+  height: 8px;
+  overflow: hidden;
+  border-radius: var(--r-full);
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
+}
+
+.settings-mic-test-meter-fill {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--foreground);
+  transform-origin: left center;
+  transition: transform 90ms ease-out;
+}
+
+.settings-mic-test-time {
+  min-width: 76px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-align: right;
+}
+
+.settings-mic-test-hidden-audio {
+  display: none;
+}
+
+.settings-mic-test-mini-scrubber {
+  width: 150px;
+  accent-color: var(--foreground);
+}
+
 .settings-version-text {
   color: var(--muted-foreground);
   font-family: var(--font-mono);

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -9,6 +9,7 @@ import { MASCOT_ENABLED_KEY } from "../lib/mascot-settings";
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
   dictationHelperCommand: vi.fn(),
+  localAudioFileSrc: vi.fn(),
   providerModelSettings: vi.fn(),
   listVeniceModels: vi.fn(),
   setVeniceModel: vi.fn(),
@@ -40,6 +41,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../lib/tauri", () => ({
   dictationSettings: mocks.dictationSettings,
   dictationHelperCommand: mocks.dictationHelperCommand,
+  localAudioFileSrc: mocks.localAudioFileSrc,
   providerModelSettings: mocks.providerModelSettings,
   listVeniceModels: mocks.listVeniceModels,
   setVeniceModel: mocks.setVeniceModel,
@@ -119,6 +121,7 @@ describe("AppSettings", () => {
     localStorage.clear();
     mocks.eventHandler = undefined;
     mocks.dictationSettings.mockResolvedValue({ settings: baseSettings });
+    mocks.localAudioFileSrc.mockImplementation((path) => `asset://${path}`);
     mocks.setDictationLanguage.mockImplementation(async (language) => ({
       ...baseSettings,
       language,
@@ -325,22 +328,254 @@ describe("AppSettings", () => {
     mocks.eventHandler?.({
       payload: JSON.stringify({
         type: "microphone_devices",
-        payload: { devices: [{ id: "usb", name: "USB Mic" }] },
+        payload: {
+          devices: [{ id: "usb", name: "USB Mic" }],
+          defaultDevice: { id: "built-in", name: "MacBook Pro Microphone" },
+        },
       }),
     });
 
     await user.click(screen.getByRole("tab", { name: "Audio" }));
+    expect(
+      screen.getByText("Auto-detect uses MacBook Pro Microphone."),
+    ).toBeInTheDocument();
     await user.click(
       screen.getByRole("button", { name: /Auto-detect|USB Mic/ }),
     );
     await user.click(await screen.findByRole("option", { name: "USB Mic" }));
 
     expect(mocks.setDictationMicrophone).toHaveBeenCalledWith("usb", "USB Mic");
+    await waitFor(() =>
+      expect(
+        screen.getByText("Input device used for dictation."),
+      ).toBeInTheDocument(),
+    );
 
     await user.click(
       screen.getByRole("switch", { name: "Capture system audio for notes" }),
     );
     expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+  });
+
+  it("records a local microphone test sample and renders playback", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
+    await user.click(screen.getByRole("button", { name: "Start test" }));
+
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "start_mic_test",
+      durationSeconds: 5,
+    });
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "mic_test_level",
+        payload: { level: "0.72" },
+      }),
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByRole("progressbar", { name: "Microphone test level" }),
+      ).toHaveAttribute("aria-valuenow", "72"),
+    );
+
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "mic_test_ready",
+        payload: {
+          path: "/tmp/os-scribe-mic-test.m4a",
+          durationMs: 5000,
+          observedAudioLevel: "0.72",
+        },
+      }),
+    });
+
+    expect(
+      await screen.findByText("Sample ready. Check volume."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Play microphone test sample" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Start over" }),
+    ).toBeInTheDocument();
+
+    const play = vi
+      .spyOn(window.HTMLMediaElement.prototype, "play")
+      .mockImplementation(function (this: HTMLMediaElement) {
+        this.dispatchEvent(new Event("play"));
+        return Promise.resolve();
+      });
+    await user.click(
+      screen.getByRole("button", { name: "Play microphone test sample" }),
+    );
+
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(
+      await screen.findByRole("slider", {
+        name: "Microphone test playback progress",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start over" })).toBeDisabled();
+
+    play.mockRestore();
+  });
+
+  it("starts a new microphone test from an existing sample", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
+    await user.click(screen.getByRole("button", { name: "Start test" }));
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "mic_test_ready",
+        payload: {
+          path: "/tmp/os-scribe-mic-test.m4a",
+          durationMs: 5000,
+          observedAudioLevel: "0.72",
+        },
+      }),
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Start over" }));
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "discard_mic_test",
+    });
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "start_mic_test",
+      durationSeconds: 5,
+    });
+  });
+
+  it("resets microphone test state when microphone selection changes", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "microphone_devices",
+        payload: { devices: [{ id: "usb", name: "USB Mic" }] },
+      }),
+    });
+    await user.click(screen.getByRole("button", { name: "Start test" }));
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "mic_test_ready",
+        payload: {
+          path: "/tmp/os-scribe-mic-test.m4a",
+          durationMs: 5000,
+          observedAudioLevel: "0.72",
+        },
+      }),
+    });
+    expect(
+      await screen.findByRole("button", {
+        name: "Play microphone test sample",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /Auto-detect|USB Mic/ }),
+    );
+    await user.click(await screen.findByRole("option", { name: "USB Mic" }));
+
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "discard_mic_test",
+    });
+    expect(mocks.setDictationMicrophone).toHaveBeenCalledWith("usb", "USB Mic");
+    expect(
+      screen.getByRole("button", { name: "Start test" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Play microphone test sample" }),
+    ).toBeNull();
+  });
+
+  it("resets microphone test state when leaving audio settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
+    await user.click(screen.getByRole("button", { name: "Start test" }));
+    mocks.eventHandler?.({
+      payload: JSON.stringify({
+        type: "mic_test_ready",
+        payload: {
+          path: "/tmp/os-scribe-mic-test.m4a",
+          durationMs: 5000,
+          observedAudioLevel: "0.72",
+        },
+      }),
+    });
+    expect(
+      await screen.findByRole("button", {
+        name: "Play microphone test sample",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Dictation" }));
+    await waitFor(() =>
+      expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+        type: "discard_mic_test",
+      }),
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Audio" }));
+    expect(
+      screen.getByRole("button", { name: "Start test" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Play microphone test sample" }),
+    ).toBeNull();
   });
 
   it("saves the default transcription language", async () => {


### PR DESCRIPTION
## Summary
- Add a Settings > Audio microphone test that records a short sample, auto-stops after 5 seconds, and plays it back inline.
- Reset mic test state when the selected microphone changes or when leaving the Audio settings tab.
- Show the auto-detect fallback device name, and wire Tauri asset playback for the recorded sample.
- Extract the mic test UI into `MicTestControl` and update styles and tests accordingly.

## Testing
- Lint and formatting passed.
- App settings tests passed, including mic test start, playback, reset, and auto-detect coverage.
- Rust test suite passed.