### PR TITLE
Fix the agent sessions list flicker on first click

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -657,6 +657,10 @@ export function AgentWorkspace({
   const [hermesSessionItems, setHermesSessionItems] = useState<
     HermesSessionInfo[]
   >(() => (initialSession ? [initialSession] : []));
+  // False until the first listHermesSessions fetch lands. Until then the
+  // items above only hold the mount seed (the clicked session, or nothing),
+  // and broadcasting that would wipe the sidebar's already-loaded list.
+  const [hermesSessionsHydrated, setHermesSessionsHydrated] = useState(false);
   // Mounting without an explicit target restores the last open conversation,
   // so app restarts and dev reloads land the user back in the session they
   // were working in instead of bouncing them to the newest one.
@@ -1053,6 +1057,7 @@ export function AgentWorkspace({
     setHermesSessionsLoading(true);
     try {
       const sessions = applySessionTitleOverrides(await listHermesSessions());
+      setHermesSessionsHydrated(true);
       const pendingMessages = pendingHermesMessagesRef.current;
       const selectedSessionId = selectedHermesSessionIdRef.current;
       const workingSessions = workingSessionIdsRef.current;
@@ -1199,6 +1204,11 @@ export function AgentWorkspace({
   }, [pendingReply]);
 
   useEffect(() => {
+    // The sidebar and App replace their session lists wholesale with this
+    // payload, so an unhydrated broadcast (mount seed only) would collapse
+    // the list they already fetched themselves and flicker it back once the
+    // real fetch lands.
+    if (!hermesSessionsHydrated) return;
     dispatchAgentSessionsChanged({
       sessions: hermesSessionItems,
       selectedSessionId: selectedHermesSessionId,
@@ -1206,6 +1216,7 @@ export function AgentWorkspace({
       waitingSessionIds: Array.from(waitingSessionIds),
     });
   }, [
+    hermesSessionsHydrated,
     hermesSessionItems,
     selectedHermesSessionId,
     waitingSessionIds,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1508,6 +1508,57 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("holds session broadcasts until the first fetch lands", async () => {
+    const sessionDetails: AgentSessionsChangedDetail[] = [];
+    const onSessionsChanged = (event: Event) =>
+      sessionDetails.push(
+        (event as CustomEvent<AgentSessionsChangedDetail>).detail,
+      );
+    window.addEventListener(AGENT_SESSIONS_CHANGED_EVENT, onSessionsChanged);
+
+    // First click after app launch: the workspace mounts seeded with only the
+    // clicked session while listHermesSessions is still in flight. The sidebar
+    // replaces its list wholesale with each broadcast, so a pre-fetch
+    // broadcast would collapse it to one row and flicker it back.
+    let resolveSessions: (sessions: (typeof existingSession)[]) => void = () =>
+      undefined;
+    mocks.listHermesSessions.mockImplementation(
+      () =>
+        new Promise<(typeof existingSession)[]>((resolve) => {
+          resolveSessions = resolve;
+        }),
+    );
+    const clickedSession = {
+      id: "session-2",
+      title: "Clicked session",
+      preview: "Clicked preview",
+      last_active: "2026-06-05T12:00:00Z",
+    };
+
+    try {
+      render(<AgentWorkspace initialSession={clickedSession} />);
+
+      await waitFor(() => expect(mocks.listHermesSessions).toHaveBeenCalled());
+      expect(sessionDetails).toEqual([]);
+
+      await act(async () => {
+        resolveSessions([clickedSession, existingSession]);
+      });
+
+      await waitFor(() => expect(sessionDetails.length).toBeGreaterThan(0));
+      expect(sessionDetails[0].sessions.map((session) => session.id)).toEqual([
+        "session-2",
+        "session-1",
+      ]);
+      expect(sessionDetails[0].selectedSessionId).toBe("session-2");
+    } finally {
+      window.removeEventListener(
+        AGENT_SESSIONS_CHANGED_EVENT,
+        onSessionsChanged,
+      );
+    }
+  });
+
   it("scrubs working state when deleting the selected session from the session bar", async () => {
     const user = userEvent.setup();
     const sessionDetails: AgentSessionsChangedDetail[] = [];


### PR DESCRIPTION
## Problem

When you first click on an agent session after opening the app, the agent sessions list in the sidebar flickers: it briefly collapses to just the clicked session, then repopulates.

## Root cause

The app launches with `AgentWorkspace` mounted in hero mode, and its `hermesSessionItems` state starts as just the mount seed (the clicked session, or empty). Its sessions-changed broadcast effect fires as soon as that state changes, and both the Sidebar and App replace their session lists **wholesale** with the broadcast payload:

1. On launch, the Sidebar fetches and shows the full sessions list itself.
2. First click sets `initialSession`, and the workspace prepends it to its still-unhydrated (empty) list.
3. The broadcast fires with `sessions: [clickedSession]`, so the sidebar list collapses to one row.
4. The workspace's own `listHermesSessions` fetch resolves moments later and a second broadcast restores the full list.

That collapse-and-restore round trip is the flicker. It only happens on the first click because the workspace stays hydrated afterward.

## Fix

Gate the sessions-changed broadcast behind a hydration flag that flips when the first `listHermesSessions` fetch succeeds. Until then the Sidebar and App keep the lists they fetched themselves. The selection highlight on first click is unaffected since the Sidebar sets it locally on click, and working/waiting status still flows after the post-submit refresh (which always runs `loadHermesSessions` first).

## Testing

- New regression test: renders the workspace with an `initialSession` while the session fetch is held pending, asserts no broadcast fires, then resolves the fetch and asserts the first broadcast carries the full list with the clicked session selected. Verified it fails without the fix.
- `tsc --noEmit` and the full vitest suite (308 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)