### PR TITLE
Add dev flag to replay onboarding and force logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ pnpm install
 pnpm tauri:dev
 ```
 
+To replay first-run onboarding, clear the saved onboarding checkpoint, and log
+out of OS Accounts without wiping the rest of your local app data:
+
+```sh
+pnpm tauri:dev --replay-onboarding
+```
+
 The desktop app talks to Scribe API for transcription, dictation cleanup,
 model listing, and note generation. Provider API keys belong only in the
 Scribe API server env; never put OpenAI, Venice, or OS Accounts App API keys in

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "tauri": "tauri",
-    "tauri:dev": "tauri dev",
+    "tauri:dev": "node scripts/tauri-dev.mjs",
     "tauri:build": "tauri build --bundles app,dmg",
     "tauri:build:signed-dmg": "./scripts/build-signed-dmg.sh",
     "build": "tsc && vite build",

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const REPLAY_ONBOARDING_FLAG = "--replay-onboarding";
+
+let replayOnboarding = false;
+const tauriArgs = [];
+
+for (const arg of process.argv.slice(2)) {
+  if (arg === REPLAY_ONBOARDING_FLAG) {
+    replayOnboarding = true;
+  } else {
+    tauriArgs.push(arg);
+  }
+}
+
+const child = spawn("tauri", ["dev", ...tauriArgs], {
+  env: {
+    ...process.env,
+    ...(replayOnboarding ? { VITE_JUNE_REPLAY_ONBOARDING: "1" } : {}),
+  },
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -104,8 +104,10 @@ import type {
 } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
 import {
+  applyOnboardingReplayFlag,
   isOnboardingComplete,
   markOnboardingComplete,
+  shouldReplayOnboarding,
 } from "../lib/onboarding";
 import { shouldBlockOnSignIn, shouldBlockOnTrial } from "../lib/account-gate";
 import {
@@ -148,6 +150,7 @@ function sidebarMaxWidth() {
 }
 
 export function App() {
+  const replayOnboarding = shouldReplayOnboarding();
   const [state, dispatch] = useReducer(
     notesReducer,
     undefined,
@@ -248,7 +251,7 @@ export function App() {
     loading: accountLoading,
     refresh: refreshAccount,
     setAccount,
-  } = useAccountStatus();
+  } = useAccountStatus({ forceLogoutOnMount: replayOnboarding });
   // The note the active recording session belongs to. recordingStatus carries
   // no noteId, so without this the finish flow could only guess from the
   // currently selected note — wrong whenever the user browsed away while
@@ -268,9 +271,10 @@ export function App() {
     !devAccountsUnconfigured && shouldBlockOnSignIn(account);
   const trialRequired =
     !devAccountsUnconfigured && !signInRequired && shouldBlockOnTrial(account);
-  const [onboardingDone, setOnboardingDone] = useState(() =>
-    isOnboardingComplete(),
-  );
+  const [onboardingDone, setOnboardingDone] = useState(() => {
+    applyOnboardingReplayFlag();
+    return isOnboardingComplete();
+  });
   // The wizard handles sign-in and the free trial itself, so it gates on
   // onboarding state alone; AccountGate/TrialGate remain for users who
   // finished onboarding and later signed out or lapsed.

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
-import { osAccountsStatus } from "./tauri";
+import { osAccountsLogout, osAccountsStatus } from "./tauri";
 import type { AccountStatus } from "./tauri";
 
 const EMPTY_STATUS: AccountStatus = { signedIn: false, configured: false };
+
+export type UseAccountStatusOptions = {
+  forceLogoutOnMount?: boolean;
+};
 
 export type UseAccountStatus = {
   account: AccountStatus;
@@ -12,7 +16,10 @@ export type UseAccountStatus = {
   setAccount: (next: AccountStatus) => void;
 };
 
-export function useAccountStatus(): UseAccountStatus {
+export function useAccountStatus(
+  options: UseAccountStatusOptions = {},
+): UseAccountStatus {
+  const { forceLogoutOnMount = false } = options;
   const [account, setAccount] = useState<AccountStatus>(EMPTY_STATUS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -32,13 +39,19 @@ export function useAccountStatus(): UseAccountStatus {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    refresh().finally(() => {
+    async function loadInitialStatus() {
+      if (forceLogoutOnMount) {
+        await osAccountsLogout();
+      }
+      await refresh();
+    }
+    loadInitialStatus().finally(() => {
       if (!cancelled) setLoading(false);
     });
     return () => {
       cancelled = true;
     };
-  }, [refresh]);
+  }, [forceLogoutOnMount, refresh]);
 
   // Refetch when the app regains attention so the user sees their post-top-up
   // balance without hunting for a refresh button. `focus` and `visibilitychange`

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -11,6 +11,25 @@ const COMPLETED_KEY = "june.onboarding.completedVersion";
 const RESUME_KEY = "june.onboarding.resumeStep";
 const AGENT_ACK_KEY = "june.agent.riskAcknowledged";
 
+type OnboardingReplayEnv = {
+  readonly DEV?: boolean;
+  readonly VITE_JUNE_REPLAY_ONBOARDING?: string;
+};
+
+export function applyOnboardingReplayFlag(
+  env: OnboardingReplayEnv = import.meta.env,
+) {
+  if (shouldReplayOnboarding(env)) {
+    resetOnboardingForReplay();
+  }
+}
+
+export function shouldReplayOnboarding(
+  env: OnboardingReplayEnv = import.meta.env,
+) {
+  return env.DEV === true && env.VITE_JUNE_REPLAY_ONBOARDING === "1";
+}
+
 export function isOnboardingComplete(): boolean {
   try {
     const raw = window.localStorage.getItem(COMPLETED_KEY);
@@ -27,6 +46,15 @@ export function markOnboardingComplete() {
     window.localStorage.removeItem(RESUME_KEY);
   } catch {
     // Ignore; worst case the wizard shows again next launch.
+  }
+}
+
+export function resetOnboardingForReplay() {
+  try {
+    window.localStorage.removeItem(COMPLETED_KEY);
+    window.localStorage.removeItem(RESUME_KEY);
+  } catch {
+    // Ignore; storage unavailable already behaves like a completed wizard.
   }
 }
 

--- a/src/test/account-status.test.tsx
+++ b/src/test/account-status.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAccountStatus } from "../lib/account-status";
+import type { AccountStatus } from "../lib/tauri";
+
+const mocks = vi.hoisted(() => ({
+  osAccountsLogout: vi.fn(),
+  osAccountsStatus: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  osAccountsLogout: mocks.osAccountsLogout,
+  osAccountsStatus: mocks.osAccountsStatus,
+}));
+
+function StatusProbe({
+  forceLogoutOnMount = false,
+}: {
+  forceLogoutOnMount?: boolean;
+}) {
+  const account = useAccountStatus({ forceLogoutOnMount }).account;
+  return <div>{account.signedIn ? "Signed in" : "Signed out"}</div>;
+}
+
+describe("useAccountStatus", () => {
+  it("logs out before loading account status when forced on mount", async () => {
+    const calls: string[] = [];
+    const signedOut: AccountStatus = { signedIn: false, configured: true };
+    mocks.osAccountsLogout.mockImplementation(async () => {
+      calls.push("logout");
+    });
+    mocks.osAccountsStatus.mockImplementation(async () => {
+      calls.push("status");
+      return signedOut;
+    });
+
+    render(<StatusProbe forceLogoutOnMount />);
+
+    await screen.findByText("Signed out");
+    await waitFor(() => expect(calls).toEqual(["logout", "status"]));
+  });
+});

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -3,8 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
 import {
+  applyOnboardingReplayFlag,
   isAgentRiskAcknowledged,
   isOnboardingComplete,
+  markOnboardingComplete,
+  onboardingResumeStep,
+  resetOnboardingForReplay,
   setOnboardingResumeStep,
 } from "../lib/onboarding";
 import type { AccountStatus } from "../lib/tauri";
@@ -342,6 +346,39 @@ describe("OnboardingFlow", () => {
     setOnboardingResumeStep("setup");
     render(<OnboardingFlow {...flowProps()} />);
     await screen.findByRole("heading", { name: "Set up dictation" });
+  });
+
+  it("resets only onboarding progress when replaying the wizard", () => {
+    markOnboardingComplete();
+    setOnboardingResumeStep("setup");
+    localStorage.setItem("june.agent.riskAcknowledged", "true");
+
+    resetOnboardingForReplay();
+
+    expect(isOnboardingComplete()).toBe(false);
+    expect(onboardingResumeStep()).toBeNull();
+    expect(isAgentRiskAcknowledged()).toBe(true);
+  });
+
+  it("applies the replay flag only in development", () => {
+    markOnboardingComplete();
+    setOnboardingResumeStep("setup");
+
+    applyOnboardingReplayFlag({
+      DEV: false,
+      VITE_JUNE_REPLAY_ONBOARDING: "1",
+    });
+
+    expect(isOnboardingComplete()).toBe(true);
+    expect(onboardingResumeStep()).toBe("setup");
+
+    applyOnboardingReplayFlag({
+      DEV: true,
+      VITE_JUNE_REPLAY_ONBOARDING: "1",
+    });
+
+    expect(isOnboardingComplete()).toBe(false);
+    expect(onboardingResumeStep()).toBeNull();
   });
 
   it("requests the mic permission when the mic screen shows", async () => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 declare const __APP_COMMIT_HASH__: string;
 
+interface ImportMetaEnv {
+  readonly VITE_JUNE_REPLAY_ONBOARDING?: string;
+}
+
 declare module "*.svg" {
   const src: string;
   export default src;


### PR DESCRIPTION
## Summary
- Add `pnpm tauri:dev --replay-onboarding` as a dev-only replay path.
- Clear onboarding completion and resume state, then force OS Accounts logout before the account snapshot loads.
- Document the workflow in the README.

## Testing
- Added unit tests for onboarding replay reset behavior.
- Added a unit test covering forced logout before account status loads.
- Full Vitest suite passed.