### PR TITLE
Warm intro-screen fade + scoped chat-bar handoff animation

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -675,6 +675,11 @@ export function AgentWorkspace({
   const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>({});
   const hydratedTaskIdsRef = useRef<Set<string>>(new Set());
   const newSessionModeRef = useRef(false);
+  // True only while a brand-new thread is being started from the hero. The
+  // hero→dock composer FLIP keys off this so it glides *only* when the empty
+  // chat hands over to a fresh thread — not when the hero is dismissed by
+  // selecting an existing chat from the sidebar (that should swap instantly).
+  const heroExitViaThreadRef = useRef(false);
   const sessionTitleOverridesRef = useRef<Record<string, string>>({});
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -849,6 +854,11 @@ export function AgentWorkspace({
   const heroMode =
     !gallerySections &&
     (newSessionMode || (!selectedHermesSessionId && !selectedTask));
+  // Holds the prior render's heroMode. Read by both the composer auto-grow
+  // effect (to skip its glide across a hero transition) and the hero→dock FLIP
+  // below (to detect the hero handoff); the FLIP effect, which runs last, is
+  // what advances it each render.
+  const prevHeroModeRef = useRef(heroMode);
 
   // Full mode is an opt-in made per new session, so the toggle re-arms to off
   // every time the hero is entered — it never carries over from the last one.
@@ -1300,6 +1310,14 @@ export function AgentWorkspace({
     ) {
       return;
     }
+    // The height is already applied above; only the glide is conditional. On a
+    // hero transition the composer changes shape (hero is full-width/taller),
+    // but we don't want to grow-animate that: entering the hero or swapping it
+    // for an existing chat should be instant, and on thread-start the hero→dock
+    // FLIP below owns the box animation — running both leaves two height
+    // animations fighting over the same box. prevHeroModeRef holds the prior
+    // render's heroMode (the FLIP effect updates it, and runs after this one).
+    if (prevHeroModeRef.current !== heroMode) return;
     // Animate the box open/closed. Its content is bottom-anchored
     // (justify-content: flex-end) and clipped (overflow: hidden), so the
     // toolbar stays pinned to the bottom edge while the top edge glides up to
@@ -1635,6 +1653,10 @@ export function AgentWorkspace({
     if (!runtimeSessionId)
       throw new Error("Hermes did not resume the session.");
     const createdAt = new Date().toISOString();
+    // A new session (no target id) means the hero is handing over to a fresh
+    // thread — arm the composer glide. Sending into an existing session leaves
+    // the flag alone so a later hero dismissal via the sidebar stays instant.
+    if (!targetSessionId) heroExitViaThreadRef.current = true;
     newSessionModeRef.current = false;
     setNewSessionMode(false);
     setRuntimeSessionIds((current) => ({
@@ -2628,7 +2650,6 @@ export function AgentWorkspace({
   // While the hero is up, every render snapshots the box; the first render
   // after leaving measures the docked position and animates the delta.
   const heroExitRectRef = useRef<DOMRect | null>(null);
-  const prevHeroModeRef = useRef(heroMode);
   useLayoutEffect(() => {
     const wasHero = prevHeroModeRef.current;
     prevHeroModeRef.current = heroMode;
@@ -2636,11 +2657,19 @@ export function AgentWorkspace({
     if (!box) return;
     if (heroMode) {
       heroExitRectRef.current = box.getBoundingClientRect();
+      // Clear any stale intent while the hero is up so a sidebar dismissal
+      // can't inherit a glide armed by an earlier (failed) submit.
+      heroExitViaThreadRef.current = false;
       return;
     }
     const prev = heroExitRectRef.current;
     heroExitRectRef.current = null;
     if (!wasHero || !prev) return;
+    // Only glide when the hero handed over to a fresh thread. Leaving the hero
+    // because the user opened an existing chat should swap in place.
+    const viaThread = heroExitViaThreadRef.current;
+    heroExitViaThreadRef.current = false;
+    if (!viaThread) return;
     if (
       typeof box.animate !== "function" ||
       (typeof window.matchMedia === "function" &&
@@ -2944,6 +2973,7 @@ export function AgentWorkspace({
       className="agent-workspace"
       aria-label="Agent"
       data-artifact-panel={artifactPanel ? "open" : undefined}
+      data-hero={heroMode ? "true" : undefined}
     >
       {!newSessionMode && !selectedHermesSessionId && selectedTask ? null : (
         <AgentSessionBar

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -303,6 +303,13 @@ input:focus-visible,
     transparent 30%,
     color-mix(in oklch, var(--brand) 11%, transparent) 100%
   );
+  /* Hairline of card-white inset around the wash: keeps a crisp rim where the
+   * terracotta meets the card edge instead of smearing into the grey shell
+   * (and the card's faint dark inset ring) behind it. Card-derived rather
+   * than literal white so it stays a quiet inner highlight in dark mode.
+   * Rides this layer so it shares the fade's radius, bounds, and opacity. */
+  border-radius: var(--r-window);
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--card) 70%, transparent);
   transition: opacity 280ms var(--ease-out);
 }
 
@@ -4323,6 +4330,14 @@ input:focus-visible,
   bottom: 0;
   height: 96px;
   background: linear-gradient(to bottom, transparent, var(--card) 78%);
+  /* Keep the hero handoff smooth in the no-scroll-timeline fallback: without
+   * this, the overlay snaps to full opacity the frame the hero's :has() rule
+   * below stops matching, flashing white over the warm wash mid-fade. Matches
+   * the wash's 280ms fade; lives here (not on the :has() rule) because the
+   * exit transition must survive the rule un-matching. In the @supports path
+   * the scroll-driven animation overrides this, as animations beat
+   * transitions. */
+  transition: opacity 280ms var(--ease-out);
 }
 
 /* New-session hero: no scrolling content to dissolve, and the scroll timeline
@@ -4331,6 +4346,12 @@ input:focus-visible,
  * white. Hide it for the hero; it returns with the conversation scroller. */
 .main-panel:has(.agent-workspace[data-hero="true"])::after {
   opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .main-panel::after {
+    transition: none;
+  }
 }
 
 @supports (animation-timeline: scroll()) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -264,6 +264,12 @@ input:focus-visible,
  * see .agent-scroll. This means filling the card exactly — not growing past it —
  * so .agent-scroll has a bounded height to scroll within. */
 .agent-workspace {
+  position: relative;
+  /* Own stacking context so the warm fade below (z-index:-1) stays local —
+   * above this element's own (transparent) background, beneath the hero
+   * content. Without it the negative layer falls behind the opaque .main-panel
+   * card and never shows. */
+  isolation: isolate;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -272,6 +278,36 @@ input:focus-visible,
   min-width: 0;
   min-height: 0;
   margin: 0 auto;
+}
+
+/* New-session warmth: a whisper of brand orange welling up from the bottom of
+ * the intro screen, clear at the top so the greeting and bar stay neutral.
+ * Full-bleed behind the centered hero column (z-index:-1 keeps it above the
+ * white card but under the content), and it fades on opacity so the warmth
+ * dissolves as the composer glides to its dock on thread handoff. */
+.agent-workspace::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 30%,
+    color-mix(in oklch, var(--brand) 11%, transparent) 100%
+  );
+  transition: opacity 280ms var(--ease-out);
+}
+
+.agent-workspace[data-hero="true"]::before {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-workspace::before {
+    transition: none;
+  }
 }
 
 /* Agent view: stop the card body from scrolling (the breadcrumb would scroll

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -288,7 +288,13 @@ input:focus-visible,
 .agent-workspace::before {
   content: "";
   position: absolute;
-  inset: 0;
+  /* Bleed past .main-panel-body's horizontal padding so the wash reaches the
+   * card's left/right edges and rounded corners (.main-panel clips the
+   * overflow); top/bottom already sit flush to the card in the agent view. */
+  top: 0;
+  bottom: 0;
+  left: calc(var(--sp-8) * -1);
+  right: calc(var(--sp-8) * -1);
   z-index: -1;
   pointer-events: none;
   opacity: 0;
@@ -3046,7 +3052,8 @@ input:focus-visible,
 .agent-hero-chip-icon {
   display: inline-grid;
   place-items: center;
-  color: var(--muted-foreground);
+  /* Warm terracotta to echo the new-session fade behind these chips. */
+  color: var(--brand);
 }
 
 .agent-hero-footnote {
@@ -4316,6 +4323,14 @@ input:focus-visible,
   bottom: 0;
   height: 96px;
   background: linear-gradient(to bottom, transparent, var(--card) 78%);
+}
+
+/* New-session hero: no scrolling content to dissolve, and the scroll timeline
+ * that would otherwise fade this overlay is inactive (no .agent-scroll), so it
+ * sits at full opacity and bleaches the bottom of the hero's warm wash back to
+ * white. Hide it for the hero; it returns with the conversation scroller. */
+.main-panel:has(.agent-workspace[data-hero="true"])::after {
+  opacity: 0;
 }
 
 @supports (animation-timeline: scroll()) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -282,10 +282,16 @@ input:focus-visible,
 
 /* New-session warmth: a whisper of brand orange welling up from the bottom of
  * the intro screen, clear at the top so the greeting and bar stay neutral.
- * Full-bleed behind the centered hero column (z-index:-1 keeps it above the
- * white card but under the content), and it fades on opacity so the warmth
- * dissolves as the composer glides to its dock on thread handoff. */
-.agent-workspace::before {
+ * Two stacked layers share the same bounds and fade: ::before paints the wash
+ * gradient, ::after paints the 1px inset rim that keeps the wash's edge crisp
+ * against the shell — a separate layer because the rim must dissolve toward
+ * the top alongside the wash (a bare hairline over the clear region reads as
+ * a stray border, most visibly in dark mode), and a box-shadow can only fade
+ * via a mask on its own element. Full-bleed behind the centered hero column
+ * (z-index:-1 keeps them above the card but under the content), fading on
+ * opacity as the composer glides to its dock on thread handoff. */
+.agent-workspace::before,
+.agent-workspace::after {
   content: "";
   position: absolute;
   /* Bleed past .main-panel-body's horizontal padding so the wash reaches the
@@ -298,27 +304,31 @@ input:focus-visible,
   z-index: -1;
   pointer-events: none;
   opacity: 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 30%,
-    color-mix(in oklch, var(--brand) 11%, transparent) 100%
-  );
-  /* Hairline of card-white inset around the wash: keeps a crisp rim where the
-   * terracotta meets the card edge instead of smearing into the grey shell
-   * (and the card's faint dark inset ring) behind it. Card-derived rather
-   * than literal white so it stays a quiet inner highlight in dark mode.
-   * Rides this layer so it shares the fade's radius, bounds, and opacity. */
-  border-radius: var(--r-window);
-  box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--card) 70%, transparent);
   transition: opacity 280ms var(--ease-out);
 }
 
-.agent-workspace[data-hero="true"]::before {
+.agent-workspace::before {
+  background: linear-gradient(to bottom, transparent 30%, var(--hero-wash));
+}
+
+.agent-workspace::after {
+  /* Per-theme rim colors live in tokens.css (--hero-wash-rim). The mask
+   * mirrors the wash gradient's stops so the rim emerges exactly where the
+   * warmth does. */
+  border-radius: var(--r-window);
+  box-shadow: inset 0 0 0 1px var(--hero-wash-rim);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 30%, #000 100%);
+  mask-image: linear-gradient(to bottom, transparent 30%, #000 100%);
+}
+
+.agent-workspace[data-hero="true"]::before,
+.agent-workspace[data-hero="true"]::after {
   opacity: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .agent-workspace::before {
+  .agent-workspace::before,
+  .agent-workspace::after {
     transition: none;
   }
 }
@@ -4330,21 +4340,25 @@ input:focus-visible,
   bottom: 0;
   height: 96px;
   background: linear-gradient(to bottom, transparent, var(--card) 78%);
-  /* Keep the hero handoff smooth in the no-scroll-timeline fallback: without
-   * this, the overlay snaps to full opacity the frame the hero's :has() rule
-   * below stops matching, flashing white over the warm wash mid-fade. Matches
-   * the wash's 280ms fade; lives here (not on the :has() rule) because the
-   * exit transition must survive the rule un-matching. In the @supports path
-   * the scroll-driven animation overrides this, as animations beat
-   * transitions. */
+  /* Soften any static opacity flip (e.g. leaving the agent view, where the
+   * :has() rule below holds the dissolve at 0) so the veil never pops in a
+   * single frame over content. Matches the warm wash's 280ms fade. Lives
+   * here, not on the :has() rule, because an exit transition must survive
+   * the rule un-matching; scroll-driven animation values are unaffected, as
+   * animations beat transitions. */
   transition: opacity 280ms var(--ease-out);
 }
 
-/* New-session hero: no scrolling content to dissolve, and the scroll timeline
- * that would otherwise fade this overlay is inactive (no .agent-scroll), so it
- * sits at full opacity and bleaches the bottom of the hero's warm wash back to
- * white. Hide it for the hero; it returns with the conversation scroller. */
-.main-panel:has(.agent-workspace[data-hero="true"])::after {
+/* Agent view: the dissolve is hidden at rest and only the scroll-driven
+ * animation reveals it. Whenever nothing scrolls — the hero (no .agent-scroll
+ * at all) or a conversation still too short to overflow — the scroll timeline
+ * is inactive, the keyframes don't apply, and the static opacity 1 would
+ * otherwise pin the veil over the hero's warm wash and the docked composer.
+ * With scrollable content the timeline activates and the animation overrides
+ * this (animations beat static declarations). In browsers without
+ * scroll-timeline support the agent view simply never shows the dissolve —
+ * a safe degradation, since it exists to dissolve scrolling content. */
+.main-panel:has(.main-panel-body[data-active-view="agent"])::after {
   opacity: 0;
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -149,6 +149,13 @@
    * "live/recording" primary action that wants a warmer feel. */
   --warm-soft: oklch(90% 0.07 55);
   --warm-strong: oklch(52% 0.16 38);
+  /* New-session hero wash — the warm gradient pooling at the bottom of the
+   * intro screen, with a 1px inset rim that keeps its edge crisp against the
+   * shell. The brand tint works over both cards (a subtle glow in dark), but
+   * the rim flips: card-white hairline in light, faint white inner highlight
+   * in dark — a card-derived line goes near-black there and muddies the rim. */
+  --hero-wash: color-mix(in oklch, var(--brand) 11%, transparent);
+  --hero-wash-rim: color-mix(in oklch, var(--card) 70%, transparent);
   /* Focus ring lives in the warm-grey family so it never reads as a cool
    * macOS-blue glow next to the rest of the palette. */
   --focus-ring: oklch(60% 0.03 84.59 / 22%);
@@ -241,6 +248,9 @@
   --popover-border: color-mix(in oklch, white 12%, transparent);
   --warm-soft: oklch(0.42 0.12 50);
   --warm-strong: oklch(0.86 0.16 60);
+  /* See the light-theme note: the wash tint carries over, the rim becomes a
+   * faint white inner highlight (kin to this theme's --shadow-inset). */
+  --hero-wash-rim: oklch(100% 0 none / 8%);
   --focus-ring: oklch(0.78 0.025 84.59 / 22%);
   --scrim: oklch(0% 0 none / 55%);
   /* Selection keeps the foreground white (no contrast flip) and lays a


### PR DESCRIPTION
## What

Two pieces of new-session polish:

**Warm fade on the intro screen.** The hero now shows a subtle terracotta wash (`--brand` at 11%) welling up from the bottom of the card, edge to edge:
- The workspace gets its own stacking context (`isolation: isolate`) so the `z-index: -1` gradient paints over the card instead of vanishing behind it.
- The wash bleeds past `.main-panel-body`'s 24px gutters to reach the card's edges and rounded corners.
- The card's 96px bottom dissolve overlay (`.main-panel::after`) is hidden while the hero is up — its scroll timeline is inactive there (no `.agent-scroll`) and it was bleaching the wash back to white.
- Fades out on opacity as the composer docks; disabled under reduced motion.
- Suggestion-chip icons pick up the same terracotta to echo the wash.

**Chat bar animates only on real thread starts.** The hero→dock composer FLIP fired on any hero exit, including switching to an existing chat from the sidebar. It's now armed only when `submitHermesSession` creates a brand-new session, and the flag is cleared while the hero is up so a failed submit can't leak a stale glide. The composer auto-grow effect also skips its height glide across hero transitions — it was double-animating the box against the FLIP on handoff (visible jitter).

| Action | Before | After |
|---|---|---|
| Switch to an existing chat from the hero | bar glided + height-animated | instant swap |
| Empty chat → start a thread | glide + competing height animation | single clean glide |

## Validation

- `tsc --noEmit` clean; all 32 agent-workspace tests pass.
- Verified visually in `tauri:dev`: fade fills the card to the bottom corners, dissolve overlay returns with the conversation scroller, sidebar switches are instant, thread-start glide is smooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)