### PR TITLE
Show reset controls for customized dictation shortcuts

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -108,6 +108,7 @@ const EMPTY_MODIFIERS: DictationShortcutModifiers = {
 
 const DEFAULT_SETTINGS: DictationSettingsDto = {
   pushToTalkShortcut: {
+    keyCode: 0x02,
     code: "KeyD",
     label: "Ctrl+Opt+D",
     pressCount: 1,
@@ -118,6 +119,7 @@ const DEFAULT_SETTINGS: DictationSettingsDto = {
     },
   },
   toggleShortcut: {
+    keyCode: 0x11,
     code: "KeyT",
     label: "Ctrl+Opt+T",
     pressCount: 1,
@@ -130,6 +132,14 @@ const DEFAULT_SETTINGS: DictationSettingsDto = {
   microphone: {},
   style: "standard",
   language: undefined,
+};
+
+const DEFAULT_SHORTCUTS: Record<
+  DictationShortcutKind,
+  DictationShortcutSetting
+> = {
+  push_to_talk: DEFAULT_SETTINGS.pushToTalkShortcut,
+  toggle: DEFAULT_SETTINGS.toggleShortcut,
 };
 
 const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
@@ -833,6 +843,7 @@ export function AppSettings({
                   title="Push to talk"
                   description="Hold this shortcut to dictate, then release to paste."
                   shortcut={settings.pushToTalkShortcut}
+                  defaultShortcut={DEFAULT_SHORTCUTS.push_to_talk}
                   capturing={capturingShortcut === "push_to_talk"}
                   disabled={
                     !!capturingShortcut && capturingShortcut !== "push_to_talk"
@@ -843,6 +854,12 @@ export function AppSettings({
                       : undefined
                   }
                   onChange={() => void startShortcutCapture("push_to_talk")}
+                  onReset={() =>
+                    void saveShortcut(
+                      "push_to_talk",
+                      DEFAULT_SHORTCUTS.push_to_talk,
+                    )
+                  }
                   onCancel={() => void cancelShortcutCapture()}
                 />
 
@@ -850,6 +867,7 @@ export function AppSettings({
                   title="Toggle dictation"
                   description="Press this shortcut to start or stop dictation."
                   shortcut={settings.toggleShortcut}
+                  defaultShortcut={DEFAULT_SHORTCUTS.toggle}
                   capturing={capturingShortcut === "toggle"}
                   disabled={
                     !!capturingShortcut && capturingShortcut !== "toggle"
@@ -858,6 +876,9 @@ export function AppSettings({
                     capturingShortcut === "toggle" ? shortcutError : undefined
                   }
                   onChange={() => void startShortcutCapture("toggle")}
+                  onReset={() =>
+                    void saveShortcut("toggle", DEFAULT_SHORTCUTS.toggle)
+                  }
                   onCancel={() => void cancelShortcutCapture()}
                 />
               </div>
@@ -1429,21 +1450,28 @@ function ShortcutRow({
   title,
   description,
   shortcut,
+  defaultShortcut,
   capturing,
   disabled,
   error,
   onChange,
+  onReset,
   onCancel,
 }: {
   title: string;
   description: string;
   shortcut: DictationShortcutSetting;
+  defaultShortcut: DictationShortcutSetting;
   capturing: boolean;
   disabled: boolean;
   error?: string;
   onChange: () => void;
+  onReset: () => void;
   onCancel: () => void;
 }) {
+  const canReset =
+    !capturing && !shortcutsMatch(shortcut, defaultShortcut) && !disabled;
+
   return (
     <div className="settings-row">
       <div className="settings-row-info">
@@ -1461,6 +1489,16 @@ function ShortcutRow({
         >
           {capturing ? "Cancel" : "Change"}
         </button>
+        {canReset ? (
+          <button
+            type="button"
+            className="btn btn-secondary"
+            aria-label={`Reset ${title} shortcut to default`}
+            onClick={onReset}
+          >
+            Reset
+          </button>
+        ) : null}
       </div>
     </div>
   );
@@ -1725,6 +1763,23 @@ function shortcutForKind(
   return kind === "toggle"
     ? settings.toggleShortcut
     : settings.pushToTalkShortcut;
+}
+
+function shortcutsMatch(
+  first: DictationShortcutSetting,
+  second: DictationShortcutSetting,
+) {
+  return (
+    first.keyCode === second.keyCode &&
+    first.code === second.code &&
+    first.label === second.label &&
+    first.pressCount === second.pressCount &&
+    first.modifiers.command === second.modifiers.command &&
+    first.modifiers.control === second.modifiers.control &&
+    first.modifiers.option === second.modifiers.option &&
+    first.modifiers.shift === second.modifiers.shift &&
+    first.modifiers.function === second.modifiers.function
+  );
 }
 
 function languageLabel(value: string) {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1769,8 +1769,13 @@ function shortcutsMatch(
   first: DictationShortcutSetting,
   second: DictationShortcutSetting,
 ) {
+  const keyCodesMatch =
+    first.keyCode === undefined ||
+    second.keyCode === undefined ||
+    first.keyCode === second.keyCode;
+
   return (
-    first.keyCode === second.keyCode &&
+    keyCodesMatch &&
     first.code === second.code &&
     first.label === second.label &&
     first.pressCount === second.pressCount &&

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -75,6 +75,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const baseSettings: DictationSettingsDto = {
   pushToTalkShortcut: {
+    keyCode: 0x02,
     code: "KeyD",
     label: "Ctrl+Opt+D",
     pressCount: 1,
@@ -87,6 +88,7 @@ const baseSettings: DictationSettingsDto = {
     },
   },
   toggleShortcut: {
+    keyCode: 0x11,
     code: "KeyT",
     label: "Ctrl+Opt+T",
     pressCount: 1,
@@ -853,6 +855,86 @@ describe("AppSettings", () => {
         },
         pressCount: 1,
       }),
+    );
+  });
+
+  it("resets customized dictation shortcuts and hides reset for defaults", async () => {
+    const user = userEvent.setup();
+    mocks.dictationSettings.mockResolvedValue({
+      settings: {
+        ...baseSettings,
+        pushToTalkShortcut: {
+          code: "KeyP",
+          label: "Ctrl+P",
+          pressCount: 1,
+          modifiers: {
+            command: false,
+            control: true,
+            option: false,
+            shift: false,
+            function: false,
+          },
+        },
+      },
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Reset Push to talk shortcut to default",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset Toggle dictation shortcut to default",
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Reset Push to talk shortcut to default",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith(
+        "push_to_talk",
+        {
+          keyCode: 0x02,
+          code: "KeyD",
+          label: "Ctrl+Opt+D",
+          pressCount: 1,
+          modifiers: {
+            command: false,
+            control: true,
+            option: true,
+            shift: false,
+            function: false,
+          },
+        },
+      ),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", {
+          name: "Reset Push to talk shortcut to default",
+        }),
+      ).not.toBeInTheDocument(),
     );
   });
 

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -864,6 +864,7 @@ describe("AppSettings", () => {
       settings: {
         ...baseSettings,
         pushToTalkShortcut: {
+          keyCode: 0x23,
           code: "KeyP",
           label: "Ctrl+P",
           pressCount: 1,
@@ -936,6 +937,50 @@ describe("AppSettings", () => {
         }),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("does not show reset for legacy default shortcuts without key codes", async () => {
+    const user = userEvent.setup();
+    const { keyCode: _pushKeyCode, ...legacyPushToTalkShortcut } =
+      baseSettings.pushToTalkShortcut;
+    const { keyCode: _toggleKeyCode, ...legacyToggleShortcut } =
+      baseSettings.toggleShortcut;
+
+    mocks.dictationSettings.mockResolvedValue({
+      settings: {
+        ...baseSettings,
+        pushToTalkShortcut: legacyPushToTalkShortcut,
+        toggleShortcut: legacyToggleShortcut,
+      },
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
+    expect(await screen.findByText("Push to talk")).toBeInTheDocument();
+    expect(screen.getByText("Toggle dictation")).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset Push to talk shortcut to default",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Reset Toggle dictation shortcut to default",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("loads Venice model options and saves selected models", async () => {


### PR DESCRIPTION
## Summary
- Added per-row reset behavior for dictation shortcuts in Settings.
- Reset buttons now appear only when a shortcut differs from its default value.
- Resetting a shortcut restores the built-in defaults for push-to-talk and toggle dictation.
- Kept the shortcut comparison aligned with the backend defaults by including the native `keyCode` values.

## Testing
- Added UI coverage for showing `Reset` only on customized shortcuts.
- Added coverage for restoring push-to-talk back to its default shortcut.
- `pnpm test src/test/app-settings.test.tsx`
- `pnpm run lint`