### PR TITLE
Open the trial portal through Rust — webview anchors go nowhere

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,7 +145,8 @@ pub fn run() {
             os_accounts::os_accounts_login,
             os_accounts::os_accounts_cancel_login,
             os_accounts::os_accounts_logout,
-            os_accounts::os_accounts_top_up
+            os_accounts::os_accounts_top_up,
+            os_accounts::os_accounts_open_portal
         ])
         .manage(hermes_bridge::HermesBridge::default())
         .manage(os_accounts::LoginFlow::default())

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -389,6 +389,22 @@ pub fn os_accounts_top_up() -> Result<(), AppError> {
     open_in_browser(cfg.accounts_url.trim_end_matches('/'))
 }
 
+/// Opens the accounts portal in the default browser. The webview swallows
+/// `target="_blank"` anchors, so any in-app "go to the portal" affordance
+/// (trial gate, billing) must route through this command.
+#[tauri::command]
+pub fn os_accounts_open_portal() -> Result<(), AppError> {
+    let cfg = Config::load();
+    let url = cfg.accounts_url.trim_end_matches('/');
+    if url.is_empty() {
+        return Err(AppError::new(
+            "os_accounts_unconfigured",
+            "OS Accounts is not configured for this build.",
+        ));
+    }
+    open_in_browser(url)
+}
+
 /// Register the deep-link handler at app setup. Drains any in-flight
 /// login's callback slot when an `osscribe://auth/callback?...` URL
 /// arrives — works in both cold-launch (OS starts the app with the URL)

--- a/src/components/account/TrialGate.tsx
+++ b/src/components/account/TrialGate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { osAccountsOpenPortal } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 
 type Props = {
@@ -19,11 +20,24 @@ const POLL_INTERVAL_MS = 10_000;
  * subscription to become active. */
 export function TrialGate({ account, onRefresh, onSignOut }: Props) {
   const [checking, setChecking] = useState(false);
+  const [status, setStatus] = useState<string>();
   // No fallback: portalUrl mirrors this build's accounts_url, and a hardcoded
   // production URL would silently send dev/staging builds to the prod portal.
+  // Presence only gates the button; the actual navigation goes through Rust
+  // (os_accounts_open_portal) because the webview swallows _blank anchors.
   const portalUrl = account.portalUrl;
   const handle = account.user?.handle;
   const pastDue = account.subscription?.status === "past_due";
+
+  async function handleOpenPortal() {
+    setStatus(undefined);
+    try {
+      await osAccountsOpenPortal();
+      setStatus("Opened your account portal in the browser.");
+    } catch (error) {
+      setStatus(messageFromError(error));
+    }
+  }
 
   useEffect(() => {
     const interval = window.setInterval(() => {
@@ -55,14 +69,13 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
 
         <div className="welcome-providers">
           {portalUrl ? (
-            <a
+            <button
+              type="button"
               className="primary-action"
-              href={portalUrl}
-              target="_blank"
-              rel="noreferrer"
+              onClick={() => void handleOpenPortal()}
             >
               {pastDue ? "Manage billing" : "Start free trial"}
-            </a>
+            </button>
           ) : (
             <p className="welcome-status welcome-status-info">
               The accounts portal is not configured for this build.
@@ -78,6 +91,8 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
           </button>
         </div>
 
+        {status ? <p className="welcome-status">{status}</p> : null}
+
         <p className="welcome-terms">
           {handle ? <>Signed in as @{handle}. </> : null}
           <button
@@ -91,4 +106,11 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
       </div>
     </div>
   );
+}
+
+function messageFromError(error: unknown) {
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1042,6 +1042,12 @@ export async function osAccountsTopUp() {
   return invoke<void>("os_accounts_top_up");
 }
 
+/** Opens the accounts portal in the default browser — the webview swallows
+ * target="_blank" anchors, so portal navigation must go through Rust. */
+export async function osAccountsOpenPortal() {
+  return invoke<void>("os_accounts_open_portal");
+}
+
 export async function dictationSettings() {
   return invoke<DictationSettingsResponse>("dictation_settings");
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9216,16 +9216,7 @@ input:focus-visible,
   text-underline-offset: 2px;
 }
 
-/* Trial gate — same card chrome as the sign-in gate; the primary action is
- * an anchor (opens the portal in the browser), so it inherits .primary-action
- * with the link reset below. */
-.welcome-providers a.primary-action {
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
+/* Trial gate — same card chrome as the sign-in gate. */
 .trial-gate-refresh {
   margin-top: var(--sp-2);
 }


### PR DESCRIPTION
Clicking **Start free trial** on the trial gate did nothing: the action was a `target="_blank"` anchor, and this webview has no opener plugin, so blank-target anchors are silently swallowed (the Terms/Privacy links in the sign-in gate share this defect — follow-up material).

Fix: new `os_accounts_open_portal` Tauri command using the same `open_in_browser` path that login and top-up already use; the gate's button invokes it and surfaces failures ("OS Accounts is not configured…") on the card. Removed the now-dead anchor CSS reset.

Verified: `cargo check`, `tsc`, gate tests 10/10, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)