### PR TITLE
Chatbox redesign: two-row composer, Unrestricted picker, fade fixes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -244,6 +244,7 @@ export function App() {
       : "microphoneOnly";
   const {
     account,
+    error: accountError,
     loading: accountLoading,
     refresh: refreshAccount,
     setAccount,
@@ -259,7 +260,10 @@ export function App() {
   // can never complete sign-in, so the sign-in and trial gates would be dead
   // ends — skip them and let account-dependent features surface their own
   // errors. Release builds always gate; so do dev builds once configured.
-  const devAccountsUnconfigured = import.meta.env.DEV && !account.configured;
+  const devAccountsUnconfigured =
+    import.meta.env.DEV &&
+    !account.signedIn &&
+    (accountLoading || !!accountError || !account.configured);
   const signInRequired =
     !devAccountsUnconfigured && shouldBlockOnSignIn(account);
   const trialRequired =

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -255,8 +255,15 @@ export function App() {
   const recordingNoteIdRef = useRef<string | undefined>(undefined);
   // Sessions with a finishRecording call in flight; guards stop double-clicks.
   const finishingSessionsRef = useRef<Set<string>>(new Set());
-  const signInRequired = shouldBlockOnSignIn(account);
-  const trialRequired = !signInRequired && shouldBlockOnTrial(account);
+  // A dev build without the OS Accounts env vars (fresh workspace, no .env)
+  // can never complete sign-in, so the sign-in and trial gates would be dead
+  // ends — skip them and let account-dependent features surface their own
+  // errors. Release builds always gate; so do dev builds once configured.
+  const devAccountsUnconfigured = import.meta.env.DEV && !account.configured;
+  const signInRequired =
+    !devAccountsUnconfigured && shouldBlockOnSignIn(account);
+  const trialRequired =
+    !devAccountsUnconfigured && !signInRequired && shouldBlockOnTrial(account);
   const [onboardingDone, setOnboardingDone] = useState(() =>
     isOnboardingComplete(),
   );

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -652,6 +652,8 @@ export function AgentWorkspace({
   const [confirmUnrestricted, setConfirmUnrestricted] = useState(false);
   const sandboxTriggerRef = useRef<HTMLButtonElement | null>(null);
   const sandboxMenuRef = useRef<HTMLDivElement | null>(null);
+  const sandboxFirstItemRef = useRef<HTMLButtonElement | null>(null);
+  const sandboxMenuWasOpenRef = useRef(false);
   const [hermesSessionItems, setHermesSessionItems] = useState<
     HermesSessionInfo[]
   >(() => (initialSession ? [initialSession] : []));
@@ -980,7 +982,10 @@ export function AgentWorkspace({
       setSandboxMenuOpen(false);
     }
     function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") setSandboxMenuOpen(false);
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSandboxMenuOpen(false);
+      }
     }
     window.addEventListener("mousedown", onPointer);
     window.addEventListener("keydown", onKey);
@@ -988,6 +993,17 @@ export function AgentWorkspace({
       window.removeEventListener("mousedown", onPointer);
       window.removeEventListener("keydown", onKey);
     };
+  }, [sandboxMenuOpen]);
+
+  useLayoutEffect(() => {
+    if (sandboxMenuOpen) {
+      sandboxMenuWasOpenRef.current = true;
+      sandboxFirstItemRef.current?.focus();
+      return;
+    }
+    if (!sandboxMenuWasOpenRef.current) return;
+    sandboxMenuWasOpenRef.current = false;
+    sandboxTriggerRef.current?.focus();
   }, [sandboxMenuOpen]);
 
   // The conversation scroller's thumb fades in with scroll activity and back
@@ -2973,9 +2989,10 @@ export function AgentWorkspace({
             aria-label="What can June change?"
           >
             <p className="agent-sandbox-menu-title">What can June change?</p>
-            {SANDBOX_OPTIONS.map((option) => (
+            {SANDBOX_OPTIONS.map((option, index) => (
               <button
                 key={option.title}
+                ref={index === 0 ? sandboxFirstItemRef : undefined}
                 type="button"
                 role="menuitemradio"
                 aria-checked={fullModeDraft === option.unrestricted}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -60,6 +60,7 @@ import {
   useState,
 } from "react";
 import { BackButton } from "../ui/BackButton";
+import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
 import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
@@ -344,6 +345,49 @@ function sampleImageBytes(): Uint8Array {
 
 type AgentPanel = "chat" | "skills" | "messaging";
 
+/**
+ * The two write-access modes a new session can start the runtime in. The
+ * sandbox is a kernel write-jail (reads are unrestricted either way), chosen
+ * per new session — switching restarts June's runtime, so the picker only
+ * appears in the hero composer.
+ */
+// The Unrestricted confirm is a speed bump, not a recurring gate: one
+// acknowledgment per app session, after which picking it arms directly.
+// sessionStorage scopes that to the running app (a relaunch asks again) and
+// survives the workspace remounting on view switches.
+const UNRESTRICTED_ACK_KEY = "june.agent.unrestrictedAcknowledged";
+
+function unrestrictedAcknowledged(): boolean {
+  try {
+    return window.sessionStorage.getItem(UNRESTRICTED_ACK_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function rememberUnrestrictedAcknowledged() {
+  try {
+    window.sessionStorage.setItem(UNRESTRICTED_ACK_KEY, "true");
+  } catch {
+    // Ignore; worst case the dialog shows again.
+  }
+}
+
+const SANDBOX_OPTIONS = [
+  {
+    unrestricted: false,
+    icon: <IconShieldCheck size={16} aria-hidden />,
+    title: "Sandboxed",
+    description: "June can read your files but only change its own workspace.",
+  },
+  {
+    unrestricted: true,
+    icon: <IconShieldCrossed size={16} aria-hidden />,
+    title: "Unrestricted",
+    description: "June can change any file your account can.",
+  },
+] as const;
+
 type AgentShortcut = {
   key: string;
   icon: ReactNode;
@@ -458,6 +502,40 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
   },
 ];
 
+/**
+ * Hero greetings, one per visit: the heading cycles through this pool each
+ * time the hero is entered, tracked in localStorage so the rotation continues
+ * across launches. Exported so tests can match "any greeting".
+ */
+export const HERO_GREETINGS = [
+  "What can June do for you?",
+  "What should we work on?",
+  "Where should June start?",
+  "What can June take off your plate?",
+] as const;
+
+const HERO_GREETING_INDEX_KEY = "scribe:agent:hero-greeting";
+
+function advanceHeroGreeting(): string {
+  try {
+    const index =
+      Math.abs(
+        Number.parseInt(
+          window.localStorage.getItem(HERO_GREETING_INDEX_KEY) ?? "0",
+          10,
+        ) || 0,
+      ) % HERO_GREETINGS.length;
+    window.localStorage.setItem(
+      HERO_GREETING_INDEX_KEY,
+      String((index + 1) % HERO_GREETINGS.length),
+    );
+    return HERO_GREETINGS[index];
+  } catch {
+    // Storage unavailable: any greeting beats none.
+    return HERO_GREETINGS[Math.floor(Math.random() * HERO_GREETINGS.length)];
+  }
+}
+
 // Three per hand so the row never wraps — a row-count jump mid-rotation would
 // shove the footnote around every cycle.
 const HERO_SHORTCUT_COUNT = 3;
@@ -568,6 +646,12 @@ export function AgentWorkspace({
   // without the OS sandbox. Read through a ref inside the async submit path.
   const [fullModeDraft, setFullModeDraft] = useState(false);
   const fullModeDraftRef = useRef(false);
+  const [sandboxMenuOpen, setSandboxMenuOpen] = useState(false);
+  // Codex-style speed bump: picking Unrestricted from the menu confirms in a
+  // dialog before arming, instead of a persistent warning line.
+  const [confirmUnrestricted, setConfirmUnrestricted] = useState(false);
+  const sandboxTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const sandboxMenuRef = useRef<HTMLDivElement | null>(null);
   const [hermesSessionItems, setHermesSessionItems] = useState<
     HermesSessionInfo[]
   >(() => (initialSession ? [initialSession] : []));
@@ -582,6 +666,8 @@ export function AgentWorkspace({
   );
   const lastAutoSubmittedRef = useRef<{ prompt: string; at: number }>();
   const [newSessionMode, setNewSessionMode] = useState(false);
+  const [heroGreeting, setHeroGreeting] = useState(advanceHeroGreeting);
+  const heroGreetingConsumedRef = useRef(false);
   const [heroDeck, setHeroDeck] = useState(shuffleAgentShortcuts);
   const [heroDeckStart, setHeroDeckStart] = useState(0);
   const [heroChipPhase, setHeroChipPhase] = useState<"in" | "out">("in");
@@ -686,7 +772,6 @@ export function AgentWorkspace({
   const agentScrollRef = useRef<HTMLDivElement | null>(null);
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const composerBoxRef = useRef<HTMLDivElement | null>(null);
-  const [composerMultiline, setComposerMultiline] = useState(false);
 
   useEffect(() => {
     runtimeSessionIdsRef.current = runtimeSessionIds;
@@ -860,13 +945,50 @@ export function AgentWorkspace({
   // what advances it each render.
   const prevHeroModeRef = useRef(heroMode);
 
-  // Full mode is an opt-in made per new session, so the toggle re-arms to off
-  // every time the hero is entered — it never carries over from the last one.
+  // A fresh greeting each time the hero is landed on. The state initializer
+  // already consumed one for the mount, so the first hero entry (which may be
+  // the mount itself) keeps it; later entries advance the cycle. Pre-paint so
+  // a re-entry never flashes the previous greeting.
+  useLayoutEffect(() => {
+    if (!heroMode) return;
+    if (!heroGreetingConsumedRef.current) {
+      heroGreetingConsumedRef.current = true;
+      return;
+    }
+    setHeroGreeting(advanceHeroGreeting());
+  }, [heroMode]);
+
+  // Unrestricted is an opt-in made per new session, so the picker re-arms to
+  // sandboxed every time the hero is entered — it never carries over from the
+  // last one.
   useEffect(() => {
     if (!heroMode) return;
     fullModeDraftRef.current = false;
     setFullModeDraft(false);
+    setSandboxMenuOpen(false);
+    setConfirmUnrestricted(false);
   }, [heroMode]);
+
+  // The sandbox picker closes on a click anywhere outside it or Esc, same as
+  // the session-bar overflow menu.
+  useEffect(() => {
+    if (!sandboxMenuOpen) return;
+    function onPointer(event: MouseEvent) {
+      const target = event.target as Node;
+      if (sandboxMenuRef.current?.contains(target)) return;
+      if (sandboxTriggerRef.current?.contains(target)) return;
+      setSandboxMenuOpen(false);
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setSandboxMenuOpen(false);
+    }
+    window.addEventListener("mousedown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [sandboxMenuOpen]);
 
   // The conversation scroller's thumb fades in with scroll activity and back
   // out when idle (native-overlay feel; see scroll-thumb-fade.ts). The hero
@@ -1280,26 +1402,6 @@ export function AgentWorkspace({
       for (const animation of el.getAnimations()) animation.cancel();
       for (const animation of box.getAnimations()) animation.cancel();
     }
-    // The toolbar drops below the input once the text can't fit on one line
-    // beside the buttons — so probe that at the narrow single-line width.
-    // Deciding at the *current* width feeds back into itself: text that
-    // overflows the narrow slot can fit on one full-width line, so the modes
-    // would flip-flop on every keystroke right at the wrap boundary.
-    box.dataset.multiline = "false";
-    el.style.height = "auto";
-    const styles = getComputedStyle(el);
-    const lineHeight = parseFloat(styles.lineHeight) || 20;
-    const padding =
-      parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
-    const lines = Math.round((el.scrollHeight - padding) / lineHeight);
-    const multiline = lines >= 2;
-    setComposerMultiline(multiline);
-    // Flip the layout attribute now rather than waiting for the re-render so
-    // the height below and the FLIP "last" measurement both see the final
-    // layout in this same effect (none of the probe states ever paint).
-    box.dataset.multiline = multiline ? "true" : "false";
-    // Size to the content at the final width, never the probe width — a
-    // narrow-width height on a full-width textarea leaves a phantom line.
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
     const nextBoxHeight = box.offsetHeight;
@@ -1331,8 +1433,7 @@ export function AgentWorkspace({
       grow,
     );
     // Glide the textarea from its old spot, bottom-left anchored so the line
-    // being typed stays put while space opens above it (most visible on the
-    // one→two line hop, where it leaves the slot between the +/mic buttons).
+    // being typed stays put while space opens above it.
     const nextRect = el.getBoundingClientRect();
     const dx = prevRect.left - nextRect.left;
     const dy = prevRect.bottom - nextRect.bottom;
@@ -1345,10 +1446,9 @@ export function AgentWorkspace({
         grow,
       );
     }
-    // heroMode is a dependency because the hero composer is a different shape
-    // (full-width textarea, taller min-height): leaving the hero must re-probe
-    // the line count and clear the stale inline height, or the docked
-    // composer keeps the hero's 76px textarea and multiline toolbar.
+    // heroMode is a dependency because the hero textarea is taller at rest:
+    // leaving the hero must re-measure and clear the stale inline height, or
+    // the docked composer keeps the hero's 76px field.
   }, [draft, attachments.length, heroMode]);
 
   useEffect(() => {
@@ -1608,8 +1708,9 @@ export function AgentWorkspace({
     const titlePromise = targetSessionId
       ? undefined
       : agentSessionTitleForPrompt(content);
-    // Only a session being created applies the Full mode opt-in; follow-ups
-    // on existing sessions never change the runtime's mode under them.
+    // Only a session being created applies the unrestricted opt-in;
+    // follow-ups on existing sessions never change the runtime's mode under
+    // them.
     const gateway = await ensureHermesGateway(
       targetSessionId ? undefined : fullModeDraftRef.current,
     );
@@ -2728,12 +2829,7 @@ export function AgentWorkspace({
             </motion.p>
           ) : null}
         </AnimatePresence>
-        <div
-          ref={composerBoxRef}
-          className="agent-composer-box"
-          data-dirty={draft.trim() || attachments.length ? "true" : "false"}
-          data-multiline={composerMultiline ? "true" : "false"}
-        >
+        <div ref={composerBoxRef} className="agent-composer-box">
           {attachments.length ? (
             <div className="agent-composer-attachments">
               {attachments.map((attachment) => (
@@ -2765,7 +2861,30 @@ export function AgentWorkspace({
               ))}
             </div>
           ) : null}
-          <div className="agent-composer-row">
+          <textarea
+            ref={composerRef}
+            value={draft}
+            onChange={(event) => setDraft(event.currentTarget.value)}
+            placeholder={
+              importingFiles
+                ? "Attaching file…"
+                : heroMode
+                  ? "Describe a task for June…"
+                  : "Send a message"
+            }
+            rows={1}
+            onKeyDown={(event) => {
+              // Ignore the Enter that commits an IME composition
+              // (Japanese/Chinese/Korean input) — only a real Enter
+              // press should send the message.
+              if (event.nativeEvent.isComposing) return;
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                event.currentTarget.form?.requestSubmit();
+              }
+            }}
+          />
+          <div className="agent-composer-toolbar">
             <button
               type="button"
               className="agent-composer-attach"
@@ -2775,29 +2894,30 @@ export function AgentWorkspace({
             >
               <IconPlusMedium size={18} />
             </button>
-            <textarea
-              ref={composerRef}
-              value={draft}
-              onChange={(event) => setDraft(event.currentTarget.value)}
-              placeholder={
-                importingFiles
-                  ? "Attaching file…"
-                  : heroMode
-                    ? "Describe a task for June…"
-                    : "Send a message"
-              }
-              rows={1}
-              onKeyDown={(event) => {
-                // Ignore the Enter that commits an IME composition
-                // (Japanese/Chinese/Korean input) — only a real Enter
-                // press should send the message.
-                if (event.nativeEvent.isComposing) return;
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  event.currentTarget.form?.requestSubmit();
-                }
-              }}
-            />
+            {heroMode ? (
+              // Unrestricted only applies to the session being created, so
+              // the picker lives in the hero composer's toolbar and nowhere
+              // else. The menu itself renders as a sibling of the box (below)
+              // because the box clips its overflow for the FLIP glide.
+              <button
+                type="button"
+                ref={sandboxTriggerRef}
+                className="agent-sandbox-trigger"
+                data-unrestricted={fullModeDraft ? "true" : undefined}
+                aria-haspopup="menu"
+                aria-expanded={sandboxMenuOpen}
+                title="Change what June can touch"
+                onClick={() => setSandboxMenuOpen((open) => !open)}
+              >
+                {fullModeDraft ? (
+                  <IconShieldCrossed size={14} aria-hidden />
+                ) : (
+                  <IconShieldCheck size={14} aria-hidden />
+                )}
+                {fullModeDraft ? "Unrestricted" : "Sandboxed"}
+                <IconChevronDownSmall size={12} aria-hidden />
+              </button>
+            ) : null}
             <div className="agent-composer-actions">
               <button
                 type="button"
@@ -2833,10 +2953,6 @@ export function AgentWorkspace({
                     importingFiles ||
                     (!draft.trim() && !attachments.length)
                   }
-                  tabIndex={draft.trim() || attachments.length ? 0 : -1}
-                  aria-hidden={
-                    draft.trim() || attachments.length ? undefined : true
-                  }
                   aria-label={
                     selectedHermesSessionId || selectedTask
                       ? "Send message"
@@ -2849,6 +2965,88 @@ export function AgentWorkspace({
             </div>
           </div>
         </div>
+        {heroMode && sandboxMenuOpen ? (
+          <div
+            ref={sandboxMenuRef}
+            className="agent-sandbox-menu"
+            role="menu"
+            aria-label="What can June change?"
+          >
+            <p className="agent-sandbox-menu-title">What can June change?</p>
+            {SANDBOX_OPTIONS.map((option) => (
+              <button
+                key={option.title}
+                type="button"
+                role="menuitemradio"
+                aria-checked={fullModeDraft === option.unrestricted}
+                onClick={() => {
+                  setSandboxMenuOpen(false);
+                  // First arm of the app session goes through the confirm
+                  // dialog; once acknowledged it arms directly, and going
+                  // back to sandboxed never asks.
+                  if (
+                    option.unrestricted &&
+                    !fullModeDraft &&
+                    !unrestrictedAcknowledged()
+                  ) {
+                    setConfirmUnrestricted(true);
+                    return;
+                  }
+                  fullModeDraftRef.current = option.unrestricted;
+                  setFullModeDraft(option.unrestricted);
+                }}
+              >
+                {option.icon}
+                <span className="agent-sandbox-option">
+                  <span className="agent-sandbox-option-title">
+                    {option.title}
+                  </span>
+                  <span className="agent-sandbox-option-desc">
+                    {option.description}
+                  </span>
+                </span>
+                {fullModeDraft === option.unrestricted ? (
+                  <IconCheckmark1Small
+                    size={16}
+                    aria-hidden
+                    className="agent-sandbox-option-check"
+                  />
+                ) : null}
+              </button>
+            ))}
+          </div>
+        ) : null}
+        <Dialog
+          open={confirmUnrestricted}
+          onClose={() => setConfirmUnrestricted(false)}
+          title="Turn on Unrestricted?"
+          description="June will be able to change any file your account can, not just its own workspace. This comes with risks like data loss if something goes wrong."
+          footer={
+            <>
+              <button
+                type="button"
+                className="primary-action"
+                onClick={() => setConfirmUnrestricted(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="primary-action primary-solid"
+                onClick={() => {
+                  rememberUnrestrictedAcknowledged();
+                  fullModeDraftRef.current = true;
+                  setFullModeDraft(true);
+                  setConfirmUnrestricted(false);
+                }}
+              >
+                Turn on Unrestricted
+              </button>
+            </>
+          }
+        >
+          {null}
+        </Dialog>
       </form>
     ) : null;
 
@@ -3021,34 +3219,9 @@ export function AgentWorkspace({
             />
           ) : null}
           <div className="agent-hero-heading">
-            <h2 className="agent-hero-title">What can June do for you?</h2>
+            <h2 className="agent-hero-title">{heroGreeting}</h2>
           </div>
           {composer}
-          {activePanel === "chat" ? (
-            <div className="agent-fullmode-row">
-              <button
-                type="button"
-                role="switch"
-                aria-checked={fullModeDraft}
-                className="agent-fullmode-toggle"
-                title="Start this session without the file sandbox. June can then change any file your account can. Switching modes restarts June's runtime and stops sessions that are still working."
-                onClick={() => {
-                  const next = !fullModeDraft;
-                  fullModeDraftRef.current = next;
-                  setFullModeDraft(next);
-                }}
-              >
-                <IconShieldCrossed size={14} aria-hidden />
-                Full mode
-              </button>
-              {fullModeDraft ? (
-                <p className="agent-fullmode-hint" role="alert">
-                  June won't be sandboxed and can change any file your account
-                  can.
-                </p>
-              ) : null}
-            </div>
-          ) : null}
           {activePanel === "chat" ? (
             <div className="agent-hero-suggestions">
               <div
@@ -3147,19 +3320,19 @@ function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
 }
 
 // Honest indicator of the live runtime, not of any one session: the jail is
-// per-process, so while the user has it in Full mode every session it serves
+// per-process, so while the user has it unrestricted every session it serves
 // runs unsandboxed.
-function FullModeBadge() {
+function UnrestrictedBadge() {
   const description =
-    "June is running without the file sandbox and can change any file your account can. Start a session with Full mode off to restore the sandbox.";
+    "June is running without the file sandbox and can change any file your account can. Start a session with Unrestricted off to restore the sandbox.";
   return (
     <span
-      className="agent-safety-badge agent-fullmode-badge"
+      className="agent-safety-badge agent-sandbox-badge"
       title={description}
-      aria-label={`Full mode - ${description}`}
+      aria-label={`Unrestricted - ${description}`}
     >
       <IconShieldCrossed size={13} aria-hidden />
-      Full mode
+      Unrestricted
     </span>
   );
 }
@@ -3291,7 +3464,7 @@ function AgentSessionBar({
         </ol>
       </nav>
       <div className="detail-bar-actions">
-        {fullMode ? <FullModeBadge /> : null}
+        {fullMode ? <UnrestrictedBadge /> : null}
         {onToggleArtifacts && artifactCount > 0 ? (
           <button
             type="button"

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { osAccountsStatus } from "./tauri";
 import type { AccountStatus } from "./tauri";
 
-const EMPTY_STATUS: AccountStatus = { signedIn: false, configured: true };
+const EMPTY_STATUS: AccountStatus = { signedIn: false, configured: false };
 
 export type UseAccountStatus = {
   account: AccountStatus;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -248,14 +248,6 @@ input:focus-visible,
   left: 5px;
 }
 
-/* Width tracks the cursor raw while dragging — the slide-over transitions
- * would lag the pointer. */
-.app-shell[data-files-resizing="true"] .main-panel,
-.app-shell[data-files-resizing="true"] .agent-composer,
-.app-shell[data-files-resizing="true"] .agent-artifact-panel {
-  transition: none;
-}
-
 /* Agent ------------------------------------------------------------- */
 
 /* The breadcrumb is a fixed header and the conversation scrolls in .agent-scroll,
@@ -360,14 +352,24 @@ input:focus-visible,
 
 /* The card-edge fades animate off .main-panel-body's scroll, but in the agent
  * view that body is frozen and the conversation scrolls in .agent-scroll. Drive
- * the named timeline off that inner scroller instead so the bottom fade still
- * dissolves the conversation into the fixed composer, rather than sticking on. */
+ * the named timeline off that inner scroller instead so the top fade still
+ * tracks the conversation, rather than sticking on. */
 @supports (animation-timeline: scroll()) {
   .main-panel-body[data-active-view="agent"] {
     scroll-timeline: none;
   }
   .main-panel-body[data-active-view="agent"] .agent-scroll {
     scroll-timeline: --main-panel-scroll block;
+  }
+  /* The card-level bottom veil cannot paint beneath the composer — the
+   * workspace isolates its own stacking context, capping the composer's
+   * z-index below the panel's ::after — so in the agent view that veil stays
+   * off (the scroll-driven animation would otherwise override the static
+   * opacity below, and a timeline that goes inactive on the hero can leave
+   * it stuck on). The dissolve lives in .agent-scroll::after instead, inside
+   * the workspace context where the composer wins. */
+  .main-panel:has(.main-panel-body[data-active-view="agent"])::after {
+    animation: none;
   }
   .main-panel-body[data-note-detail-scroller="true"] {
     scroll-timeline: none;
@@ -555,6 +557,32 @@ input:focus-visible,
 
 .agent-scroll::-webkit-scrollbar-track {
   margin-top: var(--detail-bar-h);
+}
+
+/* Bottom dissolve for the conversation — the agent-view stand-in for the
+ * card's ::after veil, which is disabled here (see the @supports block above
+ * .main-panel::after): it must paint beneath the composer, so it lives inside
+ * the workspace's stacking context (z 4 under the composer's 5). Sticky to
+ * the scrollport bottom with zero net layout (the negative top margin), and
+ * bled past the side padding so it spans the full card width. */
+.agent-scroll::after {
+  content: "";
+  position: sticky;
+  bottom: 0;
+  z-index: 4;
+  flex: 0 0 auto;
+  height: 96px;
+  margin: -96px calc(-1 * var(--sp-8)) 0;
+  background: linear-gradient(to bottom, transparent, var(--card) 78%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+@supports (animation-timeline: scroll()) {
+  .agent-scroll::after {
+    animation: main-panel-fade-end linear both;
+    animation-timeline: --main-panel-scroll;
+  }
 }
 
 .agent-main {
@@ -2056,6 +2084,16 @@ input:focus-visible,
   transition: right var(--t-slow) var(--ease-spring);
 }
 
+/* Width tracks the cursor raw while dragging — the slide-over transitions
+ * would lag the pointer (and let the panel ride over the composer). Equal
+ * specificity to the composer rule above, so it must stay after it in the
+ * cascade. */
+.app-shell[data-files-resizing="true"] .main-panel,
+.app-shell[data-files-resizing="true"] .agent-composer,
+.app-shell[data-files-resizing="true"] .agent-artifact-panel {
+  transition: none;
+}
+
 /* No divider under the header — the body's top scroll fade is what signals
  * content passing underneath (same trick as the dictation history dialog). */
 .agent-artifact-panel-bar {
@@ -2610,9 +2648,9 @@ input:focus-visible,
   display: none;
 }
 
-/* Single-line at rest. The textarea grows upward to its max while the controls
- * stay pinned to the bottom edge. Quiet by default; the border firms up and the
- * surface lifts on focus. */
+/* Two rows always: the textarea owns the top and grows upward to its max, the
+ * toolbar (attach, dictation, send) sits in a fixed metadata row beneath it.
+ * Quiet by default; the border firms up and the surface lifts on focus. */
 .agent-composer-box {
   pointer-events: auto;
   display: flex;
@@ -2630,46 +2668,24 @@ input:focus-visible,
   border-radius: var(--r-xl);
   background: var(--card);
   box-shadow: var(--shadow-sm);
-  /* Clips the send button to the field as it slides in from the edge. */
+  /* Clips the rising top edge during the FLIP height glide. */
   overflow: hidden;
   transition:
     border-color var(--t-fast) var(--ease-out),
     box-shadow var(--t-fast) var(--ease-out);
 }
 
-.agent-composer-row {
+.agent-composer-toolbar {
   display: flex;
-  flex-wrap: wrap;
-  /* The single-line textarea (33px) runs 1px taller than the 32px controls;
-   * centering splits the difference so the send button sits evenly inset
-   * instead of flush-bottom with a fatter top gap. On the multiline toolbar
-   * row every control is the same height, so centering is a no-op there. */
   align-items: center;
   gap: var(--sp-1);
 }
 
-.agent-composer-attach {
-  order: 1;
-}
-
-.agent-composer-row > textarea {
-  order: 2;
-  min-width: 0;
-}
-
 .agent-composer-actions {
-  order: 3;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: var(--sp-1);
   margin-left: auto;
-}
-
-/* Two lines or more: the textarea claims the top row and the +/mic/send toolbar
- * slides down beneath it. */
-.agent-composer-box[data-multiline="true"] .agent-composer-row > textarea {
-  order: 0;
-  flex: 1 1 100%;
 }
 
 /* Attach (+) and dictation (mic) are both quiet ghost buttons that round to a
@@ -2793,7 +2809,7 @@ input:focus-visible,
 }
 
 .agent-composer textarea {
-  flex: 1;
+  width: 100%;
   min-height: var(--control-lg);
   max-height: 200px;
   resize: none;
@@ -2857,6 +2873,7 @@ input:focus-visible,
   background: var(--warm-soft);
   color: var(--warm-strong);
   transition: background-color var(--t-fast) var(--ease-out);
+  animation: agent-composer-action-in var(--t-fast) var(--ease-out);
 }
 
 .agent-composer-stop:hover {
@@ -2868,11 +2885,9 @@ input:focus-visible,
   pointer-events: none;
 }
 
-/* Send slides in from the right (pushing the mic over) only once there's
- * something to send — an up arrow in a solid circle. */
 /* Send is the primary action in the brand terracotta (the logo mark color);
- * dictation stays a ghost. It slides in fast-but-smooth (pushing the mic over)
- * only once there's text, clipped by the field. */
+ * dictation stays a ghost. The arrow is always in its slot — it just goes
+ * quiet while there's nothing to send, and lights up as the user types. */
 .agent-composer-send {
   display: inline-grid;
   place-items: center;
@@ -2885,27 +2900,35 @@ input:focus-visible,
   background: var(--brand);
   color: oklch(100% 0 none);
   transition:
-    width var(--t-fast) var(--ease-spring),
-    margin var(--t-fast) var(--ease-spring),
-    opacity var(--t-fast) var(--ease-out),
-    transform var(--t-fast) var(--ease-spring),
-    background-color var(--t-fast) var(--ease-out);
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+  animation: agent-composer-action-in var(--t-fast) var(--ease-out);
 }
 
 .agent-composer-send:hover {
   background: color-mix(in oklch, var(--brand) 88%, black);
 }
 
-.agent-composer-box[data-dirty="false"] .agent-composer-send {
-  width: 0;
-  margin-left: calc(var(--sp-1) * -1);
-  opacity: 0;
-  transform: translateX(8px) scale(0.7);
-  pointer-events: none;
+.agent-composer-send:disabled {
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+  cursor: default;
 }
 
-.agent-composer-send:disabled {
-  cursor: default;
+/* Send and stop trade the same slot; the incoming control scales up out of
+ * the other so the swap reads as a state change rather than a teleport. */
+@keyframes agent-composer-action-in {
+  from {
+    opacity: 0;
+    scale: 0.7;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-composer-send,
+  .agent-composer-stop {
+    animation: none;
+  }
 }
 
 /* "Responding" affordance pinned to the bottom of the timeline while the agent
@@ -2957,8 +2980,7 @@ input:focus-visible,
   transform: translateY(-10px);
 }
 
-.agent-main[data-hero-leaving="true"] .agent-hero-suggestions,
-.agent-main[data-hero-leaving="true"] .agent-fullmode-row {
+.agent-main[data-hero-leaving="true"] .agent-hero-suggestions {
   opacity: 0;
   transform: translateY(10px);
   pointer-events: none;
@@ -2974,9 +2996,13 @@ input:focus-visible,
 
 /* In the hero the composer leaves its fixed bottom dock and sits inline at
  * the column's center — taller at rest and a touch narrower than the reading
- * column, so it reads as "start here" rather than "reply here". */
+ * column, so it reads as "start here" rather than "reply here". Relative so
+ * the sandbox menu can anchor to it; the dock's left/right/bottom offsets
+ * must be cleared or relative re-applies them as a visual shift (static
+ * ignored them for free). */
 .agent-composer[data-hero="true"] {
-  position: static;
+  position: relative;
+  inset: auto;
   pointer-events: auto;
 }
 
@@ -2985,11 +3011,9 @@ input:focus-visible,
   box-shadow: var(--shadow-md);
 }
 
-/* Big-box at rest: the textarea owns the full top rows and the +/mic/send
- * toolbar always sits beneath it, regardless of the JS multiline probe. */
-.agent-composer[data-hero="true"] .agent-composer-row > textarea {
-  order: 0;
-  flex: 1 1 100%;
+/* Big-box at rest: same two-row anatomy as the docked composer, just a
+ * taller field so it reads as "start here". */
+.agent-composer[data-hero="true"] textarea {
   min-height: 76px;
 }
 
@@ -3079,63 +3103,123 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
-/* Full mode opt-in under the hero composer: a quiet switch-styled pill that
- * turns destructive-tinted once armed, with the consequence spelled out
- * beside it rather than only in the tooltip. */
-.agent-fullmode-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sp-3);
-  margin-top: var(--sp-3);
-  transition:
-    opacity 280ms var(--ease-out),
-    transform 280ms var(--ease-out);
-}
-
-.agent-fullmode-toggle {
+/* Sandbox picker — a mode trigger in the hero composer's toolbar, styled
+ * like Codex's permission control: a borderless ghost button (icon + current
+ * mode + chevron) that opens a small menu of modes. Unrestricted tints the
+ * trigger in the warm terracotta family; no border in either state. */
+.agent-sandbox-trigger {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: var(--sp-1);
-  padding: 2px var(--sp-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--r-sm);
-  background: none;
+  height: var(--control-lg);
+  padding: 0 var(--sp-2);
+  border: 0;
+  border-radius: var(--r-lg);
+  background: transparent;
   color: var(--muted-foreground);
   font: inherit;
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   transition:
     background-color var(--t-fast) var(--ease-out),
-    border-color var(--t-fast) var(--ease-out),
     color var(--t-fast) var(--ease-out);
 }
 
-.agent-fullmode-toggle:hover {
-  border-color: var(--border);
+.agent-sandbox-trigger:hover {
+  background: var(--surface-subtle);
   color: var(--foreground);
 }
 
-.agent-fullmode-toggle[aria-checked="true"] {
-  border-color: color-mix(in oklch, var(--destructive) 40%, transparent);
-  background: var(--destructive-soft);
-  color: var(--destructive);
+.agent-sandbox-trigger[data-unrestricted="true"] {
+  color: var(--warm-strong);
 }
 
-.agent-fullmode-hint {
+/* A lighter wash than the stop button's solid --warm-soft — at full strength
+ * the hover read like an armed alarm rather than a hover. */
+.agent-sandbox-trigger[data-unrestricted="true"]:hover {
+  background: color-mix(in oklch, var(--warm-soft) 45%, transparent);
+  color: var(--warm-strong);
+}
+
+/* The menu drops below the composer box (a sibling, since the box clips its
+ * overflow for the FLIP glide), left-aligned to the box's 640px column. */
+.agent-sandbox-menu {
+  position: absolute;
+  top: calc(100% + var(--sp-1));
+  left: max(0px, calc(50% - 320px));
+  z-index: 30;
+  width: min(400px, 100%);
+  padding: var(--sp-1);
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-md);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-md);
+}
+
+.agent-sandbox-menu-title {
   margin: 0;
-  color: var(--destructive);
-  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
 }
 
-/* Session-bar twin of .agent-safety-badge, tinted destructive: the runtime is
- * live without the write-jail. */
-.agent-fullmode-badge {
-  background: var(--destructive-soft);
-  color: var(--destructive);
+.agent-sandbox-menu button {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-2);
+  width: 100%;
+  padding: var(--sp-2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--popover-foreground);
+  text-align: left;
 }
 
-.agent-fullmode-badge svg {
-  color: var(--destructive);
+.agent-sandbox-menu button:hover {
+  background: color-mix(in oklch, var(--muted) 50%, transparent);
+}
+
+.agent-sandbox-menu button > svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--muted-foreground);
+}
+
+.agent-sandbox-option {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.agent-sandbox-option-title {
+  font-size: var(--fs-md);
+  font-weight: 500;
+}
+
+.agent-sandbox-option-desc {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.agent-sandbox-menu button > svg.agent-sandbox-option-check {
+  margin-left: auto;
+  align-self: center;
+  color: var(--foreground);
+}
+
+/* Session-bar twin of .agent-safety-badge in the warm terracotta family: the
+ * runtime is live without the write-jail. */
+.agent-sandbox-badge {
+  background: var(--warm-soft);
+  color: var(--warm-strong);
+}
+
+.agent-sandbox-badge svg {
+  color: var(--warm-strong);
 }
 
 /* Hero teardown: while a shortcut/submit is creating the session, the

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -14,10 +14,16 @@ import {
   AGENT_NEW_SESSION_PENDING_KEY,
   AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
+  HERO_GREETINGS,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
 import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 import { HermesGatewayError } from "../lib/hermes-gateway";
+
+// The hero greeting cycles per visit, so tests match any entry in the pool.
+const HERO_GREETING = new RegExp(
+  `^(?:${HERO_GREETINGS.map((greeting) => greeting.replace("?", "\\?")).join("|")})$`,
+);
 
 const mocks = vi.hoisted(() => ({
   cancelAgentTask: vi.fn(),
@@ -237,9 +243,7 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace />);
 
-    expect(
-      await screen.findByText("What can June do for you?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
     await waitFor(() => expect(mocks.listHermesSessions).toHaveBeenCalled());
     expect(screen.queryByText("Existing session")).toBeNull();
     expect(screen.queryByText("Existing task")).toBeNull();
@@ -499,9 +503,7 @@ describe("AgentWorkspace", () => {
 
     window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
 
-    expect(
-      await screen.findByText("What can June do for you?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
     expect(screen.queryByText("Existing session")).toBeNull();
   });
 
@@ -1083,9 +1085,7 @@ describe("AgentWorkspace", () => {
 
     // The source toggle swaps the rendered document for the raw markdown.
     await user.click(within(panel).getByRole("button", { name: "Source" }));
-    expect(
-      within(panel).getByText(/# Quarterly summary/),
-    ).toBeInTheDocument();
+    expect(within(panel).getByText(/# Quarterly summary/)).toBeInTheDocument();
 
     await user.click(
       within(panel).getByRole("button", { name: "Close files" }),
@@ -1607,7 +1607,7 @@ describe("AgentWorkspace", () => {
     }
   });
 
-  it("starts a new session in full mode only after the explicit opt-in", async () => {
+  it("starts a new session unrestricted only after the explicit opt-in", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now() }),
@@ -1615,8 +1615,9 @@ describe("AgentWorkspace", () => {
     const user = userEvent.setup();
     render(<AgentWorkspace />);
 
-    const toggle = await screen.findByRole("switch", { name: "Full mode" });
-    expect(toggle).toHaveAttribute("aria-checked", "false");
+    // The picker rests on Sandboxed for a fresh hero.
+    const trigger = await screen.findByRole("button", { name: "Sandboxed" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
 
     // Submitting without the opt-in must not touch the runtime's mode — the
     // running sandboxed bridge is reused as-is.
@@ -1633,17 +1634,29 @@ describe("AgentWorkspace", () => {
     );
     expect(mocks.startHermesBridge).not.toHaveBeenCalled();
 
-    // Re-entering the hero re-arms the opt-in to off, then opting in and
-    // submitting restarts the runtime in full mode.
+    // Re-entering the hero re-arms the picker to Sandboxed. Choosing
+    // Unrestricted from the menu routes through the confirm dialog before
+    // arming; submitting then restarts the runtime unsandboxed.
     act(() => {
       window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
     });
-    const rearmed = await screen.findByRole("switch", { name: "Full mode" });
-    expect(rearmed).toHaveAttribute("aria-checked", "false");
+    const rearmed = await screen.findByRole("button", { name: "Sandboxed" });
     await user.click(rearmed);
-    expect(rearmed).toHaveAttribute("aria-checked", "true");
+    await user.click(
+      screen.getByRole("menuitemradio", { name: /^Unrestricted/ }),
+    );
     expect(
-      screen.getByText(/won't be sandboxed and can change any file/),
+      screen.queryByRole("menu", { name: "What can June change?" }),
+    ).not.toBeInTheDocument();
+    // Not armed until the dialog confirms.
+    expect(
+      screen.getByRole("button", { name: "Sandboxed" }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Turn on Unrestricted" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Unrestricted" }),
     ).toBeInTheDocument();
 
     await user.type(
@@ -1655,9 +1668,25 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, true),
     );
+
+    // The confirm is once per app session: with the acknowledgment stored,
+    // the next arm goes straight through without the dialog.
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+    await user.click(await screen.findByRole("button", { name: "Sandboxed" }));
+    await user.click(
+      screen.getByRole("menuitemradio", { name: /^Unrestricted/ }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Turn on Unrestricted" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Unrestricted" }),
+    ).toBeInTheDocument();
   });
 
-  it("shows the full mode badge while the runtime is unsandboxed by choice", async () => {
+  it("shows the unrestricted badge while the runtime is unsandboxed by choice", async () => {
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
       connection: {
@@ -1669,9 +1698,9 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    expect(await screen.findByText("Full mode")).toBeInTheDocument();
+    expect(await screen.findByText("Unrestricted")).toBeInTheDocument();
     expect(
-      screen.getByLabelText(/Full mode - June is running without the file/),
+      screen.getByLabelText(/Unrestricted - June is running without the file/),
     ).toBeInTheDocument();
   });
 
@@ -1835,9 +1864,7 @@ describe("AgentWorkspace", () => {
       />,
     );
 
-    expect(
-      await screen.findByText("What can June do for you?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
     expect(screen.getByText("Projects")).toBeInTheDocument();
     expect(screen.getByText("Scribe")).toBeInTheDocument();
     expect(screen.getByText("New session")).toBeInTheDocument();

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1686,6 +1686,32 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
   });
 
+  it("moves focus into the sandbox menu and restores it on close", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    const trigger = await screen.findByRole("button", { name: "Sandboxed" });
+    await user.click(trigger);
+
+    const firstOption = screen.getByRole("menuitemradio", {
+      name: /^Sandboxed/,
+    });
+    expect(firstOption).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menu", { name: "What can June change?" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(trigger).toHaveFocus();
+  });
+
   it("shows the unrestricted badge while the runtime is unsandboxed by choice", async () => {
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -2,6 +2,12 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
+import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
+
+// The hero greeting cycles per visit, so tests match any entry in the pool.
+const HERO_GREETING = new RegExp(
+  `^(?:${HERO_GREETINGS.map((greeting) => greeting.replace("?", "\\?")).join("|")})$`,
+);
 import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
@@ -259,7 +265,7 @@ describe("App shortcuts", () => {
     await waitFor(() => expect(mocks.bootstrapApp).toHaveBeenCalledOnce());
     // Clearing the gate lands on a fresh agent session, not a new note.
     expect(
-      await screen.findByRole("heading", { name: "What can June do for you?" }),
+      await screen.findByRole("heading", { name: HERO_GREETING }),
     ).toBeInTheDocument();
     expect(mocks.createNote).not.toHaveBeenCalled();
   });
@@ -291,7 +297,7 @@ describe("App shortcuts", () => {
     });
 
     expect(
-      await screen.findByRole("heading", { name: "What can June do for you?" }),
+      await screen.findByRole("heading", { name: HERO_GREETING }),
     ).toBeInTheDocument();
   });
 });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -3,12 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
+import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
   `^(?:${HERO_GREETINGS.map((greeting) => greeting.replace("?", "\\?")).join("|")})$`,
 );
-import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   listen: vi.fn(),
@@ -299,5 +299,19 @@ describe("App shortcuts", () => {
     expect(
       await screen.findByRole("heading", { name: HERO_GREETING }),
     ).toBeInTheDocument();
+  });
+
+  it("bypasses account gates in dev when account status is unavailable", async () => {
+    mocks.osAccountsStatus.mockRejectedValue(new Error("accounts unavailable"));
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", { name: HERO_GREETING }),
+    ).toBeInTheDocument();
+    expect(mocks.bootstrapApp).toHaveBeenCalledOnce();
+    expect(
+      screen.queryByRole("button", { name: "Continue with OpenSoftware" }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## What

### Composer redesign
- **Two rows, always**: the textarea owns the top row and auto-grows; attach (+), dictation, and send live in a fixed toolbar row beneath it, in the hero and in conversations. The single-line collapsed mode and its multiline wrap-probe are removed.
- **Send is always in its slot**: muted + disabled while there's nothing to send, brand terracotta once there is. The send/stop handoff is a small scale/fade swap instead of the old width-collapse slide-in.

### "Unrestricted" (was Full mode)
- Renamed: it removes a restriction (the Seatbelt write-jail) rather than granting a tier or autonomy, so neither "Full access" (reads like pricing) nor "Auto" (reads like auto-approve, which this does not change) fit.
- Codex-style picker in the hero composer toolbar: borderless ghost trigger (shield + current mode + chevron) opening a menu with a header ("What can June change?") and described options, checkmark on the selected one.
- Warm terracotta tints (`--warm-soft`/`--warm-strong`) everywhere instead of destructive red; armed trigger has no border; armed hover is a 45% wash so it doesn't read like an alarm.
- Arming routes through a confirm dialog ("Turn on Unrestricted?") **once per app session** (sessionStorage); switching back to Sandboxed never asks. The persistent warning line under the composer is gone.
- Session bar badge renamed to match. Mode remains a per-new-session choice — follow-ups never flip the runtime.

### Hero greeting
Cycles through a four-line pool per visit ("What can June do for you?", "What should we work on?", "Where should June start?", "What can June take off your plate?"), position kept in localStorage so the rotation survives relaunches. Copy no longer genders June.

## Fixes
- **Files-panel resize lag**: the drag-time transition suppression rule lost the cascade to the later-declared composer slide-over transition, so the composer chased the pointer on a slow spring. The suppression now sits after it.
- **Composer washed out / "clipped"**: the card's scroll-driven bottom veil (`.main-panel::after`) always paints over the composer because the workspace's `isolation: isolate` caps the composer's z-index below it, and a scroll timeline that goes inactive on the hero (no scroller) can hold the veil stuck on. The agent view now disables the card veil and paints the dissolve as a sticky gradient inside `.agent-scroll`, beneath the composer in the same stacking context.
- **Unconfigured dev builds**: when the OS Accounts env vars are absent, the sign-in/trial gates are unwinnable dead ends; dev builds now skip them (release builds and configured dev builds gate as before).

## Test plan
- `vitest run`: 305/305 across 37 files, including new coverage for the picker menu flow, the confirm dialog, the once-per-session acknowledgment, and the unrestricted badge.
- `tsc --noEmit` and `prettier --check` clean.
- Manually exercised in `tauri:dev`: hero composer, picker menu, confirm dialog, hero-to-dock handoff, files-panel drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)