### PR TITLE
Require macOS 14.2, matching the system-audio helper

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -139,7 +139,8 @@
       "entitlements": "Entitlements.plist",
       "exceptionDomain": "",
       "frameworks": [],
-      "infoPlist": "Info.plist"
+      "infoPlist": "Info.plist",
+      "minimumSystemVersion": "14.2"
     }
   }
 }


### PR DESCRIPTION
The app declared Tauri's default minimum (macOS 10.13) while the bundled system-audio recorder helper requires 14.2 (its Info.plist says so, but that only stops the helper, not the install). A Ventura user could install June and hit silently broken meeting recording. One line: declare the real floor so Gatekeeper/Finder refuse cleanly with "requires macOS 14.2 or later".

Verified the key lands in Info.plist as LSMinimumSystemVersion via tauri's bundle config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)