### PR TITLE
Ban typographic dashes in user-facing copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ shell commands, and other important information, read
 ## UI conventions
 
 See the "UI conventions" section in [CLAUDE.md](CLAUDE.md) — sentence-case
-labels, design tokens from `src/styles/tokens.css`, and **icons from
-`central-icons` / `central-icons-filled` only (never lucide-react or any
-other icon set; lucide was deliberately removed from the dependencies)**.
+labels, **no en-dashes (–) or em-dashes (—) in user-facing copy** (hyphen
+or "to" for ranges; rewrite asides with a period, comma, colon, or
+parentheses), design tokens from
+`src/styles/tokens.css`, and **icons from `central-icons` /
+`central-icons-filled` only (never lucide-react or any other icon set;
+lucide was deliberately removed from the dependencies)**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,13 @@ shell commands, and other important information, read
 - **Sentence case for UI labels.** Section titles, button text, menu items, and
   tabs use sentence case ("Notes", "Filter notes", "New note") — never
   ALL CAPS / `text-transform: uppercase`. Eyebrows and pill labels included.
+- **No en-dashes (–) or em-dashes (—) in copy.** User-facing strings never
+  use typographic dashes. Ranges get a plain hyphen ("5-10 min", "Mon-Fri")
+  or the word "to". Where an em-dash would join clauses, rewrite: a period,
+  comma, colon, or parentheses, whichever reads best. This applies across
+  the board: UI labels, titles, body copy, tooltips, aria-labels,
+  notifications, empty states, error messages, HTML pages. (Code comments
+  are exempt; they're not copy.)
 - **Design tokens live in `src/styles/tokens.css`.** Reach for the variables
   there before adding hand-coded sizes, colors, radii, or motion values.
 - **Iconography:** `central-icons` ONLY — never lucide-react or any other

--- a/meeting-hud.html
+++ b/meeting-hud.html
@@ -12,7 +12,7 @@
       data-state="recording"
       role="button"
       tabindex="0"
-      aria-label="Recording — click to open June"
+      aria-label="Recording. Click to open June"
     >
       <div class="mhud-content" aria-hidden="true">
         <span class="mhud-dot"></span>

--- a/scribe-api/crates/api/src/handlers/verify.rs
+++ b/scribe-api/crates/api/src/handlers/verify.rs
@@ -51,7 +51,7 @@ fn render_page(info: &AttestationInfo) -> String {
             )
         }
         None => (
-            "<em>not stamped — local or development build</em>".to_string(),
+            "<em>not stamped (local or development build)</em>".to_string(),
             "&lt;short-sha&gt;".to_string(),
         ),
     };
@@ -71,7 +71,7 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Verify this server — @SERVICE@</title>
+<title>Verify this server · @SERVICE@</title>
 <style>
   :root {
     color-scheme: light dark;
@@ -168,7 +168,7 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
   <span class="badge">Intel TDX · Phala Cloud</span>
   <h1>Verify this server</h1>
   <p class="lede">@SERVICE@ runs inside an Intel TDX confidential VM. This page is
-  served from inside that VM and explains how to check — without trusting us —
+  served from inside that VM and explains how to check, without trusting us,
   that the code running here is exactly the public source code.</p>
 </header>
 
@@ -184,7 +184,7 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
 <h2>Why this matters</h2>
 <p>Audio, transcripts, and notes pass through this server. Because the running
 image is remotely attested, neither Phala (the platform) nor Open Software (us)
-can quietly swap it for one that reads your data — any change to the running
+can quietly swap it for one that reads your data. Any change to the running
 code is visible in the chain below.</p>
 <p>The chain has three links: <strong>source</strong> (a public git commit),
 <strong>image</strong> (a container image our CI builds from that commit, published
@@ -215,22 +215,22 @@ git tag -l 'deploy/*/@SHORT_SHA@' -n3</code></pre>
   </li>
   <li>
     <p>Read the source at that commit. The commit linked above is the exact tree
-    the image was built from — the build stamps it into the image itself.</p>
+    the image was built from. The build stamps it into the image itself.</p>
   </li>
 </ol>
 <p class="muted">This proves the running digest is the one our public CI built
-and recorded for that commit. Bit-for-bit reproducible rebuilds — regenerating
-the digest yourself instead of trusting our CI — are in progress; see
+and recorded for that commit. Bit-for-bit reproducible rebuilds (regenerating
+the digest yourself instead of trusting our CI) are in progress; see
 <a href="@REPO_URL@/blob/main/docs/reproducible-builds.md">docs/reproducible-builds.md</a>.</p>
 
 <h2>What this does not cover</h2>
-<p>The chain verifies the <strong>code</strong> running in the confidential VM —
+<p>The chain verifies the <strong>code</strong> running in the confidential VM,
 not what upstream providers do. Audio still leaves the TEE when forwarded to
 OpenAI or Venice for transcription, under those providers' own privacy
 policies. End-to-end private speech-to-text is a separate workstream.</p>
 
 <footer>
-  <p>Open Software — <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>
+  <p>Open Software · <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>
 </footer>
 </body>
 </html>

--- a/src/components/account/TrialGate.tsx
+++ b/src/components/account/TrialGate.tsx
@@ -78,9 +78,9 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
             ? "Your subscription payment didn't go through. Update your billing details to keep using June."
             : waiting
               ? checkout.usedPortalFallback
-                ? "We opened your account portal — start the free trial there. June will notice the moment you're done."
-                : "We opened a secure Stripe checkout. June will notice the moment you're done — no need to come back and click anything."
-              : "June runs on your OpenSoftware membership. Checkout opens in your browser — no charge until the trial ends, cancel anytime."}
+                ? "We opened your account portal. Start the free trial there. June will notice the moment you're done."
+                : "We opened a secure Stripe checkout. June will notice the moment you're done. No need to come back and click anything."
+              : "June runs on your OpenSoftware membership. Checkout opens in your browser. No charge until the trial ends, cancel anytime."}
         </p>
 
         <div className="welcome-providers">
@@ -128,7 +128,7 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
             disabled={checking}
             onClick={() => void handleRefresh()}
           >
-            {checking ? "Checking…" : "I've done it — check again"}
+            {checking ? "Checking…" : "I've done it, check again"}
           </button>
         </div>
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -228,7 +228,7 @@ if (import.meta.env.DEV && typeof window !== "undefined") {
       }),
     );
     return show
-      ? "Seeding sample files and opening the viewer (needs an open conversation — repeat runs add numbered copies). Run __agentFiles(false) to clear."
+      ? "Seeding sample files and opening the viewer (needs an open conversation; repeat runs add numbered copies). Run __agentFiles(false) to clear."
       : "Sample files cleared from the viewer (workspace copies remain).";
   };
 }
@@ -250,7 +250,7 @@ A sample document that exercises **bold**, *italic*, ~~strikethrough~~,
 2. Collect feedback for two weeks
 3. General availability
 
-> Blockquotes hold paragraphs, lists, or code — anything a block can.
+> Blockquotes hold anything a block can: paragraphs, lists, or code.
 
 ### Numbers
 
@@ -398,7 +398,7 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     key: "health-check",
     icon: <IconHeartBeat size={18} />,
     title: "Check my Mac's health",
-    description: "Disk, memory, login items — what needs attention.",
+    description: "Disk, memory, and login items that need attention.",
     prompt:
       "Give my Mac a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
     action: "run",
@@ -1536,7 +1536,7 @@ export function AgentWorkspace({
       const bytes = await readFileBytes(file).catch(() => {
         // Reading fails for directories, which Finder happily lets you drop.
         throw new Error(
-          `Could not read "${file.name}" — folders can't be attached.`,
+          `Could not read "${file.name}". Folders can't be attached.`,
         );
       });
       return importHermesBridgeFileBytes(file.name, bytes);
@@ -4083,7 +4083,7 @@ function AgentResponseGallery({
           </strong>
           <p>
             {errors
-              ? "Every error surface in agent chat — the banner above and the composer notice below are forced samples too."
+              ? "Every error surface in agent chat. The banner above and the composer notice below are forced samples too."
               : "Every response part type and status, for styling."}{" "}
             Close from the console with{" "}
             <code>{errors ? "__agentErrors" : "__agentGallery"}(false)</code>.

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -481,7 +481,7 @@ function GetMoreCard({
             <span className="dictation-hint-item-body">
               <span className="dictation-hint-item-name">Writing style</span>
               <span className="dictation-hint-item-desc">
-                Choose how transcriptions read — casual, standard, or formal.
+                Choose how transcriptions read: casual, standard, or formal.
               </span>
             </span>
             <span className="dictation-hint-setup">

--- a/src/components/onboarding/steps/FinishStep.tsx
+++ b/src/components/onboarding/steps/FinishStep.tsx
@@ -15,16 +15,16 @@ export function FinishStep({
       />
       <ul className="onboarding-feature-list">
         <li>
-          <strong>Dictate anywhere</strong> — hold{" "}
+          <strong>Dictate anywhere</strong>: hold{" "}
           <kbd className="onboarding-kbd">{shortcutLabel}</kbd> in any app and
           speak.
         </li>
         <li>
-          <strong>Take meeting notes</strong> — start a recording from the
+          <strong>Take meeting notes</strong>: start a recording from the
           sidebar when your next meeting begins.
         </li>
         <li>
-          <strong>Hand off a task</strong> — open the agent and ask it to
+          <strong>Hand off a task</strong>: open the agent and ask it to
           summarize a folder or research a topic.
         </li>
       </ul>

--- a/src/components/onboarding/steps/LearnSteps.tsx
+++ b/src/components/onboarding/steps/LearnSteps.tsx
@@ -22,7 +22,7 @@ export function DictationPracticeStep({
   return (
     <section className="onboarding-step">
       <StepHeading
-        title="Try it — reply by voice"
+        title="Try it: reply by voice"
         subtitle={
           <>
             Click into the message box, hold{" "}
@@ -46,7 +46,7 @@ export function DictationPracticeStep({
         />
         {succeeded ? (
           <p className="onboarding-practice-success" role="status">
-            Good work! That's all dictation is — anywhere on your Mac.
+            Good work! That's all dictation is, anywhere on your Mac.
           </p>
         ) : null}
       </div>
@@ -85,7 +85,7 @@ export function MeetingNotesStep({ onContinue }: { onContinue: () => void }) {
       </div>
       <p className="onboarding-footnote">
         Transcripts and notes stay on your Mac. The first time you record a
-        meeting, macOS will ask for system audio — that's the permission we
+        meeting, macOS will ask for system audio. That's the permission we
         mentioned earlier.
       </p>
       <StepActions onContinue={onContinue} />
@@ -98,11 +98,11 @@ export function AgentIntroStep({ onContinue }: { onContinue: () => void }) {
     <section className="onboarding-step">
       <StepHeading
         title="Hand off real work"
-        subtitle="Give June a task, not just a question. Draft the doc, dig through the files, pull the research together — the agent works on your Mac and comes back with it done."
+        subtitle="Give June a task, not just a question. Draft the doc, dig through the files, pull the research together. The agent works on your Mac and comes back with it done."
       />
       <div className="onboarding-practice-card">
         <div className="onboarding-practice-header">
-          Browser — waiting for you
+          Browser: waiting for you
         </div>
         <p className="onboarding-approval-body">
           June found the file and prepared the edit. Nothing changes until you
@@ -160,14 +160,15 @@ export function AgentHonestyStep({
         </li>
         <li>
           <h2>
-            Private inference protects your data — it doesn't approve the
+            Private inference protects your data. It doesn't approve the
             agent's actions.
           </h2>
           <p>
             When June thinks, your prompts go to zero-retention models: nothing
-            stored, nothing trained on. That's always on. When the agent acts —
-            visits a site, calls a tool, sends an email you approved — the other
-            side sees what it shares, exactly as if you'd done it yourself. June
+            stored, nothing trained on. That's always on. When the agent acts
+            (visits a site, calls a tool, sends an email you approved), the
+            other side sees what it shares, exactly as if you'd done it
+            yourself. June
             keeps your data private; it can't make the rest of the internet
             private. That's why you're the approval step.
           </p>

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -100,7 +100,7 @@ export function PermissionsStep({
             micGranted
               ? "Only while you hold the dictation key or a meeting note is recording."
               : micDenied
-                ? "Microphone access is turned off for June. Flip the toggle in System Settings, then come back — we'll notice."
+                ? "Microphone access is turned off for June. Flip the toggle in System Settings, then come back. We'll notice."
                 : "June only listens while you hold the dictation key or while a meeting note is recording."
           }
           action={
@@ -128,7 +128,7 @@ export function PermissionsStep({
           body={
             accessibilityGranted
               ? "Your spoken words land at your cursor, in any app."
-              : "Turn on June in System Settings → Privacy & Security → Accessibility, then come back — we'll notice."
+              : "Turn on June in System Settings → Privacy & Security → Accessibility, then come back. We'll notice."
           }
           action={{
             label: "Open System Settings",

--- a/src/components/onboarding/steps/PrivacySteps.tsx
+++ b/src/components/onboarding/steps/PrivacySteps.tsx
@@ -3,7 +3,7 @@ import { StepActions, StepHeading } from "../StepChrome";
 const PRIVACY_CARDS = [
   {
     title: "Local by default",
-    body: "The agent runs on your Mac, built on open-source Hermes. Your files, sessions, and memory stay on your disk — never mirrored to a cloud.",
+    body: "The agent runs on your Mac, built on open-source Hermes. Your files, sessions, and memory stay on your disk, never mirrored to a cloud.",
   },
   {
     title: "Private inference",
@@ -11,7 +11,7 @@ const PRIVACY_CARDS = [
   },
   {
     title: "Verifiable",
-    body: "Our code is open source and our backend runs in a secure enclave. You don't have to trust us — you can check.",
+    body: "Our code is open source and our backend runs in a secure enclave. You don't have to trust us. You can check.",
   },
 ];
 
@@ -37,8 +37,7 @@ export function PrivacyStep({ onContinue }: { onContinue: () => void }) {
           rel="noreferrer"
         >
           Verify it yourself
-        </a>{" "}
-        — how routing, retention, and attestation work.
+        </a>: how routing, retention, and attestation work.
       </p>
       <StepActions onContinue={onContinue} />
     </section>

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -83,15 +83,15 @@ export function SignInStep({
       />
       <ul className="onboarding-feature-list">
         <li>
-          <strong>Talk, don't type</strong> — hold a key and speak; June types
+          <strong>Talk, don't type</strong>: hold a key and speak; June types
           at your cursor in whatever app has focus.
         </li>
         <li>
-          <strong>Never take notes again</strong> — decisions, action items, and
+          <strong>Never take notes again</strong>: decisions, action items, and
           who said what, written for you.
         </li>
         <li>
-          <strong>Hand off real work</strong> — give June a task, not just a
+          <strong>Hand off real work</strong>: give June a task, not just a
           question. It comes back with it done.
         </li>
       </ul>

--- a/src/components/onboarding/steps/TrialStep.tsx
+++ b/src/components/onboarding/steps/TrialStep.tsx
@@ -55,7 +55,7 @@ export function TrialStep({
     return (
       <section className="onboarding-step">
         <StepHeading
-          title="You're in — your free trial is active"
+          title="You're in! Your free trial is active"
           subtitle="No charge until the trial ends, and you can cancel anytime from your account. Now for the fun part."
         />
         <StepActions
@@ -73,8 +73,8 @@ export function TrialStep({
           title="Finish checkout in your browser"
           subtitle={
             checkout.usedPortalFallback
-              ? "We opened your account portal — start the free trial there. June will notice the moment you're done."
-              : "We opened a secure Stripe checkout. June will notice the moment you're done — no need to come back and click anything."
+              ? "We opened your account portal. Start the free trial there. June will notice the moment you're done."
+              : "We opened a secure Stripe checkout. June will notice the moment you're done. No need to come back and click anything."
           }
         />
         <div
@@ -91,7 +91,7 @@ export function TrialStep({
             className="onboarding-skip"
             onClick={() => void checkout.checkNow()}
           >
-            I've finished — check now
+            I've finished, check now
           </button>
           <button
             type="button"
@@ -109,19 +109,19 @@ export function TrialStep({
     <section className="onboarding-step">
       <StepHeading
         title="Start your free trial"
-        subtitle="Everything you just set up — dictation, meeting notes, the agent — runs on your June membership."
+        subtitle="Everything you just set up (dictation, meeting notes, the agent) runs on your June membership."
       />
       <ul className="onboarding-feature-list">
         <li>
-          <strong>Free to start</strong> — you won't be charged until the trial
+          <strong>Free to start</strong>: you won't be charged until the trial
           ends.
         </li>
         <li>
-          <strong>Cancel anytime</strong> — one click in your account, keep
+          <strong>Cancel anytime</strong>: one click in your account, keep
           access through the trial.
         </li>
         <li>
-          <strong>One step left</strong> — checkout opens in your browser, then
+          <strong>One step left</strong>: checkout opens in your browser, then
           June brings you right back.
         </li>
       </ul>

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -200,7 +200,7 @@ export function RoutinesView({
           label="Create your first routine"
           icon={<IconArrowsRepeat size={28} />}
           title="Put June on a schedule"
-          description="Describe something June should do every morning, every hour, or at a specific time — a routine runs it for you automatically."
+          description="Describe something June should do every morning, every hour, or at a specific time. A routine runs it for you automatically."
           footer={
             <button
               type="button"
@@ -236,7 +236,7 @@ export function RoutinesView({
         onClose={() => setCreateOpen(false)}
         leading={<IconArrowsRepeat size={15} />}
         title="New routine"
-        description="Tell June what to do and when. It opens a new session to set the routine up — you can fine-tune the schedule there."
+        description="Tell June what to do and when. It opens a new session to set the routine up, and you can fine-tune the schedule there."
         footer={
           <>
             <button
@@ -277,7 +277,7 @@ export function RoutinesView({
         onClose={() => setEditTarget(null)}
         leading={<IconPencil size={15} />}
         title={`Edit “${editTarget?.name ?? ""}”`}
-        description="Tell June what should change — the schedule, the task, or the name. It opens a session to apply the update."
+        description="Tell June what should change: the schedule, the task, or the name. It opens a session to apply the update."
         footer={
           <>
             <button

--- a/src/components/settings/StyleSettingsSection.tsx
+++ b/src/components/settings/StyleSettingsSection.tsx
@@ -14,12 +14,12 @@ const SAMPLES: Record<DictationStyle, { description: string; sample: string }> =
     standard: {
       description: "Sentence case with light cleanup. Keeps your natural tone.",
       sample:
-        "Got it. Let me know when you're free to chat about the Q3 plan — happy to jump on in the morning.",
+        "Got it. Let me know when you're free to chat about the Q3 plan. Happy to jump on in the morning.",
     },
     casualLowercase: {
       description: "Lowercase sentences, contractions, minimal cleanup.",
       sample:
-        "got it. let me know when you're free to chat about the q3 plan — happy to jump on in the morning.",
+        "got it. let me know when you're free to chat about the q3 plan. happy to jump on in the morning.",
     },
     formal: {
       description:

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1196,7 +1196,7 @@ function SidebarIdentity({
         className="sidebar-nav-item sidebar-identity"
         aria-haspopup="menu"
         aria-expanded={menuOpen}
-        aria-label={`${name} — account menu`}
+        aria-label={`${name}, account menu`}
         onClick={onToggleMenu}
       >
         <span className="sidebar-nav-icon">

--- a/src/lib/agent-chat-gallery.ts
+++ b/src/lib/agent-chat-gallery.ts
@@ -101,7 +101,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     {
       label: "Assistant text (markdown)",
       description:
-        "Standard assistant prose — exercises every markdown element.",
+        "Standard assistant prose. Exercises every markdown element.",
       turns: [
         assistantTurn("text", [
           { type: "text", text: MARKDOWN_SAMPLE, status: "complete" },
@@ -116,7 +116,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
         assistantTurn("artifacts", [
           {
             type: "text",
-            text: "Done — I exported three files: the chart as `revenue-chart.png`, the write-up in `summary.md`, and the raw run output in `build-log.txt`.",
+            text: "Done. I exported three files: the chart as `revenue-chart.png`, the write-up in `summary.md`, and the raw run output in `build-log.txt`.",
             status: "complete",
           },
         ]),
@@ -143,7 +143,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Thinking — in progress",
+      label: "Thinking: in progress",
       description:
         "Reasoning + tool still running. Shows the shimmering “Thinking” disclosure and a running tool row.",
       turns: [
@@ -168,7 +168,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Thought — completed, with tools",
+      label: "Thought: completed, with tools",
       description:
         "Collapsed “Thought” disclosure folding completed + failed tool calls, followed by the answer text.",
       turns: [
@@ -194,7 +194,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
           },
           {
             type: "text",
-            text: "Done — I found two action items and added them to the recap above.",
+            text: "Done. I found two action items and added them to the recap above.",
             status: "complete",
           },
         ]),
@@ -259,7 +259,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
               type: "context",
               preview:
                 "Earlier turns were compacted; fallback summary generated without the LLM summarizer.",
-              text: "[CONTEXT COMPACTION — deterministic fallback]: Summarizer unavailable; kept the most recent turns verbatim.",
+              text: "[CONTEXT COMPACTION - deterministic fallback]: Summarizer unavailable; kept the most recent turns verbatim.",
               status: "complete",
             },
           ],
@@ -267,7 +267,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Approval — pending",
+      label: "Approval: pending",
       description:
         "Approval request awaiting a choice. Buttons: Explain first / Approve once / This session / Always / Deny.",
       turns: [
@@ -284,7 +284,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Approval — pending (no “Always”)",
+      label: "Approval: pending (no “Always”)",
       description:
         "When allowPermanent is false the “Always” button is hidden.",
       turns: [
@@ -301,7 +301,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Approval — resolved",
+      label: "Approval: resolved",
       description:
         "Each resolved outcome: approved once / session / always / denied.",
       turns: [
@@ -352,7 +352,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Clarify — pending (choices)",
+      label: "Clarify: pending (choices)",
       description:
         "Question with multiple-choice answers plus an “Other” escape hatch.",
       turns: [
@@ -368,9 +368,9 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Clarify — pending (free-form)",
+      label: "Clarify: pending (free-form)",
       description:
-        "No preset choices — renders the free-form textarea directly.",
+        "No preset choices. Renders the free-form textarea directly.",
       turns: [
         assistantTurn("clarify-freeform", [
           {
@@ -384,7 +384,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Clarify — answered",
+      label: "Clarify: answered",
       description: "Resolved clarify showing the chosen answer.",
       turns: [
         assistantTurn("clarify-answered", [
@@ -400,7 +400,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Clarify — skipped",
+      label: "Clarify: skipped",
       description:
         "Resolved clarify where the person skipped without answering.",
       turns: [
@@ -417,7 +417,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
       ],
     },
     {
-      label: "Empty — thinking placeholder",
+      label: "Empty: thinking placeholder",
       description:
         "An assistant turn with no parts yet shows the shimmering “Thinking…” fallback.",
       turns: [assistantTurn("empty", [], "running")],

--- a/src/lib/trial-checkout.ts
+++ b/src/lib/trial-checkout.ts
@@ -86,7 +86,7 @@ export function useTrialCheckout({
     const unlisten = listen<string>(BILLING_CALLBACK_EVENT, (event) => {
       if (event.payload === "cancel") {
         setPhase("idle");
-        setNotice("Checkout canceled — ready when you are.");
+        setNotice("Checkout canceled. Ready when you are.");
         return;
       }
       void onRefreshRef.current();

--- a/src/meeting-hud.ts
+++ b/src/meeting-hud.ts
@@ -41,7 +41,7 @@ function applyStatus(status: RecordingStatusDto) {
     pill.dataset.state = paused ? "paused" : "recording";
     pill.setAttribute(
       "aria-label",
-      paused ? "Paused — click to open June" : "Recording — click to open June",
+      paused ? "Paused. Click to open June" : "Recording. Click to open June",
     );
   }
 

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -276,7 +276,7 @@ describe("OnboardingFlow", () => {
     // step to its success state and pulls the app forward.
     rerender(<OnboardingFlow {...props} account={account} />);
     await screen.findByRole("heading", {
-      name: "You're in — your free trial is active",
+      name: "You're in! Your free trial is active",
     });
     expect(mocks.focusMainWindow).toHaveBeenCalledOnce();
 


### PR DESCRIPTION
Adds a UI-conventions directive to CLAUDE.md and AGENTS.md: no en-dashes or em-dashes in user-facing copy (plain hyphen or "to" for ranges; period, comma, colon, or parentheses for asides). Sweeps every existing em-dash out of shipped strings: onboarding steps, trial/checkout surfaces, routines, dictation settings, agent workspace copy, tray HUD labels, the dev chat gallery, and the public verify page in scribe-api. Code comments, LLM prompts, logs, and test describe-names are exempt and untouched. The onboarding test was updated for the new trial-success title; the full vitest suite passes (305/305).

🤖 Generated with [Claude Code](https://claude.com/claude-code)