### PR TITLE
Verify-page copy: audio goes to Venice private models by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Together these bind the running image to a public commit: you can confirm the at
 
 Every deployment also serves its own walkthrough of this chain at [`/verify`](https://scribe-api.opensoftware.co/verify) — served from inside the TEE, it reports the exact commit and image the running server was built from, with step-by-step instructions for checking each link.
 
-By default, everything leaving the TEE for model inference (audio for transcription, prompts and context for note generation and the agent) goes only to Venice private models (zero data retention, no training). If you select an anonymized model not run by Venice, those requests are forwarded to that provider with identifying metadata stripped, under that provider's own privacy policy. This chain verifies the **code** running in the confidential VM, not what upstream providers do. End-to-end private inference is a separate workstream.
+Everything leaving the TEE for model inference (audio for transcription, prompts and context for note generation and the agent) goes through Venice. By default it runs on Venice private models: zero data retention, no training. If you select an anonymized model not run by Venice, the request is still routed and anonymized by Venice, but the underlying model provider may retain data under its own privacy policy. This chain verifies the **code** running in the confidential VM, not what upstream providers do. End-to-end private inference is a separate workstream.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Together these bind the running image to a public commit: you can confirm the at
 
 Every deployment also serves its own walkthrough of this chain at [`/verify`](https://scribe-api.opensoftware.co/verify) — served from inside the TEE, it reports the exact commit and image the running server was built from, with step-by-step instructions for checking each link.
 
-By default, audio leaves the TEE only to Venice private models (zero data retention, no training). If you select an anonymized model not run by Venice, audio is forwarded to that provider with identifying metadata stripped, under that provider's own privacy policy. This chain verifies the **code** running in the confidential VM, not what upstream providers do with audio. End-to-end private STT is a separate workstream.
+By default, everything leaving the TEE for model inference (audio for transcription, prompts and context for note generation and the agent) goes only to Venice private models (zero data retention, no training). If you select an anonymized model not run by Venice, those requests are forwarded to that provider with identifying metadata stripped, under that provider's own privacy policy. This chain verifies the **code** running in the confidential VM, not what upstream providers do. End-to-end private inference is a separate workstream.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Together these bind the running image to a public commit: you can confirm the at
 
 Every deployment also serves its own walkthrough of this chain at [`/verify`](https://scribe-api.opensoftware.co/verify) — served from inside the TEE, it reports the exact commit and image the running server was built from, with step-by-step instructions for checking each link.
 
-Audio still leaves the TEE when forwarded to OpenAI or Venice for transcription, under those providers' own privacy policies. This chain verifies the **code** running in the confidential VM, not what upstream providers do with audio. End-to-end private STT is a separate workstream.
+By default, audio leaves the TEE only to Venice private models (zero data retention, no training). If you select an anonymized model not run by Venice, audio is forwarded to that provider with identifying metadata stripped, under that provider's own privacy policy. This chain verifies the **code** running in the confidential VM, not what upstream providers do with audio. End-to-end private STT is a separate workstream.
 
 ## Development
 

--- a/scribe-api/crates/api/src/handlers/verify.rs
+++ b/scribe-api/crates/api/src/handlers/verify.rs
@@ -225,13 +225,13 @@ the digest yourself instead of trusting our CI) are in progress; see
 
 <h2>What this does not cover</h2>
 <p>The chain verifies the <strong>code</strong> running in the confidential VM,
-not what upstream providers do. By default, everything leaving the TEE for
-model inference (audio for transcription, prompts and context for note
-generation and the agent) goes only to Venice private models (zero data
-retention, no training). If you select an anonymized model not run by Venice,
-those requests are forwarded to that provider with identifying metadata
-stripped, under that provider's own privacy policy. End-to-end private
-inference is a separate workstream.</p>
+not what upstream providers do. Everything leaving the TEE for model inference
+(audio for transcription, prompts and context for note generation and the
+agent) goes through Venice. By default it runs on Venice private models: zero
+data retention, no training. If you select an anonymized model not run by
+Venice, the request is still routed and anonymized by Venice, but the
+underlying model provider may retain data under its own privacy policy.
+End-to-end private inference is a separate workstream.</p>
 
 <footer>
   <p>Open Software · <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>

--- a/scribe-api/crates/api/src/handlers/verify.rs
+++ b/scribe-api/crates/api/src/handlers/verify.rs
@@ -225,11 +225,13 @@ the digest yourself instead of trusting our CI) are in progress; see
 
 <h2>What this does not cover</h2>
 <p>The chain verifies the <strong>code</strong> running in the confidential VM,
-not what upstream providers do. By default, audio leaves the TEE only to
-Venice private models (zero data retention, no training). If you select an
-anonymized model not run by Venice, audio is forwarded to that provider with
-identifying metadata stripped, under that provider's own privacy policy.
-End-to-end private speech-to-text is a separate workstream.</p>
+not what upstream providers do. By default, everything leaving the TEE for
+model inference (audio for transcription, prompts and context for note
+generation and the agent) goes only to Venice private models (zero data
+retention, no training). If you select an anonymized model not run by Venice,
+those requests are forwarded to that provider with identifying metadata
+stripped, under that provider's own privacy policy. End-to-end private
+inference is a separate workstream.</p>
 
 <footer>
   <p>Open Software · <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>

--- a/scribe-api/crates/api/src/handlers/verify.rs
+++ b/scribe-api/crates/api/src/handlers/verify.rs
@@ -225,9 +225,11 @@ the digest yourself instead of trusting our CI) are in progress; see
 
 <h2>What this does not cover</h2>
 <p>The chain verifies the <strong>code</strong> running in the confidential VM,
-not what upstream providers do. Audio still leaves the TEE when forwarded to
-OpenAI or Venice for transcription, under those providers' own privacy
-policies. End-to-end private speech-to-text is a separate workstream.</p>
+not what upstream providers do. By default, audio leaves the TEE only to
+Venice private models (zero data retention, no training). If you select an
+anonymized model not run by Venice, audio is forwarded to that provider with
+identifying metadata stripped, under that provider's own privacy policy.
+End-to-end private speech-to-text is a separate workstream.</p>
 
 <footer>
   <p>Open Software · <a href="@REPO_URL@">source</a> · <a href="@TRUST_CENTER_URL@">attestation</a></p>


### PR DESCRIPTION
The "What this does not cover" section on `/verify` (and the matching README paragraph) read as if audio is routinely forwarded to OpenAI or Venice interchangeably — and only mentioned audio, when generation and agent prompts leave the TEE the same way.

Corrected to match actual routing and the privacy positioning:

- **Everything** leaving the TEE for model inference — audio for transcription, prompts and context for note generation and the agent — **routes through Venice**.
- **By default** it runs on Venice private models: zero data retention, no training.
- If the user selects an **anonymized model not run by Venice**, the request is still routed and anonymized by Venice, but the underlying model provider may retain data under its own privacy policy.
- The verification-scope caveat is unchanged, generalized from "private speech-to-text" to "private inference" as the separate workstream.

Verify handler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
