### PR TITLE
Point the default Scribe API at the deployed production host

### DIFF
--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -10,7 +10,10 @@ use std::{
     time::Duration,
 };
 
-const DEFAULT_SCRIBE_API_URL: &str = "https://scribe-api.opensoftware.network";
+// The deployed production API (Phala dstack; see scribe-api/deploy/
+// docker-compose.production.yml). NOT .network — that hostname has no DNS
+// record, and the v0.0.3 DMG shipped pointing at it.
+const DEFAULT_SCRIBE_API_URL: &str = "https://scribe-api.opensoftware.co";
 const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "nvidia-nemotron-3-nano-30b-a3b";
 const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
 const AGENT_HTTP_TIMEOUT: Duration = Duration::from_secs(600);

--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -99,8 +99,11 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
 
         <p className="welcome-terms">
           By continuing, you agree to the{" "}
+          {/* opensoftware.network serves nothing; the accounts portal is the
+              live domain we control, so legal pages can be published there
+              without shipping a new desktop build. */}
           <a
-            href="https://opensoftware.network/terms"
+            href="https://accounts.opensoftware.co/terms"
             target="_blank"
             rel="noreferrer"
           >
@@ -108,7 +111,7 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
           </a>{" "}
           and{" "}
           <a
-            href="https://opensoftware.network/privacy"
+            href="https://accounts.opensoftware.co/privacy"
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
## What

- `DEFAULT_SCRIBE_API_URL` → `https://scribe-api.opensoftware.co` (was `.network`).
- Sign-in gate Terms/Privacy links → `accounts.opensoftware.co/terms|privacy` (were on `opensoftware.network`).

## Why

Production-readiness audit findings:

- **`scribe-api.opensoftware.network` has no DNS record.** The shipped v0.0.3 DMG bakes exactly that URL (verified via `strings` on the release binary), so every metered feature — agent chat, transcription, note generation — fails with connection errors for anyone who installs it. The deployed production API is at **`scribe-api.opensoftware.co`** (Phala dstack, `/healthz` and `/readyz` both 200; matches `scribe-api/deploy/docker-compose.production.yml`).
- The `PRODUCTION_SCRIBE_API_URL` GitHub environment secret has already been updated to the `.co` host — this PR fixes the compiled-in fallback so a missing/empty secret can never resurrect the dead default.
- `opensoftware.network` serves nothing (connection refused), so the onboarding legal links 404-at-best for new users. The accounts portal is the live domain we control; pages can be published there server-side. **Note: the /terms and /privacy pages still need to be created on the portal.**

## Verification

`cargo check`, `tsc`, Prettier clean. After merge, a new `production-desktop-release` run should be dispatched and the resulting DMG strings-checked for the `.co` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)