### PR TITLE
[codex] Fix agents list selection

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -23,6 +23,7 @@ import {
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
 import { AgentSessionsList } from "../components/agent/AgentSessionsList";
+import type { AgentSessionsListHandle } from "../components/agent/AgentSessionsList";
 import { DictationHistoryView } from "../components/dictation/DictationHistoryView";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
 import { RoutinesView } from "../components/routines/RoutinesView";
@@ -196,9 +197,9 @@ export function App() {
   const [sessionFolders, setSessionFolders] = useState<
     Record<string, string[]>
   >({});
-  const [moveDialogSessionId, setMoveDialogSessionId] = useState<string | null>(
-    null,
-  );
+  const [moveDialogSessionIds, setMoveDialogSessionIds] = useState<
+    string[] | null
+  >(null);
   // Where an open agent session was drilled into from — a project or the
   // Routines run history — drives the breadcrumb above the agent workspace,
   // mirroring notes-from-folder.
@@ -218,6 +219,7 @@ export function App() {
   const mainPanelBodyRef = useRef<HTMLDivElement | null>(null);
   const noteDetailScrollRef = useRef<HTMLDivElement | null>(null);
   const notesListRef = useRef<NotesListHandle | null>(null);
+  const agentSessionsListRef = useRef<AgentSessionsListHandle | null>(null);
   // Where the back affordance in settings returns to — captured when settings
   // is opened so "back" lands the user where they were, not on Notes.
   const [settingsReturnView, setSettingsReturnView] =
@@ -1851,6 +1853,7 @@ export function App() {
               />
             ) : activeView === "agent-sessions" ? (
               <AgentSessionsList
+                ref={agentSessionsListRef}
                 sessions={agentSessions}
                 folders={state.folders}
                 sessionFolderIds={sessionFolders}
@@ -1863,7 +1866,10 @@ export function App() {
                 }}
                 onNewSession={handleNewAgentSession}
                 onOpenMoveDialog={(sessionId) =>
-                  setMoveDialogSessionId(sessionId)
+                  setMoveDialogSessionIds([sessionId])
+                }
+                onOpenMoveSessions={(sessionIds) =>
+                  setMoveDialogSessionIds(sessionIds)
                 }
                 onRemoveFromProject={(sessionId, folderId) =>
                   void handleRemoveSessionFromFolder(sessionId, folderId)
@@ -1948,7 +1954,7 @@ export function App() {
                   void handleRemoveSessionFromFolder(sessionId, folderId)
                 }
                 onOpenSessionMoveDialog={(sessionId) =>
-                  setMoveDialogSessionId(sessionId)
+                  setMoveDialogSessionIds([sessionId])
                 }
               />
             ) : selectedNote ? (
@@ -2114,20 +2120,24 @@ export function App() {
         onMoved={() => notesListRef.current?.resetSelection()}
       />
       <MoveSessionToProjectDialog
-        open={moveDialogSessionId !== null}
-        onClose={() => setMoveDialogSessionId(null)}
-        session={
-          moveDialogSessionId
-            ? (agentSessions.find((s) => s.id === moveDialogSessionId) ?? null)
-            : null
+        open={moveDialogSessionIds !== null}
+        onClose={() => setMoveDialogSessionIds(null)}
+        sessions={
+          moveDialogSessionIds
+            ? moveDialogSessionIds
+                .map((id) => agentSessions.find((s) => s.id === id))
+                .filter(
+                  (session): session is HermesSessionInfo =>
+                    session !== undefined,
+                )
+            : []
         }
-        currentFolderIds={
-          moveDialogSessionId ? (sessionFolders[moveDialogSessionId] ?? []) : []
-        }
+        sessionFolderIds={sessionFolders}
         folders={state.folders}
         onSetFolder={(sessionId, folderId) =>
           handleSetSessionFolder(sessionId, folderId)
         }
+        onMoved={() => agentSessionsListRef.current?.resetSelection()}
       />
       <UpdateDialog
         payload={pendingUpdate}

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -73,24 +73,6 @@ export const AgentSessionsList = forwardRef<
   const [exit, setExit] = useState<null | "slide" | "fade">(null);
   const exitCauseRef = useRef<"slide" | "fade">("fade");
 
-  const filteredSessions = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
-    const sorted = [...sessions].sort((a, b) => {
-      const statusDelta =
-        sessionStatusPriority(b.id, workingSessionIds, waitingSessionIds) -
-        sessionStatusPriority(a.id, workingSessionIds, waitingSessionIds);
-      if (statusDelta !== 0) return statusDelta;
-      return sessionTimestamp(b).localeCompare(sessionTimestamp(a));
-    });
-    if (!normalized) return sorted;
-    return sorted.filter((session) =>
-      `${session.title ?? ""} ${session.preview ?? ""} ${sessionStatusLabel(
-        sessionStatus(session.id, workingSessionIds, waitingSessionIds),
-      )}`
-        .toLowerCase()
-        .includes(normalized),
-    );
-  }, [sessions, query, waitingSessionIds, workingSessionIds]);
   const sortedSessions = useMemo(
     () =>
       [...sessions].sort((a, b) => {
@@ -102,6 +84,17 @@ export const AgentSessionsList = forwardRef<
       }),
     [sessions, waitingSessionIds, workingSessionIds],
   );
+  const filteredSessions = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return sortedSessions;
+    return sortedSessions.filter((session) =>
+      `${session.title ?? ""} ${session.preview ?? ""} ${sessionStatusLabel(
+        sessionStatus(session.id, workingSessionIds, waitingSessionIds),
+      )}`
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [sortedSessions, query, waitingSessionIds, workingSessionIds]);
   const selectedSessionIds = useMemo(
     () =>
       sortedSessions
@@ -326,6 +319,7 @@ export const AgentSessionsList = forwardRef<
               type="button"
               className="meetings-bulk-action"
               onClick={selectAllVisibleSessions}
+              disabled={isExiting}
             >
               Select all
             </button>
@@ -334,6 +328,7 @@ export const AgentSessionsList = forwardRef<
             type="button"
             className="meetings-bulk-action"
             onClick={deselectAllVisibleSessions}
+            disabled={isExiting}
           >
             Deselect all
           </button>
@@ -341,6 +336,7 @@ export const AgentSessionsList = forwardRef<
             type="button"
             className="meetings-bulk-action"
             onClick={() => onOpenMoveSessions(selectedSessionIds)}
+            disabled={isExiting}
           >
             Move
           </button>
@@ -348,6 +344,7 @@ export const AgentSessionsList = forwardRef<
             type="button"
             className="meetings-bulk-action"
             onClick={() => setConfirmBulkDelete(true)}
+            disabled={isExiting}
           >
             Delete
           </button>
@@ -356,6 +353,7 @@ export const AgentSessionsList = forwardRef<
             className="meetings-bulk-dismiss"
             aria-label="Clear selection"
             onClick={resetSelection}
+            disabled={isExiting}
           >
             <IconCrossMedium size={14} />
           </button>

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -1,5 +1,7 @@
+import { IconCheckmark2Medium } from "central-icons-filled/IconCheckmark2Medium";
 import { IconArrowsRepeat } from "central-icons/IconArrowsRepeat";
 import { IconBubble3 } from "central-icons/IconBubble3";
+import { IconCrossMedium } from "central-icons/IconCrossMedium";
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
 import { IconFolderAddRight } from "central-icons/IconFolderAddRight";
 import { IconFolderDelete } from "central-icons/IconFolderDelete";
@@ -7,7 +9,15 @@ import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMoveFolder } from "central-icons/IconMoveFolder";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { IconTrashCan } from "central-icons/IconTrashCan";
-import { useEffect, useMemo, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   deleteHermesSession,
   isScheduledRunSession,
@@ -28,23 +38,41 @@ type AgentSessionsListProps = {
   onSelectSession: (session: HermesSessionInfo) => void;
   onNewSession: () => void;
   onOpenMoveDialog: (sessionId: string) => void;
+  onOpenMoveSessions: (sessionIds: string[]) => void;
   onRemoveFromProject: (sessionId: string, folderId: string) => void;
+};
+
+export type AgentSessionsListHandle = {
+  resetSelection: () => void;
 };
 
 const EMPTY_SESSION_IDS: ReadonlySet<string> = new Set();
 
-export function AgentSessionsList({
-  sessions,
-  folders,
-  sessionFolderIds,
-  workingSessionIds = EMPTY_SESSION_IDS,
-  waitingSessionIds = EMPTY_SESSION_IDS,
-  onSelectSession,
-  onNewSession,
-  onOpenMoveDialog,
-  onRemoveFromProject,
-}: AgentSessionsListProps) {
+export const AgentSessionsList = forwardRef<
+  AgentSessionsListHandle,
+  AgentSessionsListProps
+>(function AgentSessionsList(
+  {
+    sessions,
+    folders,
+    sessionFolderIds,
+    workingSessionIds = EMPTY_SESSION_IDS,
+    waitingSessionIds = EMPTY_SESSION_IDS,
+    onSelectSession,
+    onNewSession,
+    onOpenMoveDialog,
+    onOpenMoveSessions,
+    onRemoveFromProject,
+  },
+  ref,
+) {
   const [query, setQuery] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
+  const [bulkDeleteError, setBulkDeleteError] = useState<string | null>(null);
+  const [exit, setExit] = useState<null | "slide" | "fade">(null);
+  const exitCauseRef = useRef<"slide" | "fade">("fade");
+
   const filteredSessions = useMemo(() => {
     const normalized = query.trim().toLowerCase();
     const sorted = [...sessions].sort((a, b) => {
@@ -63,6 +91,130 @@ export function AgentSessionsList({
         .includes(normalized),
     );
   }, [sessions, query, waitingSessionIds, workingSessionIds]);
+  const sortedSessions = useMemo(
+    () =>
+      [...sessions].sort((a, b) => {
+        const statusDelta =
+          sessionStatusPriority(b.id, workingSessionIds, waitingSessionIds) -
+          sessionStatusPriority(a.id, workingSessionIds, waitingSessionIds);
+        if (statusDelta !== 0) return statusDelta;
+        return sessionTimestamp(b).localeCompare(sessionTimestamp(a));
+      }),
+    [sessions, waitingSessionIds, workingSessionIds],
+  );
+  const selectedSessionIds = useMemo(
+    () =>
+      sortedSessions
+        .filter((session) => selectedIds.has(session.id))
+        .map((session) => session.id),
+    [sortedSessions, selectedIds],
+  );
+  const visibleSelectedCount = filteredSessions.filter((session) =>
+    selectedIds.has(session.id),
+  ).length;
+  const selectedCount = selectedSessionIds.length;
+  const hasUnselectedVisibleSessions =
+    filteredSessions.length > 0 &&
+    visibleSelectedCount < filteredSessions.length;
+
+  const lastCountRef = useRef(selectedCount);
+  if (selectedCount > 0) lastCountRef.current = selectedCount;
+  const displayCount = selectedCount > 0 ? selectedCount : lastCountRef.current;
+
+  const previousCountRef = useRef(0);
+  useEffect(() => {
+    const previousCount = previousCountRef.current;
+    previousCountRef.current = selectedCount;
+    if (selectedCount > 0) {
+      setExit(null);
+      return;
+    }
+    if (previousCount === 0) return;
+    const cause = exitCauseRef.current;
+    exitCauseRef.current = "fade";
+    setExit((current) => current ?? cause);
+  }, [selectedCount]);
+
+  const barMounted = selectedCount > 0 || exit !== null;
+  const isExiting = selectedCount === 0 && exit !== null;
+
+  useEffect(() => {
+    const sessionIds = new Set(sessions.map((session) => session.id));
+    setSelectedIds((previous) => {
+      const next = new Set([...previous].filter((id) => sessionIds.has(id)));
+      return next.size === previous.size ? previous : next;
+    });
+    if (sessions.length === 0) {
+      setConfirmBulkDelete(false);
+      setBulkDeleteError(null);
+    }
+  }, [sessions]);
+
+  function toggleSelected(sessionId: string) {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(sessionId)) next.delete(sessionId);
+      else next.add(sessionId);
+      return next;
+    });
+  }
+
+  const resetSelection = useCallback(() => {
+    exitCauseRef.current = "slide";
+    setSelectedIds(new Set());
+    setConfirmBulkDelete(false);
+    setBulkDeleteError(null);
+  }, []);
+
+  useImperativeHandle(ref, () => ({ resetSelection }), [resetSelection]);
+
+  function selectAllVisibleSessions() {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      for (const session of filteredSessions) {
+        next.add(session.id);
+      }
+      return next;
+    });
+  }
+
+  function deselectAllVisibleSessions() {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      for (const session of filteredSessions) {
+        next.delete(session.id);
+      }
+      return next;
+    });
+  }
+
+  useEffect(() => {
+    if (selectedCount === 0 || confirmBulkDelete) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") resetSelection();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedCount, confirmBulkDelete, resetSelection]);
+
+  async function handleBulkDelete() {
+    try {
+      for (const sessionId of selectedSessionIds) {
+        await deleteHermesSession(sessionId);
+        window.setTimeout(() => {
+          window.dispatchEvent(
+            new CustomEvent(AGENT_DELETE_SESSION_EVENT, {
+              detail: { sessionId },
+            }),
+          );
+        }, 0);
+      }
+      resetSelection();
+    } catch (err) {
+      setBulkDeleteError(messageFromError(err));
+      throw err;
+    }
+  }
 
   return (
     <section
@@ -77,9 +229,6 @@ export function AgentSessionsList({
               <span className="folders-count">{sessions.length}</span>
             ) : null}
           </h1>
-          <p className="folders-subtitle">
-            Every conversation with June across your workspace.
-          </p>
         </div>
         <button
           type="button"
@@ -122,7 +271,11 @@ export function AgentSessionsList({
           <p>No sessions match “{query.trim()}”.</p>
         </div>
       ) : (
-        <ul className="folder-notes all-notes-list" role="list">
+        <ul
+          className="folder-notes all-notes-list"
+          role="list"
+          data-selecting={selectedCount > 0}
+        >
           {filteredSessions.map((session) => (
             <AgentSessionListRow
               key={session.id}
@@ -138,6 +291,8 @@ export function AgentSessionsList({
                 workingSessionIds,
                 waitingSessionIds,
               )}
+              checked={selectedIds.has(session.id)}
+              onToggleSelected={() => toggleSelected(session.id)}
               onSelect={() => onSelectSession(session)}
               onOpenMove={() => onOpenMoveDialog(session.id)}
               onRemoveFromProject={(folderId) =>
@@ -147,9 +302,88 @@ export function AgentSessionsList({
           ))}
         </ul>
       )}
+
+      {barMounted ? (
+        <div
+          className="meetings-bulk-bar"
+          role="toolbar"
+          aria-label="Selection"
+          data-exit={isExiting ? exit : undefined}
+          onAnimationEnd={(event) => {
+            if (!isExiting || event.target !== event.currentTarget) return;
+            if (
+              event.animationName &&
+              !event.animationName.startsWith("meetings-bulk-bar-out")
+            ) {
+              return;
+            }
+            setExit(null);
+          }}
+        >
+          <span className="meetings-bulk-count">{displayCount} selected</span>
+          {hasUnselectedVisibleSessions ? (
+            <button
+              type="button"
+              className="meetings-bulk-action"
+              onClick={selectAllVisibleSessions}
+            >
+              Select all
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="meetings-bulk-action"
+            onClick={deselectAllVisibleSessions}
+          >
+            Deselect all
+          </button>
+          <button
+            type="button"
+            className="meetings-bulk-action"
+            onClick={() => onOpenMoveSessions(selectedSessionIds)}
+          >
+            Move
+          </button>
+          <button
+            type="button"
+            className="meetings-bulk-action"
+            onClick={() => setConfirmBulkDelete(true)}
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            className="meetings-bulk-dismiss"
+            aria-label="Clear selection"
+            onClick={resetSelection}
+          >
+            <IconCrossMedium size={14} />
+          </button>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={confirmBulkDelete}
+        onClose={() => {
+          setConfirmBulkDelete(false);
+          setBulkDeleteError(null);
+        }}
+        onConfirm={() => handleBulkDelete()}
+        title={`Delete ${selectedCount} ${
+          selectedCount === 1 ? "session" : "sessions"
+        }?`}
+        description={
+          bulkDeleteError ||
+          "This cannot be undone. These agent sessions will be removed."
+        }
+        confirmLabel={
+          selectedCount === 1 ? "Delete session" : "Delete sessions"
+        }
+        destructive
+      />
     </section>
   );
-}
+});
 
 function projectNameFor(
   sessionId: string,
@@ -194,6 +428,8 @@ function AgentSessionListRow({
   projectName,
   currentFolderId,
   status,
+  checked,
+  onToggleSelected,
   onSelect,
   onOpenMove,
   onRemoveFromProject,
@@ -202,6 +438,8 @@ function AgentSessionListRow({
   projectName?: string;
   currentFolderId?: string;
   status?: AgentSessionListStatus;
+  checked: boolean;
+  onToggleSelected: () => void;
   onSelect: () => void;
   onOpenMove: () => void;
   onRemoveFromProject: (folderId: string) => void;
@@ -255,11 +493,23 @@ function AgentSessionListRow({
   return (
     <li>
       <div
-        className="folder-note-row all-notes-row"
+        className="folder-note-row all-notes-row agent-session-row"
+        data-selected={checked}
         data-has-actions="true"
         data-menu-open={menu !== null}
         data-status={status}
       >
+        <label className="folder-note-checkbox">
+          <input
+            type="checkbox"
+            checked={checked}
+            aria-label={`Select ${title}`}
+            onChange={onToggleSelected}
+          />
+          <span className="folder-note-select-box" aria-hidden>
+            {checked ? <IconCheckmark2Medium size={10} /> : null}
+          </span>
+        </label>
         <button type="button" className="folder-note-main" onClick={onSelect}>
           <span className="folder-note-icon" aria-hidden>
             {isScheduledRunSession(session) ? (

--- a/src/components/folders/MoveSessionToProjectDialog.tsx
+++ b/src/components/folders/MoveSessionToProjectDialog.tsx
@@ -8,20 +8,22 @@ import { Dialog } from "../ui/Dialog";
 type Props = {
   open: boolean;
   onClose: () => void;
-  session: HermesSessionInfo | null;
-  /** Project ids the session is currently filed under (first one wins). */
-  currentFolderIds: string[];
+  sessions: HermesSessionInfo[];
+  /** sessionId -> project ids the session is currently filed under. */
+  sessionFolderIds: Record<string, string[]>;
   folders: FolderDto[];
   onSetFolder: (sessionId: string, folderId: string) => Promise<unknown> | void;
+  onMoved?: () => void;
 };
 
 export function MoveSessionToProjectDialog({
   open,
   onClose,
-  session,
-  currentFolderIds,
+  sessions,
+  sessionFolderIds,
   folders,
   onSetFolder,
+  onMoved,
 }: Props) {
   const [query, setQuery] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -34,9 +36,19 @@ export function MoveSessionToProjectDialog({
     setSubmitting(false);
   }, [open]);
 
-  const currentFolderId = currentFolderIds[0];
+  const isSingle = sessions.length === 1;
+  const sharedFolderId =
+    sessions.length > 0 &&
+    sessions.every(
+      (session) =>
+        sessionFolderIds[session.id]?.[0] ===
+        sessionFolderIds[sessions[0].id]?.[0],
+    )
+      ? sessionFolderIds[sessions[0].id]?.[0]
+      : undefined;
+  const currentFolderId = sharedFolderId;
   const currentFolder = folders.find((f) => f.id === currentFolderId);
-  const hasCurrent = Boolean(currentFolder);
+  const hasCurrent = isSingle && Boolean(currentFolder);
 
   const candidates = useMemo(() => {
     const available = folders.filter((folder) => folder.id !== currentFolderId);
@@ -54,21 +66,30 @@ export function MoveSessionToProjectDialog({
   }, [folders, currentFolderId, query]);
 
   async function handleCommit() {
-    if (!session || !selectedId || submitting) return;
+    if (sessions.length === 0 || !selectedId || submitting) return;
     setSubmitting(true);
     try {
-      await onSetFolder(session.id, selectedId);
+      for (const session of sessions) {
+        await onSetFolder(session.id, selectedId);
+      }
+      onMoved?.();
       onClose();
     } finally {
       setSubmitting(false);
     }
   }
 
-  const title = hasCurrent ? "Move session" : "Add session to project";
-  const description = hasCurrent
-    ? `This session is in "${currentFolder?.name}". Pick another project to move it to.`
-    : "Pick a project for this session.";
-  const commitLabel = hasCurrent ? "Move" : "Add";
+  const title = isSingle
+    ? hasCurrent
+      ? "Move session"
+      : "Add session to project"
+    : `Move ${sessions.length} sessions`;
+  const description = isSingle
+    ? hasCurrent
+      ? `This session is in "${currentFolder?.name}". Pick another project to move it to.`
+      : "Pick a project for this session."
+    : "Pick a project to move them to.";
+  const commitLabel = isSingle && !hasCurrent ? "Add" : "Move";
 
   return (
     <Dialog

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9138,8 +9138,13 @@ button.agent-safety-badge:hover {
 
 .folder-note-row[data-has-actions="true"]:hover .folder-note-time,
 .folder-note-row[data-has-actions="true"]:focus-within .folder-note-time,
+.folder-note-row[data-has-actions="true"]:hover .agent-session-list-status,
+.folder-note-row[data-has-actions="true"]:focus-within
+  .agent-session-list-status,
 .folder-note-row[data-has-actions="true"][data-menu-open="true"]
-  .folder-note-time {
+  .folder-note-time,
+.folder-note-row[data-has-actions="true"][data-menu-open="true"]
+  .agent-session-list-status {
   opacity: 0;
 }
 

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentSessionsList } from "../components/agent/AgentSessionsList";
 import type { HermesSessionInfo } from "../lib/tauri";
 
@@ -36,6 +37,11 @@ const sessions: HermesSessionInfo[] = [
 ];
 
 describe("AgentSessionsList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hermesMocks.deleteHermesSession.mockResolvedValue(undefined);
+  });
+
   it("surfaces active session status and sorts active work first", () => {
     render(
       <AgentSessionsList
@@ -47,6 +53,7 @@ describe("AgentSessionsList", () => {
         onSelectSession={vi.fn()}
         onNewSession={vi.fn()}
         onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={vi.fn()}
         onRemoveFromProject={vi.fn()}
       />,
     );
@@ -65,10 +72,78 @@ describe("AgentSessionsList", () => {
     );
 
     const list = screen.getByRole("list");
+    expect(list.querySelector(".agent-session-row")).toBeTruthy();
+    expect(list.querySelector(".agent-session-row.all-notes-row")).toBeTruthy();
     expect(
       Array.from(list.querySelectorAll(".folder-note-title")).map((node) =>
         node.textContent?.trim(),
       ),
     ).toEqual(["Waiting session", "Running session", "Idle session"]);
+  });
+
+  it("selects agent sessions and moves them in list order", async () => {
+    const user = userEvent.setup();
+    const onOpenMoveSessions = vi.fn();
+    render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        workingSessionIds={new Set(["running-session"])}
+        waitingSessionIds={new Set(["waiting-session"])}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={onOpenMoveSessions}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Select Waiting session"));
+    await user.click(screen.getByLabelText("Select Running session"));
+
+    expect(
+      screen.getByRole("toolbar", { name: "Selection" }),
+    ).toHaveTextContent("2 selected");
+
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(onOpenMoveSessions).toHaveBeenCalledWith([
+      "waiting-session",
+      "running-session",
+    ]);
+  });
+
+  it("bulk deletes selected agent sessions", async () => {
+    const user = userEvent.setup();
+    render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        workingSessionIds={new Set(["running-session"])}
+        waitingSessionIds={new Set(["waiting-session"])}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={vi.fn()}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Select Waiting session"));
+    await user.click(screen.getByLabelText("Select Running session"));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete sessions" }));
+
+    expect(hermesMocks.deleteHermesSession).toHaveBeenCalledTimes(2);
+    expect(hermesMocks.deleteHermesSession).toHaveBeenNthCalledWith(
+      1,
+      "waiting-session",
+    );
+    expect(hermesMocks.deleteHermesSession).toHaveBeenNthCalledWith(
+      2,
+      "running-session",
+    );
   });
 });

--- a/src/test/agent-sessions-list.test.tsx
+++ b/src/test/agent-sessions-list.test.tsx
@@ -2,7 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentSessionsList } from "../components/agent/AgentSessionsList";
-import type { HermesSessionInfo } from "../lib/tauri";
+import { MoveSessionToProjectDialog } from "../components/folders/MoveSessionToProjectDialog";
+import type { FolderDto, HermesSessionInfo } from "../lib/tauri";
 
 const hermesMocks = vi.hoisted(() => ({
   deleteHermesSession: vi.fn(),
@@ -33,6 +34,21 @@ const sessions: HermesSessionInfo[] = [
     title: "Waiting session",
     preview: "Needs permission",
     last_active: "2026-06-04T11:00:00Z",
+  },
+];
+
+const folders: FolderDto[] = [
+  {
+    id: "project-alpha",
+    name: "Alpha",
+    createdAt: "2026-06-04T10:00:00Z",
+    updatedAt: "2026-06-04T10:00:00Z",
+  },
+  {
+    id: "project-beta",
+    name: "Beta",
+    createdAt: "2026-06-04T10:00:00Z",
+    updatedAt: "2026-06-04T10:00:00Z",
   },
 ];
 
@@ -114,6 +130,37 @@ describe("AgentSessionsList", () => {
     ]);
   });
 
+  it("keeps the exiting bulk bar actions inert after selection clears", async () => {
+    const user = userEvent.setup();
+    const onOpenMoveSessions = vi.fn();
+    render(
+      <AgentSessionsList
+        sessions={sessions}
+        folders={[]}
+        sessionFolderIds={{}}
+        workingSessionIds={new Set(["running-session"])}
+        waitingSessionIds={new Set(["waiting-session"])}
+        onSelectSession={vi.fn()}
+        onNewSession={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onOpenMoveSessions={onOpenMoveSessions}
+        onRemoveFromProject={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Select Waiting session"));
+    await user.click(screen.getByRole("button", { name: "Deselect all" }));
+
+    const bar = screen.getByRole("toolbar", { name: "Selection" });
+    expect(bar).toHaveAttribute("data-exit", "fade");
+
+    const moveButton = screen.getByRole("button", { name: "Move" });
+    expect(moveButton).toBeDisabled();
+    await user.click(moveButton);
+
+    expect(onOpenMoveSessions).not.toHaveBeenCalled();
+  });
+
   it("bulk deletes selected agent sessions", async () => {
     const user = userEvent.setup();
     render(
@@ -145,5 +192,51 @@ describe("AgentSessionsList", () => {
       2,
       "running-session",
     );
+  });
+});
+
+describe("MoveSessionToProjectDialog", () => {
+  it("moves every selected agent session to the picked project", async () => {
+    const user = userEvent.setup();
+    const onSetFolder = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const onMoved = vi.fn();
+
+    render(
+      <MoveSessionToProjectDialog
+        open
+        onClose={onClose}
+        sessions={[sessions[2], sessions[1]]}
+        sessionFolderIds={{
+          "waiting-session": ["project-alpha"],
+          "running-session": ["project-alpha"],
+        }}
+        folders={folders}
+        onSetFolder={onSetFolder}
+        onMoved={onMoved}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Move 2 sessions" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Alpha/ })).toBeNull();
+
+    await user.click(screen.getByRole("option", { name: /Beta/ }));
+    await user.click(screen.getByRole("button", { name: "Move" }));
+
+    expect(onSetFolder).toHaveBeenCalledTimes(2);
+    expect(onSetFolder).toHaveBeenNthCalledWith(
+      1,
+      "waiting-session",
+      "project-beta",
+    );
+    expect(onSetFolder).toHaveBeenNthCalledWith(
+      2,
+      "running-session",
+      "project-beta",
+    );
+    expect(onMoved).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Pulls in the latest `main` notes multi-select interaction and ports the same gutter checkbox plus floating bulk action bar behavior to the Agents list.
- Keeps single-row session actions intact while adding bulk move and bulk delete for selected agent sessions.
- Generalizes the session project dialog so it can move one session or many sessions.
- Removes the Agents page subtitle so the page header stays closer to the title-only chat history reference.

## Root cause
The Agents list was still sharing row chrome with the notes list without matching the notes selection behavior. After the latest notes-list update, the shared `all-notes-row` class is the right base for the hover checkbox treatment, but Agents needed its own selection state and bulk session actions.

## Validation
- `pnpm test -- src/test/agent-sessions-list.test.tsx src/test/folders.test.tsx`
- `pnpm run lint`
- `pnpm test` (403 tests passed)
- `pnpm run build`
- `pnpm exec prettier --check src/components/agent/AgentSessionsList.tsx src/test/agent-sessions-list.test.tsx src/app/App.tsx src/components/folders/MoveSessionToProjectDialog.tsx src/styles/app.css`

Note: repo-wide `pnpm run format` still flags `src-tauri/tauri.conf.json`, which is unrelated to this PR and came from current `main`. Rendered browser validation was not captured because the in-app Browser reported `Browser is not available: iab`, and Playwright is not installed in this repo.