### PR TITLE
First-class agent CLI support: opt-in sandbox grants plus self-aware copy

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -72,6 +72,45 @@ Your environment: sessions run by default inside a macOS kernel sandbox (Seatbel
 - If the user asks whether you can damage their system, answer honestly: in a sandboxed session, destructive writes outside your workspace are blocked at the kernel level, not just by policy; in an Unrestricted session that protection is off because they chose to turn it off.
 "#;
 
+/// Appended after the sandbox section when the user has NOT enabled Agent
+/// CLI access: the agent must recognize CLI failures as sandbox-caused and
+/// say so instead of misdiagnosing them as the user's auth problem.
+const JUNE_SOUL_CLI_BLOCKED_MD: &str = r#"
+Agent CLIs (Claude Code, Codex, Gemini, opencode): in sandboxed sessions their state folders (~/.claude and ~/.claude.json, ~/.codex, ~/.gemini, opencode's config and state) are write-blocked like the rest of the user's files. Those tools then fail to save sessions or store refreshed logins, and often report "not logged in" even when the user is. When a CLI fails this way, name the sandbox as the cause first, then give the user their real options: enable "Agent CLI access" in Settings, Agent tab (covers new sessions), or start this work in an Unrestricted session. Interactive logins (for example `claude /login`) are browser flows you can never complete; the user runs those once in their own terminal.
+"#;
+
+/// Appended after the sandbox section when the user HAS enabled Agent CLI
+/// access in Settings.
+const JUNE_SOUL_CLI_ALLOWED_MD: &str = r#"
+Agent CLIs (Claude Code, Codex, Gemini, opencode): the user enabled Agent CLI access, so sandboxed sessions can also write those tools' own state folders (~/.claude and ~/.claude.json, ~/.codex, ~/.gemini, opencode's config and state). Driving the user's installed CLIs is a first-class job: run them directly; they can keep sessions and refreshed credentials. Everything else stays jailed. Do not edit their settings or hook files unless the user explicitly asks, because configuration in those folders runs outside this sandbox later. Interactive logins (for example `claude /login`) are browser flows you can never complete; ask the user to run them once in their own terminal.
+"#;
+
+/// Flag file in the app data dir that records the "Agent CLI access"
+/// opt-in. A file rather than a DB row so the synchronous spawn path can
+/// read it without async storage plumbing.
+const AGENT_CLI_ACCESS_FLAG_FILE: &str = "agent-cli-access";
+
+/// State locations of the agent CLIs the opt-in covers, relative to $HOME.
+/// Directories become `subpath` grants. Kept in sync with the SOUL.md
+/// sections above and the Settings copy.
+const AGENT_CLI_STATE_DIRS: &[&str] = &[
+    // Claude Code: sessions, todos, settings, plugins.
+    ".claude",
+    // Codex: sessions and auth.json.
+    ".codex",
+    // Gemini CLI.
+    ".gemini",
+    // opencode.
+    ".config/opencode",
+    ".local/share/opencode",
+    ".local/state/opencode",
+];
+
+/// Top-level state FILES in $HOME (Claude Code's config). Granted via a
+/// prefix regex rather than literals because the CLI writes them atomically
+/// through randomly suffixed temp names (`.claude.json.<hash>` + rename).
+const AGENT_CLI_STATE_FILE_PREFIXES: &[&str] = &[".claude.json"];
+
 const ISOLATED_HERMES_ENV_VARS: &[&str] = &[
     "HERMES_HOME",
     "HERMES_CONFIG",
@@ -472,10 +511,11 @@ async fn start_hermes_bridge_inner(
     // are denied by the kernel rather than by Hermes' own pattern checks.
     // Resolved before the soul write so June's self-knowledge about the jail
     // matches what sandboxed spawns actually enforce.
+    let agent_cli_access = agent_cli_access_enabled(app);
     let sandbox_profile = if full_mode {
         None
     } else {
-        prepare_sandbox(app, &hermes_home)
+        prepare_sandbox(app, &hermes_home, agent_cli_access)
     };
     let sandboxed = sandbox_profile.is_some();
     // SOUL.md is shared by both processes (single home), so its sandbox
@@ -485,7 +525,7 @@ async fn start_hermes_bridge_inner(
     } else {
         sandboxed
     };
-    sync_june_soul(&hermes_home, sandbox_available)?;
+    sync_june_soul(&hermes_home, sandbox_available, agent_cli_access)?;
     if sandboxed {
         eprintln!("Spawning Hermes under the macOS Seatbelt write-jail.");
     } else if full_mode {
@@ -660,6 +700,71 @@ pub async fn toggle_hermes_bridge_skill(
         })),
     )
     .await
+}
+
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCliAccessStatus {
+    pub enabled: bool,
+}
+
+#[tauri::command]
+pub fn hermes_agent_cli_access(app: AppHandle) -> AgentCliAccessStatus {
+    AgentCliAccessStatus {
+        enabled: agent_cli_access_enabled(&app),
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetAgentCliAccessRequest {
+    pub enabled: bool,
+}
+
+/// Records the Agent CLI access opt-in and retires the sandboxed runtime so
+/// the next session spawns with the matching Seatbelt grants (the profile is
+/// applied at spawn and can't change on a live process). The unrestricted
+/// runtime is untouched: it has no jail to widen.
+#[tauri::command]
+pub fn set_hermes_agent_cli_access(
+    app: AppHandle,
+    bridge: State<'_, HermesBridge>,
+    request: SetAgentCliAccessRequest,
+) -> Result<AgentCliAccessStatus, AppError> {
+    let path = agent_cli_access_flag_path(&app).ok_or_else(|| {
+        AppError::new(
+            "agent_cli_access_unavailable",
+            "Could not resolve the app data directory.",
+        )
+    })?;
+    if request.enabled {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| AppError::new("agent_cli_access_failed", error.to_string()))?;
+        }
+        std::fs::write(&path, b"1")
+            .map_err(|error| AppError::new("agent_cli_access_failed", error.to_string()))?;
+    } else if let Err(error) = std::fs::remove_file(&path) {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            return Err(AppError::new("agent_cli_access_failed", error.to_string()));
+        }
+    }
+    stop_hermes_mode(&bridge, false)?;
+    Ok(AgentCliAccessStatus {
+        enabled: request.enabled,
+    })
+}
+
+/// Stops the runtime in one mode slot, leaving the other mode running.
+fn stop_hermes_mode(bridge: &HermesBridge, full_mode: bool) -> Result<(), AppError> {
+    let process = {
+        let mut guard = bridge.processes.lock().map_err(|_| {
+            AppError::new("hermes_bridge_unavailable", "Hermes bridge lock failed.")
+        })?;
+        guard.remove(&full_mode)
+    };
+    shutdown_hermes_process(process);
+    Ok(())
 }
 
 #[tauri::command]
@@ -1697,7 +1802,7 @@ fn apply_isolated_hermes_env(cmd: &mut Command, hermes_home: &std::path::Path, t
 /// jailed agent can't rewrite the policy that governs it or the one the next
 /// spawn will read.
 #[cfg(target_os = "macos")]
-fn prepare_sandbox(app: &AppHandle, hermes_home: &Path) -> Option<PathBuf> {
+fn prepare_sandbox(app: &AppHandle, hermes_home: &Path, agent_cli_access: bool) -> Option<PathBuf> {
     // The caller logs the sandboxed/unsandboxed outcome; this only short-circuits.
     if env_flag_enabled(SCRIBE_HERMES_DISABLE_SANDBOX_ENV) {
         return None;
@@ -1708,7 +1813,7 @@ fn prepare_sandbox(app: &AppHandle, hermes_home: &Path) -> Option<PathBuf> {
     let home = std::env::var_os("HOME").map(PathBuf::from)?;
     let runtime_dir = managed_hermes_runtime_dir(app).ok()?;
     let write_roots = sandbox_write_roots(hermes_home, &runtime_dir);
-    let profile = build_sandbox_profile(&home, &write_roots);
+    let profile = build_sandbox_profile(&home, &write_roots, agent_cli_access);
     let app_data_dir = app.path().app_data_dir().ok()?;
     if std::fs::create_dir_all(&app_data_dir).is_err() {
         return None;
@@ -1724,8 +1829,24 @@ fn prepare_sandbox(app: &AppHandle, hermes_home: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn prepare_sandbox(_app: &AppHandle, _hermes_home: &Path) -> Option<PathBuf> {
+fn prepare_sandbox(
+    _app: &AppHandle,
+    _hermes_home: &Path,
+    _agent_cli_access: bool,
+) -> Option<PathBuf> {
     None
+}
+
+fn agent_cli_access_flag_path(app: &AppHandle) -> Option<PathBuf> {
+    app.path()
+        .app_data_dir()
+        .ok()
+        .map(|dir| dir.join(AGENT_CLI_ACCESS_FLAG_FILE))
+}
+
+/// Whether the user opted into Agent CLI access (Settings, Agent tab).
+pub(crate) fn agent_cli_access_enabled(app: &AppHandle) -> bool {
+    agent_cli_access_flag_path(app).is_some_and(|path| path.exists())
 }
 
 /// Whether a *sandboxed* spawn on this machine would actually engage the
@@ -1804,7 +1925,7 @@ fn sandbox_write_roots(hermes_home: &Path, runtime_dir: &Path) -> Vec<PathBuf> {
 /// and re-grant only the app-owned roots, and deny reads of credential stores.
 /// Pure (no IO) so it can be unit-tested.
 #[cfg(target_os = "macos")]
-fn build_sandbox_profile(home: &Path, write_roots: &[PathBuf]) -> String {
+fn build_sandbox_profile(home: &Path, write_roots: &[PathBuf], agent_cli_access: bool) -> String {
     let mut out = String::new();
     out.push_str("(version 1)\n");
     out.push_str(";; June desktop agent sandbox — generated by Scribe, do not edit.\n");
@@ -1823,6 +1944,30 @@ fn build_sandbox_profile(home: &Path, write_roots: &[PathBuf]) -> String {
         ));
     }
     out.push_str(")\n\n");
+
+    if agent_cli_access {
+        out.push_str(";; Agent CLI state (explicit user opt-in from Settings > Agent):\n");
+        out.push_str(";; lets installed coding CLIs (Claude Code, Codex, Gemini, opencode)\n");
+        out.push_str(";; run under the jail while keeping their sessions and refreshed\n");
+        out.push_str(";; logins. These folders configure tools that later run OUTSIDE the\n");
+        out.push_str(";; sandbox (hooks, settings), which is why this is off by default.\n");
+        out.push_str("(allow file-write*\n");
+        for relative in AGENT_CLI_STATE_DIRS {
+            out.push_str(&format!(
+                "  (subpath {})\n",
+                sbpl_quote(&home.join(relative).to_string_lossy())
+            ));
+        }
+        for prefix in AGENT_CLI_STATE_FILE_PREFIXES {
+            // Prefix regex instead of a literal: the CLIs write these files
+            // atomically through randomly suffixed temp names + rename.
+            out.push_str(&format!(
+                "  (regex #\"^{}.*$\")\n",
+                sbpl_regex_escape(&home.join(prefix).to_string_lossy())
+            ));
+        }
+        out.push_str(")\n\n");
+    }
 
     out.push_str(";; Character devices and pipes the runtime needs to write.\n");
     out.push_str("(allow file-write*\n");
@@ -1888,6 +2033,27 @@ fn sbpl_quote(value: &str) -> String {
     quoted
 }
 
+/// Escapes a path for embedding in an SBPL `(regex #"...")` pattern so it
+/// matches itself literally — dots in file names and any other regex
+/// metacharacters must not widen the grant.
+fn sbpl_regex_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(
+            ch,
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '^' | '$' | '|'
+        ) {
+            escaped.push('\\');
+        }
+        if ch == '"' {
+            // SBPL string layer: a quote would end the #"..." pattern.
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
 fn resolve_scribe_hermes_home(app: &AppHandle) -> Result<PathBuf, AppError> {
     let path = app
         .path()
@@ -1934,9 +2100,18 @@ display:
 /// this machine actually engage the jail (it's omitted when sandbox-exec is
 /// missing or the escape-hatch env var disabled it, so the agent never
 /// claims a protection that isn't enforced).
-fn sync_june_soul(hermes_home: &std::path::Path, sandbox_available: bool) -> Result<(), AppError> {
+fn sync_june_soul(
+    hermes_home: &std::path::Path,
+    sandbox_available: bool,
+    agent_cli_access: bool,
+) -> Result<(), AppError> {
     let soul = if sandbox_available {
-        format!("{JUNE_SOUL_MD}{JUNE_SOUL_SANDBOX_MD}")
+        let cli_section = if agent_cli_access {
+            JUNE_SOUL_CLI_ALLOWED_MD
+        } else {
+            JUNE_SOUL_CLI_BLOCKED_MD
+        };
+        format!("{JUNE_SOUL_MD}{JUNE_SOUL_SANDBOX_MD}{cli_section}")
     } else {
         JUNE_SOUL_MD.to_string()
     };
@@ -2540,7 +2715,7 @@ mod tests {
         )
         .expect("seed default soul");
 
-        sync_june_soul(home.path(), true).expect("sync soul");
+        sync_june_soul(home.path(), true, false).expect("sync soul");
 
         let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
         assert!(soul.contains("You are June"));
@@ -2552,19 +2727,37 @@ mod tests {
     fn sandboxed_soul_describes_the_write_jail() {
         let home = tempfile::tempdir().expect("tempdir");
 
-        sync_june_soul(home.path(), true).expect("sync soul");
+        sync_june_soul(home.path(), true, false).expect("sync soul");
 
         let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
         assert!(soul.contains("Seatbelt"));
         assert!(soul.contains("write-jail"));
         assert!(soul.contains("operation not permitted"));
+        // CLI access off: the soul teaches the failure mode and the remedy.
+        assert!(soul.contains("Agent CLI access"));
+        assert!(soul.contains("name the sandbox as the cause"));
+        assert!(!soul.contains("first-class job"));
+    }
+
+    #[test]
+    fn sandboxed_soul_with_cli_access_describes_the_grant() {
+        let home = tempfile::tempdir().expect("tempdir");
+
+        sync_june_soul(home.path(), true, true).expect("sync soul");
+
+        let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
+        assert!(soul.contains("the user enabled Agent CLI access"));
+        assert!(soul.contains("first-class job"));
+        // Both variants tell June it can never complete interactive logins.
+        assert!(soul.contains("claude /login"));
+        assert!(!soul.contains("name the sandbox as the cause"));
     }
 
     #[test]
     fn unsandboxed_soul_makes_no_sandbox_claims() {
         let home = tempfile::tempdir().expect("tempdir");
 
-        sync_june_soul(home.path(), false).expect("sync soul");
+        sync_june_soul(home.path(), false, false).expect("sync soul");
 
         let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
         assert!(soul.contains("You are June"));
@@ -2603,7 +2796,7 @@ mod tests {
     fn sandbox_profile_jails_writes_to_allowed_roots() {
         let home = PathBuf::from("/Users/test");
         let workspace = PathBuf::from("/Users/test/Library/Application Support/scribe/hermes");
-        let profile = build_sandbox_profile(&home, std::slice::from_ref(&workspace));
+        let profile = build_sandbox_profile(&home, std::slice::from_ref(&workspace), false);
 
         // Allow-everything base, then a hard write-jail re-granting the root.
         assert!(profile.contains("(allow default)"));
@@ -2622,6 +2815,51 @@ mod tests {
         assert!(profile.contains("(deny file-read*"));
         assert!(profile.contains("(subpath \"/Users/test/.ssh\")"));
         assert!(profile.contains("(subpath \"/Users/test/Library/Keychains\")"));
+
+        // Without the opt-in, no agent CLI state dir is writable.
+        assert!(!profile.contains(".claude"));
+        assert!(!profile.contains(".codex"));
+        assert!(!profile.contains(".gemini"));
+        assert!(!profile.contains("opencode"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sandbox_profile_opt_in_grants_agent_cli_state_only() {
+        let home = PathBuf::from("/Users/test");
+        let workspace = PathBuf::from("/Users/test/Library/Application Support/scribe/hermes");
+        let profile = build_sandbox_profile(&home, std::slice::from_ref(&workspace), true);
+
+        // The CLI state dirs become writable...
+        assert!(profile.contains("(subpath \"/Users/test/.claude\")"));
+        assert!(profile.contains("(subpath \"/Users/test/.codex\")"));
+        assert!(profile.contains("(subpath \"/Users/test/.gemini\")"));
+        assert!(profile.contains("(subpath \"/Users/test/.config/opencode\")"));
+        // ...including Claude Code's atomically written top-level config (a
+        // prefix regex, because writes go through random temp suffixes), with
+        // the path's dots escaped so the grant can't widen.
+        assert!(profile.contains("(regex #\"^/Users/test/\\.claude\\.json.*$\")"));
+
+        // The jail and the secret-read denylist are unchanged.
+        assert!(profile.contains("(deny file-write*)"));
+        assert!(profile.contains("(subpath \"/Users/test/.ssh\")"));
+        assert!(profile.contains("(subpath \"/Users/test/Library/Keychains\")"));
+        // The CLI grant must come after the blanket write deny to take effect.
+        let deny_at = profile.find("(deny file-write*)").expect("deny present");
+        let cli_grant_at = profile
+            .find("(subpath \"/Users/test/.claude\")")
+            .expect("cli grant present");
+        assert!(deny_at < cli_grant_at);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn sbpl_regex_escape_neutralizes_metacharacters() {
+        assert_eq!(
+            sbpl_regex_escape("/Users/test/.claude.json"),
+            "/Users/test/\\.claude\\.json"
+        );
+        assert_eq!(sbpl_regex_escape("a+b(c)[d]"), "a\\+b\\(c\\)\\[d\\]");
     }
 
     #[cfg(target_os = "macos")]
@@ -2648,7 +2886,7 @@ mod tests {
         std::fs::create_dir_all(home.join(".ssh")).expect("create .ssh");
         std::fs::write(home.join(".ssh").join("id_secret"), "TOPSECRET").expect("seed secret");
 
-        let profile_text = build_sandbox_profile(&home, std::slice::from_ref(&workspace));
+        let profile_text = build_sandbox_profile(&home, std::slice::from_ref(&workspace), false);
         let profile_path = home.join("test.sb");
         std::fs::write(&profile_path, &profile_text).expect("write profile");
 
@@ -2688,6 +2926,68 @@ mod tests {
         assert!(
             !String::from_utf8_lossy(&out.stdout).contains("TOPSECRET"),
             "secret read must be denied, but the contents leaked"
+        );
+    }
+
+    /// Same kernel-level proof for the Agent CLI access opt-in: the CLI state
+    /// paths become writable (including Claude Code's atomic temp-name
+    /// config writes) while the rest of the jail holds.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn cli_access_profile_is_enforced_by_the_kernel() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let home = std::fs::canonicalize(dir.path()).expect("canonicalize home");
+        let workspace = home.join("workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+
+        let profile_text = build_sandbox_profile(&home, std::slice::from_ref(&workspace), true);
+        let profile_path = home.join("test.sb");
+        std::fs::write(&profile_path, &profile_text).expect("write profile");
+
+        let run = |script: &str| {
+            std::process::Command::new(SANDBOX_EXEC_PATH)
+                .arg("-f")
+                .arg(&profile_path)
+                .arg("/bin/bash")
+                .arg("-c")
+                .arg(script)
+                .output()
+                .expect("run sandbox-exec")
+        };
+
+        // Allowed: create ~/.claude itself and write session state under it.
+        let claude_state = home.join(".claude").join("session.json");
+        let out = run(&format!(
+            "mkdir -p {} && echo state > {}",
+            sbpl_shell_quote(&home.join(".claude")),
+            sbpl_shell_quote(&claude_state)
+        ));
+        assert!(
+            out.status.success() && claude_state.exists(),
+            "CLI state write should be allowed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // Allowed: the atomic config write pattern (temp suffix + rename).
+        let config_tmp = home.join(".claude.json.1a2b3c");
+        let config = home.join(".claude.json");
+        let out = run(&format!(
+            "echo cfg > {tmp} && mv {tmp} {cfg}",
+            tmp = sbpl_shell_quote(&config_tmp),
+            cfg = sbpl_shell_quote(&config)
+        ));
+        assert!(
+            out.status.success() && config.exists(),
+            "atomic CLI config write should be allowed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // Still denied: anything else in the home directory.
+        let outside = home.join("escaped.txt");
+        run(&format!("echo bad > {}", sbpl_shell_quote(&outside)));
+        assert!(
+            !outside.exists(),
+            "write outside the jail must stay denied with CLI access on"
         );
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,8 @@ pub fn run() {
             hermes_bridge::toggle_hermes_bridge_skill,
             hermes_bridge::toggle_hermes_bridge_toolset,
             hermes_bridge::update_hermes_bridge_messaging_platform,
+            hermes_bridge::hermes_agent_cli_access,
+            hermes_bridge::set_hermes_agent_cli_access,
             commands::get_microphone_permission_state,
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -5,11 +5,13 @@ import {
   SkillsToolsPanel,
 } from "../agent/AgentWorkspace";
 import {
+  hermesAgentCliAccess,
   hermesBridgeFilesystemSnapshot,
   hermesBridgeMessagingPlatforms,
   hermesBridgeSkills,
   hermesBridgeToolsets,
   agentHudHide,
+  setHermesAgentCliAccess,
   toggleHermesBridgeSkill,
   toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform,
@@ -46,6 +48,39 @@ export function AgentSettingsSection() {
   const [agentHudEnabled, setAgentHudEnabledState] = useState(() =>
     getAgentHudEnabled(),
   );
+  // null until the stored value loads, so the switch never flashes a wrong
+  // default for a setting with security weight.
+  const [cliAccessEnabled, setCliAccessEnabled] = useState<boolean | null>(
+    null,
+  );
+  const [cliAccessSaving, setCliAccessSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    hermesAgentCliAccess()
+      .then((status) => {
+        if (!cancelled) setCliAccessEnabled(status.enabled);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(messageFromError(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleCliAccessChange(enabled: boolean) {
+    setCliAccessSaving(true);
+    try {
+      const status = await setHermesAgentCliAccess(enabled);
+      setCliAccessEnabled(status.enabled);
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setCliAccessSaving(false);
+    }
+  }
 
   useEffect(() => {
     if (panel === "skills" && (!skills || !toolsets)) {
@@ -253,6 +288,30 @@ export function AgentSettingsSection() {
                   void handleAgentHudEnabledChange(enabled)
                 }
                 aria-label="Show agent HUD"
+              />
+            </div>
+          </div>
+          <div className="settings-row">
+            <div className="settings-row-info">
+              <h3 className="settings-row-title">Agent CLI access</h3>
+              <p className="settings-row-description">
+                Let June drive the coding CLIs you already use (Claude Code,
+                Codex, Gemini, opencode). Sandboxed sessions gain write access
+                to those tools' own settings and session folders so they stay
+                logged in and can save their work. Those folders configure
+                software that also runs outside June's sandbox, so leave this
+                off unless you want June operating your CLIs. Applies to new
+                sessions.
+              </p>
+            </div>
+            <div className="settings-row-control">
+              <Switch
+                checked={cliAccessEnabled === true}
+                disabled={cliAccessEnabled === null || cliAccessSaving}
+                onCheckedChange={(enabled) =>
+                  void handleCliAccessChange(enabled)
+                }
+                aria-label="Allow agent CLI access"
               />
             </div>
           </div>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -860,6 +860,24 @@ export async function toggleHermesBridgeToolset(input: {
   );
 }
 
+export type AgentCliAccessStatus = {
+  enabled: boolean;
+};
+
+/** Whether sandboxed sessions may write the state folders of installed
+ * agent CLIs (Claude Code, Codex, Gemini, opencode). */
+export async function hermesAgentCliAccess() {
+  return invoke<AgentCliAccessStatus>("hermes_agent_cli_access");
+}
+
+/** Persists the Agent CLI access opt-in and retires the sandboxed runtime so
+ * the next session spawns with matching sandbox grants. */
+export async function setHermesAgentCliAccess(enabled: boolean) {
+  return invoke<AgentCliAccessStatus>("set_hermes_agent_cli_access", {
+    request: { enabled },
+  });
+}
+
 export async function hermesBridgeMessagingPlatforms() {
   return invoke<HermesMessagingPlatformsResponse>(
     "hermes_bridge_messaging_platforms",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -31,6 +31,8 @@ const mocks = vi.hoisted(() => ({
   updateHermesBridgeMessagingPlatform: vi.fn(),
   agentHudShow: vi.fn(),
   agentHudHide: vi.fn(),
+  hermesAgentCliAccess: vi.fn(),
+  setHermesAgentCliAccess: vi.fn(),
   listDictionaryEntries: vi.fn(),
   createDictionaryEntry: vi.fn(),
   updateDictionaryEntry: vi.fn(),
@@ -65,6 +67,8 @@ vi.mock("../lib/tauri", () => ({
     mocks.updateHermesBridgeMessagingPlatform,
   agentHudShow: mocks.agentHudShow,
   agentHudHide: mocks.agentHudHide,
+  hermesAgentCliAccess: mocks.hermesAgentCliAccess,
+  setHermesAgentCliAccess: mocks.setHermesAgentCliAccess,
   listDictionaryEntries: mocks.listDictionaryEntries,
   createDictionaryEntry: mocks.createDictionaryEntry,
   updateDictionaryEntry: mocks.updateDictionaryEntry,
@@ -254,6 +258,10 @@ describe("AppSettings", () => {
     mocks.openPrivacySettings.mockResolvedValue(undefined);
     mocks.agentHudShow.mockResolvedValue(undefined);
     mocks.agentHudHide.mockResolvedValue(undefined);
+    mocks.hermesAgentCliAccess.mockResolvedValue({ enabled: false });
+    mocks.setHermesAgentCliAccess.mockImplementation(
+      async (enabled: boolean) => ({ enabled }),
+    );
     mocks.setDictationShortcut.mockImplementation(async (kind, shortcut) => ({
       ...baseSettings,
       ...(kind === "toggle"
@@ -1292,5 +1300,43 @@ describe("AppSettings", () => {
     await user.click(hudSwitch);
     expect(localStorage.getItem(AGENT_HUD_ENABLED_KEY)).toBe("true");
     expect(mocks.agentHudShow).not.toHaveBeenCalled();
+  });
+
+  it("opts into agent CLI access from Agent settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Agent" }));
+    const cliSwitch = await screen.findByRole("switch", {
+      name: "Allow agent CLI access",
+    });
+    // The disclosure names the deferred-execution risk, not just the benefit.
+    expect(screen.getByText(/runs outside June's sandbox/)).toBeInTheDocument();
+
+    await waitFor(() => expect(cliSwitch).toBeEnabled());
+    expect(cliSwitch).toHaveAttribute("aria-checked", "false");
+
+    await user.click(cliSwitch);
+    await waitFor(() =>
+      expect(mocks.setHermesAgentCliAccess).toHaveBeenCalledWith(true),
+    );
+    expect(cliSwitch).toHaveAttribute("aria-checked", "true");
+
+    await user.click(cliSwitch);
+    await waitFor(() =>
+      expect(mocks.setHermesAgentCliAccess).toHaveBeenCalledWith(false),
+    );
+    expect(cliSwitch).toHaveAttribute("aria-checked", "false");
   });
 });


### PR DESCRIPTION
## Problem

People drive their existing coding CLIs (Claude Code, Codex, Gemini, opencode) through June, and the default Seatbelt write-jail silently breaks them: the CLIs cannot write their own state (`~/.claude`, `~/.codex`, ...), so they fail to save sessions and to store refreshed OAuth tokens, and mid-run they start reporting "not logged in" even when the user is. June then misdiagnoses the failure as the user's auth problem (see the user report this PR responds to), and the only remedy was full Unrestricted mode. Whitelisting these folders silently would be wrong too: they configure tools that later run OUTSIDE the sandbox (hooks, settings), so a sandboxed write there is a deferred-execution escape vector.

## What

Three coordinated fixes:

**1. An explicit "Agent CLI access" opt-in (Settings > Agent).** When enabled, sandboxed sessions get write access to exactly the CLI state locations and nothing else:
- `~/.claude`, `~/.codex`, `~/.gemini`, and opencode's `~/.config/opencode` + `~/.local/{share,state}/opencode` as `subpath` grants
- Claude Code's top-level `~/.claude.json` via a metacharacter-escaped prefix regex, because the CLI writes it atomically through randomly suffixed temp names + rename (plain literals would break every config write)

The rest of the jail (including the secret-read denylist) is untouched. The setting is a flag file the synchronous spawn path reads; toggling retires the sandboxed runtime so the next session spawns with the matching profile (Seatbelt is applied at spawn). The settings copy names the actual risk, not just the benefit: "Those folders configure software that also runs outside June's sandbox, so leave this off unless you want June operating your CLIs."

**2. June now understands its own sandbox (the "it probs should know to say that" fix).** SOUL.md gains a CLI section in both states:
- Opt-in off: recognize CLI "logged out" failures as sandbox-caused, name the sandbox as the cause FIRST, then offer the real options (the setting, or an Unrestricted session) instead of walking the user through pointless re-auth.
- Opt-in on: treat driving the user's CLIs as a first-class job, but never edit their settings or hook files unprompted, because configuration there executes outside the sandbox later.
- Both: interactive logins (`claude /login`) are browser flows June can never complete; the user runs them once in their own terminal.

**3. Containment of the "june -> codex -> anything" backdoor concern.** The grant is deliberately NOT part of the default sandbox and NOT bundled into a broader permission: it is a separate, persistent, disclosed opt-in, narrower than Unrestricted, and the agent is instructed not to touch hook/settings files without an explicit ask (defense in depth on top of the disclosure).

## Testing

- **Kernel-level proof**, not just string assertions: a new test feeds the generated opt-in profile to `sandbox-exec` and verifies `mkdir ~/.claude` + state writes succeed, the atomic `.claude.json.<tmp>` + rename pattern succeeds, and a write elsewhere in `$HOME` is still denied. The existing kernel test keeps proving the default profile unchanged.
- Profile unit tests: default profile contains no CLI grants; opt-in profile contains exactly the expected subpaths and the dot-escaped regex; regex escaping covered separately.
- SOUL.md tests for both variants (failure-diagnosis copy vs first-class-job copy, `/login` guidance in both).
- Settings UI test: the toggle loads the stored value, round-trips through the new commands, and the disclosure text is asserted to mention the outside-the-sandbox risk.
- Full suites green: 118 Rust lib tests, 382 frontend tests, `tsc --noEmit`, prettier, no new clippy warnings.

## Follow-ups worth considering (not in this PR)

- A per-session "ask permission for just that" prompt (the approval-style flow) instead of a settings toggle — requires making the Seatbelt profile per-session, since it is fixed at spawn; the settings opt-in delivers the unblock now without that refactor.
- Detecting installed CLIs and surfacing the toggle contextually (e.g. June deep-linking to the setting when it hits the failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)