### PR TITLE
Add a dismiss control to the meeting-detected prompt

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -53,6 +53,25 @@
         Start transcription
       </button>
       <button
+        id="hud-meeting-dismiss"
+        class="hud-meeting-dismiss"
+        type="button"
+        aria-label="Dismiss meeting prompt"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M6 6l12 12M18 6L6 18" />
+        </svg>
+      </button>
+      <button
         id="hud-stop"
         class="hud-stop"
         type="button"

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -40,6 +40,9 @@ const agentLabel = document.querySelector<HTMLElement>("#hud-agent-label");
 const stopButton = document.querySelector<HTMLButtonElement>("#hud-stop");
 const meetingStartButton =
   document.querySelector<HTMLButtonElement>("#hud-meeting-start");
+const meetingDismissButton = document.querySelector<HTMLButtonElement>(
+  "#hud-meeting-dismiss",
+);
 const statusText = document.querySelector<HTMLElement>("#hud-status");
 
 let hideTimer: number | undefined;
@@ -607,6 +610,19 @@ meetingStartButton?.addEventListener("click", async (event) => {
   void hideHud().finally(() => {
     meetingStartButton.disabled = false;
   });
+});
+
+meetingDismissButton?.addEventListener("click", (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  if (hud?.dataset.state !== "meeting") return;
+
+  // Same semantics as letting the prompt time out: stay quiet for the rest
+  // of this meeting (detection heartbeats keep arriving while the call is
+  // live) and prompt again once it clears.
+  meetingPromptSuppressed = true;
+  clearMeetingPromptTimer();
+  void hideHud();
 });
 
 void listen("dictation-event", async (event) => {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -307,6 +307,31 @@ body {
   transform: none;
 }
 
+/* Quiet ghost next to the filled primary action: dismissal must read as
+ * secondary to "Start transcription". */
+.hud-meeting-dismiss {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--hud-handle);
+  cursor: pointer;
+}
+
+.hud-meeting-dismiss:hover {
+  background: var(--hud-stop-bg-hover);
+  color: var(--foreground);
+}
+
+.hud-meeting-dismiss:active {
+  transform: translateY(0.5px);
+}
+
 /* Stop button ---------------------------------------------------------- */
 .hud-stop {
   position: relative;
@@ -401,7 +426,8 @@ body {
 }
 
 .hud[data-state="meeting"] .hud-meeting-label,
-.hud[data-state="meeting"] .hud-meeting-start {
+.hud[data-state="meeting"] .hud-meeting-start,
+.hud[data-state="meeting"] .hud-meeting-dismiss {
   display: inline-flex;
 }
 

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -91,6 +91,43 @@ describe("meeting detection HUD", () => {
     vi.useRealTimers();
   });
 
+  it("dismisses the prompt and stays quiet until the meeting clears", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    document.querySelector<HTMLButtonElement>("#hud-meeting-dismiss")?.click();
+    await Promise.resolve();
+
+    expect(hudElement().dataset.state).toBe("exiting");
+    await vi.advanceTimersByTimeAsync(220);
+    expect(mocks.hide).toHaveBeenCalledOnce();
+
+    // Detection heartbeats keep arriving while the same meeting is live; the
+    // dismissed prompt must not come back for any of them.
+    mocks.show.mockClear();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+    expect(mocks.show).not.toHaveBeenCalled();
+
+    // The next meeting prompts again.
+    await emit("meeting-detection-event", { type: "meeting_cleared" });
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+    expect(hudElement().dataset.state).toBe("meeting");
+    expect(mocks.show).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a dismiss click outside the meeting prompt state", async () => {
+    await loadHud();
+    hudElement().dataset.state = "listening";
+    mocks.hide.mockClear();
+
+    document.querySelector<HTMLButtonElement>("#hud-meeting-dismiss")?.click();
+    await Promise.resolve();
+
+    expect(hudElement().dataset.state).toBe("listening");
+    expect(mocks.hide).not.toHaveBeenCalled();
+  });
+
   it("clears the prompt when microphone usage stops", async () => {
     await loadHud();
     await emit("meeting-detection-event", { type: "meeting_detected" });
@@ -318,6 +355,7 @@ function hudMarkup() {
       <span id="hud-agent-label" class="hud-agent-label" aria-hidden="true"></span>
       <span id="hud-meeting-label" class="hud-meeting-label">Meeting detected</span>
       <button id="hud-meeting-start" class="hud-meeting-start" type="button">Start transcription</button>
+      <button id="hud-meeting-dismiss" class="hud-meeting-dismiss" type="button" aria-label="Dismiss meeting prompt"></button>
       <button id="hud-stop" class="hud-stop" type="button" aria-label="Stop dictation">
         <span class="hud-stop-glyph" aria-hidden="true"></span>
       </button>


### PR DESCRIPTION
## Summary

The "Meeting detected / Start transcription" HUD pill had no way to be closed — it sat on screen until the 30s timeout fired or the meeting ended. This adds a small **dismiss button** (quiet ghost ×, after the primary action so "Start transcription" stays the obvious choice) that hides the pill immediately.

## Behavior

Dismissing uses the **same semantics as letting the prompt time out**: `meetingPromptSuppressed` is set, so the detection heartbeats that keep arriving while the meeting is live don't bring the prompt back, and the suppression resets on `meeting_cleared` — the *next* meeting prompts normally. The click is a no-op outside the meeting state (the shared pill cycles through dictation states).

No native plumbing needed: HUD clicks already work in the webview (the Rust rect mechanism is only the hover highlight for the dictation stop button).

## Testing

- New tests: dismiss hides the pill and keeps it hidden through subsequent `meeting_detected` heartbeats, prompts again after `meeting_cleared`; a dismiss click outside the meeting state does nothing. Full HUD suite 16/16.
- `tsc` and Prettier clean.
- Note: `agent-workspace.test.tsx > stops a working session from the composer` currently fails on `main` (semantic conflict between #152 and #153, both merged this morning) — unrelated to this change, fails identically on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)