### PR TITLE
Hide the issue-report prompt wrapper from the session transcript

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -145,6 +145,10 @@ import {
   type ProviderModelSettingsChangedDetail,
 } from "../../lib/model-privacy";
 import { messageFromError } from "../../lib/errors";
+import {
+  displayedUserMessageText,
+  issueReportPrompt,
+} from "../../lib/issue-report-prompt";
 import { hermesConnectionForMode } from "../../lib/hermes-connection";
 import {
   forgetSessionMode,
@@ -606,23 +610,6 @@ Extra details (when it started, steps to reproduce, attach a screenshot if you h
 
 /** Frames the user's bug report for June: investigate and write a diagnosis
  * for the team instead of treating it as a normal request for help. */
-function issueReportPrompt(report: string) {
-  return [
-    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report and sent to the June development team, so write it for them.",
-    "",
-    "Do not try to fix the issue or walk the user through troubleshooting. Instead:",
-    "1. Read the report below and inspect any attached files or screenshots closely. Describe exactly what they show, including any visible error text.",
-    "2. Give your assessment of what is going wrong and which part of the app is likely involved.",
-    "3. Note anything else the team should look at.",
-    "",
-    "Keep it concise and factual. Close by thanking the user and letting them know the report and your assessment are being sent to the June team.",
-    "",
-    "---USER REPORT---",
-    report,
-    "---END USER REPORT---",
-  ].join("\n");
-}
-
 type PendingIssueReport = {
   description: string;
   attachmentNames: string[];
@@ -4996,7 +4983,9 @@ function AgentChatTurnRow({
           {textParts.map((part, index) => (
             <MarkdownContent
               key={`${turn.id}:text:${index}`}
-              markdown={part.text}
+              // Issue-report sessions open with the wrapped investigation
+              // prompt; the transcript shows only what the user typed.
+              markdown={displayedUserMessageText(part.text)}
             />
           ))}
         </div>
@@ -6233,7 +6222,12 @@ function renderMarkdownBlocks(
     if (heading) {
       flushParagraph();
       const level = Math.min(heading[1].length, 3);
-      const content = renderInlineMarkdown(heading[2], key, highlight, repairProse);
+      const content = renderInlineMarkdown(
+        heading[2],
+        key,
+        highlight,
+        repairProse,
+      );
       blocks.push(
         level === 1 ? (
           <h2 key={`h-${key++}`}>{content}</h2>
@@ -6764,7 +6758,8 @@ function stripHermesVisibleContext(value: string) {
     "",
   );
   const marker = withoutWarnings.search(/\n*--- Attached Context ---/m);
-  const visible = marker >= 0 ? withoutWarnings.slice(0, marker) : withoutWarnings;
+  const visible =
+    marker >= 0 ? withoutWarnings.slice(0, marker) : withoutWarnings;
   // Drop the scheduled-run delivery preamble so a routine's title and dedup
   // key come from its actual prompt, not the cron scaffolding.
   return stripScheduledRunPreamble(visible.trim());

--- a/src/lib/issue-report-prompt.ts
+++ b/src/lib/issue-report-prompt.ts
@@ -1,0 +1,40 @@
+/**
+ * The issue-report investigation prompt. The user's report is wrapped in an
+ * instruction preamble for June, and the wrapped whole becomes the session's
+ * first user message — the runtime needs it verbatim. The transcript, on the
+ * other hand, must show only what the user actually typed: the preamble is
+ * plumbing, not conversation (see `displayedUserMessageText`).
+ */
+
+const USER_REPORT_START = "---USER REPORT---";
+const USER_REPORT_END = "---END USER REPORT---";
+
+export function issueReportPrompt(report: string) {
+  return [
+    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report and sent to the June development team, so write it for them.",
+    "",
+    "Do not try to fix the issue or walk the user through troubleshooting. Instead:",
+    "1. Read the report below and inspect any attached files or screenshots closely. Describe exactly what they show, including any visible error text.",
+    "2. Give your assessment of what is going wrong and which part of the app is likely involved.",
+    "3. Note anything else the team should look at.",
+    "",
+    "Keep it concise and factual. Close by thanking the user and letting them know the report and your assessment are being sent to the June team.",
+    "",
+    USER_REPORT_START,
+    report,
+    USER_REPORT_END,
+  ].join("\n");
+}
+
+/** What a user message should look like in the transcript: an issue-report
+ * wrapper renders as just the report the user typed. Both markers must be
+ * present and ordered, so ordinary messages — even ones discussing the
+ * markers — pass through untouched. */
+export function displayedUserMessageText(content: string): string {
+  const start = content.indexOf(USER_REPORT_START);
+  if (start === -1) return content;
+  const end = content.lastIndexOf(USER_REPORT_END);
+  if (end <= start) return content;
+  const report = content.slice(start + USER_REPORT_START.length, end).trim();
+  return report || content;
+}

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -396,6 +396,13 @@ describe("AgentWorkspace", () => {
     expect(submitted.text).toContain(
       "The recorder crashes after long meetings",
     );
+    // The transcript shows the user's words only — the investigation
+    // framing is plumbing between June and the runtime, never UI.
+    expect(
+      await screen.findByText(/The recorder crashes after long meetings/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/in-app reporting flow/)).toBeNull();
+    expect(screen.queryByText(/---USER REPORT---/)).toBeNull();
     // The report waits for June's diagnosis; nothing is filed yet.
     expect(mocks.submitIssueReport).not.toHaveBeenCalled();
 
@@ -961,7 +968,9 @@ describe("AgentWorkspace", () => {
       }
     });
 
-    expect(await screen.findByText(/Reading one more file/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Reading one more file/),
+    ).toBeInTheDocument();
     expect(screen.getByText("Thinking").closest("details")).toHaveAttribute(
       "open",
     );

--- a/src/test/issue-report-prompt.test.ts
+++ b/src/test/issue-report-prompt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  displayedUserMessageText,
+  issueReportPrompt,
+} from "../lib/issue-report-prompt";
+
+describe("issue report prompt display", () => {
+  it("shows only the user's report for a wrapped prompt", () => {
+    const report =
+      "I want to report an issue with June.\n\nWhat happened: the recorder crashes";
+    const wrapped = issueReportPrompt(report);
+    expect(wrapped).toContain("in-app reporting flow");
+    expect(displayedUserMessageText(wrapped)).toBe(report);
+  });
+
+  it("passes ordinary messages through untouched", () => {
+    expect(displayedUserMessageText("just a normal question")).toBe(
+      "just a normal question",
+    );
+  });
+
+  it("does not mask a message that merely mentions one marker", () => {
+    const tricky = "what does ---END USER REPORT--- mean in the logs?";
+    expect(displayedUserMessageText(tricky)).toBe(tricky);
+  });
+
+  it("falls back to the full content when the wrapper is empty", () => {
+    const wrapped = issueReportPrompt("   ");
+    expect(displayedUserMessageText(wrapped)).toBe(wrapped);
+  });
+});


### PR DESCRIPTION
## Why

Opening an issue-report session showed the user the entire investigation prompt — "The user is filing a bug report… your reply will be attached to the report…", the numbered instructions, and the `---USER REPORT---` markers — rendered as *their own message*. That wrapper is plumbing between June and the runtime, not conversation.

## What

- `issueReportPrompt` moves to `src/lib/issue-report-prompt.ts` next to its new counterpart `displayedUserMessageText`, which returns just the text between the report markers.
- The user-turn renderer passes message text through it, so both the optimistic pending bubble and the persisted transcript show only what the user typed.
- Deliberately conservative masking: both markers must be present and ordered (a message merely *mentioning* a marker passes through untouched), and an empty wrapper falls back to the full content instead of a blank bubble. The runtime still receives the full wrapped prompt verbatim — nothing about the investigation behavior changes.

## Tests

Unit suite for the masking (wrapped → report only, ordinary messages untouched, single-marker mentions untouched, empty wrapper fallback) plus a transcript assertion in the existing report-flow test: the typed report is visible, the preamble and markers are not. Full suite passes; tsc and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)