### PR TITLE
[codex] Improve agent session titles

### DIFF
--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -563,8 +563,8 @@ fn clean_agent_session_title(value: &str) -> Option<String> {
         "Can you ",
         "Could you ",
         "Would you ",
-        "Help me ",
         "Help me to ",
+        "Help me ",
         "I want you to ",
         "I want to ",
         "I need you to ",
@@ -758,6 +758,10 @@ mod tests {
         assert_eq!(
             clean_agent_session_title("I want you to Keep this CLI run organized.").as_deref(),
             Some("Keep this CLI run organized")
+        );
+        assert_eq!(
+            clean_agent_session_title("Help me to organize files").as_deref(),
+            Some("organize files")
         );
         assert_eq!(
             clean_agent_session_title(

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -497,7 +497,7 @@ pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppErro
         "messages": [
             {
                 "role": "system",
-                "content": "Create a concise title for an agent session from the user's first request. Return only the title. Use 2 to 6 words. No quotes, punctuation wrappers, markdown, or explanations."
+                "content": "Name this agent session by the work being done, not by repeating the user's request. Return only a concrete 2 to 5 word title. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations."
             },
             {
                 "role": "user",
@@ -555,9 +555,35 @@ fn clean_agent_session_title(value: &str) -> Option<String> {
         .trim()
         .trim_matches(|ch: char| ch == '"' || ch == '\'' || ch == '`')
         .replace(['\r', '\n'], " ");
-    for prefix in ["Title:", "Session title:", "Request:"] {
-        if title.to_lowercase().starts_with(&prefix.to_lowercase()) {
-            title = title[prefix.len()..].trim_start().to_string();
+    let prefixes = [
+        "Title:",
+        "Session title:",
+        "Request:",
+        "Please ",
+        "Can you ",
+        "Could you ",
+        "Would you ",
+        "Help me ",
+        "Help me to ",
+        "I want you to ",
+        "I want to ",
+        "I need you to ",
+        "I need to ",
+        "I'd like you to ",
+        "I'd like to ",
+        "Ask June to ",
+        "Have June ",
+    ];
+    loop {
+        let mut changed = false;
+        for prefix in prefixes {
+            if title.to_lowercase().starts_with(&prefix.to_lowercase()) {
+                title = title[prefix.len()..].trim_start().to_string();
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
         }
     }
     title = title
@@ -728,6 +754,10 @@ mod tests {
         assert_eq!(
             clean_agent_session_title("Title: \"Open GarageBand\"").as_deref(),
             Some("Open GarageBand")
+        );
+        assert_eq!(
+            clean_agent_session_title("I want you to Keep this CLI run organized.").as_deref(),
+            Some("Keep this CLI run organized")
         );
         assert_eq!(
             clean_agent_session_title(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3058,7 +3058,7 @@ function isReplaceableAgentSessionTitle(title: unknown) {
     normalized === "untitled session" ||
     normalized.endsWith("...") ||
     normalized.length > 52 ||
-    /^(?:i\s|i'm\s|i want|i need|please\s|can you\s|could you\s|would you\s|help me\s|who are you|what can you|what are you|what do you|summarize\s|set up\s|test$)/.test(
+    /^(?:i'm\s+|i\s+(?:want|need)\s+|please\s+|can you\s+|could you\s+|would you\s+|help me\s+|who are you|what can you|what are you|what do you|summarize\s+|set up\s+|test$)/.test(
       normalized,
     )
   );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3053,7 +3053,15 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
 
 function isReplaceableAgentSessionTitle(title: unknown) {
   const normalized = safeText(title).trim().toLowerCase();
-  return !normalized || normalized === "untitled session";
+  return (
+    !normalized ||
+    normalized === "untitled session" ||
+    normalized.endsWith("...") ||
+    normalized.length > 52 ||
+    /^(?:i\s|i'm\s|i want|i need|please\s|can you\s|could you\s|would you\s|help me\s|who are you|what can you|what are you|what do you|summarize\s|set up\s|test$)/.test(
+      normalized,
+    )
+  );
 }
 
 function PanelTabs({

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -86,7 +86,6 @@ function promptTitleSource(prompt: string) {
     .replace(/\n+Attached files copied into[\s\S]*$/i, "")
     .replace(/\s+/g, " ")
     .trim()
-    .trim()
     .replace(/^["'`]+|["'`]+$/g, "");
 }
 
@@ -95,7 +94,7 @@ function stripRequestPrefix(value: string) {
   const prefixes = [
     /^(?:hey\s+)?june,?\s+/i,
     /^(?:please\s+)?(?:can|could|would)\s+you\s+/i,
-    /^(?:please\s+)?(?:help\s+me(?:\s+to)?|help\s+me)\s+/i,
+    /^(?:please\s+)?help\s+me(?:\s+to)?\s+/i,
     /^(?:i\s+want\s+you\s+to|i\s+want\s+to|i\s+need\s+you\s+to|i\s+need\s+to|i'd\s+like\s+you\s+to|i'd\s+like\s+to)\s+/i,
     /^(?:have|ask)\s+june\s+to\s+/i,
     /^please\s+/i,

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -62,9 +62,89 @@ export function sessionTimestamp(session: HermesSessionInfo) {
 }
 
 export function titleFromPrompt(prompt: string) {
-  const title = prompt.replace(/\s+/g, " ").trim();
+  const source = promptTitleSource(prompt);
+  if (!source) return "Untitled session";
+  const stripped = stripRequestPrefix(source) || source;
+  const firstClause = stripped
+    .split(/(?:[.!?;:]|\s+-\s+|\s+--\s+)/)
+    .at(0)
+    ?.trim();
+  const words = (firstClause || stripped)
+    .replace(/\s+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 6);
+  const title = titleCaseSessionTitle(words.join(" "));
   if (title.length <= 72) return title || "Untitled session";
   return `${title.slice(0, 69).trim()}...`;
+}
+
+function promptTitleSource(prompt: string) {
+  return prompt
+    .replace(/\n*--- Attached Context ---[\s\S]*$/m, "")
+    .replace(/\n*--- Context Warnings ---[\s\S]*$/m, "")
+    .replace(/\n+Attached files copied into[\s\S]*$/i, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, "");
+}
+
+function stripRequestPrefix(value: string) {
+  let title = value.trim();
+  const prefixes = [
+    /^(?:hey\s+)?june,?\s+/i,
+    /^(?:please\s+)?(?:can|could|would)\s+you\s+/i,
+    /^(?:please\s+)?(?:help\s+me(?:\s+to)?|help\s+me)\s+/i,
+    /^(?:i\s+want\s+you\s+to|i\s+want\s+to|i\s+need\s+you\s+to|i\s+need\s+to|i'd\s+like\s+you\s+to|i'd\s+like\s+to)\s+/i,
+    /^(?:have|ask)\s+june\s+to\s+/i,
+    /^please\s+/i,
+  ];
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const prefix of prefixes) {
+      const next = title.replace(prefix, "").trim();
+      if (next !== title) {
+        title = next;
+        changed = true;
+      }
+    }
+  }
+  return title;
+}
+
+function titleCaseSessionTitle(value: string) {
+  const smallWords = new Set([
+    "a",
+    "an",
+    "and",
+    "as",
+    "at",
+    "but",
+    "by",
+    "for",
+    "from",
+    "in",
+    "into",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+  ]);
+  return value
+    .split(" ")
+    .map((word, index) => {
+      if (!word) return word;
+      if (/[A-Z]/.test(word) && word === word.toUpperCase()) return word;
+      const lower = word.toLowerCase();
+      if (index > 0 && smallWords.has(lower)) return lower;
+      return lower.replace(/^([a-z])/, (match) => match.toUpperCase());
+    })
+    .join(" ")
+    .trim();
 }
 
 function extractList(response: unknown, preferredKey: "sessions" | "messages") {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -321,6 +321,36 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("CLI Run Tracking")).toBeInTheDocument();
   });
 
+  it("keeps generated titles that begin with past-tense request words", async () => {
+    const generatedTitle = "I Wanted Outcomes";
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-generated",
+        title: generatedTitle,
+        preview: "Finished planning outcomes",
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "user",
+        content: "plan outcomes",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(generatedTitle)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith(
+        "session-generated",
+      ),
+    );
+    expect(mocks.suggestAgentSessionTitle).not.toHaveBeenCalled();
+  });
+
   it("forgets the persisted session when it is deleted", async () => {
     render(<AgentWorkspace />);
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -294,6 +294,33 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Newer session")).toBeNull();
   });
 
+  it("renames prompt-like existing session titles after messages load", async () => {
+    const rawTitle = "I want you to keep this running inside my CLI";
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-raw",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "user",
+        content: rawTitle,
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({
+      title: "CLI Run Tracking",
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("CLI Run Tracking")).toBeInTheDocument();
+  });
+
   it("forgets the persisted session when it is deleted", async () => {
     render(<AgentWorkspace />);
 

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -93,6 +93,7 @@ describe("Hermes adapter", () => {
     expect(titleFromPrompt("I want you to keep this running in my CLI")).toBe(
       "Keep This Running in My CLI",
     );
+    expect(titleFromPrompt("Help me to organize files")).toBe("Organize Files");
     expect(
       titleFromPrompt(
         "please summarize the key points from today's standup\n\n--- Attached Context ---\n{}",

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -89,7 +89,15 @@ describe("Hermes adapter", () => {
         last_active: 1_780_603_200 as unknown as string,
       }),
     ).toBe("2026-06-04T20:00:00.000Z");
-    expect(titleFromPrompt("  Write   a note  ")).toBe("Write a note");
+    expect(titleFromPrompt("  Write   a note  ")).toBe("Write a Note");
+    expect(titleFromPrompt("I want you to keep this running in my CLI")).toBe(
+      "Keep This Running in My CLI",
+    );
+    expect(
+      titleFromPrompt(
+        "please summarize the key points from today's standup\n\n--- Attached Context ---\n{}",
+      ),
+    ).toBe("Summarize the Key Points from Today's");
     expect(titleFromPrompt("")).toBe("Untitled session");
   });
 });


### PR DESCRIPTION
## Summary

- Strengthen the backend session-title prompt so generated titles describe the work instead of echoing the request.
- Improve the deterministic frontend fallback by stripping request boilerplate and title-casing short labels.
- Repair prompt-like existing session titles after messages load, including long/truncated raw prompts.

## Validation

- `vitest run src/test/hermes-adapter.test.ts src/test/agent-workspace.test.tsx`
- `tsc --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml scribe_api::tests::cleans_agent_session_titles`