### PR TITLE
Keep an in-flight agent session alive across workspace remounts

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1470,6 +1470,13 @@ export function AgentWorkspace({
 
   useEffect(() => {
     let cancelled = false;
+    // This mount owns the snapshot now — consume it so it can't hydrate a
+    // second mount (error-boundary remount, overlapping test renders) with
+    // data this mount is about to mutate. Consumed here rather than in the
+    // continuity initializer because StrictMode double-invokes lazy
+    // initializers, which must stay pure; the unmount capture below writes
+    // a fresh snapshot either way.
+    sessionContinuity = null;
     void (async () => {
       try {
         const status = await hermesBridgeStatus();

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -628,12 +628,79 @@ type AgentWorkspaceProps = {
 // in its pendingReply state.
 const handledMascotReplyIds = new Set<string>();
 
+// Mid-run continuity across remounts. While June is working, a session has
+// state that exists nowhere outside this component: the optimistic list entry
+// (title + preview), the just-sent user bubble Hermes hasn't persisted yet,
+// the working/waiting flags that drive the reconcile poll, the stored→runtime
+// session mapping, the buffered live events, and the title override.
+// Navigating away (e.g. to Settings) unmounts the workspace; without this
+// snapshot the remount restores only the selected id from localStorage, and a
+// session whose first turn hasn't persisted renders as an empty "Untitled
+// session" that nothing ever polls back to life. Captured on unmount for the
+// sessions with active work, hydrated by the next mount's state initializers
+// so the working poll picks the run straight back up.
+type AgentSessionContinuity = {
+  sessionItems: HermesSessionInfo[];
+  pendingMessages: Record<string, HermesSessionMessage[]>;
+  workingSessionIds: string[];
+  waitingSessionIds: string[];
+  runtimeSessionIds: Record<string, string>;
+  liveEvents: Record<string, LiveHermesEvent[]>;
+  titleOverrides: Record<string, string>;
+};
+
+let sessionContinuity: AgentSessionContinuity | null = null;
+
+function captureSessionContinuity(state: {
+  sessionItems: HermesSessionInfo[];
+  pendingMessages: Record<string, HermesSessionMessage[]>;
+  workingSessionIds: Set<string>;
+  waitingSessionIds: Set<string>;
+  runtimeSessionIds: Record<string, string>;
+  liveEvents: Record<string, LiveHermesEvent[]>;
+  titleOverrides: Record<string, string>;
+}): AgentSessionContinuity | null {
+  const activeIds = new Set([
+    ...state.workingSessionIds,
+    ...state.waitingSessionIds,
+  ]);
+  for (const [sessionId, pending] of Object.entries(state.pendingMessages)) {
+    if (pending.length > 0) activeIds.add(sessionId);
+  }
+  if (activeIds.size === 0) return null;
+  const pick = <T,>(record: Record<string, T>) =>
+    Object.fromEntries(
+      Object.entries(record).filter(([sessionId]) => activeIds.has(sessionId)),
+    );
+  return {
+    sessionItems: state.sessionItems.filter((session) =>
+      activeIds.has(session.id),
+    ),
+    pendingMessages: pick(state.pendingMessages),
+    workingSessionIds: [...state.workingSessionIds],
+    waitingSessionIds: [...state.waitingSessionIds],
+    runtimeSessionIds: pick(state.runtimeSessionIds),
+    liveEvents: pick(state.liveEvents),
+    titleOverrides: pick(state.titleOverrides),
+  };
+}
+
+/** Test hook: the snapshot is module state, so a test that unmounts with a
+ * working session (testing-library auto-cleanup) would otherwise leak it into
+ * the next test's mount. */
+export function resetAgentSessionContinuity() {
+  sessionContinuity = null;
+}
+
 export function AgentWorkspace({
   initialSession,
   pendingReply,
   origin,
 }: AgentWorkspaceProps = {}) {
   const initialSessionId = initialSession?.id;
+  // Read once per mount (lazy initializer): the continuity snapshot the
+  // previous mount captured on unmount, if any session was still mid-run.
+  const [continuity] = useState(() => sessionContinuity);
   const [tasks, setTasks] = useState<AgentTaskDto[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string>();
   const [activePanel, setActivePanel] = useState<AgentPanel>("chat");
@@ -666,7 +733,15 @@ export function AgentWorkspace({
   const sandboxMenuWasOpenRef = useRef(false);
   const [hermesSessionItems, setHermesSessionItems] = useState<
     HermesSessionInfo[]
-  >(() => (initialSession ? [initialSession] : []));
+  >(() => {
+    const restored = continuity?.sessionItems ?? [];
+    if (!initialSession) return restored;
+    return [
+      initialSession,
+      ...restored.filter((session) => session.id !== initialSession.id),
+    ];
+  });
+  const hermesSessionItemsRef = useRef(hermesSessionItems);
   // False until the first listHermesSessions fetch lands. Until then the
   // items above only hold the mount seed (the clicked session, or nothing),
   // and broadcasting that would wipe the sidebar's already-loaded list.
@@ -707,28 +782,28 @@ export function AgentWorkspace({
   >({});
   const [pendingHermesMessages, setPendingHermesMessages] = useState<
     Record<string, HermesSessionMessage[]>
-  >({});
+  >(() => continuity?.pendingMessages ?? {});
   const pendingHermesMessagesRef = useRef<
     Record<string, HermesSessionMessage[]>
-  >({});
+  >(pendingHermesMessages);
   const [hermesSessionsLoading, setHermesSessionsLoading] = useState(false);
   const [liveEvents, setLiveEvents] = useState<
     Record<string, LiveHermesEvent[]>
-  >({});
+  >(() => continuity?.liveEvents ?? {});
   const [workingTaskIds, setWorkingTaskIds] = useState<Set<string>>(
     () => new Set(),
   );
   const [workingSessionIds, setWorkingSessionIds] = useState<Set<string>>(
-    () => new Set(),
+    () => new Set(continuity?.workingSessionIds),
   );
-  const workingSessionIdsRef = useRef<Set<string>>(new Set());
+  const workingSessionIdsRef = useRef<Set<string>>(workingSessionIds);
   const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
-    () => new Set(),
+    () => new Set(continuity?.waitingSessionIds),
   );
-  const waitingSessionIdsRef = useRef<Set<string>>(new Set());
+  const waitingSessionIdsRef = useRef<Set<string>>(waitingSessionIds);
   const [runtimeSessionIds, setRuntimeSessionIds] = useState<
     Record<string, string>
-  >({});
+  >(() => continuity?.runtimeSessionIds ?? {});
   const runtimeSessionIdsRef = useRef(runtimeSessionIds);
   // Consecutive runtime-reconcile polls in which a locally-working session was
   // absent from the gateway's live list. Cleared the moment it's seen live.
@@ -784,7 +859,7 @@ export function AgentWorkspace({
   // the previous turn is still streaming must replace the old handler, not
   // stack a second one — otherwise every event lands twice in liveEvents.
   const sessionGatewayUnlistenRef = useRef<Map<string, () => void>>(new Map());
-  const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>({});
+  const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>(liveEvents);
   const hydratedTaskIdsRef = useRef<Set<string>>(new Set());
   // Tasks whose hydration fetch has resolved (hydratedTaskIdsRef only says
   // the fetch *started*) — the scroll-settling logic needs the landing.
@@ -795,7 +870,9 @@ export function AgentWorkspace({
   // chat hands over to a fresh thread — not when the hero is dismissed by
   // selecting an existing chat from the sidebar (that should swap instantly).
   const heroExitViaThreadRef = useRef(false);
-  const sessionTitleOverridesRef = useRef<Record<string, string>>({});
+  const sessionTitleOverridesRef = useRef<Record<string, string>>(
+    continuity?.titleOverrides ?? {},
+  );
   const titleSuggestionSessionIdsRef = useRef<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
   const agentScrollRef = useRef<HTMLDivElement | null>(null);
@@ -811,7 +888,9 @@ export function AgentWorkspace({
     workingSessionIdsRef.current = workingSessionIds;
     waitingSessionIdsRef.current = waitingSessionIds;
     pendingHermesMessagesRef.current = pendingHermesMessages;
+    hermesSessionItemsRef.current = hermesSessionItems;
   }, [
+    hermesSessionItems,
     pendingHermesMessages,
     selectedHermesSessionId,
     waitingSessionIds,
@@ -1402,6 +1481,17 @@ export function AgentWorkspace({
     })();
     return () => {
       cancelled = true;
+      // Keep any mid-run session alive for the next mount before the gateway
+      // (and with it the live event stream) goes away.
+      sessionContinuity = captureSessionContinuity({
+        sessionItems: hermesSessionItemsRef.current,
+        pendingMessages: pendingHermesMessagesRef.current,
+        workingSessionIds: workingSessionIdsRef.current,
+        waitingSessionIds: waitingSessionIdsRef.current,
+        runtimeSessionIds: runtimeSessionIdsRef.current,
+        liveEvents: liveEventsRef.current,
+        titleOverrides: sessionTitleOverridesRef.current,
+      });
       gatewayRef.current?.close();
     };
   }, []);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -15,6 +15,7 @@ import {
   AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
   HERO_GREETINGS,
+  resetAgentSessionContinuity,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
 import {
@@ -161,6 +162,10 @@ describe("AgentWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.gatewayEventHandlers.clear();
+    // Auto-cleanup unmounts the workspace after each test, which snapshots
+    // any still-working session for the next mount — across tests that would
+    // leak one test's mid-run session into the next.
+    resetAgentSessionContinuity();
     window.sessionStorage.clear();
     window.localStorage.clear();
     mocks.listAgentTasks.mockResolvedValue({ items: [existingTask] });
@@ -498,6 +503,45 @@ describe("AgentWorkspace", () => {
       "session-2",
     );
     expect(screen.queryByText("Newer session")).toBeNull();
+  });
+
+  it("restores an in-flight new session across a remount (settings round trip)", async () => {
+    // Start a brand-new session whose first turn is still running: Hermes has
+    // persisted nothing yet (no messages, absent from the server session
+    // list), so every trace of the run lives in component state. Navigating
+    // to Settings and back unmounts and remounts the workspace — without the
+    // continuity snapshot the session came back as an empty "Untitled
+    // session" that nothing ever refreshed.
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), prompt: "audit the repo" }),
+    );
+    const first = render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "audit the repo",
+      }),
+    );
+    expect(await screen.findByText("audit the repo")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Summarize Current Page"),
+    ).toBeInTheDocument();
+
+    first.unmount();
+    render(<AgentWorkspace />);
+
+    // The sent message and the session title survive the round trip.
+    expect(await screen.findByText("audit the repo")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Summarize Current Page"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Untitled session")).toBeNull();
+    // The run is still treated as working, so the reconcile poll can pick it
+    // up: the composer offers the stop control instead of an idle send.
+    expect(
+      await screen.findByRole("button", { name: "Stop June" }),
+    ).toBeInTheDocument();
   });
 
   it("renames prompt-like existing session titles after messages load", async () => {


### PR DESCRIPTION
## Problem

Start a new agent session, and while June is working navigate to Settings and come back: the session shows as "Untitled session" with nothing in it, and never recovers on its own.

## Root cause

Navigating away unmounts `AgentWorkspace`. For a session whose first turn Hermes has not persisted yet, everything about the run lives only in component state and dies with the unmount:

- the optimistic session list entry (title + preview)
- the just-sent user message bubble (`pendingHermesMessages`)
- the working/waiting flags that gate the 2.5s reconcile poll
- the stored-to-runtime session id mapping
- the buffered live events
- the title override from `agentSessionTitleForPrompt`

The remount restores only the selected session id from localStorage. The message fetch returns an empty list (nothing persisted), the server session list has no usable title for it, and with the working flag gone the reconcile poll never starts, so nothing ever refreshes the view. The existing mid-run restore path (`shouldResumeSessionActivity`) cannot help either: it keys off the latest persisted user message, which does not exist yet.

## Fix

On unmount, capture the continuity state for sessions with active work (or unpersisted sends) into a module-scoped snapshot, following the existing `handledMascotReplyIds` precedent in the same file. The next mount hydrates its state initializers from the snapshot, so:

- the session keeps its title and the sent message stays on screen
- the working poll re-arms immediately and reconciles the run from persisted messages when the turn lands (the same poll-based pickup the code already uses after gateway drops)
- sessions with no active work are not captured, so the snapshot never goes stale (`null` when idle)

A `resetAgentSessionContinuity()` test hook is exported and called in `beforeEach`, since testing-library auto-cleanup unmounts after every test and would otherwise leak one test's mid-run session into the next.

## Relationship to #200

Complementary, no conflicts (different regions of the same files). #200 hides message-less sessions from the default list query (`min_messages=1`) and relies on the workspace's optimistic in-memory entry to keep a just-created session visible; this PR is what makes that entry survive a Settings round trip. Without this fix, #200 would make the symptom slightly worse (the running session would vanish from the list entirely instead of showing untitled).

## Testing

- New regression test: starts a fresh session mid-run (nothing persisted server-side), unmounts, remounts, and asserts the message, the title, and the working state survive; verified it fails without the hydration and passes with it.
- `tsc` clean; full vitest suite green (39 files, 330 tests), three consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)