### PR TITLE
Fix menu bar stuck on "Working…" with no agent actually running

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -427,6 +427,10 @@ export function AgentWorkspace({
   const [runtimeSessionIds, setRuntimeSessionIds] = useState<
     Record<string, string>
   >({});
+  const runtimeSessionIdsRef = useRef(runtimeSessionIds);
+  // Consecutive runtime-reconcile polls in which a locally-working session was
+  // absent from the gateway's live list. Cleared the moment it's seen live.
+  const workingReconcileMissesRef = useRef(new Map<string, number>());
   const [stoppingSessionIds, setStoppingSessionIds] = useState<
     ReadonlySet<string>
   >(new Set());
@@ -478,6 +482,10 @@ export function AgentWorkspace({
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const composerBoxRef = useRef<HTMLDivElement | null>(null);
   const [composerMultiline, setComposerMultiline] = useState(false);
+
+  useEffect(() => {
+    runtimeSessionIdsRef.current = runtimeSessionIds;
+  }, [runtimeSessionIds]);
 
   useEffect(() => {
     selectedHermesSessionIdRef.current = selectedHermesSessionId;
@@ -927,6 +935,7 @@ export function AgentWorkspace({
       for (const sessionId of sessionIds) {
         void refreshHermesSession(sessionId);
       }
+      void reconcileWorkingSessionsAgainstRuntime();
     }, 2500);
     return () => window.clearInterval(interval);
   }, [bridge.running, workingSessionIds]);
@@ -1483,6 +1492,75 @@ export function AgentWorkspace({
       throw err;
     } finally {
       setBridgeStarting(false);
+    }
+  }
+
+  // Message-based reconciliation above can only END a run when an assistant
+  // reply eventually persists. A run that died without one (provider failure,
+  // gateway drop, app quit mid-turn) — or a session wrongly resumed as
+  // working from a trailing user message — would otherwise stay "working"
+  // forever, leaving the menu bar stuck on "Working…". The gateway's
+  // session.active_list is ground truth for what is actually running, so any
+  // locally-working session absent from it (or sitting idle) for two
+  // consecutive polls gets its activity cleared. Two misses, not one: a
+  // just-submitted prompt can race the runtime session registering.
+  async function reconcileWorkingSessionsAgainstRuntime() {
+    const working = Array.from(workingSessionIdsRef.current);
+    const misses = workingReconcileMissesRef.current;
+    for (const sessionId of misses.keys()) {
+      if (!working.includes(sessionId)) misses.delete(sessionId);
+    }
+    if (working.length === 0) return;
+    let rows: Array<{ id?: string; session_key?: string; status?: string }>;
+    try {
+      const gateway = await ensureHermesGateway();
+      const response = await gateway.request<{
+        sessions?: Array<{
+          id?: string;
+          session_key?: string;
+          status?: string;
+        }>;
+      }>("session.active_list", {});
+      rows = Array.isArray(response?.sessions) ? response.sessions : [];
+    } catch {
+      // Can't reach the runtime — keep the current state rather than guess.
+      return;
+    }
+    const live = new Set<string>();
+    for (const row of rows) {
+      // "idle" means the runtime session exists but isn't processing a turn.
+      if (!row || row.status === "idle") continue;
+      if (row.session_key) live.add(String(row.session_key));
+      if (row.id) live.add(String(row.id));
+    }
+    for (const sessionId of working) {
+      const runtimeSessionId = runtimeSessionIdsRef.current[sessionId];
+      if (
+        live.has(sessionId) ||
+        (runtimeSessionId && live.has(runtimeSessionId))
+      ) {
+        misses.delete(sessionId);
+        continue;
+      }
+      const seen = (misses.get(sessionId) ?? 0) + 1;
+      if (seen < 2) {
+        misses.set(sessionId, seen);
+        continue;
+      }
+      misses.delete(sessionId);
+      const activityCounts = clearSessionActivity(sessionId);
+      // "completed" (not "failed") keeps the tray quiet: its title falls back
+      // to lastStatus when nothing is active, and a stale "running" there
+      // would still render "Working…".
+      dispatchAgentSessionStatus({
+        sessionId,
+        title:
+          hermesSessionItems.find((session) => session.id === sessionId)
+            ?.title ?? "Agent session",
+        status: "completed",
+        summary: "June stopped.",
+        ...activityCounts,
+      });
     }
   }
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -377,7 +377,11 @@ describe("AgentWorkspace", () => {
   it("stops a working session from the composer", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
-      JSON.stringify({ prompt: "summarize the current page" }),
+      // Markers must carry a fresh createdAt or the TTL check discards them.
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "summarize the current page",
+      }),
     );
     mocks.listHermesSessions.mockResolvedValue([
       {
@@ -467,6 +471,104 @@ describe("AgentWorkspace", () => {
       await screen.findByText("Summarize Current Page"),
     ).toBeInTheDocument();
     expect(screen.getByText("open the release notes")).toBeInTheDocument();
+  });
+
+  it("clears a working session the runtime is no longer running", async () => {
+    // A recent trailing user message with no reply resumes the session as
+    // working on mount — the exact state a dead run (provider failure, app
+    // quit mid-turn) leaves behind.
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "still waiting on this",
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.active_list") {
+        return Promise.resolve({ sessions: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    // The whole flow runs under fake timers so the working-gated poll's
+    // interval is created on the fake clock and can be advanced.
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+
+      // Two reconcile polls: the first miss is tolerated (a fresh submit can
+      // race the runtime registering), the second clears the activity.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "session.active_list",
+        {},
+      );
+      expect(screen.queryByText("Thinking…")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a session working while the runtime reports it live", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "long running task",
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.active_list") {
+        return Promise.resolve({
+          sessions: [
+            {
+              id: "runtime-session-1",
+              session_key: "session-1",
+              status: "working",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "session.active_list",
+        {},
+      );
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps polling when a follow-up user message is still only pending locally", async () => {


### PR DESCRIPTION
## The bug

The macOS menu bar showed **"Working…"** while nothing was running in Agents (screenshot in Slack). 

## Root cause

The tray is a passive display: it renders "Working…" whenever the workspace's published `workingSessionIds` is non-empty. Sessions enter that set two ways — live gateway events, and a **resume heuristic** (a session whose latest message is a user prompt < 15 min old with no reply is assumed in-flight). But the only thing that ever *removed* a session was seeing an assistant reply land in its persisted messages.

So any run that died without a reply — provider 502, gateway drop, app quit mid-turn — and any session wrongly resumed from a dead trailing user message stayed "working" **forever**: the 15-minute window gates entering working state but nothing gated staying in it. With recent provider failures producing exactly those dead sessions, the tray stuck immediately.

(Clearing on workspace unmount would be wrong — sessions legitimately keep running while you browse Notes; that's the tray's whole purpose. The fix has to make the state truthful instead.)

## The fix

The existing 2.5s working-gated poll now also reconciles against **runtime ground truth**: `session.active_list` (verified present in the pinned Hermes runtime `NousResearch/hermes-agent@31c40c72`, handler at `tui_gateway/server.py:3095`) reports the live in-memory sessions with their status. Any locally-working session that is absent from that list — or present but `idle` — for **two consecutive polls** gets its activity cleared and a terminal status dispatched. Two misses, not one, because a fresh submit can race the runtime session registering (~5s worst case). If the gateway itself is unreachable, nothing is cleared — no guessing.

The terminal status is `completed` (summary "June stopped.") rather than `failed`: the tray title falls back to `lastStatus` when nothing is active, and `status_title("failed")` would pin "Failed" in the menu bar for what is usually just a stale inference.

## Also in this PR

The `stops a working session from the composer` test **fails on a clean main checkout** — a #152/#153 merge overlap (#153's test still wrote the pending marker without `createdAt`, which #152's TTL contract discards). Fixed the marker shape.

## Testing

- New: a session resumed as working with no live runtime clears after exactly two reconcile polls (and not one); a session the runtime reports as `working` stays working through reconcile polls.
- Full suite 257/257 (including the previously failing stop test), `tsc` + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)