### PR TITLE
Model picker: lead with a curated Suggested tab

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -64,6 +64,7 @@ import {
   modelPrivacyBadge,
   modelPrivacyFlags,
 } from "../../lib/model-privacy";
+import { suggestedModelsForMode } from "../../lib/suggested-models";
 import { ProviderLogo } from "./ProviderLogo";
 import { AgentSettingsSection } from "./AgentSettingsSection";
 import { DictionarySettingsSection } from "./DictionarySettingsSection";
@@ -1536,17 +1537,49 @@ function ModelPickerDialog({
   onClose: () => void;
   onSelect: (modelId: string) => void;
 }) {
+  // "Suggested" leads with the few models we actually recommend (benchmarks,
+  // price, tool use, privacy — see SUGGESTED_MODELS); "All" is the full
+  // catalog. Suggested is the default on every open; typing a search always
+  // looks across the whole catalog, since three curated rows aren't worth
+  // searching.
+  const [tab, setTab] = useState<"suggested" | "all">("suggested");
+  useEffect(() => {
+    if (open) setTab("suggested");
+  }, [open, mode]);
+  const suggested = useMemo(
+    () => suggestedModelsForMode(mode, options),
+    [mode, options],
+  );
+  const query = search.trim().toLowerCase();
+  const searching = query.length > 0;
+  const reasonsById = useMemo(
+    () => new Map(suggested.map((item) => [item.model.id, item.reason])),
+    [suggested],
+  );
   const filteredOptions = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) return options;
-    return options.filter((model) =>
-      [model.name, model.id, model.description, model.privacy, ...model.traits]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase()
-        .includes(query),
-    );
-  }, [options, search]);
+    if (searching) {
+      return options.filter((model) =>
+        [
+          model.name,
+          model.id,
+          model.description,
+          model.privacy,
+          ...model.traits,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase()
+          .includes(query),
+      );
+    }
+    // No suggestions in the catalog (drift, still loading): the empty tab
+    // would read as "no models", so fall through to the full list.
+    if (tab === "suggested" && suggested.length > 0) {
+      return suggested.map((item) => item.model);
+    }
+    return options;
+  }, [options, query, searching, suggested, tab]);
+  const showReasons = !searching && tab === "suggested" && suggested.length > 0;
   const title = mode === "transcription" ? "Transcription model" : "Text model";
 
   return (
@@ -1568,9 +1601,34 @@ function ModelPickerDialog({
           aria-label="Search models"
         />
       </label>
+      {!searching && suggested.length > 0 ? (
+        <div
+          className="model-picker-tabs"
+          role="tablist"
+          aria-label="Model groups"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "suggested"}
+            onClick={() => setTab("suggested")}
+          >
+            Suggested
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "all"}
+            onClick={() => setTab("all")}
+          >
+            All
+          </button>
+        </div>
+      ) : null}
       <div className="model-picker-list" role="listbox" aria-label={title}>
         {filteredOptions.map((model) => {
           const selected = model.id === value;
+          const reason = showReasons ? reasonsById.get(model.id) : undefined;
           return (
             <button
               key={model.id}
@@ -1597,6 +1655,9 @@ function ModelPickerDialog({
               <span className="model-picker-meta">
                 <ModelMeta model={model} />
               </span>
+              {reason ? (
+                <span className="model-picker-reason">{reason}</span>
+              ) : null}
             </button>
           );
         })}

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -1,0 +1,73 @@
+import type { ProviderModelMode, VeniceModelDto } from "./tauri";
+
+export type SuggestedModel = {
+  id: string;
+  /** One-line "why we recommend it", rendered under the model's meta row. */
+  reason: string;
+};
+
+/**
+ * Curated picks for the model picker's "Suggested" tab — the handful of
+ * models we actually recommend, weighed on benchmark performance, price,
+ * tool use, and privacy (June's agent needs tool calling, and June's pitch
+ * is zero-retention privacy, so every pick here is a "private" catalog model
+ * that supports tools).
+ *
+ * Curation snapshot (June 2026), from the live Venice catalog plus public
+ * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
+ * index):
+ * - GLM 5: state-of-the-art agentic coding among open models (~78%
+ *   SWE-bench), strong tool use, $1/$3.20 per 1M tokens — June's default.
+ * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
+ *   agentic tool runs, 256K context, $0.85/$4.66.
+ * - GLM 4.7: Venice's own catalog default and "function calling default" —
+ *   near-flagship quality at roughly half GLM 5's price, $0.55/$2.65.
+ * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
+ * - Whisper Large v3: best multilingual accuracy at the same low price.
+ *
+ * Ids are matched against the live catalog at render time, so a delisted
+ * model silently drops out instead of rendering a dead row.
+ */
+export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
+  generation: [
+    {
+      id: "zai-org-glm-5",
+      reason:
+        "Best overall: top-tier agentic coding and tool use among open models, with zero data retention.",
+    },
+    {
+      id: "kimi-k2-6",
+      reason:
+        "Most capable open-weights model: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
+    },
+    {
+      id: "zai-org-glm-4.7",
+      reason:
+        "Best value: near-flagship quality at about half the price, and Venice's own default for tool calling, with zero data retention.",
+    },
+  ],
+  transcription: [
+    {
+      id: "nvidia/parakeet-tdt-0.6b-v3",
+      reason:
+        "Fast and accurate for everyday dictation and meetings, zero data retention, lowest price tier.",
+    },
+    {
+      id: "openai/whisper-large-v3",
+      reason:
+        "Best multilingual accuracy at the same low price, with zero data retention.",
+    },
+  ],
+};
+
+/** The curated picks that are actually present in the live catalog, in
+ * curated order, with their recommendation reasons attached. */
+export function suggestedModelsForMode(
+  mode: ProviderModelMode,
+  options: VeniceModelDto[],
+): Array<{ model: VeniceModelDto; reason: string }> {
+  return SUGGESTED_MODELS[mode].flatMap((suggested) => {
+    const model = options.find((option) => option.id === suggested.id);
+    return model ? [{ model, reason: suggested.reason }] : [];
+  });
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7167,6 +7167,38 @@ input:focus-visible,
   margin: calc(-1 * var(--sp-1));
 }
 
+/* Suggested / All segmented control between search and list — same recipe
+ * as .agent-panel-tabs. */
+.model-picker-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  width: fit-content;
+  min-height: var(--control-md);
+  margin-top: var(--sp-3);
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  background: var(--surface-subtle);
+}
+
+.model-picker-tabs [role="tab"] {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: calc(var(--r-sm) - 2px);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.model-picker-tabs [role="tab"][aria-selected="true"] {
+  background: var(--card);
+  color: var(--foreground);
+}
+
 .model-picker-option {
   /* Check spans both rows so it sits vertically centered against the
    * logo + name + meta stack. Transparent border reserves space so the
@@ -7174,8 +7206,9 @@ input:focus-visible,
   display: grid;
   grid-template-columns: 28px minmax(0, 1fr) 22px;
   grid-template-areas:
-    "logo name  check"
-    "logo meta  check";
+    "logo name   check"
+    "logo meta   check"
+    "logo reason check";
   row-gap: 2px;
   column-gap: var(--sp-3);
   width: 100%;
@@ -7193,6 +7226,15 @@ input:focus-visible,
 
 .model-picker-option:hover {
   background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+/* "Why we recommend it" line on Suggested rows. */
+.model-picker-reason {
+  grid-area: reason;
+  margin-top: 2px;
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
 }
 
 /* Selected gets the system surface-subtle wash. Hover stacks darker so

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1032,6 +1032,8 @@ describe("AppSettings", () => {
       expect(
         await screen.findByRole("option", { name: /Parakeet/ }),
       ).toBeInTheDocument();
+      // The non-suggested catalog lives under the All tab.
+      await user.click(screen.getByRole("tab", { name: "All" }));
       expect(
         screen.getAllByText("$0.0001 per second audio").length,
       ).toBeGreaterThan(0);
@@ -1057,6 +1059,7 @@ describe("AppSettings", () => {
           name: "Change text model",
         }),
       );
+      await user.click(screen.getByRole("tab", { name: "All" }));
       expect(
         screen.getAllByText("$1.00 input / $3.20 output per 1M tokens").length,
       ).toBeGreaterThan(0);
@@ -1084,6 +1087,58 @@ describe("AppSettings", () => {
         modelChanged,
       );
     }
+  });
+
+  it("defaults the model picker to curated suggestions", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Change text model" }),
+    );
+
+    // Suggested is the default view: only the curated picks present in the
+    // catalog show, each with its recommendation reason.
+    expect(
+      await screen.findByRole("option", { name: /GLM 5/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /Venice Uncensored/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Best overall/)).toBeInTheDocument();
+
+    // All shows the full catalog, without recommendation copy.
+    await user.click(screen.getByRole("tab", { name: "All" }));
+    expect(
+      screen.getByRole("option", { name: /Venice Uncensored/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Best overall/)).not.toBeInTheDocument();
+
+    // Searching looks across the whole catalog even from Suggested, and a
+    // suggested pick stays selectable.
+    await user.click(screen.getByRole("tab", { name: "Suggested" }));
+    await user.type(screen.getByLabelText("Search models"), "uncensored");
+    expect(
+      screen.getByRole("option", { name: /Venice Uncensored/ }),
+    ).toBeInTheDocument();
+    await user.clear(screen.getByLabelText("Search models"));
+    await user.click(screen.getByRole("option", { name: /GLM 5/ }));
+    expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+      "generation",
+      "zai-org-glm-5",
+    );
   });
 
   it("shows app build metadata", async () => {


### PR DESCRIPTION
The model picker now opens on a **Suggested** tab — the few models we actually recommend, each with a one-line reason — with an **All** tab for the full ~90-model catalog. Suggested is the default on every open.

## Research

Pulled the live catalog from the local scribe API (89 text models, 7 ASR models) with privacy tier, tool-calling capability, pricing, and context, then cross-checked benchmark standing for the finalists (sources below). Hard constraints applied first: June's agent requires **tool calling**, and June's product pitch is **zero-retention privacy** — so every pick is a `private`-tier catalog model with tools. (E2EE models are excluded automatically: encrypted inference can't expose tools.)

## The picks (June 2026)

| Model | Why | Price (1M in/out) |
|---|---|---|
| **GLM 5** | Best overall — state-of-the-art open-model agentic coding (~78% SWE-bench), June's default | $1.00 / $3.20 |
| **Kimi K2.6** | Most capable open-weights — leads the Artificial Analysis open-weights index (54), built for long tool runs, 256K ctx | $0.85 / $4.66 |
| **GLM 4.7** | Best value — Venice's own catalog default + `function_calling_default` trait, near-flagship at ~half GLM 5's price | $0.55 / $2.65 |
| **Parakeet** (ASR) | Fast, accurate everyday dictation; June's default | $0.0001/s |
| **Whisper Large v3** (ASR) | Best multilingual accuracy, same price | $0.0001/s |

Frontier closed models (Claude, GPT-5.x, Gemini) all sit in the weaker `anonymized` privacy tier on Venice, so they don't make the cut despite benchmark strength.

## Behavior

- Suggestions are matched against the live catalog at render time — a delisted model drops out instead of rendering a dead row; if none match, the picker falls through to the full list (no empty tab).
- Each suggested row shows its "why" line; the All tab is the unchanged full list.
- Typing a search always searches the whole catalog (tabs hide while searching).
- Curated ids and rationale live in `src/lib/suggested-models.ts` with the curation snapshot documented for future updates.

## Testing

New test covers: Suggested as default (curated rows + reasons, non-suggested hidden), All showing the full catalog, search crossing tabs, and selecting a suggested model. Existing picker test updated for the new default. `tsc` clean, full suite passes (39 files, 330 tests).

Benchmark sources: [GLM-5 paper](https://arxiv.org/pdf/2602.15763), [open-weights coding comparison](https://codersera.com/blog/kimi-k2-6-vs-deepseek-v4-vs-glm-5-1-2026/), [SWE-bench Pro cost ranking](https://www.morphllm.com/best-ai-model-for-coding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)