### PR TITLE
Refine notes list selection: gutter checkboxes and floating action bar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -100,6 +100,7 @@ import type {
   HermesSessionInfo,
 } from "../lib/tauri";
 import type {
+  NoteListItemDto,
   RecordingSourceMode,
   RecordingSourceReadinessDto,
 } from "../lib/tauri";
@@ -223,7 +224,9 @@ export function App() {
   const [folderReturnTarget, setFolderReturnTarget] = useState<
     { noteId: string; label: string } | undefined
   >();
-  const [moveDialogNoteId, setMoveDialogNoteId] = useState<string | null>(null);
+  const [moveDialogNoteIds, setMoveDialogNoteIds] = useState<string[] | null>(
+    null,
+  );
   // User's intent for system audio. Defaults true ("record everything").
   // The actual sourceMode is derived below so that granting/revoking
   // permission in System Settings flips the toggle without losing intent.
@@ -1660,7 +1663,7 @@ export function App() {
         onReportIssue={handleReportIssue}
         onSelectNote={(noteId) => void handleSelectNote(noteId)}
         onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
-        onOpenMoveDialog={(noteId) => setMoveDialogNoteId(noteId)}
+        onOpenMoveDialog={(noteId) => setMoveDialogNoteIds([noteId])}
         onRemoveNoteFromFolder={(noteId, folderId) =>
           void handleRemoveNoteFromFolder(noteId, folderId)
         }
@@ -1838,12 +1841,12 @@ export function App() {
             ) : activeView === "notes" || activeView === "all-notes" ? (
               <NotesList
                 notes={state.notes}
-                selectedNoteId={state.selectedNoteId}
                 onSelectNote={(noteId) =>
                   void handleSelectNoteFromAllNotes(noteId)
                 }
                 onCreateNote={() => void handleCreateNote(null)}
-                onOpenMoveDialog={(noteId) => setMoveDialogNoteId(noteId)}
+                onOpenMoveDialog={(noteId) => setMoveDialogNoteIds([noteId])}
+                onOpenMoveNotes={(noteIds) => setMoveDialogNoteIds(noteIds)}
                 onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
                 onDeleteNotes={(noteIds) => void handleDeleteNotes(noteIds)}
               />
@@ -1888,7 +1891,7 @@ export function App() {
                 onRemoveNoteFromFolder={(noteId, folderId) =>
                   void handleRemoveNoteFromFolder(noteId, folderId)
                 }
-                onOpenMoveDialog={(noteId) => setMoveDialogNoteId(noteId)}
+                onOpenMoveDialog={(noteId) => setMoveDialogNoteIds([noteId])}
                 onDeleteNote={(noteId) => void handleDeleteNote(noteId)}
                 onCreateSession={(folderId) =>
                   handleNewAgentSessionInProject(folderId)
@@ -2059,12 +2062,14 @@ export function App() {
         </div>
       </section>
       <MoveNoteToFolderDialog
-        open={moveDialogNoteId !== null}
-        onClose={() => setMoveDialogNoteId(null)}
-        note={
-          moveDialogNoteId
-            ? (state.notes.find((n) => n.id === moveDialogNoteId) ?? null)
-            : null
+        open={moveDialogNoteIds !== null}
+        onClose={() => setMoveDialogNoteIds(null)}
+        notes={
+          moveDialogNoteIds
+            ? moveDialogNoteIds
+                .map((id) => state.notes.find((n) => n.id === id))
+                .filter((note): note is NoteListItemDto => note !== undefined)
+            : []
         }
         folders={state.folders}
         onSetFolder={(noteId, folderId) =>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,7 +29,10 @@ import { RoutinesView } from "../components/routines/RoutinesView";
 import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDialog";
 import { MoveSessionToProjectDialog } from "../components/folders/MoveSessionToProjectDialog";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
-import { NotesList } from "../components/notes-list/NotesList";
+import {
+  NotesList,
+  type NotesListHandle,
+} from "../components/notes-list/NotesList";
 import { PermissionBanner } from "../components/permissions/PermissionBanner";
 import {
   AppSettings,
@@ -211,6 +214,7 @@ export function App() {
   const agentMenuBarLastStatusRef = useRef<AgentSessionStatusDetail>();
   const mainPanelBodyRef = useRef<HTMLDivElement | null>(null);
   const noteDetailScrollRef = useRef<HTMLDivElement | null>(null);
+  const notesListRef = useRef<NotesListHandle | null>(null);
   // Where the back affordance in settings returns to — captured when settings
   // is opened so "back" lands the user where they were, not on Notes.
   const [settingsReturnView, setSettingsReturnView] =
@@ -1840,6 +1844,7 @@ export function App() {
               />
             ) : activeView === "notes" || activeView === "all-notes" ? (
               <NotesList
+                ref={notesListRef}
                 notes={state.notes}
                 onSelectNote={(noteId) =>
                   void handleSelectNoteFromAllNotes(noteId)
@@ -2075,6 +2080,7 @@ export function App() {
         onSetFolder={(noteId, folderId) =>
           handleSetNoteFolder(noteId, folderId)
         }
+        onMoved={() => notesListRef.current?.resetSelection()}
       />
       <MoveSessionToProjectDialog
         open={moveDialogSessionId !== null}

--- a/src/components/folders/MoveNoteToFolderDialog.tsx
+++ b/src/components/folders/MoveNoteToFolderDialog.tsx
@@ -8,7 +8,7 @@ import { Dialog } from "../ui/Dialog";
 type Props = {
   open: boolean;
   onClose: () => void;
-  note: NoteListItemDto | null;
+  notes: NoteListItemDto[];
   folders: FolderDto[];
   onSetFolder: (noteId: string, folderId: string) => Promise<unknown> | void;
 };
@@ -16,7 +16,7 @@ type Props = {
 export function MoveNoteToFolderDialog({
   open,
   onClose,
-  note,
+  notes,
   folders,
   onSetFolder,
 }: Props) {
@@ -31,9 +31,17 @@ export function MoveNoteToFolderDialog({
     setSubmitting(false);
   }, [open]);
 
-  const currentFolderId = note?.folderIds[0];
+  const isSingle = notes.length === 1;
+  // The "currently in" exclusion only makes sense when every selected note
+  // shares the same first folder; a mixed selection excludes nothing.
+  const sharedFolderId =
+    notes.length > 0 &&
+    notes.every((note) => note.folderIds[0] === notes[0].folderIds[0])
+      ? notes[0].folderIds[0]
+      : undefined;
+  const currentFolderId = sharedFolderId;
   const currentFolder = folders.find((f) => f.id === currentFolderId);
-  const hasCurrent = Boolean(currentFolder);
+  const hasCurrent = isSingle && Boolean(currentFolder);
 
   const candidates = useMemo(() => {
     const available = folders.filter((folder) => folder.id !== currentFolderId);
@@ -51,23 +59,31 @@ export function MoveNoteToFolderDialog({
   }, [folders, currentFolderId, query]);
 
   async function handleCommit() {
-    if (!note || !selectedId || submitting) return;
+    if (notes.length === 0 || !selectedId || submitting) return;
     setSubmitting(true);
     try {
-      await onSetFolder(note.id, selectedId);
+      // Sequential awaits: handleSetNoteFolder dispatches optimistic state
+      // updates per note, so we let each settle before the next.
+      for (const note of notes) {
+        await onSetFolder(note.id, selectedId);
+      }
       onClose();
     } finally {
       setSubmitting(false);
     }
   }
 
-  const title = hasCurrent
-    ? "Move meeting note"
-    : "Add meeting note to project";
-  const description = hasCurrent
-    ? `This meeting note is in "${currentFolder?.name}". Pick another project to move it to.`
-    : "Pick a project for this meeting note.";
-  const commitLabel = hasCurrent ? "Move" : "Add";
+  const title = isSingle
+    ? hasCurrent
+      ? "Move meeting note"
+      : "Add meeting note to project"
+    : `Move ${notes.length} meeting notes`;
+  const description = isSingle
+    ? hasCurrent
+      ? `This meeting note is in "${currentFolder?.name}". Pick another project to move it to.`
+      : "Pick a project for this meeting note."
+    : "Pick a project to move them to.";
+  const commitLabel = isSingle && !hasCurrent ? "Add" : "Move";
 
   return (
     <Dialog

--- a/src/components/folders/MoveNoteToFolderDialog.tsx
+++ b/src/components/folders/MoveNoteToFolderDialog.tsx
@@ -11,6 +11,7 @@ type Props = {
   notes: NoteListItemDto[];
   folders: FolderDto[];
   onSetFolder: (noteId: string, folderId: string) => Promise<unknown> | void;
+  onMoved?: () => void;
 };
 
 export function MoveNoteToFolderDialog({
@@ -19,6 +20,7 @@ export function MoveNoteToFolderDialog({
   notes,
   folders,
   onSetFolder,
+  onMoved,
 }: Props) {
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -67,6 +69,7 @@ export function MoveNoteToFolderDialog({
       for (const note of notes) {
         await onSetFolder(note.id, selectedId);
       }
+      onMoved?.();
       onClose();
     } finally {
       setSubmitting(false);

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -1,20 +1,21 @@
 import { IconCheckmark2Medium } from "central-icons-filled/IconCheckmark2Medium";
+import { IconCrossMedium } from "central-icons/IconCrossMedium";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { NoteListItemDto } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 
 type NotesListProps = {
   notes: NoteListItemDto[];
-  selectedNoteId?: string;
   onSelectNote: (noteId: string) => void;
   onCreateNote: () => void;
   onOpenMoveDialog: (noteId: string) => void;
+  onOpenMoveNotes: (noteIds: string[]) => void;
   onDeleteNote: (noteId: string) => void;
   onDeleteNotes: (noteIds: string[]) => void | Promise<unknown>;
 };
@@ -35,10 +36,10 @@ const VIEWPORT_MARGIN = 8;
 
 export function NotesList({
   notes,
-  selectedNoteId,
   onSelectNote,
   onCreateNote,
   onOpenMoveDialog,
+  onOpenMoveNotes,
   onDeleteNote,
   onDeleteNotes,
 }: NotesListProps) {
@@ -46,6 +47,16 @@ export function NotesList({
   const [openMenu, setOpenMenu] = useState<OpenMenu | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+  // The bar plays one of two exits when the selection ends. A deliberate
+  // dismiss (×, Escape, post-delete) slides out; the selection merely emptying
+  // (deselect all, unchecking the last row) fades. We capture the cause the
+  // moment the selection drops to zero, keep the bar mounted with data-exit,
+  // and unmount when its animation finishes.
+  const [exit, setExit] = useState<null | "slide" | "fade">(null);
+  // The cause of the *next* empty transition, latched by the call sites.
+  // Toggling a row can't know it's the last box until the set settles, so
+  // unchecking defaults to fade unless a dismiss intent was latched first.
+  const exitCauseRef = useRef<"slide" | "fade">("fade");
 
   const sortedNotes = useMemo(
     () => [...notes].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
@@ -75,6 +86,33 @@ export function NotesList({
   const allVisibleNotesSelected =
     filteredNotes.length > 0 && visibleSelectedCount === filteredNotes.length;
 
+  // Snapshot the last nonzero count so the exiting bar keeps its real label
+  // instead of flashing "0 selected".
+  const lastCountRef = useRef(selectedCount);
+  if (selectedCount > 0) lastCountRef.current = selectedCount;
+  const displayCount = selectedCount > 0 ? selectedCount : lastCountRef.current;
+
+  // Drive the exit/cancel transitions off the live count. Selecting again
+  // mid-exit cancels the exit and replays the live bar. The previous-count
+  // guard keeps the initial mount (0, with nothing to exit from) from arming
+  // a ghost exit.
+  const previousCountRef = useRef(0);
+  useEffect(() => {
+    const previousCount = previousCountRef.current;
+    previousCountRef.current = selectedCount;
+    if (selectedCount > 0) {
+      setExit(null);
+      return;
+    }
+    if (previousCount === 0) return;
+    const cause = exitCauseRef.current;
+    exitCauseRef.current = "fade";
+    setExit((current) => current ?? cause);
+  }, [selectedCount]);
+
+  const barMounted = selectedCount > 0 || exit !== null;
+  const isExiting = selectedCount === 0 && exit !== null;
+
   useEffect(() => {
     const noteIds = new Set(notes.map((note) => note.id));
     setSelectedIds((previous) => {
@@ -95,7 +133,9 @@ export function NotesList({
     });
   }
 
+  // A deliberate dismiss — ×, Escape, post-delete — slides the bar out.
   function resetSelection() {
+    exitCauseRef.current = "slide";
     setSelectedIds(new Set());
     setConfirmBulkDelete(false);
   }
@@ -119,6 +159,18 @@ export function NotesList({
       return next;
     });
   }
+
+  // Escape clears an active selection. Skipped while the bulk-delete confirm
+  // dialog is open so the two don't fight over the same keypress — there the
+  // dialog owns Escape (it dismisses itself, leaving the selection intact).
+  useEffect(() => {
+    if (selectedCount === 0 || confirmBulkDelete) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") resetSelection();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedCount, confirmBulkDelete]);
 
   return (
     <section className="all-notes-workspace" aria-label="Meeting notes">
@@ -156,51 +208,6 @@ export function NotesList({
               onChange={(event) => setQuery(event.currentTarget.value)}
             />
           </label>
-          <div className="meetings-bulk-actions">
-            {selectedCount > 0 ? (
-              <>
-                <span className="meetings-selected-count">
-                  {selectedCount} selected
-                </span>
-                {hasUnselectedVisibleNotes ? (
-                  <button
-                    type="button"
-                    className="primary-action"
-                    onClick={selectAllVisibleNotes}
-                  >
-                    Select all
-                  </button>
-                ) : null}
-                {allVisibleNotesSelected ? (
-                  <button
-                    type="button"
-                    className="primary-action"
-                    onClick={deselectAllVisibleNotes}
-                  >
-                    Deselect all
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  className="primary-action"
-                  onClick={resetSelection}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="primary-action primary-solid primary-destructive"
-                  disabled={selectedCount === 0}
-                  onClick={() => setConfirmBulkDelete(true)}
-                >
-                  <IconTrashCan size={13} />
-                  {selectedCount === 1
-                    ? "Delete 1 note"
-                    : `Delete ${selectedCount} notes`}
-                </button>
-              </>
-            ) : null}
-          </div>
         </div>
       ) : null}
 
@@ -221,12 +228,15 @@ export function NotesList({
           <p>No notes match “{query.trim()}”.</p>
         </div>
       ) : (
-        <ul className="folder-notes all-notes-list" role="list">
+        <ul
+          className="folder-notes all-notes-list"
+          role="list"
+          data-selecting={selectedCount > 0}
+        >
           {filteredNotes.map((note) => (
             <AllNoteRow
               key={note.id}
               note={note}
-              selected={selectedNoteId === note.id}
               menu={
                 openMenu?.noteId === note.id
                   ? { right: openMenu.right, top: openMenu.top }
@@ -245,6 +255,72 @@ export function NotesList({
           ))}
         </ul>
       )}
+
+      {barMounted ? (
+        <div
+          className="meetings-bulk-bar"
+          role="toolbar"
+          aria-label="Selection"
+          data-exit={isExiting ? exit : undefined}
+          onAnimationEnd={(event) => {
+            // Only the bar's own exit keyframes unmount it. Child button
+            // hovers fire transitionend, not animationend, but a descendant
+            // animation could still bubble here — so require the event to
+            // originate on the bar and, when the name is reported, to be an
+            // exit keyframe. (jsdom omits animationName, hence the optional
+            // check rather than a hard requirement.)
+            if (!isExiting || event.target !== event.currentTarget) return;
+            if (
+              event.animationName &&
+              !event.animationName.startsWith("meetings-bulk-bar-out")
+            ) {
+              return;
+            }
+            setExit(null);
+          }}
+        >
+          <span className="meetings-bulk-count">{displayCount} selected</span>
+          {hasUnselectedVisibleNotes ? (
+            <button
+              type="button"
+              className="meetings-bulk-action"
+              onClick={selectAllVisibleNotes}
+            >
+              Select all
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="meetings-bulk-action"
+            onClick={deselectAllVisibleNotes}
+          >
+            Deselect all
+          </button>
+          <button
+            type="button"
+            className="meetings-bulk-action"
+            onClick={() => onOpenMoveNotes(selectedNoteIds)}
+          >
+            Move
+          </button>
+          <button
+            type="button"
+            className="meetings-bulk-action"
+            onClick={() => setConfirmBulkDelete(true)}
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            className="meetings-bulk-dismiss"
+            aria-label="Clear selection"
+            onClick={resetSelection}
+          >
+            <IconCrossMedium size={14} />
+          </button>
+        </div>
+      ) : null}
+
       <ConfirmDialog
         open={confirmBulkDelete}
         onClose={() => setConfirmBulkDelete(false)}
@@ -265,7 +341,6 @@ export function NotesList({
 
 function AllNoteRow({
   note,
-  selected,
   menu,
   onSelect,
   checked,
@@ -276,7 +351,6 @@ function AllNoteRow({
   onDelete,
 }: {
   note: NoteListItemDto;
-  selected: boolean;
   menu: MenuPosition | null;
   onSelect: () => void;
   checked: boolean;
@@ -310,7 +384,7 @@ function AllNoteRow({
     <li>
       <div
         className="folder-note-row all-notes-row"
-        data-selected={selected || checked}
+        data-selected={checked}
         data-has-actions="true"
         data-menu-open={menu !== null}
       >
@@ -322,7 +396,7 @@ function AllNoteRow({
             onChange={onToggleSelected}
           />
           <span className="folder-note-select-box" aria-hidden>
-            {checked ? <IconCheckmark2Medium size={11} /> : null}
+            {checked ? <IconCheckmark2Medium size={10} /> : null}
           </span>
         </label>
         <button type="button" className="folder-note-main" onClick={onSelect}>

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -6,7 +6,15 @@ import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { NoteListItemDto } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 
@@ -18,6 +26,10 @@ type NotesListProps = {
   onOpenMoveNotes: (noteIds: string[]) => void;
   onDeleteNote: (noteId: string) => void;
   onDeleteNotes: (noteIds: string[]) => void | Promise<unknown>;
+};
+
+export type NotesListHandle = {
+  resetSelection: () => void;
 };
 
 type MenuPosition = {
@@ -34,310 +46,322 @@ const MEETING_MENU_HEIGHT = 74;
 const MENU_GAP = 4;
 const VIEWPORT_MARGIN = 8;
 
-export function NotesList({
-  notes,
-  onSelectNote,
-  onCreateNote,
-  onOpenMoveDialog,
-  onOpenMoveNotes,
-  onDeleteNote,
-  onDeleteNotes,
-}: NotesListProps) {
-  const [query, setQuery] = useState("");
-  const [openMenu, setOpenMenu] = useState<OpenMenu | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
-  // The bar plays one of two exits when the selection ends. A deliberate
-  // dismiss (×, Escape, post-delete) slides out; the selection merely emptying
-  // (deselect all, unchecking the last row) fades. We capture the cause the
-  // moment the selection drops to zero, keep the bar mounted with data-exit,
-  // and unmount when its animation finishes.
-  const [exit, setExit] = useState<null | "slide" | "fade">(null);
-  // The cause of the *next* empty transition, latched by the call sites.
-  // Toggling a row can't know it's the last box until the set settles, so
-  // unchecking defaults to fade unless a dismiss intent was latched first.
-  const exitCauseRef = useRef<"slide" | "fade">("fade");
+export const NotesList = forwardRef<NotesListHandle, NotesListProps>(
+  function NotesList(
+    {
+      notes,
+      onSelectNote,
+      onCreateNote,
+      onOpenMoveDialog,
+      onOpenMoveNotes,
+      onDeleteNote,
+      onDeleteNotes,
+    },
+    ref,
+  ) {
+    const [query, setQuery] = useState("");
+    const [openMenu, setOpenMenu] = useState<OpenMenu | null>(null);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+    // The bar plays one of two exits when the selection ends. A deliberate
+    // dismiss (×, Escape, post-delete) slides out; the selection merely emptying
+    // (deselect all, unchecking the last row) fades. We capture the cause the
+    // moment the selection drops to zero, keep the bar mounted with data-exit,
+    // and unmount when its animation finishes.
+    const [exit, setExit] = useState<null | "slide" | "fade">(null);
+    // The cause of the *next* empty transition, latched by the call sites.
+    // Toggling a row can't know it's the last box until the set settles, so
+    // unchecking defaults to fade unless a dismiss intent was latched first.
+    const exitCauseRef = useRef<"slide" | "fade">("fade");
 
-  const sortedNotes = useMemo(
-    () => [...notes].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
-    [notes],
-  );
-  const filteredNotes = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    if (!normalized) return sortedNotes;
-    return sortedNotes.filter((note) => {
-      return `${note.title} ${note.preview}`.toLowerCase().includes(normalized);
-    });
-  }, [sortedNotes, query]);
+    const sortedNotes = useMemo(
+      () => [...notes].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+      [notes],
+    );
+    const filteredNotes = useMemo(() => {
+      const normalized = query.trim().toLowerCase();
+      if (!normalized) return sortedNotes;
+      return sortedNotes.filter((note) => {
+        return `${note.title} ${note.preview}`
+          .toLowerCase()
+          .includes(normalized);
+      });
+    }, [sortedNotes, query]);
 
-  const selectedNoteIds = useMemo(
-    () =>
-      sortedNotes
-        .filter((note) => selectedIds.has(note.id))
-        .map((note) => note.id),
-    [sortedNotes, selectedIds],
-  );
-  const visibleSelectedCount = filteredNotes.filter((note) =>
-    selectedIds.has(note.id),
-  ).length;
-  const selectedCount = selectedNoteIds.length;
-  const hasUnselectedVisibleNotes =
-    filteredNotes.length > 0 && visibleSelectedCount < filteredNotes.length;
-  const allVisibleNotesSelected =
-    filteredNotes.length > 0 && visibleSelectedCount === filteredNotes.length;
+    const selectedNoteIds = useMemo(
+      () =>
+        sortedNotes
+          .filter((note) => selectedIds.has(note.id))
+          .map((note) => note.id),
+      [sortedNotes, selectedIds],
+    );
+    const visibleSelectedCount = filteredNotes.filter((note) =>
+      selectedIds.has(note.id),
+    ).length;
+    const selectedCount = selectedNoteIds.length;
+    const hasUnselectedVisibleNotes =
+      filteredNotes.length > 0 && visibleSelectedCount < filteredNotes.length;
+    const allVisibleNotesSelected =
+      filteredNotes.length > 0 && visibleSelectedCount === filteredNotes.length;
 
-  // Snapshot the last nonzero count so the exiting bar keeps its real label
-  // instead of flashing "0 selected".
-  const lastCountRef = useRef(selectedCount);
-  if (selectedCount > 0) lastCountRef.current = selectedCount;
-  const displayCount = selectedCount > 0 ? selectedCount : lastCountRef.current;
+    // Snapshot the last nonzero count so the exiting bar keeps its real label
+    // instead of flashing "0 selected".
+    const lastCountRef = useRef(selectedCount);
+    if (selectedCount > 0) lastCountRef.current = selectedCount;
+    const displayCount =
+      selectedCount > 0 ? selectedCount : lastCountRef.current;
 
-  // Drive the exit/cancel transitions off the live count. Selecting again
-  // mid-exit cancels the exit and replays the live bar. The previous-count
-  // guard keeps the initial mount (0, with nothing to exit from) from arming
-  // a ghost exit.
-  const previousCountRef = useRef(0);
-  useEffect(() => {
-    const previousCount = previousCountRef.current;
-    previousCountRef.current = selectedCount;
-    if (selectedCount > 0) {
-      setExit(null);
-      return;
+    // Drive the exit/cancel transitions off the live count. Selecting again
+    // mid-exit cancels the exit and replays the live bar. The previous-count
+    // guard keeps the initial mount (0, with nothing to exit from) from arming
+    // a ghost exit.
+    const previousCountRef = useRef(0);
+    useEffect(() => {
+      const previousCount = previousCountRef.current;
+      previousCountRef.current = selectedCount;
+      if (selectedCount > 0) {
+        setExit(null);
+        return;
+      }
+      if (previousCount === 0) return;
+      const cause = exitCauseRef.current;
+      exitCauseRef.current = "fade";
+      setExit((current) => current ?? cause);
+    }, [selectedCount]);
+
+    const barMounted = selectedCount > 0 || exit !== null;
+    const isExiting = selectedCount === 0 && exit !== null;
+
+    useEffect(() => {
+      const noteIds = new Set(notes.map((note) => note.id));
+      setSelectedIds((previous) => {
+        const next = new Set([...previous].filter((id) => noteIds.has(id)));
+        return next.size === previous.size ? previous : next;
+      });
+      if (notes.length === 0) {
+        setConfirmBulkDelete(false);
+      }
+    }, [notes]);
+
+    function toggleSelected(noteId: string) {
+      setSelectedIds((previous) => {
+        const next = new Set(previous);
+        if (next.has(noteId)) next.delete(noteId);
+        else next.add(noteId);
+        return next;
+      });
     }
-    if (previousCount === 0) return;
-    const cause = exitCauseRef.current;
-    exitCauseRef.current = "fade";
-    setExit((current) => current ?? cause);
-  }, [selectedCount]);
 
-  const barMounted = selectedCount > 0 || exit !== null;
-  const isExiting = selectedCount === 0 && exit !== null;
-
-  useEffect(() => {
-    const noteIds = new Set(notes.map((note) => note.id));
-    setSelectedIds((previous) => {
-      const next = new Set([...previous].filter((id) => noteIds.has(id)));
-      return next.size === previous.size ? previous : next;
-    });
-    if (notes.length === 0) {
+    // A deliberate dismiss — ×, Escape, post-delete — slides the bar out.
+    const resetSelection = useCallback(() => {
+      exitCauseRef.current = "slide";
+      setSelectedIds(new Set());
       setConfirmBulkDelete(false);
+    }, []);
+
+    useImperativeHandle(ref, () => ({ resetSelection }), [resetSelection]);
+
+    function selectAllVisibleNotes() {
+      setSelectedIds((previous) => {
+        const next = new Set(previous);
+        for (const note of filteredNotes) {
+          next.add(note.id);
+        }
+        return next;
+      });
     }
-  }, [notes]);
 
-  function toggleSelected(noteId: string) {
-    setSelectedIds((previous) => {
-      const next = new Set(previous);
-      if (next.has(noteId)) next.delete(noteId);
-      else next.add(noteId);
-      return next;
-    });
-  }
-
-  // A deliberate dismiss — ×, Escape, post-delete — slides the bar out.
-  function resetSelection() {
-    exitCauseRef.current = "slide";
-    setSelectedIds(new Set());
-    setConfirmBulkDelete(false);
-  }
-
-  function selectAllVisibleNotes() {
-    setSelectedIds((previous) => {
-      const next = new Set(previous);
-      for (const note of filteredNotes) {
-        next.add(note.id);
-      }
-      return next;
-    });
-  }
-
-  function deselectAllVisibleNotes() {
-    setSelectedIds((previous) => {
-      const next = new Set(previous);
-      for (const note of filteredNotes) {
-        next.delete(note.id);
-      }
-      return next;
-    });
-  }
-
-  // Escape clears an active selection. Skipped while the bulk-delete confirm
-  // dialog is open so the two don't fight over the same keypress — there the
-  // dialog owns Escape (it dismisses itself, leaving the selection intact).
-  useEffect(() => {
-    if (selectedCount === 0 || confirmBulkDelete) return;
-    function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") resetSelection();
+    function deselectAllVisibleNotes() {
+      setSelectedIds((previous) => {
+        const next = new Set(previous);
+        for (const note of filteredNotes) {
+          next.delete(note.id);
+        }
+        return next;
+      });
     }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [selectedCount, confirmBulkDelete]);
 
-  return (
-    <section className="all-notes-workspace" aria-label="Meeting notes">
-      <header className="folders-header">
-        <div className="folders-heading">
-          <h1>
-            Meeting notes
-            {notes.length > 0 ? (
-              <span className="folders-count">{notes.length}</span>
-            ) : null}
-          </h1>
-          <p className="folders-subtitle">Everything across your workspace.</p>
-        </div>
-        <button
-          type="button"
-          className="primary-action primary-solid folders-create"
-          onClick={onCreateNote}
-        >
-          <IconPlusMedium size={13} />
-          New note
-          <kbd className="primary-action-kbd" aria-hidden>
-            ⌘N
-          </kbd>
-        </button>
-      </header>
+    // Escape clears an active selection. Skipped while the bulk-delete confirm
+    // dialog is open so the two don't fight over the same keypress — there the
+    // dialog owns Escape (it dismisses itself, leaving the selection intact).
+    useEffect(() => {
+      if (selectedCount === 0 || confirmBulkDelete) return;
+      function onKey(event: KeyboardEvent) {
+        if (event.key === "Escape") resetSelection();
+      }
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }, [selectedCount, confirmBulkDelete]);
 
-      {notes.length > 0 ? (
-        <div className="folders-controls">
-          <label className="folders-search">
-            <IconMagnifyingGlass size={14} />
-            <input
-              type="search"
-              placeholder="Search"
-              value={query}
-              onChange={(event) => setQuery(event.currentTarget.value)}
-            />
-          </label>
-        </div>
-      ) : null}
-
-      {notes.length === 0 ? (
-        <div className="folders-empty">
-          <p>No notes yet.</p>
+    return (
+      <section className="all-notes-workspace" aria-label="Meeting notes">
+        <header className="folders-header">
+          <div className="folders-heading">
+            <h1>
+              Meeting notes
+              {notes.length > 0 ? (
+                <span className="folders-count">{notes.length}</span>
+              ) : null}
+            </h1>
+            <p className="folders-subtitle">
+              Everything across your workspace.
+            </p>
+          </div>
           <button
             type="button"
-            className="primary-action primary-solid"
+            className="primary-action primary-solid folders-create"
             onClick={onCreateNote}
           >
             <IconPlusMedium size={13} />
-            Create your first note
+            New note
+            <kbd className="primary-action-kbd" aria-hidden>
+              ⌘N
+            </kbd>
           </button>
-        </div>
-      ) : filteredNotes.length === 0 ? (
-        <div className="folders-empty">
-          <p>No notes match “{query.trim()}”.</p>
-        </div>
-      ) : (
-        <ul
-          className="folder-notes all-notes-list"
-          role="list"
-          data-selecting={selectedCount > 0}
-        >
-          {filteredNotes.map((note) => (
-            <AllNoteRow
-              key={note.id}
-              note={note}
-              menu={
-                openMenu?.noteId === note.id
-                  ? { right: openMenu.right, top: openMenu.top }
-                  : null
-              }
-              onSelect={() => onSelectNote(note.id)}
-              checked={selectedIds.has(note.id)}
-              onToggleSelected={() => toggleSelected(note.id)}
-              onOpenMenu={(position) =>
-                setOpenMenu({ noteId: note.id, ...position })
-              }
-              onCloseMenu={() => setOpenMenu(null)}
-              onOpenMove={() => onOpenMoveDialog(note.id)}
-              onDelete={() => onDeleteNote(note.id)}
-            />
-          ))}
-        </ul>
-      )}
+        </header>
 
-      {barMounted ? (
-        <div
-          className="meetings-bulk-bar"
-          role="toolbar"
-          aria-label="Selection"
-          data-exit={isExiting ? exit : undefined}
-          onAnimationEnd={(event) => {
-            // Only the bar's own exit keyframes unmount it. Child button
-            // hovers fire transitionend, not animationend, but a descendant
-            // animation could still bubble here — so require the event to
-            // originate on the bar and, when the name is reported, to be an
-            // exit keyframe. (jsdom omits animationName, hence the optional
-            // check rather than a hard requirement.)
-            if (!isExiting || event.target !== event.currentTarget) return;
-            if (
-              event.animationName &&
-              !event.animationName.startsWith("meetings-bulk-bar-out")
-            ) {
-              return;
-            }
-            setExit(null);
-          }}
-        >
-          <span className="meetings-bulk-count">{displayCount} selected</span>
-          {hasUnselectedVisibleNotes ? (
+        {notes.length > 0 ? (
+          <div className="folders-controls">
+            <label className="folders-search">
+              <IconMagnifyingGlass size={14} />
+              <input
+                type="search"
+                placeholder="Search"
+                value={query}
+                onChange={(event) => setQuery(event.currentTarget.value)}
+              />
+            </label>
+          </div>
+        ) : null}
+
+        {notes.length === 0 ? (
+          <div className="folders-empty">
+            <p>No notes yet.</p>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              onClick={onCreateNote}
+            >
+              <IconPlusMedium size={13} />
+              Create your first note
+            </button>
+          </div>
+        ) : filteredNotes.length === 0 ? (
+          <div className="folders-empty">
+            <p>No notes match “{query.trim()}”.</p>
+          </div>
+        ) : (
+          <ul
+            className="folder-notes all-notes-list"
+            role="list"
+            data-selecting={selectedCount > 0}
+          >
+            {filteredNotes.map((note) => (
+              <AllNoteRow
+                key={note.id}
+                note={note}
+                menu={
+                  openMenu?.noteId === note.id
+                    ? { right: openMenu.right, top: openMenu.top }
+                    : null
+                }
+                onSelect={() => onSelectNote(note.id)}
+                checked={selectedIds.has(note.id)}
+                onToggleSelected={() => toggleSelected(note.id)}
+                onOpenMenu={(position) =>
+                  setOpenMenu({ noteId: note.id, ...position })
+                }
+                onCloseMenu={() => setOpenMenu(null)}
+                onOpenMove={() => onOpenMoveDialog(note.id)}
+                onDelete={() => onDeleteNote(note.id)}
+              />
+            ))}
+          </ul>
+        )}
+
+        {barMounted ? (
+          <div
+            className="meetings-bulk-bar"
+            role="toolbar"
+            aria-label="Selection"
+            data-exit={isExiting ? exit : undefined}
+            onAnimationEnd={(event) => {
+              // Only the bar's own exit keyframes unmount it. Child button
+              // hovers fire transitionend, not animationend, but a descendant
+              // animation could still bubble here — so require the event to
+              // originate on the bar and, when the name is reported, to be an
+              // exit keyframe. (jsdom omits animationName, hence the optional
+              // check rather than a hard requirement.)
+              if (!isExiting || event.target !== event.currentTarget) return;
+              if (
+                event.animationName &&
+                !event.animationName.startsWith("meetings-bulk-bar-out")
+              ) {
+                return;
+              }
+              setExit(null);
+            }}
+          >
+            <span className="meetings-bulk-count">{displayCount} selected</span>
+            {hasUnselectedVisibleNotes ? (
+              <button
+                type="button"
+                className="meetings-bulk-action"
+                onClick={selectAllVisibleNotes}
+              >
+                Select all
+              </button>
+            ) : null}
             <button
               type="button"
               className="meetings-bulk-action"
-              onClick={selectAllVisibleNotes}
+              onClick={deselectAllVisibleNotes}
             >
-              Select all
+              Deselect all
             </button>
-          ) : null}
-          <button
-            type="button"
-            className="meetings-bulk-action"
-            onClick={deselectAllVisibleNotes}
-          >
-            Deselect all
-          </button>
-          <button
-            type="button"
-            className="meetings-bulk-action"
-            onClick={() => onOpenMoveNotes(selectedNoteIds)}
-          >
-            Move
-          </button>
-          <button
-            type="button"
-            className="meetings-bulk-action"
-            onClick={() => setConfirmBulkDelete(true)}
-          >
-            Delete
-          </button>
-          <button
-            type="button"
-            className="meetings-bulk-dismiss"
-            aria-label="Clear selection"
-            onClick={resetSelection}
-          >
-            <IconCrossMedium size={14} />
-          </button>
-        </div>
-      ) : null}
+            <button
+              type="button"
+              className="meetings-bulk-action"
+              onClick={() => onOpenMoveNotes(selectedNoteIds)}
+            >
+              Move
+            </button>
+            <button
+              type="button"
+              className="meetings-bulk-action"
+              onClick={() => setConfirmBulkDelete(true)}
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              className="meetings-bulk-dismiss"
+              aria-label="Clear selection"
+              onClick={resetSelection}
+            >
+              <IconCrossMedium size={14} />
+            </button>
+          </div>
+        ) : null}
 
-      <ConfirmDialog
-        open={confirmBulkDelete}
-        onClose={() => setConfirmBulkDelete(false)}
-        onConfirm={async () => {
-          await onDeleteNotes(selectedNoteIds);
-          resetSelection();
-        }}
-        title={`Delete ${selectedCount} ${
-          selectedCount === 1 ? "note" : "notes"
-        }?`}
-        description="This cannot be undone. Audio, transcripts, and generated notes for these notes will be removed."
-        confirmLabel={selectedCount === 1 ? "Delete note" : "Delete notes"}
-        destructive
-      />
-    </section>
-  );
-}
+        <ConfirmDialog
+          open={confirmBulkDelete}
+          onClose={() => setConfirmBulkDelete(false)}
+          onConfirm={async () => {
+            await onDeleteNotes(selectedNoteIds);
+            resetSelection();
+          }}
+          title={`Delete ${selectedCount} ${
+            selectedCount === 1 ? "note" : "notes"
+          }?`}
+          description="This cannot be undone. Audio, transcripts, and generated notes for these notes will be removed."
+          confirmLabel={selectedCount === 1 ? "Delete note" : "Delete notes"}
+          destructive
+        />
+      </section>
+    );
+  },
+);
 
 function AllNoteRow({
   note,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8064,18 +8064,153 @@ button.agent-safety-badge:hover {
   color: var(--muted-foreground);
 }
 
-.meetings-bulk-actions {
+/* Floating selection bar — a quiet elevated pill pinned at the bottom of the
+ * notes panel while the list scrolls. Sticky inside the workspace flex column
+ * so it tracks the content center and the scroller; negative margin keeps it
+ * from reserving layout height (it overlaps the list's trailing padding). It
+ * rides above the bottom scroll fade (z-index 2) so it never dissolves. The
+ * all-notes view has no record dock, so the bottom offset only clears the
+ * scroller's own padding. Left to right: count, actions, the × dismiss at the
+ * end. Separation comes from the plain count sitting beside squircle actions
+ * on a faint muted wash that firms up on hover — no dividers. Concentric
+ * corners: bar --r-lg (10px) minus the 4px inset leaves --r-sm (6px) for the
+ * controls inside.
+ *
+ * Two exits, picked by how the selection ended (data-exit): a deliberate
+ * dismiss (×, Escape, post-delete) slides back down, mirroring the entrance;
+ * the selection merely emptying (deselect all, unchecking the last row) fades
+ * — it's become irrelevant, not been pushed away. */
+.meetings-bulk-bar {
+  position: sticky;
+  bottom: var(--sp-4);
+  z-index: 3;
   display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: var(--sp-2);
-  min-height: var(--control-lg);
+  gap: var(--sp-1);
+  align-self: center;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: calc(-1 * var(--control-sm));
+  padding: var(--sp-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+  background: var(--card);
+  box-shadow: var(--shadow-lg);
+  animation: meetings-bulk-bar-in var(--t-slow) var(--ease-spring);
 }
 
-.meetings-selected-count {
+/* During either exit the bar is inert and shows its last real content. */
+.meetings-bulk-bar[data-exit] {
+  pointer-events: none;
+}
+
+.meetings-bulk-bar[data-exit="slide"] {
+  animation: meetings-bulk-bar-out-slide var(--t-med) var(--ease-in-out)
+    forwards;
+}
+
+.meetings-bulk-bar[data-exit="fade"] {
+  animation: meetings-bulk-bar-out-fade var(--t-med) var(--ease-out) forwards;
+}
+
+/* Glides up from below the panel edge and settles with the spring curve; a
+ * fast opacity ramp (front-loaded via the 40% stop) means it's visible early
+ * in the travel instead of popping in mid-glide. */
+@keyframes meetings-bulk-bar-in {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  40% {
+    opacity: 1;
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Mirror of the entrance, a touch quicker: slides back down and holds full
+ * opacity through most of the travel so it doesn't vanish mid-slide. The
+ * spring curve is deceleration-heavy and reads wrong in reverse, so the exit
+ * uses the symmetric in-out ease for a clean departure. */
+@keyframes meetings-bulk-bar-out-slide {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  60% {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+}
+
+/* The bar quietly drops out: a quick fade with a few px of downward drift. */
+@keyframes meetings-bulk-bar-out-fade {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+}
+
+.meetings-bulk-dismiss {
+  display: inline-grid;
+  place-items: center;
+  margin-left: var(--sp-1);
+  width: var(--control-sm);
+  height: var(--control-sm);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
   color: var(--muted-foreground);
-  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.meetings-bulk-dismiss:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.meetings-bulk-count {
+  padding: 0 var(--sp-2);
+  margin-right: var(--sp-1);
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
   white-space: nowrap;
+}
+
+.meetings-bulk-action {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  height: var(--control-sm);
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.meetings-bulk-action:hover {
+  background: var(--muted);
+  color: var(--foreground);
 }
 
 /* Sort dropdown trigger ------------------------------------------- */
@@ -8712,8 +8847,8 @@ button.agent-safety-badge:hover {
 .folder-note-checkbox {
   display: inline-grid;
   place-items: center;
-  width: 18px;
-  height: 18px;
+  width: 15px;
+  height: 15px;
   cursor: pointer;
 }
 
@@ -8728,20 +8863,25 @@ button.agent-safety-badge:hover {
 .folder-note-select-box {
   display: inline-grid;
   place-items: center;
-  width: 18px;
-  height: 18px;
+  width: 15px;
+  height: 15px;
   border: 1px solid var(--border);
-  border-radius: var(--r-sm);
+  border-radius: 4px;
   background: var(--card);
-  color: var(--primary);
+  color: var(--brand);
   transition:
     background-color var(--t-fast) var(--ease-out),
     border-color var(--t-fast) var(--ease-out);
 }
 
+.folder-note-checkbox:hover .folder-note-select-box {
+  border-color: color-mix(in oklch, var(--muted-foreground) 35%, var(--border));
+}
+
 .folder-note-checkbox:has(input:checked) .folder-note-select-box {
-  border-color: var(--primary);
-  background: color-mix(in oklch, var(--primary) 12%, var(--card));
+  border-color: var(--brand);
+  background: var(--brand);
+  color: #fff;
 }
 
 .folder-note-checkbox:focus-within .folder-note-select-box {
@@ -8826,8 +8966,40 @@ button.agent-safety-badge:hover {
   gap: 2px;
 }
 
+/* Flush edges, Granola-style: the row's hover/selected background box sits
+ * within the page's exact text bounds (heading, subtitle, search), with the
+ * icon and title inset by the row padding rather than bleeding past the
+ * column. */
 .all-notes-row {
-  grid-template-columns: 18px minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
+  margin: 0;
+}
+
+/* The select box hangs in the page's free left margin, just outside the row's
+ * flush left edge, so the title column keeps the page's text alignment with
+ * the heading and search bar. The label is a roomy hit area butted right up
+ * against that edge (right: 100%, no dead gap) with the 15px box centered in
+ * it, so the pointer never leaves the row on its way to the checkbox and the
+ * reveal can't flicker. It surfaces only on hover, when checked, on focus, or
+ * while a selection is in progress. */
+.all-notes-row .folder-note-checkbox {
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  translate: 0 -50%;
+  width: 28px;
+  height: 28px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.all-notes-row:hover .folder-note-checkbox,
+.all-notes-row:focus-within .folder-note-checkbox,
+.all-notes-row .folder-note-checkbox:has(input:checked),
+.all-notes-list[data-selecting="true"] .folder-note-checkbox {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .dictation-history-groups {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8866,7 +8866,7 @@ button.agent-safety-badge:hover {
   width: 15px;
   height: 15px;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--r-xs);
   background: var(--card);
   color: var(--brand);
   transition:

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { createRef } from "react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -14,7 +15,10 @@ import {
   AGENT_SESSIONS_CHANGED_EVENT,
 } from "../components/agent/AgentWorkspace";
 import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDialog";
-import { NotesList } from "../components/notes-list/NotesList";
+import {
+  NotesList,
+  type NotesListHandle,
+} from "../components/notes-list/NotesList";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import type { FolderDto, NoteListItemDto } from "../lib/tauri";
 
@@ -615,6 +619,39 @@ describe("folders UI", () => {
     expect(onOpenMoveNotes).toHaveBeenCalledWith(["note-2", "note-1"]);
   });
 
+  it("can clear selected meetings after a bulk move succeeds", async () => {
+    const user = userEvent.setup();
+    const notesListRef = createRef<NotesListHandle>();
+    render(
+      <NotesList
+        ref={notesListRef}
+        notes={notes}
+        onSelectNote={vi.fn()}
+        onCreateNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onDeleteNotes={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
+    await user.click(screen.getByRole("checkbox", { name: "Select New note" }));
+
+    expect(
+      screen.getByRole("toolbar", { name: "Selection" }),
+    ).toHaveTextContent("2 selected");
+
+    act(() => notesListRef.current?.resetSelection());
+
+    const bar = screen.getByRole("toolbar", { name: "Selection" });
+    expect(bar).toHaveAttribute("data-exit", "slide");
+    fireEvent.animationEnd(bar, {
+      animationName: "meetings-bulk-bar-out-slide",
+    });
+    expect(screen.queryByRole("toolbar", { name: "Selection" })).toBeNull();
+  });
+
   it("selects all visible meetings after one meeting is selected", async () => {
     const user = userEvent.setup();
     const onDeleteNotes = vi.fn();
@@ -751,6 +788,7 @@ describe("MoveNoteToFolderDialog", () => {
     const user = userEvent.setup();
     const onSetFolder = vi.fn().mockResolvedValue(undefined);
     const onClose = vi.fn();
+    const onMoved = vi.fn();
     render(
       <MoveNoteToFolderDialog
         open
@@ -758,6 +796,7 @@ describe("MoveNoteToFolderDialog", () => {
         notes={notes}
         folders={moveFolders}
         onSetFolder={onSetFolder}
+        onMoved={onMoved}
       />,
     );
 
@@ -771,6 +810,7 @@ describe("MoveNoteToFolderDialog", () => {
     expect(onSetFolder).toHaveBeenCalledTimes(2);
     expect(onSetFolder).toHaveBeenNthCalledWith(1, "note-2", "folder-2");
     expect(onSetFolder).toHaveBeenNthCalledWith(2, "note-1", "folder-2");
+    expect(onMoved).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -1,4 +1,11 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -6,9 +13,10 @@ import {
   AGENT_NEW_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
 } from "../components/agent/AgentWorkspace";
+import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDialog";
 import { NotesList } from "../components/notes-list/NotesList";
 import { Sidebar } from "../components/sidebar/Sidebar";
-import type { NoteListItemDto } from "../lib/tauri";
+import type { FolderDto, NoteListItemDto } from "../lib/tauri";
 
 const hermesMocks = vi.hoisted(() => ({
   deleteHermesSession: vi.fn(),
@@ -393,10 +401,10 @@ describe("folders UI", () => {
     const { container } = render(
       <NotesList
         notes={notes}
-        selectedNoteId="note-2"
         onSelectNote={onSelectNote}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={vi.fn()}
       />,
@@ -420,6 +428,7 @@ describe("folders UI", () => {
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={vi.fn()}
       />,
@@ -467,6 +476,7 @@ describe("folders UI", () => {
           onSelectNote={vi.fn()}
           onCreateNote={vi.fn()}
           onOpenMoveDialog={vi.fn()}
+          onOpenMoveNotes={vi.fn()}
           onDeleteNote={vi.fn()}
           onDeleteNotes={vi.fn()}
         />,
@@ -519,6 +529,7 @@ describe("folders UI", () => {
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={vi.fn()}
       />,
@@ -534,6 +545,7 @@ describe("folders UI", () => {
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={vi.fn()}
       />,
@@ -554,6 +566,7 @@ describe("folders UI", () => {
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={onDeleteNotes}
       />,
@@ -566,10 +579,40 @@ describe("folders UI", () => {
 
     await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
     await user.click(screen.getByRole("checkbox", { name: "Select New note" }));
-    await user.click(screen.getByRole("button", { name: "Delete 2 notes" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
     await user.click(screen.getByRole("button", { name: "Delete notes" }));
 
     expect(onDeleteNotes).toHaveBeenCalledWith(["note-2", "note-1"]);
+
+    // A confirmed delete clears the selection and slides the bar out.
+    const bar = screen.getByRole("toolbar", { name: "Selection" });
+    expect(bar).toHaveAttribute("data-exit", "slide");
+    fireEvent.animationEnd(bar, {
+      animationName: "meetings-bulk-bar-out-slide",
+    });
+    expect(screen.queryByRole("toolbar", { name: "Selection" })).toBeNull();
+  });
+
+  it("opens the move dialog with every selected meeting", async () => {
+    const user = userEvent.setup();
+    const onOpenMoveNotes = vi.fn();
+    render(
+      <NotesList
+        notes={notes}
+        onSelectNote={vi.fn()}
+        onCreateNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={onOpenMoveNotes}
+        onDeleteNote={vi.fn()}
+        onDeleteNotes={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
+    await user.click(screen.getByRole("checkbox", { name: "Select New note" }));
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(onOpenMoveNotes).toHaveBeenCalledWith(["note-2", "note-1"]);
   });
 
   it("selects all visible meetings after one meeting is selected", async () => {
@@ -581,6 +624,7 @@ describe("folders UI", () => {
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={onDeleteNotes}
       />,
@@ -588,7 +632,7 @@ describe("folders UI", () => {
 
     await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
     await user.click(screen.getByRole("button", { name: "Select all" }));
-    await user.click(screen.getByRole("button", { name: "Delete 2 notes" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
     await user.click(screen.getByRole("button", { name: "Delete notes" }));
 
     expect(onDeleteNotes).toHaveBeenCalledWith(["note-2", "note-1"]);
@@ -602,6 +646,7 @@ describe("folders UI", () => {
         onSelectNote={vi.fn()}
         onCreateNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
         onDeleteNote={vi.fn()}
         onDeleteNotes={vi.fn()}
       />,
@@ -611,12 +656,139 @@ describe("folders UI", () => {
     await user.click(screen.getByRole("button", { name: "Select all" }));
     await user.click(screen.getByRole("button", { name: "Deselect all" }));
 
-    expect(screen.queryByRole("button", { name: "Delete 2 notes" })).toBeNull();
+    // Deselect all empties the selection, so the bar fades out and unmounts
+    // once its exit animation ends. jsdom never fires animation events, so
+    // drive it manually.
+    const bar = screen.getByRole("toolbar", { name: "Selection" });
+    expect(bar).toHaveAttribute("data-exit", "fade");
+    fireEvent.animationEnd(bar, {
+      animationName: "meetings-bulk-bar-out-fade",
+    });
+
+    expect(screen.queryByRole("toolbar", { name: "Selection" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
     expect(
       screen.getByRole("checkbox", { name: "Select Second" }),
     ).not.toBeChecked();
     expect(
       screen.getByRole("checkbox", { name: "Select New note" }),
     ).not.toBeChecked();
+  });
+
+  it("slides the bar out and unmounts it after clearing the selection", async () => {
+    const user = userEvent.setup();
+    render(
+      <NotesList
+        notes={notes}
+        onSelectNote={vi.fn()}
+        onCreateNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onDeleteNotes={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
+    await user.click(screen.getByRole("button", { name: "Clear selection" }));
+
+    // The × is a deliberate dismiss, so the bar slides out before unmounting.
+    const bar = screen.getByRole("toolbar", { name: "Selection" });
+    expect(bar).toHaveAttribute("data-exit", "slide");
+    fireEvent.animationEnd(bar, {
+      animationName: "meetings-bulk-bar-out-slide",
+    });
+
+    expect(screen.queryByRole("toolbar", { name: "Selection" })).toBeNull();
+  });
+
+  it("cancels the exit when a note is reselected mid-animation", async () => {
+    const user = userEvent.setup();
+    render(
+      <NotesList
+        notes={notes}
+        onSelectNote={vi.fn()}
+        onCreateNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveNotes={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onDeleteNotes={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select Second" }));
+    await user.click(screen.getByRole("button", { name: "Clear selection" }));
+    expect(screen.getByRole("toolbar", { name: "Selection" })).toHaveAttribute(
+      "data-exit",
+      "slide",
+    );
+
+    // Re-selecting mid-exit shows the live bar again.
+    await user.click(screen.getByRole("checkbox", { name: "Select New note" }));
+    const bar = screen.getByRole("toolbar", { name: "Selection" });
+    expect(bar).not.toHaveAttribute("data-exit");
+    expect(within(bar).getByText("1 selected")).toBeInTheDocument();
+  });
+});
+
+describe("MoveNoteToFolderDialog", () => {
+  const moveFolders: FolderDto[] = [
+    {
+      id: "folder-1",
+      name: "Alpha",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "folder-2",
+      name: "Beta",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+
+  it("moves every selected note to the picked project", async () => {
+    const user = userEvent.setup();
+    const onSetFolder = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(
+      <MoveNoteToFolderDialog
+        open
+        onClose={onClose}
+        notes={notes}
+        folders={moveFolders}
+        onSetFolder={onSetFolder}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Move 2 meeting notes" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("option", { name: /Beta/ }));
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(onSetFolder).toHaveBeenCalledTimes(2);
+    expect(onSetFolder).toHaveBeenNthCalledWith(1, "note-2", "folder-2");
+    expect(onSetFolder).toHaveBeenNthCalledWith(2, "note-1", "folder-2");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps single-note copy and excludes its current project", async () => {
+    render(
+      <MoveNoteToFolderDialog
+        open
+        onClose={vi.fn()}
+        notes={[notes[0]]}
+        folders={moveFolders}
+        onSetFolder={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Move meeting note" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Alpha/ })).toBeNull();
+    expect(screen.getByRole("option", { name: /Beta/ })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed

Reworks multi-select on the Meeting notes page, iterated through several design review rounds.

### Row checkboxes
- Moved outside the row into the left gutter (Granola-style), so the note content keeps the page's exact text alignment; rows now sit flush with the column's text bounds instead of bleeding past them on hover.
- Hidden at rest; revealed on row hover, keyboard focus, when checked, or while any selection is active.
- 15px box with a 28px hit area butted against the row edge (no dead hover gap), full-strength border at rest, solid terracotta (brand) fill with a white check when checked.

### Floating bulk action bar
- Bulk actions moved from the search row into a floating squircle bar (10px radius, concentric 6px controls) pinned bottom-center of the list while it scrolls.
- Contents: plain "N selected" count, then Select all / Deselect all / Move / Delete on a subtle muted wash, and an × dismiss at the end. Delete is neutral; the destructive red lives in the confirm dialog.
- Slides up on enter (spring ease); two exits: slides back down on deliberate dismissal (×, Escape, post-delete), quick fade when the selection merely empties (deselect all, unchecking the last row).
- Escape clears the selection (without fighting the confirm dialog).

### Bulk move
- "Move" applies a project to every selected note: `MoveNoteToFolderDialog` generalized from one note to many (single-note copy unchanged), `App` tracks an id array, sequential commits to respect optimistic per-note updates.

### Misc
- The active note no longer renders highlighted on the all-notes page (the editor's `selectedNoteId` was leaking in as a row tint); dead prop plumbing removed.
- Agent sessions list inherits the flush row edges and drops a phantom empty grid column.

## Testing
- `pnpm lint` (tsc) clean, full `vitest run`: 373 tests across 39 files pass.
- New tests: bulk move via the bar, both bar exit variants, reselect-mid-exit cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)