### PR TITLE
Deterministically fire the meeting-start event in app tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 .pre-flight-reviews/
 keys/
 .tmp/
+coverage

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,32 +80,21 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$TEMP/os-scribe-dictation-*.m4a"
-        ]
+        "scope": ["$TEMP/os-scribe-dictation-*.m4a"]
       },
-      "capabilities": [
-        "main",
-        "hud",
-        "mascot",
-        "meeting-hud"
-      ]
+      "capabilities": ["main", "hud", "mascot", "meeting-hud"]
     }
   },
   "plugins": {
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "osscribe"
-          ],
+          "scheme": ["osscribe"],
           "appLink": false
         }
       ],
       "desktop": {
-        "schemes": [
-          "osscribe"
-        ]
+        "schemes": ["osscribe"]
       }
     },
     "updater": {
@@ -125,10 +114,7 @@
       "icons/icon.icns",
       "icons/icon.png"
     ],
-    "targets": [
-      "app",
-      "dmg"
-    ],
+    "targets": ["app", "dmg"],
     "resources": {
       "../.tauri-helper/June.app": "native/bin/June.app",
       "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app"

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -183,6 +183,29 @@ describe("meeting start transcription event", () => {
     }));
   });
 
+  // The meeting-start listener silently drops events until the effect
+  // re-subscribes with bootstrapped=true — and that happens in a passive
+  // effect of a commit made outside act (getNote's resolution), so on slow
+  // (coverage) runs the listener in the map can still be a stale closure
+  // when we fire. Re-fire until the live listener takes the event; the
+  // calls-length guard makes a successful start fire exactly once, so this
+  // can never double-start a recording.
+  async function fireMeetingStartUntilRecording() {
+    await waitFor(async () => {
+      if (mocks.startRecording.mock.calls.length === 0) {
+        await act(async () => {
+          await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+            payload: undefined,
+          });
+        });
+      }
+      expect(mocks.startRecording).toHaveBeenCalledWith(
+        "note-1",
+        "microphonePlusSystem",
+      );
+    });
+  }
+
   it("starts recording through the existing recorder flow", async () => {
     render(<App />);
 
@@ -191,18 +214,7 @@ describe("meeting start transcription event", () => {
     );
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
-    await act(async () => {
-      await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
-        payload: undefined,
-      });
-    });
-
-    await waitFor(() =>
-      expect(mocks.startRecording).toHaveBeenCalledWith(
-        "note-1",
-        "microphonePlusSystem",
-      ),
-    );
+    await fireMeetingStartUntilRecording();
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
   });
 
@@ -214,13 +226,8 @@ describe("meeting start transcription event", () => {
     );
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
-    await act(async () => {
-      await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
-        payload: undefined,
-      });
-    });
-
-    await waitFor(() => expect(mocks.startRecording).toHaveBeenCalledOnce());
+    await fireMeetingStartUntilRecording();
+    expect(mocks.startRecording).toHaveBeenCalledOnce();
     expect(screen.getByLabelText("Meeting title")).toHaveValue("First note");
 
     await act(async () => {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -207,17 +207,26 @@ describe("notes recording reliability", () => {
       expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true),
     );
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
-    await act(async () => {
-      await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
-        payload: undefined,
-      });
-    });
-    await waitFor(() =>
+    // The meeting-start listener silently drops events until the effect
+    // re-subscribes with bootstrapped=true — and that happens in a passive
+    // effect of a commit made outside act (getNote's resolution), so on slow
+    // (coverage) runs the listener in the map can still be a stale closure
+    // when we fire. Re-fire until the live listener takes the event; the
+    // calls-length guard makes a successful start fire exactly once, so this
+    // can never double-start a recording.
+    await waitFor(async () => {
+      if (mocks.startRecording.mock.calls.length === 0) {
+        await act(async () => {
+          await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+            payload: undefined,
+          });
+        });
+      }
       expect(mocks.startRecording).toHaveBeenCalledWith(
         "note-1",
         "microphonePlusSystem",
-      ),
-    );
+      );
+    });
   }
 
   it("does not mark a different note transcribing when finishing a recording started elsewhere", async () => {
@@ -240,7 +249,9 @@ describe("notes recording reliability", () => {
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-2"));
 
     // The recorder bar is global, so Done is still reachable from note-2.
-    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    // findByRole: the bar re-renders while getNote("note-2") settles, so a
+    // sync query can race the view switch on slow runs.
+    await userEvent.click(await screen.findByRole("button", { name: "Done" }));
     await waitFor(() =>
       expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1"),
     );


### PR DESCRIPTION
## What

Fixes the flaky CI failure in `pnpm test:coverage`:

```
FAIL src/test/app-notes-reliability.test.tsx > does not mark a different note transcribing when finishing a recording started elsewhere
AssertionError: expected "spy" to be called with arguments: [ 'note-1', 'microphonePlusSystem' ]  — Number of calls: 0
```

## Root cause

The `MEETING_START_TRANSCRIPTION_EVENT` listener in `App.tsx` guards with `if (appBlocked || !bootstrapped) return;` and re-subscribes via an effect whenever those change. `setBootstrapped(true)` only commits after `getNote` resolves, and the re-subscription is a **passive effect of a commit made outside act** (a mock resolution), so on slow runners (CI + v8 coverage instrumentation) the test fired the event while the registered listener was still a stale closure with `bootstrapped=false` — the event was silently dropped and `startRecording` was never called. Locally the bootstrap chain resolves fast enough to win the race, which is why it only surfaced in CI.

Reproduced deterministically by delaying the `getNote` mock by 30ms — same assertion failure, 0 calls.

## Fix

- `app-notes-reliability.test.tsx` and `app-meeting-start.test.tsx` (same fragile pattern): instead of firing the event once and hoping the live listener is registered, **re-fire inside `waitFor` until the handler takes it**, guarded on `startRecording`'s call count so a successful start fires exactly once (no double-start). An empty-`act` flush was tried first and is not sufficient — the re-subscription effect of an outside-act commit can stay pending across it.
- `app-notes-reliability.test.tsx`: query the recorder bar's Done button with `findByRole` (retrying) instead of `getByRole`, since the view switch to the second note settles asynchronously.
- `tauri.conf.json`: re-formatted — the v0.0.5 release bump rewrote it with plain `JSON.stringify`, which fails `pnpm format`. Heads-up: `scripts/bump-version.mjs` will reintroduce this on every bump until it formats its output (left out of scope here).
- `.gitignore`: ignore the `coverage/` output directory.

## Validation

- With the 30ms `getNote` delay injected (the CI repro), both test files pass 5/5 consecutive runs; without the fix they fail every run.
- Clean runs: `pnpm test:coverage` (CI's exact command) — 279/279 passing; `pnpm lint`; `pnpm format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
