### PR TITLE
Repair gateway-dropped spaces after contractions in assistant prose

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -151,6 +151,7 @@ import {
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
+  repairContractionSpacing,
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
@@ -4756,7 +4757,7 @@ function AgentChatTurnRow({
         {turn.parts.map((part, index) =>
           part.type === "text" ? (
             <div key={`${turn.id}:text:${index}`}>
-              <MarkdownContent markdown={part.text} />
+              <MarkdownContent markdown={part.text} repairProse />
             </div>
           ) : part.type === "context" ? (
             <ContextCompactionPart
@@ -5792,13 +5793,18 @@ function isMarkdownPath(path: string) {
 function MarkdownContent({
   markdown,
   highlight,
+  // Repairs the gateway's dropped-space-after-contraction artifact ("it'snot"
+  // -> "it's not"). Only set for assistant prose: it must never touch code or
+  // a user's own text. See repairContractionSpacing.
+  repairProse = false,
 }: {
   markdown: string;
   highlight?: string;
+  repairProse?: boolean;
 }) {
   return (
     <div className="agent-markdown">
-      {renderMarkdownBlocks(markdown, highlight)}
+      {renderMarkdownBlocks(markdown, highlight, repairProse)}
     </div>
   );
 }
@@ -5833,7 +5839,11 @@ function highlightText(
   return nodes;
 }
 
-function renderMarkdownBlocks(markdown: string, highlight?: string) {
+function renderMarkdownBlocks(
+  markdown: string,
+  highlight?: string,
+  repairProse = false,
+) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const blocks: ReactNode[] = [];
   let paragraph: string[] = [];
@@ -5844,7 +5854,9 @@ function renderMarkdownBlocks(markdown: string, highlight?: string) {
     paragraph = [];
     if (!text) return;
     blocks.push(
-      <p key={`p-${key++}`}>{renderInlineMarkdown(text, key, highlight)}</p>,
+      <p key={`p-${key++}`}>
+        {renderInlineMarkdown(text, key, highlight, repairProse)}
+      </p>,
     );
   };
 
@@ -5896,7 +5908,7 @@ function renderMarkdownBlocks(markdown: string, highlight?: string) {
       index -= 1;
       blocks.push(
         <blockquote key={`quote-${key++}`}>
-          {renderMarkdownBlocks(quoted.join("\n"), highlight)}
+          {renderMarkdownBlocks(quoted.join("\n"), highlight, repairProse)}
         </blockquote>,
       );
       continue;
@@ -5931,7 +5943,7 @@ function renderMarkdownBlocks(markdown: string, highlight?: string) {
               <tr>
                 {header.map((cell, cellIndex) => (
                   <th key={cellIndex}>
-                    {renderInlineMarkdown(cell, key, highlight)}
+                    {renderInlineMarkdown(cell, key, highlight, repairProse)}
                   </th>
                 ))}
               </tr>
@@ -5941,7 +5953,7 @@ function renderMarkdownBlocks(markdown: string, highlight?: string) {
                 <tr key={rowIndex}>
                   {row.map((cell, cellIndex) => (
                     <td key={cellIndex}>
-                      {renderInlineMarkdown(cell, key, highlight)}
+                      {renderInlineMarkdown(cell, key, highlight, repairProse)}
                     </td>
                   ))}
                 </tr>
@@ -5957,7 +5969,7 @@ function renderMarkdownBlocks(markdown: string, highlight?: string) {
     if (heading) {
       flushParagraph();
       const level = Math.min(heading[1].length, 3);
-      const content = renderInlineMarkdown(heading[2], key, highlight);
+      const content = renderInlineMarkdown(heading[2], key, highlight, repairProse);
       blocks.push(
         level === 1 ? (
           <h2 key={`h-${key++}`}>{content}</h2>
@@ -5986,7 +5998,7 @@ function renderMarkdownBlocks(markdown: string, highlight?: string) {
       index -= 1;
       const listItems = items.map((item, itemIndex) => (
         <li key={`li-${key}-${itemIndex}`}>
-          {renderInlineMarkdown(item, key + itemIndex, highlight)}
+          {renderInlineMarkdown(item, key + itemIndex, highlight, repairProse)}
         </li>
       ));
       blocks.push(
@@ -6010,10 +6022,15 @@ function renderInlineMarkdown(
   text: string,
   keySeed: number,
   highlight?: string,
+  repairProse = false,
 ): ReactNode[] {
   const nodes: ReactNode[] = [];
   const mark = (value: string, slot: string) =>
     highlightText(value, highlight, `${keySeed}-${slot}`);
+  // Prose runs (plain text, emphasis, link text) get the contraction-spacing
+  // repair; code spans and URLs go through `mark` untouched.
+  const markProse = (value: string, slot: string) =>
+    mark(repairProse ? repairContractionSpacing(value) : value, slot);
   const pattern =
     /(\*\*([^*]+)\*\*|\*([^*]+)\*|~~([^~]+)~~|`([^`]+)`|\[([^\]]+)\]\((https?:\/\/[^)\s]+)\))/g;
   let lastIndex = 0;
@@ -6021,22 +6038,24 @@ function renderInlineMarkdown(
   let index = 0;
   while ((match = pattern.exec(text))) {
     if (match.index > lastIndex) {
-      nodes.push(...mark(text.slice(lastIndex, match.index), `g${index}`));
+      nodes.push(...markProse(text.slice(lastIndex, match.index), `g${index}`));
     }
     if (match[2]) {
       nodes.push(
         <strong key={`strong-${keySeed}-${index}`}>
-          {mark(match[2], `s${index}`)}
+          {markProse(match[2], `s${index}`)}
         </strong>,
       );
     } else if (match[3]) {
       nodes.push(
-        <em key={`em-${keySeed}-${index}`}>{mark(match[3], `e${index}`)}</em>,
+        <em key={`em-${keySeed}-${index}`}>
+          {markProse(match[3], `e${index}`)}
+        </em>,
       );
     } else if (match[4]) {
       nodes.push(
         <del key={`del-${keySeed}-${index}`}>
-          {mark(match[4], `d${index}`)}
+          {markProse(match[4], `d${index}`)}
         </del>,
       );
     } else if (match[5]) {
@@ -6053,7 +6072,7 @@ function renderInlineMarkdown(
           rel="noreferrer"
           target="_blank"
         >
-          {mark(match[6], `a${index}`)}
+          {markProse(match[6], `a${index}`)}
         </a>,
       );
     }
@@ -6061,7 +6080,7 @@ function renderInlineMarkdown(
     index += 1;
   }
   if (lastIndex < text.length) {
-    nodes.push(...mark(text.slice(lastIndex), "t"));
+    nodes.push(...markProse(text.slice(lastIndex), "t"));
   }
   return nodes;
 }

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -199,6 +199,29 @@ export function buildHermesSessionChatTurns(
     .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 }
 
+// Contraction/possessive enclitics the gateway tokenizes as their own chunk
+// (`'s`, `'re`, `'t`, …). When it reassembles a streamed message for storage
+// it strips the leading space off the chunk that follows one, so the next
+// word glues on: "it's not" persists as "it'snot", "Mac's camera" as
+// "Mac'scamera". The damage is in the persisted text and survives reloads, so
+// the live-stream reconciliation (whitespaceLossyCopyOf) can't undo it — this
+// repairs it at display time.
+const CONTRACTION_GLUE = /([A-Za-z])('(?:s|re|ve|ll|m|d|t))(?=[A-Za-z])/gi;
+
+/**
+ * Re-inserts the space a gateway streaming-reassembly bug drops after a
+ * contraction or possessive ("it'snot" -> "it's not"). Pure and idempotent:
+ * already-spaced text has no match. Deliberately conservative — it skips an
+ * apostrophe preceded by "s" so a plural possessive glued to the next word
+ * ("kids'toys") is left untouched rather than mis-split into "kids't oys".
+ * Apply only to assistant prose (never code spans, URLs, or user text).
+ */
+export function repairContractionSpacing(text: string): string {
+  return text.replace(CONTRACTION_GLUE, (whole, pre: string, enclitic: string) =>
+    pre.toLowerCase() === "s" ? whole : `${pre}${enclitic} `,
+  );
+}
+
 export function completedHermesMessageText(events: LiveHermesEvent[]) {
   const turn = buildAgentChatTurns([], [], events)
     .filter((item) => item.role === "assistant")

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -3,9 +3,51 @@ import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   completedHermesMessageText,
+  repairContractionSpacing,
   toolEventKey,
 } from "../lib/agent-chat-runtime";
 import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
+
+describe("repairContractionSpacing", () => {
+  it("re-inserts the space the gateway drops after a contraction", () => {
+    // Real cases pulled from the persisted Hermes store.
+    expect(repairContractionSpacing("it'snot")).toBe("it's not");
+    expect(repairContractionSpacing("you'rereferring")).toBe(
+      "you're referring",
+    );
+    expect(repairContractionSpacing("Mac'scamera")).toBe("Mac's camera");
+    expect(repairContractionSpacing("here'swhat'sthere:")).toBe(
+      "here's what's there:",
+    );
+    expect(repairContractionSpacing("we'vechecked and they'lldo it")).toBe(
+      "we've checked and they'll do it",
+    );
+    expect(repairContractionSpacing("I'mdone, don'tworry")).toBe(
+      "I'm done, don't worry",
+    );
+  });
+
+  it("leaves correctly spaced and non-contraction text untouched", () => {
+    // Idempotent: already-spaced text has no match.
+    expect(repairContractionSpacing("it's not there")).toBe("it's not there");
+    expect(repairContractionSpacing("its not a contraction")).toBe(
+      "its not a contraction",
+    );
+    // Trailing punctuation, not a following word, isn't a dropped space.
+    expect(repairContractionSpacing("that's it.")).toBe("that's it.");
+    // Names with apostrophes aren't contraction enclitics.
+    expect(repairContractionSpacing("d'Artagnan and O'Brien")).toBe(
+      "d'Artagnan and O'Brien",
+    );
+  });
+
+  it("does not corrupt a plural possessive glued to the next word", () => {
+    // "kids' toys" glued is ambiguous with "kids'" + a "t…" word; the 's'
+    // guard keeps it untouched rather than mis-splitting into "kids't oys".
+    expect(repairContractionSpacing("kids'toys")).toBe("kids'toys");
+    expect(repairContractionSpacing("the cars'doors")).toBe("the cars'doors");
+  });
+});
 
 describe("Agent chat runtime", () => {
   it("renders persisted Hermes user and assistant messages", () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -612,6 +612,32 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("CLI Run Tracking")).toBeInTheDocument();
   });
 
+  it("repairs gateway-glued contractions in assistant prose but not code or user text", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "what'sthere",
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here'swhat I found. Run `git'sstatus` to check.",
+        timestamp: "2026-06-04T12:00:01Z",
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    // Assistant prose is de-glued…
+    expect(await screen.findByText(/Here's what I found/)).toBeInTheDocument();
+    // …but an inline code span keeps the agent's literal text…
+    expect(screen.getByText("git'sstatus")).toBeInTheDocument();
+    // …and the user's own message is never rewritten.
+    expect(screen.getByText("what'sthere")).toBeInTheDocument();
+  });
+
   it("keeps generated titles that begin with past-tense request words", async () => {
     const generatedTitle = "I Wanted Outcomes";
     mocks.listHermesSessions.mockResolvedValue([


### PR DESCRIPTION
## The bug

From time to time the agent renders concatenated words — the report was "what'sthere:" (should be "what's there:").

## Root cause (investigated, confirmed with real data)

The dropped space is **always right after a contraction or possessive apostrophe**. I copied the running app's Hermes message store and grepped the persisted assistant text:

```
it'snot          (it's not)
you'rereferring  (you're referring)
Mac'scamera      (Mac's camera)
```

So the lossy text is **in the persisted store**, not just a live-render glitch. The mechanism: the gateway (Hermes) tokenizes enclitics (`'s`, `'re`, `'t`, `'ve`, `'ll`, `'d`, `'m`) as their own chunk, and when it reassembles a streamed message for storage it strips the leading space off the *next* chunk (`" referring"` → `"referring"`). I verified the rest of the pipeline is clean: the Rust provider proxy forwards SSE byte-for-byte (`write_streaming_response`), and the frontend appends deltas verbatim. The existing live-stream reconciliation (`whitespaceLossyCopyOf`) only repairs the **live** view from a good `message.complete`; once the turn persists, the lossy stored text is authoritative and wins on every reload — which is why it sticks.

The real fix belongs upstream in Hermes (external to this repo). What we can do here is repair it at display time.

## The fix

A small pure `repairContractionSpacing()` re-inserts the space, applied **only to assistant prose runs** in the markdown renderer:

- **Scoped to assistant prose** — never code spans, never URLs, never the user's own messages. Threaded a `repairProse` flag through the renderer; inline code (`` `…` ``) and fenced blocks are structurally excluded, and user turns don't pass the flag.
- **Idempotent** — already-spaced text has no match, so correct output is untouched.
- **Conservative** — skips an apostrophe preceded by `s`, so a plural possessive glued to the next word (`kids'toys`) is left intact rather than mis-split into `kids't oys`. Possessive singular (`Mac'scamera`) and all standard contractions are still fixed.

## Testing

- Unit tests for `repairContractionSpacing`: the real glued cases, idempotence/non-contraction safety (`its`, `that's it.`, `d'Artagnan`), and the plural-possessive guard.
- Render test: assistant prose is de-glued while an inline code span and the user's own message are left verbatim.
- `tsc` clean, full suite passes (39 files, 360 tests).

Cross-cutting note: this is a display-layer mitigation. Worth filing the underlying space-strip upstream in the Hermes gateway so the stored text is correct at the source (would also fix search/copy of older messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)