### PR TITLE
Present scheduled routine runs as routines, not raw cron prompts

### DIFF
--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -1,3 +1,4 @@
+import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
 import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
 import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
@@ -9,6 +10,7 @@ import { IconTrashCan } from "central-icons/IconTrashCan";
 import { useEffect, useMemo, useState } from "react";
 import {
   deleteHermesSession,
+  isScheduledRunSession,
   sessionTimestamp,
 } from "../../lib/hermes-adapter";
 import { AGENT_DELETE_SESSION_EVENT } from "../../lib/agent-events";
@@ -260,7 +262,11 @@ function AgentSessionListRow({
       >
         <button type="button" className="folder-note-main" onClick={onSelect}>
           <span className="folder-note-icon" aria-hidden>
-            <IconBubble3 size={15} />
+            {isScheduledRunSession(session) ? (
+              <IconArrowsRepeat size={15} />
+            ) : (
+              <IconBubble3 size={15} />
+            )}
           </span>
           <span className="folder-note-body">
             <span className="folder-note-title">{title}</span>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1,6 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { IconArrowInbox } from "central-icons/IconArrowInbox";
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
+import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
 import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconBubbleWide } from "central-icons/IconBubbleWide";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
@@ -116,6 +117,7 @@ import {
   listHermesSessionMessages,
   listHermesSessions,
   sessionTimestamp,
+  stripScheduledRunPreamble,
   titleFromPrompt,
 } from "../../lib/hermes-adapter";
 import {
@@ -4890,7 +4892,16 @@ function AgentChatTurnRow({
 
   if (turn.role === "user") {
     return (
-      <article className="agent-user-turn">
+      <article
+        className="agent-user-turn"
+        data-scheduled-run={turn.isScheduledRun ? "true" : undefined}
+      >
+        {turn.isScheduledRun ? (
+          <span className="agent-user-turn-eyebrow">
+            <IconArrowsRepeat size={12} aria-hidden />
+            Scheduled routine run
+          </span>
+        ) : null}
         <div className="agent-user-turn-body">
           {textParts.map((part, index) => (
             <MarkdownContent
@@ -6655,9 +6666,10 @@ function stripHermesVisibleContext(value: string) {
     "",
   );
   const marker = withoutWarnings.search(/\n*--- Attached Context ---/m);
-  return (
-    marker >= 0 ? withoutWarnings.slice(0, marker) : withoutWarnings
-  ).trim();
+  const visible = marker >= 0 ? withoutWarnings.slice(0, marker) : withoutWarnings;
+  // Drop the scheduled-run delivery preamble so a routine's title and dedup
+  // key come from its actual prompt, not the cron scaffolding.
+  return stripScheduledRunPreamble(visible.trim());
 }
 
 function compactPath(path: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -6,6 +6,10 @@ import type {
 } from "./tauri";
 import type { HermesGatewayEvent } from "./hermes-gateway";
 import { isInsufficientCreditsMessage } from "./errors";
+import {
+  isScheduledRunPreamble,
+  stripScheduledRunPreamble,
+} from "./hermes-adapter";
 
 export type LiveHermesEvent = HermesGatewayEvent & {
   receivedAt: string;
@@ -84,6 +88,9 @@ export type AgentChatTurn = {
   createdAt: string;
   status: "running" | "complete";
   parts: AgentChatPart[];
+  /** True for the opening prompt of a scheduled-routine run — the UI labels it
+   * so a cron run reads as a routine rather than a message the user sent. */
+  isScheduledRun?: boolean;
 };
 
 export function buildAgentChatTurns(
@@ -142,6 +149,7 @@ export function buildHermesSessionChatTurns(
       createdAt: messageTimestamp(message),
       status: "complete",
       parts: [],
+      isScheduledRun: isScheduledRunMessage(message) || undefined,
     };
 
     if (contextPart) {
@@ -775,15 +783,29 @@ function safeJsonParse(value: string) {
   }
 }
 
-function displayContentForHermesMessage(message: HermesSessionMessage) {
-  const content =
+function resolveHermesMessageText(message: HermesSessionMessage) {
+  return (
     textFromHermesContent(message.content) ??
     textFromHermesContent(message.text) ??
     textFromHermesContent(message.context) ??
     stringValue(message.name, true) ??
-    "";
+    ""
+  );
+}
+
+function displayContentForHermesMessage(message: HermesSessionMessage) {
+  const content = resolveHermesMessageText(message);
   if (message.role !== "user") return content.trim();
-  return stripHermesContextMarkers(content);
+  // Scheduled runs lead with the cron delivery preamble; show the routine's
+  // own instructions, not the machine scaffolding.
+  return stripScheduledRunPreamble(stripHermesContextMarkers(content));
+}
+
+function isScheduledRunMessage(message: HermesSessionMessage) {
+  return (
+    message.role === "user" &&
+    isScheduledRunPreamble(resolveHermesMessageText(message))
+  );
 }
 
 function contextCompactionPartForHermesContent(

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -48,7 +48,61 @@ export async function deleteHermesSession(sessionId: string) {
 export function normalizeHermesSessionsResponse(response: unknown) {
   return extractList(response, "sessions")
     .filter(isHermesSessionInfo)
+    .map(withScheduledRunDisplay)
     .sort((a, b) => sessionTimestamp(b).localeCompare(sessionTimestamp(a)));
+}
+
+/** Hermes tags scheduled-routine runs with source "cron". */
+export const SCHEDULED_RUN_SOURCE = "cron";
+
+export function isScheduledRunSession(session: HermesSessionInfo) {
+  return session.source === SCHEDULED_RUN_SOURCE;
+}
+
+/** A scheduled run's first message is the routine prompt wrapped in a machine
+ * delivery preamble the cron runner injects: `[IMPORTANT: You are running as a
+ * scheduled cron job. … nothing more.]`. Recognized by that exact opener so a
+ * user message that merely starts with "[IMPORTANT" is never mistaken for it. */
+export function isScheduledRunPreamble(content: string) {
+  return /^\s*\[IMPORTANT:\s*You are running as a scheduled cron job\.?/i.test(
+    content,
+  );
+}
+
+/** Strips the leading delivery preamble from a scheduled run's prompt, leaving
+ * the routine's actual instructions. The preamble embeds bracketed tokens
+ * (`[SILENT]`), so it's removed by matching brackets rather than to the first
+ * `]`. A prompt without the preamble is returned unchanged. */
+export function stripScheduledRunPreamble(content: string) {
+  if (!isScheduledRunPreamble(content)) return content.trim();
+  const start = content.indexOf("[");
+  let depth = 0;
+  for (let index = start; index < content.length; index += 1) {
+    const char = content[index];
+    if (char === "[") depth += 1;
+    else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) return content.slice(index + 1).trim();
+    }
+  }
+  // Unbalanced (truncated preview): drop the opener line so it's not gibberish.
+  return content.slice(start).replace(/^\[IMPORTANT:[^\n]*/i, "").trim();
+}
+
+/** Gives a scheduled-run session a readable title and a clean preview when the
+ * stored ones are empty or still the raw delivery preamble, so every list
+ * surface stops showing "[IMPORTANT…". Non-cron sessions pass through. */
+function withScheduledRunDisplay(session: HermesSessionInfo): HermesSessionInfo {
+  if (!isScheduledRunSession(session)) return session;
+  const cleanedPreview = stripScheduledRunPreamble(session.preview ?? "");
+  const storedTitle = session.title?.trim() ?? "";
+  // Replace the stored title when it's empty or is the cron scaffolding — a
+  // stored title is often truncated ("[IMPORTANT: You are running as"), so a
+  // leading "[IMPORTANT" is enough to treat it as raw here, where we already
+  // know this is a cron session.
+  const looksRaw = !storedTitle || /^\[IMPORTANT\b/i.test(storedTitle);
+  const title = looksRaw ? titleFromPrompt(cleanedPreview) : storedTitle;
+  return { ...session, title, preview: cleanedPreview || session.preview };
 }
 
 export function normalizeHermesSessionMessagesResponse(response: unknown) {
@@ -87,7 +141,7 @@ export function titleFromPrompt(prompt: string) {
 }
 
 function promptTitleSource(prompt: string) {
-  return prompt
+  return stripScheduledRunPreamble(prompt)
     .replace(/\n*--- Attached Context ---[\s\S]*$/m, "")
     .replace(/\n*--- Context Warnings ---[\s\S]*$/m, "")
     .replace(/\n+Attached files copied into[\s\S]*$/i, "")

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1490,6 +1490,26 @@ button.agent-safety-badge:hover {
   line-height: 1.55;
 }
 
+/* A scheduled routine run opens with the cron prompt; stack a quiet eyebrow
+ * above the right-aligned bubble so it reads as a routine, not a user message. */
+.agent-user-turn[data-scheduled-run="true"] {
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--sp-1);
+}
+
+.agent-user-turn-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.agent-user-turn-eyebrow svg {
+  color: var(--muted-foreground);
+}
+
 .agent-assistant-empty {
   margin: 0;
   color: var(--muted-foreground);

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -8,6 +8,44 @@ import {
 import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
 
 describe("Agent chat runtime", () => {
+  it("strips the cron preamble and flags a scheduled-run turn", () => {
+    const preamble =
+      '[IMPORTANT: You are running as a scheduled cron job. SILENT: respond ' +
+      'with exactly "[SILENT]" if nothing is new. Never combine [SILENT] ' +
+      "with content — say [SILENT] and nothing more.]";
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "user",
+        content: `${preamble}\n\nSummarize GitHub activity for the team.`,
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.isScheduledRun).toBe(true);
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Summarize GitHub activity for the team.",
+        status: "complete",
+      },
+    ]);
+  });
+
+  it("leaves an ordinary user turn unflagged", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "user",
+        content: "Summarize GitHub activity for the team.",
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.isScheduledRun).toBeUndefined();
+  });
+
   it("renders persisted Hermes user and assistant messages", () => {
     const turns = buildHermesSessionChatTurns([
       {

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -7,7 +7,8 @@ const hermesMocks = vi.hoisted(() => ({
   deleteHermesSession: vi.fn(),
 }));
 
-vi.mock("../lib/hermes-adapter", () => ({
+vi.mock("../lib/hermes-adapter", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/hermes-adapter")>()),
   deleteHermesSession: hermesMocks.deleteHermesSession,
   sessionTimestamp: (session: HermesSessionInfo) =>
     session.last_active ?? session.started_at ?? "",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -123,7 +123,11 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: mocks.listen,
 }));
 
-vi.mock("../lib/hermes-adapter", () => ({
+vi.mock("../lib/hermes-adapter", async (importOriginal) => ({
+  // Spread the real module so the pure scheduled-run helpers
+  // (isScheduledRunPreamble/stripScheduledRunPreamble) are present for the
+  // chat runtime; only the network-touching calls are overridden.
+  ...(await importOriginal<typeof import("../lib/hermes-adapter")>()),
   deleteHermesSession: mocks.deleteHermesSession,
   listHermesSessionMessages: mocks.listHermesSessionMessages,
   listHermesSessions: mocks.listHermesSessions,

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,12 +1,76 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  isScheduledRunPreamble,
+  isScheduledRunSession,
   listHermesSessions,
   normalizeHermesSessionMessagesResponse,
   normalizeHermesSessionsResponse,
   sessionTimestamp,
+  stripScheduledRunPreamble,
   titleFromPrompt,
 } from "../lib/hermes-adapter";
 import type { HermesSessionInfo } from "../lib/tauri";
+
+const SCHEDULED_PREAMBLE =
+  '[IMPORTANT: You are running as a scheduled cron job. DELIVERY: produce ' +
+  'your report as your final response. SILENT: if there is nothing new, ' +
+  'respond with exactly "[SILENT]" (nothing else). Never combine [SILENT] ' +
+  "with content — either report normally, or say [SILENT] and nothing more.]";
+
+describe("scheduled-run helpers", () => {
+  it("recognizes the cron delivery preamble, not arbitrary bracketed text", () => {
+    expect(isScheduledRunPreamble(SCHEDULED_PREAMBLE)).toBe(true);
+    expect(isScheduledRunPreamble("[IMPORTANT] read this carefully")).toBe(
+      false,
+    );
+    expect(isScheduledRunPreamble("Summarize today's standup")).toBe(false);
+  });
+
+  it("strips the preamble to the routine's own prompt, balancing brackets", () => {
+    const prompt = `${SCHEDULED_PREAMBLE}\n\nYou are a daily standup reporter. Summarize GitHub activity.`;
+    expect(stripScheduledRunPreamble(prompt)).toBe(
+      "You are a daily standup reporter. Summarize GitHub activity.",
+    );
+    // The inner [SILENT] tokens must not end the preamble early.
+    expect(stripScheduledRunPreamble(prompt)).not.toContain("SILENT");
+    // A normal prompt is returned untouched (just trimmed).
+    expect(stripScheduledRunPreamble("  hello there  ")).toBe("hello there");
+  });
+
+  it("gives cron sessions a readable title and clean preview", () => {
+    const sessions = normalizeHermesSessionsResponse({
+      sessions: [
+        {
+          id: "cron-1",
+          source: "cron",
+          title: "",
+          preview: `${SCHEDULED_PREAMBLE}\n\nSummarize GitHub activity for the team.`,
+          last_active: "2026-06-11T12:00:00Z",
+        },
+      ],
+    });
+    const session = sessions[0];
+    expect(isScheduledRunSession(session as HermesSessionInfo)).toBe(true);
+    expect(session?.title).toBe("Summarize Github Activity for the Team");
+    expect(session?.title).not.toContain("IMPORTANT");
+    expect(session?.preview?.startsWith("Summarize GitHub activity")).toBe(true);
+  });
+
+  it("derives the title from a cron title that is itself the raw preamble", () => {
+    const sessions = normalizeHermesSessionsResponse({
+      sessions: [
+        {
+          id: "cron-2",
+          source: "cron",
+          title: SCHEDULED_PREAMBLE.slice(0, 30),
+          preview: `${SCHEDULED_PREAMBLE}\n\nPost the weekly metrics digest.`,
+          last_active: "2026-06-11T12:00:00Z",
+        },
+      ],
+    });
+    expect(sessions[0]?.title).toBe("Post the Weekly Metrics Digest");
+  });
+});
 
 const mocks = vi.hoisted(() => ({
   hermesBridgeSessions: vi.fn(),


### PR DESCRIPTION
## The problem

When a routine's cron job fires, the runner injects a machine delivery preamble ahead of the routine's prompt and runs it as a session:

> `[IMPORTANT: You are running as a scheduled cron job. DELIVERY: … SILENT: … [SILENT] and nothing more.]`

The session then showed up titled **"[IMPORTANT"** with the entire scaffolding wall as the first "user" message — unreadable, and indistinguishable from a message the user typed. (Screenshot in the thread.)

## Root cause / signal

The preamble is injected by Hermes (the cron runner), so our frontend just receives it as the first message. I confirmed against the local session store that Hermes tags these sessions with **`source = "cron"`** — so they're identified reliably by source, not by sniffing message content.

## What changed

**Session lists** (sidebar, menu bar, session list, session bar) — normalized once in the adapter so every surface benefits:
- Derive a readable title from the routine's actual prompt when the stored title is empty or is the raw preamble (so "[IMPORTANT" → e.g. "Summarize Github Activity For The Team").
- Strip the preamble from the preview text.
- Mark cron rows with the **Routines icon** instead of the chat-bubble icon.

**Conversation**:
- Strip the delivery preamble so the opening bubble shows the routine's own instructions.
- Flag the opening turn as a scheduled run and render a quiet **"Scheduled routine run"** eyebrow above it, so it reads as a routine rather than a user message.

**Robustness**: the preamble embeds bracketed `[SILENT]` tokens, so it's removed by **matching brackets** (depth count), not by cutting to the first `]`. Recognition keys off the exact `[IMPORTANT: You are running as a scheduled cron job` opener, so an ordinary message that merely starts with `[IMPORTANT` is never mistaken for one.

## Scope note

This is the focused display fix for the "[IMPORTANT" sessions. A fuller "routine run history under the Routines tab" view (the other half of the original ask) is a natural follow-up — this PR makes the runs readable and recognizable everywhere they already appear.

## Testing

- Adapter unit tests: preamble recognition (and rejection of arbitrary `[IMPORTANT…]` text), bracket-balanced stripping, and cron-session title/preview derivation (including a truncated-preamble stored title).
- Runtime tests: a cron message strips to the routine prompt and flags `isScheduledRun`; an ordinary message stays unflagged.
- `tsc` clean, `vite build` clean, full suite passes (39 files, 369 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)