### PR TITLE
Onboarding: ask where the user discovered June

### DIFF
--- a/onboarding-preview.html
+++ b/onboarding-preview.html
@@ -87,9 +87,11 @@
           accessibility: permsMode ? "missing" : "granted",
         };
 
-        // The wizard always replays in the preview.
+        // The wizard always replays in the preview, with the discovery
+        // question unanswered so the practice step shows the whole card.
         try {
           localStorage.removeItem("june.onboarding.completedVersion");
+          localStorage.removeItem("june.onboarding.discoverySource");
           if (step) localStorage.setItem("june.onboarding.resumeStep", step);
           else localStorage.removeItem("june.onboarding.resumeStep");
         } catch (e) {}

--- a/src/components/onboarding/steps/PracticeStep.tsx
+++ b/src/components/onboarding/steps/PracticeStep.tsx
@@ -1,13 +1,28 @@
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { discoverySource, setDiscoverySource } from "../../../lib/onboarding";
 import { JuneMark } from "../../account/AccountGate";
 import { KeycapShortcut } from "../../shortcuts/KeycapShortcut";
 import { useShortcutCapture } from "../../shortcuts/use-shortcut-capture";
+import { Select } from "../../ui/Select";
 import { StepActions, StepCard } from "../StepChrome";
 
 // June "types" for a beat before its greeting lands — the small theater that
 // makes the demo read as a live session rather than a printed screenshot.
 const TYPING_MS = 1100;
+
+const DISCOVERY_QUESTION = "Where did you hear about June?";
+
+const DISCOVERY_OPTIONS = [
+  { value: "friend", label: "Friend or coworker" },
+  { value: "x-twitter", label: "X (Twitter)" },
+  { value: "youtube", label: "YouTube" },
+  { value: "instagram-tiktok", label: "Instagram or TikTok" },
+  { value: "podcast-newsletter", label: "Podcast or newsletter" },
+  { value: "ai-chat", label: "ChatGPT or another AI" },
+  { value: "search", label: "Search engine" },
+  { value: "other", label: "Other" },
+];
 
 /**
  * First contact with June, and the dictation rep in one: a session card where
@@ -32,6 +47,12 @@ export function DictationPracticeStep({
   const [value, setValue] = useState("");
   const [greeted, setGreeted] = useState(false);
   const succeeded = value.trim().length >= 4;
+
+  // One last question, Mobbin's end-of-flow attribution slot. Asked only if
+  // it has never been answered — a version-bump replay must not survey the
+  // same user twice — and it never gates Continue.
+  const [discovered, setDiscovered] = useState<string | null>(discoverySource);
+  const askDiscovery = useRef(discoverySource() === null).current;
 
   const capture = useShortcutCapture({
     kind: "push_to_talk",
@@ -113,6 +134,23 @@ export function DictationPracticeStep({
         </div>
       </div>
       {capture.error ? <p className="welcome-status">{capture.error}</p> : null}
+      {askDiscovery ? (
+        <div className="onboarding-discovery">
+          <span className="onboarding-discovery-label">
+            {DISCOVERY_QUESTION}
+          </span>
+          <Select
+            ariaLabel={DISCOVERY_QUESTION}
+            value={discovered}
+            options={DISCOVERY_OPTIONS}
+            placeholder="Choose one (optional)"
+            onChange={(source) => {
+              setDiscovered(source);
+              setDiscoverySource(source);
+            }}
+          />
+        </div>
+      ) : null}
       <StepActions
         continueLabel="Start using June"
         onContinue={onContinue}

--- a/src/components/onboarding/steps/PracticeStep.tsx
+++ b/src/components/onboarding/steps/PracticeStep.tsx
@@ -1,4 +1,3 @@
-import { IconBubbleQuestion } from "central-icons/IconBubbleQuestion";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { useEffect, useRef, useState } from "react";
 import { discoverySource, setDiscoverySource } from "../../../lib/onboarding";
@@ -138,13 +137,8 @@ export function DictationPracticeStep({
       {askDiscovery ? (
         <div className="onboarding-discovery">
           <div className="onboarding-discovery-head">
-            <span className="onboarding-discovery-icon" aria-hidden>
-              <IconBubbleQuestion size={15} />
-            </span>
-            <div className="onboarding-discovery-copy">
-              <h2>{DISCOVERY_QUESTION}</h2>
-              <p>Optional, but it helps us out.</p>
-            </div>
+            <h2>{DISCOVERY_QUESTION}</h2>
+            <span className="onboarding-discovery-optional">Optional</span>
           </div>
           <Select
             ariaLabel={DISCOVERY_QUESTION}

--- a/src/components/onboarding/steps/PracticeStep.tsx
+++ b/src/components/onboarding/steps/PracticeStep.tsx
@@ -1,3 +1,4 @@
+import { IconBubbleQuestion } from "central-icons/IconBubbleQuestion";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { useEffect, useRef, useState } from "react";
 import { discoverySource, setDiscoverySource } from "../../../lib/onboarding";
@@ -136,14 +137,20 @@ export function DictationPracticeStep({
       {capture.error ? <p className="welcome-status">{capture.error}</p> : null}
       {askDiscovery ? (
         <div className="onboarding-discovery">
-          <span className="onboarding-discovery-label">
-            {DISCOVERY_QUESTION}
-          </span>
+          <div className="onboarding-discovery-head">
+            <span className="onboarding-discovery-icon" aria-hidden>
+              <IconBubbleQuestion size={15} />
+            </span>
+            <div className="onboarding-discovery-copy">
+              <h2>{DISCOVERY_QUESTION}</h2>
+              <p>Optional, but it helps us out.</p>
+            </div>
+          </div>
           <Select
             ariaLabel={DISCOVERY_QUESTION}
             value={discovered}
             options={DISCOVERY_OPTIONS}
-            placeholder="Choose one (optional)"
+            placeholder="Choose one"
             onChange={(source) => {
               setDiscovered(source);
               setDiscoverySource(source);

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -51,6 +51,11 @@ import { KeycapShortcut } from "../shortcuts/KeycapShortcut";
 import { shortcutFromCapturePayload } from "../shortcuts/use-shortcut-capture";
 import { Dialog } from "../ui/Dialog";
 import { HoverTip } from "../ui/HoverTip";
+import {
+  selectPopoverPlacement,
+  selectPopoverStyle,
+  type SelectPopoverPlacement,
+} from "../ui/Select";
 import { SegmentedControl } from "../ui/SegmentedControl";
 import { Switch } from "../ui/Switch";
 import { APP_COMMIT_HASH, APP_VERSION } from "../../app/build-info";
@@ -173,8 +178,6 @@ export type SettingsTab =
   | "models"
   | "agent"
   | "about";
-
-type SelectPopoverPlacement = "align-selected" | "below" | "above";
 
 export const SETTINGS_TABS: { id: SettingsTab; label: string }[] = [
   { id: "general", label: "General" },
@@ -1853,55 +1856,6 @@ function shortcutsMatch(
     first.modifiers.shift === second.modifiers.shift &&
     first.modifiers.function === second.modifiers.function
   );
-}
-
-function selectPopoverPlacement(
-  anchor: HTMLElement | null,
-  optionCount: number,
-  selectedIndex: number,
-): SelectPopoverPlacement {
-  if (!anchor) return "align-selected";
-  const rect = anchor.getBoundingClientRect();
-
-  const viewportPadding = 12;
-  const rowHeight = 28;
-  const popoverPadding = 8;
-  const popoverHeight = optionCount * rowHeight + popoverPadding;
-  const selectedOffset = 2 + selectedIndex * rowHeight;
-  const panel = anchor.closest(".main-panel");
-  const panelRect = panel?.getBoundingClientRect();
-  const topBound = Math.max(viewportPadding, (panelRect?.top ?? 0) + 12);
-  const bottomBound = Math.min(
-    window.innerHeight - viewportPadding,
-    (panelRect?.bottom ?? window.innerHeight) - 12,
-  );
-  const alignedTop = rect.top - selectedOffset;
-  const alignedBottom = alignedTop + popoverHeight;
-  const belowBottom = rect.bottom + 4 + popoverHeight;
-  const aboveTop = rect.top - 4 - popoverHeight;
-  const spaceBelow = bottomBound - rect.bottom;
-  const spaceAbove = rect.top - topBound;
-
-  if (alignedTop >= topBound && alignedBottom <= bottomBound) {
-    return "align-selected";
-  }
-  if (belowBottom <= bottomBound || spaceBelow >= spaceAbove) {
-    return "below";
-  }
-  return aboveTop >= topBound ? "above" : "below";
-}
-
-function selectPopoverStyle(
-  placement: SelectPopoverPlacement,
-  selectedIndex: number,
-): CSSProperties {
-  if (placement === "below") {
-    return { top: "calc(100% + 4px)" };
-  }
-  if (placement === "above") {
-    return { bottom: "calc(100% + 4px)" };
-  }
-  return { top: -(2 + selectedIndex * 28) };
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -138,6 +138,7 @@ export function Select({
       <button
         type="button"
         className="select-trigger"
+        data-placeholder={!selected}
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,182 @@
+import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
+import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+
+export type SelectPopoverPlacement = "align-selected" | "below" | "above";
+
+/**
+ * Native-macOS popup behavior, shared by every select-trigger surface: the
+ * popover prefers sliding up so the currently selected option lines up with
+ * the trigger's position, and falls back to a plain below/above dropdown
+ * when that would leave the panel (or the viewport).
+ */
+export function selectPopoverPlacement(
+  anchor: HTMLElement | null,
+  optionCount: number,
+  selectedIndex: number,
+): SelectPopoverPlacement {
+  if (!anchor) return "align-selected";
+  const rect = anchor.getBoundingClientRect();
+
+  const viewportPadding = 12;
+  const rowHeight = 28;
+  const popoverPadding = 8;
+  const popoverHeight = optionCount * rowHeight + popoverPadding;
+  const selectedOffset = 2 + selectedIndex * rowHeight;
+  const panel = anchor.closest(".main-panel");
+  const panelRect = panel?.getBoundingClientRect();
+  const topBound = Math.max(viewportPadding, (panelRect?.top ?? 0) + 12);
+  const bottomBound = Math.min(
+    window.innerHeight - viewportPadding,
+    (panelRect?.bottom ?? window.innerHeight) - 12,
+  );
+  const alignedTop = rect.top - selectedOffset;
+  const alignedBottom = alignedTop + popoverHeight;
+  const belowBottom = rect.bottom + 4 + popoverHeight;
+  const aboveTop = rect.top - 4 - popoverHeight;
+  const spaceBelow = bottomBound - rect.bottom;
+  const spaceAbove = rect.top - topBound;
+
+  if (alignedTop >= topBound && alignedBottom <= bottomBound) {
+    return "align-selected";
+  }
+  if (belowBottom <= bottomBound || spaceBelow >= spaceAbove) {
+    return "below";
+  }
+  return aboveTop >= topBound ? "above" : "below";
+}
+
+export function selectPopoverStyle(
+  placement: SelectPopoverPlacement,
+  selectedIndex: number,
+): CSSProperties {
+  if (placement === "below") {
+    return { top: "calc(100% + 4px)" };
+  }
+  if (placement === "above") {
+    return { bottom: "calc(100% + 4px)" };
+  }
+  return { top: -(2 + selectedIndex * 28) };
+}
+
+export type SelectOption = {
+  value: string;
+  label: string;
+};
+
+/**
+ * The settings select (trigger + listbox popover) as a self-contained
+ * control, for surfaces that don't hand-roll the open/placement state the
+ * way AppSettings does. Same classes, so it is pixel-identical to the
+ * Language and Microphone pickers.
+ */
+export function Select({
+  value,
+  options,
+  placeholder,
+  onChange,
+  ariaLabel,
+  className,
+}: {
+  value: string | null;
+  options: SelectOption[];
+  /** Trigger text while nothing is selected yet. */
+  placeholder: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [placement, setPlacement] =
+    useState<SelectPopoverPlacement>("align-selected");
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  const selectedIndex = options.findIndex((option) => option.value === value);
+  const selected = selectedIndex === -1 ? undefined : options[selectedIndex];
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointer(event: MouseEvent) {
+      if (!wrapRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("mousedown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  function toggle() {
+    if (!open) {
+      // An unanswered select has no row to align with, so it opens as a
+      // plain dropdown; Math.max keeps the offset math on row 0.
+      setPlacement(
+        selectedIndex === -1
+          ? "below"
+          : selectPopoverPlacement(
+              wrapRef.current,
+              options.length,
+              selectedIndex,
+            ),
+      );
+    }
+    setOpen((current) => !current);
+  }
+
+  return (
+    <div
+      className={`select-control${className ? ` ${className}` : ""}`}
+      ref={wrapRef}
+    >
+      <button
+        type="button"
+        className="select-trigger"
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={toggle}
+      >
+        <span>{selected?.label ?? placeholder}</span>
+        <IconChevronDownSmall size={14} />
+      </button>
+      {open ? (
+        <ul
+          className="select-popover"
+          role="listbox"
+          data-placement={placement}
+          style={selectPopoverStyle(placement, Math.max(selectedIndex, 0))}
+        >
+          {options.map((option) => {
+            const isSelected = option.value === value;
+            return (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  data-selected={isSelected}
+                  onClick={() => {
+                    onChange(option.value);
+                    setOpen(false);
+                  }}
+                >
+                  <span>{option.label}</span>
+                  <span className="select-check" aria-hidden>
+                    {isSelected ? <IconCheckmark1Small size={14} /> : null}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -10,6 +10,7 @@ const ONBOARDING_VERSION = 7;
 const COMPLETED_KEY = "june.onboarding.completedVersion";
 const RESUME_KEY = "june.onboarding.resumeStep";
 const AGENT_ACK_KEY = "june.agent.riskAcknowledged";
+const DISCOVERY_KEY = "june.onboarding.discoverySource";
 
 type OnboardingReplayEnv = {
   readonly DEV?: boolean;
@@ -53,6 +54,10 @@ export function resetOnboardingForReplay() {
   try {
     window.localStorage.removeItem(COMPLETED_KEY);
     window.localStorage.removeItem(RESUME_KEY);
+    // Dev-only path: forget the discovery answer too, so the replayed
+    // wizard shows the whole flow. Real version-bump replays don't come
+    // through here and keep it.
+    window.localStorage.removeItem(DISCOVERY_KEY);
   } catch {
     // Ignore; storage unavailable already behaves like a completed wizard.
   }
@@ -77,6 +82,28 @@ export function setOnboardingResumeStep(stepId: string) {
     window.localStorage.setItem(RESUME_KEY, stepId);
   } catch {
     // Ignore; worst case the wizard restarts from the top.
+  }
+}
+
+/**
+ * Where the user says they discovered June, asked once at the end of the
+ * wizard. A non-null answer is never re-asked, even when a version bump
+ * replays the wizard. Stored locally for now; reporting it home needs a
+ * scribe-api endpoint, and this is the single place to hook that up.
+ */
+export function discoverySource(): string | null {
+  try {
+    return window.localStorage.getItem(DISCOVERY_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setDiscoverySource(source: string) {
+  try {
+    window.localStorage.setItem(DISCOVERY_KEY, source);
+  } catch {
+    // Ignore; worst case the question is asked again on a replay.
   }
 }
 
@@ -109,6 +136,7 @@ export function setAgentRiskAcknowledged(acknowledged: boolean) {
 export function replayOnboarding(stepId?: string) {
   try {
     window.localStorage.removeItem(COMPLETED_KEY);
+    window.localStorage.removeItem(DISCOVERY_KEY);
     if (stepId) window.localStorage.setItem(RESUME_KEY, stepId);
     else window.localStorage.removeItem(RESUME_KEY);
   } catch {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6792,6 +6792,13 @@ button.agent-safety-badge:hover {
   background: var(--muted);
 }
 
+/* Anchor for the self-contained Select control's popover (settings rows
+ * anchor to .settings-row-control instead). */
+.select-control {
+  position: relative;
+  display: inline-flex;
+}
+
 /* Select trigger — transparent bg, subtle border only; hover deepens the
  * border. Chevron absolutely positioned at right. */
 .select-trigger {
@@ -10992,4 +10999,25 @@ button.agent-safety-badge:hover {
   background: color-mix(in oklch, var(--success) 12%, transparent);
   color: var(--success);
   animation: onboarding-rise var(--t-med) var(--ease-out);
+}
+
+/* One last question: where the user discovered June. A quiet form row —
+   muted label over a full-width select — sitting between the practice card
+   and the primary action, never gating it. */
+.onboarding-discovery {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  text-align: left;
+}
+
+.onboarding-discovery-label {
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+.onboarding-discovery .select-control,
+.onboarding-discovery .select-trigger {
+  width: 100%;
+  min-width: 0;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6835,6 +6835,11 @@ button.agent-safety-badge:hover {
   white-space: nowrap;
 }
 
+/* Nothing chosen yet: the placeholder reads as a prompt, not a value. */
+.select-trigger[data-placeholder="true"] > span:first-child {
+  color: var(--muted-foreground);
+}
+
 .select-trigger svg {
   position: absolute;
   top: 50%;
@@ -10671,8 +10676,7 @@ button.agent-safety-badge:hover {
   border-top: 1px solid var(--border-subtle);
 }
 
-.onboarding-perm-icon,
-.onboarding-discovery-icon {
+.onboarding-perm-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -11002,42 +11006,47 @@ button.agent-safety-badge:hover {
   animation: onboarding-rise var(--t-med) var(--ease-out);
 }
 
-/* One last question: where the user discovered June. Dressed exactly like
-   the permission rows' card (same border, radius, shadow, icon chip) so it
-   reads as a deliberate part of the step, not a floating form field. The
-   select goes full width below the copy — beside it, neither fits in the
-   360px card. */
+/* One last question: where the user discovered June, in its own card so it
+   reads as a deliberate part of the step, not a floating form field. Same
+   surface recipe as the permission card, with the shortcut tray's softer
+   16px corners; a quiet muted "Optional" in the top right carries what a
+   detail line would have said. The select goes full width below the
+   title — beside it, neither fits in the 360px card. */
 .onboarding-discovery {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-3);
-  padding: var(--sp-3);
+  gap: var(--sp-4);
+  /* On top of the welcome-card's own gap — the card needs clear air from
+     the practice surface above so the two don't read as one stack. */
+  margin-top: var(--sp-4);
+  padding: var(--sp-6);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--r-lg);
+  border-radius: 16px;
   background: var(--card);
   box-shadow: var(--shadow-sm);
   text-align: left;
 }
 
 .onboarding-discovery-head {
-  display: grid;
-  grid-template-columns: 28px 1fr;
-  column-gap: var(--sp-3);
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
 }
 
-.onboarding-discovery-copy h2 {
+.onboarding-discovery-head h2 {
   margin: 0;
   font-size: var(--fs-lg);
-  font-weight: 600;
+  font-weight: 400;
   color: var(--foreground);
 }
 
-.onboarding-discovery-copy p {
-  margin: 2px 0 0;
+/* A step smaller than the question and lighter than muted, so it recedes
+   to a whisper — subtle over badge-loud. */
+.onboarding-discovery-optional {
+  flex: 0 0 auto;
   font-size: var(--fs-md);
-  line-height: 1.5;
-  color: var(--muted-foreground);
+  color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
 }
 
 .onboarding-discovery .select-control,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10671,7 +10671,8 @@ button.agent-safety-badge:hover {
   border-top: 1px solid var(--border-subtle);
 }
 
-.onboarding-perm-icon {
+.onboarding-perm-icon,
+.onboarding-discovery-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -11001,19 +11002,42 @@ button.agent-safety-badge:hover {
   animation: onboarding-rise var(--t-med) var(--ease-out);
 }
 
-/* One last question: where the user discovered June. A quiet form row —
-   muted label over a full-width select — sitting between the practice card
-   and the primary action, never gating it. */
+/* One last question: where the user discovered June. Dressed exactly like
+   the permission rows' card (same border, radius, shadow, icon chip) so it
+   reads as a deliberate part of the step, not a floating form field. The
+   select goes full width below the copy — beside it, neither fits in the
+   360px card. */
 .onboarding-discovery {
   display: flex;
   flex-direction: column;
-  gap: var(--sp-2);
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--card);
+  box-shadow: var(--shadow-sm);
   text-align: left;
 }
 
-.onboarding-discovery-label {
-  color: var(--muted-foreground);
+.onboarding-discovery-head {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  column-gap: var(--sp-3);
+  align-items: center;
+}
+
+.onboarding-discovery-copy h2 {
+  margin: 0;
+  font-size: var(--fs-lg);
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.onboarding-discovery-copy p {
+  margin: 2px 0 0;
   font-size: var(--fs-md);
+  line-height: 1.5;
+  color: var(--muted-foreground);
 }
 
 .onboarding-discovery .select-control,

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
 import {
   applyOnboardingReplayFlag,
+  discoverySource,
   isAgentRiskAcknowledged,
   isOnboardingComplete,
   markOnboardingComplete,
   onboardingResumeStep,
   resetOnboardingForReplay,
+  setDiscoverySource,
   setOnboardingResumeStep,
 } from "../lib/onboarding";
 import type { AccountStatus } from "../lib/tauri";
@@ -613,15 +615,49 @@ describe("OnboardingFlow", () => {
     await screen.findByRole("heading", { name: "Talk to June" });
   });
 
+  it("records where the user heard about June", async () => {
+    const user = userEvent.setup();
+    setOnboardingResumeStep("dictation-practice");
+    render(<OnboardingFlow {...flowProps()} />);
+    await screen.findByRole("heading", { name: "Talk to June" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Where did you hear about June?" }),
+    );
+    await user.click(screen.getByRole("option", { name: "YouTube" }));
+
+    expect(discoverySource()).toBe("youtube");
+    // The trigger keeps showing the choice, and answering never gates the
+    // step: Continue still waits on the dictation rep, not the survey.
+    expect(
+      screen.getByRole("button", { name: "Where did you hear about June?" }),
+    ).toHaveTextContent("YouTube");
+  });
+
+  it("never re-asks an answered discovery question", async () => {
+    // A version-bump replay walks existing users through the wizard again;
+    // the survey must not come back for someone who already answered it.
+    setDiscoverySource("youtube");
+    setOnboardingResumeStep("dictation-practice");
+    render(<OnboardingFlow {...flowProps()} />);
+    await screen.findByRole("heading", { name: "Talk to June" });
+
+    expect(screen.queryByText("Where did you hear about June?")).toBeNull();
+  });
+
   it("resets only onboarding progress when replaying the wizard", () => {
     markOnboardingComplete();
     setOnboardingResumeStep("setup");
+    setDiscoverySource("youtube");
     localStorage.setItem("june.agent.riskAcknowledged", "true");
 
     resetOnboardingForReplay();
 
     expect(isOnboardingComplete()).toBe(false);
     expect(onboardingResumeStep()).toBeNull();
+    // The dev replay forgets the discovery answer (so the replayed wizard
+    // shows the whole flow) but keeps the agent-risk acknowledgment.
+    expect(discoverySource()).toBeNull();
     expect(isAgentRiskAcknowledged()).toBe(true);
   });
 


### PR DESCRIPTION
## What

Adds the "Where did you hear about June?" attribution question to onboarding — no fifth page. It rides on the final practice step as one quiet form row (muted label + the settings select) between the practice card and the primary action, the "one last question" slot most products use for this (Lyssna, Wrangle, Clay on Mobbin).


## Why the practice step

- It is the only step every user reaches: sign-in skips when signed in, and the trial step auto-skips for subscribed users (wizard replays, second machines).
- It is the lowest-stakes moment — no permission ask, no payment CTA to distract from. The trial step stays a clean pitch.
- The user idles there anyway while June "types" and they try the dictation rep.

## Behavior

- Answering is optional and never gates Continue.
- The answer persists locally (`june.onboarding.discoverySource`) and the question is **never re-asked**, including version-bump wizard replays.
- Dev replays forget the answer so the full flow stays visible: `june.replayOnboarding()`, the `VITE_JUNE_REPLAY_ONBOARDING` flag, and the preview page.
- Options: Friend or coworker, X (Twitter), YouTube, Instagram or TikTok, Podcast or newsletter, ChatGPT or another AI, Search engine, Other. Stored as stable slugs.

## Reuse

The settings select's trigger + listbox popover is now a self-contained `ui/Select` component (same classes, pixel-identical to the Language/Microphone pickers, same macOS align-selected popover behavior). `AppSettings` imports the shared placement helpers instead of carrying private copies.

## Known gap

There is no telemetry pipeline yet, so the answer is recorded locally only. `setDiscoverySource` in `src/lib/onboarding.ts` is the single seam to report it through a future scribe-api endpoint.

## Test plan

- [x] 394/394 tests (3 new: records the answer, never re-asks once answered, dev replay forgets it)
- [x] `tsc`, Prettier, production build
- [ ] Eyeball at `http://127.0.0.1:1421/onboarding-preview.html?step=dictation-practice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up task: collect the discovery answer on the backend

> Self-contained spec for whoever picks this up. The frontend in this PR is done and needs no changes beyond step 3 below.

**Context.** This PR asks new users "Where did you hear about June?" on the last onboarding step. The answer is captured locally only: `localStorage` key `june.onboarding.discoverySource`, holding one slug from `friend`, `x-twitter`, `youtube`, `instagram-tiktok`, `podcast-newsletter`, `ai-chat`, `search`, `other`. Nothing reports it to us yet. The intended pipe mirrors issue reports end to end (desktop command → scribe-api endpoint → sink).

**Goal.** Each install's answer reaches the team exactly once, fire and forget, and can never block or re-prompt onboarding.

### 1. scribe-api: `POST /v1/onboarding-surveys`

- New handler beside `scribe-api/crates/api/src/handlers/issues.rs`, registered in `crates/api/src/lib.rs` with the JSON body limit. Same `authenticated_user` guard and `ApiResponse` envelope as `issues::submit`.
- JSON body: `{ "source": "<slug>", "appVersion": "0.0.8", "platform": "macos" }`. Reject unknown slugs with a 4xx (the slug list above is the contract; keep it in one const).
- Domain: a small `SurveySink` trait modeled on `IssueReportSink` (`crates/domain/src/lib.rs:296`).
- Providers: a webhook sink copying `WebhookIssueReportSink` (`crates/providers/src/issue_reports.rs:340`) that forwards the JSON to a configured URL, falling back to a structured log line (`survey source=<slug> app_version=<v> user=<id>`) when no webhook is configured, so answers are scrapeable from deploy logs either way. Do NOT file os-platform Issues per answer (one Issue per signup is noise).
- Config: a `[surveys] webhook_url` section modeled on `IssueReportsConfig`.

### 2. Desktop: `submit_discovery_source` command

- Mirror `submit_issue_report` (`src-tauri/src/scribe_api.rs:538` + `src-tauri/src/commands.rs`), minus multipart: plain JSON POST of source, app version, and platform.

### 3. Frontend hookup (one seam, already marked)

- `setDiscoverySource` in `src/lib/onboarding.ts` fires the command best effort (`void submitDiscoverySource(...).catch(() => undefined)`).
- Exactly-once: set a `june.onboarding.discoveryReported` flag only after the command resolves; on app launch, if a source exists without the flag, retry once in the background. The user is never re-prompted in any case.

### Acceptance

- [ ] Picking an answer in onboarding produces exactly one webhook POST (or log line) with the slug.
- [ ] Offline during onboarding: the flow is unaffected and the answer is delivered on a later launch.
- [ ] No duplicate sends across wizard replays or relaunches once delivered.
- [ ] scribe-api `cargo test` (rstest + wiremock for the webhook sink, per house style) and frontend tests green.

**Open decision:** the webhook destination (Slack collector vs. relying on log scraping). The sink shape is identical either way; pick whatever ops prefers.
