### PR TITLE
Make the staging DMG build manual-only

### DIFF
--- a/.github/workflows/staging-desktop-dmg.yml
+++ b/.github/workflows/staging-desktop-dmg.yml
@@ -1,22 +1,10 @@
 name: staging-desktop-dmg
 
+# Manual-only: a signed + notarized staging DMG costs a long macOS runner job
+# and an Apple notarization round-trip per merge, and back-to-back merges just
+# cancelled each other's builds anyway. Dispatch it from the Actions tab (or
+# `gh workflow run staging-desktop-dmg.yml`) when a staging artifact is needed.
 on:
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/staging-desktop-dmg.yml"
-      - "hud.html"
-      - "index.html"
-      - "mascot.html"
-      - "meeting-hud.html"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "public/**"
-      - "scripts/**"
-      - "src/**"
-      - "src-tauri/**"
-      - "tsconfig.json"
-      - "vite.config.ts"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Every merge to main kicked off a full signed + notarized staging DMG build. Besides the runner cost and the Apple notarization round-trip per merge, busy merge windows make the builds cancel each other (`cancel-in-progress: true`) - today three consecutive merges killed each other's runs mid-notarization, so fast merge days produce no staging artifact at all.

The staging DMG is consumed on demand, not per-commit, so this drops the `push` trigger and keeps `workflow_dispatch` only: run it from the Actions tab or `gh workflow run staging-desktop-dmg.yml` when you actually want an installable staging build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)