### PR TITLE
Link the agent privacy badge to the server verification page

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -90,6 +90,7 @@ import {
   osAccountsTopUp,
   providerModelSettings,
   retryAgentTask,
+  scribeVerifyUrl,
   sendAgentMessage,
   startHermesBridge,
   suggestAgentSessionTitle,
@@ -743,6 +744,9 @@ export function AgentWorkspace({
   >(null);
   const [generationPrivacyBadge, setGenerationPrivacyBadge] =
     useState<ModelPrivacyBadge>();
+  // Attestation walkthrough URL served by the backend (same page as Settings
+  // → About → Verify server); the privacy badge links to it when known.
+  const [verifyUrl, setVerifyUrl] = useState<string>();
   const [capabilityQuery, setCapabilityQuery] = useState("");
   const [capabilityLoading, setCapabilityLoading] = useState(false);
   const [capabilitySaving, setCapabilitySaving] = useState<string | null>(null);
@@ -1181,6 +1185,20 @@ export function AgentWorkspace({
         PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
         handleProviderModelSettingsChanged,
       );
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    scribeVerifyUrl()
+      .then((url) => {
+        if (!cancelled && url) setVerifyUrl(url);
+      })
+      // Without a configured backend there is nothing to verify; the badge
+      // stays a plain tooltip.
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
     };
   }, []);
 
@@ -3214,7 +3232,10 @@ export function AgentWorkspace({
           />
           <div className="agent-detail-heading">
             <h2>{selectedTask.title}</h2>
-            <SafetyBadge privacyBadge={generationPrivacyBadge} />
+            <SafetyBadge
+              privacyBadge={generationPrivacyBadge}
+              verifyUrl={verifyUrl}
+            />
           </div>
         </div>
         <div className="agent-actions">
@@ -3296,6 +3317,7 @@ export function AgentWorkspace({
             setArtifactPanel((open) => (open ? null : { view: "list" }))
           }
           privacyBadge={generationPrivacyBadge}
+          verifyUrl={verifyUrl}
           fullMode={Boolean(bridge.running && bridge.connection?.fullMode)}
           title={
             !newSessionMode && selectedHermesSessionId
@@ -3414,24 +3436,57 @@ export function AgentWorkspace({
   );
 }
 
-function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
+// The badge's claims (zero retention, enclave inference) are verifiable, not
+// just asserted — when the backend's attestation walkthrough URL is known,
+// the badge links straight to it instead of leaving the proof buried in
+// Settings → About.
+function SafetyBadge({
+  privacyBadge,
+  verifyUrl,
+}: {
+  privacyBadge?: ModelPrivacyBadge;
+  verifyUrl?: string;
+}) {
   if (!privacyBadge) return null;
+  const icon =
+    privacyBadge.mode === "e2ee" ? (
+      <IconLock size={13} aria-hidden />
+    ) : privacyBadge.mode === "private" ? (
+      <IconShieldAi size={13} aria-hidden />
+    ) : (
+      <IconAnonymous size={13} aria-hidden />
+    );
+  const label = (
+    <span className="agent-safety-badge-label">{privacyBadge.label}</span>
+  );
+  if (!verifyUrl) {
+    return (
+      <HoverTip
+        tip={privacyBadge.description}
+        className="agent-safety-badge"
+        data-mode={privacyBadge.mode}
+        tabIndex={0}
+        aria-label={`${privacyBadge.label} - ${privacyBadge.description}`}
+      >
+        {icon}
+        {label}
+      </HoverTip>
+    );
+  }
+  const description = `${privacyBadge.description} Click to see exactly what code June's server runs and how to verify it yourself.`;
   return (
-    <HoverTip
-      tip={privacyBadge.description}
-      className="agent-safety-badge"
-      data-mode={privacyBadge.mode}
-      tabIndex={0}
-      aria-label={`${privacyBadge.label} - ${privacyBadge.description}`}
-    >
-      {privacyBadge.mode === "e2ee" ? (
-        <IconLock size={13} aria-hidden />
-      ) : privacyBadge.mode === "private" ? (
-        <IconShieldAi size={13} aria-hidden />
-      ) : (
-        <IconAnonymous size={13} aria-hidden />
-      )}
-      <span className="agent-safety-badge-label">{privacyBadge.label}</span>
+    <HoverTip tip={description} className="agent-safety-badge-wrap">
+      <a
+        className="agent-safety-badge"
+        data-mode={privacyBadge.mode}
+        href={verifyUrl}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`${privacyBadge.label} - ${description}`}
+      >
+        {icon}
+        {label}
+      </a>
     </HoverTip>
   );
 }
@@ -3463,6 +3518,7 @@ function UnrestrictedBadge() {
 function AgentSessionBar({
   origin,
   privacyBadge,
+  verifyUrl,
   fullMode,
   title,
   artifactCount = 0,
@@ -3473,6 +3529,7 @@ function AgentSessionBar({
 }: {
   origin?: AgentWorkspaceOrigin;
   privacyBadge?: ModelPrivacyBadge;
+  verifyUrl?: string;
   fullMode?: boolean;
   title?: string;
   artifactCount?: number;
@@ -3596,7 +3653,7 @@ function AgentSessionBar({
             <span aria-hidden>{artifactCount}</span>
           </button>
         ) : null}
-        <SafetyBadge privacyBadge={privacyBadge} />
+        <SafetyBadge privacyBadge={privacyBadge} verifyUrl={verifyUrl} />
         {hasMenu ? (
           <div className="agent-session-menu-wrap" ref={menuWrapRef}>
             <button

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -684,6 +684,23 @@ input:focus-visible,
   color: var(--warm-strong);
 }
 
+/* Linked badge (attestation walkthrough known): same chrome, but it reads as
+ * clickable and brightens on hover. The wrap keeps HoverTip's anchor span
+ * from adding box styling of its own. */
+.agent-safety-badge-wrap {
+  display: inline-flex;
+}
+
+a.agent-safety-badge {
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+a.agent-safety-badge:hover {
+  background: color-mix(in oklch, var(--brand) 24%, transparent);
+}
+
 .agent-actions {
   display: flex;
   align-items: center;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
   osAccountsTopUp: vi.fn(),
+  scribeVerifyUrl: vi.fn(),
   providerModelSettings: vi.fn(),
   retryAgentTask: vi.fn(),
   saveAgentAssistantMessage: vi.fn(),
@@ -98,6 +99,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsTopUp: mocks.osAccountsTopUp,
   providerModelSettings: mocks.providerModelSettings,
   retryAgentTask: mocks.retryAgentTask,
+  scribeVerifyUrl: mocks.scribeVerifyUrl,
   saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
   saveAgentHermesSession: mocks.saveAgentHermesSession,
   sendAgentMessage: mocks.sendAgentMessage,
@@ -188,6 +190,9 @@ describe("AgentWorkspace", () => {
       ],
     });
     mocks.getAgentTask.mockResolvedValue(existingTask);
+    // Empty by default so badge tests assert the plain (unlinked) badge; the
+    // verify-link test overrides this with a real URL.
+    mocks.scribeVerifyUrl.mockResolvedValue("");
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
       connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
@@ -372,6 +377,22 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument(),
     );
+  });
+
+  it("links the privacy badge to the server verification page", async () => {
+    mocks.scribeVerifyUrl.mockResolvedValue(
+      "https://scribe-api.example.test/verify",
+    );
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    const badge = await screen.findByRole("link", { name: /Private mode/ });
+    expect(badge).toHaveAttribute(
+      "href",
+      "https://scribe-api.example.test/verify",
+    );
+    expect(badge).toHaveAttribute("target", "_blank");
+    expect(badge).toHaveAccessibleName(/how to verify it yourself/i);
   });
 
   it("refreshes the model privacy label when generation model settings change", async () => {

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -101,6 +101,7 @@ vi.mock("../lib/tauri", () => ({
   // these tests focused on the meetings surfaces.
   hermesBridgeStatus: vi.fn(async () => ({ running: false })),
   listAgentTasks: vi.fn(async () => ({ items: [] })),
+  scribeVerifyUrl: vi.fn(async () => ""),
   providerModelSettings: vi.fn(async () => ({
     settings: { generationModel: "" },
   })),

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -102,6 +102,7 @@ vi.mock("../lib/tauri", () => ({
   // these tests focused on the meetings surfaces.
   hermesBridgeStatus: vi.fn(async () => ({ running: false })),
   listAgentTasks: vi.fn(async () => ({ items: [] })),
+  scribeVerifyUrl: vi.fn(async () => ""),
   providerModelSettings: vi.fn(async () => ({
     settings: { generationModel: "" },
   })),

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -96,6 +96,7 @@ vi.mock("../lib/tauri", () => ({
   // these tests focused on the meetings surfaces.
   hermesBridgeStatus: vi.fn(async () => ({ running: false })),
   listAgentTasks: vi.fn(async () => ({ items: [] })),
+  scribeVerifyUrl: vi.fn(async () => ""),
   providerModelSettings: vi.fn(async () => ({
     settings: { generationModel: "" },
   })),


### PR DESCRIPTION
> -- let's have this link to /verify

The backend's attestation walkthrough (`<api>/verify`) was only reachable from Settings → About → Verify server. Meanwhile the privacy badge in the agent session bar — the surface users actually see while working — makes the claims that page proves (zero retention, enclave inference) without linking to it.

## What changed

- The session-bar privacy badge (E2EE / Private mode / Anonymous mode) is now a link to the same verification URL the About page uses (`scribe_verify_url` → `<api>/verify`), opening in the browser.
- Its hover tip gains: "Click to see exactly what code June's server runs and how to verify it yourself."
- When the verify URL isn't available, the badge stays the plain tooltip span it was — no dead link.
- Same chrome as before, with a subtle hover brighten so it reads as clickable.

## Testing

New test asserts the badge renders as a link with the verify href, `target="_blank"`, and the verification copy in its accessible name; the default test mock keeps the unlinked badge for the existing label tests. App-level suites' tauri mocks gained the new export. `tsc` clean, full suite passes (39 files, 330 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)