### PR TITLE
Scope Unrestricted per session, served by side-by-side sandboxed and unrestricted runtimes

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -3,6 +3,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     fs, io,
     net::TcpListener,
     path::{Path, PathBuf},
@@ -63,12 +64,12 @@ You are helpful, knowledgeable, and direct. Communicate clearly, admit uncertain
 /// write-jail, so the soul never claims protections that aren't active (the
 /// escape hatch and non-macOS spawns run unsandboxed).
 const JUNE_SOUL_SANDBOX_MD: &str = r#"
-Your environment: you run inside a macOS kernel sandbox (Seatbelt) that the June app applies to you and to every subprocess you start. It is a write-jail, part of the same privacy-by-architecture story:
+Your environment: sessions run by default inside a macOS kernel sandbox (Seatbelt) that the June app applies to you and to every subprocess you start. It is a write-jail, part of the same privacy-by-architecture story. The user chooses the mode per session: sessions are Sandboxed unless they explicitly started this one in Unrestricted mode. In a sandboxed session:
 
 - You can write only inside your own area — your Hermes home (including your workspace), your runtime directory, and your temp directory. Writes anywhere else (the user's dotfiles, Desktop, Documents, system settings) are denied by the kernel.
 - Reads stay broad so you can work with the user's files, except credential stores (~/.ssh, ~/.aws, ~/.gnupg, keychains, .netrc), which are blocked.
-- When a command fails with "operation not permitted" on a write outside your area, that is the sandbox working as designed. Don't retry or look for workarounds: produce the file in your workspace and tell the user where it is, or ask them to do that one step.
-- If the user asks whether you can damage their system, answer honestly: destructive writes outside your workspace are blocked at the kernel level, not just by policy.
+- When a command fails with "operation not permitted" on a write outside your area, that is the sandbox working as designed. Don't retry or look for workarounds: produce the file in your workspace and tell the user where it is, or ask them to do that one step. If the user wants you to write outside the jail, they can start a new session in Unrestricted mode.
+- If the user asks whether you can damage their system, answer honestly: in a sandboxed session, destructive writes outside your workspace are blocked at the kernel level, not just by policy; in an Unrestricted session that protection is off because they chose to turn it off.
 "#;
 
 const ISOLATED_HERMES_ENV_VARS: &[&str] = &[
@@ -97,28 +98,42 @@ const ISOLATED_HERMES_ENV_VARS: &[&str] = &[
 
 #[derive(Default)]
 pub struct HermesBridge {
-    process: Mutex<Option<HermesProcess>>,
+    /// Up to one runtime process per write-access mode, keyed by `full_mode`.
+    /// The Seatbelt jail is applied at spawn and can't change on a live
+    /// process, so per-session modes are served by a *pair* of processes —
+    /// sandboxed and unrestricted — over the same Hermes home (sessions live
+    /// in the runtime's WAL-mode SQLite store, which is built for
+    /// multi-process access). Starting one mode never disturbs the other.
+    processes: Mutex<HashMap<bool, HermesProcess>>,
     /// Serializes the whole start sequence (config sync, runtime install,
     /// spawn, readiness wait). Concurrent starts would otherwise write
-    /// `config.yaml` with different proxy ports/tokens and could run two
-    /// installers at once. This must be an async mutex because it is held
-    /// across awaits; the `process` mutex above is std::sync and must never
-    /// be held across an await.
+    /// `config.yaml` concurrently and could run two installers at once.
+    /// This must be an async mutex because it is held across awaits; the
+    /// `processes` mutex above is std::sync and must never be held across
+    /// an await.
     start_lock: tokio::sync::Mutex<()>,
     /// Monotonic id assigned to each spawned Hermes process so a start
     /// attempt only tears down the exact process it launched (and not a
     /// replacement that arrived after a stop/restart).
     next_generation: AtomicU64,
+    /// One local provider proxy shared by both runtime processes. The
+    /// runtime reads its model endpoint from the single shared
+    /// `HERMES_HOME/config.yaml` (no per-process override exists upstream),
+    /// so the proxy coordinates must be identical for every spawn — a
+    /// per-process proxy would rewrite the file under the other process.
+    /// Started lazily on the first spawn, lives until app shutdown.
+    provider_proxy: Mutex<Option<SharedProviderProxy>>,
 }
 
 struct HermesProcess {
     generation: u64,
     child: Child,
     connection: HermesBridgeConnection,
-    proxy: Option<ScribeProviderProxy>,
 }
 
-struct ScribeProviderProxy {
+struct SharedProviderProxy {
+    port: u16,
+    token: String,
     shutdown: Option<oneshot::Sender<()>>,
 }
 
@@ -163,8 +178,16 @@ pub struct HermesBridgeConnection {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HermesBridgeStatus {
+    /// True when any runtime process is up.
     pub running: bool,
+    /// The primary connection — the requested mode's process for a start
+    /// call, otherwise sandboxed-first. Kept alongside `connections` so
+    /// existing callers that only care about "the runtime" keep working.
     pub connection: Option<HermesBridgeConnection>,
+    /// Every live runtime process (at most one per mode). Mode-aware
+    /// callers pick by `full_mode`.
+    #[serde(default)]
+    pub connections: Vec<HermesBridgeConnection>,
     pub message: Option<String>,
 }
 
@@ -173,11 +196,11 @@ pub struct HermesBridgeStatus {
 pub struct StartHermesBridgeRequest {
     #[serde(default)]
     pub cwd: Option<String>,
-    /// `Some(_)` is an explicit, user-chosen mode: a running runtime whose
-    /// mode differs is restarted to honor it. `None` means "no preference" —
-    /// reuse whatever is running, and start sandboxed when starting fresh —
-    /// so background callers (auto-start, routines) can never flip a mode the
-    /// user opted into, and Full mode never survives an app relaunch.
+    /// `Some(_)` names the mode to ensure; the other mode's process (if
+    /// any) is left untouched — the two run side by side. `None` means "no
+    /// preference": ensure the sandboxed default, so background callers
+    /// (auto-start, routines) never widen write access, and Full mode never
+    /// survives an app relaunch on its own.
     #[serde(default)]
     pub full_mode: Option<bool>,
 }
@@ -287,35 +310,65 @@ pub struct HermesFilesystemEntry {
 pub async fn hermes_bridge_status(
     bridge: State<'_, HermesBridge>,
 ) -> Result<HermesBridgeStatus, AppError> {
+    let connections = live_connections(&bridge)?;
+    Ok(status_for(connections, None))
+}
+
+/// Reap-and-collect: drops map entries whose process has exited and returns
+/// the connections that are still live, sandboxed first.
+fn live_connections(bridge: &HermesBridge) -> Result<Vec<HermesBridgeConnection>, AppError> {
     let mut guard = bridge
-        .process
+        .processes
         .lock()
         .map_err(|_| AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed."))?;
-    let Some(process) = guard.as_mut() else {
-        return Ok(HermesBridgeStatus {
-            running: false,
-            connection: None,
-            message: Some("Hermes bridge is not running.".to_string()),
-        });
-    };
-    match process.child.try_wait() {
-        Ok(Some(status)) => {
-            *guard = None;
-            Ok(HermesBridgeStatus {
-                running: false,
-                connection: None,
-                message: Some(format!("Hermes exited with status {status}.")),
-            })
+    let mut connections = Vec::new();
+    for full_mode in [false, true] {
+        let exited = match guard.get_mut(&full_mode) {
+            None => continue,
+            Some(process) => match process.child.try_wait() {
+                Ok(Some(_)) => true,
+                Ok(None) => false,
+                Err(error) => {
+                    return Err(AppError::new(
+                        "hermes_bridge_status_failed",
+                        error.to_string(),
+                    ));
+                }
+            },
+        };
+        if exited {
+            guard.remove(&full_mode);
+        } else if let Some(process) = guard.get(&full_mode) {
+            connections.push(process.connection.clone());
         }
-        Ok(None) => Ok(HermesBridgeStatus {
-            running: true,
-            connection: Some(process.connection.clone()),
-            message: None,
-        }),
-        Err(error) => Err(AppError::new(
-            "hermes_bridge_status_failed",
-            error.to_string(),
-        )),
+    }
+    Ok(connections)
+}
+
+/// Builds the wire status. `primary_mode` selects which connection fills the
+/// legacy `connection` field (a start call reports the mode it ensured);
+/// `None` prefers the sandboxed process.
+fn status_for(
+    connections: Vec<HermesBridgeConnection>,
+    primary_mode: Option<bool>,
+) -> HermesBridgeStatus {
+    let primary = match primary_mode {
+        Some(mode) => connections
+            .iter()
+            .find(|connection| connection.full_mode == mode)
+            .cloned(),
+        None => connections.first().cloned(),
+    };
+    let running = !connections.is_empty();
+    HermesBridgeStatus {
+        running,
+        connection: primary,
+        message: if running {
+            None
+        } else {
+            Some("Hermes bridge is not running.".to_string())
+        },
+        connections,
     }
 }
 
@@ -375,22 +428,18 @@ async fn start_hermes_bridge_inner(
     // sees the winner's running process.
     let _start_guard = bridge.start_lock.lock().await;
 
-    if let Some(status) = existing_running_status(bridge)? {
-        let running_full_mode = status
-            .connection
-            .as_ref()
-            .is_some_and(|connection| connection.full_mode);
-        match request.full_mode {
-            // An explicit mode choice that differs from the running runtime
-            // restarts it; the jail is applied at spawn and can't be changed
-            // on a live process. Implicit (None) callers reuse what's up.
-            Some(requested) if requested != running_full_mode => {
-                stop_hermes_bridge_inner(bridge)?;
-            }
-            _ => return Ok(status),
-        }
-    }
+    // Ensure the requested mode (None = the sandboxed default). The other
+    // mode's process — if one is up — is deliberately untouched: the pair
+    // runs side by side so a session in one mode never kills the other's
+    // in-flight work.
     let full_mode = request.full_mode.unwrap_or(false);
+    let connections = live_connections(bridge)?;
+    if connections
+        .iter()
+        .any(|connection| connection.full_mode == full_mode)
+    {
+        return Ok(status_for(connections, Some(full_mode)));
+    }
 
     let port = pick_port()?;
     let token = random_token();
@@ -414,23 +463,29 @@ async fn start_hermes_bridge_inner(
         .map(std::path::PathBuf::from)
         .unwrap_or(default_cwd);
     let cwd_display = Some(cwd.to_string_lossy().into_owned());
-    let provider_proxy_token = random_token();
-    let provider_proxy = start_scribe_provider_proxy(provider_proxy_token.clone()).await?;
-    sync_hermes_config(&hermes_home, provider_proxy.port, &provider_proxy_token)?;
+    let provider_proxy = ensure_provider_proxy(bridge).await?;
+    sync_hermes_config(&hermes_home, provider_proxy.port, &provider_proxy.token)?;
 
     // Wrap the spawn in a macOS Seatbelt write-jail when possible. The model,
     // its tool calls, and any subprocess it forks all inherit the profile, so
     // destructive writes (rm -rf of user dirs, dotfile rewrites, TCC db edits)
     // are denied by the kernel rather than by Hermes' own pattern checks.
     // Resolved before the soul write so June's self-knowledge about the jail
-    // matches what this spawn actually enforces.
+    // matches what sandboxed spawns actually enforce.
     let sandbox_profile = if full_mode {
         None
     } else {
         prepare_sandbox(app, &hermes_home)
     };
     let sandboxed = sandbox_profile.is_some();
-    sync_june_soul(&hermes_home, sandboxed)?;
+    // SOUL.md is shared by both processes (single home), so its sandbox
+    // section describes the per-session mode split rather than this spawn.
+    let sandbox_available = if full_mode {
+        sandbox_would_engage(app, &hermes_home)
+    } else {
+        sandboxed
+    };
+    sync_june_soul(&hermes_home, sandbox_available)?;
     if sandboxed {
         eprintln!("Spawning Hermes under the macOS Seatbelt write-jail.");
     } else if full_mode {
@@ -495,35 +550,30 @@ async fn start_hermes_bridge_inner(
 
     let generation = bridge.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
     {
-        let mut guard = bridge.process.lock().map_err(|_| {
+        let mut guard = bridge.processes.lock().map_err(|_| {
             AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
         })?;
         // The start guard serializes starts, so no concurrent start can have
-        // populated the slot since the `existing_running_status` check above.
+        // populated this mode's slot since the live-connections check above.
         // Keep a defensive check anyway: if a live process is somehow present
         // we keep it and tear down the redundant one we just launched instead
         // of leaking it.
-        if let Some(existing) = guard.as_mut() {
+        if let Some(existing) = guard.get_mut(&full_mode) {
             if matches!(existing.child.try_wait(), Ok(None)) {
-                let existing_connection = existing.connection.clone();
                 let _ = child.kill();
                 let _ = child.wait();
-                let _ = provider_proxy.shutdown.send(());
-                return Ok(HermesBridgeStatus {
-                    running: true,
-                    connection: Some(existing_connection),
-                    message: None,
-                });
+                drop(guard);
+                return Ok(status_for(live_connections(bridge)?, Some(full_mode)));
             }
         }
-        *guard = Some(HermesProcess {
-            generation,
-            child,
-            connection: connection.clone(),
-            proxy: Some(ScribeProviderProxy {
-                shutdown: Some(provider_proxy.shutdown),
-            }),
-        });
+        guard.insert(
+            full_mode,
+            HermesProcess {
+                generation,
+                child,
+                connection: connection.clone(),
+            },
+        );
     }
 
     if let Err(error) = wait_for_hermes(&base_url, &token).await {
@@ -534,11 +584,45 @@ async fn start_hermes_bridge_inner(
         return Err(error);
     }
 
-    Ok(HermesBridgeStatus {
-        running: true,
-        connection: Some(connection),
-        message: None,
+    Ok(status_for(live_connections(bridge)?, Some(full_mode)))
+}
+
+/// The shared provider proxy's coordinates, starting it on first use. Both
+/// runtime processes point at it through the one shared config.yaml.
+async fn ensure_provider_proxy(bridge: &HermesBridge) -> Result<SharedProviderProxyInfo, AppError> {
+    {
+        let guard = bridge.provider_proxy.lock().map_err(|_| {
+            AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
+        })?;
+        if let Some(proxy) = guard.as_ref() {
+            return Ok(SharedProviderProxyInfo {
+                port: proxy.port,
+                token: proxy.token.clone(),
+            });
+        }
+    }
+    let token = random_token();
+    let started = start_scribe_provider_proxy(token.clone()).await?;
+    let mut guard = bridge
+        .provider_proxy
+        .lock()
+        .map_err(|_| AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed."))?;
+    // The start_lock serializes callers, so the slot is still empty here;
+    // insert unconditionally.
+    *guard = Some(SharedProviderProxy {
+        port: started.port,
+        token: token.clone(),
+        shutdown: Some(started.shutdown),
+    });
+    Ok(SharedProviderProxyInfo {
+        port: started.port,
+        token,
     })
+}
+
+struct SharedProviderProxyInfo {
+    port: u16,
+    token: String,
 }
 
 #[tauri::command]
@@ -549,6 +633,7 @@ pub async fn stop_hermes_bridge(
     Ok(HermesBridgeStatus {
         running: false,
         connection: None,
+        connections: Vec::new(),
         message: Some("Hermes bridge stopped.".to_string()),
     })
 }
@@ -1115,42 +1200,35 @@ fn image_mime_type(path: &Path) -> Option<&'static str> {
 pub fn shutdown(app: &tauri::AppHandle) {
     let bridge = app.state::<HermesBridge>();
     let _ = stop_hermes_bridge_inner(&bridge);
+    let proxy = bridge
+        .provider_proxy
+        .lock()
+        .ok()
+        .and_then(|mut guard| guard.take());
+    if let Some(mut proxy) = proxy {
+        if let Some(shutdown) = proxy.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
 }
 
+/// Sends a dashboard API request to any live runtime process, sandboxed
+/// first. Sessions, skills, and platform state all live in the shared
+/// Hermes home, so either process answers these identically.
 async fn hermes_api_json(
     bridge: &State<'_, HermesBridge>,
     method: reqwest::Method,
     path: &str,
     body: Option<serde_json::Value>,
 ) -> Result<serde_json::Value, AppError> {
-    let connection = {
-        let mut guard = bridge.process.lock().map_err(|_| {
-            AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
-        })?;
-        let Some(process) = guard.as_mut() else {
-            return Err(AppError::new(
-                "hermes_bridge_not_running",
-                "Hermes bridge is not running.",
-            ));
-        };
-        match process.child.try_wait() {
-            Ok(Some(status)) => {
-                *guard = None;
-                return Err(AppError::new(
-                    "hermes_bridge_not_running",
-                    format!("Hermes exited with status {status}."),
-                ));
-            }
-            Ok(None) => process.connection.clone(),
-            Err(error) => {
-                return Err(AppError::new(
-                    "hermes_bridge_status_failed",
-                    error.to_string(),
-                ));
-            }
-        }
+    let connections = live_connections(bridge)?;
+    let Some(connection) = connections.first() else {
+        return Err(AppError::new(
+            "hermes_bridge_not_running",
+            "Hermes bridge is not running.",
+        ));
     };
-    hermes_connection_json(&connection, method, path, body).await
+    hermes_connection_json(connection, method, path, body).await
 }
 
 async fn start_hermes_gateway_if_needed(
@@ -1294,58 +1372,36 @@ async fn hermes_connection_json(
         .map_err(|error| AppError::new("hermes_bridge_api_failed", error.to_string()))
 }
 
-fn existing_running_status(bridge: &HermesBridge) -> Result<Option<HermesBridgeStatus>, AppError> {
-    let mut guard = bridge
-        .process
-        .lock()
-        .map_err(|_| AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed."))?;
-    let Some(process) = guard.as_mut() else {
-        return Ok(None);
-    };
-    match process.child.try_wait() {
-        Ok(Some(_)) => {
-            *guard = None;
-            Ok(None)
-        }
-        Ok(None) => Ok(Some(HermesBridgeStatus {
-            running: true,
-            connection: Some(process.connection.clone()),
-            message: None,
-        })),
-        Err(error) => Err(AppError::new(
-            "hermes_bridge_status_failed",
-            error.to_string(),
-        )),
-    }
-}
-
+/// Stops every runtime process. The shared provider proxy stays up — it is
+/// process-independent and the next start reuses it; `shutdown()` is the
+/// only place that tears it down.
 fn stop_hermes_bridge_inner(bridge: &HermesBridge) -> Result<(), AppError> {
-    let process = bridge
-        .process
-        .lock()
-        .map_err(|_| AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed."))?
-        .take();
-    shutdown_hermes_process(process);
+    let processes: Vec<HermesProcess> = {
+        let mut guard = bridge.processes.lock().map_err(|_| {
+            AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
+        })?;
+        guard.drain().map(|(_, process)| process).collect()
+    };
+    for process in processes {
+        shutdown_hermes_process(Some(process));
+    }
     Ok(())
 }
 
-/// Stops the bridge only if the slot still holds the process spawned by the
-/// start attempt identified by `generation`. A stop (or stop+restart) that
-/// raced with that start leaves a different process in the slot, which must
-/// not be killed by the stale start attempt's cleanup.
+/// Stops only the process spawned by the start attempt identified by
+/// `generation`, whichever mode slot it sits in. A stop (or stop+restart)
+/// that raced with that start leaves a different process in the slot, which
+/// must not be killed by the stale start attempt's cleanup.
 fn stop_hermes_bridge_generation(bridge: &HermesBridge, generation: u64) -> Result<(), AppError> {
     let process = {
-        let mut guard = bridge.process.lock().map_err(|_| {
+        let mut guard = bridge.processes.lock().map_err(|_| {
             AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
         })?;
-        if guard
-            .as_ref()
-            .is_some_and(|process| process.generation == generation)
-        {
-            guard.take()
-        } else {
-            None
-        }
+        let key = guard
+            .iter()
+            .find(|(_, process)| process.generation == generation)
+            .map(|(key, _)| *key);
+        key.and_then(|key| guard.remove(&key))
     };
     shutdown_hermes_process(process);
     Ok(())
@@ -1355,11 +1411,6 @@ fn shutdown_hermes_process(mut process: Option<HermesProcess>) {
     if let Some(process) = process.as_mut() {
         let _ = process.child.kill();
         let _ = process.child.wait();
-        if let Some(proxy) = process.proxy.as_mut() {
-            if let Some(shutdown) = proxy.shutdown.take() {
-                let _ = shutdown.send(());
-            }
-        }
     }
 }
 
@@ -1677,6 +1728,26 @@ fn prepare_sandbox(_app: &AppHandle, _hermes_home: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Whether a *sandboxed* spawn on this machine would actually engage the
+/// jail. Used by unrestricted spawns to keep the shared SOUL.md's sandbox
+/// section accurate without touching the profile on disk.
+#[cfg(target_os = "macos")]
+fn sandbox_would_engage(app: &AppHandle, hermes_home: &Path) -> bool {
+    if env_flag_enabled(SCRIBE_HERMES_DISABLE_SANDBOX_ENV) {
+        return false;
+    }
+    if !Path::new(SANDBOX_EXEC_PATH).exists() {
+        return false;
+    }
+    let _ = hermes_home;
+    std::env::var_os("HOME").is_some() && managed_hermes_runtime_dir(app).is_ok()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn sandbox_would_engage(_app: &AppHandle, _hermes_home: &Path) -> bool {
+    false
+}
+
 #[cfg(target_os = "macos")]
 fn env_flag_enabled(name: &str) -> bool {
     match std::env::var(name) {
@@ -1858,10 +1929,13 @@ display:
 /// Writes the June persona to `SOUL.md` in the Scribe-managed Hermes home.
 /// Runs on every start so the app-owned identity wins over the default soul
 /// Hermes seeds on first run (and over any stale copy from earlier versions).
-/// The sandbox section is included only when this spawn's jail engaged, so
-/// the agent's self-knowledge tracks the actual enforcement.
-fn sync_june_soul(hermes_home: &std::path::Path, sandboxed: bool) -> Result<(), AppError> {
-    let soul = if sandboxed {
+/// Both mode processes read this one file, so the sandbox section describes
+/// the per-session mode split; it is included only when sandboxed spawns on
+/// this machine actually engage the jail (it's omitted when sandbox-exec is
+/// missing or the escape-hatch env var disabled it, so the agent never
+/// claims a protection that isn't enforced).
+fn sync_june_soul(hermes_home: &std::path::Path, sandbox_available: bool) -> Result<(), AppError> {
+    let soul = if sandbox_available {
         format!("{JUNE_SOUL_MD}{JUNE_SOUL_SANDBOX_MD}")
     } else {
         JUNE_SOUL_MD.to_string()

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -142,6 +142,11 @@ import {
 } from "../../lib/model-privacy";
 import { messageFromError } from "../../lib/errors";
 import {
+  forgetSessionMode,
+  rememberSessionMode,
+  sessionUnrestricted,
+} from "../../lib/agent-session-modes";
+import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   type AgentApprovalChoice,
@@ -1765,11 +1770,15 @@ export function AgentWorkspace({
     const titlePromise = targetSessionId
       ? undefined
       : agentSessionTitleForPrompt(content);
-    // Only a session being created applies the unrestricted opt-in;
-    // follow-ups on existing sessions never change the runtime's mode under
-    // them.
+    // The Unrestricted opt-in is made per session: a new session applies the
+    // picker draft, and a follow-up applies the mode its session was created
+    // with — restarting the runtime when the running mode differs. Without
+    // this, one Unrestricted session would leave the runtime unsandboxed
+    // under every other session's follow-ups.
     const gateway = await ensureHermesGateway(
-      targetSessionId ? undefined : fullModeDraftRef.current,
+      targetSessionId
+        ? sessionUnrestricted(targetSessionId)
+        : fullModeDraftRef.current,
     );
     const sessionTitle = titlePromise ? await titlePromise : undefined;
     const created = targetSessionId
@@ -1781,6 +1790,9 @@ export function AgentWorkspace({
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
+    if (!targetSessionId) {
+      rememberSessionMode(storedSessionId, fullModeDraftRef.current);
+    }
     const sessionDisplayTitle =
       explicitSession?.title?.trim() ||
       explicitSession?.preview?.trim() ||
@@ -2537,6 +2549,7 @@ export function AgentWorkspace({
   async function deleteSelectedHermesSession(sessionId: string) {
     try {
       await deleteHermesSession(sessionId);
+      forgetSessionMode(sessionId);
       // Clearing the selection falls the workspace back to empty.
       removeHermesSessionLocally(sessionId, false);
     } catch (err) {
@@ -3296,7 +3309,14 @@ export function AgentWorkspace({
             setArtifactPanel((open) => (open ? null : { view: "list" }))
           }
           privacyBadge={generationPrivacyBadge}
-          fullMode={Boolean(bridge.running && bridge.connection?.fullMode)}
+          // The badge describes the selected session, not the live runtime:
+          // every send re-enforces the session's recorded mode, so a
+          // sandboxed session stays sandboxed even while an Unrestricted
+          // runtime from another session is still up. The hero composer's
+          // picker covers the new-session draft.
+          fullMode={
+            !newSessionMode && sessionUnrestricted(selectedHermesSessionId)
+          }
           title={
             !newSessionMode && selectedHermesSessionId
               ? (selectedHermesSession?.title ?? "")
@@ -3436,12 +3456,13 @@ function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
   );
 }
 
-// Honest indicator of the live runtime, not of any one session: the jail is
-// per-process, so while the user has it unrestricted every session it serves
-// runs unsandboxed.
+// Indicator of the selected session's opt-in. The jail itself is
+// per-process, but every send restarts the runtime into the target session's
+// recorded mode, so the session — not the runtime's current state — is the
+// honest unit to label.
 function UnrestrictedBadge() {
   const description =
-    "June is running without the file sandbox and can change any file your account can. Start a session with Unrestricted off to restore the sandbox.";
+    "This session runs without the file sandbox — June can change any file your account can. Sessions started as Sandboxed keep their jail; it is re-applied whenever you message them.";
   return (
     <HoverTip
       tip={description}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2568,12 +2568,17 @@ export function AgentWorkspace({
       return next;
     });
     scrubHermesSessionState(sessionId);
+    // Every deletion funnels through here (the in-workspace delete and the
+    // sidebar/sessions-list AGENT_DELETE_SESSION_EVENT), so this is the one
+    // place that drops the session's Unrestricted record — a stale entry
+    // would hand full write access to any future session that recycled the
+    // id.
+    forgetSessionMode(sessionId);
   }
 
   async function deleteSelectedHermesSession(sessionId: string) {
     try {
       await deleteHermesSession(sessionId);
-      forgetSessionMode(sessionId);
       // Clearing the selection falls the workspace back to empty.
       removeHermesSessionLocally(sessionId, false);
     } catch (err) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -788,7 +788,9 @@ export function AgentWorkspace({
   // it routes through this ref to always run the latest render's recovery
   // closure (see recoverFromGatewayClose).
   const gatewayCloseHandlerRef = useRef((_fullMode: boolean) => {});
-  const gatewayRecoveringRef = useRef(false);
+  // Per-mode: both gateways can drop together (network reconnect), and one
+  // mode's in-flight recovery must not swallow the other's only onClose.
+  const gatewayRecoveringRef = useRef<Set<boolean>>(new Set());
   // One live gateway subscription per Hermes session. A follow-up send while
   // the previous turn is still streaming must replace the old handler, not
   // stack a second one — otherwise every event lands twice in liveEvents.
@@ -2025,14 +2027,14 @@ export function AgentWorkspace({
   // their true state from persisted messages. Only the dropped mode's
   // gateway is rebuilt — sessions of that mode are the ones it served.
   async function recoverFromGatewayClose(fullMode: boolean) {
-    if (gatewayRecoveringRef.current) return;
+    if (gatewayRecoveringRef.current.has(fullMode)) return;
     const activeSessionIds = new Set(
       [...workingSessionIdsRef.current, ...waitingSessionIdsRef.current].filter(
         (sessionId) => sessionUnrestricted(sessionId) === fullMode,
       ),
     );
     if (!activeSessionIds.size) return;
-    gatewayRecoveringRef.current = true;
+    gatewayRecoveringRef.current.add(fullMode);
     try {
       const gateway = await ensureHermesGateway(fullMode);
       await Promise.all(
@@ -2057,7 +2059,7 @@ export function AgentWorkspace({
     } catch {
       // Reconnect failed — fall back to the persisted-message poll.
     } finally {
-      gatewayRecoveringRef.current = false;
+      gatewayRecoveringRef.current.delete(fullMode);
     }
     for (const sessionId of activeSessionIds) {
       void refreshHermesSession(sessionId);
@@ -2105,8 +2107,9 @@ export function AgentWorkspace({
     );
     let rows: Array<{ id?: string; session_key?: string; status?: string }> =
       [];
-    try {
-      for (const mode of modes) {
+    const reachableModes = new Set<boolean>();
+    for (const mode of modes) {
+      try {
         const gateway = await ensureHermesGateway(mode);
         const response = await gateway.request<{
           sessions?: Array<{
@@ -2118,11 +2121,13 @@ export function AgentWorkspace({
         rows = rows.concat(
           Array.isArray(response?.sessions) ? response.sessions : [],
         );
+        reachableModes.add(mode);
+      } catch {
+        // Can't reach this runtime — keep ITS sessions' current state rather
+        // than guess, while the reachable mode still reconciles below.
       }
-    } catch {
-      // Can't reach a runtime — keep the current state rather than guess.
-      return;
     }
+    if (reachableModes.size === 0) return;
     const live = new Set<string>();
     for (const row of rows) {
       // "idle" means the runtime session exists but isn't processing a turn.
@@ -2131,6 +2136,9 @@ export function AgentWorkspace({
       if (row.id) live.add(String(row.id));
     }
     for (const sessionId of working) {
+      // Sessions of an unreachable mode were not in any answer we got;
+      // counting them as misses would mark live work dead.
+      if (!reachableModes.has(sessionUnrestricted(sessionId))) continue;
       const runtimeSessionId = runtimeSessionIdsRef.current[sessionId];
       if (
         live.has(sessionId) ||

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -141,6 +141,7 @@ import {
   type ProviderModelSettingsChangedDetail,
 } from "../../lib/model-privacy";
 import { messageFromError } from "../../lib/errors";
+import { hermesConnectionForMode } from "../../lib/hermes-connection";
 import {
   forgetSessionMode,
   rememberSessionMode,
@@ -779,11 +780,14 @@ export function AgentWorkspace({
     AgentChatGallerySection[] | null
   >(null);
   const [galleryErrors, setGalleryErrors] = useState(false);
-  const gatewayRef = useRef<HermesGatewayClient | null>(null);
+  // One gateway client per write-access mode: the sandboxed and unrestricted
+  // runtime processes run side by side, each with its own socket. Sessions
+  // route to the gateway matching their recorded mode.
+  const gatewaysRef = useRef<Map<boolean, HermesGatewayClient>>(new Map());
   // The gateway's close listener is registered once per client instance, so
   // it routes through this ref to always run the latest render's recovery
   // closure (see recoverFromGatewayClose).
-  const gatewayCloseHandlerRef = useRef(() => {});
+  const gatewayCloseHandlerRef = useRef((_fullMode: boolean) => {});
   const gatewayRecoveringRef = useRef(false);
   // One live gateway subscription per Hermes session. A follow-up send while
   // the previous turn is still streaming must replace the old handler, not
@@ -1261,8 +1265,8 @@ export function AgentWorkspace({
       startNewTask,
       removeHermesSessionLocally,
     };
-    gatewayCloseHandlerRef.current = () => {
-      void recoverFromGatewayClose();
+    gatewayCloseHandlerRef.current = (fullMode: boolean) => {
+      void recoverFromGatewayClose(fullMode);
     };
   });
 
@@ -1407,7 +1411,9 @@ export function AgentWorkspace({
     })();
     return () => {
       cancelled = true;
-      gatewayRef.current?.close();
+      for (const gateway of gatewaysRef.current.values()) {
+        gateway.close();
+      }
     };
   }, []);
 
@@ -1771,10 +1777,10 @@ export function AgentWorkspace({
       ? undefined
       : agentSessionTitleForPrompt(content);
     // The Unrestricted opt-in is made per session: a new session applies the
-    // picker draft, and a follow-up applies the mode its session was created
-    // with — restarting the runtime when the running mode differs. Without
-    // this, one Unrestricted session would leave the runtime unsandboxed
-    // under every other session's follow-ups.
+    // picker draft, and a follow-up routes to the runtime process matching
+    // the mode its session was created with. Without this, one Unrestricted
+    // session would leave the runtime unsandboxed under every other
+    // session's follow-ups.
     const gateway = await ensureHermesGateway(
       targetSessionId
         ? sessionUnrestricted(targetSessionId)
@@ -1971,31 +1977,29 @@ export function AgentWorkspace({
     }
   }
 
-  // `fullMode` is an explicit per-new-session choice: when the running
-  // runtime's mode differs, the backend restarts it (the sandbox is applied at
-  // spawn and can't change on a live process). Callers acting on an existing
-  // session pass undefined and reuse whatever runtime is up.
-  async function ensureHermesGateway(fullMode?: boolean) {
-    let current = bridge.running ? bridge : await startBridge(fullMode);
-    if (
-      fullMode !== undefined &&
-      current.connection &&
-      Boolean(current.connection.fullMode) !== fullMode
-    ) {
-      // Close the gateway socket before the restart kills the old process, so
-      // the drop reads as intentional and doesn't trigger close-recovery.
-      gatewayRef.current?.close();
-      current = await startBridge(fullMode);
+  // Returns the gateway for the given write-access mode, starting that
+  // mode's runtime process if it isn't up. The two modes run side by side
+  // (the sandbox is applied at spawn and can't change on a live process, so
+  // per-session modes mean a process per mode) — ensuring one never touches
+  // the other's process or in-flight work.
+  async function ensureHermesGateway(fullMode = false) {
+    let connection = hermesConnectionForMode(
+      bridge.running ? bridge : undefined,
+      fullMode,
+    );
+    if (!connection) {
+      const next = await startBridge(fullMode);
+      connection = hermesConnectionForMode(next, fullMode);
     }
-    const wsUrl = current.connection?.wsUrl;
+    const wsUrl = connection?.wsUrl;
     if (!wsUrl) throw new Error("Hermes bridge did not return a gateway URL.");
-    let gateway = gatewayRef.current;
+    let gateway = gatewaysRef.current.get(fullMode);
     if (!gateway) {
       gateway = new HermesGatewayClient();
-      gatewayRef.current = gateway;
+      gatewaysRef.current.set(fullMode, gateway);
       // Fires only on unexpected drops — the unmount close() detaches the
       // socket first, and a superseded socket never notifies.
-      gateway.onClose(() => gatewayCloseHandlerRef.current());
+      gateway.onClose(() => gatewayCloseHandlerRef.current(fullMode));
     }
     await gateway.connect(wsUrl);
     return gateway;
@@ -2018,17 +2022,19 @@ export function AgentWorkspace({
   // session would otherwise stay "working" (and broadcast "June is working.")
   // forever. Try to reconnect and resubscribe the active runtime sessions;
   // either way, refresh them immediately so the working-gated poll reconciles
-  // their true state from persisted messages.
-  async function recoverFromGatewayClose() {
+  // their true state from persisted messages. Only the dropped mode's
+  // gateway is rebuilt — sessions of that mode are the ones it served.
+  async function recoverFromGatewayClose(fullMode: boolean) {
     if (gatewayRecoveringRef.current) return;
-    const activeSessionIds = new Set([
-      ...workingSessionIdsRef.current,
-      ...waitingSessionIdsRef.current,
-    ]);
+    const activeSessionIds = new Set(
+      [...workingSessionIdsRef.current, ...waitingSessionIdsRef.current].filter(
+        (sessionId) => sessionUnrestricted(sessionId) === fullMode,
+      ),
+    );
     if (!activeSessionIds.size) return;
     gatewayRecoveringRef.current = true;
     try {
-      const gateway = await ensureHermesGateway();
+      const gateway = await ensureHermesGateway(fullMode);
       await Promise.all(
         Array.from(activeSessionIds).map(async (sessionId) => {
           try {
@@ -2090,19 +2096,31 @@ export function AgentWorkspace({
       if (!working.includes(sessionId)) misses.delete(sessionId);
     }
     if (working.length === 0) return;
-    let rows: Array<{ id?: string; session_key?: string; status?: string }>;
+    // Working sessions may span both runtime processes; ask each mode that
+    // has one and union the answers. A mode we can't reach keeps its
+    // sessions' current state rather than guessing — so a one-gateway
+    // failure must not mark the other mode's sessions dead either.
+    const modes = Array.from(
+      new Set(working.map((sessionId) => sessionUnrestricted(sessionId))),
+    );
+    let rows: Array<{ id?: string; session_key?: string; status?: string }> =
+      [];
     try {
-      const gateway = await ensureHermesGateway();
-      const response = await gateway.request<{
-        sessions?: Array<{
-          id?: string;
-          session_key?: string;
-          status?: string;
-        }>;
-      }>("session.active_list", {});
-      rows = Array.isArray(response?.sessions) ? response.sessions : [];
+      for (const mode of modes) {
+        const gateway = await ensureHermesGateway(mode);
+        const response = await gateway.request<{
+          sessions?: Array<{
+            id?: string;
+            session_key?: string;
+            status?: string;
+          }>;
+        }>("session.active_list", {});
+        rows = rows.concat(
+          Array.isArray(response?.sessions) ? response.sessions : [],
+        );
+      }
     } catch {
-      // Can't reach the runtime — keep the current state rather than guess.
+      // Can't reach a runtime — keep the current state rather than guess.
       return;
     }
     const live = new Set<string>();
@@ -2198,10 +2216,13 @@ export function AgentWorkspace({
     sessionId: string,
     requestId: string,
     choice: AgentApprovalChoice,
+    unrestricted = false,
   ) {
     setApprovalSubmitting((current) => ({ ...current, [requestId]: choice }));
     try {
-      const gateway = await ensureHermesGateway();
+      // The approval lives in the runtime process that asked, so the
+      // response must go out on that mode's gateway.
+      const gateway = await ensureHermesGateway(unrestricted);
       await gateway.request("approval.respond", {
         session_id: sessionId,
         choice,
@@ -2250,10 +2271,11 @@ export function AgentWorkspace({
     liveEventKey: string,
     requestId: string,
     answer: string,
+    unrestricted = false,
   ) {
     setClarifySubmitting((current) => ({ ...current, [requestId]: answer }));
     try {
-      const gateway = await ensureHermesGateway();
+      const gateway = await ensureHermesGateway(unrestricted);
       await gateway.request("clarify.respond", {
         request_id: requestId,
         answer,
@@ -2413,7 +2435,9 @@ export function AgentWorkspace({
     try {
       const runtimeSessionId = runtimeSessionIds[sessionId];
       if (runtimeSessionId) {
-        const gateway = await ensureHermesGateway();
+        const gateway = await ensureHermesGateway(
+          sessionUnrestricted(sessionId),
+        );
         await gateway.request("session.interrupt", {
           session_id: runtimeSessionId,
         });
@@ -3200,6 +3224,7 @@ export function AgentWorkspace({
               part.sessionId ?? selectedHermesSessionId,
               part.id,
               choice,
+              sessionUnrestricted(selectedHermesSessionId),
             )
           }
           onTopUp={() =>
@@ -3208,7 +3233,12 @@ export function AgentWorkspace({
             )
           }
           onClarify={(part, answer) =>
-            void respondToClarify(selectedHermesSessionId, part.id, answer)
+            void respondToClarify(
+              selectedHermesSessionId,
+              part.id,
+              answer,
+              sessionUnrestricted(selectedHermesSessionId),
+            )
           }
         />
       ))}
@@ -3278,10 +3308,16 @@ export function AgentWorkspace({
                 sessionId,
                 part.id,
                 choice,
+                sessionUnrestricted(selectedTask.hermesSessionId),
               );
             }}
             onClarify={(part, answer) =>
-              void respondToClarify(selectedTask.id, part.id, answer)
+              void respondToClarify(
+                selectedTask.id,
+                part.id,
+                answer,
+                sessionUnrestricted(selectedTask.hermesSessionId),
+              )
             }
           />
         ))}
@@ -3462,7 +3498,7 @@ function SafetyBadge({ privacyBadge }: { privacyBadge?: ModelPrivacyBadge }) {
 // honest unit to label.
 function UnrestrictedBadge() {
   const description =
-    "This session runs without the file sandbox — June can change any file your account can. Sessions started as Sandboxed keep their jail; it is re-applied whenever you message them.";
+    "This session runs without the file sandbox — June can change any file your account can. Sandboxed sessions keep their jail and run alongside on a separate, jailed runtime.";
   return (
     <HoverTip
       tip={description}

--- a/src/lib/agent-session-modes.ts
+++ b/src/lib/agent-session-modes.ts
@@ -1,0 +1,60 @@
+/**
+ * Per-session record of the Unrestricted opt-in. The Seatbelt write-jail is
+ * applied when June's runtime process spawns, so the mode can't vary across
+ * the sessions a single process serves — instead, every send restarts the
+ * runtime into the target session's recorded mode when they differ. This map
+ * is what makes that enforcement possible: absence means sandboxed, so
+ * sessions from before this record existed fall back to the safe default.
+ *
+ * localStorage (not the backend) because the runtime's session store is
+ * machine-local too, and the map must be readable synchronously on render
+ * for the session bar's badge.
+ */
+
+const STORAGE_KEY = "june.agent.unrestrictedSessions";
+
+function readStore(): Record<string, true> {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, true>;
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, true>) {
+  try {
+    if (Object.keys(store).length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Ignore; worst case a follow-up runs sandboxed — the safe direction.
+  }
+}
+
+/** Whether this session opted into Unrestricted at creation. */
+export function sessionUnrestricted(sessionId: string | undefined): boolean {
+  if (!sessionId) return false;
+  return readStore()[sessionId] === true;
+}
+
+export function rememberSessionMode(sessionId: string, unrestricted: boolean) {
+  const store = readStore();
+  if (unrestricted) {
+    store[sessionId] = true;
+  } else {
+    delete store[sessionId];
+  }
+  writeStore(store);
+}
+
+export function forgetSessionMode(sessionId: string) {
+  rememberSessionMode(sessionId, false);
+}

--- a/src/lib/hermes-connection.ts
+++ b/src/lib/hermes-connection.ts
@@ -1,0 +1,19 @@
+import type { HermesBridgeConnection, HermesBridgeStatus } from "./tauri";
+
+/** The live connection serving the given write-access mode, if any. The
+ * bridge runs up to one runtime process per mode side by side; mode-aware
+ * callers pick their process here instead of assuming a single runtime. */
+export function hermesConnectionForMode(
+  status: HermesBridgeStatus | undefined,
+  fullMode: boolean,
+): HermesBridgeConnection | undefined {
+  if (!status?.running) return undefined;
+  const fromList = status.connections?.find(
+    (connection) => Boolean(connection.fullMode) === fullMode,
+  );
+  if (fromList) return fromList;
+  // Older payload shape without `connections`.
+  return status.connection && Boolean(status.connection.fullMode) === fullMode
+    ? status.connection
+    : undefined;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -374,8 +374,13 @@ export type HermesBridgeConnection = {
 };
 
 export type HermesBridgeStatus = {
+  /** True when any runtime process is up. */
   running: boolean;
+  /** Primary connection (the requested mode for a start call, otherwise
+   * sandboxed-first). Mode-aware callers should use `connections`. */
   connection?: HermesBridgeConnection;
+  /** Every live runtime process — at most one per write-access mode. */
+  connections?: HermesBridgeConnection[];
   message?: string;
 };
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1913,7 +1913,23 @@ describe("AgentWorkspace", () => {
     expect(trigger).toHaveFocus();
   });
 
-  it("shows the unrestricted badge while the runtime is unsandboxed by choice", async () => {
+  it("shows the unrestricted badge only on sessions that opted in", async () => {
+    window.localStorage.setItem(
+      "june.agent.unrestrictedSessions",
+      JSON.stringify({ "session-1": true }),
+    );
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Unrestricted")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Unrestricted - This session runs without/),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the badge off a sandboxed session even while the runtime is unsandboxed", async () => {
+    // Another session's opt-in left the runtime in full mode; this session
+    // never opted in, and its sends re-apply the jail — no badge.
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
       connection: {
@@ -1925,10 +1941,62 @@ describe("AgentWorkspace", () => {
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    expect(await screen.findByText("Unrestricted")).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/Unrestricted - June is running without the file/),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    expect(screen.queryByText("Unrestricted")).not.toBeInTheDocument();
+  });
+
+  it("restores the sandbox before a follow-up to a session that never opted in", async () => {
+    const user = userEvent.setup();
+    // The runtime is still unsandboxed from another session's opt-in.
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: {
+        port: 61234,
+        wsUrl: "ws://127.0.0.1:61234",
+        fullMode: true,
+      },
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Send a message"), "hello");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    // The send restarts the runtime back into the jail before submitting.
+    await waitFor(() =>
+      expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, false),
+    );
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({ text: "hello" }),
+      ),
+    );
+  });
+
+  it("keeps an opted-in session unrestricted across follow-ups", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "june.agent.unrestrictedSessions",
+      JSON.stringify({ "session-1": true }),
+    );
+    // The runtime has since dropped back to the sandbox (relaunch, or a
+    // sandboxed session ran in between).
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Send a message"), "continue");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, true),
+    );
   });
 
   it("explains a busy rejection and removes the ghost bubble", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -576,6 +576,13 @@ describe("AgentWorkspace", () => {
   });
 
   it("forgets the persisted session when it is deleted", async () => {
+    // The Unrestricted record must die with the session too — deletions
+    // arriving via the sidebar event included — or a future session that
+    // recycled the id would inherit full write access.
+    window.localStorage.setItem(
+      "june.agent.unrestrictedSessions",
+      JSON.stringify({ "session-1": true }),
+    );
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("Existing session")).toBeInTheDocument();
@@ -598,6 +605,9 @@ describe("AgentWorkspace", () => {
         window.localStorage.getItem("scribe:agent:last-open-session"),
       ).toBeNull(),
     );
+    expect(
+      window.localStorage.getItem("june.agent.unrestrictedSessions"),
+    ).toBeNull();
   });
 
   it("keeps the blank composer after a New Session event during refresh", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -63,6 +63,10 @@ const mocks = vi.hoisted(() => ({
   listHermesSessions: vi.fn(),
   gatewayRequest: vi.fn(),
   gatewayEventHandlers: new Set<(event: Record<string, unknown>) => void>(),
+  gatewayInstances: [] as Array<{
+    connect: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  }>,
   eventHandlers: new Map<
     string,
     (event: { payload?: { paths?: string[] } }) => void
@@ -127,6 +131,11 @@ vi.mock("../lib/hermes-gateway", async (importOriginal) => ({
   // Real HermesGatewayError / isSessionBusyError — only the client is faked.
   ...(await importOriginal<typeof import("../lib/hermes-gateway")>()),
   HermesGatewayClient: class {
+    constructor() {
+      mocks.gatewayInstances.push(
+        this as unknown as (typeof mocks.gatewayInstances)[number],
+      );
+    }
     connect = vi.fn();
     close = vi.fn();
     onEvent = vi.fn((handler: (event: Record<string, unknown>) => void) => {
@@ -161,6 +170,7 @@ describe("AgentWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.gatewayEventHandlers.clear();
+    mocks.gatewayInstances.length = 0;
     window.sessionStorage.clear();
     window.localStorage.clear();
     mocks.listAgentTasks.mockResolvedValue({ items: [existingTask] });
@@ -192,10 +202,18 @@ describe("AgentWorkspace", () => {
       running: true,
       connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
     });
-    mocks.startHermesBridge.mockResolvedValue({
-      running: true,
-      connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
-    });
+    // Mirrors the backend: starting a mode yields a status that contains
+    // that mode's connection (alongside any other live mode).
+    mocks.startHermesBridge.mockImplementation(
+      async (_cwd?: string, fullMode?: boolean) => {
+        const connection = {
+          port: 61234,
+          wsUrl: "ws://127.0.0.1:61234",
+          fullMode: Boolean(fullMode),
+        };
+        return { running: true, connection, connections: [connection] };
+      },
+    );
     mocks.listHermesSessions.mockResolvedValue([existingSession]);
     mocks.listHermesSessionMessages.mockResolvedValue([]);
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
@@ -1928,8 +1946,8 @@ describe("AgentWorkspace", () => {
   });
 
   it("keeps the badge off a sandboxed session even while the runtime is unsandboxed", async () => {
-    // Another session's opt-in left the runtime in full mode; this session
-    // never opted in, and its sends re-apply the jail — no badge.
+    // Another session's opt-in has the unrestricted runtime up; this session
+    // never opted in, and its sends route to the sandboxed process — no badge.
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
       connection: {
@@ -1963,7 +1981,8 @@ describe("AgentWorkspace", () => {
     await user.type(screen.getByPlaceholderText("Send a message"), "hello");
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
-    // The send restarts the runtime back into the jail before submitting.
+    // The send brings up the sandboxed process for this session — the
+    // unrestricted one (and its in-flight work) is left alone.
     await waitFor(() =>
       expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, false),
     );
@@ -1997,6 +2016,70 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.startHermesBridge).toHaveBeenCalledWith(undefined, true),
     );
+  });
+
+  it("serves both modes concurrently — neither runtime is torn down", async () => {
+    const user = userEvent.setup();
+    // session-1 opted into Unrestricted; both runtime processes are up.
+    window.localStorage.setItem(
+      "june.agent.unrestrictedSessions",
+      JSON.stringify({ "session-1": true }),
+    );
+    const sandboxedConnection = {
+      port: 61234,
+      wsUrl: "ws://127.0.0.1:61234",
+      fullMode: false,
+    };
+    const unrestrictedConnection = {
+      port: 61235,
+      wsUrl: "ws://127.0.0.1:61235",
+      fullMode: true,
+    };
+    mocks.hermesBridgeStatus.mockResolvedValue({
+      running: true,
+      connection: sandboxedConnection,
+      connections: [sandboxedConnection, unrestrictedConnection],
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    // Follow-up to the unrestricted session rides its own gateway.
+    await user.type(screen.getByPlaceholderText("Send a message"), "continue");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({ text: "continue" }),
+      ),
+    );
+
+    // A fresh sandboxed session starts alongside it on the other gateway.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+          detail: { prompt: "new sandboxed work" },
+        }),
+      );
+    });
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({ text: "new sandboxed work" }),
+      ),
+    );
+
+    // Both processes were already up: no start call, one socket per mode,
+    // and crucially nothing closed the other mode's gateway mid-flight.
+    expect(mocks.startHermesBridge).not.toHaveBeenCalled();
+    const connectedUrls = mocks.gatewayInstances.flatMap((instance) =>
+      instance.connect.mock.calls.map((call) => call[0]),
+    );
+    expect(connectedUrls).toContain("ws://127.0.0.1:61235");
+    expect(connectedUrls).toContain("ws://127.0.0.1:61234");
+    for (const instance of mocks.gatewayInstances) {
+      expect(instance.close).not.toHaveBeenCalled();
+    }
   });
 
   it("explains a busy rejection and removes the ghost bubble", async () => {


### PR DESCRIPTION
## The report

> When I start a session in Unrestricted mode, the Unrestricted pill appears on EVERY session. Is that how it works? I toggle it, and it changes it for every agent session?

**Yes — and it was worse than the pill.** The Seatbelt write-jail is applied when the runtime process spawns, and one process served all sessions. Starting one Unrestricted session restarted the runtime unsandboxed; from then on **a follow-up to any other session — including ones created as Sandboxed — silently ran with full write access** (follow-ups reused whatever runtime was up). The badge keyed off the live runtime and was honestly reporting the leak.

This PR replaces #201 + the stacked follow-up as one piece, since they only make sense together.

## Part 1 — the opt-in becomes truly per session

- Each session **records its mode at creation** (`june.agent.unrestrictedSessions` in localStorage; absence = sandboxed, so every pre-existing session gets the safe default). The record dies with the session on **every** delete path — the in-workspace delete and the sidebar/sessions-list event both funnel through `removeHermesSessionLocally`, which now drops it (review catch from Greptile on #201: the event path used to leak entries, and a recycled id would have inherited full write access).
- **Every session-scoped call enforces the session's recorded mode** — submit, resume, approval/clarify responses, interrupt, drop-recovery, reconciliation.
- **The pill describes the selected session, not the live process** — a sandboxed session shows no badge even while another session's unrestricted runtime is up, which is now truthful because that session's own sends are jailed.

## Part 2 — both modes run side by side (no restart-kill)

Enforcing per-session modes by restarting the single runtime would kill the other mode's in-flight work. Instead, the jail being fixed-at-spawn means a **process per mode**:

- **The bridge holds a runtime pair** (`processes: HashMap<full_mode, HermesProcess>`, at most one per mode). Ensuring one mode never touches the other's process; `full_mode: None` means "ensure the sandboxed default", so auto-start can never widen access. Stop/shutdown tear down both; per-generation cleanup finds its process in either slot.
- **One shared Hermes home.** Sessions live in the runtime's WAL-mode SQLite store, which upstream explicitly supports across processes — the session list stays unified, and either process serves session/skills/platform reads (sandboxed preferred).
- **One shared provider proxy.** Verified upstream that `config.yaml` has no per-process override, so the local model proxy is now bridge-level with stable coordinates across spawns (torn down only at app shutdown); the gateway port and dashboard token were already per-spawn.
- **SOUL.md describes the mode split.** Both processes read the same soul file, so its sandbox section now explains that sessions are jailed by default with a per-session Unrestricted opt-in — included only when sandboxed spawns actually engage the jail, so the agent never claims an unenforced protection.
- **Frontend: one gateway client per mode**, with routing everywhere a session talks to the runtime. A gateway drop recovers only that mode's sessions; `session.active_list` reconciliation unions both runtimes so one unreachable mode can't mark the other's sessions dead. `HermesBridgeStatus` gains a `connections` list (legacy `connection` kept as the primary).

## Resource note

Two embedded runtimes means two processes when both modes are in use; the unrestricted one only spawns on first opt-in. An idle-reaper for it is a reasonable follow-up, deliberately left out to keep this reviewable.

## Tests

- Badge scoping: shows only on opted-in sessions; stays off a sandboxed session while the unrestricted runtime is up.
- Enforcement: a follow-up to a never-opted-in session brings up the sandboxed process before `prompt.submit`; an opted-in session gets Unrestricted back after the runtime dropped to default.
- Concurrency: both modes served at once — one socket per mode, no process start when both are up, **no gateway ever closed mid-flight**.
- Deletion drops the Unrestricted record via the sidebar event path too.
- 333 frontend tests, 124 Rust tests, tsc, prettier, cargo fmt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)