### PR TITLE
Stop stale fetches erasing chat messages; hide message-less sessions

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -710,6 +710,11 @@ export function AgentWorkspace({
   const pendingHermesMessagesRef = useRef<
     Record<string, HermesSessionMessage[]>
   >({});
+  // Per-session ordering for message fetches: the sequence handed out at
+  // fetch start, and the highest sequence whose response was applied. See
+  // listSessionMessagesOrdered.
+  const sessionMessagesFetchSeqRef = useRef<Map<string, number>>(new Map());
+  const sessionMessagesAppliedSeqRef = useRef<Map<string, number>>(new Map());
   const [hermesSessionsLoading, setHermesSessionsLoading] = useState(false);
   const [liveEvents, setLiveEvents] = useState<
     Record<string, LiveHermesEvent[]>
@@ -1293,9 +1298,9 @@ export function AgentWorkspace({
   useEffect(() => {
     if (!bridge.running || !selectedHermesSessionId) return;
     let cancelled = false;
-    listHermesSessionMessages(selectedHermesSessionId)
+    listSessionMessagesOrdered(selectedHermesSessionId)
       .then((messages) => {
-        if (cancelled) return;
+        if (cancelled || !messages) return;
         const retainedPending = retainUnpersistedPendingMessages(
           pendingHermesMessagesRef.current[selectedHermesSessionId] ?? [],
           messages,
@@ -2130,9 +2135,30 @@ export function AgentWorkspace({
     }
   }
 
+  // Message fetches for one session can overlap: the selection effect, the
+  // 2.5s working poll, and the terminal-event refresh all call
+  // listHermesSessionMessages without awaiting each other, and each applies
+  // its response as a whole-list overwrite. Responses can land out of order
+  // (a slow fetch started before a fast one resolves after it), so without
+  // ordering a stale list clobbers a newer one — the classic symptom is a
+  // just-sent user message vanishing (its pending bubble was dropped when the
+  // newer fetch persisted it) until a later refresh restores it. Fetches are
+  // stamped with a per-session sequence at start; a response only applies if
+  // no later-started fetch has applied first.
+  async function listSessionMessagesOrdered(sessionId: string) {
+    const seq = (sessionMessagesFetchSeqRef.current.get(sessionId) ?? 0) + 1;
+    sessionMessagesFetchSeqRef.current.set(sessionId, seq);
+    const messages = await listHermesSessionMessages(sessionId);
+    const applied = sessionMessagesAppliedSeqRef.current.get(sessionId) ?? 0;
+    if (seq < applied) return undefined;
+    sessionMessagesAppliedSeqRef.current.set(sessionId, seq);
+    return messages;
+  }
+
   async function refreshHermesSession(sessionId: string) {
     try {
-      const messages = await listHermesSessionMessages(sessionId);
+      const messages = await listSessionMessagesOrdered(sessionId);
+      if (!messages) return;
       const retainedPending = retainUnpersistedPendingMessages(
         pendingHermesMessagesRef.current[sessionId] ?? [],
         messages,

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -22,7 +22,14 @@ export async function listHermesSessions(
     limit: 100,
     offset: 0,
     archived: "exclude",
-    minMessages: 0,
+    // Sessions exist before their first message persists (a routine run that
+    // hasn't produced a turn yet, or a created session whose submit failed) —
+    // listed at minMessages 0 they render as empty "Untitled session" rows
+    // that vanish or morph moments later. A just-created session the user is
+    // typing into is not affected: every list surface shows the workspace's
+    // merged list, which carries the optimistic local entry until the first
+    // message persists.
+    minMessages: 1,
     order: "recent",
     ...options,
   });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1998,6 +1998,107 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("does not let a stale message fetch erase a newer follow-up", async () => {
+    // The selection effect, working poll, and terminal-event refresh all
+    // fetch session messages without awaiting each other. A slow fetch that
+    // started first can resolve last; applying it as a whole-list overwrite
+    // used to erase the follow-up the newer fetch had just persisted (and
+    // whose optimistic bubble was dropped at that point) — the user's
+    // message visibly vanished until a later refresh restored it.
+    const user = userEvent.setup();
+    const oldHistory = [
+      {
+        id: "m1",
+        role: "user",
+        content: "previous request",
+        timestamp: "2026-06-04T12:00:00.000Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "previous answer",
+        timestamp: "2026-06-04T12:00:01.000Z",
+      },
+    ];
+    let resolveStale: (value: unknown) => void = () => {};
+    const stale = new Promise((resolve) => {
+      resolveStale = resolve;
+    });
+    mocks.listHermesSessionMessages
+      .mockImplementationOnce(() => stale) // the mount-selection fetch hangs
+      .mockImplementation(async () => [
+        ...oldHistory,
+        {
+          id: "m3",
+          role: "user",
+          content: "follow up while racing",
+          timestamp: new Date().toISOString(),
+        },
+        {
+          id: "m4",
+          role: "assistant",
+          content: "raced reply",
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      return Promise.resolve({});
+    });
+    // Hold the submit just before completion so the working poll's interval
+    // is created on the fake clock (a real-clock interval can't be advanced).
+    let resolveEnsureSession: (value: unknown) => void = () => {};
+    mocks.ensureHermesBridgeSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveEnsureSession = resolve;
+        }),
+    );
+
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox"), "follow up while racing");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalled(),
+    );
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        resolveEnsureSession({});
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "follow up while racing",
+      });
+
+      // The working poll's refresh applies the newer history (follow-up +
+      // reply persisted; the optimistic bubble is dropped against it).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+      expect(screen.getByText("raced reply")).toBeInTheDocument();
+
+      // The stale mount-time fetch finally resolves — without per-session
+      // fetch ordering this overwrote the list and the follow-up vanished.
+      await act(async () => {
+        resolveStale(oldHistory);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByText("follow up while racing")).toBeInTheDocument();
+      expect(screen.getByText("raced reply")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Last in the suite: mounting the workspace kicks off bridge/session
   // bootstrap promises that can leak into a later test's pending-session
   // flow, so nothing runs after this one.

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  listHermesSessions,
   normalizeHermesSessionMessagesResponse,
   normalizeHermesSessionsResponse,
   sessionTimestamp,
@@ -7,7 +8,34 @@ import {
 } from "../lib/hermes-adapter";
 import type { HermesSessionInfo } from "../lib/tauri";
 
+const mocks = vi.hoisted(() => ({
+  hermesBridgeSessions: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  hermesBridgeSessions: mocks.hermesBridgeSessions,
+  hermesBridgeSessionMessages: vi.fn(),
+  deleteHermesBridgeSession: vi.fn(),
+}));
+
 describe("Hermes adapter", () => {
+  it("excludes message-less sessions from the default list query", async () => {
+    // Sessions exist before their first message persists (routine runs,
+    // failed submits) — listing them renders empty "Untitled session" rows
+    // that vanish moments later.
+    mocks.hermesBridgeSessions.mockResolvedValue({ sessions: [] });
+
+    await listHermesSessions();
+    expect(mocks.hermesBridgeSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ minMessages: 1 }),
+    );
+
+    await listHermesSessions({ minMessages: 0 });
+    expect(mocks.hermesBridgeSessions).toHaveBeenLastCalledWith(
+      expect.objectContaining({ minMessages: 0 }),
+    );
+  });
+
   it("normalizes raw gateway session lists and sorts by recent activity", () => {
     const sessions = normalizeHermesSessionsResponse({
       data: [


### PR DESCRIPTION
Fixes two user-visible reliability bugs in the agent chat.

## Bug 1: sent messages vanish, then reappear later

**Root cause:** three code paths fetch a session's messages concurrently without ordering — the selection effect, the 2.5s working poll (`void refreshHermesSession(...)` per tick, no await), and the terminal-event refresh. Each applies its response as a whole-list overwrite of `hermesSessionMessages[sessionId]`. When a slow fetch that *started earlier* resolves *after* a faster one, the stale list clobbers the newer one.

The sequence the user experiences:
1. They send a message → optimistic bubble renders.
2. A fresh fetch shows it persisted → the optimistic bubble is dropped (correct).
3. A stale fetch from before the send resolves late and overwrites the list → the message is gone entirely, with no bubble to fall back on.
4. It only reappears at whatever refresh happens next (next poll tick, terminal event, or re-selecting the session) — "comes back MAYBE sometime later."

**Fix:** message fetches are stamped with a per-session sequence at start (`listSessionMessagesOrdered`); a response only applies if no later-started fetch has applied first. Both writers (selection effect, `refreshHermesSession`) go through the guard.

## Bug 2: empty "Untitled session" rows that appear and disappear

**Root cause:** Hermes stores sessions before their first message persists — a routine/cron run that hasn't produced its first turn yet, or a created session whose `prompt.submit` failed — and the session list was fetched with `min_messages=0`. With no title and no preview, those render as empty "Untitled session" rows that vanish or morph into a real session moments later.

**Fix:** the list adapter now defaults to `min_messages=1`. A just-created session the user is typing into is unaffected: the workspace keeps an optimistic local entry (retained while selected/working/pending), and the sidebar and menu bar render the workspace's merged list via the sessions-changed event, so there's no visible gap.

## Testing

- New regression test simulates the out-of-order fetch race; verified it **fails** with the ordering guard disabled and passes with it.
- New adapter test pins the `minMessages: 1` default (and that explicit overrides still win).
- `tsc` clean; full vitest suite passes (38 files, 321 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)