### PR TITLE
Block picking a text model that can't use tools

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -63,6 +63,7 @@ import {
   dispatchProviderModelSettingsChanged,
   modelPrivacyBadge,
   modelPrivacyFlags,
+  modelSupportsTools,
 } from "../../lib/model-privacy";
 import { ProviderLogo } from "./ProviderLogo";
 import { AgentSettingsSection } from "./AgentSettingsSection";
@@ -1517,6 +1518,9 @@ function ShortcutRow({
   );
 }
 
+const NO_TOOLS_MODEL_EXPLANATION =
+  "This model can't use tools, so June's agent can't work with it. Pick a tool-capable model to use June.";
+
 function ModelPickerDialog({
   open,
   mode,
@@ -1571,6 +1575,15 @@ function ModelPickerDialog({
       <div className="model-picker-list" role="listbox" aria-label={title}>
         {filteredOptions.map((model) => {
           const selected = model.id === value;
+          // The text model powers June's agent, which works through tool
+          // calls — a model that can't use tools (Venice's E2EE models)
+          // bricks the agent, so it can't be picked. Only catalog entries
+          // are judged: the synthesized placeholder for a selection the
+          // catalog hasn't loaded yet has no capability data to judge by.
+          const noTools =
+            mode === "generation" &&
+            Boolean(model.provider) &&
+            !modelSupportsTools(model);
           return (
             <button
               key={model.id}
@@ -1578,8 +1591,13 @@ function ModelPickerDialog({
               className="model-picker-option"
               role="option"
               aria-selected={selected}
+              aria-disabled={noTools || undefined}
               data-selected={selected}
-              onClick={() => onSelect(model.id)}
+              data-no-tools={noTools || undefined}
+              title={noTools ? NO_TOOLS_MODEL_EXPLANATION : undefined}
+              onClick={() => {
+                if (!noTools) onSelect(model.id);
+              }}
             >
               <span className="model-picker-logo" aria-hidden>
                 <ProviderLogo
@@ -1595,6 +1613,9 @@ function ModelPickerDialog({
                 {selected ? <IconCheckmark2Small size={14} /> : null}
               </span>
               <span className="model-picker-meta">
+                {noTools ? (
+                  <span className="model-picker-no-tools">No tools</span>
+                ) : null}
                 <ModelMeta model={model} />
               </span>
             </button>

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -44,6 +44,24 @@ export const ANONYMOUS_MODEL_DESCRIPTION =
 type ModelPrivacySignals = Pick<VeniceModelDto, "privacy" | "traits"> &
   Partial<Pick<VeniceModelDto, "capabilities">>;
 
+/** The agent drives everything through tool calls, so a text model without
+ * function calling bricks June — prompts run but no file, shell, or memory
+ * tool ever executes. Venice's E2EE models are the common case: encrypted
+ * inference can't expose tools. The capability name comes from Venice's
+ * catalog (`supportsFunctionCalling`); match defensively on the normalized
+ * name so a rename to snake_case or "tool calling" keeps working. */
+export function modelSupportsTools(
+  model: Partial<Pick<VeniceModelDto, "capabilities">>,
+) {
+  return (model.capabilities ?? []).some((capability) => {
+    const normalized = capability.toLowerCase().replace(/[^a-z]/g, "");
+    return (
+      normalized.includes("functioncalling") ||
+      normalized.includes("toolcalling")
+    );
+  });
+}
+
 // Strongest claim wins: E2EE models are also private, but "encrypted into the
 // enclave" is the property worth surfacing.
 export function modelPrivacyBadge(

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7205,6 +7205,33 @@ input:focus-visible,
   background: color-mix(in oklch, var(--muted) 80%, transparent);
 }
 
+/* A text model that can't use tools can't power June's agent: shown so the
+ * lineup stays explainable, but visibly inert and unselectable. */
+.model-picker-option[data-no-tools="true"] {
+  cursor: default;
+}
+
+.model-picker-option[data-no-tools="true"]:hover {
+  background: transparent;
+}
+
+.model-picker-option[data-no-tools="true"] .model-picker-name,
+.model-picker-option[data-no-tools="true"] .model-picker-logo,
+.model-picker-option[data-no-tools="true"] .model-meta-items {
+  opacity: 0.45;
+}
+
+.model-picker-no-tools {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--sp-2);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted-foreground) 14%, transparent);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+}
+
 .model-picker-logo {
   grid-area: logo;
   display: inline-grid;

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -215,6 +215,18 @@ describe("AppSettings", () => {
                 pricing: { input: { usd: 0.2 }, output: { usd: 0.8 } },
                 contextTokens: 65536,
                 traits: ["anonymized", "uncensored"],
+                capabilities: ["supportsFunctionCalling"],
+              },
+              {
+                provider: "venice",
+                id: "e2ee-private",
+                name: "E2EE Private",
+                modelType: "text",
+                description: "End-to-end encrypted text model.",
+                privacy: "e2ee",
+                pricing: { input: { usd: 0.3 }, output: { usd: 1.2 } },
+                contextTokens: 32768,
+                traits: ["e2ee"],
                 capabilities: [],
               },
               {
@@ -1084,6 +1096,47 @@ describe("AppSettings", () => {
         modelChanged,
       );
     }
+  });
+
+  it("blocks selecting a text model that cannot use tools", async () => {
+    // June's agent works through tool calls — a tool-less model (Venice's
+    // E2EE models) bricks it, so the picker must not let it be selected.
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Change text model" }),
+    );
+
+    const toolless = await screen.findByRole("option", {
+      name: /E2EE Private/,
+    });
+    expect(toolless).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getAllByText("No tools").length).toBeGreaterThan(0);
+
+    await user.click(toolless);
+    expect(mocks.setVeniceModel).not.toHaveBeenCalled();
+
+    // Tool-capable models stay selectable.
+    await user.click(
+      screen.getByRole("option", { name: /Venice Uncensored/ }),
+    );
+    expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+      "generation",
+      "venice-uncensored",
+    );
   });
 
   it("shows app build metadata", async () => {


### PR DESCRIPTION
> -- i shouldn't be able to pick a model that bricks June (i.e. no tools)

June's agent drives everything through tool calls, but the text-model picker let you select models without function calling — Venice's E2EE models, where encrypted inference can't expose tools. Picking one bricks June: prompts run but no tool ever executes.

## What changed

- New `modelSupportsTools()` helper checks the Venice catalog's capability names (`supportsFunctionCalling`, matched defensively against renames like snake_case or "tool calling").
- In the **text model** picker, tool-less catalog models render dimmed with a "No tools" chip and tooltip ("This model can't use tools, so June's agent can't work with it…"), are `aria-disabled`, and clicks don't select. They stay listed so the lineup remains explainable — an E2EE model disappearing entirely would read as a bug to privacy-focused users.
- The synthesized placeholder row (current selection before the catalog loads) is never judged — it has no capability data.
- Transcription picker unaffected.

## Testing

New test: the E2EE fixture model renders disabled with the chip, clicking it does not call `set_venice_model`, and a tool-capable model still selects. Fixture updated to carry realistic capabilities. `tsc` clean, full suite passes (39 files, 330 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)