### PR TITLE
Update release pipeline for the os-scribe-releases → os-june-releases rename

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -40,10 +40,10 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: open-software-network
-          # The source repo was renamed os-scribe -> os-june; the token request
-          # 404s on the old name even though the App installation follows the
-          # rename.
-          repositories: os-june,os-scribe-releases
+          # Both repos were renamed (os-scribe -> os-june, os-scribe-releases
+          # -> os-june-releases); the token request rejects old names even
+          # though the App installation follows renames.
+          repositories: os-june,os-june-releases
 
       - uses: actions/checkout@v4
         with:
@@ -230,7 +230,7 @@ jobs:
           SCRIBE_API_URL: ${{ secrets.PRODUCTION_SCRIBE_API_URL }}
         with:
           owner: open-software-network
-          repo: os-scribe-releases
+          repo: os-june-releases
           tagName: v${{ env.VERSION }}
           releaseName: June v${{ env.VERSION }}
           releaseBody: "Stable June release v${{ env.VERSION }}."
@@ -268,6 +268,6 @@ jobs:
           {
             echo "### Production macOS release"
             echo "- Version: \`$VERSION\`"
-            echo "- Release repo: \`open-software-network/os-scribe-releases\`"
-            echo "- Update manifest: \`https://github.com/open-software-network/os-scribe-releases/releases/latest/download/latest.json\`"
+            echo "- Release repo: \`open-software-network/os-june-releases\`"
+            echo "- Update manifest: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/latest.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -100,7 +100,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwMDUxRDBGNzYyRDU0MTgKUldRWVZDMTJEeDBGVUZWQ3VsVWxCdmhFbk9McWFVWjBGTEZZZHN0NFZRQjFZaFZRVzF4Sm9NdnkK",
       "endpoints": [
-        "https://github.com/open-software-network/os-scribe-releases/releases/latest/download/latest.json"
+        "https://github.com/open-software-network/os-june-releases/releases/latest/download/latest.json"
       ]
     }
   },


### PR DESCRIPTION
Second half of the rename fallout (after #161): the **releases repo** was renamed too (`os-scribe-releases` → `os-june-releases`, confirmed in the App installation's repository access). The App-token endpoint rejects old repo names, so the release run still failed at the token mint despite access being correctly granted.

- `repositories:` → `os-june,os-june-releases`
- tauri-action `repo:` → `os-june-releases`
- Updater endpoint in `tauri.conf.json` → `os-june-releases` `latest.json` (GitHub's rename redirect keeps already-shipped v0.0.3 builds updating from the old URL)
- Release summary text updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)