### PR TITLE
Add a production watchdog for scribe-api

### DIFF
--- a/.github/workflows/scribe-api-watchdog.yml
+++ b/.github/workflows/scribe-api-watchdog.yml
@@ -1,0 +1,149 @@
+name: scribe-api-watchdog
+
+# Production watchdog for scribe-api on Phala Cloud. Two independent checks:
+#
+#   health    - probes the public production endpoint. The June 2026 outage
+#               mode was a dead CVM behind a healthy dstack gateway: TCP
+#               connects, then the TLS handshake gets cut because nothing
+#               inside the CVM terminates it. A plain curl catches that.
+#   staleness - compares the newest deploy/production/* tag against the
+#               newest deploy/staging/* tag and flags production trailing
+#               staging by more than the threshold, so manual promotion
+#               doesn't silently fall behind.
+#
+# Failures open (or update) a single deduplicated issue labeled
+# `scribe-api-watchdog`; recovery closes it. The job itself also fails so
+# the run shows red in the Actions list.
+
+on:
+  schedule:
+    # Every 30 minutes. The watchdog is read-only and cheap; the issue
+    # dedup below keeps repeated failures from spamming.
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: scribe-api-watchdog
+  cancel-in-progress: false
+
+env:
+  PROD_BASE_URL: https://scribe-api.opensoftware.co
+  # Production may trail staging by this many days before the watchdog
+  # flags it. Promotion is deliberately manual (attested releases soak on
+  # staging first), so a short lag is normal.
+  MAX_PROMOTION_LAG_DAYS: "7"
+  ISSUE_LABEL: scribe-api-watchdog
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is not needed, but all tags are: the staleness
+          # check reads deploy/production/* and deploy/staging/* tag dates.
+          fetch-depth: 1
+          fetch-tags: true
+
+      - name: Probe production health
+        id: health
+        run: |
+          set -uo pipefail
+          status=ok
+          detail=""
+          # --retry covers transient blips; --retry-all-errors makes curl
+          # also retry connect/TLS-level failures, not just 5xx.
+          if ! curl -fsS --max-time 20 --retry 3 --retry-delay 10 --retry-all-errors \
+              "${PROD_BASE_URL}/healthz" > /dev/null 2> /tmp/curl-err; then
+            status=down
+            detail="$(tr -d '\n' < /tmp/curl-err | head -c 300)"
+            echo "::error::Production health probe failed: ${detail}"
+          else
+            echo "Production /healthz responded."
+          fi
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          echo "detail=${detail}" >> "$GITHUB_OUTPUT"
+
+      - name: Check promotion staleness
+        id: staleness
+        run: |
+          set -euo pipefail
+          newest_tag_date() {
+            # Newest tagger date (unix epoch) among tags matching the
+            # pattern; empty when no tags match.
+            git for-each-ref "refs/tags/$1" \
+              --sort=-taggerdate --count=1 \
+              --format='%(taggerdate:unix)|%(refname:short)'
+          }
+          prod="$(newest_tag_date 'deploy/production/*')"
+          staging="$(newest_tag_date 'deploy/staging/*')"
+          status=ok
+          detail=""
+          if [[ -z "$prod" || -z "$staging" ]]; then
+            echo "Missing deploy tags (prod='${prod}' staging='${staging}'); skipping staleness check."
+          else
+            prod_date="${prod%%|*}";    prod_tag="${prod##*|}"
+            staging_date="${staging%%|*}"; staging_tag="${staging##*|}"
+            lag_days=$(( (staging_date - prod_date) / 86400 ))
+            echo "Newest production deploy: ${prod_tag}; newest staging deploy: ${staging_tag}; lag: ${lag_days}d."
+            if (( lag_days > MAX_PROMOTION_LAG_DAYS )); then
+              status=stale
+              detail="Production (${prod_tag}) trails staging (${staging_tag}) by ${lag_days} days (threshold: ${MAX_PROMOTION_LAG_DAYS})."
+              echo "::warning::${detail}"
+            fi
+          fi
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          echo "detail=${detail}" >> "$GITHUB_OUTPUT"
+
+      - name: Open, update, or close the watchdog issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEALTH_STATUS: ${{ steps.health.outputs.status }}
+          HEALTH_DETAIL: ${{ steps.health.outputs.detail }}
+          STALE_STATUS: ${{ steps.staleness.outputs.status }}
+          STALE_DETAIL: ${{ steps.staleness.outputs.detail }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create "$ISSUE_LABEL" \
+            --description "Opened automatically by the scribe-api production watchdog" \
+            --color D93F0B --force
+
+          existing=$(gh issue list --label "$ISSUE_LABEL" --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [[ "$HEALTH_STATUS" == "ok" && "$STALE_STATUS" == "ok" ]]; then
+            if [[ -n "$existing" ]]; then
+              gh issue close "$existing" --comment \
+                "Watchdog: production is healthy again and promotion lag is within threshold ([run](${RUN_URL}))."
+            fi
+            exit 0
+          fi
+
+          title="scribe-api production watchdog: "
+          body="Automated report from the scribe-api production watchdog ([run](${RUN_URL}))."$'\n\n'
+          if [[ "$HEALTH_STATUS" != "ok" ]]; then
+            title+="production endpoint down"
+            body+="**Health:** \`${PROD_BASE_URL}/healthz\` is unreachable."$'\n'
+            body+="Probe error: \`${HEALTH_DETAIL:-no detail}\`"$'\n\n'
+            body+="Likely causes: the production CVM is stopped or crashed (check the Phala Cloud dashboard and credits). Redeploying via the \`promote-scribe-api\` workflow restarts it."$'\n\n'
+          fi
+          if [[ "$STALE_STATUS" != "ok" ]]; then
+            [[ "$HEALTH_STATUS" != "ok" ]] && title+=", promotion stale" || title+="promotion stale"
+            body+="**Staleness:** ${STALE_DETAIL}"$'\n'
+            body+="Run the \`promote-scribe-api\` workflow to promote the current staging image."$'\n'
+          fi
+
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --body "$body"
+            gh issue edit "$existing" --title "$title"
+          else
+            gh issue create --title "$title" --label "$ISSUE_LABEL" --body "$body"
+          fi
+
+          echo "::error::Watchdog detected problems: ${title#scribe-api production watchdog: }"
+          exit 1


### PR DESCRIPTION
## Why

Production scribe-api went down silently: the CVM behind the dstack prod5 gateway died sometime after the June 3 promotion (TCP connected but TLS handshakes were cut, since dstack passes TLS through into the CVM and nothing inside was terminating it). Staging on the same gateway was fine because every push to main redeploys it; production only changes on manual promotion, so nothing noticed until the dead endpoint was hit by hand.

## What

A scheduled workflow (every 30 minutes, plus manual dispatch) with two read-only checks:

- **Health:** `curl` against `https://scribe-api.opensoftware.co/healthz` with retries that also cover connect/TLS-level failures, which is exactly the observed outage mode.
- **Staleness:** compares the newest `deploy/production/*` tag against the newest `deploy/staging/*` tag and flags production trailing staging by more than 7 days, so manual promotion does not silently fall behind.

On failure it opens a single deduplicated issue labeled `scribe-api-watchdog` (updating it on repeat failures) and fails the run; on recovery it closes the issue. Promotion itself stays manual by design.

## Testing

- `actionlint` and YAML parse pass.
- Staleness logic dry-run locally against the real deploy tags (currently `deploy/production/5fd0f40` vs `deploy/staging/97234b5`, lag 7 days).
- The schedule only runs from the default branch, so the first live run lands after merge; it can also be exercised immediately via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)