### PR TITLE
Serve a /verify attestation page from inside the TEE

### DIFF
--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -65,6 +65,10 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+          # Stamped into the runtime env for the /verify attestation page.
+          # Derived from the commit, so it does not break reproducibility.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=scribe-api
           cache-to: type=gha,scope=scribe-api,mode=max
           # No provenance/SBOM attestations: they make build.outputs.digest an OCI

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The `scribe-api` backend runs in an Intel TDX confidential VM on Phala Cloud. Be
 
 Together these bind the running image to a public commit: you can confirm the attested digest is the one our CI built and recorded for that commit. (Bit-for-bit _rebuild-from-source_ reproducibility — so you can regenerate the digest yourself instead of trusting our CI — is in progress.)
 
+Every deployment also serves its own walkthrough of this chain at [`/verify`](https://scribe-api.opensoftware.co/verify) — served from inside the TEE, it reports the exact commit and image the running server was built from, with step-by-step instructions for checking each link.
+
 Audio still leaves the TEE when forwarded to OpenAI or Venice for transcription, under those providers' own privacy policies. This chain verifies the **code** running in the confidential VM, not what upstream providers do with audio. End-to-end private STT is a separate workstream.
 
 ## Development

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -190,6 +190,7 @@ Usage: verify-reproducible.sh <git-ref>
      trap 'git worktree remove /tmp/verify --force' EXIT   # always clean up
   2. SOURCE_DATE_EPOCH=$(git -C /tmp/verify log -1 --pretty=%ct) \
        docker buildx build --provenance=false --sbom=false \
+       --build-arg GIT_SHA=$(git -C /tmp/verify rev-parse HEAD) \   # match CI: /verify stamps the commit into the runtime env
        --output type=image,rewrite-timestamp=true,push=false \
        --metadata-file /tmp/meta.json /tmp/verify/scribe-api   # build the worktree, NOT cwd
   3. local=$(jq -r '.["containerimage.digest"]' /tmp/meta.json)

--- a/scribe-api/Dockerfile
+++ b/scribe-api/Dockerfile
@@ -26,6 +26,12 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 WORKDIR /app
 COPY --from=builder /app/target/release/scribe /usr/local/bin/scribe
 COPY config.toml /app/config.toml
+# Source commit stamped into the runtime env so /verify can report which
+# public commit this image was built from. Build-arg only: the same commit
+# always passes the same value, so the image digest stays reproducible, and
+# the binary itself is unaffected.
+ARG GIT_SHA=""
+ENV SCRIBE__ATTESTATION__SOURCE_COMMIT=${GIT_SHA}
 USER scribe
 EXPOSE 8080
 ENV RUST_LOG=scribe=info,scribe_api=info,scribe_services=info,scribe_providers=info,tower_http=info

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -5,6 +5,13 @@ request_timeout_secs = 600
 max_audio_bytes = 26214400
 max_json_bytes = 524288
 
+# Public facts shown on the /verify attestation page. source_commit is not
+# set here — the Docker build stamps it via SCRIBE__ATTESTATION__SOURCE_COMMIT.
+[attestation]
+source_repo_url = "https://github.com/open-software-network/os-scribe"
+image_repo = "ghcr.io/open-software-network/scribe-api"
+trust_center_url = "https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c"
+
 [os_accounts]
 # api_url has no default — must come from SCRIBE__OS_ACCOUNTS__API_URL
 # per environment so a missing override fails loud against the dev

--- a/scribe-api/crates/api/src/handlers/mod.rs
+++ b/scribe-api/crates/api/src/handlers/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod dictate;
 pub(crate) mod health;
 pub(crate) mod models;
 pub(crate) mod notes;
+pub(crate) mod verify;

--- a/scribe-api/crates/api/src/handlers/verify.rs
+++ b/scribe-api/crates/api/src/handlers/verify.rs
@@ -1,0 +1,304 @@
+use axum::{extract::State, response::Html};
+
+use crate::state::{ApiState, AttestationInfo};
+
+/// Human-facing attestation walkthrough. Served from inside the TEE so the
+/// page itself is covered by the same attestation it explains. Public and
+/// unauthenticated like the health probes, and deliberately HTML rather than
+/// the `ApiResponse` envelope — the audience is a person, not a client.
+pub(crate) async fn verify(State(state): State<ApiState>) -> Html<String> {
+    Html(render_page(state.attestation()))
+}
+
+/// First seven characters of the commit, only when it looks like a real git
+/// sha. Anything else (empty, placeholder text) renders as "not stamped".
+fn short_commit(commit: &str) -> Option<&str> {
+    let trimmed = commit.trim();
+    let looks_like_sha = trimmed.len() >= 7 && trimmed.chars().all(|c| c.is_ascii_hexdigit());
+    looks_like_sha.then(|| &trimmed[..7])
+}
+
+fn escape_html(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
+}
+
+fn render_page(info: &AttestationInfo) -> String {
+    let repo_url = escape_html(&info.source_repo_url);
+    let image_repo = escape_html(&info.image_repo);
+    let trust_center_url = escape_html(&info.trust_center_url);
+
+    let (commit_value, short_sha) = match short_commit(&info.source_commit) {
+        Some(short) => {
+            let full = escape_html(info.source_commit.trim());
+            let short = escape_html(short);
+            (
+                format!(
+                    "<a href=\"{repo_url}/commit/{full}\"><code>{short}</code></a> \
+                     <span class=\"muted\"><code>{full}</code></span>"
+                ),
+                short,
+            )
+        }
+        None => (
+            "<em>not stamped — local or development build</em>".to_string(),
+            "&lt;short-sha&gt;".to_string(),
+        ),
+    };
+
+    PAGE_TEMPLATE
+        .replace("@SERVICE@", env!("CARGO_PKG_NAME"))
+        .replace("@VERSION@", env!("CARGO_PKG_VERSION"))
+        .replace("@COMMIT_VALUE@", &commit_value)
+        .replace("@SHORT_SHA@", &short_sha)
+        .replace("@REPO_URL@", &repo_url)
+        .replace("@IMAGE_REPO@", &image_repo)
+        .replace("@TRUST_CENTER_URL@", &trust_center_url)
+}
+
+const PAGE_TEMPLATE: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Verify this server — @SERVICE@</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #fdfdfc;
+    --fg: #1c1b18;
+    --muted: #6f6c64;
+    --border: #e6e4de;
+    --surface: #f4f3ef;
+    --accent: #1f6f4a;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #161513;
+      --fg: #e9e7e1;
+      --muted: #9b988f;
+      --border: #2c2a26;
+      --surface: #201f1c;
+      --accent: #6fbf95;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0 auto;
+    padding: 3.5rem 1.25rem 5rem;
+    max-width: 42rem;
+    background: var(--bg);
+    color: var(--fg);
+    font: 16px/1.65 system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  h1, h2 {
+    font-family: ui-serif, Georgia, "Times New Roman", serif;
+    font-weight: 400;
+    line-height: 1.2;
+  }
+  h1 { font-size: 2.1rem; margin: 0 0 0.5rem; }
+  h2 { font-size: 1.35rem; margin: 2.75rem 0 0.75rem; }
+  p { margin: 0.75rem 0; }
+  a { color: var(--accent); }
+  .lede { color: var(--muted); margin: 0 0 2rem; }
+  .muted { color: var(--muted); }
+  code {
+    font: 0.875em ui-monospace, SFMono-Regular, Menlo, monospace;
+    background: var(--surface);
+    border-radius: 4px;
+    padding: 0.1em 0.35em;
+    overflow-wrap: anywhere;
+  }
+  pre {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.85rem 1rem;
+    overflow-x: auto;
+  }
+  pre code { background: none; padding: 0; }
+  dl.facts {
+    margin: 0;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  dl.facts > div {
+    display: grid;
+    grid-template-columns: 9.5rem 1fr;
+    gap: 1rem;
+    padding: 0.7rem 1rem;
+  }
+  dl.facts > div + div { border-top: 1px solid var(--border); }
+  dl.facts dt { margin: 0; color: var(--muted); }
+  dl.facts dd { margin: 0; overflow-wrap: anywhere; }
+  ol.steps { padding-left: 1.25rem; }
+  ol.steps > li { margin: 1.1rem 0; }
+  ol.steps > li::marker { color: var(--muted); }
+  .badge {
+    display: inline-block;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.1rem 0.7rem;
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 1.25rem;
+  }
+  footer {
+    margin-top: 3.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.875rem;
+  }
+</style>
+</head>
+<body>
+<header>
+  <span class="badge">Intel TDX · Phala Cloud</span>
+  <h1>Verify this server</h1>
+  <p class="lede">@SERVICE@ runs inside an Intel TDX confidential VM. This page is
+  served from inside that VM and explains how to check — without trusting us —
+  that the code running here is exactly the public source code.</p>
+</header>
+
+<h2>This deployment</h2>
+<dl class="facts">
+  <div><dt>Service</dt><dd><code>@SERVICE@</code> v@VERSION@</dd></div>
+  <div><dt>Source commit</dt><dd>@COMMIT_VALUE@</dd></div>
+  <div><dt>Source code</dt><dd><a href="@REPO_URL@">@REPO_URL@</a></dd></div>
+  <div><dt>Image</dt><dd><code>@IMAGE_REPO@:@SHORT_SHA@</code></dd></div>
+  <div><dt>Attestation</dt><dd><a href="@TRUST_CENTER_URL@">Phala Trust Center report</a></dd></div>
+</dl>
+
+<h2>Why this matters</h2>
+<p>Audio, transcripts, and notes pass through this server. Because the running
+image is remotely attested, neither Phala (the platform) nor Open Software (us)
+can quietly swap it for one that reads your data — any change to the running
+code is visible in the chain below.</p>
+<p>The chain has three links: <strong>source</strong> (a public git commit),
+<strong>image</strong> (a container image our CI builds from that commit, published
+with a content digest), and <strong>attestation</strong> (third-party-verifiable
+proof that the image with that digest is what is actually executing inside a
+genuine Intel TDX VM).</p>
+
+<h2>Check it yourself</h2>
+<ol class="steps">
+  <li>
+    <p>Open the <a href="@TRUST_CENTER_URL@">Trust Center report</a>. Confirm the
+    attestation verifies, then find the image reference pinned in the attested
+    compose file. It should be:</p>
+    <pre><code>@IMAGE_REPO@:@SHORT_SHA@</code></pre>
+  </li>
+  <li>
+    <p>Resolve that tag to its content digest in the public registry:</p>
+    <pre><code>docker buildx imagetools inspect @IMAGE_REPO@:@SHORT_SHA@ \
+  --format '{{.Manifest.Digest}}'</code></pre>
+  </li>
+  <li>
+    <p>Compare against the digest our CI recorded in the repository at deploy
+    time, as an immutable <code>deploy/&lt;env&gt;/&lt;sha&gt;</code> git tag:</p>
+    <pre><code>git clone @REPO_URL@ &amp;&amp; cd os-scribe
+git tag -l 'deploy/*/@SHORT_SHA@' -n3</code></pre>
+    <p>The tag message states which image digest commit <code>@SHORT_SHA@</code>
+    deployed. It must match the digest from step 2.</p>
+  </li>
+  <li>
+    <p>Read the source at that commit. The commit linked above is the exact tree
+    the image was built from — the build stamps it into the image itself.</p>
+  </li>
+</ol>
+<p class="muted">This proves the running digest is the one our public CI built
+and recorded for that commit. Bit-for-bit reproducible rebuilds — regenerating
+the digest yourself instead of trusting our CI — are in progress; see
+<a href="@REPO_URL@/blob/main/docs/reproducible-builds.md">docs/reproducible-builds.md</a>.</p>
+
+<h2>What this does not cover</h2>
+<p>The chain verifies the <strong>code</strong> running in the confidential VM —
+not what upstream providers do. Audio still leaves the TEE when forwarded to
+OpenAI or Venice for transcription, under those providers' own privacy
+policies. End-to-end private speech-to-text is a separate workstream.</p>
+
+<footer>
+  <p>Open Software — <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>
+</footer>
+</body>
+</html>
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::{AttestationInfo, escape_html, render_page, short_commit};
+    use pretty_assertions::assert_eq;
+
+    fn info() -> AttestationInfo {
+        AttestationInfo {
+            source_commit: "0123abc4567890def0123abc4567890def012345".to_string(),
+            source_repo_url: "https://github.com/open-software-network/os-scribe".to_string(),
+            image_repo: "ghcr.io/open-software-network/scribe-api".to_string(),
+            trust_center_url: "https://trust.phala.com/app/15f8d2fd".to_string(),
+        }
+    }
+
+    #[test]
+    fn short_commit_accepts_full_sha() {
+        assert_eq!(
+            short_commit("0123abc4567890def0123abc4567890def012345"),
+            Some("0123abc")
+        );
+    }
+
+    #[test]
+    fn short_commit_rejects_non_sha_values() {
+        assert_eq!(short_commit(""), None);
+        assert_eq!(short_commit("unknown"), None);
+        assert_eq!(short_commit("abc"), None);
+    }
+
+    #[test]
+    fn escape_html_neutralizes_markup() {
+        assert_eq!(
+            escape_html("<script>\"&'"),
+            "&lt;script&gt;&quot;&amp;&#39;"
+        );
+    }
+
+    #[test]
+    fn render_links_commit_and_attestation() {
+        let html = render_page(&info());
+        assert!(html.contains(
+            "https://github.com/open-software-network/os-scribe/commit/0123abc4567890def0123abc4567890def012345"
+        ));
+        assert!(html.contains("ghcr.io/open-software-network/scribe-api:0123abc"));
+        assert!(html.contains("https://trust.phala.com/app/15f8d2fd"));
+        assert!(!html.contains("@SHORT_SHA@"));
+    }
+
+    #[test]
+    fn render_without_commit_says_not_stamped() {
+        let mut info = info();
+        info.source_commit = String::new();
+        let html = render_page(&info);
+        assert!(html.contains("not stamped"));
+        assert!(html.contains("&lt;short-sha&gt;"));
+    }
+
+    #[test]
+    fn render_escapes_configured_values() {
+        let mut info = info();
+        info.image_repo = "ghcr.io/<evil>".to_string();
+        let html = render_page(&info);
+        assert!(!html.contains("ghcr.io/<evil>"));
+        assert!(html.contains("ghcr.io/&lt;evil&gt;"));
+    }
+}

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -29,7 +29,7 @@ pub use handlers::dictate::{
 pub use handlers::health::HealthDto;
 pub use handlers::models::ModelDto;
 pub use handlers::notes::{GenerateRequest, GenerateResponse, TranscribeResponse};
-pub use state::{ApiLimits, ApiState, ApiStateParams};
+pub use state::{ApiLimits, ApiState, ApiStateParams, AttestationInfo};
 
 pub fn router(state: ApiState) -> Router {
     let limits = state.limits();
@@ -41,6 +41,7 @@ pub fn router(state: ApiState) -> Router {
         .route("/livez", get(handlers::health::livez))
         .route("/readyz", get(handlers::health::readyz))
         .route("/healthz", get(handlers::health::healthz))
+        .route("/verify", get(handlers::verify::verify))
         .route("/v1/models", get(handlers::models::list_models))
         .route(
             "/v1/notes/transcribe",

--- a/scribe-api/crates/api/src/state.rs
+++ b/scribe-api/crates/api/src/state.rs
@@ -17,6 +17,7 @@ struct ApiStateInner {
     agent_chat: Arc<AgentChatService>,
     dictate: Arc<DictateService>,
     limits: ApiLimits,
+    attestation: AttestationInfo,
 }
 
 #[derive(Clone, Copy)]
@@ -24,6 +25,17 @@ pub struct ApiLimits {
     pub max_audio_bytes: usize,
     pub max_json_bytes: usize,
     pub request_timeout_secs: u64,
+}
+
+/// Public deployment facts rendered by the `/verify` attestation page.
+#[derive(Clone)]
+pub struct AttestationInfo {
+    /// Full git commit the running image was built from; empty when the
+    /// build did not stamp one (local/dev builds).
+    pub source_commit: String,
+    pub source_repo_url: String,
+    pub image_repo: String,
+    pub trust_center_url: String,
 }
 
 pub struct ApiStateParams {
@@ -34,6 +46,7 @@ pub struct ApiStateParams {
     pub agent_chat: Arc<AgentChatService>,
     pub dictate: Arc<DictateService>,
     pub limits: ApiLimits,
+    pub attestation: AttestationInfo,
 }
 
 impl ApiState {
@@ -47,6 +60,7 @@ impl ApiState {
                 agent_chat: params.agent_chat,
                 dictate: params.dictate,
                 limits: params.limits,
+                attestation: params.attestation,
             }),
         }
     }
@@ -77,5 +91,9 @@ impl ApiState {
 
     pub(crate) fn limits(&self) -> ApiLimits {
         self.inner.limits
+    }
+
+    pub(crate) fn attestation(&self) -> &AttestationInfo {
+        &self.inner.attestation
     }
 }

--- a/scribe-api/crates/api/tests/http_boundary.rs
+++ b/scribe-api/crates/api/tests/http_boundary.rs
@@ -5,7 +5,7 @@ use axum::{
     http::{Method, Request, StatusCode, header},
 };
 use pretty_assertions::assert_eq;
-use scribe_api::{ApiLimits, ApiState, ApiStateParams, router};
+use scribe_api::{ApiLimits, ApiState, ApiStateParams, AttestationInfo, router};
 use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
 use scribe_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe, AuthError,
@@ -161,11 +161,72 @@ async fn integration_dictate_cleanup_returns_enveloped_response() -> Result<(), 
     Ok(())
 }
 
+#[tokio::test]
+async fn integration_verify_page_is_public_html() -> Result<(), Box<dyn Error>> {
+    let response = send(get_request("/verify")?).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        content_type.starts_with("text/html"),
+        "unexpected content type: {content_type}"
+    );
+    let body = response_text(response).await?;
+    assert!(body.contains("Verify this server"));
+    assert!(body.contains("ghcr.io/open-software-network/scribe-api:0123abc"));
+    assert!(body.contains(&format!(
+        "https://github.com/open-software-network/os-scribe/commit/{TEST_COMMIT}"
+    )));
+    assert!(body.contains("https://trust.phala.com/app/test-app-id"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_verify_page_without_commit_reports_unstamped_build()
+-> Result<(), Box<dyn Error>> {
+    let attestation = AttestationInfo {
+        source_commit: String::new(),
+        ..test_attestation()
+    };
+    let response = match router(test_state_with_attestation(attestation))
+        .oneshot(get_request("/verify")?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_text(response).await?;
+    assert!(body.contains("not stamped"));
+    Ok(())
+}
+
 fn test_router() -> Router {
     router(test_state())
 }
 
+const TEST_COMMIT: &str = "0123abc4567890def0123abc4567890def012345";
+
+fn test_attestation() -> AttestationInfo {
+    AttestationInfo {
+        source_commit: TEST_COMMIT.to_string(),
+        source_repo_url: "https://github.com/open-software-network/os-scribe".to_string(),
+        image_repo: "ghcr.io/open-software-network/scribe-api".to_string(),
+        trust_center_url: "https://trust.phala.com/app/test-app-id".to_string(),
+    }
+}
+
 fn test_state() -> ApiState {
+    test_state_with_attestation(test_attestation())
+}
+
+fn test_state_with_attestation(attestation: AttestationInfo) -> ApiState {
     let pricing = Arc::new(PricingTable::new(models()));
     let os_accounts = Arc::new(FakeOsAccounts);
     let transcriber = Arc::new(FakeTranscriber);
@@ -214,6 +275,7 @@ fn test_state() -> ApiState {
             max_json_bytes: 1024 * 1024,
             request_timeout_secs: 5,
         },
+        attestation,
     })
 }
 
@@ -283,6 +345,13 @@ fn json_request(
     builder.body(Body::from(value.to_string()))
 }
 
+fn get_request(uri: &str) -> Result<Request<Body>, axum::http::Error> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+}
+
 fn multipart_request(uri: &str, body: Vec<u8>) -> Result<Request<Body>, axum::http::Error> {
     Request::builder()
         .method(Method::POST)
@@ -300,6 +369,11 @@ async fn response_json(
 ) -> Result<serde_json::Value, Box<dyn Error>> {
     let bytes = to_bytes(response.into_body(), usize::MAX).await?;
     Ok(serde_json::from_slice(&bytes)?)
+}
+
+async fn response_text(response: axum::response::Response) -> Result<String, Box<dyn Error>> {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    Ok(String::from_utf8(bytes.to_vec())?)
 }
 
 fn boundary() -> &'static str {

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use scribe_api::{ApiLimits, ApiState, ApiStateParams};
+use scribe_api::{ApiLimits, ApiState, ApiStateParams, AttestationInfo};
 use scribe_config::{AppConfig, ModelPriceConfig, ModelProvider};
 use scribe_providers::{
     JwksTokenVerifier, MultiFormatDurationProbe, OsAccountsHttpClient, RoutingTranscriber,
@@ -151,6 +151,12 @@ fn build_router(
             max_audio_bytes: config.server.max_audio_bytes,
             max_json_bytes: config.server.max_json_bytes,
             request_timeout_secs: config.server.request_timeout_secs,
+        },
+        attestation: AttestationInfo {
+            source_commit: config.attestation.source_commit.clone(),
+            source_repo_url: config.attestation.source_repo_url.clone(),
+            image_repo: config.attestation.image_repo.clone(),
+            trust_center_url: config.attestation.trust_center_url.clone(),
         },
     });
     scribe_api::router(state)

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -16,6 +16,7 @@ pub struct AppConfig {
     pub server: ServerConfig,
     pub os_accounts: OsAccountsConfig,
     pub upstreams: UpstreamsConfig,
+    pub attestation: AttestationConfig,
     pub pricing: BTreeMap<String, ModelPriceConfig>,
 }
 
@@ -26,9 +27,23 @@ impl Debug for AppConfig {
             .field("server", &self.server)
             .field("os_accounts", &self.os_accounts)
             .field("upstreams", &self.upstreams)
+            .field("attestation", &self.attestation)
             .field("pricing", &self.pricing)
             .finish()
     }
+}
+
+/// Public facts the `/verify` attestation page reports. Nothing here is a
+/// secret; all fields have working defaults so local builds need no setup.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AttestationConfig {
+    /// Full git commit the running image was built from. Stamped into the
+    /// image env by the Docker build (`ARG GIT_SHA`); empty for local builds.
+    #[serde(default)]
+    pub source_commit: String,
+    pub source_repo_url: String,
+    pub image_repo: String,
+    pub trust_center_url: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -287,6 +302,14 @@ impl Default for AppConfig {
                     api_key: String::new(),
                     base_url: "https://api.venice.ai/api/v1".to_string(),
                 },
+            },
+            attestation: AttestationConfig {
+                source_commit: String::new(),
+                source_repo_url: "https://github.com/open-software-network/os-scribe".to_string(),
+                image_repo: "ghcr.io/open-software-network/scribe-api".to_string(),
+                trust_center_url:
+                    "https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c"
+                        .to_string(),
             },
             pricing,
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -505,6 +505,11 @@ pub async fn check_recording_source_readiness(
 }
 
 #[tauri::command]
+pub fn scribe_verify_url() -> String {
+    crate::scribe_api::verify_url()
+}
+
+#[tauri::command]
 pub async fn open_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
     #[cfg(target_os = "macos")]
     {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,7 @@ pub fn run() {
             commands::get_microphone_permission_state,
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,
+            commands::scribe_verify_url,
             commands::start_recording,
             commands::pause_recording,
             commands::resume_recording,

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -536,6 +536,12 @@ pub fn configured() -> bool {
     !scribe_api_url().is_empty()
 }
 
+/// Public URL of the attestation walkthrough the backend serves from inside
+/// its confidential VM — same origin every metered request already goes to.
+pub fn verify_url() -> String {
+    format!("{}/verify", scribe_api_url())
+}
+
 fn extract_chat_completion_text(value: &serde_json::Value) -> Option<String> {
     value
         .get("choices")?

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -21,6 +21,7 @@ import {
   listVeniceModels,
   localAudioFileSrc,
   providerModelSettings,
+  scribeVerifyUrl,
   setDictationLanguage,
   setDictationMicrophone,
   setDictationShortcut,
@@ -274,6 +275,7 @@ export function AppSettings({
   const [micTestSampleSrc, setMicTestSampleSrc] = useState<string>();
   const [micTestError, setMicTestError] = useState<string>();
   const [micTestPlaying, setMicTestPlaying] = useState(false);
+  const [verifyUrl, setVerifyUrl] = useState<string>();
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
   const activeTab = controlled ? controlledTab : internalTab;
   const setActiveTab = (tab: SettingsTab) => {
@@ -307,6 +309,18 @@ export function AppSettings({
       void resetMicTestState(true);
     }
   }, [activeTab]);
+
+  useEffect(() => {
+    let cancelled = false;
+    scribeVerifyUrl()
+      .then((url) => {
+        if (!cancelled && url) setVerifyUrl(url);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -1165,6 +1179,31 @@ export function AppSettings({
                     </span>
                   </div>
                 </div>
+
+                {verifyUrl ? (
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">
+                        Server verification
+                      </h3>
+                      <p className="settings-row-description">
+                        June&apos;s server runs in a confidential VM. See
+                        exactly what code is running and how to verify it
+                        yourself.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <a
+                        className="btn btn-secondary"
+                        href={verifyUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Verify server
+                      </a>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </div>
           </section>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -593,6 +593,10 @@ export async function bootstrapApp() {
   return invoke<BootstrapResponse>("bootstrap_app");
 }
 
+export async function scribeVerifyUrl() {
+  return invoke<string>("scribe_verify_url");
+}
+
 export async function createNote(folderId?: string) {
   return invoke<NoteDto>("create_note", { request: { folderId } });
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6009,6 +6009,8 @@ input:focus-visible,
   color: var(--foreground);
   font-size: var(--fs-md);
   font-weight: 500;
+  /* Anchors styled as buttons keep the UA underline otherwise. */
+  text-decoration: none;
   cursor: pointer;
   transition:
     background-color var(--t-fast) var(--ease-out),

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   createDictionaryEntry: vi.fn(),
   updateDictionaryEntry: vi.fn(),
   deleteDictionaryEntry: vi.fn(),
+  scribeVerifyUrl: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
@@ -67,6 +68,7 @@ vi.mock("../lib/tauri", () => ({
   createDictionaryEntry: mocks.createDictionaryEntry,
   updateDictionaryEntry: mocks.updateDictionaryEntry,
   deleteDictionaryEntry: mocks.deleteDictionaryEntry,
+  scribeVerifyUrl: mocks.scribeVerifyUrl,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -129,6 +131,9 @@ describe("AppSettings", () => {
       language,
     }));
     mocks.listDictionaryEntries.mockResolvedValue([]);
+    mocks.scribeVerifyUrl.mockResolvedValue(
+      "https://scribe-api.example.test/verify",
+    );
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
         transcriptionProvider: "venice",
@@ -912,22 +917,19 @@ describe("AppSettings", () => {
     );
 
     await waitFor(() =>
-      expect(mocks.setDictationShortcut).toHaveBeenCalledWith(
-        "push_to_talk",
-        {
-          keyCode: 0x02,
-          code: "KeyD",
-          label: "Ctrl+Opt+D",
-          pressCount: 1,
-          modifiers: {
-            command: false,
-            control: true,
-            option: true,
-            shift: false,
-            function: false,
-          },
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith("push_to_talk", {
+        keyCode: 0x02,
+        code: "KeyD",
+        label: "Ctrl+Opt+D",
+        pressCount: 1,
+        modifiers: {
+          command: false,
+          control: true,
+          option: true,
+          shift: false,
+          function: false,
         },
-      ),
+      }),
     );
 
     await waitFor(() =>
@@ -1060,6 +1062,30 @@ describe("AppSettings", () => {
     expect(screen.getByText(APP_VERSION)).toBeInTheDocument();
     expect(screen.getByText("Commit")).toBeInTheDocument();
     expect(screen.getByText(APP_COMMIT_HASH)).toBeInTheDocument();
+  });
+
+  it("links to the server attestation page from About", async () => {
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("tab", { name: "About" }));
+    const link = await screen.findByRole("link", { name: "Verify server" });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://scribe-api.example.test/verify",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
   });
 
   it("shows agent workspace and memory files inside Agent settings", async () => {


### PR DESCRIPTION
## What

Adds a public **`GET /verify`** endpoint to scribe-api — a human-facing attestation page served from inside the Intel TDX CVM, so the page itself is covered by the attestation it explains. It shows what's running and walks a user through verifying the **source → image → attestation** chain without trusting us:

1. Open the Phala Trust Center report and find the attested compose's image tag.
2. Resolve that tag to its content digest in GHCR (`docker buildx imagetools inspect`).
3. Compare against the digest CI recorded in-repo as the immutable `deploy/<env>/<sha>` git tag.
4. Read the source at the linked commit.

It's deliberately honest about scope: it claims "the running digest matches our public CI build for this commit" (not "rebuild it yourself" — that's gated on reproducible-builds Phase B, which the page links to), and it states plainly that audio still leaves the TEE to OpenAI/Venice.

The desktop app links to it from **Settings → About**: a "Server verification" row opens the running server's `/verify` page in the browser.

## How

**Backend (scribe-api):**
- **`attestation` config section** (`scribe-config`): `source_commit`, `source_repo_url`, `image_repo`, `trust_center_url` — all defaulted, nothing secret, zero setup for local runs.
- **Commit stamping**: new `GIT_SHA` build-arg → `ENV SCRIBE__ATTESTATION__SOURCE_COMMIT` in the Dockerfile **runtime stage only**. The binary is untouched and the value is a pure function of the commit, so reproducible-build determinism is preserved (the Phase B rebuild snippet in `docs/reproducible-builds.md` is updated to pass the same arg). `build-scribe-api.yml` passes `GIT_SHA=${{ github.sha }}`.
- **Handler** (`crates/api/src/handlers/verify.rs`): renders a self-contained HTML page (no JS, light/dark via `prefers-color-scheme`), config values HTML-escaped. Unauthenticated like the health probes; intentionally HTML rather than the `ApiResponse` envelope since the audience is a person.
- **Unknown-commit fallback**: a build without the stamp (local/dev) renders "not stamped — local or development build" rather than a fake value.

**Desktop (June):**
- New `scribe_verify_url` Tauri command returns `{scribe_api_url}/verify`, reusing the same `SCRIBE_API_URL` resolution (runtime env → build-time env → default) every metered request already uses.
- Settings → About row with title, description, and a "Verify server" button (`<a target="_blank">`).
- `.btn` gains `text-decoration: none` so anchors styled as buttons drop the UA underline (no-op for existing `<button>` users).

## Tests

- scribe-api unit: sha validation, HTML escaping, rendered links, fallback state, escaping of configured values.
- scribe-api integration (`http_boundary.rs`): `/verify` is public, returns `text/html`, contains the commit link / image ref / Trust Center URL; empty-commit state reports the unstamped build.
- Desktop: settings test asserts the About tab renders the link with the command-resolved href and `target="_blank"`.
- `cargo fmt --check` + pedantic clippy clean (scribe-api), `cargo test` (src-tauri), `tsc --noEmit`, prettier, full vitest suite (260 passing).

## Follow-up (not in this PR)

- Once reproducible builds Phase B converges (two independent builds matching), upgrade the page's wording to "rebuild and compare" per the Phase C gate in `docs/reproducible-builds.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
