### PR TITLE
Show routine schedules in plain language instead of raw cron

### DIFF
--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -16,6 +16,7 @@ import {
   routineEditPrompt,
   type RoutineJob,
 } from "../../lib/hermes-routines";
+import { humanizeSchedule } from "../../lib/routine-schedule";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
@@ -69,7 +70,9 @@ export function RoutinesView({
     const normalized = query.trim().toLowerCase();
     if (!normalized) return routines;
     return routines.filter((routine) =>
-      `${routine.name} ${routine.prompt_preview} ${routine.schedule}`
+      // Match the displayed wording too, so "weekdays" finds a routine whose
+      // stored schedule is "0 9 * * 1-5".
+      `${routine.name} ${routine.prompt_preview} ${routine.schedule} ${humanizeSchedule(routine.schedule)}`
         .toLowerCase()
         .includes(normalized),
     );
@@ -342,7 +345,7 @@ function RoutineRow({
   const paused = routine.state === "paused";
   const completed = routine.state === "completed";
   const meta = [
-    routine.schedule,
+    humanizeSchedule(routine.schedule),
     completed
       ? routine.last_run_at
         ? `Last ran ${formatRunTime(routine.last_run_at)}`

--- a/src/lib/routine-schedule.ts
+++ b/src/lib/routine-schedule.ts
@@ -1,0 +1,252 @@
+/** Turns the cron expressions Hermes stores for routines into plain language
+ * for the Routines list ("0 8 * * 1-5" reads as "Weekdays at 8:00 AM").
+ *
+ * Hermes passes the job's schedule through verbatim, so the field may hold a
+ * five-field cron expression, an interval ("every 30m"), a one-off ISO date,
+ * or text that is already human. Only the cron case needs translation; every
+ * other input — and any cron shape too exotic to phrase with confidence
+ * (combined day-of-month + day-of-week restrictions, stepped ranges) — is
+ * returned unchanged rather than risk describing a schedule wrongly. */
+
+type CronField =
+  | { kind: "any" }
+  | { kind: "step"; step: number }
+  | { kind: "values"; values: number[] };
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+const DAY_TOKENS = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+const MONTH_TOKENS = [
+  "jan",
+  "feb",
+  "mar",
+  "apr",
+  "may",
+  "jun",
+  "jul",
+  "aug",
+  "sep",
+  "oct",
+  "nov",
+  "dec",
+];
+
+const MACROS: Record<string, string> = {
+  "@hourly": "0 * * * *",
+  "@daily": "0 0 * * *",
+  "@midnight": "0 0 * * *",
+  "@weekly": "0 0 * * 0",
+  "@monthly": "0 0 1 * *",
+  "@yearly": "0 0 1 1 *",
+  "@annually": "0 0 1 1 *",
+};
+
+export function humanizeSchedule(schedule: string): string {
+  const trimmed = schedule.trim();
+  const source =
+    MACROS[trimmed.toLowerCase()] ?? trimmed.replace(/^cron:?\s+/i, "");
+  const fields = source.split(/\s+/);
+  if (fields.length !== 5) return schedule;
+
+  const minute = parseField(fields[0], 0, 59);
+  const hour = parseField(fields[1], 0, 23);
+  const dayOfMonth = parseField(fields[2], 1, 31);
+  const month = parseField(fields[3], 1, 12, MONTH_TOKENS);
+  const dayOfWeek = parseField(fields[4], 0, 7, DAY_TOKENS);
+  if (!minute || !hour || !dayOfMonth || !month || !dayOfWeek) return schedule;
+
+  return (
+    phrase(minute, hour, dayOfMonth, month, normalizeDayOfWeek(dayOfWeek)) ??
+    schedule
+  );
+}
+
+function parseField(
+  raw: string,
+  min: number,
+  max: number,
+  names?: string[],
+): CronField | null {
+  if (raw === "*") return { kind: "any" };
+
+  const step = raw.match(/^\*\/(\d+)$/);
+  if (step) {
+    const value = Number(step[1]);
+    if (value < 1) return null;
+    return value === 1 ? { kind: "any" } : { kind: "step", step: value };
+  }
+
+  const values: number[] = [];
+  for (const part of raw.split(",")) {
+    const range = part.match(/^([a-z0-9]+)-([a-z0-9]+)$/i);
+    if (range) {
+      const from = tokenValue(range[1], min, max, names);
+      const to = tokenValue(range[2], min, max, names);
+      if (from === null || to === null || to < from) return null;
+      for (let value = from; value <= to; value += 1) values.push(value);
+      continue;
+    }
+    const value = tokenValue(part, min, max, names);
+    if (value === null) return null;
+    values.push(value);
+  }
+  if (values.length === 0) return null;
+  return { kind: "values", values: [...new Set(values)].sort((a, b) => a - b) };
+}
+
+function tokenValue(
+  token: string,
+  min: number,
+  max: number,
+  names?: string[],
+): number | null {
+  if (names) {
+    const index = names.indexOf(token.slice(0, 3).toLowerCase());
+    if (index !== -1) return index + Math.min(min, 1);
+  }
+  if (!/^\d+$/.test(token)) return null;
+  const value = Number(token);
+  return value >= min && value <= max ? value : null;
+}
+
+/** Cron accepts both 0 and 7 for Sunday; a full 0-6 list is just "any day". */
+function normalizeDayOfWeek(field: CronField): CronField {
+  if (field.kind !== "values") return field;
+  const values = [
+    ...new Set(field.values.map((value) => (value === 7 ? 0 : value))),
+  ].sort((a, b) => a - b);
+  if (values.length === 7) return { kind: "any" };
+  return { kind: "values", values };
+}
+
+function phrase(
+  minute: CronField,
+  hour: CronField,
+  dayOfMonth: CronField,
+  month: CronField,
+  dayOfWeek: CronField,
+): string | null {
+  const unrestrictedDate =
+    dayOfMonth.kind === "any" &&
+    month.kind === "any" &&
+    dayOfWeek.kind === "any";
+
+  if (unrestrictedDate) {
+    if (minute.kind === "any" && hour.kind === "any") return "Every minute";
+    if (minute.kind === "step" && hour.kind === "any")
+      return `Every ${minute.step} minutes`;
+    const fixedMinute = singleValue(minute);
+    if (fixedMinute !== null && hour.kind === "any")
+      return fixedMinute === 0
+        ? "Every hour"
+        : `Every hour at :${String(fixedMinute).padStart(2, "0")}`;
+    if (fixedMinute === 0 && hour.kind === "step")
+      return `Every ${hour.step} hours`;
+    const time = timeText(minute, hour);
+    return time ? `Every day at ${time}` : null;
+  }
+
+  const time = timeText(minute, hour);
+  if (!time) return null;
+
+  if (
+    dayOfWeek.kind === "values" &&
+    dayOfMonth.kind === "any" &&
+    month.kind === "any"
+  )
+    return `${dayPhrase(dayOfWeek.values)} at ${time}`;
+
+  if (
+    dayOfMonth.kind === "values" &&
+    dayOfWeek.kind === "any" &&
+    month.kind === "any"
+  )
+    return `Monthly on the ${joinAnd(dayOfMonth.values.map(ordinal))} at ${time}`;
+
+  if (
+    month.kind === "values" &&
+    month.values.length === 1 &&
+    dayOfMonth.kind === "values" &&
+    dayOfWeek.kind === "any"
+  ) {
+    const monthName = MONTH_NAMES[month.values[0] - 1];
+    const dates = dayOfMonth.values.map((day) => `${monthName} ${day}`);
+    return `Every year on ${joinAnd(dates)} at ${time}`;
+  }
+
+  return null;
+}
+
+/** A concrete clock time needs one minute value and one or more hour values;
+ * anything else (wildcards, steps) has no single time to print. */
+function timeText(minute: CronField, hour: CronField): string | null {
+  const fixedMinute = singleValue(minute);
+  if (fixedMinute === null || hour.kind !== "values") return null;
+  return joinAnd(hour.values.map((h) => formatClockTime(h, fixedMinute)));
+}
+
+function dayPhrase(days: number[]): string {
+  if (sameValues(days, [1, 2, 3, 4, 5])) return "Weekdays";
+  if (sameValues(days, [0, 6])) return "Weekends";
+  if (days.length === 1) return `Every ${DAY_NAMES[days[0]]}`;
+  const contiguous = days.every(
+    (value, index) => index === 0 || value === days[index - 1] + 1,
+  );
+  if (contiguous && days.length >= 3)
+    return `Every ${DAY_NAMES[days[0]]} to ${DAY_NAMES[days[days.length - 1]]}`;
+  return `Every ${joinAnd(days.map((day) => DAY_NAMES[day]))}`;
+}
+
+function formatClockTime(hourOfDay: number, minute: number): string {
+  return new Date(2000, 0, 1, hourOfDay, minute).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function singleValue(field: CronField): number | null {
+  return field.kind === "values" && field.values.length === 1
+    ? field.values[0]
+    : null;
+}
+
+function sameValues(left: number[], right: number[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function joinAnd(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? "";
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}
+
+function ordinal(value: number): string {
+  const tens = value % 100;
+  if (tens >= 11 && tens <= 13) return `${value}th`;
+  const suffix = { 1: "st", 2: "nd", 3: "rd" }[value % 10] ?? "th";
+  return `${value}${suffix}`;
+}

--- a/src/test/routine-schedule.test.ts
+++ b/src/test/routine-schedule.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { humanizeSchedule } from "../lib/routine-schedule";
+
+/** Mirrors the formatter's locale-aware clock rendering so assertions hold
+ * regardless of the machine locale running the suite. */
+function time(hour: number, minute: number) {
+  return new Date(2000, 0, 1, hour, minute).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+describe("humanizeSchedule", () => {
+  it("translates daily schedules", () => {
+    expect(humanizeSchedule("0 8 * * *")).toBe(`Every day at ${time(8, 0)}`);
+    expect(humanizeSchedule("30 17 * * *")).toBe(
+      `Every day at ${time(17, 30)}`,
+    );
+    expect(humanizeSchedule("0 9,17 * * *")).toBe(
+      `Every day at ${time(9, 0)} and ${time(17, 0)}`,
+    );
+  });
+
+  it("translates minute and hour cadences", () => {
+    expect(humanizeSchedule("* * * * *")).toBe("Every minute");
+    expect(humanizeSchedule("*/15 * * * *")).toBe("Every 15 minutes");
+    expect(humanizeSchedule("*/1 * * * *")).toBe("Every minute");
+    expect(humanizeSchedule("0 * * * *")).toBe("Every hour");
+    expect(humanizeSchedule("30 * * * *")).toBe("Every hour at :30");
+    expect(humanizeSchedule("0 */2 * * *")).toBe("Every 2 hours");
+  });
+
+  it("translates day-of-week schedules", () => {
+    expect(humanizeSchedule("0 9 * * 1-5")).toBe(`Weekdays at ${time(9, 0)}`);
+    expect(humanizeSchedule("0 10 * * 0,6")).toBe(`Weekends at ${time(10, 0)}`);
+    expect(humanizeSchedule("0 8 * * 1")).toBe(`Every Monday at ${time(8, 0)}`);
+    expect(humanizeSchedule("0 8 * * mon")).toBe(
+      `Every Monday at ${time(8, 0)}`,
+    );
+    // Cron allows 7 for Sunday alongside 0.
+    expect(humanizeSchedule("0 8 * * 7")).toBe(`Every Sunday at ${time(8, 0)}`);
+    expect(humanizeSchedule("0 8 * * 1,3,5")).toBe(
+      `Every Monday, Wednesday, and Friday at ${time(8, 0)}`,
+    );
+    expect(humanizeSchedule("0 8 * * 1-3")).toBe(
+      `Every Monday to Wednesday at ${time(8, 0)}`,
+    );
+    expect(humanizeSchedule("0 8 * * 0-6")).toBe(`Every day at ${time(8, 0)}`);
+  });
+
+  it("translates monthly and yearly schedules", () => {
+    expect(humanizeSchedule("0 9 1 * *")).toBe(
+      `Monthly on the 1st at ${time(9, 0)}`,
+    );
+    expect(humanizeSchedule("0 9 1,15 * *")).toBe(
+      `Monthly on the 1st and 15th at ${time(9, 0)}`,
+    );
+    expect(humanizeSchedule("0 9 22 * *")).toBe(
+      `Monthly on the 22nd at ${time(9, 0)}`,
+    );
+    expect(humanizeSchedule("0 9 11 6 *")).toBe(
+      `Every year on Jun 11 at ${time(9, 0)}`,
+    );
+    expect(humanizeSchedule("0 9 11 jun *")).toBe(
+      `Every year on Jun 11 at ${time(9, 0)}`,
+    );
+  });
+
+  it("translates macros", () => {
+    expect(humanizeSchedule("@hourly")).toBe("Every hour");
+    expect(humanizeSchedule("@daily")).toBe(`Every day at ${time(0, 0)}`);
+    expect(humanizeSchedule("@weekly")).toBe(`Every Sunday at ${time(0, 0)}`);
+    expect(humanizeSchedule("@monthly")).toBe(
+      `Monthly on the 1st at ${time(0, 0)}`,
+    );
+    expect(humanizeSchedule("@yearly")).toBe(
+      `Every year on Jan 1 at ${time(0, 0)}`,
+    );
+  });
+
+  it("accepts a cron: prefix", () => {
+    expect(humanizeSchedule("cron: 0 8 * * *")).toBe(
+      `Every day at ${time(8, 0)}`,
+    );
+  });
+
+  it("passes non-cron schedules through unchanged", () => {
+    expect(humanizeSchedule("every day at 9:00")).toBe("every day at 9:00");
+    expect(humanizeSchedule("every 30m")).toBe("every 30m");
+    expect(humanizeSchedule("2026-06-12T09:00:00")).toBe("2026-06-12T09:00:00");
+    expect(humanizeSchedule("")).toBe("");
+  });
+
+  it("passes invalid or exotic cron expressions through unchanged", () => {
+    // Out-of-range minute.
+    expect(humanizeSchedule("61 9 * * *")).toBe("61 9 * * *");
+    // Six fields (seconds-style cron) is not the gateway's format.
+    expect(humanizeSchedule("0 0 9 * * *")).toBe("0 0 9 * * *");
+    // Stepped range: too exotic to phrase confidently.
+    expect(humanizeSchedule("1-5/2 * * * *")).toBe("1-5/2 * * * *");
+    // Day-of-month and day-of-week combined use cron's OR semantics; saying
+    // it wrongly is worse than showing the expression.
+    expect(humanizeSchedule("0 9 1 * 1")).toBe("0 9 1 * 1");
+    expect(humanizeSchedule("*/0 * * * *")).toBe("*/0 * * * *");
+  });
+});

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -61,6 +61,33 @@ describe("RoutinesView", () => {
     expect(screen.getByText("Summarize my unread notes")).toBeInTheDocument();
   });
 
+  it("shows cron schedules as plain language and matches it in search", async () => {
+    mocks.listRoutines.mockResolvedValue([
+      job({ schedule: "0 9 * * 1-5" }),
+      job({
+        job_id: "def456",
+        name: "Weekly digest",
+        prompt_preview: "Compile a digest of the week",
+        schedule: "0 8 * * 1",
+      }),
+    ]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+
+    const nine = new Date(2000, 0, 1, 9, 0).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    expect(
+      await screen.findByText(`Weekdays at ${nine}`, { exact: false }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("0 9 * * 1-5", { exact: false })).toBeNull();
+
+    // The search box matches the displayed wording, not just the raw cron.
+    await userEvent.type(screen.getByRole("searchbox"), "weekdays");
+    expect(screen.getByText("Morning summary")).toBeInTheDocument();
+    expect(screen.queryByText("Weekly digest")).toBeNull();
+  });
+
   it("shows the empty state and routes creation through the agent prompt", async () => {
     mocks.listRoutines.mockResolvedValue([]);
     const onCreateRoutine = vi.fn();


### PR DESCRIPTION
## Problem

The Routines list renders the job's `schedule` field verbatim. When the schedule is stored as a cron expression, users see strings like `0 8 * * 1-5`, which mean nothing to a regular person.

## Change

- New `src/lib/routine-schedule.ts` exporting `humanizeSchedule`, which translates five-field cron expressions and `@daily`-style macros into plain language:
  - `0 8 * * 1-5` reads as "Weekdays at 8:00 AM"
  - `*/15 * * * *` reads as "Every 15 minutes"
  - `0 9 1,15 * *` reads as "Monthly on the 1st and 15th at 9:00 AM"
  - `0 9 11 6 *` reads as "Every year on Jun 11 at 9:00 AM"
- `RoutinesView` uses it for the row meta, and the search filter also matches the displayed wording (typing "weekdays" finds a `0 9 * * 1-5` routine).
- Clock times go through `toLocaleTimeString`, matching how the view already formats next and last run times (12h or 24h per the user's locale).

## Deliberately unchanged

- Non-cron schedules pass through untouched: already-human text ("every day at 9:00"), intervals ("every 30m"), one-off ISO dates.
- Cron shapes we cannot phrase confidently also pass through rather than risk describing a schedule wrongly: combined day-of-month + day-of-week restrictions (cron ORs them), stepped ranges, out-of-range or malformed fields.
- The agent edit prompt (`routineEditPrompt`) keeps sending the raw schedule, which is more precise for June's cronjob tool.

## Testing

- New unit suite `src/test/routine-schedule.test.ts` covering daily, weekly, monthly, yearly, cadence, macro, and pass-through cases (locale-independent assertions).
- New `RoutinesView` test asserting the humanized text renders, the raw cron does not, and search matches the displayed wording.
- `pnpm lint` and the full `pnpm test` suite (39 files, 324 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)