### PR TITLE
[codex] Fix model privacy mode labels

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -121,8 +121,10 @@ import {
   type HermesGatewayEvent,
 } from "../../lib/hermes-gateway";
 import {
+  PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
   modelPrivacyBadge,
   type ModelPrivacyBadge,
+  type ProviderModelSettingsChangedDetail,
 } from "../../lib/model-privacy";
 import { messageFromError } from "../../lib/errors";
 import {
@@ -713,7 +715,9 @@ export function AgentWorkspace({
 
   useEffect(() => {
     let cancelled = false;
+    let requestSequence = 0;
     async function loadGenerationPrivacyBadge() {
+      const requestId = ++requestSequence;
       try {
         const [settingsResponse, modelsResponse] = await Promise.all([
           providerModelSettings(),
@@ -725,18 +729,37 @@ export function AgentWorkspace({
         const selectedModel = modelsResponse.models.find(
           (model) => model.id === selectedModelId,
         );
-        if (!cancelled) {
+        if (!cancelled && requestId === requestSequence) {
           setGenerationPrivacyBadge(
             selectedModel ? modelPrivacyBadge(selectedModel) : undefined,
           );
         }
       } catch {
-        if (!cancelled) setGenerationPrivacyBadge(undefined);
+        if (!cancelled && requestId === requestSequence) {
+          setGenerationPrivacyBadge(undefined);
+        }
       }
     }
+    function handleProviderModelSettingsChanged(event: Event) {
+      const { mode } = (
+        event as CustomEvent<ProviderModelSettingsChangedDetail>
+      ).detail;
+      if (mode === "generation") {
+        void loadGenerationPrivacyBadge();
+      }
+    }
+
     void loadGenerationPrivacyBadge();
+    window.addEventListener(
+      PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
+      handleProviderModelSettingsChanged,
+    );
     return () => {
       cancelled = true;
+      window.removeEventListener(
+        PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
+        handleProviderModelSettingsChanged,
+      );
     };
   }, []);
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
+import { IconAnonymous } from "central-icons/IconAnonymous";
 import { IconArrowUp } from "central-icons/IconArrowUp";
 import { IconCameraSparkle } from "central-icons/IconCameraSparkle";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
@@ -69,8 +70,10 @@ import {
   hermesBridgeToolsets,
   importHermesBridgeFile,
   importHermesBridgeFileBytes,
+  listVeniceModels,
   listAgentTasks,
   downloadHermesBridgeFile,
+  providerModelSettings,
   retryAgentTask,
   sendAgentMessage,
   startHermesBridge,
@@ -117,6 +120,10 @@ import {
   HermesGatewayClient,
   type HermesGatewayEvent,
 } from "../../lib/hermes-gateway";
+import {
+  modelPrivacyBadge,
+  type ModelPrivacyBadge,
+} from "../../lib/model-privacy";
 import { messageFromError } from "../../lib/errors";
 import {
   buildAgentChatTurns,
@@ -442,6 +449,8 @@ export function AgentWorkspace({
   const [messagingPlatforms, setMessagingPlatforms] = useState<
     HermesMessagingPlatformInfo[] | null
   >(null);
+  const [generationPrivacyBadge, setGenerationPrivacyBadge] =
+    useState<ModelPrivacyBadge>();
   const [capabilityQuery, setCapabilityQuery] = useState("");
   const [capabilityLoading, setCapabilityLoading] = useState(false);
   const [capabilitySaving, setCapabilitySaving] = useState<string | null>(null);
@@ -701,6 +710,35 @@ export function AgentWorkspace({
   useEffect(() => {
     void loadTasks();
   }, [loadTasks]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadGenerationPrivacyBadge() {
+      try {
+        const [settingsResponse, modelsResponse] = await Promise.all([
+          providerModelSettings(),
+          listVeniceModels("generation"),
+        ]);
+        const selectedModelId =
+          settingsResponse.settings.generationModel ||
+          modelsResponse.selectedModel;
+        const selectedModel = modelsResponse.models.find(
+          (model) => model.id === selectedModelId,
+        );
+        if (!cancelled) {
+          setGenerationPrivacyBadge(
+            selectedModel ? modelPrivacyBadge(selectedModel) : undefined,
+          );
+        }
+      } catch {
+        if (!cancelled) setGenerationPrivacyBadge(undefined);
+      }
+    }
+    void loadGenerationPrivacyBadge();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!bridge.running) return;
@@ -2442,7 +2480,7 @@ export function AgentWorkspace({
           />
           <div className="agent-detail-heading">
             <h2>{selectedTask.title}</h2>
-            <SafetyBadge />
+            <SafetyBadge privacyBadge={generationPrivacyBadge} />
           </div>
         </div>
         <div className="agent-actions">
@@ -2511,6 +2549,7 @@ export function AgentWorkspace({
       {!newSessionMode && !selectedHermesSessionId && selectedTask ? null : (
         <AgentSessionBar
           origin={origin}
+          privacyBadge={generationPrivacyBadge}
           title={
             !newSessionMode && selectedHermesSessionId
               ? (selectedHermesSession?.title ?? "")
@@ -2836,15 +2875,21 @@ function completedHermesMessageText(events: LiveHermesEvent[]) {
   return message.item.text.trim();
 }
 
-function SafetyBadge() {
+function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
+  if (!privacyBadge) return null;
   return (
     <span
       className="agent-safety-badge"
-      title="Sensitive desktop, credential, payment, and destructive actions are blocked or escalated."
-      aria-label="Private mode — sensitive desktop, credential, payment, and destructive actions are blocked or escalated."
+      data-mode={privacyBadge.mode}
+      title={privacyBadge.description}
+      aria-label={`${privacyBadge.label} - ${privacyBadge.description}`}
     >
-      <IconShieldAi size={13} aria-hidden />
-      Private mode
+      {privacyBadge.mode === "private" ? (
+        <IconShieldAi size={13} aria-hidden />
+      ) : (
+        <IconAnonymous size={13} aria-hidden />
+      )}
+      {privacyBadge.label}
     </span>
   );
 }
@@ -2856,11 +2901,13 @@ function SafetyBadge() {
 // conversation keeps the focus (no separate title heading).
 function AgentSessionBar({
   origin,
+  privacyBadge,
   title,
   onRename,
   onDelete,
 }: {
   origin?: AgentWorkspaceOrigin;
+  privacyBadge?: ModelPrivacyBadge;
   title?: string;
   onRename?: (title: string) => void;
   onDelete?: () => void;
@@ -2966,7 +3013,7 @@ function AgentSessionBar({
         </ol>
       </nav>
       <div className="detail-bar-actions">
-        <SafetyBadge />
+        <SafetyBadge privacyBadge={privacyBadge} />
         {hasMenu ? (
           <div className="agent-session-menu-wrap" ref={menuWrapRef}>
             <button

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -55,6 +55,7 @@ import {
   type ThemePreference,
 } from "../../lib/theme";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
+import { modelPrivacyBadge, modelPrivacyFlags } from "../../lib/model-privacy";
 import { ProviderLogo } from "./ProviderLogo";
 import { AgentSettingsSection } from "./AgentSettingsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
@@ -1383,24 +1384,25 @@ function ModelRow({
 
 function ModelMeta({ model }: { model: VeniceModelDto }) {
   const flags = traitFlags(model);
+  const privacyBadge = modelPrivacyBadge(model);
   const context = contextLabel(model);
   const price = pricingLabel(model);
   const items: ReactNode[] = [];
   if (price) items.push(<span className="model-meta-price">{price}</span>);
   if (context) items.push(<span>{context}</span>);
-  if (flags.private) {
+  if (privacyBadge) {
     items.push(
-      <span className="model-trait-icon" title="Private">
-        <IconGhost2 size={14} />
-        <span>Private</span>
-      </span>,
-    );
-  }
-  if (flags.anon) {
-    items.push(
-      <span className="model-trait-icon" title="Anonymous">
-        <IconAnonymous size={14} />
-        <span>Anon</span>
+      <span
+        className="model-trait-icon"
+        title={privacyBadge.description}
+        aria-label={privacyBadge.description}
+      >
+        {privacyBadge.mode === "private" ? (
+          <IconGhost2 size={14} />
+        ) : (
+          <IconAnonymous size={14} />
+        )}
+        <span>{privacyBadge.label}</span>
       </span>,
     );
   }
@@ -1432,18 +1434,7 @@ function ModelMeta({ model }: { model: VeniceModelDto }) {
 }
 
 function traitFlags(model: VeniceModelDto) {
-  const privacy = (model.privacy ?? "").toLowerCase();
-  const traits = model.traits.map((trait) => trait.toLowerCase());
-  return {
-    private: privacy === "private",
-    anon:
-      privacy.includes("anonymous") ||
-      privacy.includes("anonymized") ||
-      traits.some(
-        (trait) => trait.includes("anonymous") || trait.includes("anonymized"),
-      ),
-    uncensored: traits.some((trait) => trait.includes("uncensored")),
-  };
+  return modelPrivacyFlags(model);
 }
 
 function ShortcutRow({

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -55,7 +55,11 @@ import {
   type ThemePreference,
 } from "../../lib/theme";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
-import { modelPrivacyBadge, modelPrivacyFlags } from "../../lib/model-privacy";
+import {
+  dispatchProviderModelSettingsChanged,
+  modelPrivacyBadge,
+  modelPrivacyFlags,
+} from "../../lib/model-privacy";
 import { ProviderLogo } from "./ProviderLogo";
 import { AgentSettingsSection } from "./AgentSettingsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
@@ -613,6 +617,7 @@ export function AppSettings({
     try {
       const next = await setVeniceModel(mode, modelId);
       setProviderSettings(next);
+      dispatchProviderModelSettingsChanged({ mode, modelId });
       setStatus(
         mode === "transcription"
           ? "Transcription model updated."
@@ -1383,8 +1388,8 @@ function ModelRow({
 }
 
 function ModelMeta({ model }: { model: VeniceModelDto }) {
-  const flags = traitFlags(model);
-  const privacyBadge = modelPrivacyBadge(model);
+  const flags = modelPrivacyFlags(model);
+  const privacyBadge = modelPrivacyBadge(model, flags);
   const context = contextLabel(model);
   const price = pricingLabel(model);
   const items: ReactNode[] = [];
@@ -1431,10 +1436,6 @@ function ModelMeta({ model }: { model: VeniceModelDto }) {
       ))}
     </span>
   );
-}
-
-function traitFlags(model: VeniceModelDto) {
-  return modelPrivacyFlags(model);
 }
 
 function ShortcutRow({

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -1,0 +1,53 @@
+import type { VeniceModelDto } from "./tauri";
+
+export type ModelPrivacyMode = "private" | "anonymous";
+
+export type ModelPrivacyBadge = {
+  mode: ModelPrivacyMode;
+  label: string;
+  description: string;
+};
+
+export const PRIVATE_MODEL_DESCRIPTION =
+  "You're using a model that is private and anonymous.";
+export const ANONYMOUS_MODEL_DESCRIPTION =
+  "You're using a model that is anonymizing your prompts but may still train on your data.";
+
+export function modelPrivacyBadge(
+  model: Pick<VeniceModelDto, "privacy" | "traits">,
+): ModelPrivacyBadge | undefined {
+  const flags = modelPrivacyFlags(model);
+  if (flags.private) {
+    return {
+      mode: "private",
+      label: "Private mode",
+      description: PRIVATE_MODEL_DESCRIPTION,
+    };
+  }
+  if (flags.anonymous) {
+    return {
+      mode: "anonymous",
+      label: "Anonymous mode",
+      description: ANONYMOUS_MODEL_DESCRIPTION,
+    };
+  }
+  return undefined;
+}
+
+export function modelPrivacyFlags(
+  model: Pick<VeniceModelDto, "privacy" | "traits">,
+) {
+  const privacy = (model.privacy ?? "").toLowerCase();
+  const traits = model.traits.map((trait) => trait.toLowerCase());
+  return {
+    private:
+      privacy === "private" || traits.some((trait) => trait === "private"),
+    anonymous:
+      privacy.includes("anonymous") ||
+      privacy.includes("anonymized") ||
+      traits.some(
+        (trait) => trait.includes("anonymous") || trait.includes("anonymized"),
+      ),
+    uncensored: traits.some((trait) => trait.includes("uncensored")),
+  };
+}

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -1,4 +1,4 @@
-import type { VeniceModelDto } from "./tauri";
+import type { ProviderModelMode, VeniceModelDto } from "./tauri";
 
 export type ModelPrivacyMode = "private" | "anonymous";
 
@@ -8,6 +8,31 @@ export type ModelPrivacyBadge = {
   description: string;
 };
 
+export type ModelPrivacyFlags = {
+  private: boolean;
+  anonymous: boolean;
+  uncensored: boolean;
+};
+
+export const PROVIDER_MODEL_SETTINGS_CHANGED_EVENT =
+  "scribe:provider-model-settings-changed";
+
+export type ProviderModelSettingsChangedDetail = {
+  mode: ProviderModelMode;
+  modelId: string;
+};
+
+export function dispatchProviderModelSettingsChanged(
+  detail: ProviderModelSettingsChangedDetail,
+) {
+  window.dispatchEvent(
+    new CustomEvent<ProviderModelSettingsChangedDetail>(
+      PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
+      { detail },
+    ),
+  );
+}
+
 export const PRIVATE_MODEL_DESCRIPTION =
   "You're using a model that is private and anonymous.";
 export const ANONYMOUS_MODEL_DESCRIPTION =
@@ -15,8 +40,8 @@ export const ANONYMOUS_MODEL_DESCRIPTION =
 
 export function modelPrivacyBadge(
   model: Pick<VeniceModelDto, "privacy" | "traits">,
+  flags = modelPrivacyFlags(model),
 ): ModelPrivacyBadge | undefined {
-  const flags = modelPrivacyFlags(model);
   if (flags.private) {
     return {
       mode: "private",
@@ -36,7 +61,7 @@ export function modelPrivacyBadge(
 
 export function modelPrivacyFlags(
   model: Pick<VeniceModelDto, "privacy" | "traits">,
-) {
+): ModelPrivacyFlags {
   const privacy = (model.privacy ?? "").toLowerCase();
   const traits = model.traits.map((trait) => trait.toLowerCase());
   return {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -15,6 +15,7 @@ import {
   AgentWorkspace,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
+import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 
 const mocks = vi.hoisted(() => ({
   cancelAgentTask: vi.fn(),
@@ -272,6 +273,49 @@ describe("AgentWorkspace", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
+  });
+
+  it("refreshes the model privacy label when generation model settings change", async () => {
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Private mode")).toBeInTheDocument();
+
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "anonymous-only",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "anonymous-only",
+      models: [
+        {
+          provider: "venice",
+          id: "anonymous-only",
+          name: "Anonymous Only",
+          modelType: "text",
+          privacy: "anonymous",
+          traits: [],
+          capabilities: [],
+        },
+      ],
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_MODEL_SETTINGS_CHANGED_EVENT, {
+          detail: { mode: "generation", modelId: "anonymous-only" },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("Private mode")).not.toBeInTheDocument(),
+    );
   });
 
   it("ignores a stale pending New Session marker left over from a reload", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -29,8 +29,10 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeToolsets: vi.fn(),
   importHermesBridgeFile: vi.fn(),
   importHermesBridgeFileBytes: vi.fn(),
+  listVeniceModels: vi.fn(),
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
+  providerModelSettings: vi.fn(),
   retryAgentTask: vi.fn(),
   saveAgentAssistantMessage: vi.fn(),
   saveAgentHermesSession: vi.fn(),
@@ -73,8 +75,10 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
   importHermesBridgeFile: mocks.importHermesBridgeFile,
   importHermesBridgeFileBytes: mocks.importHermesBridgeFileBytes,
+  listVeniceModels: mocks.listVeniceModels,
   listAgentTasks: mocks.listAgentTasks,
   downloadHermesBridgeFile: mocks.downloadHermesBridgeFile,
+  providerModelSettings: mocks.providerModelSettings,
   retryAgentTask: mocks.retryAgentTask,
   saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
   saveAgentHermesSession: mocks.saveAgentHermesSession,
@@ -139,6 +143,29 @@ describe("AgentWorkspace", () => {
     window.sessionStorage.clear();
     window.localStorage.clear();
     mocks.listAgentTasks.mockResolvedValue({ items: [existingTask] });
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "zai-org-glm-5",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "zai-org-glm-5",
+      models: [
+        {
+          provider: "venice",
+          id: "zai-org-glm-5",
+          name: "GLM 5",
+          modelType: "text",
+          privacy: "private",
+          traits: [],
+          capabilities: [],
+        },
+      ],
+    });
     mocks.getAgentTask.mockResolvedValue(existingTask);
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
@@ -209,6 +236,42 @@ describe("AgentWorkspace", () => {
     expect(
       window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY),
     ).toBeNull();
+  });
+
+  it("labels anonymous-only agent models as anonymous mode", async () => {
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "anonymous-only",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "anonymous-only",
+      models: [
+        {
+          provider: "venice",
+          id: "anonymous-only",
+          name: "Anonymous Only",
+          modelType: "text",
+          privacy: "anonymous",
+          traits: [],
+          capabilities: [],
+        },
+      ],
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(
+        "Anonymous mode - You're using a model that is anonymizing your prompts but may still train on your data.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
   });
 
   it("ignores a stale pending New Session marker left over from a reload", async () => {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -211,6 +211,18 @@ describe("AppSettings", () => {
                 traits: ["anonymized", "uncensored"],
                 capabilities: [],
               },
+              {
+                provider: "venice",
+                id: "anonymous-only",
+                name: "Anonymous Only",
+                modelType: "text",
+                description: "Anonymizes prompts before upstream inference.",
+                privacy: "anonymous",
+                pricing: { input: { usd: 0.1 }, output: { usd: 0.4 } },
+                contextTokens: 32768,
+                traits: [],
+                capabilities: [],
+              },
             ],
     }));
     mocks.setVeniceModel.mockImplementation(async (mode, modelId) => ({
@@ -912,22 +924,19 @@ describe("AppSettings", () => {
     );
 
     await waitFor(() =>
-      expect(mocks.setDictationShortcut).toHaveBeenCalledWith(
-        "push_to_talk",
-        {
-          keyCode: 0x02,
-          code: "KeyD",
-          label: "Ctrl+Opt+D",
-          pressCount: 1,
-          modifiers: {
-            command: false,
-            control: true,
-            option: true,
-            shift: false,
-            function: false,
-          },
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith("push_to_talk", {
+        keyCode: 0x02,
+        code: "KeyD",
+        label: "Ctrl+Opt+D",
+        pressCount: 1,
+        modifiers: {
+          command: false,
+          control: true,
+          option: true,
+          shift: false,
+          function: false,
         },
-      ),
+      }),
     );
 
     await waitFor(() =>
@@ -1030,7 +1039,9 @@ describe("AppSettings", () => {
     expect(
       screen.getAllByText("$1.00 input / $3.20 output per 1M tokens").length,
     ).toBeGreaterThan(0);
-    expect(screen.getAllByText("Anon").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Private mode").length).toBeGreaterThan(0);
+    expect(screen.getByText("Anonymous mode")).toBeInTheDocument();
+    expect(screen.queryByText("Anon")).not.toBeInTheDocument();
     await user.click(
       await screen.findByRole("option", { name: /Venice Uncensored/ }),
     );

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -5,6 +5,7 @@ import { AppSettings } from "../components/settings/AppSettings";
 import type { DictationSettingsDto } from "../lib/tauri";
 import { APP_COMMIT_HASH, APP_VERSION } from "../app/build-info";
 import { MASCOT_ENABLED_KEY } from "../lib/mascot-settings";
+import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
@@ -994,61 +995,90 @@ describe("AppSettings", () => {
 
   it("loads Venice model options and saves selected models", async () => {
     const user = userEvent.setup();
-    render(
-      <AppSettings
-        account={signedInAccount}
-        accountLoading={false}
-        sourceMode="microphoneOnly"
-        checkingSourceReadiness={false}
-        onAccountChanged={vi.fn()}
-        onAccountRefresh={vi.fn()}
-        onSourceModeChange={vi.fn()}
-        onEnableSystemAudio={vi.fn()}
-      />,
+    const modelChanged = vi.fn();
+    window.addEventListener(
+      PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
+      modelChanged,
     );
 
-    await waitFor(() =>
-      expect(mocks.listVeniceModels).toHaveBeenCalledWith("transcription"),
-    );
-    await user.click(screen.getByRole("tab", { name: "Models" }));
-    await user.click(
-      await screen.findByRole("button", {
-        name: "Change transcription model",
-      }),
-    );
-    expect(
-      await screen.findByRole("option", { name: /Parakeet/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getAllByText("$0.0001 per second audio").length,
-    ).toBeGreaterThan(0);
-    expect(screen.getAllByText("$0.003/min audio").length).toBeGreaterThan(0);
-    await user.click(
-      await screen.findByRole("option", { name: /GPT-4o Transcribe/ }),
-    );
-    expect(mocks.setVeniceModel).toHaveBeenCalledWith(
-      "transcription",
-      "gpt-4o-transcribe",
-    );
+    try {
+      render(
+        <AppSettings
+          account={signedInAccount}
+          accountLoading={false}
+          sourceMode="microphoneOnly"
+          checkingSourceReadiness={false}
+          onAccountChanged={vi.fn()}
+          onAccountRefresh={vi.fn()}
+          onSourceModeChange={vi.fn()}
+          onEnableSystemAudio={vi.fn()}
+        />,
+      );
 
-    await user.click(
-      screen.getByRole("button", {
-        name: "Change text model",
-      }),
-    );
-    expect(
-      screen.getAllByText("$1.00 input / $3.20 output per 1M tokens").length,
-    ).toBeGreaterThan(0);
-    expect(screen.getAllByText("Private mode").length).toBeGreaterThan(0);
-    expect(screen.getByText("Anonymous mode")).toBeInTheDocument();
-    expect(screen.queryByText("Anon")).not.toBeInTheDocument();
-    await user.click(
-      await screen.findByRole("option", { name: /Venice Uncensored/ }),
-    );
-    expect(mocks.setVeniceModel).toHaveBeenCalledWith(
-      "generation",
-      "venice-uncensored",
-    );
+      await waitFor(() =>
+        expect(mocks.listVeniceModels).toHaveBeenCalledWith("transcription"),
+      );
+      await user.click(screen.getByRole("tab", { name: "Models" }));
+      await user.click(
+        await screen.findByRole("button", {
+          name: "Change transcription model",
+        }),
+      );
+      expect(
+        await screen.findByRole("option", { name: /Parakeet/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByText("$0.0001 per second audio").length,
+      ).toBeGreaterThan(0);
+      expect(screen.getAllByText("$0.003/min audio").length).toBeGreaterThan(0);
+      await user.click(
+        await screen.findByRole("option", { name: /GPT-4o Transcribe/ }),
+      );
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "transcription",
+        "gpt-4o-transcribe",
+      );
+      expect(modelChanged).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            mode: "transcription",
+            modelId: "gpt-4o-transcribe",
+          },
+        }),
+      );
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Change text model",
+        }),
+      );
+      expect(
+        screen.getAllByText("$1.00 input / $3.20 output per 1M tokens").length,
+      ).toBeGreaterThan(0);
+      expect(screen.getAllByText("Private mode").length).toBeGreaterThan(0);
+      expect(screen.getByText("Anonymous mode")).toBeInTheDocument();
+      expect(screen.queryByText("Anon")).not.toBeInTheDocument();
+      await user.click(
+        await screen.findByRole("option", { name: /Venice Uncensored/ }),
+      );
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "generation",
+        "venice-uncensored",
+      );
+      expect(modelChanged).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            mode: "generation",
+            modelId: "venice-uncensored",
+          },
+        }),
+      );
+    } finally {
+      window.removeEventListener(
+        PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
+        modelChanged,
+      );
+    }
   });
 
   it("shows app build metadata", async () => {

--- a/src/test/model-privacy.test.ts
+++ b/src/test/model-privacy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { modelPrivacyBadge } from "../lib/model-privacy";
+
+describe("model privacy labels", () => {
+  it("uses private mode for private models even when they are anonymized", () => {
+    expect(
+      modelPrivacyBadge({ privacy: "private", traits: ["anonymized"] }),
+    ).toMatchObject({
+      mode: "private",
+      label: "Private mode",
+      description: "You're using a model that is private and anonymous.",
+    });
+  });
+
+  it("uses anonymous mode for anonymous-only models", () => {
+    expect(
+      modelPrivacyBadge({ privacy: "anonymous", traits: [] }),
+    ).toMatchObject({
+      mode: "anonymous",
+      label: "Anonymous mode",
+      description:
+        "You're using a model that is anonymizing your prompts but may still train on your data.",
+    });
+  });
+
+  it("does not label models without a privacy signal", () => {
+    expect(modelPrivacyBadge({ privacy: "OpenAI", traits: ["prompt"] })).toBe(
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replace stacked Private/Anon model chips with a single privacy mode label.
- Show `Private mode` for private model routing and `Anonymous mode` for anonymous-only models.
- Add hover/aria explainer copy for both modes and wire the agent session badge to the selected generation model.

## Validation

- `vitest run src/test/model-privacy.test.ts src/test/app-settings.test.tsx src/test/agent-workspace.test.tsx`
- `tsc --noEmit`