### PR TITLE
Agent approvals: "Explain first" now asks the model for a real explanation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25,15 +25,16 @@ use crate::{
             CheckRecordingSourceReadinessRequest, CreateAgentTaskRequest,
             CreateDictionaryEntryRequest, CreateFolderRequest, CreateNoteRequest,
             DeleteDictionaryEntryRequest, DeleteFolderRequest, DeleteNoteRequest,
-            DictionaryEntryDto, FinishRecordingResponse, GetAgentTaskRequest, GetNoteRequest,
-            ListNotesRequest, ListNotesResponse, MicrophonePermissionResponse, NoteDto,
-            OpenPrivacySettingsRequest, RecordingSessionDto, RecordingSource, RecordingSourceMode,
-            RecordingSourceReadinessDto, RecordingStatusDto, RemoveNoteFromFolderRequest,
-            RemoveSessionFromFolderRequest, RenameFolderRequest, RetryProcessingRequest,
-            SaveAgentAssistantMessageRequest, SaveAgentHermesSessionRequest,
-            SendAgentMessageRequest, SessionFolderDto, SessionRequest, SourceReadinessDto,
-            StartRecordingRequest, SuggestAgentSessionTitleRequest,
-            SuggestAgentSessionTitleResponse, UpdateDictionaryEntryRequest, UpdateNoteRequest,
+            DictionaryEntryDto, ExplainAgentApprovalRequest, ExplainAgentApprovalResponse,
+            FinishRecordingResponse, GetAgentTaskRequest, GetNoteRequest, ListNotesRequest,
+            ListNotesResponse, MicrophonePermissionResponse, NoteDto, OpenPrivacySettingsRequest,
+            RecordingSessionDto, RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto,
+            RecordingStatusDto, RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest,
+            RenameFolderRequest, RetryProcessingRequest, SaveAgentAssistantMessageRequest,
+            SaveAgentHermesSessionRequest, SendAgentMessageRequest, SessionFolderDto,
+            SessionRequest, SourceReadinessDto, StartRecordingRequest,
+            SuggestAgentSessionTitleRequest, SuggestAgentSessionTitleResponse,
+            UpdateDictionaryEntryRequest, UpdateNoteRequest,
         },
     },
 };
@@ -387,6 +388,16 @@ pub async fn suggest_agent_session_title(
 ) -> Result<SuggestAgentSessionTitleResponse, AppError> {
     let title = crate::scribe_api::suggest_agent_session_title(&request.prompt).await?;
     Ok(SuggestAgentSessionTitleResponse { title })
+}
+
+#[tauri::command]
+pub async fn explain_agent_approval(
+    request: ExplainAgentApprovalRequest,
+) -> Result<ExplainAgentApprovalResponse, AppError> {
+    let explanation =
+        crate::scribe_api::explain_agent_approval(&request.description, request.command.as_deref())
+            .await?;
+    Ok(ExplainAgentApprovalResponse { explanation })
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -579,6 +579,20 @@ pub struct SuggestAgentSessionTitleResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ExplainAgentApprovalRequest {
+    pub description: String,
+    #[serde(default)]
+    pub command: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExplainAgentApprovalResponse {
+    pub explanation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AgentTaskRequest {
     pub task_id: String,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,7 @@ pub fn run() {
             commands::save_agent_assistant_message,
             commands::save_agent_hermes_session,
             commands::suggest_agent_session_title,
+            commands::explain_agent_approval,
             commands::cancel_agent_task,
             commands::retry_agent_task,
             commands::list_agent_tool_events,

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -531,6 +531,69 @@ pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppErro
     })
 }
 
+/// Plain-language explanation of a pending approval request, written by the
+/// generation model. The agent runtime is parked waiting on the approval, so
+/// this is a one-shot side call — it never touches the paused session.
+pub async fn explain_agent_approval(
+    description: &str,
+    command: Option<&str>,
+) -> Result<String, AppError> {
+    let description = description.trim();
+    let command = command.map(str::trim).filter(|value| !value.is_empty());
+    if description.is_empty() && command.is_none() {
+        return Err(AppError::new(
+            "approval_explanation_empty",
+            "There is nothing to explain for this approval request.",
+        ));
+    }
+    let mut request_text = format!("Permission request: {description}");
+    if let Some(command) = command {
+        request_text.push_str("\nExact command or action:\n");
+        request_text.push_str(command);
+    }
+    let response = proxy_agent_chat_completions(serde_json::json!({
+        "messages": [
+            {
+                "role": "system",
+                "content": "An AI agent paused mid-task to ask its user for permission. Explain what this specific request would actually do, in plain language the user can act on: name the files, hosts, or data involved, decode any flags or shell syntax, and call out anything risky or hard to undo (deleting or overwriting files, sending data off the machine, spending money). Use 2 to 4 short sentences. Never be generic, never use markdown or headings, and never tell the user which button to press."
+            },
+            {
+                "role": "user",
+                "content": request_text
+            }
+        ],
+        "temperature": 0.2,
+        "max_tokens": 220
+    }))
+    .await?;
+    if !(200..300).contains(&response.status) {
+        return Err(AppError::new(
+            "approval_explanation_failed",
+            format!(
+                "Explanation generation returned status {}.",
+                response.status
+            ),
+        ));
+    }
+    let body = response.collect_body().await?;
+    let value: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|error| AppError::new("approval_explanation_invalid", error.to_string()))?;
+    let text = extract_chat_completion_text(&value).ok_or_else(|| {
+        AppError::new(
+            "approval_explanation_invalid",
+            "Explanation generation did not return text.",
+        )
+    })?;
+    let explanation = text.trim();
+    if explanation.is_empty() {
+        return Err(AppError::new(
+            "approval_explanation_empty",
+            "Explanation generation returned an empty explanation.",
+        ));
+    }
+    Ok(explanation.to_string())
+}
+
 pub fn dictation_provider_for_model(model_id: &str) -> &'static str {
     crate::providers::transcription_provider_for_model(model_id)
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -71,6 +71,7 @@ import {
   cancelAgentTask,
   createAgentTask,
   dictationHelperCommand,
+  explainAgentApproval,
   getAgentTask,
   ensureHermesBridgeSession,
   hermesBridgeFilesystemSnapshot,
@@ -4762,7 +4763,36 @@ function ApprovalPart({
   const activeChoice = part.choice ?? submitting;
   const resolved = part.status !== "pending" || activeChoice !== undefined;
   const [explainOpen, setExplainOpen] = useState(false);
+  // "Explain first" asks the generation model what this specific request
+  // would do — the request stays parked, nothing is approved by asking.
+  // The answer is cached for the card's lifetime; an error retries on the
+  // next open and falls back to static copy meanwhile.
+  const [explanation, setExplanation] = useState<string>();
+  const [explainState, setExplainState] = useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle");
   const explanationId = useId();
+
+  function toggleExplain() {
+    const nextOpen = !explainOpen;
+    setExplainOpen(nextOpen);
+    if (!nextOpen || explainState === "loading" || explainState === "ready") {
+      return;
+    }
+    setExplainState("loading");
+    explainAgentApproval({
+      description: part.description,
+      command: part.command || undefined,
+    })
+      .then((response) => {
+        setExplanation(response.explanation);
+        setExplainState("ready");
+      })
+      .catch(() => {
+        setExplainState("error");
+      });
+  }
+
   return (
     <article className="agent-approval-card" data-status={part.status}>
       <span className="agent-tool-icon">
@@ -4782,10 +4812,25 @@ function ApprovalPart({
         {part.command ? <pre>{part.command}</pre> : null}
         {!resolved && explainOpen ? (
           <div className="agent-approval-explanation" id={explanationId}>
-            <p>
-              June is paused because this request needs your explicit permission
-              before it can continue.
-            </p>
+            {explainState === "loading" ? (
+              <p
+                className="agent-approval-explanation-loading"
+                role="status"
+                aria-live="polite"
+              >
+                <Spinner aria-hidden />
+                <span>Working out what this request does…</span>
+              </p>
+            ) : explainState === "ready" && explanation ? (
+              <p>{explanation}</p>
+            ) : (
+              // Generation unavailable (offline, signed out): keep the
+              // static framing rather than an empty panel.
+              <p>
+                June is paused because this request needs your explicit
+                permission before it can continue.
+              </p>
+            )}
             <p>
               Approve once allows only this request. This session allows
               matching requests until the session ends.{" "}
@@ -4818,7 +4863,7 @@ function ApprovalPart({
               aria-expanded={explainOpen}
               aria-controls={explanationId}
               disabled={disabled}
-              onClick={() => setExplainOpen((value) => !value)}
+              onClick={toggleExplain}
             >
               <IconCircleQuestionmark size={14} />
               {explainOpen ? "Hide explanation" : "Explain first"}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -767,6 +767,21 @@ export async function suggestAgentSessionTitle(prompt: string) {
   );
 }
 
+export type ExplainAgentApprovalResponse = {
+  explanation: string;
+};
+
+/** One-shot generation call that explains a pending approval request in
+ * plain language — the agent runtime stays parked on the approval. */
+export async function explainAgentApproval(input: {
+  description: string;
+  command?: string;
+}) {
+  return invoke<ExplainAgentApprovalResponse>("explain_agent_approval", {
+    request: input,
+  });
+}
+
 export async function cancelAgentTask(taskId: string) {
   return invoke<AgentTaskDto>("cancel_agent_task", { request: { taskId } });
 }

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -54,6 +54,7 @@ const mocks = vi.hoisted(() => ({
   sendAgentMessage: vi.fn(),
   startHermesBridge: vi.fn(),
   suggestAgentSessionTitle: vi.fn(),
+  explainAgentApproval: vi.fn(),
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
   updateHermesBridgeMessagingPlatform: vi.fn(),
@@ -102,6 +103,7 @@ vi.mock("../lib/tauri", () => ({
   sendAgentMessage: mocks.sendAgentMessage,
   startHermesBridge: mocks.startHermesBridge,
   suggestAgentSessionTitle: mocks.suggestAgentSessionTitle,
+  explainAgentApproval: mocks.explainAgentApproval,
   toggleHermesBridgeSkill: mocks.toggleHermesBridgeSkill,
   toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform:
@@ -224,6 +226,10 @@ describe("AgentWorkspace", () => {
     mocks.deleteHermesSession.mockResolvedValue(undefined);
     mocks.suggestAgentSessionTitle.mockResolvedValue({
       title: "Summarize Current Page",
+    });
+    mocks.explainAgentApproval.mockResolvedValue({
+      explanation:
+        "This deletes the build folder, then rebuilds the project from scratch.",
     });
     mocks.gatewayRequest.mockImplementation((method: string) => {
       if (method === "session.create") {
@@ -712,9 +718,15 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Approval required")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Explain first" }));
 
+    // The explanation comes from the generation model, scoped to this
+    // request — not canned copy.
+    expect(mocks.explainAgentApproval).toHaveBeenCalledWith({
+      description: "Security scan requires approval.",
+      command: "npm run build",
+    });
     expect(
-      screen.getByText(
-        "June is paused because this request needs your explicit permission before it can continue.",
+      await screen.findByText(
+        "This deletes the build folder, then rebuilds the project from scratch.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -728,10 +740,68 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Approve once" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Always" })).toBeEnabled();
+    // Asking for an explanation never answers the approval.
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
       "approval.respond",
       expect.anything(),
     );
+
+    // Reopening reuses the cached answer instead of paying for another call.
+    await user.click(screen.getByRole("button", { name: "Hide explanation" }));
+    await user.click(screen.getByRole("button", { name: "Explain first" }));
+    expect(
+      await screen.findByText(
+        "This deletes the build folder, then rebuilds the project from scratch.",
+      ),
+    ).toBeInTheDocument();
+    expect(mocks.explainAgentApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to static copy when the explanation call fails", async () => {
+    const user = userEvent.setup();
+    mocks.explainAgentApproval.mockRejectedValue(new Error("offline"));
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the build",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the build",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "approval-1",
+            description: "Security scan requires approval.",
+            command: "npm run build",
+            allow_permanent: true,
+          },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Explain first" }));
+
+    expect(
+      await screen.findByText(
+        "June is paused because this request needs your explicit permission before it can continue.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Approve once allows only this request/),
+    ).toBeInTheDocument();
   });
 
   it("omits the permanent approval explanation when Always is unavailable", async () => {


### PR DESCRIPTION
## Why

"Explain first" on the approval card showed two hardcoded paragraphs — one generic line about June being paused and one about what the buttons mean. Nothing about what the request would *actually do*, which is the whole reason someone clicks it before approving a shell command they don't recognize.

## What

- **New one-shot generation call.** `explain_agent_approval` (scribe_api → the agent chat-completions proxy, same metered path as session-title suggestions) sends the approval's description and exact command. The system prompt requires a concrete 2–4 sentence plain-language explanation — name the files/hosts/data involved, decode flags and shell syntax, call out anything risky or hard to undo — and forbids generic filler, markdown, and "press this button" advice. The agent runtime stays parked on the approval; asking never answers it.
- **Card behavior.** First open shows a spinner ("Working out what this request does…"), then the model's explanation. The answer is cached for the card's lifetime, so toggling doesn't re-bill. If the call fails (offline, signed out, no credits), the card falls back to the old static line instead of an empty panel — and retries on the next open. The static "Approve once / This session / Always / Deny" semantics line stays beneath the explanation; that part is UI documentation and belongs hardcoded.
- Plumbing: Tauri command + DTOs, TS binding, registered in lib.rs.

## Tests

- Existing explain test reworked: asserts the model is called with the request's description+command, the returned explanation renders, asking doesn't respond to the approval, and reopening reuses the cached answer (exactly one call).
- New test: rejection falls back to the static copy.
- 316 frontend tests, cargo check/fmt, tsc, prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)