### PR TITLE
Gate the app behind the free trial, not just sign-in

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -81,6 +81,14 @@ struct BalanceWire {
     usd_millis: i64,
 }
 
+#[derive(Deserialize)]
+struct SubscriptionWire {
+    subscribed: bool,
+    status: Option<String>,
+    trial_end: Option<String>,
+    current_period_end: Option<String>,
+}
+
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountUser {
@@ -101,6 +109,18 @@ pub struct AccountBalance {
     pub usd_millis: i64,
 }
 
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountSubscription {
+    pub subscribed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trial_end: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_period_end: Option<String>,
+}
+
 #[derive(Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountStatus {
@@ -110,6 +130,13 @@ pub struct AccountStatus {
     pub user: Option<AccountUser>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance: Option<AccountBalance>,
+    /// None when the subscription endpoint is unavailable (older accounts
+    /// API) or the fetch failed — distinct from "not subscribed".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscription: Option<AccountSubscription>,
+    /// The accounts portal origin, where the free-trial flow lives.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub portal_url: Option<String>,
 }
 
 impl From<MeWire> for AccountUser {
@@ -249,13 +276,15 @@ pub async fn os_accounts_status() -> Result<AccountStatus, AppError> {
         });
     }
     match fetch_snapshot(&cfg).await {
-        Ok((user, balance)) => {
+        Ok((user, balance, subscription)) => {
             set_cached_signed_in(true);
             Ok(AccountStatus {
                 signed_in: true,
                 configured: cfg.configured(),
                 user: Some(user),
                 balance: Some(balance),
+                subscription,
+                portal_url: portal_url(&cfg),
             })
         }
         Err(_) => {
@@ -311,13 +340,15 @@ pub async fn os_accounts_login(
     let pair = exchange_code(&cfg, &code, &verifier, &redirect_uri).await?;
     store_tokens(&pair).await?;
 
-    let (user, balance) = fetch_snapshot(&cfg).await?;
+    let (user, balance, subscription) = fetch_snapshot(&cfg).await?;
     set_cached_signed_in(true);
     Ok(AccountStatus {
         signed_in: true,
         configured: true,
         user: Some(user),
         balance: Some(balance),
+        subscription,
+        portal_url: portal_url(&cfg),
     })
 }
 
@@ -776,10 +807,28 @@ async fn authed_get<T: for<'de> Deserialize<'de>>(cfg: &Config, path: &str) -> R
     Err(AppError::new("unauthorized", "Not signed in."))
 }
 
-async fn fetch_snapshot(cfg: &Config) -> Result<(AccountUser, AccountBalance), AppError> {
+async fn fetch_snapshot(
+    cfg: &Config,
+) -> Result<(AccountUser, AccountBalance, Option<AccountSubscription>), AppError> {
     let me: MeWire = authed_get(cfg, "/me").await?;
     let balance: BalanceWire = authed_get(cfg, "/billing/balance").await?;
-    Ok((me.into(), balance.into()))
+    // Best-effort: an accounts API without the subscription endpoint must not
+    // break sign-in. None means "unknown", not "not subscribed".
+    let subscription = authed_get::<SubscriptionWire>(cfg, "/billing/subscription")
+        .await
+        .ok()
+        .map(|w| AccountSubscription {
+            subscribed: w.subscribed,
+            status: w.status,
+            trial_end: w.trial_end,
+            current_period_end: w.current_period_end,
+        });
+    Ok((me.into(), balance.into(), subscription))
+}
+
+fn portal_url(cfg: &Config) -> Option<String> {
+    let url = cfg.accounts_url.trim_end_matches('/');
+    (!url.is_empty()).then(|| url.to_string())
 }
 
 fn net_error(e: reqwest::Error) -> AppError {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import {
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
 import { flushSync } from "react-dom";
 import { AccountGate } from "../components/account/AccountGate";
+import { TrialGate } from "../components/account/TrialGate";
 import {
   AGENT_DELETE_SESSION_EVENT,
   AGENT_NEW_SESSION_EVENT,
@@ -101,7 +102,7 @@ import type {
   RecordingSourceReadinessDto,
 } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
-import { shouldBlockOnSignIn } from "../lib/account-gate";
+import { shouldBlockOnSignIn, shouldBlockOnTrial } from "../lib/account-gate";
 import {
   checkScribeUpdate,
   relaunchScribe,
@@ -238,7 +239,8 @@ export function App() {
   // Sessions with a finishRecording call in flight; guards stop double-clicks.
   const finishingSessionsRef = useRef<Set<string>>(new Set());
   const signInRequired = shouldBlockOnSignIn(account);
-  const appBlocked = accountLoading || signInRequired;
+  const trialRequired = !signInRequired && shouldBlockOnTrial(account);
+  const appBlocked = accountLoading || signInRequired || trialRequired;
   const publishAgentMenuBarState = useCallback(() => {
     void emitAgentMenuBarState(
       buildAgentMenuBarState({
@@ -1445,6 +1447,24 @@ export function App() {
           account={account}
           loading={accountLoading}
           onAccountChanged={handleAccountChanged}
+        />
+      </main>
+    );
+  }
+
+  if (trialRequired) {
+    return (
+      <main className="account-gate-shell">
+        <div
+          className="titlebar-drag"
+          aria-hidden
+          data-tauri-drag-region
+          onPointerDown={handleTitlebarPointerDown}
+        />
+        <TrialGate
+          account={account}
+          onRefresh={refreshAccount}
+          onSignOut={() => void handleSignOut()}
         />
       </main>
     );

--- a/src/components/account/TrialGate.tsx
+++ b/src/components/account/TrialGate.tsx
@@ -19,7 +19,9 @@ const POLL_INTERVAL_MS = 10_000;
  * subscription to become active. */
 export function TrialGate({ account, onRefresh, onSignOut }: Props) {
   const [checking, setChecking] = useState(false);
-  const portalUrl = account.portalUrl ?? "https://accounts.opensoftware.co";
+  // No fallback: portalUrl mirrors this build's accounts_url, and a hardcoded
+  // production URL would silently send dev/staging builds to the prod portal.
+  const portalUrl = account.portalUrl;
   const handle = account.user?.handle;
   const pastDue = account.subscription?.status === "past_due";
 
@@ -52,14 +54,20 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
         </p>
 
         <div className="welcome-providers">
-          <a
-            className="primary-action"
-            href={portalUrl}
-            target="_blank"
-            rel="noreferrer"
-          >
-            {pastDue ? "Manage billing" : "Start free trial"}
-          </a>
+          {portalUrl ? (
+            <a
+              className="primary-action"
+              href={portalUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {pastDue ? "Manage billing" : "Start free trial"}
+            </a>
+          ) : (
+            <p className="welcome-status welcome-status-info">
+              The accounts portal is not configured for this build.
+            </p>
+          )}
           <button
             type="button"
             className="btn btn-secondary trial-gate-refresh"

--- a/src/components/account/TrialGate.tsx
+++ b/src/components/account/TrialGate.tsx
@@ -12,10 +12,11 @@ type Props = {
 // the portal-in-another-window case where focus never returns here.
 const POLL_INTERVAL_MS = 10_000;
 
-/** Signed in but unfunded: the app stays unusable until the user starts the
- * free trial (or otherwise funds the account). The trial flow — Stripe
- * Checkout with card capture — lives in the accounts portal, so this gate
- * hands off to the browser and watches for the account to become funded. */
+/** Signed in but not a member: the app stays unusable until the user is on a
+ * subscription (trialing or active) — credits alone don't grant access. The
+ * trial flow — Stripe Checkout with card capture — lives in the accounts
+ * portal, so this gate hands off to the browser and watches for the
+ * subscription to become active. */
 export function TrialGate({ account, onRefresh, onSignOut }: Props) {
   const [checking, setChecking] = useState(false);
   const portalUrl = account.portalUrl ?? "https://accounts.opensoftware.co";

--- a/src/components/account/TrialGate.tsx
+++ b/src/components/account/TrialGate.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import type { AccountStatus } from "../../lib/tauri";
+
+type Props = {
+  account: AccountStatus;
+  onRefresh: () => Promise<AccountStatus | undefined>;
+  onSignOut: () => void;
+};
+
+// The account hook already refreshes on window focus, which covers the
+// common "came back from the portal" path; this poll is the fallback for
+// the portal-in-another-window case where focus never returns here.
+const POLL_INTERVAL_MS = 10_000;
+
+/** Signed in but unfunded: the app stays unusable until the user starts the
+ * free trial (or otherwise funds the account). The trial flow — Stripe
+ * Checkout with card capture — lives in the accounts portal, so this gate
+ * hands off to the browser and watches for the account to become funded. */
+export function TrialGate({ account, onRefresh, onSignOut }: Props) {
+  const [checking, setChecking] = useState(false);
+  const portalUrl = account.portalUrl ?? "https://accounts.opensoftware.co";
+  const handle = account.user?.handle;
+  const pastDue = account.subscription?.status === "past_due";
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      void onRefresh();
+    }, POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [onRefresh]);
+
+  async function handleRefresh() {
+    setChecking(true);
+    try {
+      await onRefresh();
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <div className="welcome-screen">
+      <div className="welcome-card">
+        <h1 className="welcome-title">
+          {pastDue ? "Payment needed" : "Start your free trial"}
+        </h1>
+        <p className="welcome-subtitle">
+          {pastDue
+            ? "Your subscription payment didn't go through. Update your billing details to keep using June."
+            : "June runs on your OpenSoftware account. Start the free trial in your account portal — no charge until the trial ends."}
+        </p>
+
+        <div className="welcome-providers">
+          <a
+            className="primary-action"
+            href={portalUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {pastDue ? "Manage billing" : "Start free trial"}
+          </a>
+          <button
+            type="button"
+            className="btn btn-secondary trial-gate-refresh"
+            disabled={checking}
+            onClick={() => void handleRefresh()}
+          >
+            {checking ? "Checking…" : "I've done it — check again"}
+          </button>
+        </div>
+
+        <p className="welcome-terms">
+          {handle ? <>Signed in as @{handle}. </> : null}
+          <button
+            type="button"
+            className="trial-gate-signout"
+            onClick={onSignOut}
+          >
+            Sign out
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/account-gate.ts
+++ b/src/lib/account-gate.ts
@@ -9,19 +9,14 @@ export function shouldBlockOnSignIn(account: AccountStatus): boolean {
   return !account.signedIn;
 }
 
-// Signed in but unfunded: signup alone must not make the app usable — the
-// free trial (a card-on-file subscription with trial credits) is the entry
-// point. The gate mirrors what /authorize would decide anyway:
-// - trialing/active subscribers pass (an active subscriber at zero balance
-//   still has the credit-line floor, so authorize admits them);
-// - anyone else passes only with a positive balance (e.g. permanent top-up
-//   credits), which is spendable regardless of subscription state.
+// Membership is mandatory: every user must be on a subscription (trialing or
+// active) to use the app at all — credits alone do NOT grant access, so a
+// leftover promo balance or a cancelled subscriber with unspent top-ups still
+// lands on the trial gate. An unknown subscription state (transient fetch
+// failure) also blocks; the gate's poll and the account hook's focus refresh
+// recover it within seconds, which beats silently admitting non-members.
 export function shouldBlockOnTrial(account: AccountStatus): boolean {
   if (!account.signedIn) return false;
   const status = account.subscription?.status;
-  if (status === "trialing" || status === "active") return false;
-  // Fail open when the balance shape is unknown — locking someone out over a
-  // missing field would strand them; /authorize is the real enforcement.
-  const credits = account.balance?.credits;
-  return credits !== undefined && credits <= 0;
+  return status !== "trialing" && status !== "active";
 }

--- a/src/lib/account-gate.ts
+++ b/src/lib/account-gate.ts
@@ -8,3 +8,20 @@ import type { AccountStatus } from "./tauri";
 export function shouldBlockOnSignIn(account: AccountStatus): boolean {
   return !account.signedIn;
 }
+
+// Signed in but unfunded: signup alone must not make the app usable — the
+// free trial (a card-on-file subscription with trial credits) is the entry
+// point. The gate mirrors what /authorize would decide anyway:
+// - trialing/active subscribers pass (an active subscriber at zero balance
+//   still has the credit-line floor, so authorize admits them);
+// - anyone else passes only with a positive balance (e.g. permanent top-up
+//   credits), which is spendable regardless of subscription state.
+export function shouldBlockOnTrial(account: AccountStatus): boolean {
+  if (!account.signedIn) return false;
+  const status = account.subscription?.status;
+  if (status === "trialing" || status === "active") return false;
+  // Fail open when the balance shape is unknown — locking someone out over a
+  // missing field would strand them; /authorize is the real enforcement.
+  const credits = account.balance?.credits;
+  return credits !== undefined && credits <= 0;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -993,7 +993,17 @@ export type AccountUser = {
 };
 
 export type AccountBalance = {
+  /** Present whenever the backend snapshot succeeds; optional so older
+   * payload shapes (and test fixtures) without it don't lock the app. */
+  credits?: number;
   usdMillis: number;
+};
+
+export type AccountSubscription = {
+  subscribed: boolean;
+  status?: "trialing" | "active" | "past_due" | "canceled" | (string & {});
+  trialEnd?: string;
+  currentPeriodEnd?: string;
 };
 
 export type AccountStatus = {
@@ -1001,6 +1011,11 @@ export type AccountStatus = {
   configured: boolean;
   user?: AccountUser;
   balance?: AccountBalance;
+  /** Absent when the subscription state couldn't be determined — distinct
+   * from `{ subscribed: false }`. */
+  subscription?: AccountSubscription;
+  /** The accounts portal origin, where the free-trial flow lives. */
+  portalUrl?: string;
 };
 
 export async function osAccountsStatus() {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9171,3 +9171,28 @@ input:focus-visible,
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+
+/* Trial gate — same card chrome as the sign-in gate; the primary action is
+ * an anchor (opens the portal in the browser), so it inherits .primary-action
+ * with the link reset below. */
+.welcome-providers a.primary-action {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.trial-gate-refresh {
+  margin-top: var(--sp-2);
+}
+
+.trial-gate-signout {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--foreground);
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}

--- a/src/test/account-gate.test.ts
+++ b/src/test/account-gate.test.ts
@@ -37,12 +37,34 @@ describe("shouldBlockOnTrial", () => {
     );
   });
 
-  it("blocks a fresh signup with zero credits and no subscription", () => {
+  it("blocks a fresh signup with no subscription", () => {
     expect(
       shouldBlockOnTrial(
         signedIn({
           balance: { credits: 0, usdMillis: 0 },
           subscription: { subscribed: false },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks credit holders without a subscription — membership is mandatory", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 5000, usdMillis: 5000 },
+          subscription: { subscribed: false },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks a cancelled subscriber even with unspent credits", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 1200, usdMillis: 1200 },
+          subscription: { subscribed: false, status: "canceled" },
         }),
       ),
     ).toBe(true);
@@ -81,21 +103,10 @@ describe("shouldBlockOnTrial", () => {
     ).toBe(true);
   });
 
-  it("allows positive credits regardless of subscription state", () => {
-    expect(
-      shouldBlockOnTrial(
-        signedIn({
-          balance: { credits: 1200, usdMillis: 1200 },
-          subscription: { subscribed: false },
-        }),
-      ),
-    ).toBe(false);
-  });
-
-  it("fails open when the balance shape is unknown", () => {
+  it("blocks when the subscription state is unknown until a refresh resolves it", () => {
     expect(shouldBlockOnTrial(signedIn({ balance: { usdMillis: 0 } }))).toBe(
-      false,
+      true,
     );
-    expect(shouldBlockOnTrial(signedIn())).toBe(false);
+    expect(shouldBlockOnTrial(signedIn())).toBe(true);
   });
 });

--- a/src/test/account-gate.test.ts
+++ b/src/test/account-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { shouldBlockOnSignIn } from "../lib/account-gate";
+import { shouldBlockOnSignIn, shouldBlockOnTrial } from "../lib/account-gate";
+import type { AccountStatus } from "../lib/tauri";
 
 describe("shouldBlockOnSignIn", () => {
   it("blocks when the user is not signed in", () => {
@@ -17,5 +18,84 @@ describe("shouldBlockOnSignIn", () => {
         balance: { usdMillis: 0 },
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldBlockOnTrial", () => {
+  function signedIn(overrides: Partial<AccountStatus> = {}): AccountStatus {
+    return {
+      signedIn: true,
+      configured: true,
+      user: { id: "usr_1", handle: "jakub" },
+      ...overrides,
+    };
+  }
+
+  it("never blocks signed-out users (the sign-in gate owns that)", () => {
+    expect(shouldBlockOnTrial({ signedIn: false, configured: true })).toBe(
+      false,
+    );
+  });
+
+  it("blocks a fresh signup with zero credits and no subscription", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 0, usdMillis: 0 },
+          subscription: { subscribed: false },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("allows a trialing subscriber even at zero balance", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 0, usdMillis: 0 },
+          subscription: { subscribed: true, status: "trialing" },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("allows an active subscriber even at zero balance (credit-line floor)", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 0, usdMillis: 0 },
+          subscription: { subscribed: true, status: "active" },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("blocks a past-due subscriber with no credits left", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 0, usdMillis: 0 },
+          subscription: { subscribed: true, status: "past_due" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("allows positive credits regardless of subscription state", () => {
+    expect(
+      shouldBlockOnTrial(
+        signedIn({
+          balance: { credits: 1200, usdMillis: 1200 },
+          subscription: { subscribed: false },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails open when the balance shape is unknown", () => {
+    expect(shouldBlockOnTrial(signedIn({ balance: { usdMillis: 0 } }))).toBe(
+      false,
+    );
+    expect(shouldBlockOnTrial(signedIn())).toBe(false);
   });
 });

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -148,6 +148,7 @@ describe("meeting start transcription event", () => {
       configured: true,
       user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
       balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
     };
 
     mocks.getCurrentWindow.mockReturnValue({

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -159,6 +159,7 @@ describe("notes recording reliability", () => {
       configured: true,
       user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
       balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
     };
 
     mocks.getCurrentWindow.mockReturnValue({

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -147,12 +147,14 @@ describe("App shortcuts", () => {
       configured: true,
       user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
       balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
     });
     mocks.osAccountsLogin.mockResolvedValue({
       signedIn: true,
       configured: true,
       user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
       balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
     });
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
@@ -271,6 +273,7 @@ describe("App shortcuts", () => {
       configured: true,
       user: { id: "usr_123", handle: "junho", email: "junho@example.com" },
       balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
     });
 
     expect(


### PR DESCRIPTION
## What

Signed-in users without a **trialing or active subscription** hit a "Start your free trial" gate — the app is unusable until they're a member. **Credits alone do not grant access**: promo grants, leftover top-ups, and cancelled subscribers with unspent balances all land on the gate.

## How

- **Rust:** `fetch_snapshot` now also fetches `GET /billing/subscription` (best-effort — `None` means *unknown*, not *unsubscribed*) and exposes `subscription` + `portalUrl` on `AccountStatus`. `AccountBalance.credits` is surfaced to TS.
- **Gate policy** (`account-gate.ts`): `shouldBlockOnTrial` blocks unless `subscription.status` is `trialing` or `active`. Unknown subscription state (transient fetch failure) **fails closed** — the gate's 10s poll and the account hook's focus refresh recover it within seconds, which beats silently admitting non-members. Verified the prod accounts API serves `/billing/subscription` (403 auth-required, not 404) before choosing fail-closed.
- **TrialGate screen:** same card chrome as the sign-in gate; primary action opens the portal (where Stripe Checkout lives), `past_due` gets "Manage billing" copy, manual re-check button, 10s poll, sign-out.

## Server prerequisites — must land BEFORE this merges

Without these, new users hit the gate and the portal's trial button 501s:

- Stripe: monthly Product/Price created; webhook has `invoice.paid`, `invoice.payment_failed`, `customer.subscription.deleted`.
- Railway (os-accounts-api production): `ACCOUNTS_SUBSCRIPTION__STRIPE_PRICE_ID`, `ACCOUNTS_SUBSCRIPTION__PLAN_CREDITS>0`, `ACCOUNTS_SUBSCRIPTION__TRIAL_GRANT_CREDITS`, and `ACCOUNTS_CREDITS__STARTING_GRANT_CREDITS=0`.

## Testing

- 8 `shouldBlockOnTrial` unit tests: fresh signup blocked; **credit holders without subscription blocked**; cancelled-with-credits blocked; trialing/active pass at zero balance; past_due blocked; unknown state blocked.
- App-level fixtures updated to carry an active subscription.
- Full JS suite 270/270, `tsc`, Prettier, `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)