### PR TITLE
Add shared Conductor config; retire legacy conductor.json

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,29 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+
+# Shared Conductor config for the os-june Tauri desktop app. Committed so every
+# workspace of this repo (and the os-scribe checkouts of the same remote) loads
+# the same setup/run behavior. Supersedes the legacy conductor.json, which only
+# defined `run` + `runScriptMode`.
+
+[scripts]
+# pnpm is the repo's declared package manager (packageManager: pnpm@9.15.4).
+# Installs the front-end deps; the Rust crates (src-tauri, scribe-api) compile
+# on the first `tauri:dev` run. The .env files are copied in via
+# .worktreeinclude, so setup doesn't need to handle them.
+setup = "pnpm install"
+
+# Launch the Tauri desktop app in dev (migrated verbatim from conductor.json).
+# `tauri:dev` also starts the scribe-api backend via the beforeDevCommand hook.
+# The Vite dev server binds a fixed strictPort (127.0.0.1:1421, hardcoded in
+# both vite.config.ts and tauri.conf.json's devUrl), so the port is NOT
+# CONDUCTOR_PORT-configurable — leaving it fixed is intentional.
+run = "pnpm tauri:dev"
+
+# One workspace at a time: the fixed strictPort 1421 can't be shared (the
+# before-dev script even stops Vite from other workspaces), and each run opens
+# a native app window. Carried over from the legacy runScriptMode.
+run_mode = "nonconcurrent"
+
+# On archive, reclaim the large regenerable Rust build caches (gitignored and
+# rebuilt on the next dev run). `|| true` keeps archiving from ever failing.
+archive = "rm -rf src-tauri/target scribe-api/target || true"

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,0 @@
-{
-  "scripts": {
-    "run": "pnpm tauri:dev"
-  },
-  "runScriptMode": "nonconcurrent"
-}


### PR DESCRIPTION
## What

Migrates the repo's Conductor setup from the legacy `conductor.json` to the committed, teammate-shareable `.conductor/settings.toml` (stamped with the repo settings schema), and fills out the script table:

- `setup = "pnpm install"` — pnpm is the declared package manager; Rust crates compile on first run. Env files are copied per-workspace by the existing `.worktreeinclude` (unchanged).
- `run = "pnpm tauri:dev"` — carried over verbatim; also boots scribe-api via the `beforeDevCommand` hook.
- `run_mode = "nonconcurrent"` — carried over, and matches reality: the dev server is pinned to strictPort 1421 in both `vite.config.ts` and `tauri.conf.json`, and `scripts/tauri-before-dev.sh` actively stops Vite from other workspaces.
- `archive` — clears the regenerable `src-tauri/target` / `scribe-api/target` caches when a workspace is archived.

No `CONDUCTOR_PORT` on purpose: the port is hardcoded end-to-end, so it isn't configurable.

## Why

Once merged, anyone opening this repo in Conductor gets working Setup/Run buttons with zero manual setup. TOML supersedes the JSON, so the legacy file is removed to avoid drift.

## Validation

`taplo lint` passes against the stamped schema; all four script keys parse. After merge: create a fresh Conductor workspace and confirm Run launches the app on port 1421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)