### PR TITLE
Add a stop control for a running agent session

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1732,6 +1732,11 @@ export function AgentWorkspace({
     } catch {
       // Fall through to the local cleanup below.
     } finally {
+      // Tear down the per-session gateway listener along with the flags —
+      // a straggler "running" event arriving after the interrupt would
+      // otherwise flip the session straight back to working (and on a
+      // gateway drop no terminal event ever comes to unregister it).
+      sessionGatewayUnlistenRef.current.get(sessionId)?.();
       const activityCounts = clearSessionActivity(sessionId);
       dispatchAgentSessionStatus({
         sessionId,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -32,6 +32,7 @@ import { IconPencilLine } from "central-icons/IconPencilLine";
 import { IconPieChart1 } from "central-icons/IconPieChart1";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconShieldAi } from "central-icons/IconShieldAi";
+import { IconStop } from "central-icons/IconStop";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import { IconPangolin } from "../icons/IconPangolin";
 import { PangolinSpinner } from "../PangolinSpinner";
@@ -422,6 +423,9 @@ export function AgentWorkspace({
   const [runtimeSessionIds, setRuntimeSessionIds] = useState<
     Record<string, string>
   >({});
+  const [stoppingSessionIds, setStoppingSessionIds] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const [skills, setSkills] = useState<HermesSkillInfo[] | null>(null);
   const [toolsets, setToolsets] = useState<HermesToolsetInfo[] | null>(null);
   const [messagingPlatforms, setMessagingPlatforms] = useState<
@@ -1710,6 +1714,45 @@ export function AgentWorkspace({
     }
   }
 
+  // Stops a running June turn: interrupts the runtime session over the
+  // gateway, then clears the local working/waiting flags regardless — the
+  // user asked for it to stop, so the UI must not stay "thinking" even when
+  // the RPC fails (gateway drop, runtime session already gone).
+  async function stopHermesSession(sessionId: string) {
+    if (stoppingSessionIds.has(sessionId)) return;
+    setStoppingSessionIds((current) => new Set(current).add(sessionId));
+    try {
+      const runtimeSessionId = runtimeSessionIds[sessionId];
+      if (runtimeSessionId) {
+        const gateway = await ensureHermesGateway();
+        await gateway.request("session.interrupt", {
+          session_id: runtimeSessionId,
+        });
+      }
+    } catch {
+      // Fall through to the local cleanup below.
+    } finally {
+      const activityCounts = clearSessionActivity(sessionId);
+      dispatchAgentSessionStatus({
+        sessionId,
+        title:
+          hermesSessionItems.find((session) => session.id === sessionId)
+            ?.title ?? "Agent session",
+        status: "cancelled",
+        summary: "Stopped.",
+        ...activityCounts,
+      });
+      setStoppingSessionIds((current) => {
+        const next = new Set(current);
+        next.delete(sessionId);
+        return next;
+      });
+      // Pull whatever the agent managed to persist before the interrupt so
+      // the transcript reflects the partial turn.
+      void refreshHermesSession(sessionId);
+    }
+  }
+
   async function retryTask(taskId: string) {
     try {
       upsertTask(await retryAgentTask(taskId));
@@ -2180,6 +2223,21 @@ export function AgentWorkspace({
               }}
             />
             <div className="agent-composer-actions">
+              {selectedHermesSessionId &&
+              workingSessionIds.has(selectedHermesSessionId) ? (
+                <button
+                  type="button"
+                  className="agent-composer-stop"
+                  aria-label="Stop June"
+                  title="Stop June"
+                  disabled={stoppingSessionIds.has(selectedHermesSessionId)}
+                  onClick={() =>
+                    void stopHermesSession(selectedHermesSessionId)
+                  }
+                >
+                  <IconStop size={16} />
+                </button>
+              ) : null}
               <button
                 type="button"
                 className="agent-composer-mic"

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2286,6 +2286,35 @@ input:focus-visible,
   color: var(--foreground);
 }
 
+/* Stop control — appears while June is working on the open session. Same
+ * squircle as the mic so the actions row doesn't shift when it comes and
+ * goes; the destructive tint marks it as an interrupt. */
+.agent-composer-stop {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: var(--control-lg);
+  height: var(--control-lg);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-lg);
+  background: transparent;
+  color: var(--muted-foreground);
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.agent-composer-stop:hover {
+  background: color-mix(in oklch, var(--destructive) 12%, transparent);
+  color: var(--destructive);
+}
+
+.agent-composer-stop:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 /* Send slides in from the right (pushing the mic over) only once there's
  * something to send — an up arrow in a solid circle. */
 /* Send is the primary action in the brand terracotta (the logo mark color);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -253,6 +253,45 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
+  it("stops a working session from the composer", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ prompt: "summarize the current page" }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "summarize the current page",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "summarize the current page",
+      }),
+    );
+
+    // The session is now working, so the composer offers a stop control.
+    const stop = await screen.findByRole("button", { name: "Stop June" });
+    await userEvent.click(stop);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.interrupt", {
+        session_id: "runtime-session-2",
+      }),
+    );
+    // The working flag clears even before any gateway event arrives, so the
+    // stop control goes away and the session no longer reads as thinking.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Stop June" })).toBeNull(),
+    );
+  });
+
   it("creates a fresh Hermes session for a New Session prompt when an initial session is selected", async () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => ({
   listHermesSessionMessages: vi.fn(),
   listHermesSessions: vi.fn(),
   gatewayRequest: vi.fn(),
+  gatewayEventHandlers: new Set<(event: Record<string, unknown>) => void>(),
   eventHandlers: new Map<
     string,
     (event: { payload?: { paths?: string[] } }) => void
@@ -102,7 +103,10 @@ vi.mock("../lib/hermes-gateway", () => ({
   HermesGatewayClient: class {
     connect = vi.fn();
     close = vi.fn();
-    onEvent = vi.fn(() => vi.fn());
+    onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
+      mocks.gatewayEventHandlers.add(handler);
+      return () => mocks.gatewayEventHandlers.delete(handler);
+    });
     onClose = vi.fn(() => vi.fn());
     request = mocks.gatewayRequest;
   },
@@ -130,6 +134,7 @@ const existingSession = {
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.gatewayEventHandlers.clear();
     window.sessionStorage.clear();
     mocks.listAgentTasks.mockResolvedValue({ items: [existingTask] });
     mocks.getAgentTask.mockResolvedValue(existingTask);
@@ -278,6 +283,7 @@ describe("AgentWorkspace", () => {
 
     // The session is now working, so the composer offers a stop control.
     const stop = await screen.findByRole("button", { name: "Stop June" });
+    expect(mocks.gatewayEventHandlers.size).toBe(1);
     await userEvent.click(stop);
 
     await waitFor(() =>
@@ -290,6 +296,9 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Stop June" })).toBeNull(),
     );
+    // Stopping also tears down the per-session gateway listener, so a
+    // straggler "running" event can't flip the session back to working.
+    expect(mocks.gatewayEventHandlers.size).toBe(0);
   });
 
   it("creates a fresh Hermes session for a New Session prompt when an initial session is selected", async () => {


### PR DESCRIPTION
## Summary

There was no way to stop June mid-turn — a running session just showed "Thinking" until it finished (or failed). Now, while the open session is working, the composer shows a **stop button** (square icon, destructive tint on hover) next to the mic.

## How it works

- Clicking it sends `session.interrupt` for the session's runtime id over the existing gateway socket. I verified the method exists in the **pinned Hermes runtime** the app actually ships (`NousResearch/hermes-agent@31c40c72` — downloaded the pinned tarball, SHA matches `hermes_bridge.rs`, handler at `tui_gateway/server.py:3586`): it interrupts the agent, releases that session's pending prompts, and denies outstanding approvals — scoped to the one session.
- The local working/waiting flags clear **regardless of the RPC outcome** — if the gateway dropped or the runtime session is already gone, nothing is running anyway, and the UI must not stay stuck on "thinking". A `cancelled` session status is dispatched (menu bar/HUD stay in sync), and the session refreshes so whatever the agent persisted before the interrupt shows in the transcript.
- While the interrupt is in flight the button disables; it disappears when the session stops working. The button only renders for the session you're looking at, and sending a follow-up message stays available throughout (send/mic are untouched).

## Testing

- New test: submits a prompt (session working), clicks Stop, asserts `session.interrupt` goes out with the runtime session id and the stop control disappears (working flag cleared locally without waiting for a gateway event).
- Full JS suite 238/238, `tsc` and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)