### PR TITLE
Scope Unrestricted to the session that opted in

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -142,6 +142,11 @@ import {
 } from "../../lib/model-privacy";
 import { messageFromError } from "../../lib/errors";
 import {
+  forgetSessionMode,
+  rememberSessionMode,
+  sessionUnrestricted,
+} from "../../lib/agent-session-modes";
+import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   type AgentApprovalChoice,
@@ -1765,11 +1770,15 @@ export function AgentWorkspace({
     const titlePromise = targetSessionId
       ? undefined
       : agentSessionTitleForPrompt(content);
-    // Only a session being created applies the unrestricted opt-in;
-    // follow-ups on existing sessions never change the runtime's mode under
-    // them.
+    // The Unrestricted opt-in is made per session: a new session applies the
+    // picker draft, and a follow-up applies the mode its session was created
+    // with — restarting the runtime when the running mode differs. Without
+    // this, one Unrestricted session would leave the runtime unsandboxed
+    // under every other session's follow-ups.
     const gateway = await ensureHermesGateway(
-      targetSessionId ? undefined : fullModeDraftRef.current,
+      targetSessionId
+        ? sessionUnrestricted(targetSessionId)
+        : fullModeDraftRef.current,
     );
     const sessionTitle = titlePromise ? await titlePromise : undefined;
     const created = targetSessionId
@@ -1781,6 +1790,9 @@ export function AgentWorkspace({
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
+    if (!targetSessionId) {
+      rememberSessionMode(storedSessionId, fullModeDraftRef.current);
+    }
     const sessionDisplayTitle =
       explicitSession?.title?.trim() ||
       explicitSession?.preview?.trim() ||
@@ -2537,6 +2549,7 @@ export function AgentWorkspace({
   async function deleteSelectedHermesSession(sessionId: string) {
     try {
       await deleteHermesSession(sessionId);
+      forgetSessionMode(sessionId);
       // Clearing the selection falls the workspace back to empty.
       removeHermesSessionLocally(sessionId, false);
     } catch (err) {
@@ -3296,7 +3309,14 @@ export function AgentWorkspace({
             setArtifactPanel((open) => (open ? null : { view: "list" }))
           }
           privacyBadge={generationPrivacyBadge}
-          fullMode={Boolean(bridge.running && bridge.connection?.fullMode)}
+          // The badge describes the selected session, not the live runtime:
+          // every send re-enforces the session's recorded mode, so a
+          // sandboxed session stays sandboxed even while an Unrestricted
+          // runtime from another session is still up. The hero composer's
+          // picker covers the new-session draft.
+          fullMode={
+            !newSessionMode && sessionUnrestricted(selectedHermesSessionId)
+          }
           title={
             !newSessionMode && selectedHermesSessionId
               ? (selectedHermesSession?.title ?? "")
@@ -3436,12 +3456,13 @@ function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
   );
 }
 
-// Honest indicator of the live runtime, not of any one session: the jail is
-// per-process, so while the user has it unrestricted every session it serves
-// runs unsandboxed.
+// Indicator of the selected session's opt-in. The jail itself is
+// per-process, but every send restarts the runtime into the target session's
+// recorded mode, so the session — not the runtime's current state — is the
+// honest unit to label.
 function UnrestrictedBadge() {
   const description =
-    "June is running without the file sandbox and can change any file your account can. Start a session with Unrestricted off to restore the sandbox.";
+    "This session runs without the file sandbox — June can change any file your account can. Sessions started as Sandboxed keep their jail; it is re-applied whenever you message them.";
   return (
     <HoverTip
       tip={description}

--- a/src/lib/agent-session-modes.ts
+++ b/src/lib/agent-session-modes.ts
@@ -1,0 +1,60 @@
+/**
+ * Per-session record of the Unrestricted opt-in. The Seatbelt write-jail is
+ * applied when June's runtime process spawns, so the mode can't vary across
+ * the sessions a single process serves — instead, every send restarts the
+ * runtime into the target session's recorded mode when they differ. This map
+ * is what makes that enforcement possible: absence means sandboxed, so
+ * sessions from before this record existed fall back to the safe default.
+ *
+ * localStorage (not the backend) because the runtime's session store is
+ * machine-local too, and the map must be readable synchronously on render
+ * for the session bar's badge.
+ */
+
+const STORAGE_KEY = "june.agent.unrestrictedSessions";
+
+function readStore(): Record<string, true> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, true>;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, true>) {
+  try {
+    if (Object.keys(store).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore; worst case a follow-up runs sandboxed — the safe direction.
+  }
+}
+
+/** Whether this session opted into Unrestricted at creation. */
+export function sessionUnrestricted(sessionId: string | undefined): boolean {
+  if (!sessionId) return false;
+  return readStore()[sessionId] === true;
+}
+
+export function rememberSessionMode(sessionId: string, unrestricted: boolean) {
+  const store = readStore();
+  if (unrestricted) {
+    store[sessionId] = true;
+  } else {
+    delete store[sessionId];
+  }
+  writeStore(store);
+}
+
+export function forgetSessionMode(sessionId: string) {
+  rememberSessionMode(sessionId, false);
+}

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1913,7 +1913,23 @@ describe("AgentWorkspace", () => {
     expect(trigger).toHaveFocus();
   });
 
-  it("shows the unrestricted badge while the runtime is unsandboxed by choice", async () => {
+  it("shows the unrestricted badge only on sessions that opted in", async () => {
+    window.localStorage.setItem(
+      "june.agent.unrestrictedSessions",
+      JSON.stringify({ "session-1": true }),
+    );
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Unrestricted")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Unrestricted - This session runs without/),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the badge off a sandboxed session even while the runtime is unsandboxed", async () => {
+    // Another session's opt-in left the runtime in full mode; this session
+    // never opted in, and its sends re-apply the jail — no badge.
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
       connection: {
@@ -1925,10 +1941,62 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    expect(await screen.findByText("Unrestricted")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/Unrestricted - June is running without the file/),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    expect(screen.queryByText("Unrestricted")).not.toBeInTheDocument();
+  });
+
+  it("restores the sandbox before a follow-up to a session that never opted in", async () => {
+    const user = userEvent.setup();
+    // The runtime is still unsandboxed from another session's opt-in.
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: {
+        port: 61234,
+        wsUrl: "ws://127.0.0.1:61234",
+        fullMode: true,
+      },
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Send a message"), "hello");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    // The send restarts the runtime back into the jail before submitting.
+    await waitFor(() =>
+      expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, false),
+    );
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({ text: "hello" }),
+      ),
+    );
+  });
+
+  it("keeps an opted-in session unrestricted across follow-ups", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "june.agent.unrestrictedSessions",
+      JSON.stringify({ "session-1": true }),
+    );
+    // The runtime has since dropped back to the sandbox (relaunch, or a
+    // sandboxed session ran in between).
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Send a message"), "continue");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, true),
+    );
   });
 
   it("explains a busy rejection and removes the ghost bubble", async () => {


### PR DESCRIPTION
## The report

> When I start a session in Unrestricted mode, the Unrestricted pill appears on EVERY session. Is that how it works? I toggle it, and it changes it for every agent session?

**Yes — that was exactly how it worked, and the pill was honestly reporting it.** The Seatbelt write-jail is applied when June's runtime process spawns, and one process serves all sessions. Starting one Unrestricted session restarted the runtime unsandboxed; from then on, **a follow-up sent to any other session — including ones created as Sandboxed — silently ran with full write access**, because follow-ups reused whatever runtime was up (`ensureHermesGateway(undefined)`). The badge keyed off the live runtime, so it appeared everywhere. The badge wasn't the bug; the behavior was.

## The fix

The opt-in is now genuinely per session:

- **Each session records its mode at creation** (`june.agent.unrestrictedSessions` in localStorage — absence means sandboxed, so every pre-existing session falls back to the safe default).
- **Every send enforces the target session's mode.** Following up on a sandboxed session while the runtime is unrestricted restarts the runtime back into the jail before the prompt is submitted; following up on the opted-in session restores Unrestricted if the runtime has since dropped back. This reuses the exact restart path new-session creation already had — the sandbox still can't change on a live process, so mode changes mean a runtime restart.
- **The badge describes the selected session, not the live process.** A sandboxed session shows no pill even while an Unrestricted runtime from another session is still up — truthful now, because that session's own sends re-apply the jail. Hover copy updated to explain this.
- The record is dropped when a session is deleted.

## Known trade-off

Sessions of different modes can't run concurrently (one process, one jail). Switching modes mid-flight kills the other session's in-flight run — same trade-off the new-session restart already made; the existing working-state reconciliation handles it. If concurrent mixed-mode sessions ever matter, that's a per-session-process architecture change, noted here deliberately rather than smuggled in.

## Tests

- Badge: shows only on opted-in sessions; stays off a sandboxed session even while the runtime is unsandboxed.
- Enforcement: a follow-up to a never-opted-in session restarts the bridge sandboxed (`startHermesBridge(undefined, false)`) before `prompt.submit`; a follow-up to an opted-in session restores Unrestricted after the runtime dropped back.
- 332 frontend tests, tsc, prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)