### PR TITLE
Fix meeting pill leaving a stuck, undraggable gray bar on screen

### DIFF
--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -26,6 +26,9 @@ pub fn setup(app: &mut tauri::App) {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MeetingDetectionEvent {
     Detected,
+    /// Periodic re-emit while a meeting stays active, so a HUD webview that
+    /// missed the initial event (e.g. after a reload) can still catch up.
+    Heartbeat,
     Cleared,
 }
 
@@ -59,7 +62,7 @@ impl MeetingDetectionState {
             self.active_polls_since_emit = self.active_polls_since_emit.saturating_add(1);
             if self.active_polls_since_emit >= HEARTBEAT_EVERY_ACTIVE_POLLS {
                 self.active_polls_since_emit = 0;
-                return Some(MeetingDetectionEvent::Detected);
+                return Some(MeetingDetectionEvent::Heartbeat);
             }
             return None;
         }
@@ -235,6 +238,11 @@ fn emit_detection_event(
             crate::dictation::show_hud_window(app);
             "meeting_detected"
         }
+        // Heartbeats must NOT re-show the native window: after the prompt
+        // auto-suppresses, the webview renders nothing, and a re-shown window
+        // is just the bare vibrancy frost — a stuck gray bar the user can't
+        // drag or dismiss. The HUD shows itself when it decides to render.
+        MeetingDetectionEvent::Heartbeat => "meeting_detected",
         MeetingDetectionEvent::Cleared => "meeting_cleared",
     };
     let payload = MeetingDetectionEnvelope {
@@ -776,7 +784,7 @@ mod tests {
         }
         assert_eq!(
             state.update(true, true, false),
-            Some(MeetingDetectionEvent::Detected)
+            Some(MeetingDetectionEvent::Heartbeat)
         );
     }
 

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -379,6 +379,12 @@ async function hideHud() {
   if (requestId !== hideRequestId) return;
   await appWindow.hide();
   setWindowAlpha(1);
+  // Don't park on "exiting" (opacity 0, pointer-events none): if the native
+  // window is ever shown again without new content, a pill stuck in that
+  // state renders as a bare, undraggable gray bar.
+  if (hud?.dataset.state === "exiting" && requestId === hideRequestId) {
+    hud.dataset.state = "idle";
+  }
 }
 
 async function showHud() {
@@ -494,8 +500,16 @@ async function handleMeetingDetectionEventPayload(payload: unknown) {
   if (!meetingEvent) return;
 
   if (meetingEvent.type === "meeting_detected") {
-    if (meetingPromptSuppressed) return;
-    if (!canShowMeetingPrompt(hud?.dataset.state)) return;
+    if (meetingPromptSuppressed || !canShowMeetingPrompt(hud?.dataset.state)) {
+      // Rust may have shown the native window before emitting this event.
+      // When the prompt won't render and the pill has no other content, put
+      // the window back down — otherwise only the frosted surface shows: a
+      // gray bar that can't be dragged or dismissed.
+      if (pillIsBlank(hud?.dataset.state)) {
+        void appWindow.hide().catch(() => {});
+      }
+      return;
+    }
     setHud("meeting", "Meeting detected");
     await showHud();
     startMeetingPromptTimer();
@@ -507,8 +521,15 @@ async function handleMeetingDetectionEventPayload(payload: unknown) {
     clearMeetingPromptTimer();
     if (hud?.dataset.state === "meeting") {
       void hideHud();
+    } else if (pillIsBlank(hud?.dataset.state)) {
+      // Heal a contentless window left visible by an earlier show.
+      void appWindow.hide().catch(() => {});
     }
   }
+}
+
+function pillIsBlank(state: string | undefined) {
+  return state === undefined || state === "idle" || state === "exiting";
 }
 
 function canShowMeetingPrompt(state: string | undefined) {

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -122,6 +122,45 @@ describe("meeting detection HUD", () => {
     expect(mocks.show).not.toHaveBeenCalled();
   });
 
+  it("puts a re-shown window back down when a heartbeat arrives while suppressed", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+    await vi.advanceTimersByTimeAsync(30_220);
+    expect(mocks.hide).toHaveBeenCalledOnce();
+
+    // While the prompt is suppressed, Rust may have re-shown the native
+    // window before this event arrives. The pill renders nothing, so the HUD
+    // must answer by hiding the window — a bare frosted window is otherwise
+    // stuck on screen as an undraggable gray bar.
+    mocks.show.mockClear();
+    mocks.hide.mockClear();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    expect(mocks.show).not.toHaveBeenCalled();
+    expect(mocks.hide).toHaveBeenCalledOnce();
+    expect(hudElement().dataset.state).not.toBe("meeting");
+  });
+
+  it("returns the pill to idle once the exit transition completes", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+    await emit("meeting-detection-event", { type: "meeting_cleared" });
+
+    expect(hudElement().dataset.state).toBe("exiting");
+    await vi.advanceTimersByTimeAsync(220);
+    expect(hudElement().dataset.state).toBe("idle");
+  });
+
+  it("hides a contentless window when the meeting clears", async () => {
+    await loadHud();
+
+    await emit("meeting-detection-event", { type: "meeting_cleared" });
+
+    expect(mocks.hide).toHaveBeenCalledOnce();
+  });
+
   it("allows the prompt again after a timed-out meeting clears", async () => {
     vi.useFakeTimers();
     await loadHud();


### PR DESCRIPTION
## The bug

Reported via Slack with screenshots: the "Meeting detected / Start transcription" pill first got stuck on screen, then turned into a bare **gray bar in the middle of the screen that couldn't be moved or dismissed**.

## Root cause

The failure chain needs three pieces, all present:

1. While a meeting stays active, the detection monitor re-emits `Detected` as a **heartbeat every 5 polls** (`meeting_detection.rs`), and `emit_detection_event` called `show_hud_window()` unconditionally for every `Detected` — heartbeats included.
2. After the prompt auto-suppresses (the 30s timeout, or clicking "Start transcription"), the HUD webview hides and sets `meetingPromptSuppressed = true`, leaving the pill parked on `data-state="exiting"` — whose CSS is `opacity: 0; pointer-events: none`.
3. The next heartbeat re-showed the native window while the suppressed JS handler early-returned, so nothing rendered: only the window-filling vibrancy frost was visible — the gray bar. `pointer-events: none` made it undraggable, and `meeting_cleared` only hid the window when the state was `"meeting"` (it was `"exiting"`), so even ending the meeting didn't remove it.

This reproduces exactly with a long call in an allowed mic app (e.g. gather.town in a browser): pill appears → 30s auto-hide → 5s later the gray bar appears and persists indefinitely.

## The fix

**Rust** (`meeting_detection.rs`): heartbeats are now a distinct `Heartbeat` event that still emits `meeting_detected` to keep a reloaded webview informed, but does **not** show the native window. Only the initial detection transition shows it; the HUD shows itself when it decides to render.

**HUD** (`hud.ts`), defense in depth:
- A `meeting_detected` that won't render (suppressed, or pill busy) now answers by **hiding the native window** when the pill has no content on screen — healing any window shown without content.
- `hideHud()` resets the pill to `"idle"` after the window hides, so `"exiting"` is no longer a terminal state.
- `meeting_cleared` also hides a contentless visible window instead of only acting on `"meeting"`.

## Testing

- 3 new tests in `src/test/hud-meeting.test.ts` covering the exact failure sequence: suppressed heartbeat → window hidden again; exit transition → pill returns to idle; `meeting_cleared` on a contentless window → hidden. Full JS suite 228/228.
- Updated `detector_emits_heartbeat_while_active` for the new variant; `meeting_detection` Rust tests 16/16.
- `tsc`, Prettier, and `cargo fmt`/clippy clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)