### PR TITLE
Make third-party ASR requests structurally anonymous

### DIFF
--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -27,8 +27,12 @@ pub(crate) async fn transcribe(
     let model_id = form.required_text("model")?;
     validation::validate_text_len("model", &model_id, validation::MAX_MODEL_CHARS)?;
     require_priced_model(&state, &model_id, ModelKind::Asr)?;
+    // Accepted and validated for wire compatibility, but deliberately not
+    // carried into the transcription pipeline: the note title is user data
+    // an ASR provider has no business seeing.
     let title = form.required_text("title")?;
     validation::validate_text_len("title", &title, validation::MAX_TITLE_CHARS)?;
+    drop(title);
     let context = form.optional_text("context");
     validation::validate_optional_text_len(
         "context",
@@ -53,7 +57,6 @@ pub(crate) async fn transcribe(
             note_id,
             audio,
             filename,
-            title,
             context,
             language,
             model_id: ModelId(model_id),

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -110,11 +110,52 @@ pub struct Receipt {
     pub idempotent_replay: bool,
 }
 
+/// Audio container of a transcription request. The domain request carries
+/// this instead of the client's file name, so upstream providers receive a
+/// canonical, non-identifying part name no matter what the user's files are
+/// called — the anonymization is structural, not a sanitization step.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AudioFormat {
+    Wav,
+    Mp4,
+}
+
+impl AudioFormat {
+    /// Container detection by extension — the same rule the upload pipeline
+    /// has always used: m4a/mp4 are MP4 audio, everything else is WAV.
+    pub fn from_filename(filename: &str) -> Self {
+        let is_mp4 = std::path::Path::new(filename)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("m4a") || extension.eq_ignore_ascii_case("mp4")
+            });
+        if is_mp4 { Self::Mp4 } else { Self::Wav }
+    }
+
+    /// The only file name upstream providers ever see.
+    pub fn upstream_filename(self) -> &'static str {
+        match self {
+            Self::Wav => "audio.wav",
+            Self::Mp4 => "audio.m4a",
+        }
+    }
+
+    pub fn mime(self) -> &'static str {
+        match self {
+            Self::Wav => "audio/wav",
+            Self::Mp4 => "audio/mp4",
+        }
+    }
+}
+
+/// What a transcriber needs and nothing more: the audio, its container, and
+/// the inference knobs. Deliberately no file name, note title, user id, or
+/// session id — a provider cannot leak metadata it never receives.
 #[derive(Clone, Debug)]
 pub struct TranscriptionRequest {
     pub audio: Vec<u8>,
-    pub filename: String,
-    pub title: String,
+    pub format: AudioFormat,
     pub context: Option<String>,
     pub language: Option<String>,
     pub model: ModelId,
@@ -258,4 +299,28 @@ pub trait IssueReportSink: Send + Sync {
 
 pub trait AudioDurationProbe: Send + Sync {
     fn probe(&self, audio: &[u8]) -> Result<Duration, DomainError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AudioFormat;
+
+    #[test]
+    fn audio_format_detects_mp4_containers_case_insensitively() {
+        assert_eq!(AudioFormat::from_filename("clip.m4a"), AudioFormat::Mp4);
+        assert_eq!(AudioFormat::from_filename("CLIP.M4A"), AudioFormat::Mp4);
+        assert_eq!(AudioFormat::from_filename("video.mp4"), AudioFormat::Mp4);
+        assert_eq!(AudioFormat::from_filename("take.wav"), AudioFormat::Wav);
+        assert_eq!(AudioFormat::from_filename("noext"), AudioFormat::Wav);
+    }
+
+    #[test]
+    fn upstream_filenames_never_echo_the_input() {
+        // The canonical names are constants by construction; this pins the
+        // exact strings providers send so a regression is loud.
+        assert_eq!(AudioFormat::Wav.upstream_filename(), "audio.wav");
+        assert_eq!(AudioFormat::Mp4.upstream_filename(), "audio.m4a");
+        assert_eq!(AudioFormat::Wav.mime(), "audio/wav");
+        assert_eq!(AudioFormat::Mp4.mime(), "audio/mp4");
+    }
 }

--- a/scribe-api/crates/providers/src/openai.rs
+++ b/scribe-api/crates/providers/src/openai.rs
@@ -58,9 +58,11 @@ impl OpenAiTranscriber {
         request: &TranscriptionRequest,
     ) -> Result<Transcript, UpstreamAttemptError> {
         let model_id = &request.model.0;
+        // Canonical part name and mime from the container format only — the
+        // user's own file name never reaches the provider.
         let audio_part = Part::bytes(request.audio.clone())
-            .file_name(request.filename.clone())
-            .mime_str(crate::transcription::audio_mime(&request.filename))
+            .file_name(request.format.upstream_filename())
+            .mime_str(request.format.mime())
             .map_err(|error| {
                 tracing::error!(%error, %url, model = %model_id, "openai: audio mime build failed");
                 UpstreamAttemptError::fatal(DomainError::UpstreamProvider)
@@ -141,7 +143,7 @@ mod tests {
     use crate::http;
     use pretty_assertions::assert_eq;
     use scribe_config::UpstreamConfig;
-    use scribe_domain::{DomainError, ModelId, Transcriber, TranscriptionRequest};
+    use scribe_domain::{AudioFormat, DomainError, ModelId, Transcriber, TranscriptionRequest};
     use serde_json::json;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
@@ -161,12 +163,34 @@ mod tests {
     fn request() -> TranscriptionRequest {
         TranscriptionRequest {
             audio: b"fake wav".to_vec(),
-            filename: "recording.wav".to_string(),
-            title: "Title".to_string(),
+            format: AudioFormat::Wav,
             context: None,
             language: None,
             model: ModelId("gpt-4o-mini-transcribe".to_string()),
         }
+    }
+
+    #[tokio::test]
+    async fn upstream_request_carries_only_the_canonical_part_name() {
+        // The privacy guarantee for opt-in third-party ASR: the multipart
+        // body names the audio "audio.wav", whatever the user's file was
+        // called, and contains nothing identifying beyond the audio itself.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/audio/transcriptions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "text": "Hello" })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = transcriber(&server).transcribe(request()).await;
+        assert_eq!(result.map(|value| value.text), Ok("Hello".to_string()));
+
+        let received = server.received_requests().await.unwrap_or_default();
+        assert_eq!(received.len(), 1);
+        let body = String::from_utf8_lossy(&received[0].body);
+        assert!(body.contains("filename=\"audio.wav\""), "body: {body}");
+        assert!(body.contains("Content-Type: audio/wav"), "body: {body}");
     }
 
     #[tokio::test]

--- a/scribe-api/crates/providers/src/routing.rs
+++ b/scribe-api/crates/providers/src/routing.rs
@@ -79,8 +79,7 @@ mod tests {
         let transcript = transcriber
             .transcribe(TranscriptionRequest {
                 audio: b"fake wav".to_vec(),
-                filename: "recording.wav".to_string(),
-                title: "Title".to_string(),
+                format: scribe_domain::AudioFormat::Wav,
                 context: Some("Prompt context".to_string()),
                 language: Some("es".to_string()),
                 model: ModelId("gpt-4o-mini-transcribe".to_string()),

--- a/scribe-api/crates/providers/src/transcription.rs
+++ b/scribe-api/crates/providers/src/transcription.rs
@@ -1,22 +1,7 @@
 use serde::Deserialize;
-use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct TranscriptionWireResponse {
     pub text: String,
     pub language: Option<String>,
-}
-
-pub(crate) fn audio_mime(filename: &str) -> &'static str {
-    if Path::new(filename)
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| {
-            extension.eq_ignore_ascii_case("m4a") || extension.eq_ignore_ascii_case("mp4")
-        })
-    {
-        "audio/mp4"
-    } else {
-        "audio/wav"
-    }
 }

--- a/scribe-api/crates/providers/src/venice.rs
+++ b/scribe-api/crates/providers/src/venice.rs
@@ -152,9 +152,11 @@ impl VeniceTranscriber {
         request: &TranscriptionRequest,
     ) -> Result<Transcript, UpstreamAttemptError> {
         let model_id = &request.model.0;
+        // Same canonical part name as every other transcriber — providers
+        // never see the user's own file name.
         let audio_part = Part::bytes(request.audio.clone())
-            .file_name(request.filename.clone())
-            .mime_str(crate::transcription::audio_mime(&request.filename))
+            .file_name(request.format.upstream_filename())
+            .mime_str(request.format.mime())
             .map_err(|error| {
                 tracing::error!(%error, %url, model = %model_id, "venice: audio mime build failed");
                 UpstreamAttemptError::fatal(DomainError::UpstreamProvider)
@@ -1053,8 +1055,7 @@ mod tests {
             &transcriber,
             scribe_domain::TranscriptionRequest {
                 audio: b"fake wav".to_vec(),
-                filename: "dictation.wav".to_string(),
-                title: "Dictation".to_string(),
+                format: scribe_domain::AudioFormat::Wav,
                 context: None,
                 language: None,
                 model: ModelId("nvidia/parakeet-tdt-0.6b-v3".to_string()),
@@ -1063,6 +1064,16 @@ mod tests {
         .await;
 
         assert_eq!(transcript.map(|value| value.text), Ok("Hello".to_string()));
+
+        // Same anonymization property as the OpenAI path: the part is named
+        // canonically, never after the user's file.
+        let received = server.received_requests().await.unwrap_or_default();
+        let body = received
+            .iter()
+            .map(|request| String::from_utf8_lossy(&request.body).to_string())
+            .find(|body| body.contains("filename="))
+            .unwrap_or_default();
+        assert!(body.contains("filename=\"audio.wav\""), "body: {body}");
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/dictate.rs
+++ b/scribe-api/crates/services/src/dictate.rs
@@ -8,8 +8,9 @@ use crate::{
     util::ceil_seconds,
 };
 use scribe_domain::{
-    ActionSlug, AudioDurationProbe, CleanedText, Cleaner, CleanupRequest, Credits, ModelId,
-    ModelKind, OsAccountsClient, Receipt, Transcriber, Transcript, TranscriptionRequest, UserId,
+    ActionSlug, AudioDurationProbe, AudioFormat, CleanedText, Cleaner, CleanupRequest, Credits,
+    ModelId, ModelKind, OsAccountsClient, Receipt, Transcriber, Transcript, TranscriptionRequest,
+    UserId,
 };
 use std::sync::Arc;
 
@@ -74,8 +75,7 @@ impl DictateService {
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
-                filename: params.filename,
-                title: "Dictation".to_string(),
+                format: AudioFormat::from_filename(&params.filename),
                 context: params.context,
                 language: params.language,
                 model: params.model_id.clone(),

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -347,7 +347,6 @@ mod tests {
                 note_id: "note_1".to_string(),
                 audio: vec![1, 2, 3],
                 filename: "recording.wav".to_string(),
-                title: "Title".to_string(),
                 context: None,
                 language: None,
                 model_id: ModelId("audio-model".to_string()),

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -7,8 +7,8 @@ use crate::{
     util::ceil_seconds,
 };
 use scribe_domain::{
-    ActionSlug, AudioDurationProbe, Credits, ModelId, OsAccountsClient, Receipt, Transcriber,
-    Transcript, TranscriptionRequest, UserId,
+    ActionSlug, AudioDurationProbe, AudioFormat, Credits, ModelId, OsAccountsClient, Receipt,
+    Transcriber, Transcript, TranscriptionRequest, UserId,
 };
 use std::sync::Arc;
 
@@ -46,12 +46,15 @@ impl NoteTranscribeService {
         &self,
         params: NoteTranscribeParams,
     ) -> Result<NoteTranscribeOutput, ServiceError> {
+        // The client file name is reduced to its container format right here:
+        // it never reaches a provider and (being user data) never the logs.
+        let format = AudioFormat::from_filename(&params.filename);
         tracing::info!(
             user_id = %params.user_id.0,
             note_id = %params.note_id,
             model = %params.model_id.0,
             audio_bytes = params.audio.len(),
-            filename = %params.filename,
+            audio_format = ?format,
             "note_transcribe: handler entered"
         );
         // Probe duration and price BEFORE taking a hold: corrupt or
@@ -89,8 +92,7 @@ impl NoteTranscribeService {
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
-                filename: params.filename,
-                title: params.title,
+                format,
                 context: params.context,
                 language: params.language,
                 model: params.model_id.clone(),
@@ -130,8 +132,8 @@ pub struct NoteTranscribeParams {
     pub user_id: UserId,
     pub note_id: String,
     pub audio: Vec<u8>,
+    /// Used only to detect the audio container; never forwarded upstream.
     pub filename: String,
-    pub title: String,
     pub context: Option<String>,
     pub language: Option<String>,
     pub model_id: ModelId,


### PR DESCRIPTION
## Why

The privacy-claims audit found the one place where the "identifying metadata is stripped" claim didn't hold: the opt-in OpenAI transcription path forwarded the client-supplied **file name** verbatim as the multipart part name (`Part::bytes(..).file_name(request.filename)`), and the domain `TranscriptionRequest` carried the user's **note title** along for the ride even though no transcriber ever used it. The transcribe service also logged the raw file name into the TEE logs.

## What

Anonymization is now structural rather than a sanitization step: the domain request cannot carry what providers must not see.

- `TranscriptionRequest` drops `filename` and `title`, gaining `format: AudioFormat` (`Wav | Mp4`). A provider cannot leak metadata it never receives.
- `AudioFormat` owns the only strings that cross the boundary: the canonical part name (`audio.wav` / `audio.m4a`) and the mime type, derived purely from the container. Detection by extension uses the same m4a/mp4-else-wav rule the pipeline always had (the old `audio_mime` helper is deleted in favor of it).
- Both transcribers — OpenAI **and** Venice, so the property is uniform — now name the part canonically. What still crosses: the audio bytes, optional context prompt, optional language hint, and model id. That's the inference payload, nothing else.
- The note title is still accepted and validated at the HTTP layer (wire compatibility with shipped desktop builds) but stops at the handler with an explanatory comment.
- `note_transcribe` logs `audio_format = ?format` instead of `filename = %params.filename`, keeping user-named files out of server logs too.

The remaining distinction for opt-in OpenAI models is billing identity (OpenAI sees Open Software's API key as the customer, not Venice) plus OpenAI's own retention policy — which the in-app "anonymized" badge and the /verify page already describe accurately. Suggested landing-page wording: "requests carry no identifying metadata and our server proxy hides your IP" rather than "the provider sees Venice as the customer".

## Testing

- New wiremock regression test on the OpenAI path asserting the upstream multipart body names the part `audio.wav` with `Content-Type: audio/wav`; the Venice transcriber test now asserts the same canonical name.
- New domain tests pin the exact upstream strings and the container detection rules (case-insensitive m4a/mp4, extensionless fallback to wav).
- `cargo clippy --all-targets --all-features` zero warnings; `cargo fmt --check` clean; full workspace test suite passes (98 tests across crates).
- No wire-format changes for clients: the `title` form field is still accepted and required exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)