### PR TITLE
Add routine editing via a June session

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1621,6 +1621,11 @@ export function App() {
                   setActiveAgentSession(undefined);
                   setActiveView("agent");
                 }}
+                onEditRoutine={(prompt) => {
+                  markAgentNewSessionPending(prompt);
+                  setActiveAgentSession(undefined);
+                  setActiveView("agent");
+                }}
               />
             ) : activeView === "agent" ? (
               // The origin crumbs render inside the workspace's own sticky

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -2,6 +2,7 @@ import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise
 import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconPause } from "central-icons/IconPause";
+import { IconPencil } from "central-icons/IconPencil";
 import { IconPlay } from "central-icons/IconPlay";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCanSimple } from "central-icons/IconTrashCanSimple";
@@ -12,6 +13,7 @@ import {
   removeRoutine,
   resumeRoutine,
   routineCreationPrompt,
+  routineEditPrompt,
   type RoutineJob,
 } from "../../lib/hermes-routines";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
@@ -20,11 +22,16 @@ import { EmptyState } from "../ui/EmptyState";
 
 type RoutinesViewProps = {
   /** Hands off a composed agent prompt; the app opens a new June session with
-   * it so the agent does the actual cron-job creation. */
+   * it so the agent does the actual cron-job creation — and, for edits, the
+   * cron-job update. */
   onCreateRoutine: (prompt: string) => void;
+  onEditRoutine: (prompt: string) => void;
 };
 
-export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
+export function RoutinesView({
+  onCreateRoutine,
+  onEditRoutine,
+}: RoutinesViewProps) {
   const [routines, setRoutines] = useState<RoutineJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -34,6 +41,8 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
   const [pendingDelete, setPendingDelete] = useState<RoutineJob | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [draft, setDraft] = useState("");
+  const [editTarget, setEditTarget] = useState<RoutineJob | null>(null);
+  const [editDraft, setEditDraft] = useState("");
 
   // `loading` gates the whole list and only covers the first fetch;
   // `refreshing` covers every fetch so reloads keep the list visible while
@@ -109,6 +118,19 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
   function openCreate() {
     setDraft("");
     setCreateOpen(true);
+  }
+
+  function openEdit(routine: RoutineJob) {
+    setEditDraft("");
+    setEditTarget(routine);
+  }
+
+  function submitEdit() {
+    const routine = editTarget;
+    const changes = editDraft.trim();
+    if (!routine || !changes) return;
+    setEditTarget(null);
+    onEditRoutine(routineEditPrompt(routine, changes));
   }
 
   function submitCreate() {
@@ -202,6 +224,7 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
               routine={routine}
               busy={busyIds.has(routine.job_id)}
               onTogglePaused={() => void togglePaused(routine)}
+              onEdit={() => openEdit(routine)}
               onDelete={() => setPendingDelete(routine)}
             />
           ))}
@@ -249,6 +272,47 @@ export function RoutinesView({ onCreateRoutine }: RoutinesViewProps) {
         />
       </Dialog>
 
+      <Dialog
+        open={editTarget !== null}
+        onClose={() => setEditTarget(null)}
+        leading={<IconPencil size={15} />}
+        title={`Edit “${editTarget?.name ?? ""}”`}
+        description="Tell June what should change — the schedule, the task, or the name. It opens a session to apply the update."
+        footer={
+          <>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setEditTarget(null)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              disabled={!editDraft.trim()}
+              onClick={submitEdit}
+            >
+              Ask June to update it
+            </button>
+          </>
+        }
+      >
+        <textarea
+          className="routines-create-input"
+          rows={4}
+          placeholder="Run at 7am instead, and only on weekdays…"
+          value={editDraft}
+          onChange={(event) => setEditDraft(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              submitEdit();
+            }
+          }}
+        />
+      </Dialog>
+
       <ConfirmDialog
         open={pendingDelete !== null}
         onClose={() => setPendingDelete(null)}
@@ -266,11 +330,13 @@ function RoutineRow({
   routine,
   busy,
   onTogglePaused,
+  onEdit,
   onDelete,
 }: {
   routine: RoutineJob;
   busy: boolean;
   onTogglePaused: () => void;
+  onEdit: () => void;
   onDelete: () => void;
 }) {
   const paused = routine.state === "paused";
@@ -310,6 +376,15 @@ function RoutineRow({
       </div>
       <span className="routines-item-meta">{meta.join(" · ")}</span>
       <span className="routines-item-actions">
+        <button
+          type="button"
+          className="dictation-row-act"
+          aria-label="Edit"
+          disabled={busy}
+          onClick={onEdit}
+        >
+          <IconPencil size={14} />
+        </button>
         {!completed ? (
           <button
             type="button"

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -95,3 +95,19 @@ export function routineCreationPrompt(description: string) {
     "Pick a short descriptive name and an appropriate schedule (ask me if the timing is unclear), create the job, then confirm what you created and when it will first run.",
   ].join("\n\n");
 }
+
+/** Builds the agent prompt for "edit a routine". Editing also goes through
+ * June: the gateway's cron.manage has no update action (the bundled Hermes
+ * runtime is pinned upstream), while the agent's cronjob tool supports
+ * partial updates — it can change just the schedule without ever reading or
+ * re-sending the full prompt, which the list API truncates to a preview. */
+export function routineEditPrompt(
+  routine: Pick<RoutineJob, "job_id" | "name" | "schedule">,
+  changes: string,
+) {
+  return [
+    `Update my existing routine "${routine.name}" (cron job id ${routine.job_id}) using your cronjob tool's update action.`,
+    `It currently runs: ${routine.schedule}. Here is what should change: ${changes.trim()}`,
+    "Only modify the fields I asked about and leave everything else on the job untouched. Confirm the updated job and when it runs next.",
+  ].join("\n\n");
+}

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -52,7 +52,7 @@ describe("RoutinesView", () => {
         last_status: "error",
       }),
     ]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
 
     expect(await screen.findByText("Morning summary")).toBeInTheDocument();
     expect(screen.getByText("Weekly digest")).toBeInTheDocument();
@@ -64,7 +64,12 @@ describe("RoutinesView", () => {
   it("shows the empty state and routes creation through the agent prompt", async () => {
     mocks.listRoutines.mockResolvedValue([]);
     const onCreateRoutine = vi.fn();
-    render(<RoutinesView onCreateRoutine={onCreateRoutine} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={onCreateRoutine}
+        onEditRoutine={vi.fn()}
+      />,
+    );
 
     expect(await screen.findByText("Put June on a schedule")).toBeVisible();
     await userEvent.click(
@@ -86,9 +91,52 @@ describe("RoutinesView", () => {
     expect(prompt).toContain("cronjob tool");
   });
 
+  it("routes an edit through the agent prompt with the job reference", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    const onEditRoutine = vi.fn();
+    render(
+      <RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={onEditRoutine} />,
+    );
+    await screen.findByText("Morning summary");
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Edit “Morning summary”");
+    await userEvent.type(
+      within(dialog).getByRole("textbox"),
+      "run at 7am instead",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Ask June to update it" }),
+    );
+
+    expect(onEditRoutine).toHaveBeenCalledTimes(1);
+    const prompt = onEditRoutine.mock.calls[0][0] as string;
+    expect(prompt).toContain("run at 7am instead");
+    expect(prompt).toContain("abc123");
+    expect(prompt).toContain("Morning summary");
+    expect(prompt).toContain("update action");
+  });
+
+  it("does not send an edit with an empty description", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    const onEditRoutine = vi.fn();
+    render(
+      <RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={onEditRoutine} />,
+    );
+    await screen.findByText("Morning summary");
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("button", { name: "Ask June to update it" }),
+    ).toBeDisabled();
+    expect(onEditRoutine).not.toHaveBeenCalled();
+  });
+
   it("pauses a scheduled routine and reloads the list", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
     await screen.findByText("Morning summary");
 
     mocks.listRoutines.mockResolvedValue([job({ state: "paused" })]);
@@ -103,7 +151,7 @@ describe("RoutinesView", () => {
 
   it("resumes a paused routine", async () => {
     mocks.listRoutines.mockResolvedValue([job({ state: "paused" })]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
     await screen.findByText("Morning summary");
 
     await userEvent.click(screen.getByRole("button", { name: "Resume" }));
@@ -114,7 +162,7 @@ describe("RoutinesView", () => {
 
   it("deletes a routine after confirmation", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
     await screen.findByText("Morning summary");
 
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
@@ -133,7 +181,7 @@ describe("RoutinesView", () => {
 
   it("surfaces a failed reload after a successful pause", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
     await screen.findByText("Morning summary");
 
     mocks.listRoutines.mockRejectedValue(new Error("reload failed"));
@@ -145,7 +193,7 @@ describe("RoutinesView", () => {
   it("surfaces a failed delete in the error banner", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     mocks.removeRoutine.mockRejectedValue(new Error("remove failed"));
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
     await screen.findByText("Morning summary");
 
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
@@ -161,7 +209,7 @@ describe("RoutinesView", () => {
 
   it("surfaces a load error", async () => {
     mocks.listRoutines.mockRejectedValue(new Error("gateway down"));
-    render(<RoutinesView onCreateRoutine={vi.fn()} />);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
     expect(await screen.findByText("gateway down")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Adds **Edit** to the Routines view. Each row gains a pencil action that opens a dialog ("Tell June what should change — the schedule, the task, or the name"); submitting composes a prompt that references the routine by display name **and** `job_id`, and opens a fresh June session where the agent applies the change with its `cronjob` tool's `update` action.

## Why agent-mediated instead of a direct gateway call

Two hard constraints make a form-style direct edit impossible today:

- The Hermes gateway's `cron.manage` method only supports `list / add / remove / pause / resume` — there is no `update` action, and the app installs its Hermes runtime from a **pinned upstream tarball** (`NousResearch/hermes-agent@31c40c72`, SHA-verified in `hermes_bridge.rs`), so we can't extend the gateway from this repo.
- The list API truncates prompts to a 100-char `prompt_preview`, so a remove-and-re-add emulation would **clobber the routine's full prompt**.

The agent's `cronjob update` does partial updates (only the fields mentioned change), so June can change just the schedule without ever reading or re-sending the full prompt. The edit prompt instructs exactly that, and pins the job by `job_id` (unique; display names can be ambiguous).

If/when the runtime pin advances to a Hermes with a gateway `update` action, a direct inline edit form can replace this — the dialog and adapter are shaped so that swap is local.

## Testing

- 2 new tests: edit flow routes through `onEditRoutine` with the job reference and change text in the prompt; empty description keeps the submit disabled. Existing tests updated for the new required prop.
- Full JS suite 239/239, `tsc` and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)