### PR TITLE
Launch the app on a fresh agent session

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -161,7 +161,14 @@ export function App() {
     "none",
   );
   const [bootstrapped, setBootstrapped] = useState(false);
-  const [activeView, setActiveView] = useState<SidebarView>("notes");
+  // The app launches on a fresh agent session. The handshake is armed during
+  // state init — before AgentWorkspace's first mount consumes it — so the
+  // workspace opens on the hero instead of restoring the last open
+  // conversation.
+  const [activeView, setActiveView] = useState<SidebarView>(() => {
+    markAgentNewSessionPending();
+    return "agent";
+  });
   const [activeAgentSession, setActiveAgentSession] =
     useState<HermesSessionInfo>();
   const [pendingAgentReply, setPendingAgentReply] =
@@ -241,7 +248,6 @@ export function App() {
     refresh: refreshAccount,
     setAccount,
   } = useAccountStatus();
-  const startOnFreshNoteRef = useRef(false);
   // The note the active recording session belongs to. recordingStatus carries
   // no noteId, so without this the finish flow could only guess from the
   // currently selected note — wrong whenever the user browsed away while
@@ -315,7 +321,10 @@ export function App() {
   const handleAccountChanged = useCallback(
     (nextAccount: AccountStatus) => {
       if (signInRequired && !shouldBlockOnSignIn(nextAccount)) {
-        startOnFreshNoteRef.current = true;
+        // The launch handshake armed at state init has likely expired (15s
+        // TTL) while the user sat on the sign-in gate — re-arm it so clearing
+        // the gate still opens onto a fresh session.
+        markAgentNewSessionPending();
       }
       setAccount(nextAccount);
     },
@@ -813,14 +822,18 @@ export function App() {
         dispatch({ type: "bootstrapLoaded", payload: seeded.payload });
         if (seeded.fakeNote) {
           dispatch({ type: "noteLoaded", note: seeded.fakeNote });
+          // The fake-recovery dev flow inspects the notes list, so it skips
+          // the agent landing.
+          setActiveView("notes");
           setBootstrapped(true);
           return;
         }
-        if (startOnFreshNoteRef.current || seeded.payload.notes.length === 0) {
-          startOnFreshNoteRef.current = false;
+        // The app lands on the agent view, but a note is still selected
+        // up-front: the menu-bar meeting-start event records into the
+        // selected note without any further user input.
+        if (seeded.payload.notes.length === 0) {
           const note = await createNote(undefined);
           dispatch({ type: "noteLoaded", note });
-          setActiveView("meetings");
           setBootstrapped(true);
           return;
         }
@@ -828,8 +841,6 @@ export function App() {
         if (firstNoteId) {
           const note = await getNote(firstNoteId);
           dispatch({ type: "noteLoaded", note });
-        } else {
-          setActiveView("settings");
         }
         setBootstrapped(true);
       })

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -97,6 +97,19 @@ vi.mock("../lib/tauri", () => ({
   osAccountsTopUp: mocks.osAccountsTopUp,
   mascotShow: mocks.mascotShow,
   mascotHide: mocks.mascotHide,
+  // The agent workspace mounts at launch; a quiet, not-running bridge keeps
+  // these tests focused on the meetings surfaces.
+  hermesBridgeStatus: vi.fn(async () => ({ running: false })),
+  listAgentTasks: vi.fn(async () => ({ items: [] })),
+  providerModelSettings: vi.fn(async () => ({
+    settings: { generationModel: "" },
+  })),
+  listVeniceModels: vi.fn(async () => ({
+    mode: "generation",
+    modelType: "text",
+    selectedModel: "",
+    models: [],
+  })),
 }));
 
 const now = "2026-05-19T10:00:00Z";

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -98,6 +98,19 @@ vi.mock("../lib/tauri", () => ({
   osAccountsTopUp: mocks.osAccountsTopUp,
   mascotShow: mocks.mascotShow,
   mascotHide: mocks.mascotHide,
+  // The agent workspace mounts at launch; a quiet, not-running bridge keeps
+  // these tests focused on the meetings surfaces.
+  hermesBridgeStatus: vi.fn(async () => ({ running: false })),
+  listAgentTasks: vi.fn(async () => ({ items: [] })),
+  providerModelSettings: vi.fn(async () => ({
+    settings: { generationModel: "" },
+  })),
+  listVeniceModels: vi.fn(async () => ({
+    mode: "generation",
+    modelType: "text",
+    selectedModel: "",
+    models: [],
+  })),
 }));
 
 const now = "2026-05-19T10:00:00Z";
@@ -308,8 +321,11 @@ describe("notes recording reliability", () => {
     render(<App />);
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
-    // Open the note from the All notes list so the editor (and its failure
-    // banner) is on screen.
+    // The app launches on the agent view; open the note from the Meetings
+    // list so the editor (and its failure banner) is on screen.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Meetings" }),
+    );
     await userEvent.click(
       screen.getByRole("button", { name: /First note Preview/ }),
     );

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -86,6 +86,19 @@ vi.mock("../lib/tauri", () => ({
   osAccountsTopUp: mocks.osAccountsTopUp,
   mascotShow: mocks.mascotShow,
   mascotHide: mocks.mascotHide,
+  // The agent workspace mounts at launch; a quiet, not-running bridge keeps
+  // these tests focused on the meetings surfaces.
+  hermesBridgeStatus: vi.fn(async () => ({ running: false })),
+  listAgentTasks: vi.fn(async () => ({ items: [] })),
+  providerModelSettings: vi.fn(async () => ({
+    settings: { generationModel: "" },
+  })),
+  listVeniceModels: vi.fn(async () => ({
+    mode: "generation",
+    modelType: "text",
+    selectedModel: "",
+    models: [],
+  })),
 }));
 
 const now = "2026-05-19T10:00:00Z";
@@ -203,6 +216,8 @@ describe("App shortcuts", () => {
 
     render(<App />);
 
+    // The app launches on the agent view; the notes list is one hop away.
+    await user.click(await screen.findByRole("button", { name: "Meetings" }));
     await user.click(
       await screen.findByRole("button", { name: /^First note/ }),
     );
@@ -242,12 +257,11 @@ describe("App shortcuts", () => {
     );
 
     await waitFor(() => expect(mocks.bootstrapApp).toHaveBeenCalledOnce());
-    await waitFor(() =>
-      expect(mocks.createNote).toHaveBeenCalledWith(undefined),
-    );
-    await waitFor(() =>
-      expect(screen.getByLabelText("Meeting title")).toHaveValue(""),
-    );
+    // Clearing the gate lands on a fresh agent session, not a new note.
+    expect(
+      await screen.findByRole("heading", { name: "What can June do for you?" }),
+    ).toBeInTheDocument();
+    expect(mocks.createNote).not.toHaveBeenCalled();
   });
 
   it("does not flash the sign-in gate while account status is loading", async () => {
@@ -277,10 +291,7 @@ describe("App shortcuts", () => {
     });
 
     expect(
-      await screen.findByRole("heading", { name: "Meetings" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^First note/ }),
+      await screen.findByRole("heading", { name: "What can June do for you?" }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- First load used to land on Meetings: bootstrap either created a brand-new note (fresh installs, just-signed-in users) or opened the meetings list with the first note preloaded. The app now opens on the agent view's new-session hero.
- The new-session handshake (`markAgentNewSessionPending`) is armed during App state init — before `AgentWorkspace`'s first mount consumes it — so the workspace opens on the hero instead of restoring the last open conversation. It is re-armed when the sign-in gate clears, since the marker's 15s TTL won't outlive a sign-in flow.
- Bootstrap no longer switches views, but still creates/selects a note up-front so the menu-bar meeting-start event can record into it without further input. The dev-only fake-recovery path explicitly lands on the notes list, the surface it exists to exercise. `startOnFreshNoteRef` (fresh note after sign-in) is gone.
- App-level tests now mount `AgentWorkspace` at launch, so the three test files rendering `<App />` mock a quiet, not-running hermes bridge, and tests interacting with the notes list click "Meetings" first.

## Test plan
- [x] `npx vitest run` — 305 tests pass
- [x] `tsc --noEmit`, `prettier --check` clean
- [x] Manual: launch the app and confirm it opens on the agent hero; sign-in flow lands on the hero; menu-bar "start meeting" still records

🤖 Generated with [Claude Code](https://claude.com/claude-code)