### PR TITLE
[codex] Upload stable macOS download alias

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -254,6 +254,32 @@ jobs:
           # .sig updater signatures are uploaded alongside it automatically.
           includeUpdaterJson: true
 
+      - name: Upload stable macOS download alias
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmgs=(
+            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/release/bundle/dmg/*.dmg
+          )
+          if [ "${#dmgs[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one production DMG, found ${#dmgs[@]}"
+            printf 'DMG candidates:\n'
+            if [ "${#dmgs[@]}" -eq 0 ]; then
+              printf ' - <none>\n'
+            else
+              printf ' - %s\n' "${dmgs[@]}"
+            fi
+            exit 1
+          fi
+          stable_dmg="$RUNNER_TEMP/June_aarch64.dmg"
+          cp "${dmgs[0]}" "$stable_dmg"
+          gh release upload "v$VERSION" "$stable_dmg" \
+            --repo open-software-network/os-june-releases \
+            --clobber
+
       # Push the version bump to main only AFTER the release is published, so a
       # build/notarize failure never leaves an orphan `release:` commit on main
       # with no matching release. The push is authenticated as the release App
@@ -279,4 +305,5 @@ jobs:
             echo "- Version: \`$VERSION\`"
             echo "- Release repo: \`open-software-network/os-june-releases\`"
             echo "- Update manifest: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/latest.json\`"
+            echo "- Marketing download: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/June_aarch64.dmg\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed

- Adds a production release step that copies the generated DMG to `June_aarch64.dmg`.
- Uploads that stable alias to `open-software-network/os-june-releases` for the current release tag with `gh release upload --clobber`.
- Adds the stable marketing download URL to the workflow summary.

## Why

The marketing page can link to `https://github.com/open-software-network/os-june-releases/releases/latest/download/June_aarch64.dmg` without needing a site deploy for every June app release.

## Validation

- Parsed `.github/workflows/production-desktop-dmg.yml` with Ruby YAML.
- `git diff --check`

I did not run the full production release workflow locally.