### PR TITLE
Route every verify link through Rust to the scribe-api /verify page

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -546,9 +546,13 @@ pub async fn check_recording_source_readiness(
         .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
 }
 
+/// Opens the scribe-api `/verify` page (enclave attestation, routing,
+/// retention) in the default browser. Must route through Rust: the webview
+/// installs no new-window handler, so `target="_blank"` anchors are silently
+/// dropped — same reason the accounts portal links go through a command.
 #[tauri::command]
-pub fn scribe_verify_url() -> String {
-    crate::scribe_api::verify_url()
+pub fn scribe_open_verify_page() -> Result<(), AppError> {
+    crate::os_accounts::open_in_browser(&crate::scribe_api::verify_url())
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,7 +112,7 @@ pub fn run() {
             commands::get_microphone_permission_state,
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,
-            commands::scribe_verify_url,
+            commands::scribe_open_verify_page,
             commands::start_recording,
             commands::pause_recording,
             commands::resume_recording,

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -1122,7 +1122,7 @@ fn random_b64url(bytes: usize) -> String {
     URL_SAFE_NO_PAD.encode(&buf)
 }
 
-fn open_in_browser(url: &str) -> Result<(), AppError> {
+pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
     let mut child = std::process::Command::new("open")
         .arg(url)
         .spawn()

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -90,7 +90,7 @@ import {
   osAccountsTopUp,
   providerModelSettings,
   retryAgentTask,
-  scribeVerifyUrl,
+  scribeOpenVerifyPage,
   sendAgentMessage,
   startHermesBridge,
   suggestAgentSessionTitle,
@@ -751,7 +751,6 @@ export function AgentWorkspace({
     useState<ModelPrivacyBadge>();
   // Attestation walkthrough URL served by the backend (same page as Settings
   // → About → Verify server); the privacy badge links to it when known.
-  const [verifyUrl, setVerifyUrl] = useState<string>();
   const [capabilityQuery, setCapabilityQuery] = useState("");
   const [capabilityLoading, setCapabilityLoading] = useState(false);
   const [capabilitySaving, setCapabilitySaving] = useState<string | null>(null);
@@ -1190,20 +1189,6 @@ export function AgentWorkspace({
         PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
         handleProviderModelSettingsChanged,
       );
-    };
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    scribeVerifyUrl()
-      .then((url) => {
-        if (!cancelled && url) setVerifyUrl(url);
-      })
-      // Without a configured backend there is nothing to verify; the badge
-      // stays a plain tooltip.
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
     };
   }, []);
 
@@ -3260,7 +3245,6 @@ export function AgentWorkspace({
             <h2>{selectedTask.title}</h2>
             <SafetyBadge
               privacyBadge={generationPrivacyBadge}
-              verifyUrl={verifyUrl}
             />
           </div>
         </div>
@@ -3343,7 +3327,6 @@ export function AgentWorkspace({
             setArtifactPanel((open) => (open ? null : { view: "list" }))
           }
           privacyBadge={generationPrivacyBadge}
-          verifyUrl={verifyUrl}
           fullMode={Boolean(bridge.running && bridge.connection?.fullMode)}
           title={
             !newSessionMode && selectedHermesSessionId
@@ -3468,10 +3451,8 @@ export function AgentWorkspace({
 // Settings → About.
 function SafetyBadge({
   privacyBadge,
-  verifyUrl,
 }: {
   privacyBadge?: ModelPrivacyBadge;
-  verifyUrl?: string;
 }) {
   if (!privacyBadge) return null;
   const icon =
@@ -3485,34 +3466,21 @@ function SafetyBadge({
   const label = (
     <span className="agent-safety-badge-label">{privacyBadge.label}</span>
   );
-  if (!verifyUrl) {
-    return (
-      <HoverTip
-        tip={privacyBadge.description}
-        className="agent-safety-badge"
-        data-mode={privacyBadge.mode}
-        tabIndex={0}
-        aria-label={`${privacyBadge.label} - ${privacyBadge.description}`}
-      >
-        {icon}
-        {label}
-      </HoverTip>
-    );
-  }
   const description = `${privacyBadge.description} Click to see exactly what code June's server runs and how to verify it yourself.`;
+  // A button through Rust, not an anchor: the webview installs no new-window
+  // handler, so target="_blank" navigations are silently dropped.
   return (
     <HoverTip tip={description} className="agent-safety-badge-wrap">
-      <a
+      <button
+        type="button"
         className="agent-safety-badge"
         data-mode={privacyBadge.mode}
-        href={verifyUrl}
-        target="_blank"
-        rel="noreferrer"
+        onClick={() => void scribeOpenVerifyPage().catch(() => undefined)}
         aria-label={`${privacyBadge.label} - ${description}`}
       >
         {icon}
         {label}
-      </a>
+      </button>
     </HoverTip>
   );
 }
@@ -3544,7 +3512,6 @@ function UnrestrictedBadge() {
 function AgentSessionBar({
   origin,
   privacyBadge,
-  verifyUrl,
   fullMode,
   title,
   artifactCount = 0,
@@ -3555,7 +3522,6 @@ function AgentSessionBar({
 }: {
   origin?: AgentWorkspaceOrigin;
   privacyBadge?: ModelPrivacyBadge;
-  verifyUrl?: string;
   fullMode?: boolean;
   title?: string;
   artifactCount?: number;
@@ -3679,7 +3645,7 @@ function AgentSessionBar({
             <span aria-hidden>{artifactCount}</span>
           </button>
         ) : null}
-        <SafetyBadge privacyBadge={privacyBadge} verifyUrl={verifyUrl} />
+        <SafetyBadge privacyBadge={privacyBadge} />
         {hasMenu ? (
           <div className="agent-session-menu-wrap" ref={menuWrapRef}>
             <button

--- a/src/components/onboarding/steps/PrivacySteps.tsx
+++ b/src/components/onboarding/steps/PrivacySteps.tsx
@@ -1,3 +1,4 @@
+import { scribeOpenVerifyPage } from "../../../lib/tauri";
 import { StepActions, StepHeading } from "../StepChrome";
 
 const PRIVACY_CARDS = [
@@ -31,13 +32,13 @@ export function PrivacyStep({ onContinue }: { onContinue: () => void }) {
         ))}
       </div>
       <p className="onboarding-footnote">
-        <a
-          href="https://opensoftware.network/privacy"
-          target="_blank"
-          rel="noreferrer"
+        <button
+          type="button"
+          className="onboarding-footnote-link"
+          onClick={() => void scribeOpenVerifyPage().catch(() => undefined)}
         >
           Verify it yourself
-        </a>: how routing, retention, and attestation work.
+        </button>: how routing, retention, and attestation work.
       </p>
       <StepActions onContinue={onContinue} />
     </section>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -22,7 +22,7 @@ import {
   listVeniceModels,
   localAudioFileSrc,
   providerModelSettings,
-  scribeVerifyUrl,
+  scribeOpenVerifyPage,
   setDictationLanguage,
   setDictationMicrophone,
   setDictationShortcut,
@@ -259,7 +259,6 @@ export function AppSettings({
   const [micTestSampleSrc, setMicTestSampleSrc] = useState<string>();
   const [micTestError, setMicTestError] = useState<string>();
   const [micTestPlaying, setMicTestPlaying] = useState(false);
-  const [verifyUrl, setVerifyUrl] = useState<string>();
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
   const activeTab = controlled ? controlledTab : internalTab;
   const setActiveTab = (tab: SettingsTab) => {
@@ -293,18 +292,6 @@ export function AppSettings({
       void resetMicTestState(true);
     }
   }, [activeTab]);
-
-  useEffect(() => {
-    let cancelled = false;
-    scribeVerifyUrl()
-      .then((url) => {
-        if (!cancelled && url) setVerifyUrl(url);
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -1165,30 +1152,29 @@ export function AppSettings({
                   </div>
                 </div>
 
-                {verifyUrl ? (
-                  <div className="settings-row">
-                    <div className="settings-row-info">
-                      <h3 className="settings-row-title">
-                        Server verification
-                      </h3>
-                      <p className="settings-row-description">
-                        June&apos;s server runs in a confidential VM. See
-                        exactly what code is running and how to verify it
-                        yourself.
-                      </p>
-                    </div>
-                    <div className="settings-row-control">
-                      <a
-                        className="btn btn-secondary"
-                        href={verifyUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Verify server
-                      </a>
-                    </div>
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">
+                      Server verification
+                    </h3>
+                    <p className="settings-row-description">
+                      June&apos;s server runs in a confidential VM. See
+                      exactly what code is running and how to verify it
+                      yourself.
+                    </p>
                   </div>
-                ) : null}
+                  <div className="settings-row-control">
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      onClick={() =>
+                        void scribeOpenVerifyPage().catch(() => undefined)
+                      }
+                    >
+                      Verify server
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </section>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -601,8 +601,11 @@ export async function bootstrapApp() {
   return invoke<BootstrapResponse>("bootstrap_app");
 }
 
-export async function scribeVerifyUrl() {
-  return invoke<string>("scribe_verify_url");
+/** Opens the scribe-api /verify page (attestation, routing, retention) in
+ * the default browser. Routed through Rust because the webview drops
+ * target="_blank" anchors. */
+export async function scribeOpenVerifyPage() {
+  return invoke<void>("scribe_open_verify_page");
 }
 
 export async function createNote(folderId?: string) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -691,13 +691,17 @@ input:focus-visible,
   display: inline-flex;
 }
 
-a.agent-safety-badge {
+button.agent-safety-badge {
+  border: none;
+  /* font-family only: the font shorthand would out-specificity the base
+   * class's font-size and grow the badge text. */
+  font-family: inherit;
   text-decoration: none;
   cursor: pointer;
   transition: background-color var(--t-fast) var(--ease-out);
 }
 
-a.agent-safety-badge:hover {
+button.agent-safety-badge:hover {
   background: color-mix(in oklch, var(--brand) 24%, transparent);
 }
 
@@ -10439,6 +10443,18 @@ a.agent-safety-badge:hover {
 
 .onboarding-footnote a {
   color: var(--foreground);
+}
+
+/* Footnote links that act through Rust (the webview drops target="_blank"
+ * anchors) render as buttons but must read as links. */
+.onboarding-footnote-link {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: var(--foreground);
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 /* Sign-in / trial "finish it in the browser" wait state: spinner + label,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -47,7 +47,7 @@ const mocks = vi.hoisted(() => ({
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
   osAccountsTopUp: vi.fn(),
-  scribeVerifyUrl: vi.fn(),
+  scribeOpenVerifyPage: vi.fn(),
   providerModelSettings: vi.fn(),
   retryAgentTask: vi.fn(),
   saveAgentAssistantMessage: vi.fn(),
@@ -99,7 +99,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsTopUp: mocks.osAccountsTopUp,
   providerModelSettings: mocks.providerModelSettings,
   retryAgentTask: mocks.retryAgentTask,
-  scribeVerifyUrl: mocks.scribeVerifyUrl,
+  scribeOpenVerifyPage: mocks.scribeOpenVerifyPage,
   saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
   saveAgentHermesSession: mocks.saveAgentHermesSession,
   sendAgentMessage: mocks.sendAgentMessage,
@@ -192,7 +192,7 @@ describe("AgentWorkspace", () => {
     mocks.getAgentTask.mockResolvedValue(existingTask);
     // Empty by default so badge tests assert the plain (unlinked) badge; the
     // verify-link test overrides this with a real URL.
-    mocks.scribeVerifyUrl.mockResolvedValue("");
+    mocks.scribeOpenVerifyPage.mockResolvedValue(undefined);
     mocks.hermesBridgeStatus.mockResolvedValue({
       running: true,
       connection: { port: 61234, wsUrl: "ws://127.0.0.1:61234" },
@@ -330,8 +330,12 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
     expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
+    // The badge always links to the verify page now, so its accessible name
+    // carries the click-through suffix after the mode description.
     expect(
-      screen.getByLabelText(`Anonymous mode - ${ANONYMOUS_MODEL_DESCRIPTION}`),
+      screen.getByLabelText(
+        new RegExp(`^Anonymous mode - ${ANONYMOUS_MODEL_DESCRIPTION}`),
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
   });
@@ -379,20 +383,18 @@ describe("AgentWorkspace", () => {
     );
   });
 
-  it("links the privacy badge to the server verification page", async () => {
-    mocks.scribeVerifyUrl.mockResolvedValue(
-      "https://scribe-api.example.test/verify",
-    );
+  it("opens the server verification page from the privacy badge", async () => {
+    // A button through Rust, not an anchor: the webview drops
+    // target="_blank" navigations.
+    mocks.scribeOpenVerifyPage.mockResolvedValue(undefined);
+    const user = userEvent.setup();
 
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    const badge = await screen.findByRole("link", { name: /Private mode/ });
-    expect(badge).toHaveAttribute(
-      "href",
-      "https://scribe-api.example.test/verify",
-    );
-    expect(badge).toHaveAttribute("target", "_blank");
+    const badge = await screen.findByRole("button", { name: /Private mode/ });
     expect(badge).toHaveAccessibleName(/how to verify it yourself/i);
+    await user.click(badge);
+    expect(mocks.scribeOpenVerifyPage).toHaveBeenCalledOnce();
   });
 
   it("refreshes the model privacy label when generation model settings change", async () => {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -35,7 +35,7 @@ const mocks = vi.hoisted(() => ({
   createDictionaryEntry: vi.fn(),
   updateDictionaryEntry: vi.fn(),
   deleteDictionaryEntry: vi.fn(),
-  scribeVerifyUrl: vi.fn(),
+  scribeOpenVerifyPage: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
@@ -69,7 +69,7 @@ vi.mock("../lib/tauri", () => ({
   createDictionaryEntry: mocks.createDictionaryEntry,
   updateDictionaryEntry: mocks.updateDictionaryEntry,
   deleteDictionaryEntry: mocks.deleteDictionaryEntry,
-  scribeVerifyUrl: mocks.scribeVerifyUrl,
+  scribeOpenVerifyPage: mocks.scribeOpenVerifyPage,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -132,9 +132,7 @@ describe("AppSettings", () => {
       language,
     }));
     mocks.listDictionaryEntries.mockResolvedValue([]);
-    mocks.scribeVerifyUrl.mockResolvedValue(
-      "https://scribe-api.example.test/verify",
-    );
+    mocks.scribeOpenVerifyPage.mockResolvedValue(undefined);
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
         transcriptionProvider: "venice",
@@ -1161,7 +1159,9 @@ describe("AppSettings", () => {
     expect(screen.getByText(APP_COMMIT_HASH)).toBeInTheDocument();
   });
 
-  it("links to the server attestation page from About", async () => {
+  it("opens the server attestation page from About through Rust", async () => {
+    // Not an anchor: the webview drops target="_blank" navigations, so the
+    // button must invoke the scribe_open_verify_page command instead.
     render(
       <AppSettings
         account={signedInAccount}
@@ -1177,12 +1177,10 @@ describe("AppSettings", () => {
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("tab", { name: "About" }));
-    const link = await screen.findByRole("link", { name: "Verify server" });
-    expect(link).toHaveAttribute(
-      "href",
-      "https://scribe-api.example.test/verify",
+    await user.click(
+      await screen.findByRole("button", { name: "Verify server" }),
     );
-    expect(link).toHaveAttribute("target", "_blank");
+    expect(mocks.scribeOpenVerifyPage).toHaveBeenCalledOnce();
   });
 
   it("shows agent workspace and memory files inside Agent settings", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   setDictationLanguage: vi.fn(),
   setDictationShortcut: vi.fn(),
   osAccountsLogin: vi.fn(),
+  scribeOpenVerifyPage: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsStartTrialCheckout: vi.fn(),
   osAccountsOpenPortal: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock("../lib/tauri", () => ({
   setDictationLanguage: mocks.setDictationLanguage,
   setDictationShortcut: mocks.setDictationShortcut,
   osAccountsLogin: mocks.osAccountsLogin,
+  scribeOpenVerifyPage: mocks.scribeOpenVerifyPage,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsStartTrialCheckout: mocks.osAccountsStartTrialCheckout,
   osAccountsOpenPortal: mocks.osAccountsOpenPortal,
@@ -451,6 +453,26 @@ describe("OnboardingFlow", () => {
     await screen.findByRole("heading", { name: "Start your free trial" });
     await screen.findByText(/Sign-in canceled/);
     expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
+  });
+
+  it("opens the scribe-api verify page from the privacy step", async () => {
+    // The footnote is a Rust-routed button, not an anchor: the webview drops
+    // target="_blank" navigations, so it invokes scribe_open_verify_page.
+    mocks.scribeOpenVerifyPage.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    await renderFlow();
+    await user.click(
+      screen.getByRole("button", { name: "Let's get you set up" }),
+    );
+    await screen.findByRole("heading", {
+      name: "Private by architecture, not by promise",
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Verify it yourself" }),
+    );
+
+    expect(mocks.scribeOpenVerifyPage).toHaveBeenCalledOnce();
   });
 
   it("resumes a half-finished run at the saved step", async () => {


### PR DESCRIPTION
## What was broken

The onboarding privacy footnote ("Verify it yourself: how routing, retention, and attestation work.") pointed at the generic `opensoftware.network/privacy` page rather than the API's `/verify` attestation walkthrough. Worse, it did nothing when clicked - and so did the other two verify surfaces.

**Why every one of these was a dead button:** the app never installs a new-window handler (`on_new_window`), and wry's WKWebView UI delegate returns `nil` from `createWebViewWithConfiguration` in that case - `target="_blank"` navigations are silently dropped (verified in the vendored wry 0.55.1 source). It's the same reason the accounts-portal links were moved behind a Rust command back in 945d1bd. The settings "Verify server" button and the agent privacy badge from #206 shipped as anchors and were equally inert.

## The fix

One command, three consumers:

- **Rust:** `scribe_verify_url` (returned a URL for anchors that can't navigate) becomes `scribe_open_verify_page`, which opens `{SCRIBE_API_URL}/verify` in the default browser through the same `open_in_browser` helper the portal links use.
- **Onboarding footnote:** now a link-styled button invoking the command - lands on the API's /verify page as requested.
- **Settings -> About "Verify server":** anchor -> button, URL-fetch state removed.
- **Agent privacy badge:** anchor -> button; the "no verify URL -> plain tooltip" branch is gone because the URL always resolves (it only guarded the fetch latency window), so the badge always click-throughs to the proof.

## Testing

- 337/337 tests pass; `tsc` and `cargo check`/`fmt` clean.
- Updated the three surface tests to assert the command is invoked on click (instead of asserting `href`/`target` attributes on anchors that never worked), plus a new onboarding test for the footnote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)