### PR TITLE
Fix agent chat streaming artifacts and remove dead timeline pipeline

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4569,11 +4569,16 @@ function renderMarkdownBlocks(markdown: string) {
         code.push(lines[index]);
         index += 1;
       }
-      blocks.push(
-        <pre key={`code-${key++}`}>
-          <code>{code.join("\n")}</code>
-        </pre>,
-      );
+      // Skip empty fences — including a stray trailing ``` while streaming —
+      // so we don't flash an empty code block (a bare padded gray bar).
+      const body = code.join("\n");
+      if (body.trim()) {
+        blocks.push(
+          <pre key={`code-${key++}`}>
+            <code>{body}</code>
+          </pre>,
+        );
+      }
       continue;
     }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -83,10 +83,8 @@ import {
   toggleHermesBridgeSkill,
   toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform,
-  type AgentMessageDto,
   type AgentTaskDto,
   type AgentTaskStatus,
-  type AgentToolEventDto,
   type HermesBridgeStatus,
   type HermesFilesystemEntry,
   type HermesFilesystemSnapshot,
@@ -132,7 +130,6 @@ import { messageFromError } from "../../lib/errors";
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
-  toolEventKey,
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
@@ -2654,252 +2651,6 @@ export function AgentWorkspace({
   );
 }
 
-type TimelineItem =
-  | { kind: "message"; createdAt: string; message: AgentMessageDto }
-  | { kind: "tool"; createdAt: string; event: AgentToolEventDto }
-  | { kind: "hermes-message"; createdAt: string; item: HermesMessageItem }
-  | { kind: "hermes-note"; createdAt: string; item: HermesNoteItem }
-  | { kind: "hermes-tool"; createdAt: string; item: HermesToolItem };
-
-type HermesMessageItem = {
-  id: string;
-  text: string;
-  status: "running" | "completed";
-};
-
-type HermesNoteItem = {
-  id: string;
-  label: string;
-  text: string;
-  status: "running" | "completed";
-};
-
-type HermesToolItem = {
-  id: string;
-  name: string;
-  text: string;
-  status: "running" | "completed" | "failed";
-};
-
-function mergeTimeline(
-  messages: AgentMessageDto[],
-  toolEvents: AgentToolEventDto[],
-  hermesEvents: LiveHermesEvent[] = [],
-): TimelineItem[] {
-  return [
-    ...messages.map((message) => ({
-      kind: "message" as const,
-      createdAt: message.createdAt,
-      message,
-    })),
-    ...toolEvents.map((event) => ({
-      kind: "tool" as const,
-      createdAt: event.createdAt,
-      event,
-    })),
-    ...normalizeHermesEvents(hermesEvents),
-  ].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-}
-
-function normalizeHermesEvents(events: LiveHermesEvent[]): TimelineItem[] {
-  const items: TimelineItem[] = [];
-  let currentMessage:
-    | (HermesMessageItem & { createdAt: string; lastText?: string })
-    | null = null;
-  let currentNote:
-    | (HermesNoteItem & { createdAt: string; lastText?: string })
-    | null = null;
-  const tools = new Map<
-    string,
-    HermesToolItem & { createdAt: string; lastText?: string }
-  >();
-
-  const flushMessage = () => {
-    const message = currentMessage;
-    if (!message) return;
-    const text = collapseRepeatedMessageText(message.text);
-    if (!text.trim()) {
-      currentMessage = null;
-      return;
-    }
-    const previous = items.at(-1);
-    if (
-      previous?.kind === "hermes-message" &&
-      sameMessageText(previous.item.text, text)
-    ) {
-      previous.item.status = message.status;
-      currentMessage = null;
-      return;
-    }
-    items.push({
-      kind: "hermes-message",
-      createdAt: message.createdAt,
-      item: {
-        id: message.id,
-        text,
-        status: message.status,
-      },
-    });
-    currentMessage = null;
-  };
-
-  const flushNote = () => {
-    if (!currentNote?.text.trim()) {
-      currentNote = null;
-      return;
-    }
-    items.push({
-      kind: "hermes-note",
-      createdAt: currentNote.createdAt,
-      item: {
-        id: currentNote.id,
-        label: currentNote.label,
-        text: currentNote.text.trim(),
-        status: currentNote.status,
-      },
-    });
-    currentNote = null;
-  };
-
-  for (const event of events) {
-    const text = eventText(event);
-    if (event.type === "message.start") {
-      flushMessage();
-      currentMessage = {
-        id: `message:${event.receivedAt}`,
-        createdAt: event.receivedAt,
-        text: "",
-        status: "running",
-      };
-      continue;
-    }
-    if (event.type === "message.delta") {
-      flushNote();
-      if (!currentMessage) {
-        currentMessage = {
-          id: `message:${event.receivedAt}`,
-          createdAt: event.receivedAt,
-          text: "",
-          status: "running",
-        };
-      }
-      currentMessage.text = appendMessageText(currentMessage.text, text);
-      currentMessage.lastText = text;
-      continue;
-    }
-    if (event.type === "message.complete") {
-      flushNote();
-      if (!currentMessage) {
-        currentMessage = {
-          id: `message:${event.receivedAt}`,
-          createdAt: event.receivedAt,
-          text: "",
-          status: "completed",
-        };
-      }
-      if (text) {
-        currentMessage.text = completeMessageText(currentMessage.text, text);
-      }
-      currentMessage.status = "completed";
-      flushMessage();
-      continue;
-    }
-    if (event.type === "thinking.delta" || event.type === "reasoning.delta") {
-      flushMessage();
-      if (!text || text === event.type) continue;
-      const label = event.type === "thinking.delta" ? "Thinking" : "Reasoning";
-      if (!currentNote || currentNote.label !== label) {
-        flushNote();
-        currentNote = {
-          id: `${event.type}:${event.receivedAt}`,
-          createdAt: event.receivedAt,
-          label,
-          text: "",
-          status: "running",
-        };
-      }
-      currentNote.text = appendLogText(currentNote.text, text);
-      currentNote.lastText = text;
-      continue;
-    }
-    if (event.type.startsWith("tool.")) {
-      flushMessage();
-      flushNote();
-      const payload = event.payload as Record<string, unknown> | undefined;
-      const key = toolEventKey(event);
-      const status = event.type.includes("complete")
-        ? "completed"
-        : event.type.includes("error") || event.type.includes("fail")
-          ? "failed"
-          : "running";
-      const name =
-        stringValue(payload?.name) ??
-        stringValue(payload?.tool_name) ??
-        stringValue(payload?.tool) ??
-        "Tool";
-      const item =
-        tools.get(key) ??
-        ({
-          id: key,
-          createdAt: event.receivedAt,
-          name: humanizeToolName(name),
-          text: "",
-          status,
-        } satisfies HermesToolItem & { createdAt: string });
-      item.status = status;
-      item.name = humanizeToolName(name);
-      if (text && text !== item.lastText) {
-        item.text = appendLogText(item.text, text);
-        item.lastText = text;
-      }
-      tools.set(key, item);
-      continue;
-    }
-    if (event.type === "error" && text) {
-      flushMessage();
-      flushNote();
-      items.push({
-        kind: "hermes-note",
-        createdAt: event.receivedAt,
-        item: {
-          id: `error:${event.receivedAt}`,
-          label: "Error",
-          text,
-          status: "completed",
-        },
-      });
-    }
-  }
-
-  flushMessage();
-  flushNote();
-  for (const tool of tools.values()) {
-    if (!tool.text.trim()) continue;
-    items.push({
-      kind: "hermes-tool",
-      createdAt: tool.createdAt,
-      item: {
-        id: tool.id,
-        name: tool.name,
-        text: tool.text.trim(),
-        status: tool.status,
-      },
-    });
-  }
-  return items;
-}
-
-function completedHermesMessageText(events: LiveHermesEvent[]) {
-  const message = normalizeHermesEvents(events)
-    .filter(
-      (item): item is Extract<TimelineItem, { kind: "hermes-message" }> =>
-        item.kind === "hermes-message",
-    )
-    .at(-1);
-  if (!message || message.item.status !== "completed") return "";
-  return message.item.text.trim();
-}
-
 function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
   if (!privacyBadge) return null;
   return (
@@ -4475,71 +4226,6 @@ function MarkdownContent({ markdown }: { markdown: string }) {
   return <div className="agent-markdown">{renderMarkdownBlocks(markdown)}</div>;
 }
 
-function ToolEventRow({ event }: { event: AgentToolEventDto }) {
-  return (
-    <AgentToolDisclosure
-      name={event.toolName.replaceAll("_", " ")}
-      status={event.status}
-      text={event.summary}
-      redacted={event.redacted}
-      statusNode={
-        event.status === "completed" ? null : (
-          <StatusPill status={toolStatusToTaskStatus(event.status)} compact />
-        )
-      }
-    />
-  );
-}
-
-function HermesMessageRow({ item }: { item: HermesMessageItem }) {
-  return (
-    <article className="agent-hermes-message" data-status={item.status}>
-      <MarkdownContent markdown={item.text} />
-    </article>
-  );
-}
-
-function HermesToolRow({ item }: { item: HermesToolItem }) {
-  return (
-    <AgentToolDisclosure
-      name={item.name}
-      status={item.status}
-      text={item.text}
-      statusNode={
-        item.status === "completed" ? null : item.status === "failed" ? (
-          <span className="agent-tool-live-status" data-status="failed">
-            Failed
-          </span>
-        ) : (
-          <span
-            className="agent-tool-spinner"
-            role="status"
-            aria-label="Running"
-            title="Running"
-          >
-            <PangolinSpinner />
-          </span>
-        )
-      }
-    />
-  );
-}
-
-function HermesNoteRow({ item }: { item: HermesNoteItem }) {
-  const running = item.status === "running";
-  const preview = item.text.replace(/\s+/g, " ").trim();
-  const label = running ? item.label : preview || item.label;
-  return (
-    <details className="agent-hermes-note" data-status={item.status}>
-      <summary>
-        <span className={running ? "text-shimmer" : undefined}>{label}</span>
-        <IconChevronDownSmall size={14} className="agent-disclosure-chevron" />
-      </summary>
-      <MarkdownContent markdown={item.text} />
-    </details>
-  );
-}
-
 function renderMarkdownBlocks(markdown: string) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const blocks: ReactNode[] = [];
@@ -4773,75 +4459,6 @@ function eventText(event: HermesGatewayEvent) {
     if (value) return value;
   }
   return "";
-}
-
-function appendMessageText(current: string, next: string) {
-  if (!next.trim()) return current;
-  if (!current) return next;
-  if (next.startsWith(current)) return next;
-  if (current.endsWith(next)) return current;
-  return `${current}${next}`;
-}
-
-function completeMessageText(current: string, complete: string) {
-  if (!complete.trim()) return current;
-  if (!current.trim()) return complete;
-  if (complete.trim() === current.trim()) return current;
-  if (complete.includes(current.trim()) || complete.length >= current.length) {
-    return complete;
-  }
-  return appendMessageText(current, complete);
-}
-
-function collapseRepeatedMessageText(value: string) {
-  let text = value.trim();
-  if (!text) return "";
-
-  for (;;) {
-    const match = text.match(/^([\s\S]+?)\s+\1$/);
-    if (!match?.[1]) break;
-    text = match[1].trim();
-  }
-
-  const paragraphs = text.split(/\n{2,}/);
-  const dedupedParagraphs = paragraphs.filter((paragraph, index) => {
-    if (index === 0) return true;
-    return !sameMessageText(paragraph, paragraphs[index - 1] ?? "");
-  });
-  text = dedupedParagraphs.join("\n\n").trim();
-
-  const lines = text.split("\n");
-  const dedupedLines = lines.filter((line, index) => {
-    if (index === 0) return true;
-    return !sameMessageText(line, lines[index - 1] ?? "");
-  });
-  text = dedupedLines.join("\n").trim();
-
-  const half = Math.floor(text.length / 2);
-  const left = text.slice(0, half).trim();
-  const right = text.slice(half).trim();
-  if (left && sameMessageText(left, right)) return left;
-
-  return text;
-}
-
-function sameMessageText(left: string, right: string) {
-  return normalizeMessageText(left) === normalizeMessageText(right);
-}
-
-function normalizeMessageText(value: string) {
-  return value.replace(/\s+/g, " ").trim();
-}
-
-function appendLogText(current: string, next: string) {
-  if (!next.trim()) return current;
-  if (!current) return next;
-  if (current.endsWith(next)) return current;
-  const separator =
-    /\n$/.test(current) || /^\s/.test(next) || /^[.,!?;:]/.test(next)
-      ? ""
-      : "\n";
-  return `${current}${separator}${next}`;
 }
 
 function stringValue(value: unknown, preserveWhitespace = false) {
@@ -5282,24 +4899,6 @@ function messagingTrimEdits(edits: Record<string, string>) {
   );
 }
 
-function StatusPill({
-  status,
-  compact = false,
-}: {
-  status: AgentTaskStatus;
-  compact?: boolean;
-}) {
-  return (
-    <span
-      className="agent-status-pill"
-      data-status={status}
-      data-compact={compact}
-    >
-      {statusLabel(status)}
-    </span>
-  );
-}
-
 function ActivityIndicator({
   active,
   large = false,
@@ -5332,28 +4931,6 @@ function AgentThinking() {
       <span className="text-shimmer agent-thinking-label">Thinking…</span>
     </div>
   );
-}
-
-function toolStatusToTaskStatus(
-  status: AgentToolEventDto["status"],
-): AgentTaskStatus {
-  if (status === "completed") return "completed";
-  if (status === "failed") return "failed";
-  if (status === "running" || status === "proposed") return "running";
-  return "waitingForUser";
-}
-
-function isTaskActive(status: AgentTaskStatus) {
-  return status === "queued" || status === "running";
-}
-
-function statusLabel(status: AgentTaskStatus) {
-  switch (status) {
-    case "waitingForUser":
-      return "Waiting";
-    default:
-      return status[0].toUpperCase() + status.slice(1);
-  }
 }
 
 function taskActivitySummary(task: AgentTaskDto) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -488,15 +488,13 @@ function completeAssistantTextPart(parts: AgentChatPart[], text: string) {
   // The gateway builds the authoritative complete text by concatenating its
   // internal chunks, which can trim each chunk (dropping a boundary space the
   // live stream delivered correctly — "explore it." -> "exploreit.") or lag
-  // behind the stream. The streamed deltas are appended verbatim, so when the
-  // two agree apart from whitespace — or `text` is just a shorter prefix of
-  // what already streamed — keep the verbatim stream instead of overwriting it
-  // with the lossy/truncated payload.
-  const sansWhitespace = (value: string) => value.replace(/\s+/g, "");
-  if (
-    sansWhitespace(streamed) === sansWhitespace(text) ||
-    streamed.startsWith(text)
-  ) {
+  // behind the stream. The streamed deltas are appended verbatim, so when
+  // `text` equals the stream with whitespace *removed* — the signature of
+  // joining trimmed chunks — or is just a shorter prefix of it, keep the
+  // verbatim stream instead of overwriting it with the lossy/truncated
+  // payload. Whitespace that was *changed* (a streamed newline arriving as a
+  // space, say) is a genuine correction and falls through to reconciliation.
+  if (whitespaceLossyCopyOf(streamed, text) || streamed.startsWith(text)) {
     for (const part of textParts) part.status = "complete";
     return;
   }
@@ -517,6 +515,23 @@ function completeAssistantTextPart(parts: AgentChatPart[], text: string) {
   for (const part of earlier) {
     part.status = "complete";
   }
+}
+
+// True when `complete` can be derived from `streamed` purely by deleting
+// whitespace characters. Deliberately rejects whitespace substitutions:
+// deletions are the only damage joining trimmed chunks can do, so anything
+// else is a real edit the caller should honor.
+function whitespaceLossyCopyOf(streamed: string, complete: string) {
+  let from = 0;
+  for (let to = 0; to < complete.length; to += 1) {
+    while (from < streamed.length && streamed[from] !== complete[to]) {
+      if (!/\s/.test(streamed[from] as string)) return false;
+      from += 1;
+    }
+    if (from >= streamed.length) return false;
+    from += 1;
+  }
+  return !streamed.slice(from).trim();
 }
 
 function appendReasoningPart(parts: AgentChatPart[], delta: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -484,6 +484,22 @@ function completeAssistantTextPart(parts: AgentChatPart[], text: string) {
   const last = textParts[textParts.length - 1] as AgentChatTextPart;
   const earlier = textParts.slice(0, -1);
   const earlierText = earlier.map((part) => part.text).join("");
+  const streamed = earlierText + last.text;
+  // The gateway builds the authoritative complete text by concatenating its
+  // internal chunks, which can trim each chunk (dropping a boundary space the
+  // live stream delivered correctly — "explore it." -> "exploreit.") or lag
+  // behind the stream. The streamed deltas are appended verbatim, so when the
+  // two agree apart from whitespace — or `text` is just a shorter prefix of
+  // what already streamed — keep the verbatim stream instead of overwriting it
+  // with the lossy/truncated payload.
+  const sansWhitespace = (value: string) => value.replace(/\s+/g, "");
+  if (
+    sansWhitespace(streamed) === sansWhitespace(text) ||
+    streamed.startsWith(text)
+  ) {
+    for (const part of textParts) part.status = "complete";
+    return;
+  }
   if (!earlier.length) {
     last.text = text;
   } else if (text.startsWith(earlierText)) {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -438,6 +438,56 @@ describe("Agent chat runtime", () => {
     ).toEqual(["tool", "The authoritative answer."]);
   });
 
+  it("keeps the verbatim stream when the complete text drops a boundary space", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { text: "Let me explore it." },
+        },
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { text: "Let me exploreit." },
+        },
+      ],
+    );
+
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["Let me explore it."]);
+  });
+
+  it("does not truncate streamed text when the complete payload lags behind", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { text: "Here is the full answer." },
+        },
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { text: "Here is the full" },
+        },
+      ],
+    );
+
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["Here is the full answer."]);
+  });
+
   it("assigns unique turn ids to turns created in the same millisecond", () => {
     const receivedAt = "2026-06-04T10:00:00.000Z";
     const turns = buildAgentChatTurns(

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -463,6 +463,31 @@ describe("Agent chat runtime", () => {
     ).toEqual(["Let me explore it."]);
   });
 
+  it("honors a complete payload that corrects streamed whitespace", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.delta",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { text: "return\nvalue" },
+        },
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { text: "return value" },
+        },
+      ],
+    );
+
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["return value"]);
+  });
+
   it("does not truncate streamed text when the complete payload lags behind", () => {
     const turns = buildAgentChatTurns(
       [],


### PR DESCRIPTION
Fixes two visual bugs in the agent chat: an empty/unterminated markdown code fence (common mid-stream) rendered as a bare full-width gray bar, and the gateway's lossy `message.complete` payload overwrote correct streamed text — dropping boundary spaces ("explore it." → "exploreit.") or truncating the tail. The renderer now skips empty fences, and reconciliation keeps the verbatim stream when the authoritative text differs only in whitespace or is a shorter prefix, with regression tests for both. Also removes the dead legacy Hermes timeline pipeline (~420 lines: `mergeTimeline`, `normalizeHermesEvents`, unrendered row components, and their helpers), which carried a worse copy of the same reconciliation bug. Verified with tsc, prettier, and the full vitest suite (281 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)