### PR TITLE
Show each workspace file's download card only once per conversation

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2136,6 +2136,10 @@ export function AgentWorkspace({
         ),
       )
     : [];
+  const turnArtifacts = assignArtifactsToTurns(
+    selectedHermesSessionId ? hermesTurns : taskTurns,
+    chatArtifacts,
+  );
 
   // Aggregate size of the rendered conversation so streaming deltas — which
   // grow text inside an existing turn without changing any count — still keep
@@ -2399,7 +2403,7 @@ export function AgentWorkspace({
         <AgentChatTurnRow
           key={turn.id}
           turn={turn}
-          artifacts={chatArtifacts}
+          artifacts={turnArtifacts.get(turn.id)}
           approvalSubmitting={approvalSubmitting}
           clarifySubmitting={clarifySubmitting}
           onDownloadArtifact={(artifact) =>
@@ -2468,7 +2472,7 @@ export function AgentWorkspace({
           <AgentChatTurnRow
             key={turn.id}
             turn={turn}
-            artifacts={chatArtifacts}
+            artifacts={turnArtifacts.get(turn.id)}
             approvalSubmitting={approvalSubmitting}
             clarifySubmitting={clarifySubmitting}
             onDownloadArtifact={(artifact) =>
@@ -3821,14 +3825,6 @@ function AgentChatTurnRow({
       part.type === "context",
   );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
-  const mentionedArtifacts = artifactsMentionedInText(
-    artifacts ?? [],
-    turn.parts
-      .map((part) =>
-        part.type !== "context" && "text" in part ? part.text : "",
-      )
-      .join("\n"),
-  );
 
   if (
     contextParts.length &&
@@ -3914,7 +3910,7 @@ function AgentChatTurnRow({
           ) : null,
         )}
         <AgentArtifactList
-          artifacts={mentionedArtifacts}
+          artifacts={artifacts ?? []}
           onDownload={onDownloadArtifact}
         />
         {textParts.length === 0 && nonTextParts.length === 0 ? (
@@ -4856,26 +4852,46 @@ function filesystemEntriesToArtifacts(
   });
 }
 
-function artifactsMentionedInText(
+// Assigns each workspace file to the first turn that mentions it, so its
+// download card renders once instead of at the end of every later response
+// that happens to repeat the file name. User turns can claim a file too, but
+// only by full path — that's how promptWithAttachments injects attachments,
+// and a file the user just handed us shouldn't bounce back as a download.
+// Name-only matches are also deduplicated by name, so two workspace copies of
+// the same file don't produce twin cards.
+function assignArtifactsToTurns(
+  turns: AgentChatTurn[],
   artifacts: AgentArtifact[],
-  text: string,
-): AgentArtifact[] {
-  if (!artifacts.length || !text.trim()) return [];
-  const normalized = text.toLowerCase();
-  const seen = new Set<string>();
-  return artifacts.filter((artifact) => {
-    const name = artifact.name.toLowerCase();
-    const path = artifact.path.toLowerCase();
-    if (
-      !name ||
-      seen.has(artifact.path) ||
-      (!normalized.includes(name) && !normalized.includes(path))
-    ) {
-      return false;
+): Map<string, AgentArtifact[]> {
+  const byTurn = new Map<string, AgentArtifact[]>();
+  if (!artifacts.length) return byTurn;
+  const claimedPaths = new Set<string>();
+  const claimedNames = new Set<string>();
+  for (const turn of turns) {
+    const text = turn.parts
+      .map((part) =>
+        part.type !== "context" && "text" in part ? part.text : "",
+      )
+      .join("\n")
+      .toLowerCase();
+    if (!text.trim()) continue;
+    const mentioned: AgentArtifact[] = [];
+    for (const artifact of artifacts) {
+      const name = artifact.name.toLowerCase();
+      if (!name || claimedPaths.has(artifact.path)) continue;
+      const pathMentioned = text.includes(artifact.path.toLowerCase());
+      const nameMentioned =
+        turn.role === "assistant" &&
+        !claimedNames.has(name) &&
+        text.includes(name);
+      if (!pathMentioned && !nameMentioned) continue;
+      claimedPaths.add(artifact.path);
+      claimedNames.add(name);
+      if (turn.role === "assistant") mentioned.push(artifact);
     }
-    seen.add(artifact.path);
-    return true;
-  });
+    if (mentioned.length) byTurn.set(turn.id, mentioned);
+  }
+  return byTurn;
 }
 
 function isPreviewableImagePath(path: string) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -693,6 +693,157 @@ describe("AgentWorkspace", () => {
     expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(samplePath);
   });
 
+  it("renders a workspace file's download card only on the first response that mentions it", async () => {
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "report.md",
+              path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/report.md",
+              kind: "file",
+              size: 1768,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: "Done — I saved the summary as `report.md`.",
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+      {
+        id: "message-2",
+        role: "user",
+        content: "Add a conclusion section.",
+        timestamp: "2026-06-04T18:40:00Z",
+      },
+      {
+        id: "message-3",
+        role: "assistant",
+        content: "I added a conclusion to report.md.",
+        timestamp: "2026-06-04T18:41:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByLabelText("Generated files")).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Generated files")).toHaveLength(1);
+    expect(
+      screen.getAllByRole("button", { name: "Download report.md" }),
+    ).toHaveLength(1);
+  });
+
+  it("does not render download cards for files the user attached", async () => {
+    const attachedPath =
+      "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/june-context.md";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "june-context.md",
+              path: attachedPath,
+              kind: "file",
+              size: 14336,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "user",
+        content: [
+          "Summarize this.",
+          "",
+          "Attached files copied into the Scribe Hermes workspace:",
+          `- june-context.md (Workspace): ${attachedPath}`,
+          "",
+          "Use these workspace paths when inspecting or operating on the files.",
+        ].join("\n"),
+        timestamp: "2026-06-04T18:38:00Z",
+      },
+      {
+        id: "message-2",
+        role: "assistant",
+        content: "Here's a summary of june-context.md: it covers the plan.",
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(/Here's a summary/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Generated files")).not.toBeInTheDocument();
+  });
+
+  it("renders one download card when two workspace copies share a file name", async () => {
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "notes.md",
+              path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/notes.md",
+              kind: "file",
+              size: 512,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+            {
+              name: "archive",
+              path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/archive",
+              kind: "directory",
+              children: [
+                {
+                  name: "notes.md",
+                  path: "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/archive/notes.md",
+                  kind: "file",
+                  size: 512,
+                  modifiedAt: "2026-06-04T18:39:00Z",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: "I wrote everything up in notes.md.",
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByLabelText("Generated files")).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "Download notes.md" }),
+    ).toHaveLength(1);
+  });
+
   it("renders generated workspace images as thumbnails", async () => {
     const screenshotPath =
       "/Users/junho/Library/Application Support/co.opensoftware.scribe/hermes/workspace/screenshot.png";


### PR DESCRIPTION
## Problem

Once a file exists in a session's workspace, its download card keeps reappearing at the end of every response that mentions the file name — e.g. `BRIEF.md` / `june-context.md` stacking up below each reply.

The cause: `AgentChatTurnRow` matched workspace files against each turn's text independently, so any response that repeated a file name re-rendered the same card.

## Fix

Artifacts are now assigned to turns once, up front (`assignArtifactsToTurns`):

- Each file attaches to the **first turn that mentions it** and never repeats on later turns.
- **User turns claim files mentioned by full path** — that's how `promptWithAttachments` injects attachments — so a file the user just handed to the agent no longer bounces back as a download. (A name-only mention in a user message, like "create report.md", does *not* claim it, so genuinely generated files still get a card.)
- **Name-only matches dedupe by name**, so two workspace copies of the same file no longer produce twin cards (the duplicate `june-context.md` in the screenshot).

## Testing

- New tests: card renders only on the first mentioning response; user-attached files show no card; same-name copies render one card.
- `tsc` clean, all 262 tests pass, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)