### PR TITLE
Add the missing gap between the approval spinner and its label

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1404,6 +1404,14 @@ button.agent-safety-badge:hover {
   margin: 0;
 }
 
+/* Spinner + label sit flush without this — the glyph needs a gap from the
+ * "Working out…" text and a shared baseline. */
+.agent-approval-explanation-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
 /* Buttons come from the .btn system (secondary fills, ghost deny) — this
  * block only lays them out and adds the deny accent. */
 .agent-approval-actions {


### PR DESCRIPTION
## The issue

In the approval "Explain first" panel, the dot spinner sits flush against "Working out what this request does…" — no space between the glyph and the text.

## Cause

The loading row is `<p className="agent-approval-explanation-loading"><Spinner /><span>…</span></p>`, but **that class was never defined in CSS**. With no rule, the spinner and label render as adjacent inline elements with no gap (and JSX strips the whitespace between them).

## Fix

Define `.agent-approval-explanation-loading` as a flex row with `align-items: center` and `gap: var(--sp-2)` — the same spinner+label recipe used elsewhere in the app. One small CSS rule, no markup change.

Verified `vite build` compiles the stylesheet and the approval-flow test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)