### PR TITLE
Add routine run history under the Routines tab

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -195,9 +195,12 @@ export function App() {
   const [moveDialogSessionId, setMoveDialogSessionId] = useState<string | null>(
     null,
   );
-  // The project an open agent session was drilled into from — drives the
-  // breadcrumb above the agent workspace, mirroring notes-from-folder.
-  const [agentOriginFolderId, setAgentOriginFolderId] = useState<string>();
+  // Where an open agent session was drilled into from — a project or the
+  // Routines run history — drives the breadcrumb above the agent workspace,
+  // mirroring notes-from-folder.
+  const [agentOrigin, setAgentOrigin] = useState<
+    { kind: "project"; folderId: string } | { kind: "routines" }
+  >();
   // Set when "New session" is started from a project: the next brand-new
   // session AgentWorkspace selects gets filed into that project.
   const pendingSessionProjectRef = useRef<{
@@ -301,9 +304,10 @@ export function App() {
   const originFolder = originFolderId
     ? state.folders.find((folder) => folder.id === originFolderId)
     : undefined;
-  const agentOriginFolder = agentOriginFolderId
-    ? state.folders.find((folder) => folder.id === agentOriginFolderId)
-    : undefined;
+  const agentOriginFolder =
+    agentOrigin?.kind === "project"
+      ? state.folders.find((folder) => folder.id === agentOrigin.folderId)
+      : undefined;
   const recoveriesByNote = useMemo(() => {
     const map = new Map<string, (typeof state.activeRecoveries)[number]>();
     for (const recovery of state.activeRecoveries) {
@@ -433,7 +437,7 @@ export function App() {
 
   useEffect(() => {
     function openAgentWorkspace(session?: HermesSessionInfo) {
-      setAgentOriginFolderId(undefined);
+      setAgentOrigin(undefined);
       setActiveAgentSession(session);
       setActiveView("agent");
     }
@@ -464,7 +468,7 @@ export function App() {
   useEffect(() => {
     function handleReply(detail?: AgentReplyDetail) {
       if (!detail?.text.trim()) return;
-      setAgentOriginFolderId(undefined);
+      setAgentOrigin(undefined);
       setActiveAgentSession(detail.session);
       setPendingAgentReply(detail);
       setActiveView("agent");
@@ -587,7 +591,7 @@ export function App() {
         } else {
           // User switched to an existing session — abandon the pending
           // project intent so the workspace doesn't show misleading crumbs.
-          setAgentOriginFolderId(undefined);
+          setAgentOrigin(undefined);
         }
       }
       const nextWorkingSessionIds = new Set(detail.workingSessionIds);
@@ -688,7 +692,7 @@ export function App() {
 
     void installMenuBarListener<void>(AGENT_MENU_BAR_NEW_SESSION_EVENT, () => {
       pendingSessionProjectRef.current = null;
-      setAgentOriginFolderId(undefined);
+      setAgentOrigin(undefined);
       markAgentNewSessionPending();
       setActiveAgentSession(undefined);
       setActiveView("agent");
@@ -702,7 +706,7 @@ export function App() {
     void installMenuBarListener<string>(
       AGENT_MENU_BAR_OPEN_SESSION_EVENT,
       (sessionId) => {
-        setAgentOriginFolderId(undefined);
+        setAgentOrigin(undefined);
         if (!sessionId) {
           setActiveView("agent");
           return;
@@ -1223,7 +1227,7 @@ export function App() {
   // can start a fresh chat with the same pending-session handshake.
   function handleNewAgentSession() {
     pendingSessionProjectRef.current = null;
-    setAgentOriginFolderId(undefined);
+    setAgentOrigin(undefined);
     markAgentNewSessionPending();
     setActiveAgentSession(undefined);
     setActiveView("agent");
@@ -1239,7 +1243,7 @@ export function App() {
   // and files the submitted report (plus June's diagnosis) to the June team.
   function handleReportIssue() {
     pendingSessionProjectRef.current = null;
-    setAgentOriginFolderId(undefined);
+    setAgentOrigin(undefined);
     markAgentNewSessionPending(undefined, { kind: "issue-report" });
     setActiveAgentSession(undefined);
     setActiveView("agent");
@@ -1259,7 +1263,7 @@ export function App() {
       folderId,
       knownSessionIds: new Set(agentSessions.map((session) => session.id)),
     };
-    setAgentOriginFolderId(folderId);
+    setAgentOrigin({ kind: "project", folderId });
     markAgentNewSessionPending();
     setActiveAgentSession(undefined);
     setActiveView("agent");
@@ -1272,18 +1276,25 @@ export function App() {
 
   // Leaves the agent workspace for the project it was entered from.
   function handleReturnToAgentOriginFolder() {
-    if (!agentOriginFolderId) return;
+    if (agentOrigin?.kind !== "project") return;
     setActiveView("folders");
-    dispatch({ type: "folderSelected", folderId: agentOriginFolderId });
+    dispatch({ type: "folderSelected", folderId: agentOrigin.folderId });
     setActiveAgentSession(undefined);
-    setAgentOriginFolderId(undefined);
+    setAgentOrigin(undefined);
   }
 
   // Back target for sessions opened outside a project: the Agents view-all.
   function handleReturnToAgentsList() {
     setActiveView("agent-sessions");
     setActiveAgentSession(undefined);
-    setAgentOriginFolderId(undefined);
+    setAgentOrigin(undefined);
+  }
+
+  // Leaves the agent workspace for the run history it was entered from.
+  function handleReturnToRoutines() {
+    setActiveView("routines");
+    setActiveAgentSession(undefined);
+    setAgentOrigin(undefined);
   }
 
   async function handleSelectNote(noteId: string) {
@@ -1640,7 +1651,7 @@ export function App() {
             setSettingsReturnView(activeView);
           }
           setActiveView(view);
-          setAgentOriginFolderId(undefined);
+          setAgentOrigin(undefined);
           if (view !== "agent") {
             setActiveAgentSession(undefined);
             pendingSessionProjectRef.current = null;
@@ -1666,12 +1677,12 @@ export function App() {
         }
         onNewAgentSession={() => {
           pendingSessionProjectRef.current = null;
-          setAgentOriginFolderId(undefined);
+          setAgentOrigin(undefined);
           setActiveAgentSession(undefined);
           setActiveView("agent");
         }}
         onSelectAgentSession={(session) => {
-          setAgentOriginFolderId(undefined);
+          setAgentOrigin(undefined);
           setActiveAgentSession(session);
           setActiveView("agent");
         }}
@@ -1772,6 +1783,11 @@ export function App() {
                   setActiveAgentSession(undefined);
                   setActiveView("agent");
                 }}
+                onOpenRun={(session) => {
+                  setAgentOrigin({ kind: "routines" });
+                  setActiveAgentSession(session);
+                  setActiveView("agent");
+                }}
               />
             ) : activeView === "agent" ? (
               // The origin crumbs render inside the workspace's own sticky
@@ -1794,7 +1810,7 @@ export function App() {
                                 folderId: undefined,
                               });
                               setActiveAgentSession(undefined);
-                              setAgentOriginFolderId(undefined);
+                              setAgentOrigin(undefined);
                             },
                           },
                           {
@@ -1803,16 +1819,27 @@ export function App() {
                           },
                         ],
                       }
-                    : {
-                        backLabel: "Back to agents",
-                        onBack: handleReturnToAgentsList,
-                        crumbs: [
-                          {
-                            label: "Agents",
-                            onClick: handleReturnToAgentsList,
-                          },
-                        ],
-                      }
+                    : agentOrigin?.kind === "routines"
+                      ? {
+                          backLabel: "Back to routines",
+                          onBack: handleReturnToRoutines,
+                          crumbs: [
+                            {
+                              label: "Routines",
+                              onClick: handleReturnToRoutines,
+                            },
+                          ],
+                        }
+                      : {
+                          backLabel: "Back to agents",
+                          onBack: handleReturnToAgentsList,
+                          crumbs: [
+                            {
+                              label: "Agents",
+                              onClick: handleReturnToAgentsList,
+                            },
+                          ],
+                        }
                 }
               />
             ) : activeView === "agent-sessions" ? (
@@ -1823,7 +1850,7 @@ export function App() {
                 workingSessionIds={agentWorkingSessionIds}
                 waitingSessionIds={agentWaitingSessionIds}
                 onSelectSession={(session) => {
-                  setAgentOriginFolderId(undefined);
+                  setAgentOrigin(undefined);
                   setActiveAgentSession(session);
                   setActiveView("agent");
                 }}
@@ -1896,7 +1923,11 @@ export function App() {
                 onSelectSession={(session) => {
                   // Remember the project so the agent view can breadcrumb
                   // back to it.
-                  setAgentOriginFolderId(state.selectedFolderId);
+                  setAgentOrigin(
+                    state.selectedFolderId
+                      ? { kind: "project", folderId: state.selectedFolderId }
+                      : undefined,
+                  );
                   setActiveAgentSession(session);
                   setActiveView("agent");
                 }}

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -8,6 +8,11 @@ import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCanSimple } from "central-icons/IconTrashCanSimple";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  listScheduledRunSessions,
+  scheduledRunJobId,
+  sessionTimestamp,
+} from "../../lib/hermes-adapter";
+import {
   listRoutines,
   pauseRoutine,
   removeRoutine,
@@ -17,6 +22,7 @@ import {
   type RoutineJob,
 } from "../../lib/hermes-routines";
 import { humanizeSchedule } from "../../lib/routine-schedule";
+import type { HermesSessionInfo } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
@@ -27,11 +33,14 @@ type RoutinesViewProps = {
    * cron-job update. */
   onCreateRoutine: (prompt: string) => void;
   onEditRoutine: (prompt: string) => void;
+  /** Opens a past run (a cron-sourced Hermes session) in the agent view. */
+  onOpenRun: (session: HermesSessionInfo) => void;
 };
 
 export function RoutinesView({
   onCreateRoutine,
   onEditRoutine,
+  onOpenRun,
 }: RoutinesViewProps) {
   const [routines, setRoutines] = useState<RoutineJob[]>([]);
   const [loading, setLoading] = useState(true);
@@ -44,6 +53,8 @@ export function RoutinesView({
   const [draft, setDraft] = useState("");
   const [editTarget, setEditTarget] = useState<RoutineJob | null>(null);
   const [editDraft, setEditDraft] = useState("");
+  const [runs, setRuns] = useState<HermesSessionInfo[]>([]);
+  const [runsUnavailable, setRunsUnavailable] = useState(false);
 
   // `loading` gates the whole list and only covers the first fetch;
   // `refreshing` covers every fetch so reloads keep the list visible while
@@ -62,9 +73,26 @@ export function RoutinesView({
     }
   }, []);
 
+  // Run history comes from a different backend (the session store, not the
+  // cron manager), so its failure must not take the routines list down with
+  // it — it degrades to a quiet notice inside the section instead.
+  const loadRuns = useCallback(async () => {
+    try {
+      setRuns(await listScheduledRunSessions());
+      setRunsUnavailable(false);
+    } catch {
+      setRunsUnavailable(true);
+    }
+  }, []);
+
+  const refresh = useCallback(
+    () => Promise.all([loadRoutines(), loadRuns()]),
+    [loadRoutines, loadRuns],
+  );
+
   useEffect(() => {
-    void loadRoutines();
-  }, [loadRoutines]);
+    void refresh();
+  }, [refresh]);
 
   const filtered = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -77,6 +105,32 @@ export function RoutinesView({
         .includes(normalized),
     );
   }, [routines, query]);
+
+  const routinesById = useMemo(
+    () => new Map(routines.map((routine) => [routine.job_id, routine])),
+    [routines],
+  );
+
+  // A run is labeled with its routine's current name; once the routine is
+  // deleted, the session's own derived title is the best label left.
+  const runLabel = useCallback(
+    (run: HermesSessionInfo) => {
+      const jobId = scheduledRunJobId(run.id);
+      const routine = jobId ? routinesById.get(jobId) : undefined;
+      return routine?.name || run.title?.trim() || "Routine run";
+    },
+    [routinesById],
+  );
+
+  const filteredRuns = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return runs;
+    return runs.filter((run) =>
+      `${runLabel(run)} ${run.title ?? ""} ${run.preview ?? ""}`
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [runs, query, runLabel]);
 
   function markBusy(jobId: string, busy: boolean) {
     setBusyIds((current) => {
@@ -185,7 +239,7 @@ export function RoutinesView({
             aria-busy={refreshing}
             data-busy={refreshing || undefined}
             disabled={refreshing}
-            onClick={() => void loadRoutines()}
+            onClick={() => void refresh()}
           >
             <IconArrowRotateClockwise size={14} />
           </button>
@@ -233,6 +287,45 @@ export function RoutinesView({
           ))}
         </ul>
       )}
+
+      {/* Hidden while everything is empty (the routines empty state owns the
+        * page) and while a search matches no runs; shown otherwise, including
+        * when only orphaned runs of deleted routines remain. */}
+      {!loading &&
+      (query.trim()
+        ? filteredRuns.length > 0
+        : routines.length > 0 || runs.length > 0 || runsUnavailable) ? (
+        <section className="routines-runs" aria-label="Run history">
+          <header className="routines-runs-header">
+            <h2>
+              Run history
+              {runs.length > 0 ? (
+                <span className="folders-count">{runs.length}</span>
+              ) : null}
+            </h2>
+          </header>
+          {runsUnavailable ? (
+            <p className="routines-runs-empty">
+              Run history is unavailable right now.
+            </p>
+          ) : runs.length === 0 ? (
+            <p className="routines-runs-empty">
+              No runs yet. When a routine fires, its session appears here.
+            </p>
+          ) : (
+            <ul className="routines-list routines-runs-list" role="list">
+              {filteredRuns.map((run) => (
+                <RunRow
+                  key={run.id}
+                  run={run}
+                  label={runLabel(run)}
+                  onOpen={() => onOpenRun(run)}
+                />
+              ))}
+            </ul>
+          )}
+        </section>
+      ) : null}
 
       <Dialog
         open={createOpen}
@@ -409,6 +502,38 @@ function RoutineRow({
           <IconTrashCanSimple size={14} />
         </button>
       </span>
+    </li>
+  );
+}
+
+/** One past run: a cron-sourced session, labeled with its routine's name and
+ * opened in the agent view on click so the whole conversation is readable. */
+function RunRow({
+  run,
+  label,
+  onOpen,
+}: {
+  run: HermesSessionInfo;
+  label: string;
+  onOpen: () => void;
+}) {
+  const preview = run.preview?.trim();
+  return (
+    <li className="routines-run">
+      <button type="button" className="routines-run-button" onClick={onOpen}>
+        <span className="routines-item-icon" aria-hidden>
+          <IconArrowsRepeat size={14} />
+        </span>
+        <span className="routines-run-body">
+          <span className="routines-run-name">{label}</span>
+          {preview ? (
+            <span className="routines-run-preview">{preview}</span>
+          ) : null}
+        </span>
+        <span className="routines-run-time">
+          {formatRunTime(sessionTimestamp(run))}
+        </span>
+      </button>
     </li>
   );
 }

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -59,6 +59,26 @@ export function isScheduledRunSession(session: HermesSessionInfo) {
   return session.source === SCHEDULED_RUN_SOURCE;
 }
 
+/** The cron scheduler mints run session ids as
+ * `cron_<job id>_<YYYYMMDD_HHMMSS>` — the embedded job id is the only link
+ * from a run back to its routine. Returns undefined for any other id shape. */
+export function scheduledRunJobId(sessionId: string) {
+  return /^cron_(.+)_\d{8}_\d{6}$/.exec(sessionId)?.[1];
+}
+
+/** Hermes's session list has no source filter, so runs are found by fetching
+ * a recent window and filtering client-side. 200 covers weeks of mixed
+ * activity; runs older than the window age out of the history view. */
+const SCHEDULED_RUN_FETCH_LIMIT = 200;
+
+/** Recent scheduled-routine runs, newest first. */
+export async function listScheduledRunSessions() {
+  const sessions = await listHermesSessions({
+    limit: SCHEDULED_RUN_FETCH_LIMIT,
+  });
+  return sessions.filter(isScheduledRunSession);
+}
+
 /** A scheduled run's first message is the routine prompt wrapped in a machine
  * delivery preamble the cron runner injects: `[IMPORTANT: You are running as a
  * scheduled cron job. … nothing more.]`. Recognized by that exact opener so a

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7807,6 +7807,95 @@ button.agent-safety-badge:hover {
   border-color: var(--ring);
 }
 
+/* Run history: past scheduled runs under the routines list. Rows reuse the
+ * routines-item grid rhythm, but each row is one button that opens the run's
+ * session, so there is no hover action cluster to make room for. */
+.routines-runs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  margin-top: var(--sp-4);
+}
+
+.routines-runs-header h2 {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-2);
+  margin: 0;
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: var(--fs-2xl);
+  line-height: 1.2;
+}
+
+.routines-runs-empty {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.routines-run {
+  margin: 0 calc(-1 * var(--sp-4));
+}
+
+.routines-run-button {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--sp-3);
+  width: 100%;
+  padding: var(--sp-3) var(--sp-4);
+  border: none;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.routines-run-button:hover,
+.routines-run-button:focus-visible {
+  background: color-mix(in oklch, var(--muted) 35%, transparent);
+}
+
+.routines-run-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.routines-run-name {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: 500;
+  line-height: 1.45;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.routines-run-preview {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+
+.routines-run-time {
+  padding-top: 3px;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  white-space: nowrap;
+}
+
 .folders-header {
   display: flex;
   align-items: flex-start;

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -3,8 +3,10 @@ import {
   isScheduledRunPreamble,
   isScheduledRunSession,
   listHermesSessions,
+  listScheduledRunSessions,
   normalizeHermesSessionMessagesResponse,
   normalizeHermesSessionsResponse,
+  scheduledRunJobId,
   sessionTimestamp,
   stripScheduledRunPreamble,
   titleFromPrompt,
@@ -70,6 +72,17 @@ describe("scheduled-run helpers", () => {
     });
     expect(sessions[0]?.title).toBe("Post the Weekly Metrics Digest");
   });
+
+  it("extracts the routine job id from a cron run session id", () => {
+    // The scheduler mints run ids as cron_<job id>_<YYYYMMDD_HHMMSS>.
+    expect(scheduledRunJobId("cron_a1b2c3d4e5f6_20260611_093045")).toBe(
+      "a1b2c3d4e5f6",
+    );
+    // A job id containing underscores keeps the trailing timestamp out.
+    expect(scheduledRunJobId("cron_my_job_20260611_093045")).toBe("my_job");
+    expect(scheduledRunJobId("ordinary-session-id")).toBeUndefined();
+    expect(scheduledRunJobId("cron_missing_timestamp")).toBeUndefined();
+  });
 });
 
 const mocks = vi.hoisted(() => ({
@@ -98,6 +111,29 @@ describe("Hermes adapter", () => {
     expect(mocks.hermesBridgeSessions).toHaveBeenLastCalledWith(
       expect.objectContaining({ minMessages: 0 }),
     );
+  });
+
+  it("lists only cron-sourced sessions as scheduled runs", async () => {
+    mocks.hermesBridgeSessions.mockResolvedValue({
+      sessions: [
+        {
+          id: "cron_a1b2c3d4e5f6_20260611_090000",
+          source: "cron",
+          preview: "Standup digest ready.",
+          last_active: "2026-06-11T09:00:30Z",
+        },
+        {
+          id: "ordinary-session",
+          title: "Plan the offsite",
+          last_active: "2026-06-11T10:00:00Z",
+        },
+      ],
+    });
+
+    const runs = await listScheduledRunSessions();
+    expect(runs.map((run) => run.id)).toEqual([
+      "cron_a1b2c3d4e5f6_20260611_090000",
+    ]);
   });
 
   it("normalizes raw gateway session lists and sorts by recent activity", () => {

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RoutinesView } from "../components/routines/RoutinesView";
 import type { RoutineJob } from "../lib/hermes-routines";
+import type { HermesSessionInfo } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   listRoutines: vi.fn<() => Promise<RoutineJob[]>>(),
@@ -14,6 +15,15 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../lib/hermes-routines", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/hermes-routines")>()),
   ...mocks,
+}));
+
+const adapterMocks = vi.hoisted(() => ({
+  listScheduledRunSessions: vi.fn<() => Promise<HermesSessionInfo[]>>(),
+}));
+
+vi.mock("../lib/hermes-adapter", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/hermes-adapter")>()),
+  listScheduledRunSessions: adapterMocks.listScheduledRunSessions,
 }));
 
 function job(overrides: Partial<RoutineJob> = {}): RoutineJob {
@@ -33,11 +43,23 @@ function job(overrides: Partial<RoutineJob> = {}): RoutineJob {
   };
 }
 
+function run(overrides: Partial<HermesSessionInfo> = {}): HermesSessionInfo {
+  return {
+    id: "cron_abc123_20260610_090000",
+    source: "cron",
+    title: "Morning Summary Digest",
+    preview: "Here is today's summary of your unread notes.",
+    last_active: "2026-06-10T09:00:30Z",
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.pauseRoutine.mockResolvedValue({ success: true });
   mocks.resumeRoutine.mockResolvedValue({ success: true });
   mocks.removeRoutine.mockResolvedValue({ success: true });
+  adapterMocks.listScheduledRunSessions.mockResolvedValue([]);
 });
 
 describe("RoutinesView", () => {
@@ -52,7 +74,13 @@ describe("RoutinesView", () => {
         last_status: "error",
       }),
     ]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
 
     expect(await screen.findByText("Morning summary")).toBeInTheDocument();
     expect(screen.getByText("Weekly digest")).toBeInTheDocument();
@@ -71,7 +99,13 @@ describe("RoutinesView", () => {
         schedule: "0 8 * * 1",
       }),
     ]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
 
     const nine = new Date(2000, 0, 1, 9, 0).toLocaleTimeString(undefined, {
       hour: "numeric",
@@ -95,6 +129,7 @@ describe("RoutinesView", () => {
       <RoutinesView
         onCreateRoutine={onCreateRoutine}
         onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
       />,
     );
 
@@ -122,7 +157,11 @@ describe("RoutinesView", () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     const onEditRoutine = vi.fn();
     render(
-      <RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={onEditRoutine} />,
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={onEditRoutine}
+        onOpenRun={vi.fn()}
+      />,
     );
     await screen.findByText("Morning summary");
 
@@ -149,7 +188,11 @@ describe("RoutinesView", () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     const onEditRoutine = vi.fn();
     render(
-      <RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={onEditRoutine} />,
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={onEditRoutine}
+        onOpenRun={vi.fn()}
+      />,
     );
     await screen.findByText("Morning summary");
 
@@ -163,7 +206,13 @@ describe("RoutinesView", () => {
 
   it("pauses a scheduled routine and reloads the list", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
     await screen.findByText("Morning summary");
 
     mocks.listRoutines.mockResolvedValue([job({ state: "paused" })]);
@@ -178,7 +227,13 @@ describe("RoutinesView", () => {
 
   it("resumes a paused routine", async () => {
     mocks.listRoutines.mockResolvedValue([job({ state: "paused" })]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
     await screen.findByText("Morning summary");
 
     await userEvent.click(screen.getByRole("button", { name: "Resume" }));
@@ -189,7 +244,13 @@ describe("RoutinesView", () => {
 
   it("deletes a routine after confirmation", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
     await screen.findByText("Morning summary");
 
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
@@ -208,7 +269,13 @@ describe("RoutinesView", () => {
 
   it("surfaces a failed reload after a successful pause", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
     await screen.findByText("Morning summary");
 
     mocks.listRoutines.mockRejectedValue(new Error("reload failed"));
@@ -220,7 +287,13 @@ describe("RoutinesView", () => {
   it("surfaces a failed delete in the error banner", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     mocks.removeRoutine.mockRejectedValue(new Error("remove failed"));
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
     await screen.findByText("Morning summary");
 
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
@@ -236,7 +309,131 @@ describe("RoutinesView", () => {
 
   it("surfaces a load error", async () => {
     mocks.listRoutines.mockRejectedValue(new Error("gateway down"));
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
     expect(await screen.findByText("gateway down")).toBeInTheDocument();
+  });
+
+  it("lists run history under the routines and opens a run on click", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    const session = run();
+    adapterMocks.listScheduledRunSessions.mockResolvedValue([session]);
+    const onOpenRun = vi.fn();
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={onOpenRun}
+      />,
+    );
+
+    const history = await screen.findByRole("region", { name: "Run history" });
+    // The run is labeled with its routine's name (matched via the job id
+    // embedded in the cron session id), not the session's own title.
+    expect(within(history).getByText("Morning summary")).toBeInTheDocument();
+    expect(
+      within(history).getByText("Here is today's summary of your unread notes."),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(history).getByRole("button", { name: /morning summary/i }),
+    );
+    expect(onOpenRun).toHaveBeenCalledWith(session);
+  });
+
+  it("labels a run by its session title once the routine is deleted", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    adapterMocks.listScheduledRunSessions.mockResolvedValue([
+      run({
+        id: "cron_gone99_20260609_080000",
+        title: "Weekly Metrics Digest",
+        preview: "Metrics are flat week over week.",
+      }),
+    ]);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
+
+    const history = await screen.findByRole("region", { name: "Run history" });
+    expect(
+      within(history).getByText("Weekly Metrics Digest"),
+    ).toBeInTheDocument();
+  });
+
+  it("filters run history with the search query", async () => {
+    mocks.listRoutines.mockResolvedValue([
+      job(),
+      job({ job_id: "def456", name: "Weekly digest" }),
+    ]);
+    adapterMocks.listScheduledRunSessions.mockResolvedValue([
+      run(),
+      run({
+        id: "cron_def456_20260609_080000",
+        preview: "Compiled the weekly digest.",
+        last_active: "2026-06-09T08:00:30Z",
+      }),
+    ]);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
+    await screen.findByRole("region", { name: "Run history" });
+
+    await userEvent.type(screen.getByRole("searchbox"), "weekly");
+    const history = screen.getByRole("region", { name: "Run history" });
+    expect(within(history).getByText("Weekly digest")).toBeInTheDocument();
+    expect(within(history).queryByText("Morning summary")).toBeNull();
+
+    // A query matching no runs hides the section instead of leaving an
+    // empty shell under the routines results.
+    await userEvent.clear(screen.getByRole("searchbox"));
+    await userEvent.type(screen.getByRole("searchbox"), "no such run");
+    expect(screen.queryByRole("region", { name: "Run history" })).toBeNull();
+  });
+
+  it("shows a quiet hint while no routine has run yet", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
+
+    const history = await screen.findByRole("region", { name: "Run history" });
+    expect(within(history).getByText(/No runs yet/)).toBeInTheDocument();
+  });
+
+  it("keeps routines usable when run history fails to load", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    adapterMocks.listScheduledRunSessions.mockRejectedValue(
+      new Error("session store down"),
+    );
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("Morning summary")).toBeInTheDocument();
+    const history = screen.getByRole("region", { name: "Run history" });
+    expect(
+      within(history).getByText("Run history is unavailable right now."),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Completes the original ask behind #222: scheduled routine runs should be readable everywhere they appear (#222, now merged), **and** browsable as run history under the Routines tab (this PR). Branched from #222 before it merged, so the diff against main is just the run history work.

## How runs link back to routines

The cron scheduler mints each run's session id as `cron_<job id>_<YYYYMMDD_HHMMSS>` and tags the session `source = "cron"` (confirmed in the Hermes runtime: `cron/scheduler.py` builds the id, the session row carries the source). That embedded job id is the only link from a run back to its routine, and it is what this feature is built on.

## What's new

**Routines tab** gains a "Run history" section under the routines list:
- Each row is one past run, labeled with its routine's **current name** (matched via the job id in the session id). When the routine has since been deleted, the row falls back to the session's derived title.
- Rows show the run's preview text (delivery preamble already stripped by the adapter) and a relative timestamp, newest first.
- Clicking a run opens the full session in the agent view, where #222's changes render it as a routine run (eyebrow label, clean opening prompt).
- The agent view shows a **Back to routines** breadcrumb for runs opened from here, so the loop closes: Routines -> run -> conversation -> Routines. Implemented by widening the existing project-origin state into a small origin union rather than adding a parallel flag.
- Search filters runs along with routines; a query matching no runs hides the section rather than leaving an empty shell.
- Run history comes from the session store while routines come from the cron manager, so the fetches are independent: a session-store failure degrades to a quiet "Run history is unavailable right now." notice and never takes the routines list down.

**Adapter:** `scheduledRunJobId()` parses the job id out of a cron session id (bracketing the trailing timestamp so job ids containing underscores survive), and `listScheduledRunSessions()` fetches a recent window and filters on `source = "cron"` client-side, since Hermes's session list API exposes no source filter.

## Testing

- Adapter: job-id extraction (underscored ids, non-cron ids, missing timestamp) and cron-source filtering.
- RoutinesView: run rows labeled by routine name, fallback label for deleted routines, click-through to `onOpenRun`, search filtering and section hiding, the no-runs hint, and routines staying usable when the run fetch fails.
- `tsc` clean, `vite build` clean, full suite passes (39 files, 376 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)