### PR TITLE
[codex] Show active agent session status

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -164,6 +164,12 @@ export function App() {
   // project (folder) surfaces; the menu-bar refs below stay the source for
   // native menu state.
   const [agentSessions, setAgentSessions] = useState<HermesSessionInfo[]>([]);
+  const [agentWorkingSessionIds, setAgentWorkingSessionIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [agentWaitingSessionIds, setAgentWaitingSessionIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   // sessionId -> project (folder) ids. Sessions live in Hermes, so their
   // project assignments are tracked separately from the notes state.
   const [sessionFolders, setSessionFolders] = useState<
@@ -541,12 +547,12 @@ export function App() {
           setAgentOriginFolderId(undefined);
         }
       }
-      agentMenuBarWorkingSessionIdsRef.current = new Set(
-        detail.workingSessionIds,
-      );
-      agentMenuBarWaitingSessionIdsRef.current = new Set(
-        detail.waitingSessionIds ?? [],
-      );
+      const nextWorkingSessionIds = new Set(detail.workingSessionIds);
+      const nextWaitingSessionIds = new Set(detail.waitingSessionIds ?? []);
+      agentMenuBarWorkingSessionIdsRef.current = nextWorkingSessionIds;
+      agentMenuBarWaitingSessionIdsRef.current = nextWaitingSessionIds;
+      setAgentWorkingSessionIds(new Set(nextWorkingSessionIds));
+      setAgentWaitingSessionIds(new Set(nextWaitingSessionIds));
       publishAgentMenuBarState();
     }
 
@@ -559,6 +565,12 @@ export function App() {
           working: agentMenuBarWorkingSessionIdsRef.current,
           waiting: agentMenuBarWaitingSessionIdsRef.current,
         });
+        setAgentWorkingSessionIds(
+          new Set(agentMenuBarWorkingSessionIdsRef.current),
+        );
+        setAgentWaitingSessionIds(
+          new Set(agentMenuBarWaitingSessionIdsRef.current),
+        );
       }
       publishAgentMenuBarState();
     }
@@ -575,6 +587,12 @@ export function App() {
       );
       agentMenuBarWorkingSessionIdsRef.current.delete(sessionId);
       agentMenuBarWaitingSessionIdsRef.current.delete(sessionId);
+      setAgentWorkingSessionIds(
+        new Set(agentMenuBarWorkingSessionIdsRef.current),
+      );
+      setAgentWaitingSessionIds(
+        new Set(agentMenuBarWaitingSessionIdsRef.current),
+      );
       publishAgentMenuBarState();
     }
 
@@ -1674,6 +1692,8 @@ export function App() {
                 sessions={agentSessions}
                 folders={state.folders}
                 sessionFolderIds={sessionFolders}
+                workingSessionIds={agentWorkingSessionIds}
+                waitingSessionIds={agentWaitingSessionIds}
                 onSelectSession={(session) => {
                   setAgentOriginFolderId(undefined);
                   setActiveAgentSession(session);

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -21,6 +21,8 @@ type AgentSessionsListProps = {
   folders: FolderDto[];
   /** sessionId -> project (folder) ids the session is filed under. */
   sessionFolderIds: Record<string, string[]>;
+  workingSessionIds?: ReadonlySet<string>;
+  waitingSessionIds?: ReadonlySet<string>;
   onSelectSession: (session: HermesSessionInfo) => void;
   onNewSession: () => void;
   onOpenMoveDialog: (sessionId: string) => void;
@@ -31,6 +33,8 @@ export function AgentSessionsList({
   sessions,
   folders,
   sessionFolderIds,
+  workingSessionIds = new Set(),
+  waitingSessionIds = new Set(),
   onSelectSession,
   onNewSession,
   onOpenMoveDialog,
@@ -39,16 +43,22 @@ export function AgentSessionsList({
   const [query, setQuery] = useState("");
   const filteredSessions = useMemo(() => {
     const normalized = query.trim().toLowerCase();
-    const sorted = [...sessions].sort((a, b) =>
-      sessionTimestamp(b).localeCompare(sessionTimestamp(a)),
-    );
+    const sorted = [...sessions].sort((a, b) => {
+      const statusDelta =
+        sessionStatusPriority(b.id, workingSessionIds, waitingSessionIds) -
+        sessionStatusPriority(a.id, workingSessionIds, waitingSessionIds);
+      if (statusDelta !== 0) return statusDelta;
+      return sessionTimestamp(b).localeCompare(sessionTimestamp(a));
+    });
     if (!normalized) return sorted;
     return sorted.filter((session) =>
-      `${session.title ?? ""} ${session.preview ?? ""}`
+      `${session.title ?? ""} ${session.preview ?? ""} ${sessionStatusLabel(
+        sessionStatus(session.id, workingSessionIds, waitingSessionIds),
+      )}`
         .toLowerCase()
         .includes(normalized),
     );
-  }, [sessions, query]);
+  }, [sessions, query, waitingSessionIds, workingSessionIds]);
 
   return (
     <section
@@ -119,6 +129,11 @@ export function AgentSessionsList({
                 folders,
               )}
               currentFolderId={sessionFolderIds[session.id]?.[0]}
+              status={sessionStatus(
+                session.id,
+                workingSessionIds,
+                waitingSessionIds,
+              )}
               onSelect={() => onSelectSession(session)}
               onOpenMove={() => onOpenMoveDialog(session.id)}
               onRemoveFromProject={(folderId) =>
@@ -142,10 +157,39 @@ function projectNameFor(
   return folders.find((folder) => folder.id === folderId)?.name;
 }
 
+type AgentSessionListStatus = "running" | "waitingForUser" | undefined;
+
+function sessionStatus(
+  sessionId: string,
+  workingSessionIds: ReadonlySet<string>,
+  waitingSessionIds: ReadonlySet<string>,
+): AgentSessionListStatus {
+  if (waitingSessionIds.has(sessionId)) return "waitingForUser";
+  if (workingSessionIds.has(sessionId)) return "running";
+  return undefined;
+}
+
+function sessionStatusPriority(
+  sessionId: string,
+  workingSessionIds: ReadonlySet<string>,
+  waitingSessionIds: ReadonlySet<string>,
+) {
+  if (waitingSessionIds.has(sessionId)) return 2;
+  if (workingSessionIds.has(sessionId)) return 1;
+  return 0;
+}
+
+function sessionStatusLabel(status: AgentSessionListStatus) {
+  if (status === "waitingForUser") return "Needs you";
+  if (status === "running") return "Working";
+  return "";
+}
+
 function AgentSessionListRow({
   session,
   projectName,
   currentFolderId,
+  status,
   onSelect,
   onOpenMove,
   onRemoveFromProject,
@@ -153,6 +197,7 @@ function AgentSessionListRow({
   session: HermesSessionInfo;
   projectName?: string;
   currentFolderId?: string;
+  status?: AgentSessionListStatus;
   onSelect: () => void;
   onOpenMove: () => void;
   onRemoveFromProject: (folderId: string) => void;
@@ -160,6 +205,7 @@ function AgentSessionListRow({
   const title =
     session.title?.trim() || session.preview?.trim() || "Untitled session";
   const preview = session.preview?.trim() || "No messages yet";
+  const statusLabel = sessionStatusLabel(status);
   const [menu, setMenu] = useState<{ right: number; top: number } | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -208,6 +254,7 @@ function AgentSessionListRow({
         className="folder-note-row all-notes-row"
         data-has-actions="true"
         data-menu-open={menu !== null}
+        data-status={status}
       >
         <button type="button" className="folder-note-main" onClick={onSelect}>
           <span className="folder-note-icon" aria-hidden>
@@ -220,9 +267,21 @@ function AgentSessionListRow({
             </span>
           </span>
         </button>
-        <span className="folder-note-time">
-          {formatSessionTime(sessionTimestamp(session))}
-        </span>
+        {status ? (
+          <span
+            className="folder-note-time agent-session-list-status"
+            data-status={status}
+            role="status"
+            aria-label={statusLabel}
+          >
+            <span aria-hidden />
+            {statusLabel}
+          </span>
+        ) : (
+          <span className="folder-note-time">
+            {formatSessionTime(sessionTimestamp(session))}
+          </span>
+        )}
         <span className="folder-note-actions">
           <button
             type="button"

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -29,12 +29,14 @@ type AgentSessionsListProps = {
   onRemoveFromProject: (sessionId: string, folderId: string) => void;
 };
 
+const EMPTY_SESSION_IDS: ReadonlySet<string> = new Set();
+
 export function AgentSessionsList({
   sessions,
   folders,
   sessionFolderIds,
-  workingSessionIds = new Set(),
-  waitingSessionIds = new Set(),
+  workingSessionIds = EMPTY_SESSION_IDS,
+  waitingSessionIds = EMPTY_SESSION_IDS,
   onSelectSession,
   onNewSession,
   onOpenMoveDialog,
@@ -269,7 +271,7 @@ function AgentSessionListRow({
         </button>
         {status ? (
           <span
-            className="folder-note-time agent-session-list-status"
+            className="agent-session-list-status"
             data-status={status}
             role="status"
             aria-label={statusLabel}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7897,6 +7897,26 @@ input:focus-visible,
   transition: opacity var(--t-fast) var(--ease-out);
 }
 
+.agent-session-list-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  color: var(--warm-strong);
+  font-weight: 600;
+}
+
+.agent-session-list-status[data-status="waitingForUser"] {
+  color: var(--primary);
+}
+
+.agent-session-list-status > span {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--r-pill);
+  background: currentColor;
+  box-shadow: 0 0 0 3px color-mix(in oklch, currentColor 14%, transparent);
+}
+
 .folder-note-row[data-has-actions="true"]:hover .folder-note-time,
 .folder-note-row[data-has-actions="true"]:focus-within .folder-note-time,
 .folder-note-row[data-has-actions="true"][data-menu-open="true"]

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7898,11 +7898,16 @@ input:focus-visible,
 }
 
 .agent-session-list-status {
+  position: relative;
+  z-index: 2;
   display: inline-flex;
   align-items: center;
   gap: var(--sp-2);
   color: var(--warm-strong);
+  font-size: var(--fs-sm);
   font-weight: 600;
+  white-space: nowrap;
+  transition: opacity var(--t-fast) var(--ease-out);
 }
 
 .agent-session-list-status[data-status="waitingForUser"] {

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AgentSessionsList } from "../components/agent/AgentSessionsList";
+import type { HermesSessionInfo } from "../lib/tauri";
+
+const hermesMocks = vi.hoisted(() => ({
+  deleteHermesSession: vi.fn(),
+}));
+
+vi.mock("../lib/hermes-adapter", () => ({
+  deleteHermesSession: hermesMocks.deleteHermesSession,
+  sessionTimestamp: (session: HermesSessionInfo) =>
+    session.last_active ?? session.started_at ?? "",
+}));
+
+const sessions: HermesSessionInfo[] = [
+  {
+    id: "idle-session",
+    title: "Idle session",
+    preview: "Done yesterday",
+    last_active: "2026-06-04T13:00:00Z",
+  },
+  {
+    id: "running-session",
+    title: "Running session",
+    preview: "Working from CLI",
+    last_active: "2026-06-04T12:00:00Z",
+  },
+  {
+    id: "waiting-session",
+    title: "Waiting session",
+    preview: "Needs permission",
+    last_active: "2026-06-04T11:00:00Z",
+  },
+];
+
+describe("AgentSessionsList", () => {
+  it("surfaces active session status and sorts active work first", () => {
+    render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        workingSessionIds={new Set(["running-session"])}
+        waitingSessionIds={new Set(["waiting-session"])}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status", { name: "Needs you" })).toHaveTextContent(
+      "Needs you",
+    );
+    expect(screen.getByRole("status", { name: "Working" })).toHaveTextContent(
+      "Working",
+    );
+
+    const list = screen.getByRole("list");
+    expect(
+      Array.from(list.querySelectorAll(".folder-note-title")).map((node) =>
+        node.textContent?.trim(),
+      ),
+    ).toEqual(["Waiting session", "Running session", "Idle session"]);
+  });
+});

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -56,6 +56,12 @@ describe("AgentSessionsList", () => {
     expect(screen.getByRole("status", { name: "Working" })).toHaveTextContent(
       "Working",
     );
+    expect(screen.getByRole("status", { name: "Needs you" })).not.toHaveClass(
+      "folder-note-time",
+    );
+    expect(screen.getByRole("status", { name: "Working" })).not.toHaveClass(
+      "folder-note-time",
+    );
 
     const list = screen.getByRole("list");
     expect(


### PR DESCRIPTION
## Summary

- Surface `Working` and `Needs you` states in the all-agents session list.
- Sort waiting/running sessions above idle history so CLI-driven work is easier to track.
- Reuse the existing agent working/waiting session state from App instead of adding another poller.

## Validation

- `vitest run src/test/agent-sessions-list.test.tsx`
- `tsc --noEmit`