### PR TITLE
Add Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+June
+Copyright 2026 Open Software Network
+
+This product includes software developed by Open Software Network.
+
+Third-party license notices for bundled runtime components are documented in
+THIRD_PARTY_NOTICES.md.

--- a/README.md
+++ b/README.md
@@ -192,3 +192,9 @@ pnpm tauri:build
 
 Manual recording reliability checks are tracked in `specs/001-tauri-note-mvp/manual-validation.md`.
 Source-mode validation scenarios are tracked in `specs/002-system-audio-source-mode/quickstart.md`.
+
+## License
+
+June is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE).
+
+Bundled third-party runtime notices are tracked in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,20 @@
+# Third-party Notices
+
+June release artifacts may bundle third-party software. Keep upstream license
+and notice files with redistributed source or binary builds.
+
+## Hermes Agent
+
+Production desktop builds bundle Hermes Agent from
+<https://github.com/NousResearch/hermes-agent> at the commit pinned in
+`src-tauri/src/hermes_bridge.rs`. Hermes Agent is licensed under the MIT
+License.
+
+The Hermes bundle script preserves upstream license and notice files under
+`Contents/Resources/native/hermes/hermes-agent/` in the macOS app bundle and
+writes an index at
+`Contents/Resources/native/hermes/third_party_notices/THIRD_PARTY_NOTICES.txt`.
+
+The pinned Hermes Agent tarball currently includes additional license or notice
+files for bundled plugins and skills. Preserve those files when redistributing
+the bundled runtime.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "os-scribe",
   "version": "0.0.8",
   "private": true,
+  "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@9.15.4",
   "scripts": {

--- a/scribe-api/Cargo.toml
+++ b/scribe-api/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 version = "0.2.0"
 edition = "2024"
 rust-version = "1.95"
-license = "UNLICENSED"
+license = "Apache-2.0"
 authors = ["Open Software"]
 publish = false
 

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -101,6 +101,24 @@ for prune in tests website apps .github; do
   rm -rf "$out/hermes-agent/$prune"
 done
 
+hermes_license_files="$(find "$out/hermes-agent" -type f \( \
+  -name 'LICENSE' -o -name 'LICENSE.*' -o \
+  -name 'NOTICE' -o -name 'NOTICE.*' -o \
+  -name 'COPYING' -o -name 'COPYING.*' \
+\) | sort)"
+[ -f "$out/hermes-agent/LICENSE" ] || die "hermes-agent LICENSE missing from pinned tarball"
+[ -n "$hermes_license_files" ] || die "no Hermes license or notice files found"
+mkdir -p "$out/third_party_notices"
+{
+  printf 'Third-party notices for bundled Hermes runtime\n\n'
+  printf 'Hermes Agent source: %s\n' "$tarball_url"
+  printf 'Hermes Agent commit: %s\n\n' "$commit"
+  printf 'Preserved upstream license and notice files:\n'
+  while IFS= read -r license_file; do
+    printf -- '- hermes-agent/%s\n' "${license_file#$out/hermes-agent/}"
+  done <<<"$hermes_license_files"
+} > "$out/third_party_notices/THIRD_PARTY_NOTICES.txt"
+
 # The tarball has no prebuilt dashboard assets — on-device installs build them
 # in the "node-deps" stage. Build them here instead (vite outputs to
 # hermes_cli/web_dist per web/vite.config.ts) and drop node_modules afterwards.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ name = "os-scribe"
 version = "0.0.8"
 description = "June"
 authors = ["Open Software Network"]
+license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.80.0"
 


### PR DESCRIPTION
## Summary
- add Apache 2.0 LICENSE and NOTICE files
- mark npm and Rust packages as Apache-2.0
- document third-party runtime notices and make the Hermes bundler fail if upstream license files are missing

## Verification
- bash -n scripts/bundle-hermes-runtime.sh
- cargo metadata --manifest-path scribe-api/Cargo.toml --no-deps --format-version 1
- cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1
- pnpm exec prettier --check package.json README.md
- pnpm lint

Note: repo-wide pnpm format still fails on pre-existing unrelated formatting drift in src/components/account/TrialGate.tsx, src/components/agent/AgentWorkspace.tsx, src/components/onboarding/steps/LearnSteps.tsx, src/components/onboarding/steps/PrivacySteps.tsx, src/components/onboarding/steps/SignInStep.tsx, src/components/settings/AppSettings.tsx, src/lib/agent-chat-runtime.ts, src/test/agent-workspace.test.tsx, and src-tauri/tauri.conf.json.