### PR TITLE
Re-auth and retry trial checkout instead of falling back to the portal

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -53,6 +53,11 @@ const ERR_CONFLICT: i64 = 4001;
 // ApiError::unprocessable — returned for a return_url the accounts
 // deployment hasn't allowlisted (or hasn't learned about yet).
 const ERR_UNPROCESSABLE: i64 = 4201;
+/// AppError code for "the stored grant lacks a scope the direct checkout
+/// needs". The frontend reacts by re-running sign-in (which requests the
+/// current scope set) and retrying, instead of falling back to the portal.
+/// Mirrored in src/lib/trial-checkout.ts.
+const TRIAL_CHECKOUT_NEEDS_REAUTH: &str = "trial_checkout_needs_reauth";
 
 /// Tauri event fired when the `osscribe://billing/callback` deep link lands —
 /// the user just finished (or canceled) Stripe Checkout in the browser.
@@ -452,9 +457,12 @@ const BILLING_RETURN_URL: &str = "";
 
 /// One-click free trial: mint the subscription Stripe Checkout session
 /// directly from the app (the user's own token authorizes it) and open it in
-/// the system browser — no detour through the portal's billing page. Any
-/// failure other than "already subscribed" surfaces as an error so the UI can
-/// fall back to the portal flow.
+/// the system browser — no detour through the portal's billing page.
+///
+/// A persistent scope failure surfaces as `trial_checkout_needs_reauth` so
+/// the UI can re-run sign-in (picking up the scopes this build requests) and
+/// retry the direct path. Any other failure surfaces as an error the UI
+/// answers with the portal fallback.
 #[tauri::command]
 pub async fn os_accounts_start_trial_checkout() -> Result<TrialCheckout, AppError> {
     let cfg = Config::load();
@@ -499,11 +507,18 @@ pub async fn os_accounts_start_trial_checkout() -> Result<TrialCheckout, AppErro
                 return_url = None;
             }
             // 3001 doubles as "token expired" and "missing scope". Refresh
-            // once; a token from a pre-billing:write sign-in still fails the
-            // retry, and the error below sends the UI down the portal path.
+            // once; if a freshly refreshed token still 3001s, the grant
+            // itself predates a scope this build requests (refresh can never
+            // broaden a grant) — only an interactive re-auth can fix that.
             Some(ERR_TOKEN_EXPIRED) if !refreshed => {
                 refreshed = true;
                 access = refresh_locked(&cfg).await?;
+            }
+            Some(ERR_TOKEN_EXPIRED) => {
+                return Err(AppError::new(
+                    TRIAL_CHECKOUT_NEEDS_REAUTH,
+                    "Your sign-in predates the billing permission June now uses. Sign in again to continue.",
+                ));
             }
             _ => break,
         }

--- a/src/components/account/TrialGate.tsx
+++ b/src/components/account/TrialGate.tsx
@@ -224,10 +224,16 @@ export function TrialGate({ account, onRefresh, onSignOut }: Props) {
               <button
                 type="button"
                 className="primary-action"
-                disabled={checkout.phase === "opening"}
+                disabled={
+                  checkout.phase === "opening" || checkout.phase === "reauth"
+                }
                 onClick={() => void checkout.start()}
               >
-                {checkout.phase === "opening" ? "Opening checkout…" : copy.cta}
+                {checkout.phase === "reauth"
+                  ? "Confirming your sign-in…"
+                  : checkout.phase === "opening"
+                    ? "Opening checkout…"
+                    : copy.cta}
               </button>
               {trialPitch ? (
                 <p className="trial-hint">Due today: $0</p>

--- a/src/components/onboarding/steps/TrialStep.tsx
+++ b/src/components/onboarding/steps/TrialStep.tsx
@@ -127,11 +127,15 @@ export function TrialStep({
       </ul>
       <StepActions
         continueLabel={
-          checkout.phase === "opening"
-            ? "Opening checkout…"
-            : "Start free trial"
+          checkout.phase === "reauth"
+            ? "Confirming your sign-in…"
+            : checkout.phase === "opening"
+              ? "Opening checkout…"
+              : "Start free trial"
         }
-        continueDisabled={checkout.phase === "opening"}
+        continueDisabled={
+          checkout.phase === "opening" || checkout.phase === "reauth"
+        }
         onContinue={() => void checkout.start()}
       />
       {checkout.error ? (

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1075,9 +1075,11 @@ export type TrialCheckoutResult = {
 };
 
 /** Mints the free-trial Stripe Checkout session with the user's own token and
- * opens it in the system browser — no portal detour. Rejects when the direct
- * path is unavailable (old token without billing:write, subscriptions
- * disabled, network); callers fall back to the portal. */
+ * opens it in the system browser — no portal detour. Rejects with code
+ * `trial_checkout_needs_reauth` when the stored grant lacks the billing
+ * scope (callers re-run sign-in and retry), and with other codes when the
+ * direct path is unavailable (subscriptions disabled, network); callers
+ * answer those with the portal fallback. */
 export async function osAccountsStartTrialCheckout() {
   return invoke<TrialCheckoutResult>("os_accounts_start_trial_checkout");
 }

--- a/src/lib/trial-checkout.ts
+++ b/src/lib/trial-checkout.ts
@@ -2,10 +2,25 @@ import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   focusMainWindow,
+  osAccountsLogin,
   osAccountsOpenPortal,
   osAccountsStartTrialCheckout,
 } from "./tauri";
 import type { AccountStatus } from "./tauri";
+
+// Mirrored from src-tauri/src/os_accounts.rs: the stored grant lacks a scope
+// the direct checkout needs (it predates billing:write). A token refresh can
+// never broaden a grant, so the recovery is an interactive re-auth.
+const NEEDS_REAUTH_CODE = "trial_checkout_needs_reauth";
+// Raised by os_accounts_login when the user cancels the browser sign-in.
+const LOGIN_CANCELED_CODE = "login_canceled";
+
+function errorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code: unknown }).code);
+  }
+  return undefined;
+}
 
 /** Fired by the Rust core when the `osscribe://billing/callback` deep link
  * lands — the user finished (or canceled) checkout in the browser. Payload is
@@ -47,9 +62,11 @@ export function isSubscriptionActive(account: AccountStatus): boolean {
  * session and open it in the system browser, then polls the account status
  * until the subscription flips to trialing/active. When that happens the hook
  * pulls the app back to the foreground and fires `onActivated` exactly once.
- * If the direct path is unavailable (token without billing:write,
- * subscriptions disabled), it opens the accounts portal instead and keeps the
- * same polling, so no user is ever stranded without a way forward.
+ * A grant minted before this build's scopes (no billing:write) triggers a
+ * re-auth and one retry, so those users still land directly on Stripe. Only
+ * when the direct path stays unavailable (subscriptions disabled, network)
+ * does it open the accounts portal instead, keeping the same polling, so no
+ * user is ever stranded without a way forward.
  */
 export function useTrialCheckout({
   account,
@@ -123,7 +140,8 @@ export function useTrialCheckout({
     setError(undefined);
     setNotice(undefined);
     setPhase("opening");
-    try {
+
+    const openDirectCheckout = async () => {
       const result = await osAccountsStartTrialCheckout();
       if (result.outcome === "alreadySubscribed") {
         // Stale snapshot (e.g. subscribed on another machine); the refreshed
@@ -133,9 +151,9 @@ export function useTrialCheckout({
         return;
       }
       setPhase("waiting");
-    } catch {
-      // Direct checkout unavailable — older token without billing:write or
-      // subscriptions disabled server-side. The portal can always do it.
+    };
+
+    const openPortalFallback = async () => {
       try {
         await osAccountsOpenPortal();
         setUsedPortalFallback(true);
@@ -144,6 +162,39 @@ export function useTrialCheckout({
         setError(messageFromError(portalError));
         setPhase("idle");
       }
+    };
+
+    try {
+      await openDirectCheckout();
+    } catch (checkoutError) {
+      // A grant from before this build's scopes can't mint the checkout
+      // session, and refreshing can't fix that. Re-run sign-in (for an
+      // already-authenticated user it's a quick browser bounce) to pick up
+      // the current scopes, then retry the direct path — the user still
+      // lands on Stripe, not the portal.
+      if (errorCode(checkoutError) === NEEDS_REAUTH_CODE) {
+        try {
+          await osAccountsLogin();
+        } catch (loginError) {
+          if (errorCode(loginError) === LOGIN_CANCELED_CODE) {
+            setPhase("idle");
+            setNotice("Sign-in canceled. Ready when you are.");
+            return;
+          }
+          await openPortalFallback();
+          return;
+        }
+        try {
+          await openDirectCheckout();
+          return;
+        } catch {
+          // Re-auth didn't unblock the direct path; the portal always can.
+        }
+      }
+      // Direct checkout unavailable — subscriptions disabled server-side,
+      // network trouble, or a re-auth that still lacks the scope. The portal
+      // can always do it.
+      await openPortalFallback();
     }
   }, []);
 

--- a/src/lib/trial-checkout.ts
+++ b/src/lib/trial-checkout.ts
@@ -27,9 +27,11 @@ function errorCode(error: unknown): string | undefined {
  * "success" or "cancel". */
 const BILLING_CALLBACK_EVENT = "os-accounts-billing-callback";
 
-/** Phases of the one-click trial flow. `waiting` = Stripe Checkout is open in
- * the browser and we're polling for the subscription to appear. */
-export type TrialCheckoutPhase = "idle" | "opening" | "waiting";
+/** Phases of the one-click trial flow. `reauth` = the stored grant lacked a
+ * scope and a browser sign-in bounce is in flight to pick up the current
+ * ones. `waiting` = Stripe Checkout is open in the browser and we're polling
+ * for the subscription to appear. */
+export type TrialCheckoutPhase = "idle" | "opening" | "reauth" | "waiting";
 
 // Stripe's webhook usually settles within a couple of seconds of payment;
 // poll fast enough that the app reacts while the user is still looking at
@@ -173,6 +175,7 @@ export function useTrialCheckout({
       // the current scopes, then retry the direct path — the user still
       // lands on Stripe, not the portal.
       if (errorCode(checkoutError) === NEEDS_REAUTH_CODE) {
+        setPhase("reauth");
         try {
           await osAccountsLogin();
         } catch (loginError) {
@@ -184,6 +187,7 @@ export function useTrialCheckout({
           await openPortalFallback();
           return;
         }
+        setPhase("opening");
         try {
           await openDirectCheckout();
           return;

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -338,6 +338,76 @@ describe("OnboardingFlow", () => {
     await screen.findByText(/We opened your account portal/);
   });
 
+  // A grant from a sign-in that predates billing:write can't mint the
+  // checkout session and refreshing can't broaden it. The hook re-runs
+  // sign-in and retries so the user still lands on Stripe, never the portal.
+  it("re-authenticates and retries when the grant lacks the billing scope", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsStartTrialCheckout
+      .mockRejectedValueOnce({
+        code: "trial_checkout_needs_reauth",
+        message: "Sign in again to continue.",
+      })
+      .mockResolvedValueOnce({ outcome: "checkoutOpened" });
+    mocks.osAccountsLogin.mockResolvedValue(unsubscribedAccount);
+    render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+
+    await walkToTrial(user);
+    await user.click(screen.getByRole("button", { name: "Start free trial" }));
+
+    await waitFor(() => expect(mocks.osAccountsLogin).toHaveBeenCalledOnce());
+    expect(mocks.osAccountsStartTrialCheckout).toHaveBeenCalledTimes(2);
+    expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
+    await screen.findByRole("heading", {
+      name: "Finish checkout in your browser",
+    });
+    await screen.findByText(/We opened a secure Stripe checkout/);
+  });
+
+  it("falls back to the portal when re-auth does not unblock checkout", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsStartTrialCheckout.mockRejectedValue({
+      code: "trial_checkout_needs_reauth",
+      message: "Sign in again to continue.",
+    });
+    mocks.osAccountsLogin.mockResolvedValue(unsubscribedAccount);
+    mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
+    render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+
+    await walkToTrial(user);
+    await user.click(screen.getByRole("button", { name: "Start free trial" }));
+
+    await waitFor(() =>
+      expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce(),
+    );
+    expect(mocks.osAccountsStartTrialCheckout).toHaveBeenCalledTimes(2);
+    await screen.findByText(/We opened your account portal/);
+  });
+
+  it("returns to the pitch when the user cancels the re-auth", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsStartTrialCheckout.mockRejectedValue({
+      code: "trial_checkout_needs_reauth",
+      message: "Sign in again to continue.",
+    });
+    mocks.osAccountsLogin.mockRejectedValue({
+      code: "login_canceled",
+      message: "Sign-in canceled.",
+    });
+    render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+
+    await walkToTrial(user);
+    await user.click(screen.getByRole("button", { name: "Start free trial" }));
+
+    // Back at the pitch with a friendly note; no portal page forced open.
+    await screen.findByRole("heading", { name: "Start your free trial" });
+    await screen.findByText(/Sign-in canceled/);
+    expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
+  });
+
   it("resumes a half-finished run at the saved step", async () => {
     setOnboardingResumeStep("setup");
     render(<OnboardingFlow {...flowProps()} />);

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -349,20 +349,61 @@ describe("OnboardingFlow", () => {
         message: "Sign in again to continue.",
       })
       .mockResolvedValueOnce({ outcome: "checkoutOpened" });
-    mocks.osAccountsLogin.mockResolvedValue(unsubscribedAccount);
+    let finishLogin: (() => void) | undefined;
+    mocks.osAccountsLogin.mockImplementation(
+      () =>
+        new Promise<typeof unsubscribedAccount>((resolve) => {
+          finishLogin = () => resolve(unsubscribedAccount);
+        }),
+    );
     render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
     await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
 
     await walkToTrial(user);
     await user.click(screen.getByRole("button", { name: "Start free trial" }));
 
-    await waitFor(() => expect(mocks.osAccountsLogin).toHaveBeenCalledOnce());
-    expect(mocks.osAccountsStartTrialCheckout).toHaveBeenCalledTimes(2);
+    // While the sign-in bounce is in flight the button says what's happening
+    // (and stays disabled) instead of pretending checkout is opening.
+    const reauthButton = await screen.findByRole("button", {
+      name: "Confirming your sign-in…",
+    });
+    expect(reauthButton).toBeDisabled();
+    finishLogin?.();
+
+    await waitFor(() =>
+      expect(mocks.osAccountsStartTrialCheckout).toHaveBeenCalledTimes(2),
+    );
+    expect(mocks.osAccountsLogin).toHaveBeenCalledOnce();
     expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
     await screen.findByRole("heading", {
       name: "Finish checkout in your browser",
     });
     await screen.findByText(/We opened a secure Stripe checkout/);
+  });
+
+  it("falls back to the portal when the re-auth itself fails", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsStartTrialCheckout.mockRejectedValue({
+      code: "trial_checkout_needs_reauth",
+      message: "Sign in again to continue.",
+    });
+    mocks.osAccountsLogin.mockRejectedValue({
+      code: "network_error",
+      message: "Could not reach OS Accounts.",
+    });
+    mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
+    render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+
+    await walkToTrial(user);
+    await user.click(screen.getByRole("button", { name: "Start free trial" }));
+
+    await waitFor(() =>
+      expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce(),
+    );
+    // No retry without a fresh grant: the direct path was attempted once.
+    expect(mocks.osAccountsStartTrialCheckout).toHaveBeenCalledOnce();
+    await screen.findByText(/We opened your account portal/);
   });
 
   it("falls back to the portal when re-auth does not unblock checkout", async () => {


### PR DESCRIPTION
## Why users were landing on the accounts portal

The direct-to-Stripe path already exists: `os_accounts_start_trial_checkout` mints the subscription Checkout session via `POST /billing/subscription` with the user's own token and opens Stripe straight away, with the portal only as a fallback. But that endpoint requires the `billing:write` scope, and **a session whose sign-in predates `billing:write` being added to `OAUTH_SCOPES` can never use it**: OAuth refresh can only narrow a grant, never broaden it, so the request fails with 3001 ("access token is missing required scope") on every attempt and the hook detours to the portal - forever, until the user happens to sign out and back in.

Verified against staging with a real grandfathered token: its scope set is `billing:read credits:spend profile:read` (no `billing:write`), and `POST /billing/subscription` returns `error_code: 3001, "access token is missing required scope"`. The endpoint itself exists and is live on both staging and production accounts APIs.

## The fix

**Rust** (`os_accounts.rs`): the retry loop already refreshes once on 3001. A *second* 3001 from a freshly refreshed token can only mean a scope gap, so surface it as a distinct `trial_checkout_needs_reauth` error instead of the generic `trial_checkout_unavailable`.

**Frontend** (`trial-checkout.ts`): on `trial_checkout_needs_reauth`, re-run the normal `osAccountsLogin()` - for an already-authenticated user this is a quick browser bounce that returns with the current scope set - then retry the direct checkout once. The user still lands straight on Stripe. The portal remains the fallback only for failures a re-auth cannot fix (subscriptions disabled server-side, network trouble). Canceling the re-auth returns to the trial pitch with a notice, mirroring the existing checkout-cancel behavior; the login wait is bounded by the existing `LOGIN_TIMEOUT`.

Both surfaces that share the hook (onboarding `TrialStep` and the post-onboarding `TrialGate`) get the behavior for free.

## Testing

- 3 new tests in `onboarding.test.tsx`: scope error -> re-auth -> retry lands on the Stripe waiting copy with the portal never opened; re-auth that doesn't unblock falls back to the portal; canceled re-auth returns to the pitch with a notice.
- Full suite: 310/310 pass. `pnpm lint` clean. `cargo check`/`clippy`/`fmt` clean (no new warnings).
- Live API probe (staging + production) confirming the failure mode and that the endpoint is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)