### PR TITLE
Make GLM 5.1 the default text model and a suggested pick

### DIFF
--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -77,6 +77,18 @@ model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
 privacy = "private"
 
+# Fallback pricing for the default text model (zai-org-glm-5-1); the live
+# Venice catalog overrides this on boot. Keep in sync with
+# DEFAULT_GENERATION_MODEL in the Tauri providers module.
+[pricing."zai-org-glm-5-1"]
+unit = "tokens"
+input_credits_per_million_tokens = 1750
+output_credits_per_million_tokens = 5500
+provider = "venice"
+model_type = "text"
+display_name = "GLM 5.1"
+privacy = "private"
+
 [pricing."zai-org-glm-5"]
 unit = "tokens"
 input_credits_per_million_tokens = 1000

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -246,86 +246,94 @@ pub struct ModelPriceConfig {
     pub capabilities: Vec<String>,
 }
 
+/// Built-in pricing fallback, used only when the live Venice catalog can't be
+/// reached at startup so metered charges still settle. The catalog carries the
+/// authoritative numbers and extends over this on every boot. Split out of
+/// `AppConfig::default` to keep that constructor under the line limit.
+fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
+    let mut pricing = BTreeMap::new();
+    pricing.insert(
+        "gpt-4o-mini-transcribe".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Seconds,
+            credits_per_million_seconds: Some(1_000_000),
+            input_credits_per_million_tokens: None,
+            output_credits_per_million_tokens: None,
+            provider: ModelProvider::Openai,
+            model_type: ModelType::Asr,
+            display_name: "GPT-4o mini transcribe".to_string(),
+            description: Some("Fast OpenAI speech-to-text model.".to_string()),
+            privacy: Some("anonymized".to_string()),
+            pricing: Some(serde_json::json!({ "display": "$0.001/sec audio" })),
+            context_tokens: Some(16_000),
+            traits: vec!["prompt".to_string()],
+            capabilities: Vec::new(),
+        },
+    );
+    pricing.insert(
+        "nvidia/parakeet-tdt-0.6b-v3".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Seconds,
+            credits_per_million_seconds: Some(100_000),
+            input_credits_per_million_tokens: None,
+            output_credits_per_million_tokens: None,
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Asr,
+            display_name: "Parakeet TDT 0.6B v3".to_string(),
+            description: None,
+            privacy: Some("private".to_string()),
+            pricing: None,
+            context_tokens: None,
+            traits: Vec::new(),
+            capabilities: Vec::new(),
+        },
+    );
+    // Fallback pricing for the default text model, used only when the live
+    // Venice catalog can't be reached at startup so metered charges still
+    // settle. The live catalog (which carries the authoritative numbers)
+    // extends over this on every boot. Keep the first entry in sync with
+    // DEFAULT_GENERATION_MODEL in the Tauri providers module.
+    pricing.insert(
+        "zai-org-glm-5-1".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Tokens,
+            credits_per_million_seconds: None,
+            input_credits_per_million_tokens: Some(1_750),
+            output_credits_per_million_tokens: Some(5_500),
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Text,
+            display_name: "GLM 5.1".to_string(),
+            description: None,
+            privacy: Some("private".to_string()),
+            pricing: None,
+            context_tokens: Some(200_000),
+            traits: Vec::new(),
+            capabilities: Vec::new(),
+        },
+    );
+    pricing.insert(
+        "zai-org-glm-5".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Tokens,
+            credits_per_million_seconds: None,
+            input_credits_per_million_tokens: Some(1_000),
+            output_credits_per_million_tokens: Some(3_200),
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Text,
+            display_name: "GLM 5".to_string(),
+            description: None,
+            privacy: Some("private".to_string()),
+            pricing: None,
+            context_tokens: None,
+            traits: Vec::new(),
+            capabilities: Vec::new(),
+        },
+    );
+    pricing
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
-        let mut pricing = BTreeMap::new();
-        pricing.insert(
-            "gpt-4o-mini-transcribe".to_string(),
-            ModelPriceConfig {
-                unit: PriceUnit::Seconds,
-                credits_per_million_seconds: Some(1_000_000),
-                input_credits_per_million_tokens: None,
-                output_credits_per_million_tokens: None,
-                provider: ModelProvider::Openai,
-                model_type: ModelType::Asr,
-                display_name: "GPT-4o mini transcribe".to_string(),
-                description: Some("Fast OpenAI speech-to-text model.".to_string()),
-                privacy: Some("anonymized".to_string()),
-                pricing: Some(serde_json::json!({ "display": "$0.001/sec audio" })),
-                context_tokens: Some(16_000),
-                traits: vec!["prompt".to_string()],
-                capabilities: Vec::new(),
-            },
-        );
-        pricing.insert(
-            "nvidia/parakeet-tdt-0.6b-v3".to_string(),
-            ModelPriceConfig {
-                unit: PriceUnit::Seconds,
-                credits_per_million_seconds: Some(100_000),
-                input_credits_per_million_tokens: None,
-                output_credits_per_million_tokens: None,
-                provider: ModelProvider::Venice,
-                model_type: ModelType::Asr,
-                display_name: "Parakeet TDT 0.6B v3".to_string(),
-                description: None,
-                privacy: Some("private".to_string()),
-                pricing: None,
-                context_tokens: None,
-                traits: Vec::new(),
-                capabilities: Vec::new(),
-            },
-        );
-        // Fallback pricing for the default text model, used only when the live
-        // Venice catalog can't be reached at startup so metered charges still
-        // settle. The live catalog (which carries the authoritative numbers)
-        // extends over this on every boot. Keep the first entry in sync with
-        // DEFAULT_GENERATION_MODEL in the Tauri providers module.
-        pricing.insert(
-            "zai-org-glm-5-1".to_string(),
-            ModelPriceConfig {
-                unit: PriceUnit::Tokens,
-                credits_per_million_seconds: None,
-                input_credits_per_million_tokens: Some(1_750),
-                output_credits_per_million_tokens: Some(5_500),
-                provider: ModelProvider::Venice,
-                model_type: ModelType::Text,
-                display_name: "GLM 5.1".to_string(),
-                description: None,
-                privacy: Some("private".to_string()),
-                pricing: None,
-                context_tokens: Some(200_000),
-                traits: Vec::new(),
-                capabilities: Vec::new(),
-            },
-        );
-        pricing.insert(
-            "zai-org-glm-5".to_string(),
-            ModelPriceConfig {
-                unit: PriceUnit::Tokens,
-                credits_per_million_seconds: None,
-                input_credits_per_million_tokens: Some(1_000),
-                output_credits_per_million_tokens: Some(3_200),
-                provider: ModelProvider::Venice,
-                model_type: ModelType::Text,
-                display_name: "GLM 5".to_string(),
-                description: None,
-                privacy: Some("private".to_string()),
-                pricing: None,
-                context_tokens: None,
-                traits: Vec::new(),
-                capabilities: Vec::new(),
-            },
-        );
         Self {
             server: ServerConfig {
                 host: "127.0.0.1".to_string(),
@@ -366,7 +374,7 @@ impl Default for AppConfig {
                         .to_string(),
             },
             issue_reports: IssueReportsConfig::default(),
-            pricing,
+            pricing: default_pricing(),
         }
     }
 }

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -285,6 +285,29 @@ impl Default for AppConfig {
                 capabilities: Vec::new(),
             },
         );
+        // Fallback pricing for the default text model, used only when the live
+        // Venice catalog can't be reached at startup so metered charges still
+        // settle. The live catalog (which carries the authoritative numbers)
+        // extends over this on every boot. Keep the first entry in sync with
+        // DEFAULT_GENERATION_MODEL in the Tauri providers module.
+        pricing.insert(
+            "zai-org-glm-5-1".to_string(),
+            ModelPriceConfig {
+                unit: PriceUnit::Tokens,
+                credits_per_million_seconds: None,
+                input_credits_per_million_tokens: Some(1_750),
+                output_credits_per_million_tokens: Some(5_500),
+                provider: ModelProvider::Venice,
+                model_type: ModelType::Text,
+                display_name: "GLM 5.1".to_string(),
+                description: None,
+                privacy: Some("private".to_string()),
+                pricing: None,
+                context_tokens: Some(200_000),
+                traits: Vec::new(),
+                capabilities: Vec::new(),
+            },
+        );
         pricing.insert(
             "zai-org-glm-5".to_string(),
             ModelPriceConfig {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -14,7 +14,7 @@ use tauri::{AppHandle, Manager, State};
 pub const PROVIDER_OPENAI: &str = "openai";
 pub const PROVIDER_VENICE: &str = "venice";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
-pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5";
+pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-1";
 
 // Kept exported under the legacy names so existing callers compile until they
 // migrate to the names above.

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -156,7 +156,9 @@ const DEFAULT_SHORTCUTS: Record<
 const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionProvider: "venice",
   transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-  generationModel: "zai-org-glm-5",
+  // Mirrors DEFAULT_GENERATION_MODEL in the Rust providers module and the
+  // leading Suggested pick in lib/suggested-models.ts.
+  generationModel: "zai-org-glm-5-1",
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -16,14 +16,18 @@ export type SuggestedModel = {
  * Curation snapshot (June 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
  * index):
- * - GLM 5: state-of-the-art agentic coding among open models (~78%
- *   SWE-bench), strong tool use, $1/$3.20 per 1M tokens — June's default.
+ * - GLM 5.1: latest GLM flagship, top-tier agentic coding and tool use among
+ *   open models, 200K context, $1.75/$5.50 per 1M tokens — June's default.
  * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
  *   agentic tool runs, 256K context, $0.85/$4.66.
  * - GLM 4.7: Venice's own catalog default and "function calling default" —
- *   near-flagship quality at roughly half GLM 5's price, $0.55/$2.65.
+ *   near-flagship quality at a fraction of the price, $0.55/$2.65.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
  * - Whisper Large v3: best multilingual accuracy at the same low price.
+ *
+ * The default text model (DEFAULT_GENERATION_MODEL in the Rust providers
+ * module, mirrored by the frontend and scribe-api defaults) is the first
+ * generation pick here; keep them in sync when this changes.
  *
  * Ids are matched against the live catalog at render time, so a delisted
  * model silently drops out instead of rendering a dead row.
@@ -31,9 +35,9 @@ export type SuggestedModel = {
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
-      id: "zai-org-glm-5",
+      id: "zai-org-glm-5-1",
       reason:
-        "Best overall: top-tier agentic coding and tool use among open models, with zero data retention.",
+        "Best overall: the latest GLM flagship, with top-tier agentic coding and tool use among open models and zero data retention.",
     },
     {
       id: "kimi-k2-6",
@@ -43,7 +47,7 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
     {
       id: "zai-org-glm-4.7",
       reason:
-        "Best value: near-flagship quality at about half the price, and Venice's own default for tool calling, with zero data retention.",
+        "Best value: near-flagship quality at a fraction of the price, and Venice's own default for tool calling, with zero data retention.",
     },
   ],
   transcription: [

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -187,18 +187,18 @@ describe("AgentWorkspace", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5",
+        generationModel: "zai-org-glm-5-1",
       },
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5",
+      selectedModel: "zai-org-glm-5-1",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5",
-          name: "GLM 5",
+          id: "zai-org-glm-5-1",
+          name: "GLM 5.1",
           modelType: "text",
           privacy: "private",
           traits: [],

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -181,6 +181,18 @@ describe("meeting start transcription event", () => {
       ],
     });
     mocks.startRecording.mockResolvedValue(recording());
+    // The active-recording poll (App.tsx ~20Hz waveform interval) calls this
+    // on a timer; without a resolved value the tick throws on undefined.then
+    // as an unhandled error after the assertions finish - a timing-dependent
+    // CI failure that coverage instrumentation reliably triggers.
+    mocks.getRecordingStatus.mockResolvedValue({
+      sessionId: "rec-1",
+      state: "recording",
+      elapsedMs: 500,
+      level: { peak: 0.2, rms: 0.1, recentPeaks: [0.2] },
+      silenceWarning: false,
+      bytesWritten: 2048,
+    });
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.listDictationHistory.mockResolvedValue({
       items: [],

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -137,7 +137,7 @@ describe("AppSettings", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5",
+        generationModel: "zai-org-glm-5-1",
       },
     });
     mocks.listVeniceModels.mockImplementation(async (mode) => ({
@@ -146,7 +146,7 @@ describe("AppSettings", () => {
       selectedModel:
         mode === "transcription"
           ? "nvidia/parakeet-tdt-0.6b-v3"
-          : "zai-org-glm-5",
+          : "zai-org-glm-5-1",
       models:
         mode === "transcription"
           ? [
@@ -191,8 +191,8 @@ describe("AppSettings", () => {
           : [
               {
                 provider: "venice",
-                id: "zai-org-glm-5",
-                name: "GLM 5",
+                id: "zai-org-glm-5-1",
+                name: "GLM 5.1",
                 modelType: "text",
                 description: "Text model for writing notes.",
                 privacy: "private",
@@ -248,7 +248,7 @@ describe("AppSettings", () => {
           : "venice",
       transcriptionModel:
         mode === "transcription" ? modelId : "nvidia/parakeet-tdt-0.6b-v3",
-      generationModel: mode === "generation" ? modelId : "zai-org-glm-5",
+      generationModel: mode === "generation" ? modelId : "zai-org-glm-5-1",
     }));
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
@@ -1122,7 +1122,7 @@ describe("AppSettings", () => {
     // Suggested is the default view: only the curated picks present in the
     // catalog show, each with its recommendation reason.
     expect(
-      await screen.findByRole("option", { name: /GLM 5/ }),
+      await screen.findByRole("option", { name: /GLM 5\.1/ }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: /Venice Uncensored/ }),
@@ -1144,10 +1144,10 @@ describe("AppSettings", () => {
       screen.getByRole("option", { name: /Venice Uncensored/ }),
     ).toBeInTheDocument();
     await user.clear(screen.getByLabelText("Search models"));
-    await user.click(screen.getByRole("option", { name: /GLM 5/ }));
+    await user.click(screen.getByRole("option", { name: /GLM 5\.1/ }));
     expect(mocks.setVeniceModel).toHaveBeenCalledWith(
       "generation",
-      "zai-org-glm-5",
+      "zai-org-glm-5-1",
     );
   });
 


### PR DESCRIPTION
Promotes GLM 5.1 to June's default text model and the leading Suggested pick. Kimi K2.6 stays a suggested pick; GLM 5 is replaced by GLM 5.1.

## Model

Verified against the live Venice catalog: `zai-org-glm-5-1` — GLM 5.1, **private** (zero retention), **tool-capable**, 200K context, $1.75/$5.50 per 1M tokens. (The `e2ee-glm-5-1` variant has no tool calling, so it's correctly not a candidate — it would brick the agent.)

## Suggested text models now

1. **GLM 5.1** (`zai-org-glm-5-1`) — best overall, **default**
2. **Kimi K2.6** (`kimi-k2-6`) — most capable open-weights
3. **GLM 4.7** (`zai-org-glm-4.7`) — best value

## The default, kept in sync across four places

- `DEFAULT_GENERATION_MODEL` — Tauri providers module (the app's default selection)
- `DEFAULT_PROVIDER_MODELS.generationModel` — frontend settings default
- scribe-api startup pricing fallback — `config crate` default + `config.toml`, so metered charges still settle if the live Venice catalog is briefly unreachable at boot. The live catalog carries the authoritative pricing and extends over this fallback on every boot; GLM 5's fallback entry is kept since it remains selectable.
- Leading pick in `lib/suggested-models.ts`

Cross-references are noted in comments in each spot.

## Testing

Fixtures in the two affected test files updated to the new id/name; the curated-suggestions test now selects GLM 5.1. Full gates pass: `tsc`, 363 frontend tests, 114 Tauri lib tests, 7 scribe-api test binaries, `cargo fmt` clean on both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)