### PR TITLE
Pre-mint the trial checkout session so the button click feels instant

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,7 @@ pub fn run() {
             os_accounts::os_accounts_logout,
             os_accounts::os_accounts_top_up,
             os_accounts::os_accounts_open_portal,
+            os_accounts::os_accounts_prepare_trial_checkout,
             os_accounts::os_accounts_start_trial_checkout,
             focus_main_window
         ])

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -368,6 +368,10 @@ pub async fn os_accounts_login(
     let code = await_authorization_code(&cfg, &flow, &login_url, &csrf).await?;
     let pair = exchange_code(&cfg, &code, &verifier, &redirect_uri).await?;
     store_tokens(&pair).await?;
+    // The identity may have changed (a sign-in is not always preceded by an
+    // app-mediated logout); a checkout minted for the previous identity must
+    // not survive into this one.
+    clear_prepared_checkout();
 
     let (user, balance, subscription) = fetch_snapshot(&cfg).await?;
     set_cached_signed_in(true);
@@ -408,6 +412,7 @@ pub async fn os_accounts_logout() -> Result<(), AppError> {
             .await;
     }
     clear_tokens().await;
+    clear_prepared_checkout();
     set_cached_signed_in(false);
     Ok(())
 }
@@ -484,6 +489,16 @@ fn take_fresh_prepared_checkout() -> Option<String> {
     let mut slot = PREPARED_CHECKOUT.lock().ok()?;
     let prepared = slot.take()?;
     (prepared.minted_at.elapsed() < PREPARED_CHECKOUT_TTL).then_some(prepared.url)
+}
+
+/// A prepared checkout is minted under the signed-in user's Stripe identity,
+/// so it must die at every identity boundary — logout and completed login.
+/// Left cached, the next user on this machine could consume it within the
+/// TTL and attach their payment to the previous user's subscription.
+fn clear_prepared_checkout() {
+    if let Ok(mut slot) = PREPARED_CHECKOUT.lock() {
+        *slot = None;
+    }
 }
 
 fn store_prepared_checkout(url: String) {

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -470,6 +470,16 @@ const PREPARED_CHECKOUT_TTL: Duration = Duration::from_secs(30 * 60);
 
 static PREPARED_CHECKOUT: StdMutex<Option<PreparedCheckout>> = StdMutex::new(None);
 
+/// Serializes the prepare path. Without it, concurrent prepare calls (a
+/// remounting pitch screen, an effect double-fire) both see an empty cache
+/// and both mint a Stripe Checkout session — the loser's store overwrites
+/// the winner's and the discarded session sits open against Stripe's limits
+/// for 24 hours. The loser of this lock re-checks the cache once it acquires
+/// and reuses the winner's mint instead. Async because it is held across the
+/// mint's awaits; `PREPARED_CHECKOUT` above stays a std mutex because it is
+/// only ever held for a read or a swap.
+static PREPARE_TRIAL_CHECKOUT_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
+
 fn take_fresh_prepared_checkout() -> Option<String> {
     let mut slot = PREPARED_CHECKOUT.lock().ok()?;
     let prepared = slot.take()?;
@@ -587,6 +597,10 @@ pub enum TrialCheckoutPrepared {
 /// explicit click path.
 #[tauri::command]
 pub async fn os_accounts_prepare_trial_checkout() -> Result<TrialCheckoutPrepared, AppError> {
+    // Held across the mint so overlapping prepare calls can't both reach
+    // Stripe; the freshness re-check below then answers the loser from the
+    // winner's cache entry. See PREPARE_TRIAL_CHECKOUT_LOCK.
+    let _prepare_guard = PREPARE_TRIAL_CHECKOUT_LOCK.lock().await;
     if prepared_checkout_is_fresh() {
         return Ok(TrialCheckoutPrepared::Ready);
     }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -15,7 +15,7 @@ use std::{
     error::Error as StdError,
     sync::{
         atomic::{AtomicBool, Ordering},
-        OnceLock,
+        Mutex as StdMutex, OnceLock,
     },
     time::Duration,
 };
@@ -455,16 +455,57 @@ const BILLING_RETURN_URL: &str = "osscribe://billing/callback";
 #[cfg(debug_assertions)]
 const BILLING_RETURN_URL: &str = "";
 
-/// One-click free trial: mint the subscription Stripe Checkout session
-/// directly from the app (the user's own token authorizes it) and open it in
-/// the system browser — no detour through the portal's billing page.
-///
-/// A persistent scope failure surfaces as `trial_checkout_needs_reauth` so
-/// the UI can re-run sign-in (picking up the scopes this build requests) and
-/// retry the direct path. Any other failure surfaces as an error the UI
-/// answers with the portal fallback.
-#[tauri::command]
-pub async fn os_accounts_start_trial_checkout() -> Result<TrialCheckout, AppError> {
+/// A minted-but-not-opened Stripe Checkout session, cached so the click that
+/// follows only has to launch the browser instead of paying for the
+/// token-refresh + session-mint round trips while the user stares at an
+/// "Opening checkout" button.
+struct PreparedCheckout {
+    url: String,
+    minted_at: std::time::Instant,
+}
+
+/// Stripe keeps Checkout sessions live for 24 hours; this stays far inside
+/// that so a consumed cache entry never points at an expired session.
+const PREPARED_CHECKOUT_TTL: Duration = Duration::from_secs(30 * 60);
+
+static PREPARED_CHECKOUT: StdMutex<Option<PreparedCheckout>> = StdMutex::new(None);
+
+fn take_fresh_prepared_checkout() -> Option<String> {
+    let mut slot = PREPARED_CHECKOUT.lock().ok()?;
+    let prepared = slot.take()?;
+    (prepared.minted_at.elapsed() < PREPARED_CHECKOUT_TTL).then_some(prepared.url)
+}
+
+fn store_prepared_checkout(url: String) {
+    if let Ok(mut slot) = PREPARED_CHECKOUT.lock() {
+        *slot = Some(PreparedCheckout {
+            url,
+            minted_at: std::time::Instant::now(),
+        });
+    }
+}
+
+fn prepared_checkout_is_fresh() -> bool {
+    PREPARED_CHECKOUT
+        .lock()
+        .ok()
+        .and_then(|slot| {
+            slot.as_ref()
+                .map(|prepared| prepared.minted_at.elapsed() < PREPARED_CHECKOUT_TTL)
+        })
+        .unwrap_or(false)
+}
+
+enum MintedTrialCheckout {
+    Url(String),
+    AlreadySubscribed,
+}
+
+/// Mint the subscription Stripe Checkout session directly from the app (the
+/// user's own token authorizes it) — no detour through the portal's billing
+/// page. This is the slow part of starting a trial: up to a token refresh
+/// plus the accounts API creating the session at Stripe.
+async fn mint_trial_checkout() -> Result<MintedTrialCheckout, AppError> {
     let cfg = Config::load();
     if !cfg.configured() {
         return Err(AppError::new(
@@ -498,11 +539,10 @@ pub async fn os_accounts_start_trial_checkout() -> Result<TrialCheckout, AppErro
             let session = resp
                 .data
                 .ok_or_else(|| AppError::new("empty_response", "OS Accounts returned no data."))?;
-            open_in_browser(&session.url)?;
-            return Ok(TrialCheckout::CheckoutOpened);
+            return Ok(MintedTrialCheckout::Url(session.url));
         }
         match resp.error_code {
-            Some(ERR_CONFLICT) => return Ok(TrialCheckout::AlreadySubscribed),
+            Some(ERR_CONFLICT) => return Ok(MintedTrialCheckout::AlreadySubscribed),
             Some(ERR_UNPROCESSABLE) if return_url.is_some() => {
                 return_url = None;
             }
@@ -527,6 +567,61 @@ pub async fn os_accounts_start_trial_checkout() -> Result<TrialCheckout, AppErro
         "trial_checkout_unavailable",
         "Could not start the free trial checkout.",
     ))
+}
+
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "camelCase", tag = "outcome")]
+pub enum TrialCheckoutPrepared {
+    /// A Checkout session is minted and cached; the next start call opens it
+    /// without any network round trips.
+    Ready,
+    /// The accounts API reported a live subscription already exists — the
+    /// caller should refresh the account snapshot instead of pitching.
+    AlreadySubscribed,
+}
+
+/// Pre-mint the Stripe Checkout session while the user is still reading the
+/// trial pitch, so the "Start free trial" click feels instant. Best-effort:
+/// callers swallow failures and the start command falls back to minting on
+/// the spot. Never triggers an interactive re-auth — that stays on the
+/// explicit click path.
+#[tauri::command]
+pub async fn os_accounts_prepare_trial_checkout() -> Result<TrialCheckoutPrepared, AppError> {
+    if prepared_checkout_is_fresh() {
+        return Ok(TrialCheckoutPrepared::Ready);
+    }
+    match mint_trial_checkout().await? {
+        MintedTrialCheckout::AlreadySubscribed => Ok(TrialCheckoutPrepared::AlreadySubscribed),
+        MintedTrialCheckout::Url(url) => {
+            store_prepared_checkout(url);
+            Ok(TrialCheckoutPrepared::Ready)
+        }
+    }
+}
+
+/// One-click free trial: open the pre-minted Checkout session when one is
+/// cached (the instant path), otherwise mint and open in one go.
+///
+/// A persistent scope failure surfaces as `trial_checkout_needs_reauth` so
+/// the UI can re-run sign-in (picking up the scopes this build requests) and
+/// retry the direct path. Any other failure surfaces as an error the UI
+/// answers with the portal fallback.
+#[tauri::command]
+pub async fn os_accounts_start_trial_checkout() -> Result<TrialCheckout, AppError> {
+    // Consume the cached session rather than reusing it: each open gets a
+    // session that is known-unused, and the UI re-prepares in the background
+    // after a cancel.
+    if let Some(url) = take_fresh_prepared_checkout() {
+        open_in_browser(&url)?;
+        return Ok(TrialCheckout::CheckoutOpened);
+    }
+    match mint_trial_checkout().await? {
+        MintedTrialCheckout::AlreadySubscribed => Ok(TrialCheckout::AlreadySubscribed),
+        MintedTrialCheckout::Url(url) => {
+            open_in_browser(&url)?;
+            Ok(TrialCheckout::CheckoutOpened)
+        }
+    }
 }
 
 /// Register the deep-link handler at app setup. Drains any in-flight

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1093,6 +1093,20 @@ export type TrialCheckoutResult = {
   outcome: "checkoutOpened" | "alreadySubscribed";
 };
 
+export type TrialCheckoutPreparedResult = {
+  outcome: "ready" | "alreadySubscribed";
+};
+
+/** Pre-mints the free-trial Stripe Checkout session and caches it in the
+ * Rust core, so the next start call only has to open the browser. Call it
+ * while the user is reading the trial pitch; failures are safe to swallow,
+ * the start path falls back to minting on the spot. */
+export async function osAccountsPrepareTrialCheckout() {
+  return invoke<TrialCheckoutPreparedResult>(
+    "os_accounts_prepare_trial_checkout",
+  );
+}
+
 /** Mints the free-trial Stripe Checkout session with the user's own token and
  * opens it in the system browser — no portal detour. Rejects with code
  * `trial_checkout_needs_reauth` when the stored grant lacks the billing

--- a/src/lib/trial-checkout.ts
+++ b/src/lib/trial-checkout.ts
@@ -4,6 +4,7 @@ import {
   focusMainWindow,
   osAccountsLogin,
   osAccountsOpenPortal,
+  osAccountsPrepareTrialCheckout,
   osAccountsStartTrialCheckout,
 } from "./tauri";
 import type { AccountStatus } from "./tauri";
@@ -114,6 +115,30 @@ export function useTrialCheckout({
       void unlisten.then((dispose) => dispose());
     };
   }, []);
+
+  // Pre-mint the Checkout session while the pitch is on screen, so the
+  // "Start free trial" click only has to open the browser instead of paying
+  // for token refresh + Stripe session creation right when the user is
+  // watching the button. Re-arms whenever the flow lands back on the pitch
+  // (a canceled checkout consumed the previous session). Failures stay
+  // silent on purpose: start() mints on the spot as before and owns the
+  // interactive re-auth path — a background prefetch must never pop a
+  // browser sign-in.
+  useEffect(() => {
+    if (phase !== "idle" || subscribed) return;
+    let stale = false;
+    void osAccountsPrepareTrialCheckout()
+      .then((result) => {
+        if (stale || result.outcome !== "alreadySubscribed") return;
+        // Subscribed on another machine; the refreshed snapshot trips the
+        // activation watcher below instead of pitching a trial.
+        void onRefreshRef.current();
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
+  }, [phase, subscribed]);
 
   // Activation watcher. Covers every path to a live subscription — direct
   // checkout, portal fallback, even a second device — because it keys off

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   setDictationShortcut: vi.fn(),
   osAccountsLogin: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
+  osAccountsPrepareTrialCheckout: vi.fn(),
   osAccountsStartTrialCheckout: vi.fn(),
   osAccountsOpenPortal: vi.fn(),
   focusMainWindow: vi.fn(),
@@ -35,6 +36,7 @@ vi.mock("../lib/tauri", () => ({
   setDictationShortcut: mocks.setDictationShortcut,
   osAccountsLogin: mocks.osAccountsLogin,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
+  osAccountsPrepareTrialCheckout: mocks.osAccountsPrepareTrialCheckout,
   osAccountsStartTrialCheckout: mocks.osAccountsStartTrialCheckout,
   osAccountsOpenPortal: mocks.osAccountsOpenPortal,
   focusMainWindow: mocks.focusMainWindow,
@@ -102,6 +104,9 @@ describe("OnboardingFlow", () => {
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
+    mocks.osAccountsPrepareTrialCheckout.mockResolvedValue({
+      outcome: "ready",
+    });
     mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
     mocks.focusMainWindow.mockResolvedValue(undefined);
     mocks.setDictationLanguage.mockResolvedValue(undefined);
@@ -288,6 +293,81 @@ describe("OnboardingFlow", () => {
       screen.getByRole("button", { name: "Try your first dictation" }),
     );
     await screen.findByPlaceholderText(/Hold fn/i);
+  });
+
+  it("pre-mints the checkout session on the pitch and again after a cancel", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsStartTrialCheckout.mockResolvedValue({
+      outcome: "checkoutOpened",
+    });
+    render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+    // The pitch isn't on screen yet, so nothing should be minted.
+    expect(mocks.osAccountsPrepareTrialCheckout).not.toHaveBeenCalled();
+
+    await walkToTrial(user);
+    await waitFor(() =>
+      expect(mocks.osAccountsPrepareTrialCheckout).toHaveBeenCalledOnce(),
+    );
+    // Prefetching is invisible: the pitch keeps its ready button.
+    expect(
+      screen.getByRole("button", { name: "Start free trial" }),
+    ).toBeEnabled();
+
+    // A canceled checkout consumed the prepared session; landing back on
+    // the pitch must mint a fresh one in the background.
+    await user.click(screen.getByRole("button", { name: "Start free trial" }));
+    await screen.findByRole("heading", {
+      name: "Finish checkout in your browser",
+    });
+    emitBillingCallback?.({ payload: "cancel" });
+    await screen.findByRole("heading", { name: "Start your free trial" });
+    await waitFor(() =>
+      expect(mocks.osAccountsPrepareTrialCheckout).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("keeps a failed pre-mint silent and lets the click mint on the spot", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsPrepareTrialCheckout.mockRejectedValue({
+      code: "trial_checkout_unavailable",
+      message: "Could not start the free trial checkout.",
+    });
+    mocks.osAccountsStartTrialCheckout.mockResolvedValue({
+      outcome: "checkoutOpened",
+    });
+    render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+
+    await walkToTrial(user);
+    await waitFor(() =>
+      expect(mocks.osAccountsPrepareTrialCheckout).toHaveBeenCalled(),
+    );
+    // The background failure must not leak into the pitch.
+    expect(screen.queryByText(/Could not start/)).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Start free trial" }));
+    await screen.findByRole("heading", {
+      name: "Finish checkout in your browser",
+    });
+    expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the snapshot when the pre-mint reports an existing subscription", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsPrepareTrialCheckout.mockResolvedValue({
+      outcome: "alreadySubscribed",
+    });
+    const onRefreshAccount = vi.fn(async () => account);
+    render(
+      <OnboardingFlow
+        {...flowProps({ account: unsubscribedAccount, onRefreshAccount })}
+      />,
+    );
+    await screen.findByRole("heading", { name: /Welcome, Gaut!/ });
+
+    await walkToTrial(user);
+    await waitFor(() => expect(onRefreshAccount).toHaveBeenCalled());
   });
 
   it("reacts to the post-checkout deep link without waiting out the poll", async () => {


### PR DESCRIPTION
## Problem

Clicking "Start free trial" took several seconds to actually open the Stripe page. The click paid for the entire pipeline while the user stared at a disabled "Opening checkout" button: a possible OS Accounts token refresh, the accounts API creating the Stripe Checkout session (the slow part), and only then the browser launch.

## Fix

Mint the Checkout session in the background the moment the trial pitch appears, so the click only has to launch the browser.

- **Rust:** the mint loop is split out of `os_accounts_start_trial_checkout` into a shared `mint_trial_checkout`. A new `os_accounts_prepare_trial_checkout` command mints and caches the session URL in the core (never crossing the bridge). `start` consumes a fresh cached session and opens it immediately; with no cache it mints on the spot exactly as before. Cache entries are single-use and considered fresh for 30 minutes, far inside Stripe's 24 hour session lifetime, so an open never lands on an expired session.
- **Frontend:** `useTrialCheckout` prefetches whenever the flow is idle and unsubscribed, which covers both surfaces that use it (the onboarding trial step and the trial gate). It re-arms when a canceled checkout returns the user to the pitch, since the cancel consumed the prepared session. The user typically spends a few seconds reading the pitch copy, which is more than the mint needs, so the subsequent click is effectively instant.
- **Failure containment:** prefetch failures are swallowed on purpose. The background path never triggers an interactive re-auth or the portal fallback; those stay exclusively on the explicit click path, which behaves exactly as before when no session is cached. A prefetch that discovers an existing subscription (second machine) refreshes the account snapshot so the activation watcher skips the pitch.

## Testing

- 3 new onboarding tests: pre-mint fires on the pitch (not before) and re-arms after a canceled checkout; a failed pre-mint stays silent and the click path still opens checkout directly; an `alreadySubscribed` pre-mint refreshes the snapshot.
- Full frontend suite: 339 tests pass; `tsc --noEmit` and prettier clean.
- `src-tauri` compiles with no new clippy warnings (the 4 existing ones are in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)