### PR TITLE
File issue reports as Bug-tagged issues in os-platform

### DIFF
--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -13,10 +13,19 @@ image_repo = "ghcr.io/open-software-network/scribe-api"
 trust_center_url = "https://trust.phala.com/app/15f8d2fd586da8b99c6082b3c2cba64127ceeb8c"
 
 [issue_reports]
-# Webhook that receives user-submitted issue reports as a JSON POST. Often
-# embeds a secret token, so set it per environment via
-# SCRIBE__ISSUE_REPORTS__WEBHOOK_URL. Empty keeps reports in the structured
-# logs only.
+# Where user-submitted issue reports go, first match wins:
+# 1. os-platform issue tracker — reports become Issues tagged with
+#    os_platform_label in the configured Org/Project. The API key is a
+#    fellow key (osk_...) of a bot user that is a member of that Org;
+#    set it per environment via SCRIBE__ISSUE_REPORTS__OS_PLATFORM_API_KEY.
+# 2. Webhook — each report as a JSON POST. Often embeds a secret token, so
+#    set it per environment via SCRIBE__ISSUE_REPORTS__WEBHOOK_URL.
+# 3. Neither configured: reports land in the structured logs only.
+os_platform_api_url = ""
+os_platform_api_key = ""
+os_platform_org = ""
+os_platform_project = ""
+os_platform_label = "bug"
 webhook_url = ""
 
 [os_accounts]

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -26,6 +26,9 @@ os_platform_api_key = ""
 os_platform_org = ""
 os_platform_project = ""
 os_platform_label = "bug"
+# Reward asset for the zero-reward Issue (required when the target Org has
+# no default reward asset configured).
+os_platform_reward_asset = ""
 webhook_url = ""
 
 [os_accounts]

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -3,8 +3,8 @@ use scribe_api::{ApiLimits, ApiState, ApiStateParams, AttestationInfo};
 use scribe_config::{AppConfig, ModelPriceConfig, ModelProvider};
 use scribe_providers::{
     JwksTokenVerifier, LogIssueReportSink, MultiFormatDurationProbe, OsAccountsHttpClient,
-    RoutingTranscriber, VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog,
-    WebhookIssueReportSink, default_client, jwks_client,
+    OsPlatformIssueReportSink, RoutingTranscriber, VeniceAgentChat, VeniceCleaner, VeniceGenerator,
+    VeniceModelCatalog, WebhookIssueReportSink, default_client, jwks_client,
 };
 use scribe_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps,
@@ -103,11 +103,16 @@ fn build_router(
         JwksTokenVerifier::from_config(jwks_client(), &config.os_accounts),
     );
     let issue_reports: Arc<dyn scribe_domain::IssueReportSink> = if let Some(sink) =
+        OsPlatformIssueReportSink::from_config(http.clone(), &config.issue_reports)
+    {
+        tracing::info!("issue reports will be filed as os-platform issues");
+        Arc::new(sink)
+    } else if let Some(sink) =
         WebhookIssueReportSink::from_config(http.clone(), &config.issue_reports)
     {
         Arc::new(sink)
     } else {
-        tracing::info!("no issue report webhook configured; reports will be logged only");
+        tracing::info!("no issue report sink configured; reports will be logged only");
         Arc::new(LogIssueReportSink)
     };
 

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -36,16 +36,53 @@ impl Debug for AppConfig {
     }
 }
 
-/// Where user-submitted issue reports get forwarded. Defaults to empty so the
-/// section is optional: without a webhook, reports land in the structured
-/// logs only.
-#[derive(Clone, Default, Deserialize, Serialize)]
+/// Where user-submitted issue reports get forwarded. Every section is
+/// optional: with os-platform configured, reports become Issues in the
+/// tracker; else with a webhook, a JSON POST; else they land in the
+/// structured logs only.
+#[derive(Clone, Deserialize, Serialize)]
 pub struct IssueReportsConfig {
     /// Receives each report as a JSON POST. Often embeds a secret token
     /// (Slack/Discord-style webhooks), hence the redacted Debug. Set via
     /// `SCRIBE__ISSUE_REPORTS__WEBHOOK_URL`.
     #[serde(default)]
     pub webhook_url: String,
+    /// Base URL of the os-platform (fellow) API, e.g.
+    /// `https://api.platform.opensoftware.co`. Empty disables the
+    /// tracker sink. `SCRIBE__ISSUE_REPORTS__OS_PLATFORM_API_URL`.
+    #[serde(default)]
+    pub os_platform_api_url: String,
+    /// fellow API key (`osk_…`) of the reporting bot user — that user
+    /// must be a member of the target Org/Project. Redacted Debug.
+    /// `SCRIBE__ISSUE_REPORTS__OS_PLATFORM_API_KEY`.
+    #[serde(default)]
+    pub os_platform_api_key: String,
+    /// Target Org handle (or opaque `org_…` id).
+    #[serde(default)]
+    pub os_platform_org: String,
+    /// Target Project handle (or opaque `prj_…` id).
+    #[serde(default)]
+    pub os_platform_project: String,
+    /// Label slug attached to every report Issue.
+    #[serde(default = "default_issue_report_label")]
+    pub os_platform_label: String,
+}
+
+fn default_issue_report_label() -> String {
+    "bug".to_string()
+}
+
+impl Default for IssueReportsConfig {
+    fn default() -> Self {
+        Self {
+            webhook_url: String::new(),
+            os_platform_api_url: String::new(),
+            os_platform_api_key: String::new(),
+            os_platform_org: String::new(),
+            os_platform_project: String::new(),
+            os_platform_label: default_issue_report_label(),
+        }
+    }
 }
 
 impl Debug for IssueReportsConfig {
@@ -60,6 +97,18 @@ impl Debug for IssueReportsConfig {
                     &REDACTED
                 },
             )
+            .field("os_platform_api_url", &self.os_platform_api_url)
+            .field(
+                "os_platform_api_key",
+                if self.os_platform_api_key.is_empty() {
+                    &"<unset>"
+                } else {
+                    &REDACTED
+                },
+            )
+            .field("os_platform_org", &self.os_platform_org)
+            .field("os_platform_project", &self.os_platform_project)
+            .field("os_platform_label", &self.os_platform_label)
             .finish()
     }
 }

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -66,6 +66,12 @@ pub struct IssueReportsConfig {
     /// Label slug attached to every report Issue.
     #[serde(default = "default_issue_report_label")]
     pub os_platform_label: String,
+    /// Reward asset symbol for the zero-reward Issue (e.g. "POINTS").
+    /// Issues are bounties under the hood, and creation fails when neither
+    /// the Project nor the Org has a default reward asset — naming one here
+    /// sidesteps that. Empty omits the field and relies on the defaults.
+    #[serde(default)]
+    pub os_platform_reward_asset: String,
 }
 
 fn default_issue_report_label() -> String {
@@ -81,6 +87,7 @@ impl Default for IssueReportsConfig {
             os_platform_org: String::new(),
             os_platform_project: String::new(),
             os_platform_label: default_issue_report_label(),
+            os_platform_reward_asset: String::new(),
         }
     }
 }
@@ -109,6 +116,7 @@ impl Debug for IssueReportsConfig {
             .field("os_platform_org", &self.os_platform_org)
             .field("os_platform_project", &self.os_platform_project)
             .field("os_platform_label", &self.os_platform_label)
+            .field("os_platform_reward_asset", &self.os_platform_reward_asset)
             .finish()
     }
 }

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -5,13 +5,13 @@ use scribe_domain::{DomainError, IssueReport, IssueReportSink};
 use serde::{Deserialize, Serialize};
 
 /// Files issue reports as Issues in the os-platform tracker, tagged with the
-/// configured label (default `bug`). Attachments are uploaded first
-/// (best-effort — an unreadable upload never blocks the report; the names
-/// are listed in the body either way), then the Issue is created with
-/// `type: bug` and the label attached atomically. If the label doesn't exist
-/// in the target Project yet, the sink creates it once and retries; if even
-/// that fails, the Issue is filed without the label rather than dropping the
-/// report.
+/// configured label (default `bug`). Uses only os-platform's stock API:
+/// attachments are uploaded first (best-effort — a failed upload never
+/// blocks the report; the names are listed in the body either way), the
+/// Issue is created with `type: bug`, and the label is attached afterwards
+/// via the labels PUT — creating the label in the Project the first time.
+/// Every step after the create is best-effort: an Issue without its tag
+/// beats a lost report.
 pub struct OsPlatformIssueReportSink {
     http: reqwest::Client,
     api_url: String,
@@ -37,6 +37,8 @@ struct FellowFile {
 #[derive(Deserialize)]
 struct FellowIssue {
     external_id: String,
+    /// The labels PUT addresses the Issue by its per-Org number.
+    number_in_org: i64,
 }
 
 impl OsPlatformIssueReportSink {
@@ -110,20 +112,13 @@ impl OsPlatformIssueReportSink {
         &self,
         report: &IssueReport,
         file_ids: &[String],
-        with_label: bool,
     ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
-        let label_slugs: Vec<&str> = if with_label && !self.label.is_empty() {
-            vec![self.label.as_str()]
-        } else {
-            Vec::new()
-        };
         let body = serde_json::json!({
             "title": issue_title(&report.description),
             "body_markdown": issue_body(report),
             "reward_amount_units": "0",
             "type": "bug",
             "status": "todo",
-            "label_slugs": label_slugs,
             "file_ids": file_ids,
         });
         self.http
@@ -145,6 +140,30 @@ impl OsPlatformIssueReportSink {
                 tracing::error!(%error, "issue_reports: os-platform returned a malformed envelope");
                 DomainError::UpstreamProvider
             })
+    }
+
+    /// Attaches the configured label via the labels PUT (set-replace; a
+    /// just-created Issue has no labels to clobber). Returns the envelope
+    /// so the caller can spot the label-doesn't-exist rejection.
+    async fn put_label(&self, number_in_org: i64) -> Option<FellowEnvelope<serde_json::Value>> {
+        let body = serde_json::json!({ "label_slugs": [self.label] });
+        let response = self
+            .http
+            .put(format!(
+                "{}/v1/orgs/{}/bounties/{}/labels",
+                self.api_url, self.org, number_in_org
+            ))
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await;
+        match response {
+            Ok(response) => response.json().await.ok(),
+            Err(error) => {
+                tracing::warn!(%error, "issue_reports: label request failed");
+                None
+            }
+        }
     }
 
     /// Creates the configured label in the target Project. The color is
@@ -174,6 +193,34 @@ impl OsPlatformIssueReportSink {
             }
         }
     }
+
+    /// Best-effort tagging after the Issue exists. First report into a
+    /// Project: the label won't exist yet, so the missing-label rejection
+    /// creates it and retries once. Failure here never fails the delivery —
+    /// the Issue is already filed (and carries `type: bug` regardless).
+    async fn tag_issue(&self, number_in_org: i64) {
+        if self.label.is_empty() {
+            return;
+        }
+        let attached = match self.put_label(number_in_org).await {
+            Some(envelope) if envelope.success => true,
+            Some(envelope) if envelope.message.as_deref().is_some_and(is_missing_label) => {
+                self.ensure_label().await
+                    && self
+                        .put_label(number_in_org)
+                        .await
+                        .is_some_and(|retry| retry.success)
+            }
+            _ => false,
+        };
+        if !attached {
+            tracing::warn!(
+                number_in_org,
+                label = %self.label,
+                "issue_reports: issue filed but the label could not be attached"
+            );
+        }
+    }
 }
 
 #[async_trait]
@@ -181,17 +228,7 @@ impl IssueReportSink for OsPlatformIssueReportSink {
     async fn deliver(&self, report: IssueReport) -> Result<(), DomainError> {
         let file_ids = self.upload_attachments(&report).await;
 
-        let mut envelope = self.create_issue(&report, &file_ids, true).await?;
-        if !envelope.success && envelope.message.as_deref().is_some_and(is_missing_label) {
-            // First report into this Project: the label doesn't exist yet.
-            // Create it and retry once; if the label can't be created, file
-            // the Issue without it — losing the tag beats losing the report.
-            let labeled = self.ensure_label().await;
-            envelope = self.create_issue(&report, &file_ids, labeled).await?;
-            if !envelope.success && labeled {
-                envelope = self.create_issue(&report, &file_ids, false).await?;
-            }
-        }
+        let envelope = self.create_issue(&report, &file_ids).await?;
         if !envelope.success {
             tracing::error!(
                 message = envelope.message.as_deref().unwrap_or(""),
@@ -199,11 +236,12 @@ impl IssueReportSink for OsPlatformIssueReportSink {
             );
             return Err(DomainError::UpstreamProvider);
         }
+        let issue = envelope.data.as_ref();
+        if let Some(issue) = issue {
+            self.tag_issue(issue.number_in_org).await;
+        }
         tracing::info!(
-            issue = envelope
-                .data
-                .as_ref()
-                .map_or("", |issue| issue.external_id.as_str()),
+            issue = issue.map_or("", |issue| issue.external_id.as_str()),
             user_id = %report.user_id.0,
             attachments = file_ids.len(),
             "issue_reports: report filed as an os-platform issue"
@@ -522,7 +560,14 @@ mod os_platform_tests {
 
     fn issue_created() -> ResponseTemplate {
         ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "data": { "external_id": "OSN-7" },
+            "data": { "external_id": "OSN-7", "number_in_org": 7 },
+            "success": true,
+        }))
+    }
+
+    fn labels_set() -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "external_id": "OSN-7", "number_in_org": 7 },
             "success": true,
         }))
     }
@@ -571,10 +616,18 @@ mod os_platform_tests {
                 "reward_amount_units": "0",
                 "type": "bug",
                 "status": "todo",
-                "label_slugs": ["bug"],
                 "file_ids": ["fil_1"],
             })))
             .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(body_partial_json(serde_json::json!({
+                "label_slugs": ["bug"],
+            })))
+            .respond_with(labels_set())
             .expect(1)
             .mount(&server)
             .await;
@@ -590,11 +643,19 @@ mod os_platform_tests {
             .respond_with(ResponseTemplate::new(500))
             .mount(&server)
             .await;
-        // First create: label unknown. After the label is created, the retry
-        // succeeds — and the attachment-upload failure above never blocked
-        // the report (file_ids just ends up empty).
+        // The attachment-upload failure above never blocks the report —
+        // file_ids just ends up empty.
         Mock::given(method("POST"))
             .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(body_partial_json(serde_json::json!({ "file_ids": [] })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        // First labels PUT: the label doesn't exist in the Project yet.
+        // After the label create, the retried PUT lands.
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/open-software/bounties/7/labels"))
             .respond_with(label_missing())
             .up_to_n_times(1)
             .mount(&server)
@@ -612,13 +673,9 @@ mod os_platform_tests {
             .expect(1)
             .mount(&server)
             .await;
-        Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
-            .and(body_partial_json(serde_json::json!({
-                "label_slugs": ["bug"],
-                "file_ids": [],
-            })))
-            .respond_with(issue_created())
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .respond_with(labels_set())
             .expect(1)
             .mount(&server)
             .await;
@@ -627,7 +684,7 @@ mod os_platform_tests {
     }
 
     #[tokio::test]
-    async fn os_platform_sink_files_unlabelled_when_the_label_cannot_be_created() {
+    async fn os_platform_sink_keeps_the_issue_when_the_label_cannot_be_attached() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/files"))
@@ -636,8 +693,13 @@ mod os_platform_tests {
             .await;
         Mock::given(method("POST"))
             .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/open-software/bounties/7/labels"))
             .respond_with(label_missing())
-            .up_to_n_times(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
@@ -645,14 +707,9 @@ mod os_platform_tests {
             .respond_with(ResponseTemplate::new(403))
             .mount(&server)
             .await;
-        Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
-            .and(body_partial_json(serde_json::json!({ "label_slugs": [] })))
-            .respond_with(issue_created())
-            .expect(1)
-            .mount(&server)
-            .await;
 
+        // The Issue exists; a permanently missing label must not fail the
+        // delivery (the report would be re-shown to the user as unsent).
         assert!(sink(&server).deliver(report()).await.is_ok());
     }
 

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -2,7 +2,279 @@ use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use scribe_config::IssueReportsConfig;
 use scribe_domain::{DomainError, IssueReport, IssueReportSink};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+
+/// Files issue reports as Issues in the os-platform tracker, tagged with the
+/// configured label (default `bug`). Attachments are uploaded first
+/// (best-effort — an unreadable upload never blocks the report; the names
+/// are listed in the body either way), then the Issue is created with
+/// `type: bug` and the label attached atomically. If the label doesn't exist
+/// in the target Project yet, the sink creates it once and retries; if even
+/// that fails, the Issue is filed without the label rather than dropping the
+/// report.
+pub struct OsPlatformIssueReportSink {
+    http: reqwest::Client,
+    api_url: String,
+    api_key: String,
+    org: String,
+    project: String,
+    label: String,
+}
+
+/// fellow's `ApiResponse` envelope — same shape as ours.
+#[derive(Deserialize)]
+struct FellowEnvelope<T> {
+    data: Option<T>,
+    success: bool,
+    message: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct FellowFile {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct FellowIssue {
+    external_id: String,
+}
+
+impl OsPlatformIssueReportSink {
+    /// `None` when the tracker isn't configured — the caller falls through
+    /// to the webhook/log sinks.
+    pub fn from_config(http: reqwest::Client, config: &IssueReportsConfig) -> Option<Self> {
+        let api_url = config.os_platform_api_url.trim();
+        let api_key = config.os_platform_api_key.trim();
+        let org = config.os_platform_org.trim();
+        let project = config.os_platform_project.trim();
+        if api_url.is_empty() || api_key.is_empty() || org.is_empty() || project.is_empty() {
+            return None;
+        }
+        Some(Self {
+            http,
+            api_url: api_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            org: org.to_string(),
+            project: project.to_string(),
+            label: config.os_platform_label.trim().to_string(),
+        })
+    }
+
+    async fn upload_attachments(&self, report: &IssueReport) -> Vec<String> {
+        let mut file_ids = Vec::new();
+        for attachment in &report.attachments {
+            let part = match reqwest::multipart::Part::bytes(attachment.bytes.clone())
+                .file_name(attachment.name.clone())
+                .mime_str(&attachment.content_type)
+            {
+                Ok(part) => part,
+                Err(error) => {
+                    tracing::warn!(%error, name = %attachment.name, "issue_reports: skipping attachment with invalid content type");
+                    continue;
+                }
+            };
+            let form = reqwest::multipart::Form::new().part("file", part);
+            let uploaded: Result<FellowEnvelope<FellowFile>, _> = async {
+                self.http
+                    .post(format!("{}/v1/files", self.api_url))
+                    .bearer_auth(&self.api_key)
+                    .multipart(form)
+                    .send()
+                    .await?
+                    .json::<FellowEnvelope<FellowFile>>()
+                    .await
+            }
+            .await;
+            match uploaded {
+                Ok(envelope) if envelope.success => {
+                    if let Some(file) = envelope.data {
+                        file_ids.push(file.id);
+                    }
+                }
+                Ok(envelope) => {
+                    tracing::warn!(
+                        message = envelope.message.as_deref().unwrap_or(""),
+                        name = %attachment.name,
+                        "issue_reports: os-platform rejected attachment upload"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(%error, name = %attachment.name, "issue_reports: attachment upload failed");
+                }
+            }
+        }
+        file_ids
+    }
+
+    async fn create_issue(
+        &self,
+        report: &IssueReport,
+        file_ids: &[String],
+        with_label: bool,
+    ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
+        let label_slugs: Vec<&str> = if with_label && !self.label.is_empty() {
+            vec![self.label.as_str()]
+        } else {
+            Vec::new()
+        };
+        let body = serde_json::json!({
+            "title": issue_title(&report.description),
+            "body_markdown": issue_body(report),
+            "reward_amount_units": "0",
+            "type": "bug",
+            "status": "todo",
+            "label_slugs": label_slugs,
+            "file_ids": file_ids,
+        });
+        self.http
+            .post(format!(
+                "{}/v1/orgs/{}/projects/{}/bounties",
+                self.api_url, self.org, self.project
+            ))
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, "issue_reports: os-platform transport error");
+                DomainError::UpstreamProvider
+            })?
+            .json::<FellowEnvelope<FellowIssue>>()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, "issue_reports: os-platform returned a malformed envelope");
+                DomainError::UpstreamProvider
+            })
+    }
+
+    /// Creates the configured label in the target Project. The color is
+    /// fixed; an "already exists" rejection is fine — the retry will
+    /// resolve the slug either way.
+    async fn ensure_label(&self) -> bool {
+        let body = serde_json::json!({
+            "name": "Bug",
+            "color": "#ef4444",
+            "slug": self.label,
+        });
+        let response = self
+            .http
+            .post(format!(
+                "{}/v1/orgs/{}/projects/{}/labels",
+                self.api_url, self.org, self.project
+            ))
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await;
+        match response {
+            Ok(response) => response.status().is_success(),
+            Err(error) => {
+                tracing::warn!(%error, "issue_reports: could not create the report label");
+                false
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl IssueReportSink for OsPlatformIssueReportSink {
+    async fn deliver(&self, report: IssueReport) -> Result<(), DomainError> {
+        let file_ids = self.upload_attachments(&report).await;
+
+        let mut envelope = self.create_issue(&report, &file_ids, true).await?;
+        if !envelope.success && envelope.message.as_deref().is_some_and(is_missing_label) {
+            // First report into this Project: the label doesn't exist yet.
+            // Create it and retry once; if the label can't be created, file
+            // the Issue without it — losing the tag beats losing the report.
+            let labeled = self.ensure_label().await;
+            envelope = self.create_issue(&report, &file_ids, labeled).await?;
+            if !envelope.success && labeled {
+                envelope = self.create_issue(&report, &file_ids, false).await?;
+            }
+        }
+        if !envelope.success {
+            tracing::error!(
+                message = envelope.message.as_deref().unwrap_or(""),
+                "issue_reports: os-platform rejected the issue"
+            );
+            return Err(DomainError::UpstreamProvider);
+        }
+        tracing::info!(
+            issue = envelope
+                .data
+                .as_ref()
+                .map_or("", |issue| issue.external_id.as_str()),
+            user_id = %report.user_id.0,
+            attachments = file_ids.len(),
+            "issue_reports: report filed as an os-platform issue"
+        );
+        Ok(())
+    }
+}
+
+fn is_missing_label(message: &str) -> bool {
+    message.contains("label(s) not found")
+}
+
+const ISSUE_TITLE_MAX_CHARS: usize = 120;
+
+/// First line of the description, truncated on a char boundary. The full
+/// description is always in the body.
+fn issue_title(description: &str) -> String {
+    let first_line = description
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("(no description)");
+    let mut title = String::with_capacity(ISSUE_TITLE_MAX_CHARS + 16);
+    title.push_str("June report: ");
+    for (count, ch) in first_line.chars().enumerate() {
+        if count >= ISSUE_TITLE_MAX_CHARS {
+            title.push('…');
+            break;
+        }
+        title.push(ch);
+    }
+    title
+}
+
+fn issue_body(report: &IssueReport) -> String {
+    use std::fmt::Write as _;
+
+    let mut body = String::new();
+    body.push_str("## Report\n\n");
+    body.push_str(report.description.trim());
+    body.push('\n');
+    if let Some(diagnosis) = report
+        .agent_diagnosis
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body.push_str("\n## Agent diagnosis\n\n");
+        body.push_str(diagnosis);
+        body.push('\n');
+    }
+    body.push_str("\n## Metadata\n\n");
+    let _ = writeln!(body, "- Reporter: `{}`", report.user_id.0);
+    if let Some(session_id) = report.session_id.as_deref().filter(|v| !v.is_empty()) {
+        let _ = writeln!(body, "- Session: `{session_id}`");
+    }
+    if let Some(version) = report.app_version.as_deref().filter(|v| !v.is_empty()) {
+        let _ = writeln!(body, "- App version: {version}");
+    }
+    if let Some(platform) = report.platform.as_deref().filter(|v| !v.is_empty()) {
+        let _ = writeln!(body, "- Platform: {platform}");
+    }
+    if !report.attachment_names.is_empty() {
+        let _ = writeln!(
+            body,
+            "- Attachments named by the user: {}",
+            report.attachment_names.join(", ")
+        );
+    }
+    body
+}
 
 /// Forwards issue reports as a JSON POST to the configured webhook.
 pub struct WebhookIssueReportSink {
@@ -151,6 +423,7 @@ mod tests {
     fn from_config_requires_a_webhook_url() {
         let config = IssueReportsConfig {
             webhook_url: "  ".to_string(),
+            ..Default::default()
         };
         assert!(WebhookIssueReportSink::from_config(reqwest::Client::new(), &config).is_none());
     }
@@ -178,6 +451,7 @@ mod tests {
 
         let config = IssueReportsConfig {
             webhook_url: format!("{}/hook", server.uri()),
+            ..Default::default()
         };
         let sink = WebhookIssueReportSink::from_config(reqwest::Client::new(), &config)
             .expect("configured sink");
@@ -195,6 +469,7 @@ mod tests {
 
         let config = IssueReportsConfig {
             webhook_url: server.uri(),
+            ..Default::default()
         };
         let sink = WebhookIssueReportSink::from_config(reqwest::Client::new(), &config)
             .expect("configured sink");
@@ -203,5 +478,204 @@ mod tests {
             sink.deliver(report()).await,
             Err(DomainError::UpstreamProvider)
         );
+    }
+}
+
+#[cfg(test)]
+mod os_platform_tests {
+    use super::*;
+    use scribe_domain::UserId;
+    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn report() -> IssueReport {
+        IssueReport {
+            user_id: UserId("usr_test".to_string()),
+            description: "The recorder freezes\nwhen I pause it".to_string(),
+            agent_diagnosis: Some("Likely the audio capture thread".to_string()),
+            attachment_names: vec!["screenshot.png".to_string()],
+            attachments: vec![scribe_domain::IssueReportAttachment {
+                name: "screenshot.png".to_string(),
+                content_type: "image/png".to_string(),
+                bytes: b"png-bytes".to_vec(),
+            }],
+            session_id: Some("session-1".to_string()),
+            app_version: Some("0.0.7".to_string()),
+            platform: Some("macos".to_string()),
+        }
+    }
+
+    fn config(api_url: &str) -> IssueReportsConfig {
+        IssueReportsConfig {
+            os_platform_api_url: api_url.to_string(),
+            os_platform_api_key: "osk_test".to_string(),
+            os_platform_org: "open-software".to_string(),
+            os_platform_project: "june".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn sink(server: &MockServer) -> OsPlatformIssueReportSink {
+        OsPlatformIssueReportSink::from_config(reqwest::Client::new(), &config(&server.uri()))
+            .expect("configured sink")
+    }
+
+    fn issue_created() -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": { "external_id": "OSN-7" },
+            "success": true,
+        }))
+    }
+
+    fn label_missing() -> ResponseTemplate {
+        ResponseTemplate::new(422).set_body_json(serde_json::json!({
+            "data": null,
+            "success": false,
+            "error_code": 4201,
+            "message": "label(s) not found in project: bug",
+        }))
+    }
+
+    #[test]
+    fn os_platform_sink_requires_full_config() {
+        let mut incomplete = config("https://fellow.test");
+        incomplete.os_platform_api_key = String::new();
+        assert!(
+            OsPlatformIssueReportSink::from_config(reqwest::Client::new(), &incomplete).is_none()
+        );
+        assert!(
+            OsPlatformIssueReportSink::from_config(
+                reqwest::Client::new(),
+                &IssueReportsConfig::default()
+            )
+            .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_files_a_bug_tagged_issue_with_attachments() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "id": "fil_1" },
+                "success": true,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(body_partial_json(serde_json::json!({
+                "title": "June report: The recorder freezes",
+                "reward_amount_units": "0",
+                "type": "bug",
+                "status": "todo",
+                "label_slugs": ["bug"],
+                "file_ids": ["fil_1"],
+            })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(sink(&server).deliver(report()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_creates_the_label_on_first_use() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        // First create: label unknown. After the label is created, the retry
+        // succeeds — and the attachment-upload failure above never blocked
+        // the report (file_ids just ends up empty).
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(label_missing())
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/labels"))
+            .and(body_partial_json(serde_json::json!({
+                "name": "Bug",
+                "slug": "bug",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "slug": "bug" },
+                "success": true,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(body_partial_json(serde_json::json!({
+                "label_slugs": ["bug"],
+                "file_ids": [],
+            })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(sink(&server).deliver(report()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_files_unlabelled_when_the_label_cannot_be_created() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(label_missing())
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/labels"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(body_partial_json(serde_json::json!({ "label_slugs": [] })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(sink(&server).deliver(report()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_surfaces_rejections_as_upstream_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "data": null,
+                "success": false,
+                "error_code": 3001,
+                "message": "caller is not an org member",
+            })))
+            .mount(&server)
+            .await;
+
+        let result = sink(&server).deliver(report()).await;
+        assert!(matches!(result, Err(DomainError::UpstreamProvider)));
     }
 }

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -261,13 +261,31 @@ fn is_missing_label(message: &str) -> bool {
 
 const ISSUE_TITLE_MAX_CHARS: usize = 120;
 
-/// First line of the description, truncated on a char boundary. The full
-/// description is always in the body.
+/// Strips the report form's field labels so a line's *content* drives the
+/// title: "What happened: X" yields "X", and a bare label line yields ""
+/// (and is skipped by the caller).
+fn report_line_content(line: &str) -> &str {
+    for label in ["What happened:", "What I expected:"] {
+        if let Some(rest) = line.strip_prefix(label) {
+            return rest.trim();
+        }
+    }
+    if line.starts_with("Extra details") {
+        return line.rsplit_once(':').map_or("", |(_, rest)| rest.trim());
+    }
+    line
+}
+
+/// Title from the report's content, truncated on a char boundary. The
+/// app's report form opens with a canned intro and field labels; the first
+/// line with actual content wins. The full description is always in the
+/// body.
 fn issue_title(description: &str) -> String {
     let first_line = description
         .lines()
         .map(str::trim)
-        .find(|line| !line.is_empty())
+        .map(report_line_content)
+        .find(|line| !line.is_empty() && *line != "I want to report an issue with June.")
         .unwrap_or("(no description)");
     let mut title = String::with_capacity(ISSUE_TITLE_MAX_CHARS + 16);
     title.push_str("June report: ");
@@ -520,6 +538,38 @@ mod tests {
         assert_eq!(
             sink.deliver(report()).await,
             Err(DomainError::UpstreamProvider)
+        );
+    }
+}
+
+#[cfg(test)]
+mod issue_title_tests {
+    use super::issue_title;
+
+    #[test]
+    fn title_prefers_the_what_happened_line() {
+        let description = "I want to report an issue with June.\n\nWhat happened: recorder freezes on pause\n\nWhat I expected:\n";
+        assert_eq!(
+            issue_title(description),
+            "June report: recorder freezes on pause"
+        );
+    }
+
+    #[test]
+    fn title_skips_the_canned_intro_when_what_happened_is_empty() {
+        let description =
+            "I want to report an issue with June.\n\nWhat happened:\n\nIt crashed twice today.";
+        assert_eq!(
+            issue_title(description),
+            "June report: It crashed twice today."
+        );
+    }
+
+    #[test]
+    fn title_falls_back_for_free_form_reports() {
+        assert_eq!(
+            issue_title("The recorder freezes\nwhen I pause it"),
+            "June report: The recorder freezes"
         );
     }
 }

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -19,6 +19,7 @@ pub struct OsPlatformIssueReportSink {
     org: String,
     project: String,
     label: String,
+    reward_asset: String,
 }
 
 /// fellow's `ApiResponse` envelope — same shape as ours.
@@ -59,6 +60,7 @@ impl OsPlatformIssueReportSink {
             org: org.to_string(),
             project: project.to_string(),
             label: config.os_platform_label.trim().to_string(),
+            reward_asset: config.os_platform_reward_asset.trim().to_string(),
         })
     }
 
@@ -113,7 +115,7 @@ impl OsPlatformIssueReportSink {
         report: &IssueReport,
         file_ids: &[String],
     ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "title": issue_title(&report.description),
             "body_markdown": issue_body(report),
             "reward_amount_units": "0",
@@ -121,6 +123,9 @@ impl OsPlatformIssueReportSink {
             "status": "todo",
             "file_ids": file_ids,
         });
+        if !self.reward_asset.is_empty() {
+            body["asset_symbol"] = serde_json::Value::String(self.reward_asset.clone());
+        }
         self.http
             .post(format!(
                 "{}/v1/orgs/{}/projects/{}/bounties",
@@ -549,6 +554,7 @@ mod os_platform_tests {
             os_platform_api_key: "osk_test".to_string(),
             os_platform_org: "open-software".to_string(),
             os_platform_project: "june".to_string(),
+            os_platform_reward_asset: "POINTS".to_string(),
             ..Default::default()
         }
     }
@@ -614,6 +620,7 @@ mod os_platform_tests {
             .and(body_partial_json(serde_json::json!({
                 "title": "June report: The recorder freezes",
                 "reward_amount_units": "0",
+                "asset_symbol": "POINTS",
                 "type": "bug",
                 "status": "todo",
                 "file_ids": ["fil_1"],

--- a/scribe-api/crates/providers/src/lib.rs
+++ b/scribe-api/crates/providers/src/lib.rs
@@ -16,7 +16,7 @@ mod transcription;
 
 pub use audio_probe::MultiFormatDurationProbe;
 pub use http::{default_client, jwks_client};
-pub use issue_reports::{LogIssueReportSink, WebhookIssueReportSink};
+pub use issue_reports::{LogIssueReportSink, OsPlatformIssueReportSink, WebhookIssueReportSink};
 pub use jwks::{JwksTokenVerifier, JwksTokenVerifierParams};
 pub use m4a_probe::{M4aDurationProbe, M4aProbeError};
 pub use openai::OpenAiTranscriber;


### PR DESCRIPTION
## Why

In-app bug reports tell the user "this is being sent to the June team", but server-side they only went to a generic webhook — or, with none configured, the structured logs. This makes the pipeline real: every report becomes an **Issue in the os-platform tracker, tagged `bug`**, with the agent's diagnosis and the report metadata attached.

**Uses only os-platform's stock API — no platform-side changes required** (the earlier create-time `label_slugs` companion, os-platform#72, was deliberately dropped).

## What

**New `OsPlatformIssueReportSink`** (implements the existing `IssueReportSink` port):

1. **Attachments upload first** to `POST /v1/files` — best-effort: an unreadable/oversized/rejected upload never blocks the report, and the user's attachment names are listed in the body either way.
2. **Issue created** at `POST /v1/orgs/{org}/projects/{project}/bounties` with `type: bug`, `status: todo`, `reward_amount_units: "0"`, and the uploaded `file_ids`. Title is the report's first line (`June report: …`, char-boundary truncated); body carries the description, the agent diagnosis, and a metadata section (reporter, session, app version, platform).
3. **Bug tag attached second** via the existing `PUT /v1/orgs/{org}/bounties/{number}/labels` (set-replace is safe on a just-created Issue — nothing to clobber). First report into a Project: the label doesn't exist yet, so the missing-label rejection creates it (`Bug`, `#ef4444`) and retries once. Tagging is **best-effort after the Issue exists** — a permanently denied label logs a warning but never fails the delivery, because failing would re-show the report to the user as unsent while the Issue already sits in the tracker (and it carries `type: bug` regardless).

**Sink selection** in `main.rs`: os-platform when configured → webhook → log-only, first match wins.

**Config** (`[issue_reports]`, documented in config.toml): `os_platform_api_url`, `os_platform_api_key` (fellow `osk_…` key, env-only, redacted Debug), `os_platform_org`, `os_platform_project`, `os_platform_label` (default `bug`). All default-empty, so existing deployments are untouched until configured.

## Ops notes

The `osk_` key belongs to a **bot user**: create a dedicated OS Accounts account, sign it into os-platform once, invite it to the target Org (member role suffices), then as the bot `POST /v1/me/api-keys` — the plaintext key is returned exactly once.

## Tests

wiremock coverage: happy path (attachment uploaded, issue created, labels PUT asserted on the wire), first-use label creation + PUT retry, label-attachment-denied → delivery still succeeds, create rejection → upstream error, config gating. Full scribe-api suite (100 tests), clippy, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)