### PR TITLE
[codex] Add approval explanation action

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4115,8 +4115,11 @@ function ApprovalPart({
             </p>
             <p>
               Approve once allows only this request. This session allows
-              matching requests until the session ends. Always allows matching
-              requests in future sessions. Deny blocks the request.
+              matching requests until the session ends.{" "}
+              {part.allowPermanent
+                ? "Always allows matching requests in future sessions. "
+                : null}
+              Deny blocks the request.
             </p>
           </div>
         ) : null}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1,5 +1,6 @@
 import {
   CheckIcon,
+  CircleHelpIcon,
   CircleStopIcon,
   DownloadIcon,
   FileIcon,
@@ -48,6 +49,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -4086,6 +4088,8 @@ function ApprovalPart({
   const disabled = Boolean(submitting) || part.status !== "pending";
   const activeChoice = part.choice ?? submitting;
   const resolved = part.status !== "pending" || activeChoice !== undefined;
+  const [explainOpen, setExplainOpen] = useState(false);
+  const explanationId = useId();
   return (
     <article className="agent-approval-card" data-status={part.status}>
       <span className="agent-tool-icon">
@@ -4103,6 +4107,19 @@ function ApprovalPart({
         </div>
         <p>{part.description}</p>
         {part.command ? <pre>{part.command}</pre> : null}
+        {!resolved && explainOpen ? (
+          <div className="agent-approval-explanation" id={explanationId}>
+            <p>
+              June is paused because this request needs your explicit permission
+              before it can continue.
+            </p>
+            <p>
+              Approve once allows only this request. This session allows
+              matching requests until the session ends. Always allows matching
+              requests in future sessions. Deny blocks the request.
+            </p>
+          </div>
+        ) : null}
         {resolved ? (
           <p className="agent-approval-result" data-choice={activeChoice}>
             {activeChoice === "deny" ? (
@@ -4119,6 +4136,17 @@ function ApprovalPart({
           // System buttons (.btn) — quiet soft-fill choices, ghost deny. The
           // repeated per-button icons read as noise, so labels stand alone.
           <div className="agent-approval-actions">
+            <button
+              type="button"
+              className="btn btn-secondary agent-approval-explain"
+              aria-expanded={explainOpen}
+              aria-controls={explanationId}
+              disabled={disabled}
+              onClick={() => setExplainOpen((value) => !value)}
+            >
+              <CircleHelpIcon size={14} />
+              {explainOpen ? "Hide explanation" : "Explain first"}
+            </button>
             <button
               type="button"
               className="btn btn-secondary"

--- a/src/lib/agent-chat-gallery.ts
+++ b/src/lib/agent-chat-gallery.ts
@@ -249,7 +249,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     {
       label: "Approval — pending",
       description:
-        "Approval request awaiting a choice. Buttons: Approve once / This session / Always / Deny.",
+        "Approval request awaiting a choice. Buttons: Explain first / Approve once / This session / Always / Deny.",
       turns: [
         assistantTurn("approval-pending", [
           {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1268,6 +1268,19 @@ input:focus-visible,
   white-space: pre-wrap;
 }
 
+.agent-approval-explanation {
+  display: grid;
+  gap: var(--sp-2);
+  margin-top: var(--sp-3);
+  border-left: 2px solid
+    color-mix(in oklch, var(--warm-strong) 52%, var(--border));
+  padding: var(--sp-1) 0 var(--sp-1) var(--sp-3);
+}
+
+.agent-approval-explanation p {
+  margin: 0;
+}
+
 /* Buttons come from the .btn system (secondary fills, ghost deny) — this
  * block only lays them out and adds the deny accent. */
 .agent-approval-actions {
@@ -1279,6 +1292,10 @@ input:focus-visible,
 
 .agent-approval-actions button:disabled {
   opacity: 0.55;
+}
+
+.agent-approval-explain[aria-expanded="true"] {
+  color: var(--warm-strong);
 }
 
 .agent-approval-deny {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -466,13 +466,62 @@ describe("AgentWorkspace", () => {
       screen.getByText(/Approve once allows only this request/),
     ).toBeInTheDocument();
     expect(
+      screen.getByText(/Always allows matching requests in future sessions/),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "Hide explanation" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Approve once" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Always" })).toBeEnabled();
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
       "approval.respond",
       expect.anything(),
     );
+  });
+
+  it("omits the permanent approval explanation when Always is unavailable", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "inspect the repo",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "inspect the repo",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "approval-2",
+            description: "Repository inspection requires approval.",
+            command: "git status",
+            allow_permanent: false,
+          },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Explain first" }));
+
+    expect(
+      screen.getByText(/Approve once allows only this request/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Always allows matching requests in future sessions/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Always" })).toBeNull();
   });
 
   it("creates a fresh Hermes session for a New Session prompt when an initial session is selected", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -421,6 +421,60 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayEventHandlers.size).toBe(0);
   });
 
+  it("explains a pending approval before the user chooses", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the build",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the build",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "approval-1",
+            description: "Security scan requires approval.",
+            command: "npm run build",
+            allow_permanent: true,
+          },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Explain first" }));
+
+    expect(
+      screen.getByText(
+        "June is paused because this request needs your explicit permission before it can continue.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Approve once allows only this request/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide explanation" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve once" })).toBeEnabled();
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "approval.respond",
+      expect.anything(),
+    );
+  });
+
   it("creates a fresh Hermes session for a New Session prompt when an initial session is selected", async () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 


### PR DESCRIPTION
## Summary

- Add an `Explain first` button to pending approval cards.
- Reveal local explanatory copy describing why June is paused and what each approval choice means.
- Keep the explanation non-mutating: it does not approve, deny, or send an approval response.

## Validation

- `vitest run src/test/agent-workspace.test.tsx`
- `tsc --noEmit`