### PR TITLE
[codex] Smooth agent session transition

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1571,6 +1571,11 @@ export function AgentWorkspace({
     if ((!message && !attachments.length) || submitting || importingFiles)
       return;
     const content = promptWithAttachments(message, attachments);
+    // A typed hero submit plays the same teardown as a run shortcut: greeting
+    // up, suggestions down during the session-create latency. Without it they
+    // sit frozen through the wait and then vanish in a single frame when the
+    // conversation takes over.
+    if (heroMode) setHeroLeaving(true);
     setSubmitting(true);
     setDraft("");
     setAttachments([]);
@@ -1594,6 +1599,9 @@ export function AgentWorkspace({
       }
     } finally {
       setSubmitting(false);
+      // On success the hero is gone; on failure this fades the greeting and
+      // suggestions back in behind the restored draft.
+      setHeroLeaving(false);
     }
   }
 
@@ -2841,8 +2849,10 @@ export function AgentWorkspace({
   );
 
   // FLIP the composer from its hero spot (centered, big) down to the bottom
-  // dock when the hero hands over to a conversation — the same form stays
-  // mounted, so this glide is what sells the transition instead of a teleport.
+  // dock when the hero hands over to a conversation — this glide is what
+  // sells the transition instead of a teleport. The form is recreated across
+  // the handoff (the conversation branch wraps it in .agent-scroll), which is
+  // why the glide works off snapshotted rects rather than DOM identity.
   // While the hero is up, every render snapshots the box; the first render
   // after leaving measures the docked position and animates the delta.
   const heroExitRectRef = useRef<DOMRect | null>(null);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -284,8 +284,9 @@ describe("AgentWorkspace", () => {
       render(<AgentWorkspace />);
 
       expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
-      await waitFor(() => expect(mocks.listHermesSessions).toHaveBeenCalled());
-      expect(sessionDetails.length).toBeGreaterThan(0);
+      // The broadcast lands a few microtasks after the fetch resolves, so
+      // wait for the event itself rather than just the fetch call.
+      await waitFor(() => expect(sessionDetails.length).toBeGreaterThan(0));
       expect(
         sessionDetails.every((detail) => detail.selectedSessionId == null),
       ).toBe(true);
@@ -1779,6 +1780,56 @@ describe("AgentWorkspace", () => {
     } finally {
       randomSpy.mockRestore();
     }
+  });
+
+  it("plays the hero teardown while a typed submit creates the session", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+    // Hold session.create open so the in-flight teardown is observable —
+    // without it the greeting and chips sat frozen through the create
+    // latency and vanished in a single frame at the handoff.
+    let releaseCreate: (() => void) | undefined;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return new Promise((resolve) => {
+          releaseCreate = () =>
+            resolve({
+              session_id: "runtime-session-2",
+              stored_session_id: "session-2",
+            });
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      return Promise.resolve({});
+    });
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    await user.type(
+      await screen.findByPlaceholderText("Describe a task for June…"),
+      "first task",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    // Mid-flight: still the hero, but tearing down.
+    const hero = screen.getByRole("region", { name: "Agent task details" });
+    await waitFor(() =>
+      expect(hero).toHaveAttribute("data-hero-leaving", "true"),
+    );
+    expect(screen.getByText(HERO_GREETING)).toBeInTheDocument();
+
+    await waitFor(() => expect(releaseCreate).toBeDefined());
+    act(() => releaseCreate?.());
+
+    // The handoff lands in the conversation with the pending message.
+    await waitFor(() =>
+      expect(screen.queryByText(HERO_GREETING)).not.toBeInTheDocument(),
+    );
+    expect(await screen.findByText("first task")).toBeInTheDocument();
   });
 
   it("prefills the composer from a prefill shortcut without submitting", async () => {

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -85,7 +85,10 @@ describe("meeting detection HUD", () => {
     expect(mocks.emit).toHaveBeenCalledWith(
       "scribe://meeting-start-transcription",
     );
-    await vi.runAllTimersAsync();
+    // A bounded advance, not runAllTimersAsync: jsdom drives rAF off the
+    // faked setTimeout while the alpha ramp measures real time, so running
+    // "all" timers re-queues the ramp until sinon's 10000-timer abort.
+    await vi.advanceTimersByTimeAsync(220);
     expect(mocks.hide).toHaveBeenCalledOnce();
     expect(
       document.querySelector<HTMLButtonElement>("#hud-meeting-start")?.disabled,
@@ -131,12 +134,17 @@ describe("meeting detection HUD", () => {
   });
 
   it("clears the prompt when microphone usage stops", async () => {
+    vi.useFakeTimers();
     await loadHud();
     await emit("meeting-detection-event", { type: "meeting_detected" });
 
     await emit("meeting-detection-event", { type: "meeting_cleared" });
 
     expect(hudElement().dataset.state).toBe("exiting");
+    // Drain the in-flight exit: on real timers its hide() fires ~220ms after
+    // this test ends and lands mid-way through a later test's call counts.
+    await vi.advanceTimersByTimeAsync(220);
+    expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
   it("hides and suppresses the prompt after 30 seconds without a click", async () => {
@@ -246,6 +254,11 @@ describe("meeting detection HUD", () => {
 
     await vi.advanceTimersByTimeAsync(900);
     expect(hudElement().dataset.state).toBe("exiting");
+    // Drain the in-flight exit. Its fallback timeout dies with the fake
+    // clock, but the rAF alpha ramp keeps running on real time after this
+    // test ends and would land its hide() inside the next test's counts.
+    await vi.advanceTimersByTimeAsync(220);
+    expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
   it("hides when a Hey June prompt starts an agent session", async () => {
@@ -280,6 +293,9 @@ describe("meeting detection HUD", () => {
 
     await vi.advanceTimersByTimeAsync(4000);
     expect(hudElement().dataset.state).toBe("exiting");
+    // Drain the in-flight exit so its hide() can't leak into a later test.
+    await vi.advanceTimersByTimeAsync(220);
+    expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
   it("keeps the agent handoff visible when it races the dictation handoff hide", async () => {
@@ -302,6 +318,9 @@ describe("meeting detection HUD", () => {
 
     await vi.advanceTimersByTimeAsync(4000);
     expect(hudElement().dataset.state).toBe("exiting");
+    // Drain the in-flight exit so its hide() can't leak into a later test.
+    await vi.advanceTimersByTimeAsync(220);
+    expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
   it("does not claim the HUD for ongoing agent progress", async () => {


### PR DESCRIPTION
Smooths the first typed hero submit by playing the same greeting and suggestion teardown used by run shortcuts while the session is being created. Adds a regression test that holds session creation open to verify the hero is visibly leaving before the conversation handoff. Also hardens related agent workspace and meeting HUD tests by waiting for the actual session broadcast and draining in-flight HUD exits to avoid timer leakage. Validated with targeted Vitest, full Vitest, TypeScript, production build, touched-file Prettier, and diff whitespace checks.