### PR TITLE
Offer agent sessions in the project empty state, not just meetings

### DIFF
--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -826,11 +826,14 @@ function FolderDetail({
           </>
         ) : (
           <FolderEmptyState
+            onCreateSession={() => onCreateSession(folder.id)}
             onCreateNote={() => onCreateNote(folder.id)}
             onAddExisting={() => setAddOpen(true)}
+            onAddSessions={() => setAddSessionsOpen(true)}
             hasNotesElsewhere={notes.some(
               (note) => !note.folderIds.includes(folder.id),
             )}
+            hasSessionsElsewhere={hasSessionsElsewhere}
           />
         )}
       </div>
@@ -1196,13 +1199,19 @@ function FolderAddMenu({
 }
 
 function FolderEmptyActions({
+  onCreateSession,
   onCreateNote,
   onAddExisting,
+  onAddSessions,
   hasNotesElsewhere,
+  hasSessionsElsewhere,
 }: {
+  onCreateSession: () => void;
   onCreateNote: () => void;
   onAddExisting: () => void;
+  onAddSessions: () => void;
   hasNotesElsewhere: boolean;
+  hasSessionsElsewhere: boolean;
 }) {
   return (
     <div className="folder-empty-actions">
@@ -1215,6 +1224,23 @@ function FolderEmptyActions({
           Add existing meeting
         </button>
       ) : null}
+      {hasSessionsElsewhere ? (
+        <button
+          type="button"
+          className="primary-action"
+          onClick={onAddSessions}
+        >
+          Add agent session
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className="primary-action"
+        onClick={onCreateSession}
+      >
+        <IconPangolin size={13} />
+        New session
+      </button>
       <button
         type="button"
         className="primary-action primary-solid"
@@ -1369,23 +1395,33 @@ function FolderNoteRow({
 }
 
 function FolderEmptyState({
+  onCreateSession,
   onCreateNote,
   onAddExisting,
+  onAddSessions,
   hasNotesElsewhere,
+  hasSessionsElsewhere,
 }: {
+  onCreateSession: () => void;
   onCreateNote: () => void;
   onAddExisting: () => void;
+  onAddSessions: () => void;
   hasNotesElsewhere: boolean;
+  hasSessionsElsewhere: boolean;
 }) {
   return (
     <div className="folder-empty-surface" role="group">
       <p className="folder-empty-hint">
-        Capture a meeting, a phone call, or a half-formed thought
+        Capture a meeting, a phone call, or a half-formed thought. Or start an
+        agent session on this project.
       </p>
       <FolderEmptyActions
+        onCreateSession={onCreateSession}
         onCreateNote={onCreateNote}
         onAddExisting={onAddExisting}
+        onAddSessions={onAddSessions}
         hasNotesElsewhere={hasNotesElsewhere}
+        hasSessionsElsewhere={hasSessionsElsewhere}
       />
     </div>
   );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9249,7 +9249,9 @@ input:focus-visible,
 
 .folder-empty-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
   gap: var(--sp-3);
 }
 


### PR DESCRIPTION
## Why

An empty project's call-to-action surface was meetings-only: "Capture a meeting, a phone call, or a half-formed thought" with **Add existing meeting** / **New meeting**. But projects are containers for agent sessions too — sessions render *above* meetings in a populated project, and the header's **+** menu already offers "New session" and "Add agent session". The empty state was the one surface still pretending projects were meetings-only, which is exactly when a user is deciding what this project is for.

## What changed

- Hint copy now reads: "Capture a meeting, a phone call, or a half-formed thought. Or start an agent session on this project."
- The actions row gains **New session** (pangolin icon, same label + icon as the + menu) and a conditional **Add agent session** (shown when sessions exist elsewhere, mirroring the existing "Add existing meeting" condition).
- **New meeting** remains the solid primary action.
- `.folder-empty-actions` wraps and centers so the four-button case (both "add existing" buttons visible) stays tidy.

All handlers reuse the exact plumbing the header + menu already uses (`onCreateSession(folder.id)`, `setAddSessionsOpen`, `hasSessionsElsewhere`) — no new state or data flow.

## Verification

- `tsc` clean, full `vitest` suite passes (329/329).
- Not visually inspected in the running Tauri app — the change reuses existing button classes (`primary-action`, `primary-solid`) and the icon/label pairs already rendered by the + menu, so visual risk is the wrap behavior, covered by the flex-wrap change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)