### PR TITLE
Fix cmd-tab triggering dictation: gate flagsChanged matching on the changed key

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -407,17 +407,28 @@ final class ShortcutKeyMonitor {
         CGEvent.tapEnable(tap: eventTap, enable: true)
     }
 
-    fileprivate func handle(flags: CGEventFlags) {
-        if isCapturingShortcut {
-            handleCapture(flags: flags)
-            return
+    /// A flagsChanged event names the key that changed (`keyCode`), and the
+    /// matching below is gated on it. Matching on the flag bits alone caused
+    /// phantom fn edges: releasing Cmd while fn was still held made the flags
+    /// read exactly {fn} again, which looked like a fresh fn press — so
+    /// cmd-tabbing away from a dictation could re-trigger push-to-talk, and a
+    /// quick Cmd press+release while fn was down counted as a double-press
+    /// and fired the fn+fn toggle. Arrow/Home/End/PageUp/PageDown events set
+    /// the fn bit too, faking the same edges. Only the shortcut's own
+    /// modifier keys may create a press; foreign keys can still *end* one
+    /// (adding Cmd mid-push releases it), but such an interruption is not a
+    /// physical release and must not arm the double-press detector.
+    fileprivate func handleFlagsChanged(_ current: ShortcutModifiers, changedKeyCode: UInt16) {
+        if let identity = activeIdentity, identity.modifiers != current {
+            handlePhysicalUp(
+                identity: identity,
+                isPhysicalRelease: modifierKeyCodes(for: identity.modifiers).contains(changedKeyCode)
+            )
         }
 
-        if let identity = activeIdentity, identity.keyCode == 0, !modifiersMatch(flags, identity.modifiers) {
-            handlePhysicalUp(identity: identity)
-        }
-
-        guard let identity = matchingModifierOnlyIdentity(flags: flags) else {
+        guard let identity = matchingModifierOnlyIdentity(current),
+              modifierKeyCodes(for: identity.modifiers).contains(changedKeyCode)
+        else {
             return
         }
 
@@ -442,10 +453,7 @@ final class ShortcutKeyMonitor {
             }
             handlePhysicalUp(identity: identity)
         case .flagsChanged:
-            handle(flags: event.flags)
-            if let identity = activeIdentity, !modifiersMatch(event.flags, identity.modifiers) {
-                handlePhysicalUp(identity: identity)
-            }
+            handleFlagsChanged(shortcutModifiers(from: event.flags), changedKeyCode: keyCode(from: event))
         default:
             break
         }
@@ -525,15 +533,10 @@ final class ShortcutKeyMonitor {
             }
             handlePhysicalUp(identity: identity)
         case .flagsChanged:
-            if let identity = activeIdentity, identity.keyCode == 0, !modifiersMatch(event.modifierFlags, identity.modifiers) {
-                handlePhysicalUp(identity: identity)
-            }
-            if let identity = matchingModifierOnlyIdentity(flags: event.modifierFlags) {
-                handlePhysicalDown(identity: identity)
-            }
-            if let identity = activeIdentity, !modifiersMatch(event.modifierFlags, identity.modifiers) {
-                handlePhysicalUp(identity: identity)
-            }
+            handleFlagsChanged(
+                shortcutModifiers(from: event.modifierFlags),
+                changedKeyCode: UInt16(event.keyCode)
+            )
         default:
             break
         }
@@ -669,9 +672,9 @@ final class ShortcutKeyMonitor {
         return nil
     }
 
-    private func matchingModifierOnlyIdentity(flags: CGEventFlags) -> ShortcutIdentity? {
+    private func matchingModifierOnlyIdentity(_ current: ShortcutModifiers) -> ShortcutIdentity? {
         for shortcut in shortcuts.values where shortcut.isModifierOnly {
-            guard modifiersMatch(flags, shortcut.modifiers) else {
+            guard shortcut.modifiers == current else {
                 continue
             }
             return ShortcutIdentity(shortcut)
@@ -679,14 +682,28 @@ final class ShortcutKeyMonitor {
         return nil
     }
 
-    private func matchingModifierOnlyIdentity(flags: NSEvent.ModifierFlags) -> ShortcutIdentity? {
-        for shortcut in shortcuts.values where shortcut.isModifierOnly {
-            guard modifiersMatch(flags, shortcut.modifiers) else {
-                continue
-            }
-            return ShortcutIdentity(shortcut)
+    /// The physical keys that can legitimately produce a press/release edge
+    /// for a shortcut's modifier set. flagsChanged events carry the keyCode
+    /// of the key that changed; anything outside this set (an arrow key's fn
+    /// bit, a Cmd release while fn is held) must not be read as an edge.
+    private func modifierKeyCodes(for modifiers: ShortcutModifiers) -> Set<UInt16> {
+        var codes: Set<UInt16> = []
+        if modifiers.command {
+            codes.formUnion([0x36, 0x37]) // right/left Command
         }
-        return nil
+        if modifiers.shift {
+            codes.formUnion([0x38, 0x3C]) // left/right Shift
+        }
+        if modifiers.option {
+            codes.formUnion([0x3A, 0x3D]) // left/right Option
+        }
+        if modifiers.control {
+            codes.formUnion([0x3B, 0x3E]) // left/right Control
+        }
+        if modifiers.function {
+            codes.insert(0x3F) // fn / Globe
+        }
+        return codes
     }
 
     private func shortcuts(matching identity: ShortcutIdentity) -> [(ShortcutKind, MonitoredShortcut)] {
@@ -724,7 +741,11 @@ final class ShortcutKeyMonitor {
         }
     }
 
-    private func handlePhysicalUp(identity: ShortcutIdentity) {
+    /// `isPhysicalRelease` is false when the up is synthesized by a foreign
+    /// modifier interrupting the chord (Cmd pressed mid-fn-hold): the press
+    /// ends, but it was never released, so it must not count as the first
+    /// tap of a double-press.
+    private func handlePhysicalUp(identity: ShortcutIdentity, isPhysicalRelease: Bool = true) {
         guard activeIdentity == identity else {
             return
         }
@@ -738,7 +759,8 @@ final class ShortcutKeyMonitor {
 
         cancelPendingPush()
 
-        if shortcuts(matching: identity).contains(where: { $0.0 == .toggle && $0.1.pressCount == 2 }) {
+        if isPhysicalRelease,
+           shortcuts(matching: identity).contains(where: { $0.0 == .toggle && $0.1.pressCount == 2 }) {
             lastTapIdentity = identity
             lastTapAt = Date()
         }


### PR DESCRIPTION
## The report

"Sometimes when the user is cmd-tabbing between windows, it triggers dictation." Confirmed — it's real, and it reproduces for the default post-onboarding setup (push-to-talk = bare fn, with an fn+fn double-press toggle making it worse).

## Root cause

The Swift dictation helper matched modifier-only shortcuts (bare fn, Cmd+Opt combos) against the **flag bits of flagsChanged events alone**, ignoring which key actually changed. Two consequences:

1. **Phantom fn-down on Cmd release.** Hold fn (dictating), press Cmd → the flags diverge from `{fn}`, so the helper synthesizes an fn-up (push-to-talk ends) *and arms the double-press detector*. Release Cmd (tab already tapped) → the flags read exactly `{fn}` again → the helper synthesizes a fresh fn-**down**:
   - if fn is still resting down, push-to-talk re-fires 160 ms later → **dictation starts as you land in the other window**;
   - if the Cmd press→release happened within the 340 ms double-press window → counts as **fn+fn → the toggle fires**, hands-free recording.
2. **Nav keys fake fn.** Arrow/Home/End/PageUp/PageDown events carry the fn bit in their flags, so their flagsChanged transitions could fabricate the same fn edges with no fn key involved (e.g. arrowing around right after releasing fn).

"Sometimes" because it needs fn still held (or recently released) around the cmd-tab — exactly the posture of someone finishing a dictation and switching windows.

## Fix

flagsChanged events name the key that changed (`keyCode`: Cmd 0x36/0x37, Shift 0x38/0x3C, Opt 0x3A/0x3D, Ctrl 0x3B/0x3E, fn 0x3F). The matcher now gates edges on it:

- Only a shortcut's **own modifier keys** can create a press edge. A Cmd release can never fabricate an fn press; an arrow key's fn bit can't either.
- A foreign modifier interrupting a held chord still **releases** it (pressing Cmd mid-dictation still ends the push, as before), but that interruption is not a physical release and **no longer arms the double-press detector**.
- The CGEventTap and NSEvent-monitor paths — previously three slightly different check sequences — now share one `handleFlagsChanged(_:changedKeyCode:)`.

Real usage is unchanged: fn press/release edges still come from keyCode 0x3F, double-tap toggles still work, multi-modifier combos still engage when their last modifier lands.

## Verification

- Full `swiftc` compile with the same frameworks build.rs uses: clean.
- Traced the event sequences for: cmd-tab while holding fn (no re-trigger, no toggle), nav-key fn bits (no edges), normal fn tap & double-tap (unchanged), Cmd+Opt-style combos engage/release (unchanged), keyed chords like Ctrl+Opt+T releasing a modifier first (unchanged).
- src-tauri and frontend test suites pass (the helper itself has no test harness; the matching logic lives in the singleton monitor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)