### PR TITLE
Ship the Hermes runtime inside the app bundle

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -214,6 +214,15 @@ jobs:
             $(security list-keychains -d user | tr -d '"')
           rm -f "$cert"
 
+      # Ship the Hermes runtime inside the app so first launch needs no
+      # multi-minute GitHub download. Must run after the certificate import:
+      # the script signs every Mach-O in the bundle (python, extension .so)
+      # with the Developer ID + hardened runtime, which notarization requires.
+      - name: Bundle Hermes runtime into app resources
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: ./scripts/bundle-hermes-runtime.sh
+
       - name: Build, sign, notarize, and publish updater release
         uses: tauri-apps/tauri-action@v0.6.2
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 keys/
 .tmp/
 coverage
+.tauri-hermes/

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -64,8 +64,13 @@ The workflow performs the release steps in order:
    `package.json`, refreshes `src-tauri/Cargo.lock`, commits
    `release: vX.Y.Z`, and pushes to `main`.
 5. Runs `pnpm lint`, `pnpm test`, and `pnpm test:rust`.
-6. Builds the `aarch64-apple-darwin` app and DMG with `tauri-action`.
-7. Signs with the Apple Developer ID cert, notarizes with Apple API key
+6. Builds the bundled Hermes runtime (`scripts/bundle-hermes-runtime.sh`):
+   the pinned hermes-agent checkout, a relocatable CPython, hash-verified
+   Python deps, and the prebuilt dashboard UI, signed Mach-O by Mach-O and
+   shipped under `Resources/native/hermes` so first launch needs no network
+   install. Adds roughly 110 MB compressed to the DMG.
+7. Builds the `aarch64-apple-darwin` app and DMG with `tauri-action`.
+8. Signs with the Apple Developer ID cert, notarizes with Apple API key
    credentials, signs updater artifacts with the Ed25519 updater key, and
    publishes the release assets plus `latest.json` to
    `open-software-network/os-scribe-releases`.

--- a/scripts/build-signed-dmg.sh
+++ b/scripts/build-signed-dmg.sh
@@ -137,6 +137,11 @@ elif [[ -n "${APPLE_API_KEY_P8:-}" ]]; then
 fi
 
 cd "$ROOT_DIR"
+# Build the bundled Hermes runtime before the app so first launch needs no
+# network install. Runs after the keychain import above so its Mach-O files
+# (python, extension .so) get the Developer ID + hardened runtime signature
+# notarization requires.
+./scripts/bundle-hermes-runtime.sh
 pnpm tauri build --bundles dmg "$@"
 
 shopt -s nullglob

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -69,12 +69,18 @@ log "pin: $commit"
 work="$out_parent/work"
 rm -rf "$out" "$work"
 mkdir -p "$work"
+# No curl-pipe-sh here, deliberately: this script runs in release CI after the
+# Developer ID certificate is imported, so fetching an unpinned remote
+# installer would hand keychain-adjacent execution to whoever controls (or
+# intercepts) that URL. Homebrew installs are checksum-verified by the
+# formula, and GitHub's macOS runners ship brew.
 uv_cmd="$(command -v uv || true)"
-if [ -z "$uv_cmd" ]; then
-  log "uv not found; installing a private copy"
-  curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR="$work/uv" sh >/dev/null
-  uv_cmd="$work/uv/uv"
+if [ -z "$uv_cmd" ] && command -v brew >/dev/null; then
+  log "uv not found; installing via Homebrew (checksummed)"
+  brew install --quiet uv >/dev/null
+  uv_cmd="$(command -v uv || true)"
 fi
+[ -n "$uv_cmd" ] || die "uv is required: install it via 'brew install uv' or https://docs.astral.sh/uv/"
 log "uv: $($uv_cmd --version)"
 
 # ---- source checkout, integrity-pinned ---------------------------------------
@@ -104,8 +110,11 @@ done
 # bundle on first launch (breaking the signature, and clean Macs have no node).
 command -v npm >/dev/null || die "npm is required to prebuild the dashboard web UI"
 log "prebuilding dashboard web UI"
-(cd "$out/hermes-agent/web" && npm ci --no-audit --no-fund >/dev/null 2>&1 && npm run build >/dev/null 2>&1) \
-  || die "web UI build failed"
+web_log="$work/web-build.log"
+if ! (cd "$out/hermes-agent/web" && npm ci --no-audit --no-fund && npm run build) >"$web_log" 2>&1; then
+  tail -40 "$web_log" >&2
+  die "web UI build failed (full log: $web_log)"
+fi
 rm -rf "$out/hermes-agent/web/node_modules"
 [ -f "$out/hermes-agent/hermes_cli/web_dist/index.html" ] || die "web_dist missing after build"
 
@@ -216,6 +225,11 @@ if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
 else
   log "APPLE_SIGNING_IDENTITY not set; skipping codesign (dev bundle)"
 fi
+
+# Stamp the bundle with its source pin. build.rs compares this against the
+# pins in hermes_bridge.rs and evicts a stale bundle (built before a pin
+# bump) instead of letting it ship silently from a developer machine.
+printf '%s\n' "$commit" > "$out/PIN"
 
 # ---- self-test: prove relocatability from a moved path with a space -----------
 log "self-test: running the launcher from a relocated copy"

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -41,23 +41,9 @@ bridge_rs="$root/src-tauri/src/hermes_bridge.rs"
 log() { printf '\033[1;34m[bundle-hermes]\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31m[bundle-hermes]\033[0m %s\n' "$*" >&2; exit 1; }
 
-# --ensure-placeholder: cheap guard for `tauri build` runs that don't bundle
-# the runtime (local dev). The resources mapping in tauri.conf.json must point
-# at an existing path; an empty marker keeps the build green while
-# `bundled_hermes_command` finds no launcher and falls back to the managed
-# install.
-if [ "${1:-}" = "--ensure-placeholder" ]; then
-  if [ -x "$out/bin/hermes" ]; then
-    exit 0
-  fi
-  mkdir -p "$out"
-  cat > "$out/PLACEHOLDER.md" <<'EOF'
-No bundled Hermes runtime in this build. The app installs the managed runtime
-on first launch instead. Release CI runs scripts/bundle-hermes-runtime.sh to
-ship the runtime inside the app.
-EOF
-  exit 0
-fi
+# Builds that skip this script still compile: build.rs creates a placeholder
+# at the resources mapping (`ensure_bundled_hermes_dir`), and the app falls
+# back to the managed on-device install when no launcher is present.
 
 # ---- pins, read from the Rust source of truth -------------------------------
 # Values may sit on the declaration line or (rustfmt) on the next line.

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Builds the self-contained Hermes runtime that ships inside the app bundle
+# (Resources/native/hermes), so a fresh install needs no multi-minute GitHub
+# download on first launch. `hermes_bridge.rs` prefers this bundled runtime
+# (`bundled_hermes_command`) and falls back to the on-device managed install
+# when it is absent, so dev builds keep working without running this script.
+#
+# Layout produced under .tauri-hermes/hermes/ (repo root):
+#   bin/hermes        relocatable launcher (resolves everything relative to
+#                     itself, so it survives /Applications, renames, and
+#                     Gatekeeper app translocation)
+#   python/current/   standalone CPython (uv-managed python-build-standalone,
+#                     relocatable by design)
+#   hermes-agent/     the pinned source checkout + its uv-synced venv
+#
+# Design notes, hard-won:
+# - The commit/sha256 pins are read from src-tauri/src/hermes_bridge.rs so the
+#   bundled runtime and the managed-install fallback can never drift apart.
+# - Dependencies install via `uv sync --extra all --locked` — the same
+#   hash-verified tier the on-device installer uses (install.sh "python-deps").
+# - The launcher runs the BASE python, not the venv python: venvs encode
+#   absolute build-machine paths (pyvenv.cfg home, bin symlinks, shebangs)
+#   and cannot be relocated reliably. A .pth in the base interpreter's
+#   site-packages adds the checkout and the venv's site-packages via paths
+#   RELATIVE to the .pth itself. This also makes bare `sys.executable`
+#   invocations work (the gateway's launchd job re-execs the interpreter
+#   directly, bypassing our launcher).
+# - sitecustomize.py pins sys.dont_write_bytecode and compileall uses
+#   checked-hash invalidation: Python must never write .pyc files into the
+#   bundle after signing, or it would break the app's code signature seal.
+# - Every Mach-O (python binary, dylibs, extension .so's) is signed with the
+#   Developer ID + hardened runtime when APPLE_SIGNING_IDENTITY is set;
+#   notarization rejects unsigned executables anywhere in the app.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out_parent="$root/.tauri-hermes"
+out="$out_parent/hermes"
+bridge_rs="$root/src-tauri/src/hermes_bridge.rs"
+
+log() { printf '\033[1;34m[bundle-hermes]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[bundle-hermes]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --ensure-placeholder: cheap guard for `tauri build` runs that don't bundle
+# the runtime (local dev). The resources mapping in tauri.conf.json must point
+# at an existing path; an empty marker keeps the build green while
+# `bundled_hermes_command` finds no launcher and falls back to the managed
+# install.
+if [ "${1:-}" = "--ensure-placeholder" ]; then
+  if [ -x "$out/bin/hermes" ]; then
+    exit 0
+  fi
+  mkdir -p "$out"
+  cat > "$out/PLACEHOLDER.md" <<'EOF'
+No bundled Hermes runtime in this build. The app installs the managed runtime
+on first launch instead. Release CI runs scripts/bundle-hermes-runtime.sh to
+ship the runtime inside the app.
+EOF
+  exit 0
+fi
+
+# ---- pins, read from the Rust source of truth -------------------------------
+# Values may sit on the declaration line or (rustfmt) on the next line.
+pin() {
+  local name="$1"
+  awk -v decl="const ${name}: &str =" '
+    found && match($0, /"[^"]+"/) { print substr($0, RSTART + 1, RLENGTH - 2); exit }
+    index($0, decl) {
+      if (match($0, /"[^"]+"/)) { print substr($0, RSTART + 1, RLENGTH - 2); exit }
+      found = 1
+    }
+  ' "$bridge_rs"
+}
+commit="$(pin HERMES_AGENT_INSTALL_COMMIT)"
+tarball_sha256="$(pin HERMES_SOURCE_TARBALL_SHA256)"
+tarball_url="$(pin HERMES_SOURCE_TARBALL_URL)"
+[ -n "$commit" ] || die "could not read HERMES_AGENT_INSTALL_COMMIT from $bridge_rs"
+[ -n "$tarball_sha256" ] || die "could not read HERMES_SOURCE_TARBALL_SHA256 from $bridge_rs"
+[ -n "$tarball_url" ] || die "could not read HERMES_SOURCE_TARBALL_URL from $bridge_rs"
+log "pin: $commit"
+
+# ---- uv ----------------------------------------------------------------------
+work="$out_parent/work"
+rm -rf "$out" "$work"
+mkdir -p "$work"
+uv_cmd="$(command -v uv || true)"
+if [ -z "$uv_cmd" ]; then
+  log "uv not found; installing a private copy"
+  curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR="$work/uv" sh >/dev/null
+  uv_cmd="$work/uv/uv"
+fi
+log "uv: $($uv_cmd --version)"
+
+# ---- source checkout, integrity-pinned ---------------------------------------
+log "downloading hermes-agent@$commit"
+curl -LsSf "$tarball_url" -o "$work/hermes-agent.tar.gz"
+actual_sha256="$(shasum -a 256 "$work/hermes-agent.tar.gz" | awk '{print $1}')"
+[ "$actual_sha256" = "$tarball_sha256" ] || die "tarball sha256 mismatch: expected $tarball_sha256, got $actual_sha256"
+tar -xzf "$work/hermes-agent.tar.gz" -C "$work"
+unpacked="$(find "$work" -maxdepth 1 -type d -name 'hermes-agent-*' | head -1)"
+[ -n "$unpacked" ] || die "tarball did not contain a hermes-agent directory"
+mkdir -p "$out"
+mv "$unpacked" "$out/hermes-agent"
+
+# Dev-only weight the runtime never imports. Conservative on purpose: web/ and
+# ui-tui/ stay (hermes resolves them relative to its project root), and they
+# are small without node_modules, which we never ship.
+for prune in tests website apps .github; do
+  rm -rf "$out/hermes-agent/$prune"
+done
+
+# The tarball has no prebuilt dashboard assets — on-device installs build them
+# in the "node-deps" stage. Build them here instead (vite outputs to
+# hermes_cli/web_dist per web/vite.config.ts) and drop node_modules afterwards.
+# The build also stamps the staleness sentinel (.vite/manifest.json) with a
+# fresh mtime, so _web_ui_build_needed() stays false at runtime — without it
+# the dashboard would try to npm-install and rebuild INSIDE the signed app
+# bundle on first launch (breaking the signature, and clean Macs have no node).
+command -v npm >/dev/null || die "npm is required to prebuild the dashboard web UI"
+log "prebuilding dashboard web UI"
+(cd "$out/hermes-agent/web" && npm ci --no-audit --no-fund >/dev/null 2>&1 && npm run build >/dev/null 2>&1) \
+  || die "web UI build failed"
+rm -rf "$out/hermes-agent/web/node_modules"
+[ -f "$out/hermes-agent/hermes_cli/web_dist/index.html" ] || die "web_dist missing after build"
+
+# ---- relocatable CPython + hash-verified deps --------------------------------
+log "installing standalone CPython 3.11"
+UV_PYTHON_INSTALL_DIR="$out/python" UV_PYTHON_INSTALL_BIN=0 UV_NO_CONFIG=1 \
+  "$uv_cmd" python install 3.11 >/dev/null
+pydir="$(find "$out/python" -maxdepth 1 -type d -name 'cpython-3.11*' | head -1)"
+[ -n "$pydir" ] || die "uv did not install a cpython-3.11 runtime"
+# Fixed name so the launcher needs no globbing (paths with spaces stay safe).
+mv "$pydir" "$out/python/current"
+py="$out/python/current/bin/python3.11"
+[ -x "$py" ] || die "bundled python missing at $py"
+
+# The Tauri bundler fails (opaquely: "failed to build app") on symlinked
+# resources, so the bundle must contain none. Drop uv's version-alias link,
+# the bin convenience links (the launcher execs python3.11 directly and
+# hermes re-execs sys.executable), and dev-only pkgconfig/man trees whose
+# files are links too.
+find "$out/python" -maxdepth 1 -type l -delete
+find "$out/python/current/bin" -type l -delete
+rm -rf "$out/python/current/lib/pkgconfig" "$out/python/current/share"
+
+log "installing python deps (uv sync --extra all --locked)"
+# Same tiers as install.sh "python-deps": the hash-verified lockfile sync
+# first; when the shipped lockfile is out of sync with pyproject (it is at
+# the current pin — install.sh hits the identical fallback on-device), fall
+# back to resolving the curated [all] extra from PyPI.
+(
+  cd "$out/hermes-agent"
+  export UV_PROJECT_ENVIRONMENT="$out/hermes-agent/venv"
+  export UV_NO_CONFIG=1
+  export UV_PYTHON_INSTALL_DIR="$out/python"
+  if ! "$uv_cmd" sync --extra all --locked --python "$py" >/dev/null 2>&1; then
+    log "lockfile sync unavailable; falling back to: uv pip install -e .[all]"
+    "$uv_cmd" pip install -p "$out/hermes-agent/venv" -e ".[all]" >/dev/null
+  fi
+)
+
+venv_sp="$(find "$out/hermes-agent/venv/lib" -maxdepth 1 -type d -name 'python3.*' | head -1)/site-packages"
+[ -d "$venv_sp" ] || die "venv site-packages missing"
+base_sp="$(find "$out/python/current/lib" -maxdepth 1 -type d -name 'python3.*' | head -1)/site-packages"
+[ -d "$base_sp" ] || die "base site-packages missing"
+pyver_dir="$(basename "$(dirname "$venv_sp")")"
+
+# The venv's editable hooks and bin/ scripts encode absolute build-machine
+# paths and are never executed at runtime (the launcher and the .pth below
+# replace them). Removing venv/bin also keeps bundled_hermes_command off the
+# venv-script candidate and on the relocatable launcher.
+find "$venv_sp" -maxdepth 1 \( -name '*editable*' -o -name '_hermes*' \) -exec rm -rf {} +
+rm -rf "$out/hermes-agent/venv/bin"
+
+# Make the bare base interpreter resolve hermes + deps via relative paths.
+rel_root="../../../../.."
+cat > "$base_sp/hermes-bundle.pth" <<EOF
+$rel_root/hermes-agent
+$rel_root/hermes-agent/venv/lib/$pyver_dir/site-packages
+EOF
+
+# Never write .pyc into the signed bundle (it would break the signature seal).
+cat > "$base_sp/sitecustomize.py" <<'EOF'
+# Generated by scripts/bundle-hermes-runtime.sh. The bundle is code-signed;
+# writing bytecode caches into it would invalidate the app's signature.
+import sys
+
+sys.dont_write_bytecode = True
+EOF
+
+log "precompiling bytecode (checked-hash)"
+# Some shipped templates/vendored files don't compile; that only costs them
+# the precompile (sitecustomize stops runtime writes), so don't fail the build.
+"$py" -m compileall -q --invalidation-mode checked-hash "$out/hermes-agent" "$base_sp" >/dev/null 2>&1 || true
+
+# No symlinks may survive anywhere in the bundle (Tauri bundler limitation,
+# see above) — fail loudly here instead of opaquely at app-bundling time.
+leftover_links="$(find "$out" -type l | head -5)"
+[ -z "$leftover_links" ] || die "bundle still contains symlinks:\n$leftover_links"
+
+# ---- launcher -----------------------------------------------------------------
+mkdir -p "$out/bin"
+cat > "$out/bin/hermes" <<'EOF'
+#!/bin/sh
+# Relocatable launcher for the bundled Hermes runtime. Everything resolves
+# relative to this file, so the bundle works from /Applications, a renamed
+# app, or a Gatekeeper-translocated path. Module resolution comes from
+# hermes-bundle.pth inside the bundled interpreter, so re-execs of bare
+# sys.executable (the gateway's launchd job) resolve identically.
+here="$(cd "$(dirname "$0")/.." && pwd)"
+exec "$here/python/current/bin/python3.11" -m hermes_cli.main "$@"
+EOF
+chmod +x "$out/bin/hermes"
+
+# ---- signing ------------------------------------------------------------------
+# Notarization rejects any unsigned Mach-O inside the app. Sign every binary
+# (interpreter, dylibs, extension modules) with the hardened runtime; the
+# outer app signature then seals the rest of the tree as resources.
+if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+  log "signing Mach-O files as: $APPLE_SIGNING_IDENTITY"
+  signed=0
+  while IFS= read -r -d '' candidate; do
+    if file -b "$candidate" | grep -q 'Mach-O'; then
+      codesign --force --timestamp --options runtime \
+        --sign "$APPLE_SIGNING_IDENTITY" "$candidate"
+      signed=$((signed + 1))
+    fi
+  done < <(find "$out" -type f \( -name '*.so' -o -name '*.dylib' -o -perm -u+x \) -print0)
+  log "signed $signed Mach-O files"
+else
+  log "APPLE_SIGNING_IDENTITY not set; skipping codesign (dev bundle)"
+fi
+
+# ---- self-test: prove relocatability from a moved path with a space -----------
+log "self-test: running the launcher from a relocated copy"
+selftest_root="$(mktemp -d)"
+trap 'rm -rf "$selftest_root"' EXIT
+selftest="$selftest_root/re located"
+mkdir -p "$selftest"
+cp -R "$out" "$selftest/hermes"
+test_home="$selftest_root/hermes-home"
+mkdir -p "$test_home"
+version_output="$(HERMES_HOME="$test_home" "$selftest/hermes/bin/hermes" --version)" \
+  || die "self-test failed: bundled hermes --version"
+case "$version_output" in
+  *"$selftest/hermes/hermes-agent"*) ;;
+  *) die "self-test failed: hermes resolved the wrong project root: $version_output" ;;
+esac
+"$selftest/hermes/python/current/bin/python3.11" -c "import hermes_cli.main" \
+  || die "self-test failed: bare interpreter cannot import hermes_cli (pth broken)"
+
+rm -rf "$work"
+du -sh "$out" | awk '{print "[bundle-hermes] bundle size: " $1}'
+log "done: $out"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,7 +24,14 @@ fn main() {
 /// scripts/bundle-hermes-runtime.sh before compiling; everywhere else this
 /// placeholder keeps the build green and the app falls back to the managed
 /// on-device install (`bundled_hermes_command` finds no launcher in it).
+///
+/// A populated bundle carries a PIN stamp (the hermes-agent commit it was
+/// built from). When that stamp no longer matches the pin in
+/// src/hermes_bridge.rs — a developer bumped the pin after bundling — the
+/// stale bundle is evicted and replaced with the placeholder rather than
+/// silently shipping outdated runtime code.
 fn ensure_bundled_hermes_dir() {
+    println!("cargo:rerun-if-changed=../.tauri-hermes/hermes/PIN");
     let manifest_dir = std::path::PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"),
     );
@@ -35,7 +42,28 @@ fn ensure_bundled_hermes_dir() {
         return;
     };
     if hermes_dir.exists() {
-        return;
+        if !hermes_dir.join("bin").join("hermes").exists() {
+            // Placeholder (or partial) dir: nothing to validate.
+            return;
+        }
+        let stamped = std::fs::read_to_string(hermes_dir.join("PIN"))
+            .map(|raw| raw.trim().to_string())
+            .unwrap_or_default();
+        let pinned = hermes_agent_pinned_commit(&manifest_dir);
+        if !stamped.is_empty() && stamped == pinned {
+            return;
+        }
+        println!(
+            "cargo:warning=bundled Hermes runtime is stale (built from {stamped:?}, pin is \
+             {pinned:?}); evicting it — rerun scripts/bundle-hermes-runtime.sh to bundle again"
+        );
+        if let Err(error) = std::fs::remove_dir_all(&hermes_dir) {
+            println!(
+                "cargo:warning=could not remove stale hermes bundle {}: {error}",
+                hermes_dir.display()
+            );
+            return;
+        }
     }
     if let Err(error) = std::fs::create_dir_all(&hermes_dir) {
         println!(
@@ -50,6 +78,23 @@ ship the runtime inside the app.\n";
     if let Err(error) = std::fs::write(hermes_dir.join("PLACEHOLDER.md"), note) {
         println!("cargo:warning=could not write hermes placeholder: {error}");
     }
+}
+
+/// Reads HERMES_AGENT_INSTALL_COMMIT out of src/hermes_bridge.rs. A build
+/// script cannot import crate constants, so this parses the declaration the
+/// same way scripts/bundle-hermes-runtime.sh does — one source of truth.
+fn hermes_agent_pinned_commit(manifest_dir: &std::path::Path) -> String {
+    let source = std::fs::read_to_string(manifest_dir.join("src").join("hermes_bridge.rs"))
+        .unwrap_or_default();
+    source
+        .lines()
+        .find(|line| line.contains("const HERMES_AGENT_INSTALL_COMMIT"))
+        .and_then(|line| {
+            let start = line.find('"')? + 1;
+            let end = line[start..].find('"')? + start;
+            Some(line[start..end].to_string())
+        })
+        .unwrap_or_default()
 }
 
 /// Remove pre-rename ("OS Scribe") helper bundles from `.tauri-helper` so

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -13,7 +13,43 @@ fn main() {
     clean_legacy_helper_bundles();
     build_system_audio_helper();
     build_dictation_helper();
+    ensure_bundled_hermes_dir();
     tauri_build::build();
+}
+
+/// `tauri_build::build()` validates every `bundle.resources` source path at
+/// compile time, so the `../.tauri-hermes/hermes` mapping must exist for ANY
+/// cargo invocation (`cargo test`, rust-analyzer, dev builds) — not just for
+/// `tauri build`. Release CI populates the real runtime via
+/// scripts/bundle-hermes-runtime.sh before compiling; everywhere else this
+/// placeholder keeps the build green and the app falls back to the managed
+/// on-device install (`bundled_hermes_command` finds no launcher in it).
+fn ensure_bundled_hermes_dir() {
+    let manifest_dir = std::path::PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR should be set"),
+    );
+    let Some(hermes_dir) = manifest_dir
+        .parent()
+        .map(|repo_dir| repo_dir.join(".tauri-hermes").join("hermes"))
+    else {
+        return;
+    };
+    if hermes_dir.exists() {
+        return;
+    }
+    if let Err(error) = std::fs::create_dir_all(&hermes_dir) {
+        println!(
+            "cargo:warning=could not create {}: {error}",
+            hermes_dir.display()
+        );
+        return;
+    }
+    let note = "No bundled Hermes runtime in this build. The app installs the managed \
+runtime on first launch instead. Release CI runs scripts/bundle-hermes-runtime.sh to \
+ship the runtime inside the app.\n";
+    if let Err(error) = std::fs::write(hermes_dir.join("PLACEHOLDER.md"), note) {
+        println!("cargo:warning=could not write hermes placeholder: {error}");
+    }
 }
 
 /// Remove pre-rename ("OS Scribe") helper bundles from `.tauri-helper` so

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "co.opensoftware.scribe",
   "build": {
     "beforeDevCommand": "./scripts/tauri-before-dev.sh",
-    "beforeBuildCommand": "pnpm run build && ./scripts/bundle-hermes-runtime.sh --ensure-placeholder",
+    "beforeBuildCommand": "pnpm run build",
     "devUrl": "http://127.0.0.1:1421",
     "frontendDist": "../dist"
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "co.opensoftware.scribe",
   "build": {
     "beforeDevCommand": "./scripts/tauri-before-dev.sh",
-    "beforeBuildCommand": "pnpm run build",
+    "beforeBuildCommand": "pnpm run build && ./scripts/bundle-hermes-runtime.sh --ensure-placeholder",
     "devUrl": "http://127.0.0.1:1421",
     "frontendDist": "../dist"
   },
@@ -117,7 +117,8 @@
     "targets": ["app", "dmg"],
     "resources": {
       "../.tauri-helper/June.app": "native/bin/June.app",
-      "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app"
+      "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app",
+      "../.tauri-hermes/hermes": "native/hermes"
     },
     "macOS": {
       "bundleName": "June",


### PR DESCRIPTION
## Why

First launch on a fresh Mac currently downloads the hermes-agent tarball from GitHub and builds a venv on-device: minutes of silent install (the app looks hung), and a hard failure offline or when GitHub throttles. First-run reliability matters more to us than DMG size, so ship the runtime inside the app. `hermes_bridge.rs` already prefers a bundled runtime at `Resources/native/hermes` (`bundled_hermes_command`) - nothing ever put one there until now.

**Cost: ~110 MB compressed added to the DMG** (~9 MB -> ~120 MB). The bundle is the Python core only (413 MB unpacked): pinned checkout, relocatable CPython 3.11, hash-verified deps, prebuilt dashboard UI. The Node/browser-tool stack (1.4 GB of node_modules on a managed install) stays out; the agent's browser tool keeps its existing lazy-install path, and Playwright's Chromium was always a lazy download anyway.

## How (`scripts/bundle-hermes-runtime.sh`)

- **Pins read from `hermes_bridge.rs`** (commit, tarball sha256), so the bundle and the managed-install fallback can never drift. Dev builds keep the managed install: `beforeBuildCommand` runs the script's `--ensure-placeholder` guard, which satisfies the tauri resources mapping without bundling.
- **Deps via the same hash-verified tier the on-device installer uses** (`uv sync --extra all --locked`, with the same `[all]`-extra fallback install.sh has).
- **Dashboard web UI is prebuilt at bundle time.** The tarball ships no `web_dist`; discovered the hard way that without it, the dashboard npm-installs and vite-builds *inside the signed app bundle* on first launch - a code-signature break, on machines that may not even have Node.
- **Relocatable by construction**: the launcher (`bin/hermes`) execs the bundled standalone CPython directly, with module resolution from a relative-path `.pth` in the interpreter's own site-packages. No venv at runtime (venvs hardcode absolute build-machine paths in `pyvenv.cfg`/shebangs/symlinks). This survives renames and Gatekeeper app translocation, and bare `sys.executable` re-execs - the gateway's launchd job - resolve identically.
- **The bundle is runtime-immutable**: `sitecustomize` pins `dont_write_bytecode`, bytecode is precompiled with checked-hash invalidation, so Python never writes into the signed bundle.
- **No symlinks survive** (the Tauri bundler fails opaquely on symlinked resources - also discovered the hard way; the script asserts none remain).
- **Every Mach-O signed** (python, dylibs, extension `.so`s) with Developer ID + hardened runtime when `APPLE_SIGNING_IDENTITY` is set, as notarization requires. Production workflow runs the script after the certificate import; staging runs it inside `build-signed-dmg.sh` after its keychain setup, so every merge to main exercises the signing + notarization path before a release does.

## Verification (all local, real artifacts)

- Full `pnpm tauri build`: June.app (436 MB) embeds the runtime; the bundled `hermes --version` resolves its project root inside the app.
- Self-test built into the script: runs the launcher from a relocated copy in a path containing a space, asserts the right project root, asserts the bare interpreter can import `hermes_cli`.
- Dashboard boot from the bundle against a fresh `HERMES_HOME`: serving `/api/status` 200 in ~8 seconds (vs minutes of install), with **zero files created or modified inside the bundle** (file-list diff + mtime scan) - signature-safe.
- shellcheck clean.

## Knowingly deferred

- Browser tool needs Node, which is not bundled - unchanged from today's lazy-install behavior.
- Existing installs keep their 2.6 GB managed runtime on disk (the resolver just stops using it); cleanup of the orphaned `hermes-runtime/` dir can be a follow-up.
- First real notarization pass happens on the staging build when this merges - watch that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)