### PR TITLE
Copy truth audit: align claims with what the product actually does

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -54,7 +54,7 @@ Privacy is your defining trait, by architecture rather than promise. When asked 
 
 - You run locally on the user's desktop. Files, sessions, memory, and agent state stay on the user's disk by default.
 - Prompts leave the device only for model inference, through private model routing: privacy-focused models with contract-enforced zero data retention by default. If the user opts into third-party models, identifying metadata is stripped first.
-- June's backend runs in a TEE with cryptographic attestation, so users can verify what is running rather than trust it. The agent framework you run on (Hermes) is open source. The service stores only account, login, and billing records.
+- June's backend is open source and runs in a TEE with cryptographic attestation, so users can verify it rather than trust it. The service stores only account, login, and billing records.
 - Open Software never trains on the user's data.
 
 You are helpful, knowledgeable, and direct. Communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose. Be targeted and efficient in your exploration and investigations. Treat the user's files and prompts as sensitive by default: do the work, and keep it to yourself.

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -54,7 +54,7 @@ Privacy is your defining trait, by architecture rather than promise. When asked 
 
 - You run locally on the user's desktop. Files, sessions, memory, and agent state stay on the user's disk by default.
 - Prompts leave the device only for model inference, through private model routing: privacy-focused models with contract-enforced zero data retention by default. If the user opts into third-party models, identifying metadata is stripped first.
-- June's backend is open source and runs in a TEE with cryptographic attestation, so users can verify it rather than trust it. The service stores only account, login, and billing records.
+- June's backend runs in a TEE with cryptographic attestation, so users can verify what is running rather than trust it. The agent framework you run on (Hermes) is open source. The service stores only account, login, and billing records.
 - Open Software never trains on the user's data.
 
 You are helpful, knowledgeable, and direct. Communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose. Be targeted and efficient in your exploration and investigations. Treat the user's files and prompts as sensitive by default: do the work, and keep it to yourself.

--- a/src/components/onboarding/steps/LearnSteps.tsx
+++ b/src/components/onboarding/steps/LearnSteps.tsx
@@ -70,7 +70,7 @@ export function MeetingNotesStep({ onContinue }: { onContinue: () => void }) {
     <section className="onboarding-step">
       <StepHeading
         title="Never take notes again"
-        subtitle="June listens to your meetings and writes the notes: decisions, action items, who said what."
+        subtitle="June listens to your meetings and writes the notes: decisions, action items, your side and theirs."
       />
       <div className="onboarding-practice-card">
         <div className="onboarding-practice-header">Meeting notes</div>
@@ -151,11 +151,12 @@ export function AgentHonestyStep({
           </p>
         </li>
         <li>
-          <h2>So nothing irreversible happens without you.</h2>
+          <h2>So June keeps it on a short leash.</h2>
           <p>
-            The agent asks before it edits or deletes files, sends anything, or
-            spends anything. Every session has a full activity log, and you can
-            stop it at any moment.
+            By default the agent works inside a sandbox that blocks writes
+            outside its own workspace, and it asks before running anything
+            risky. Every session has a full activity log, and you can stop it
+            at any moment.
           </p>
         </li>
         <li>
@@ -165,7 +166,8 @@ export function AgentHonestyStep({
           </h2>
           <p>
             When June thinks, your prompts go to zero-retention models: nothing
-            stored, nothing trained on. That's always on. When the agent acts
+            stored, nothing trained on. That's the default for every model June
+            suggests. When the agent acts
             (visits a site, calls a tool, sends an email you approved), the
             other side sees what it shares, exactly as if you'd done it
             yourself. June

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -98,10 +98,10 @@ export function PermissionsStep({
           }
           body={
             micGranted
-              ? "Only while you hold the dictation key or a meeting note is recording."
+              ? "Only when you ask June to listen: dictating, recording a meeting, or testing your mic."
               : micDenied
                 ? "Microphone access is turned off for June. Flip the toggle in System Settings, then come back. We'll notice."
-                : "June only listens while you hold the dictation key or while a meeting note is recording."
+                : "June only listens when you ask it to: while you hold the dictation key or record a meeting."
           }
           action={
             micDenied

--- a/src/components/onboarding/steps/PrivacySteps.tsx
+++ b/src/components/onboarding/steps/PrivacySteps.tsx
@@ -12,7 +12,7 @@ const PRIVACY_CARDS = [
   },
   {
     title: "Verifiable",
-    body: "June runs on the open-source Hermes agent, and our backend runs in a secure enclave with attestation you can inspect. You don't have to trust us. You can check.",
+    body: "Our code is open source and our backend runs in a secure enclave. You don't have to trust us. You can check.",
   },
 ];
 

--- a/src/components/onboarding/steps/PrivacySteps.tsx
+++ b/src/components/onboarding/steps/PrivacySteps.tsx
@@ -8,11 +8,11 @@ const PRIVACY_CARDS = [
   },
   {
     title: "Private inference",
-    body: "Prompts leave your Mac only for model inference, routed to zero-retention models by default. Nothing stored, nothing trained on. Ever.",
+    body: "Prompts leave your Mac only for model inference, routed to zero-retention models by default. Nothing stored, nothing trained on. The few models that work differently say so on their label.",
   },
   {
     title: "Verifiable",
-    body: "Our code is open source and our backend runs in a secure enclave. You don't have to trust us. You can check.",
+    body: "June runs on the open-source Hermes agent, and our backend runs in a secure enclave with attestation you can inspect. You don't have to trust us. You can check.",
   },
 ];
 
@@ -61,7 +61,7 @@ export function DataPracticesStep({ onContinue }: { onContinue: () => void }) {
           <h2>What we never store</h2>
           <p>
             Your prompts, transcripts, files, and memory. They stay on your Mac,
-            and inference runs through zero-retention models.
+            and inference runs through zero-retention models by default.
           </p>
         </article>
       </div>

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -87,8 +87,8 @@ export function SignInStep({
           at your cursor in whatever app has focus.
         </li>
         <li>
-          <strong>Never take notes again</strong>: decisions, action items, and
-          who said what, written for you.
+          <strong>Never take notes again</strong>: decisions, action items,
+          your side and theirs, written for you.
         </li>
         <li>
           <strong>Hand off real work</strong>: give June a task, not just a


### PR DESCRIPTION
Audited every user-facing claim in the app (onboarding steps, account/trial gates, settings, agent UI, SOUL.md persona, Info.plist permission strings) against the implementation, and fixed the ones that are not true today.

## Fixed - was false or contradicted by the app itself

1. **"Our code is open source"** (privacy card; SOUL.md says the backend is open source). The repo is **private** (verified via the GitHub API). What IS true: the Hermes agent framework is public, and the backend runs in an attested TEE you can inspect via /verify. The copy now says exactly that, keeping the "You don't have to trust us. You can check." punch - which the attestation genuinely backs.
2. **"Nothing stored, nothing trained on. Ever."** and **"That's always on."** The app's own model picker offers anonymous-mode models whose label says "the model provider may retain prompts." Both claims now scope to the default and point at the labels. (Checked that the new GLM 5.1 default is a Venice private/zero-retention model, so "by default" holds.)
3. **"The agent asks before it edits or deletes files, sends anything, or spends anything."** Reality: hermes's approval gate is a dangerous-command gate, the sandbox blocks writes outside the workspace, and agent turns meter credits without asking (every chat settles a charge). Rewritten around the real controls: sandbox by default, approval for risky commands, full activity log, stop anytime.
4. **"who said what"** (two places). The turn pipeline separates your mic from system audio - explicitly no speaker diarization per the feature spec. Now "your side and theirs".
5. **Mic permission copy** said June listens only while dictating or recording; the settings mic test also listens. Now "only when you ask June to listen".
6. **"inference runs through zero-retention models"** in the data-practices card gains the "by default" qualifier the sibling copy already carries.

## Checked and deliberately left alone

- "Dictate into any app" / "type anywhere": conventional puffery; accessibility paste works in effectively all apps.
- "Files, sessions, and memory... never mirrored to a cloud": true (hermes home is local).
- "What we store: account, login, and billing records": true for ambient collection; issue reports are explicit user submissions with consent visible in the flow.
- "Backend runs in a secure enclave": true (Phala CVM, attested).
- Trial copy ("cancel anytime", "$0 due today", end-date timeline): consistent with the subscription flow.
- E2EE/private/anonymous badge descriptions: already accurate and honest.

## Flags for follow-up (not in this PR)

- `FALLBACK_TRIAL_LENGTH_DAYS = 14` must match the live Stripe price's trial_period_days - not verifiable from code; worth a glance at the Stripe dashboard.
- README claims dictation "does not... store transcript records," but dictation history retains transcripts locally for 7 days. README is dev-facing so it's out of scope here, but it's stale.

368/368 tests pass, lint and cargo check clean. No tests pinned the changed strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)