### PR TITLE
Link new sessions started from a project to that project

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -659,15 +659,25 @@ export function AgentWorkspace({
   >(() => (initialSession ? [initialSession] : []));
   // Mounting without an explicit target restores the last open conversation,
   // so app restarts and dev reloads land the user back in the session they
-  // were working in instead of bouncing them to the newest one.
+  // were working in instead of bouncing them to the newest one. A pending
+  // new-session marker overrides the restore: the mount-time sessions-changed
+  // dispatch would otherwise announce the restored session as selected, which
+  // App reads as "switched to an existing session" and drops a pending
+  // project assignment before the new session even exists.
   const [selectedHermesSessionId, setSelectedHermesSessionId] = useState<
     string | undefined
-  >(() => initialSessionId ?? readLastOpenSessionId());
+  >(
+    () =>
+      initialSessionId ??
+      (hasPendingNewSessionRequest() ? undefined : readLastOpenSessionId()),
+  );
   const selectedHermesSessionIdRef = useRef<string | undefined>(
     selectedHermesSessionId,
   );
   const lastAutoSubmittedRef = useRef<{ prompt: string; at: number }>();
-  const [newSessionMode, setNewSessionMode] = useState(false);
+  const [newSessionMode, setNewSessionMode] = useState(
+    () => !initialSessionId && hasPendingNewSessionRequest(),
+  );
   const [heroGreeting, setHeroGreeting] = useState(advanceHeroGreeting);
   const heroGreetingConsumedRef = useRef(false);
   const [heroDeck, setHeroDeck] = useState(shuffleAgentShortcuts);
@@ -765,7 +775,7 @@ export function AgentWorkspace({
   // Tasks whose hydration fetch has resolved (hydratedTaskIdsRef only says
   // the fetch *started*) — the scroll-settling logic needs the landing.
   const taskHistoryLoadedIdsRef = useRef<Set<string>>(new Set());
-  const newSessionModeRef = useRef(false);
+  const newSessionModeRef = useRef(newSessionMode);
   // True only while a brand-new thread is being started from the hero. The
   // hero→dock composer FLIP keys off this so it glides *only* when the empty
   // chat hands over to a fresh thread — not when the hero is dismissed by
@@ -6350,6 +6360,23 @@ export function markAgentNewSessionPending(prompt?: string) {
 // would hijack whatever the user had open into a new session (and re-submit
 // the stale prompt).
 const AGENT_NEW_SESSION_PENDING_TTL_MS = 15_000;
+
+/** Non-consuming peek at the pending marker, for state init on a fresh
+ * mount. The mount effect still consumes it via pendingNewSessionRequest();
+ * peeking here must not clear it, or the auto-submit prompt would be lost. */
+function hasPendingNewSessionRequest(): boolean {
+  try {
+    const value = window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY);
+    if (value == null) return false;
+    const parsed = JSON.parse(value) as { createdAt?: number };
+    return (
+      typeof parsed.createdAt === "number" &&
+      Date.now() - parsed.createdAt <= AGENT_NEW_SESSION_PENDING_TTL_MS
+    );
+  } catch {
+    return false;
+  }
+}
 
 function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
   try {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -252,6 +252,41 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
+  it("never announces the restored session as selected while a New Session is pending", async () => {
+    // Regression: "New session" from inside a project arms the pending marker
+    // and remounts the workspace. Initializing from the last-open restore used
+    // to dispatch a mount-time sessions-changed event selecting the old
+    // session, which App reads as "switched to existing work" — dropping the
+    // pending project assignment before the new session exists.
+    window.localStorage.setItem("scribe:agent:last-open-session", "session-1");
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+    const sessionDetails: AgentSessionsChangedDetail[] = [];
+    const onSessionsChanged = (event: Event) =>
+      sessionDetails.push(
+        (event as CustomEvent<AgentSessionsChangedDetail>).detail,
+      );
+    window.addEventListener(AGENT_SESSIONS_CHANGED_EVENT, onSessionsChanged);
+
+    try {
+      render(<AgentWorkspace />);
+
+      expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+      await waitFor(() => expect(mocks.listHermesSessions).toHaveBeenCalled());
+      expect(sessionDetails.length).toBeGreaterThan(0);
+      expect(
+        sessionDetails.every((detail) => detail.selectedSessionId == null),
+      ).toBe(true);
+    } finally {
+      window.removeEventListener(
+        AGENT_SESSIONS_CHANGED_EVENT,
+        onSessionsChanged,
+      );
+    }
+  });
+
   it("labels anonymous-only agent models as anonymous mode", async () => {
     mocks.providerModelSettings.mockResolvedValue({
       settings: {


### PR DESCRIPTION
## Problem

Clicking "New session" inside a project switched to the agent workspace but the session that got created was never assigned to the project.

## Root cause

The folders view and the agent workspace render exclusively, so the click remounts `AgentWorkspace`. On mount it initialized `selectedHermesSessionId` from the last-open-session restore, and the mount-time `sessions-changed` dispatch announced that old session as selected. `App.tsx` holds the pending "file the next new session into this project" intent in `pendingSessionProjectRef`, and its handler treats a selected session it already knows as "the user switched to existing work" and abandons the intent. That mount dispatch consumed and dropped the assignment before the new session even existed; by the time the first prompt created the real session, nothing was left to link it.

## Fix

When the pending new-session marker is armed, `AgentWorkspace` now mounts straight into new-session mode with no selection instead of restoring the last open conversation, so the misleading mount dispatch never fires. The marker is peeked without consuming it (`hasPendingNewSessionRequest`); the existing mount effect still consumes it and handles auto-submit prompts. This also removes the brief restore-then-hero flash on any pending-marker mount.

## Testing

- New regression test: with a stored last-open session and a pending marker, no `sessions-changed` dispatch ever carries the restored session as selected. Verified it fails against the unfixed component.
- Full suite: 308 tests pass; `tsc --noEmit` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)