### PR TITLE
Fix release App token request after the os-scribe → os-june rename

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -40,7 +40,10 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: open-software-network
-          repositories: os-scribe,os-scribe-releases
+          # The source repo was renamed os-scribe -> os-june; the token request
+          # 404s on the old name even though the App installation follows the
+          # rename.
+          repositories: os-june,os-scribe-releases
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `production-desktop-release` workflow mints its GitHub App installation token with `repositories: os-scribe,os-scribe-releases` — the source repo's pre-rename name. The token request 404s (verified in run 27295568562, which failed at the first step), so no production DMG can be cut since the rename.

One-line fix: `os-scribe` → `os-june`. The App installation itself follows the rename; only the by-name token request breaks.

Note for the App's installation settings: confirm the release GitHub App is granted to the renamed repo in the org installation (it should be, since installations track repo ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)