### PR TITLE
Routines: sandboxed by default, per-routine unrestricted opt-in

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1899,6 +1899,30 @@ fn resolve_scribe_hermes_home(app: &AppHandle) -> Result<PathBuf, AppError> {
     Ok(path)
 }
 
+/// Toolsets a routine (cron job) runs with when it carries no per-job
+/// `enabled_toolsets` override. Hermes resolves a cron run's toolsets as:
+/// per-job `enabled_toolsets` first, then `platform_toolsets.cron` from
+/// config.yaml (`_resolve_cron_enabled_toolsets` in cron/scheduler.py).
+/// Routines execute inside the launchd gateway daemon, which must run
+/// outside the Seatbelt jail so launchd accepts it (see
+/// `spawn_hermes_gateway_start`), so this allowlist is what "Sandboxed"
+/// means for a routine: no terminal, file, code-execution, browser,
+/// computer-use, skill-management, or delegation toolsets — the job can
+/// read the web, think, remember, and deliver its report, but cannot touch
+/// the machine. The per-routine Unrestricted opt-in writes an explicit
+/// per-job `enabled_toolsets` (see CRON_UNRESTRICTED_TOOLSETS in
+/// src/lib/hermes-routines.ts), which takes precedence over this gate.
+/// The scheduler always strips `cronjob`, `messaging`, and `clarify` from
+/// cron agents on top of either list.
+const CRON_SANDBOXED_TOOLSETS: &[&str] = &[
+    "web",
+    "vision",
+    "todo",
+    "memory",
+    "session_search",
+    "context_engine",
+];
+
 fn sync_hermes_config(
     hermes_home: &std::path::Path,
     provider_proxy_port: u16,
@@ -1917,10 +1941,13 @@ agent:
   max_turns: 90
 display:
   skin: mono
+platform_toolsets:
+  cron: [{cron_toolsets}]
 "#,
         model = yaml_string(&model),
         base_url = yaml_string(&base_url),
         provider_proxy_token = yaml_string(provider_proxy_token),
+        cron_toolsets = CRON_SANDBOXED_TOOLSETS.join(", "),
     );
     std::fs::write(hermes_home.join("config.yaml"), config)
         .map_err(|error| AppError::new("hermes_bridge_config_failed", error.to_string()))
@@ -2529,6 +2556,33 @@ mod tests {
             Some("1")
         );
         assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp/hermes-home")));
+    }
+
+    #[test]
+    fn synced_config_gates_cron_runs_to_the_sandboxed_toolsets() {
+        // Routines execute in the unjailed launchd gateway, so the only
+        // default-deny boundary they have is this config gate: a cron job
+        // with no per-job enabled_toolsets must resolve to the sandboxed
+        // allowlist, never the full default toolset.
+        let home = tempfile::tempdir().expect("tempdir");
+
+        sync_hermes_config(home.path(), 4242, "proxy-token").expect("sync config");
+
+        let config = std::fs::read_to_string(home.path().join("config.yaml")).expect("read config");
+        assert!(config.contains("platform_toolsets:"));
+        assert!(config.contains(&format!("cron: [{}]", CRON_SANDBOXED_TOOLSETS.join(", "))));
+        for toolset in [
+            "terminal",
+            "file",
+            "code_execution",
+            "browser",
+            "computer_use",
+        ] {
+            assert!(
+                !CRON_SANDBOXED_TOOLSETS.contains(&toolset),
+                "machine-touching toolset {toolset} must not be in the cron default",
+            );
+        }
     }
 
     #[test]

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -5,6 +5,7 @@ import { IconPause } from "central-icons/IconPause";
 import { IconPencil } from "central-icons/IconPencil";
 import { IconPlay } from "central-icons/IconPlay";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { IconShieldCrossed } from "central-icons/IconShieldCrossed";
 import { IconTrashCanSimple } from "central-icons/IconTrashCanSimple";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -20,6 +21,7 @@ import { humanizeSchedule } from "../../lib/routine-schedule";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
+import { HoverTip } from "../ui/HoverTip";
 
 type RoutinesViewProps = {
   /** Hands off a composed agent prompt; the app opens a new June session with
@@ -156,6 +158,7 @@ export function RoutinesView({
           <p className="folders-subtitle">
             Automations June runs for you on a schedule.
           </p>
+          <UnrestrictedRoutinesBadge />
         </div>
         <button
           type="button"
@@ -239,7 +242,7 @@ export function RoutinesView({
         onClose={() => setCreateOpen(false)}
         leading={<IconArrowsRepeat size={15} />}
         title="New routine"
-        description="Tell June what to do and when. It opens a new session to set the routine up, and you can fine-tune the schedule there."
+        description="Tell June what to do and when. It opens a new session to set the routine up, and you can fine-tune the schedule there. Routines run unrestricted: when one fires, June can change any file your account can."
         footer={
           <>
             <button
@@ -457,6 +460,29 @@ function isSameDate(left: Date, right: Date) {
     left.getFullYear() === right.getFullYear() &&
     left.getMonth() === right.getMonth() &&
     left.getDate() === right.getDate()
+  );
+}
+
+/** Unconditional mode disclosure, same chrome as the session bar's
+ * Unrestricted badge. Scheduled runs execute in June's always-on background
+ * gateway, which the app must start outside the Seatbelt write-jail so
+ * launchd can manage it (see spawn_hermes_gateway_start in hermes_bridge.rs)
+ * — so the Sandboxed/Unrestricted choice made per chat session never applies
+ * to a routine run, and labeling each routine individually would just repeat
+ * the same badge on every row. */
+function UnrestrictedRoutinesBadge() {
+  const description =
+    "Routines run in June's always-on background service, which is not sandboxed. When a routine fires, June can change any file your account can, regardless of the mode of the chat that created it.";
+  return (
+    <HoverTip
+      tip={description}
+      className="agent-safety-badge agent-sandbox-badge routines-mode-badge"
+      tabIndex={0}
+      aria-label={`Unrestricted - ${description}`}
+    >
+      <IconShieldCrossed size={13} aria-hidden />
+      Unrestricted
+    </HoverTip>
   );
 }
 

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -5,6 +5,7 @@ import { IconPause } from "central-icons/IconPause";
 import { IconPencil } from "central-icons/IconPencil";
 import { IconPlay } from "central-icons/IconPlay";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
+import { IconShieldCheck } from "central-icons/IconShieldCheck";
 import { IconShieldCrossed } from "central-icons/IconShieldCrossed";
 import { IconTrashCanSimple } from "central-icons/IconTrashCanSimple";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -15,6 +16,7 @@ import {
   resumeRoutine,
   routineCreationPrompt,
   routineEditPrompt,
+  routineUnrestricted,
   type RoutineJob,
 } from "../../lib/hermes-routines";
 import { humanizeSchedule } from "../../lib/routine-schedule";
@@ -44,6 +46,10 @@ export function RoutinesView({
   const [pendingDelete, setPendingDelete] = useState<RoutineJob | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [draft, setDraft] = useState("");
+  // Per-routine mode choice for the routine being composed. Defaults to
+  // sandboxed on every open: like the chat picker, Unrestricted is a
+  // deliberate per-creation opt-in, never a sticky preference.
+  const [draftUnrestricted, setDraftUnrestricted] = useState(false);
   const [editTarget, setEditTarget] = useState<RoutineJob | null>(null);
   const [editDraft, setEditDraft] = useState("");
 
@@ -122,6 +128,7 @@ export function RoutinesView({
 
   function openCreate() {
     setDraft("");
+    setDraftUnrestricted(false);
     setCreateOpen(true);
   }
 
@@ -142,7 +149,9 @@ export function RoutinesView({
     const description = draft.trim();
     if (!description) return;
     setCreateOpen(false);
-    onCreateRoutine(routineCreationPrompt(description));
+    onCreateRoutine(
+      routineCreationPrompt(description, { unrestricted: draftUnrestricted }),
+    );
   }
 
   return (
@@ -158,7 +167,6 @@ export function RoutinesView({
           <p className="folders-subtitle">
             Automations June runs for you on a schedule.
           </p>
-          <UnrestrictedRoutinesBadge />
         </div>
         <button
           type="button"
@@ -242,7 +250,7 @@ export function RoutinesView({
         onClose={() => setCreateOpen(false)}
         leading={<IconArrowsRepeat size={15} />}
         title="New routine"
-        description="Tell June what to do and when. It opens a new session to set the routine up, and you can fine-tune the schedule there. Routines run unrestricted: when one fires, June can change any file your account can."
+        description="Tell June what to do and when. It opens a new session to set the routine up, and you can fine-tune the schedule there."
         footer={
           <>
             <button
@@ -276,6 +284,35 @@ export function RoutinesView({
             }
           }}
         />
+        <div
+          className="routines-mode-picker"
+          role="radiogroup"
+          aria-label="What can this routine change?"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={!draftUnrestricted}
+            onClick={() => setDraftUnrestricted(false)}
+          >
+            <IconShieldCheck size={14} aria-hidden />
+            Sandboxed
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={draftUnrestricted}
+            onClick={() => setDraftUnrestricted(true)}
+          >
+            <IconShieldCrossed size={14} aria-hidden />
+            Unrestricted
+          </button>
+        </div>
+        <p className="routines-mode-hint">
+          {draftUnrestricted
+            ? "When it fires, June can run commands and change any file your account can."
+            : "The routine can read the web, use memory, and message you. It cannot run commands or change your files."}
+        </p>
       </Dialog>
 
       <Dialog
@@ -366,6 +403,16 @@ function RoutineRow({
       <div className="routines-item-body">
         <span className="routines-item-title">
           <span className="routines-item-name">{routine.name}</span>
+          {routineUnrestricted(routine) ? (
+            <HoverTip
+              tip="This routine runs with full access: when it fires, June can run commands and change any file your account can. Routines without this badge run sandboxed and cannot touch your files."
+              className="routines-item-badge routines-item-badge-warm"
+              tabIndex={0}
+            >
+              <IconShieldCrossed size={11} aria-hidden />
+              Unrestricted
+            </HoverTip>
+          ) : null}
           {paused ? <span className="routines-item-badge">Paused</span> : null}
           {completed ? (
             <span className="routines-item-badge">Completed</span>
@@ -460,29 +507,6 @@ function isSameDate(left: Date, right: Date) {
     left.getFullYear() === right.getFullYear() &&
     left.getMonth() === right.getMonth() &&
     left.getDate() === right.getDate()
-  );
-}
-
-/** Unconditional mode disclosure, same chrome as the session bar's
- * Unrestricted badge. Scheduled runs execute in June's always-on background
- * gateway, which the app must start outside the Seatbelt write-jail so
- * launchd can manage it (see spawn_hermes_gateway_start in hermes_bridge.rs)
- * — so the Sandboxed/Unrestricted choice made per chat session never applies
- * to a routine run, and labeling each routine individually would just repeat
- * the same badge on every row. */
-function UnrestrictedRoutinesBadge() {
-  const description =
-    "Routines run in June's always-on background service, which is not sandboxed. When a routine fires, June can change any file your account can, regardless of the mode of the chat that created it.";
-  return (
-    <HoverTip
-      tip={description}
-      className="agent-safety-badge agent-sandbox-badge routines-mode-badge"
-      tabIndex={0}
-      aria-label={`Unrestricted - ${description}`}
-    >
-      <IconShieldCrossed size={13} aria-hidden />
-      Unrestricted
-    </HoverTip>
   );
 }
 

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -25,6 +25,15 @@ export type RoutineJob = {
    * presence with machine-touching toolsets is what makes a routine
    * unrestricted. */
   enabled_toolsets?: string[];
+  /** Shell script attached to the job (`_format_job` includes it only when
+   * set). The scheduler runs it as a plain subprocess of the unjailed
+   * gateway on every tick — as the whole job for `no_agent` jobs, as the
+   * wake-gate pre-run otherwise — so it sits entirely outside the toolset
+   * gate. Any script-backed routine is unrestricted no matter what its
+   * toolsets say. */
+  script?: string | null;
+  /** True for script-only jobs (no agent run at all). Implies `script`. */
+  no_agent?: boolean;
 };
 
 /** The toolsets June must put on a routine the user opted into Unrestricted.
@@ -63,12 +72,16 @@ const MACHINE_TOOLSETS = new Set([
   "skills",
 ]);
 
-/** Whether a routine runs with machine-touching toolsets. Derived from the
+/** Whether a routine can touch the machine when it fires. Derived from the
  * stored job rather than any UI state, so the badge reflects what the
- * scheduler will actually enforce on the next run. */
+ * scheduler will actually enforce on the next run. Two paths count:
+ * machine-touching toolsets in the per-job override, and an attached cron
+ * script — scripts run as plain subprocesses of the unjailed gateway,
+ * outside the toolset gate entirely. */
 export function routineUnrestricted(
-  routine: Pick<RoutineJob, "enabled_toolsets">,
+  routine: Pick<RoutineJob, "enabled_toolsets" | "script" | "no_agent">,
 ): boolean {
+  if (routine.script || routine.no_agent) return true;
   return (routine.enabled_toolsets ?? []).some((toolset) =>
     MACHINE_TOOLSETS.has(toolset),
   );
@@ -151,7 +164,7 @@ export function routineCreationPrompt(
 ) {
   const mode = options?.unrestricted
     ? `I chose to run this routine unrestricted. Create the job with enabled_toolsets set to exactly: ${UNRESTRICTED_ROUTINE_TOOLSETS.join(", ")}.`
-    : "I chose the sandboxed default for this routine. Do not set enabled_toolsets on the job: it then runs with the restricted cron toolset (web reading, vision, todo, memory, session search) and cannot use the terminal, change files, execute code, or drive a browser. If the task clearly needs those, stop and tell me it requires an unrestricted routine instead of creating it.";
+    : "I chose the sandboxed default for this routine. Do not set enabled_toolsets on the job: it then runs with the restricted cron toolset (web reading, vision, todo, memory, session search) and cannot use the terminal, change files, execute code, or drive a browser. Do not attach a script to the job either: cron scripts run as plain shell subprocesses outside that sandbox. If the task clearly needs any of this, stop and tell me it requires an unrestricted routine instead of creating it.";
   return [
     "Set up a new routine (a scheduled cron job) for me using your cronjob tool.",
     `Here is what it should do: ${description.trim()}`,
@@ -168,7 +181,7 @@ export function routineCreationPrompt(
 export function routineEditPrompt(
   routine: Pick<
     RoutineJob,
-    "job_id" | "name" | "schedule" | "enabled_toolsets"
+    "job_id" | "name" | "schedule" | "enabled_toolsets" | "script" | "no_agent"
   >,
   changes: string,
 ) {
@@ -176,7 +189,7 @@ export function routineEditPrompt(
   return [
     `Update my existing routine "${routine.name}" (cron job id ${routine.job_id}) using your cronjob tool's update action.`,
     `It currently runs: ${routine.schedule}. The routine is currently ${mode}. Here is what should change: ${changes.trim()}`,
-    `If I asked to make it unrestricted, update the job with enabled_toolsets set to exactly: ${UNRESTRICTED_ROUTINE_TOOLSETS.join(", ")}. If I asked to make it sandboxed, clear enabled_toolsets on the job so the restricted cron default applies again.`,
+    `If I asked to make it unrestricted, update the job with enabled_toolsets set to exactly: ${UNRESTRICTED_ROUTINE_TOOLSETS.join(", ")}. If I asked to make it sandboxed, clear enabled_toolsets and any script on the job so the restricted cron default applies again (cron scripts run as shell subprocesses outside the sandbox, so a sandboxed routine must not have one).`,
     "Only modify the fields I asked about and leave everything else on the job untouched. Confirm the updated job and when it runs next.",
   ].join("\n\n");
 }

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -18,7 +18,61 @@ export type RoutineJob = {
   state: "scheduled" | "paused" | "completed";
   paused_at?: string | null;
   paused_reason?: string | null;
+  /** Per-job toolset override (`_format_job` includes it only when set).
+   * Absent means the job runs under the sandboxed cron default the app
+   * writes into config.yaml (CRON_SANDBOXED_TOOLSETS in hermes_bridge.rs);
+   * the scheduler gives this field precedence over that gate, so its
+   * presence with machine-touching toolsets is what makes a routine
+   * unrestricted. */
+  enabled_toolsets?: string[];
 };
+
+/** The toolsets June must put on a routine the user opted into Unrestricted.
+ * Hermes's full default set minus the toolsets its scheduler always strips
+ * from cron agents (cronjob, messaging, clarify) and the default-off niche
+ * sets. Keep in sync with CRON_SANDBOXED_TOOLSETS in hermes_bridge.rs, which
+ * is the sandboxed counterpart this list overrides. */
+export const UNRESTRICTED_ROUTINE_TOOLSETS = [
+  "terminal",
+  "file",
+  "code_execution",
+  "web",
+  "browser",
+  "vision",
+  "image_gen",
+  "tts",
+  "skills",
+  "todo",
+  "memory",
+  "context_engine",
+  "session_search",
+  "delegation",
+  "computer_use",
+];
+
+/** Toolsets that let a routine change the machine or act on it: their
+ * presence in a job's override is what "Unrestricted" means for routines.
+ * The sandboxed cron default contains none of them. */
+const MACHINE_TOOLSETS = new Set([
+  "terminal",
+  "file",
+  "code_execution",
+  "browser",
+  "computer_use",
+  "delegation",
+  "skills",
+]);
+
+/** Whether a routine runs with machine-touching toolsets. Derived from the
+ * stored job rather than any UI state, so the badge reflects what the
+ * scheduler will actually enforce on the next run. */
+export function routineUnrestricted(
+  routine: Pick<RoutineJob, "enabled_toolsets">,
+): boolean {
+  return (routine.enabled_toolsets ?? []).some((toolset) =>
+    MACHINE_TOOLSETS.has(toolset),
+  );
+}
 
 type CronManageResponse = {
   success?: boolean;
@@ -87,11 +141,21 @@ export function removeRoutine(jobId: string) {
 }
 
 /** Builds the agent prompt for "create a routine": June owns naming and
- * scheduling via its cronjob tool, so the user only describes the outcome. */
-export function routineCreationPrompt(description: string) {
+ * scheduling via its cronjob tool, so the user only describes the outcome.
+ * The mode line carries the user's per-routine sandbox choice: sandboxed
+ * routines must NOT set enabled_toolsets (the cron platform gate in
+ * config.yaml then applies), unrestricted ones set the explicit override. */
+export function routineCreationPrompt(
+  description: string,
+  options?: { unrestricted?: boolean },
+) {
+  const mode = options?.unrestricted
+    ? `I chose to run this routine unrestricted. Create the job with enabled_toolsets set to exactly: ${UNRESTRICTED_ROUTINE_TOOLSETS.join(", ")}.`
+    : "I chose the sandboxed default for this routine. Do not set enabled_toolsets on the job: it then runs with the restricted cron toolset (web reading, vision, todo, memory, session search) and cannot use the terminal, change files, execute code, or drive a browser. If the task clearly needs those, stop and tell me it requires an unrestricted routine instead of creating it.";
   return [
     "Set up a new routine (a scheduled cron job) for me using your cronjob tool.",
     `Here is what it should do: ${description.trim()}`,
+    mode,
     "Pick a short descriptive name and an appropriate schedule (ask me if the timing is unclear), create the job, then confirm what you created and when it will first run.",
   ].join("\n\n");
 }
@@ -102,12 +166,17 @@ export function routineCreationPrompt(description: string) {
  * partial updates — it can change just the schedule without ever reading or
  * re-sending the full prompt, which the list API truncates to a preview. */
 export function routineEditPrompt(
-  routine: Pick<RoutineJob, "job_id" | "name" | "schedule">,
+  routine: Pick<
+    RoutineJob,
+    "job_id" | "name" | "schedule" | "enabled_toolsets"
+  >,
   changes: string,
 ) {
+  const mode = routineUnrestricted(routine) ? "unrestricted" : "sandboxed";
   return [
     `Update my existing routine "${routine.name}" (cron job id ${routine.job_id}) using your cronjob tool's update action.`,
-    `It currently runs: ${routine.schedule}. Here is what should change: ${changes.trim()}`,
+    `It currently runs: ${routine.schedule}. The routine is currently ${mode}. Here is what should change: ${changes.trim()}`,
+    `If I asked to make it unrestricted, update the job with enabled_toolsets set to exactly: ${UNRESTRICTED_ROUTINE_TOOLSETS.join(", ")}. If I asked to make it sandboxed, clear enabled_toolsets on the job so the restricted cron default applies again.`,
     "Only modify the fields I asked about and leave everything else on the job untouched. Confirm the updated job and when it runs next.",
   ].join("\n\n");
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7623,6 +7623,13 @@ button.agent-safety-badge:hover {
   gap: var(--sp-3);
 }
 
+/* The header's mode disclosure: routine runs execute in the always-on
+ * gateway outside the chat sandbox, so the badge is unconditional and sits
+ * once under the subtitle rather than repeating on every row. */
+.routines-mode-badge {
+  margin-top: var(--sp-3);
+}
+
 .routines-refresh {
   display: inline-grid;
   place-items: center;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7623,11 +7623,64 @@ button.agent-safety-badge:hover {
   gap: var(--sp-3);
 }
 
-/* The header's mode disclosure: routine runs execute in the always-on
- * gateway outside the chat sandbox, so the badge is unconditional and sits
- * once under the subtitle rather than repeating on every row. */
-.routines-mode-badge {
+/* Per-routine mode picker in the create dialog: the same Sandboxed vs
+ * Unrestricted split as the chat composer's shield menu, rendered as a
+ * two-option radio row. The selected option borrows the sandbox trigger's
+ * warm accent when Unrestricted is armed. */
+.routines-mode-picker {
   margin-top: var(--sp-3);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+}
+
+.routines-mode-picker button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 3px var(--sp-3);
+  border: 0;
+  border-radius: calc(var(--r-md) - 2px);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-family: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.routines-mode-picker button[aria-checked="true"] {
+  background: color-mix(in oklch, var(--muted) 70%, transparent);
+  color: var(--foreground);
+}
+
+.routines-mode-picker button[aria-checked="true"]:last-child {
+  background: var(--warm-soft);
+  color: var(--warm-strong);
+}
+
+.routines-mode-hint {
+  margin: var(--sp-2) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+/* Warm twin of .routines-item-badge for routines that run with full machine
+ * access (same family as the session bar's Unrestricted badge). */
+.routines-item-badge-warm {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: var(--warm-soft);
+  color: var(--warm-strong);
+}
+
+.routines-item-badge-warm svg {
+  color: var(--warm-strong);
 }
 
 .routines-refresh {

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -129,6 +129,7 @@ describe("RoutinesView", () => {
       <RoutinesView
         onCreateRoutine={onCreateRoutine}
         onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
       />,
     );
 
@@ -166,6 +167,7 @@ describe("RoutinesView", () => {
       <RoutinesView
         onCreateRoutine={onCreateRoutine}
         onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
       />,
     );
 
@@ -212,7 +214,13 @@ describe("RoutinesView", () => {
         no_agent: true,
       }),
     ]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+    render(
+      <RoutinesView
+        onCreateRoutine={vi.fn()}
+        onEditRoutine={vi.fn()}
+        onOpenRun={vi.fn()}
+      />,
+    );
 
     expect(await screen.findByText("Nightly cleanup")).toBeInTheDocument();
     // Badges for the toolset-widened and the script-backed routines, none
@@ -438,7 +446,9 @@ describe("RoutinesView", () => {
     // embedded in the cron session id), not the session's own title.
     expect(within(history).getByText("Morning summary")).toBeInTheDocument();
     expect(
-      within(history).getByText("Here is today's summary of your unread notes."),
+      within(history).getByText(
+        "Here is today's summary of your unread notes.",
+      ),
     ).toBeInTheDocument();
 
     await userEvent.click(

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -88,6 +88,25 @@ describe("RoutinesView", () => {
     expect(screen.queryByText("Weekly digest")).toBeNull();
   });
 
+  it("discloses that routines run unrestricted", async () => {
+    // Routine runs execute in the always-on background gateway, which lives
+    // outside the chat sandbox, so the disclosure is unconditional: a badge
+    // in the header and a sentence in the creation dialog.
+    mocks.listRoutines.mockResolvedValue([]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+
+    expect(await screen.findByText("Put June on a schedule")).toBeVisible();
+    expect(screen.getByText("Unrestricted")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: /new routine/i })[0],
+    );
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent(
+      "Routines run unrestricted: when one fires, June can change any file your account can.",
+    );
+  });
+
   it("shows the empty state and routes creation through the agent prompt", async () => {
     mocks.listRoutines.mockResolvedValue([]);
     const onCreateRoutine = vi.fn();

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -88,23 +88,89 @@ describe("RoutinesView", () => {
     expect(screen.queryByText("Weekly digest")).toBeNull();
   });
 
-  it("discloses that routines run unrestricted", async () => {
-    // Routine runs execute in the always-on background gateway, which lives
-    // outside the chat sandbox, so the disclosure is unconditional: a badge
-    // in the header and a sentence in the creation dialog.
+  it("defaults a new routine to sandboxed and says so in the prompt", async () => {
     mocks.listRoutines.mockResolvedValue([]);
-    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
-
-    expect(await screen.findByText("Put June on a schedule")).toBeVisible();
-    expect(screen.getByText("Unrestricted")).toBeInTheDocument();
+    const onCreateRoutine = vi.fn();
+    render(
+      <RoutinesView
+        onCreateRoutine={onCreateRoutine}
+        onEditRoutine={vi.fn()}
+      />,
+    );
 
     await userEvent.click(
-      screen.getAllByRole("button", { name: /new routine/i })[0],
+      (await screen.findAllByRole("button", { name: /new routine/i }))[0],
     );
     const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("radio", { name: "Sandboxed" }),
+    ).toHaveAttribute("aria-checked", "true");
     expect(dialog).toHaveTextContent(
-      "Routines run unrestricted: when one fires, June can change any file your account can.",
+      "It cannot run commands or change your files.",
     );
+
+    await userEvent.type(
+      within(dialog).getByRole("textbox"),
+      "watch the weather and message me",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Ask June to set it up" }),
+    );
+
+    const prompt = onCreateRoutine.mock.calls[0][0] as string;
+    expect(prompt).toContain("Do not set enabled_toolsets");
+    expect(prompt).not.toContain("Create the job with enabled_toolsets");
+  });
+
+  it("creates an unrestricted routine only after the explicit opt-in", async () => {
+    mocks.listRoutines.mockResolvedValue([]);
+    const onCreateRoutine = vi.fn();
+    render(
+      <RoutinesView
+        onCreateRoutine={onCreateRoutine}
+        onEditRoutine={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(
+      (await screen.findAllByRole("button", { name: /new routine/i }))[0],
+    );
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(dialog).getByRole("radio", { name: "Unrestricted" }),
+    );
+    expect(dialog).toHaveTextContent(
+      "June can run commands and change any file your account can.",
+    );
+
+    await userEvent.type(
+      within(dialog).getByRole("textbox"),
+      "clean up my downloads folder nightly",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Ask June to set it up" }),
+    );
+
+    const prompt = onCreateRoutine.mock.calls[0][0] as string;
+    expect(prompt).toContain(
+      "Create the job with enabled_toolsets set to exactly: terminal, file, code_execution",
+    );
+  });
+
+  it("badges only routines whose stored job carries machine toolsets", async () => {
+    mocks.listRoutines.mockResolvedValue([
+      job(),
+      job({
+        job_id: "def456",
+        name: "Nightly cleanup",
+        enabled_toolsets: ["terminal", "file", "web"],
+      }),
+    ]);
+    render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
+
+    expect(await screen.findByText("Nightly cleanup")).toBeInTheDocument();
+    // One badge for the unrestricted routine, none for the sandboxed one.
+    expect(screen.getAllByText("Unrestricted")).toHaveLength(1);
   });
 
   it("shows the empty state and routes creation through the agent prompt", async () => {
@@ -162,6 +228,9 @@ describe("RoutinesView", () => {
     expect(prompt).toContain("abc123");
     expect(prompt).toContain("Morning summary");
     expect(prompt).toContain("update action");
+    // No enabled_toolsets on the fixture, so the prompt reports the
+    // sandboxed default and carries the mode-change instructions.
+    expect(prompt).toContain("currently sandboxed");
   });
 
   it("does not send an edit with an empty description", async () => {

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -119,6 +119,9 @@ describe("RoutinesView", () => {
 
     const prompt = onCreateRoutine.mock.calls[0][0] as string;
     expect(prompt).toContain("Do not set enabled_toolsets");
+    // Cron scripts run as shell subprocesses outside the toolset gate, so a
+    // sandboxed routine must not get one either.
+    expect(prompt).toContain("Do not attach a script");
     expect(prompt).not.toContain("Create the job with enabled_toolsets");
   });
 
@@ -157,7 +160,7 @@ describe("RoutinesView", () => {
     );
   });
 
-  it("badges only routines whose stored job carries machine toolsets", async () => {
+  it("badges routines that carry machine toolsets or a cron script", async () => {
     mocks.listRoutines.mockResolvedValue([
       job(),
       job({
@@ -165,12 +168,22 @@ describe("RoutinesView", () => {
         name: "Nightly cleanup",
         enabled_toolsets: ["terminal", "file", "web"],
       }),
+      // Scripts run as shell subprocesses of the unjailed gateway, outside
+      // the toolset gate, so a script-backed job is unrestricted even with
+      // no enabled_toolsets override.
+      job({
+        job_id: "ghi789",
+        name: "Disk watchdog",
+        script: "/Users/junho/bin/check-disk.sh",
+        no_agent: true,
+      }),
     ]);
     render(<RoutinesView onCreateRoutine={vi.fn()} onEditRoutine={vi.fn()} />);
 
     expect(await screen.findByText("Nightly cleanup")).toBeInTheDocument();
-    // One badge for the unrestricted routine, none for the sandboxed one.
-    expect(screen.getAllByText("Unrestricted")).toHaveLength(1);
+    // Badges for the toolset-widened and the script-backed routines, none
+    // for the sandboxed one.
+    expect(screen.getAllByText("Unrestricted")).toHaveLength(2);
   });
 
   it("shows the empty state and routes creation through the agent prompt", async () => {


### PR DESCRIPTION
## Problem

Routines execute inside the always-on launchd gateway daemon, which the app must start outside the Seatbelt jail so launchd accepts it (`spawn_hermes_gateway_start` in `hermes_bridge.rs`). Net effect before this PR: **every routine ran with the full toolset and full file access**, regardless of the Sandboxed/Unrestricted choice in chat, and nothing in the UI said so. An early revision of this PR only disclosed that; review feedback was (correctly) that disclosure is not a fix - routines should not always run unrestricted, and the mode should be a per-routine option. This PR enforces that.

## How enforcement works

The bundled hermes-agent resolves a cron run's toolsets with this precedence (`_resolve_cron_enabled_toolsets` in `cron/scheduler.py`):

1. the job's own `enabled_toolsets` field, set via the `cronjob` tool at create/update
2. the `platform_toolsets.cron` gate in `config.yaml`
3. full default set (fallback only if both are absent)

The app owns `config.yaml` (`sync_hermes_config` rewrites it on every start), which makes layer 2 an app-enforced floor and layer 1 the documented per-job override. Both are enforced by the scheduler at tool dispatch when it constructs the cron agent - in whatever process runs the job, app open or closed. On top of either list the scheduler always strips `cronjob`, `messaging`, and `clarify` from cron agents.

## Changes

- **Rust:** `sync_hermes_config` now writes `platform_toolsets: { cron: [web, vision, todo, memory, session_search, context_engine] }`. A routine without a per-job override can read the web, think, remember, and deliver its report - it gets no terminal, file, code-execution, browser, computer-use, skill-management, or delegation toolsets. New test pins the gate and asserts no machine-touching toolset is in the default.
- **Create dialog:** a Sandboxed/Unrestricted picker (radio pair, shield icons matching the chat composer's picker). Defaults to Sandboxed and re-arms to Sandboxed on every open, mirroring the chat opt-in semantics. The hint line states exactly what each mode means. Unrestricted creation instructs June to set the job's `enabled_toolsets` to the full working set; sandboxed creation instructs June to leave the field unset and to flag tasks that clearly need machine access instead of silently creating a routine that cannot do them.
- **Edit flow:** the edit prompt tells June the routine's current mode and how to switch it in either direction (set the full list, or clear the field to fall back to the gate).
- **Per-routine badge:** rows whose stored job carries machine-touching toolsets show a warm "Unrestricted" badge with a hover explainer. Derived from the job's `enabled_toolsets` as returned by `cron.manage` (hermes `_format_job` includes the field), so the badge reflects what the scheduler will actually enforce on the next run - including a routine June was talked into widening outside this dialog, which is exactly the case the badge needs to surface.
- The blanket header "Unrestricted" badge and the always-unrestricted dialog copy from the first revision are gone.

## Behavior change for existing routines

Existing routines have no per-job override, so they fall to the sandboxed default on their next run (fail-safe direction). A routine that needs machine access again can be switched via Edit ("make it unrestricted").

## Limits, stated plainly

- This is tool-dispatch enforcement in the executor process, not a kernel write-jail: the gateway daemon itself stays unsandboxed because launchd refuses service management for jailed processes. A kernel-enforced per-routine jail would need per-job process isolation in upstream hermes-agent (jobs run in-process via `AIAgent` inside the scheduler), or per-mode gateway daemons with partitioned cron stores - both noted as possible follow-ups, neither achievable app-side today.
- The unrestricted opt-in travels through June (the `cronjob` tool is the only writer of per-job `enabled_toolsets`; the gateway's `cron.manage` RPC has no update action). The floor is app-enforced; the widening path is agent-mediated and made visible by the per-row badge.

## Testing

- Rust: new `synced_config_gates_cron_runs_to_the_sandboxed_toolsets` test; full `cargo test` suite green.
- TS: new tests pin the sandboxed default (picker state + prompt contents), the explicit unrestricted opt-in path, the per-row badge deriving from stored `enabled_toolsets`, and the edit prompt carrying the current mode. Full vitest suite green (371 tests). `tsc` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)