### PR TITLE
Integrate onboarding survey capture and PostHog delivery

### DIFF
--- a/docs/superpowers/plans/2026-06-12-onboarding-survey-pipeline.md
+++ b/docs/superpowers/plans/2026-06-12-onboarding-survey-pipeline.md
@@ -1,0 +1,69 @@
+# Onboarding Survey Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the onboarding discovery-source answer to scribe-api exactly once without blocking onboarding.
+
+**Architecture:** Add a small authenticated JSON endpoint to scribe-api, backed by a `SurveySink` trait with webhook and structured-log providers. The desktop app exposes a Tauri command that posts to the endpoint, and the frontend reports from the existing `setDiscoverySource` seam with a retry-on-launch flag.
+
+**Tech Stack:** Rust, axum, reqwest, Tauri commands, TypeScript, React, Vitest.
+
+---
+
+### Task 1: scribe-api survey endpoint
+
+**Files:**
+- Modify: `scribe-api/crates/domain/src/lib.rs`
+- Create: `scribe-api/crates/api/src/handlers/surveys.rs`
+- Modify: `scribe-api/crates/api/src/handlers/mod.rs`
+- Modify: `scribe-api/crates/api/src/lib.rs`
+- Modify: `scribe-api/crates/api/src/state.rs`
+- Modify: `scribe-api/crates/api/tests/http_boundary.rs`
+
+- [x] Write failing boundary tests for auth, slug validation, and sink delivery.
+- [x] Add domain `OnboardingSurvey`, `OnboardingSurveySource`, and `SurveySink`.
+- [x] Add `POST /v1/onboarding-surveys` with `ApiResponse<{ received: true }>` and JSON body limit.
+- [x] Wire `SurveySink` through `ApiState`.
+- [x] Run `cargo test --manifest-path scribe-api/Cargo.toml -p scribe-api --test http_boundary onboarding_survey`.
+
+### Task 2: scribe-api survey providers
+
+**Files:**
+- Modify: `scribe-api/crates/config/src/lib.rs`
+- Create: `scribe-api/crates/providers/src/surveys.rs`
+- Modify: `scribe-api/crates/providers/src/lib.rs`
+- Modify: `scribe-api/crates/app/src/main.rs`
+- Modify: `scribe-api/config.toml`
+
+- [x] Add `[surveys] webhook_url` config with redacted debug output.
+- [x] Add webhook sink that POSTs the survey JSON.
+- [x] Add log sink fallback with structured `survey source=<slug> app_version=<v> user=<id>` fields.
+- [x] Wire app startup to choose webhook else log sink.
+- [x] Run provider tests for webhook configured, webhook success, webhook rejection, and log fallback construction.
+
+### Task 3: desktop command and frontend reporting
+
+**Files:**
+- Modify: `src-tauri/src/domain/types.rs`
+- Modify: `src-tauri/src/scribe_api.rs`
+- Modify: `src-tauri/src/commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src/lib/tauri.ts`
+- Modify: `src/lib/onboarding.ts`
+- Modify: `src/main.tsx`
+- Modify: `src/test/onboarding.test.tsx`
+
+- [x] Add `submit_discovery_source` Tauri command that posts `{ source, appVersion, platform }`.
+- [x] Add TypeScript `submitDiscoverySource`.
+- [x] Report best effort from `setDiscoverySource`, setting `june.onboarding.discoveryReported` only after success.
+- [x] Retry once on launch when a source exists without the reported flag.
+- [x] Preserve dev replay behavior by clearing the reported flag together with the source.
+- [x] Run onboarding tests for exactly-once success and offline retry.
+
+### Task 4: PR review accessibility fix and verification
+
+**Files:**
+- Modify: `src/components/ui/Select.tsx`
+
+- [x] Add `role="presentation"` to `Select` list item wrappers.
+- [x] Run focused frontend, scribe-api, and Rust/Tauri checks.

--- a/scribe-api/.env.example
+++ b/scribe-api/.env.example
@@ -27,3 +27,10 @@ SCRIBE__OS_ACCOUNTS__APP_API_KEY=osk_REPLACE_ME
 # Required when the configured pricing table exposes OpenAI/Venice models.
 SCRIBE__UPSTREAMS__OPENAI__API_KEY=sk_REPLACE_ME
 SCRIBE__UPSTREAMS__VENICE__API_KEY=VENICE_API_KEY_REPLACE_ME
+
+# --- Survey analytics -------------------------------------------------------
+# Captures onboarding discovery-source answers in PostHog.
+# US cloud: https://us.i.posthog.com
+# EU cloud: https://eu.i.posthog.com
+SCRIBE__SURVEYS__POSTHOG_API_HOST=https://us.i.posthog.com
+SCRIBE__SURVEYS__POSTHOG_PROJECT_KEY=phc_REPLACE_ME

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -31,6 +31,16 @@ os_platform_label = "bug"
 os_platform_reward_asset = ""
 webhook_url = ""
 
+[surveys]
+# Where onboarding discovery answers go, first match wins:
+# 1. PostHog capture API — product analytics events, configured per
+#    environment via SCRIBE__SURVEYS__POSTHOG_*.
+# 2. Webhook — each answer as a JSON POST.
+# 3. Neither configured: answers land in the structured logs only.
+posthog_api_host = ""
+posthog_project_key = ""
+webhook_url = ""
+
 [os_accounts]
 # api_url has no default — must come from SCRIBE__OS_ACCOUNTS__API_URL
 # per environment so a missing override fails loud against the dev

--- a/scribe-api/crates/api/src/handlers/mod.rs
+++ b/scribe-api/crates/api/src/handlers/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod health;
 pub(crate) mod issues;
 pub(crate) mod models;
 pub(crate) mod notes;
+pub(crate) mod surveys;
 pub(crate) mod verify;

--- a/scribe-api/crates/api/src/handlers/surveys.rs
+++ b/scribe-api/crates/api/src/handlers/surveys.rs
@@ -1,0 +1,63 @@
+use crate::{
+    auth::authenticated_user, envelope::ApiResponse, error::ApiError, state::ApiState, validation,
+};
+use axum::{Json, extract::State, http::HeaderMap};
+use scribe_domain::{DomainError, OnboardingSurvey, OnboardingSurveySource};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingSurveyRequest {
+    source: String,
+    app_version: Option<String>,
+    platform: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingSurveyResponse {
+    pub received: bool,
+}
+
+impl OnboardingSurveyRequest {
+    fn validate(&self) -> Result<OnboardingSurveySource, ApiError> {
+        let source = OnboardingSurveySource::from_slug(self.source.trim())
+            .ok_or_else(|| ApiError::bad_request("source_invalid"))?;
+        validation::validate_optional_text_len(
+            "app_version",
+            self.app_version.as_deref(),
+            validation::MAX_ID_CHARS,
+        )?;
+        validation::validate_optional_text_len(
+            "platform",
+            self.platform.as_deref(),
+            validation::MAX_ID_CHARS,
+        )?;
+        Ok(source)
+    }
+}
+
+pub(crate) async fn submit(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    Json(request): Json<OnboardingSurveyRequest>,
+) -> Result<Json<ApiResponse<OnboardingSurveyResponse>>, ApiError> {
+    let user_id = authenticated_user(&state, &headers).await?;
+    let source = request.validate()?;
+    state
+        .surveys()
+        .deliver(OnboardingSurvey {
+            user_id,
+            source,
+            app_version: request.app_version,
+            platform: request.platform,
+        })
+        .await
+        .map_err(|error| match error {
+            DomainError::InvalidInput { reason } => ApiError::bad_request(reason),
+            _ => ApiError::Upstream,
+        })?;
+    Ok(Json(ApiResponse::ok(OnboardingSurveyResponse {
+        received: true,
+    })))
+}

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -30,6 +30,7 @@ pub use handlers::health::HealthDto;
 pub use handlers::issues::IssueReportResponse;
 pub use handlers::models::ModelDto;
 pub use handlers::notes::{GenerateRequest, GenerateResponse, TranscribeResponse};
+pub use handlers::surveys::{OnboardingSurveyRequest, OnboardingSurveyResponse};
 pub use state::{ApiLimits, ApiState, ApiStateParams, AttestationInfo};
 
 pub fn router(state: ApiState) -> Router {
@@ -71,6 +72,10 @@ pub fn router(state: ApiState) -> Router {
             // Reports carry screenshot uploads, so they get the audio-sized
             // body budget rather than the JSON one.
             post(handlers::issues::submit).layer(DefaultBodyLimit::max(limits.max_audio_bytes)),
+        )
+        .route(
+            "/v1/onboarding-surveys",
+            post(handlers::surveys::submit).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
         )
         .layer(timeout)
         .layer(TraceLayer::new_for_http())

--- a/scribe-api/crates/api/src/state.rs
+++ b/scribe-api/crates/api/src/state.rs
@@ -1,4 +1,4 @@
-use scribe_domain::{IssueReportSink, TokenVerifier};
+use scribe_domain::{IssueReportSink, SurveySink, TokenVerifier};
 use scribe_services::{
     AgentChatService, DictateService, NoteGenerateService, NoteTranscribeService, PricingTable,
 };
@@ -17,6 +17,7 @@ struct ApiStateInner {
     agent_chat: Arc<AgentChatService>,
     dictate: Arc<DictateService>,
     issue_reports: Arc<dyn IssueReportSink>,
+    surveys: Arc<dyn SurveySink>,
     limits: ApiLimits,
     attestation: AttestationInfo,
 }
@@ -47,6 +48,7 @@ pub struct ApiStateParams {
     pub agent_chat: Arc<AgentChatService>,
     pub dictate: Arc<DictateService>,
     pub issue_reports: Arc<dyn IssueReportSink>,
+    pub surveys: Arc<dyn SurveySink>,
     pub limits: ApiLimits,
     pub attestation: AttestationInfo,
 }
@@ -62,6 +64,7 @@ impl ApiState {
                 agent_chat: params.agent_chat,
                 dictate: params.dictate,
                 issue_reports: params.issue_reports,
+                surveys: params.surveys,
                 limits: params.limits,
                 attestation: params.attestation,
             }),
@@ -94,6 +97,10 @@ impl ApiState {
 
     pub(crate) fn issue_reports(&self) -> &dyn IssueReportSink {
         self.inner.issue_reports.as_ref()
+    }
+
+    pub(crate) fn surveys(&self) -> &dyn SurveySink {
+        self.inner.surveys.as_ref()
     }
 
     pub(crate) fn limits(&self) -> ApiLimits {

--- a/scribe-api/crates/api/tests/http_boundary.rs
+++ b/scribe-api/crates/api/tests/http_boundary.rs
@@ -10,8 +10,9 @@ use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
 use scribe_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe, AuthError,
     Authorization, AuthorizeRequest, CleanedText, Cleaner, CleanupRequest, Credits, DomainError,
-    GeneratedNote, GenerationRequest, Generator, IssueReport, IssueReportSink, OsAccountsClient,
-    Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest, UserId,
+    GeneratedNote, GenerationRequest, Generator, IssueReport, IssueReportSink, OnboardingSurvey,
+    OsAccountsClient, Receipt, SurveySink, TokenUsage, Transcriber, Transcript,
+    TranscriptionRequest, UserId,
 };
 use scribe_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps,
@@ -189,6 +190,87 @@ async fn integration_issue_report_delivers_attachments_to_the_sink() -> Result<(
 }
 
 #[tokio::test]
+async fn integration_onboarding_survey_requires_auth() -> Result<(), Box<dyn Error>> {
+    let response = send(json_request(
+        "/v1/onboarding-surveys",
+        &serde_json::json!({
+            "source": "friend",
+            "appVersion": "0.0.8",
+            "platform": "macos"
+        }),
+        None,
+    )?)
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], false);
+    assert_eq!(body["error_code"], 3001);
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_onboarding_survey_rejects_unknown_source() -> Result<(), Box<dyn Error>> {
+    let response = send(json_request(
+        "/v1/onboarding-surveys",
+        &serde_json::json!({
+            "source": "billboard",
+            "appVersion": "0.0.8",
+            "platform": "macos"
+        }),
+        Some(AUTHORIZATION),
+    )?)
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], false);
+    assert_eq!(body["message"], "source_invalid");
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_onboarding_survey_delivers_to_the_sink() -> Result<(), Box<dyn Error>> {
+    let sink = Arc::new(RecordingSurveySink::default());
+    let router = router(test_state_with_survey_sink(
+        sink.clone(),
+        test_attestation(),
+    ));
+
+    let response = match router
+        .oneshot(json_request(
+            "/v1/onboarding-surveys",
+            &serde_json::json!({
+                "source": "ai-chat",
+                "appVersion": "0.0.8",
+                "platform": "macos"
+            }),
+            Some(AUTHORIZATION),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["received"], true);
+
+    let surveys = sink
+        .surveys
+        .lock()
+        .map_err(|_| "survey sink mutex poisoned")?;
+    assert_eq!(surveys.len(), 1);
+    assert_eq!(surveys[0].user_id.0, "usr_test");
+    assert_eq!(surveys[0].source.as_str(), "ai-chat");
+    assert_eq!(surveys[0].app_version.as_deref(), Some("0.0.8"));
+    assert_eq!(surveys[0].platform.as_deref(), Some("macos"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_note_transcribe_accepts_valid_audio_multipart() -> Result<(), Box<dyn Error>> {
     let response = send(multipart_request(
         "/v1/notes/transcribe",
@@ -322,11 +404,38 @@ fn test_state() -> ApiState {
 }
 
 fn test_state_with_attestation(attestation: AttestationInfo) -> ApiState {
-    test_state_with_issue_sink(Arc::new(RecordingIssueReportSink::default()), attestation)
+    test_state_with_sinks(
+        Arc::new(RecordingIssueReportSink::default()),
+        Arc::new(RecordingSurveySink::default()),
+        attestation,
+    )
 }
 
 fn test_state_with_issue_sink(
     issue_reports: Arc<dyn IssueReportSink>,
+    attestation: AttestationInfo,
+) -> ApiState {
+    test_state_with_sinks(
+        issue_reports,
+        Arc::new(RecordingSurveySink::default()),
+        attestation,
+    )
+}
+
+fn test_state_with_survey_sink(
+    surveys: Arc<dyn SurveySink>,
+    attestation: AttestationInfo,
+) -> ApiState {
+    test_state_with_sinks(
+        Arc::new(RecordingIssueReportSink::default()),
+        surveys,
+        attestation,
+    )
+}
+
+fn test_state_with_sinks(
+    issue_reports: Arc<dyn IssueReportSink>,
+    surveys: Arc<dyn SurveySink>,
     attestation: AttestationInfo,
 ) -> ApiState {
     let pricing = Arc::new(PricingTable::new(models()));
@@ -373,6 +482,7 @@ fn test_state_with_issue_sink(
             flat_estimate_credits: 1_000,
         })),
         issue_reports,
+        surveys,
         limits: ApiLimits {
             max_audio_bytes: 1024 * 1024,
             max_json_bytes: 1024 * 1024,
@@ -565,6 +675,22 @@ fn valid_wav() -> Vec<u8> {
 #[derive(Default)]
 struct RecordingIssueReportSink {
     reports: Mutex<Vec<IssueReport>>,
+}
+
+#[derive(Default)]
+struct RecordingSurveySink {
+    surveys: Mutex<Vec<OnboardingSurvey>>,
+}
+
+#[async_trait]
+impl SurveySink for RecordingSurveySink {
+    async fn deliver(&self, survey: OnboardingSurvey) -> Result<(), DomainError> {
+        self.surveys
+            .lock()
+            .map_err(|_| DomainError::UpstreamProvider)?
+            .push(survey);
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -2,9 +2,10 @@ use clap::{Parser, Subcommand};
 use scribe_api::{ApiLimits, ApiState, ApiStateParams, AttestationInfo};
 use scribe_config::{AppConfig, ModelPriceConfig, ModelProvider};
 use scribe_providers::{
-    JwksTokenVerifier, LogIssueReportSink, MultiFormatDurationProbe, OsAccountsHttpClient,
-    OsPlatformIssueReportSink, RoutingTranscriber, VeniceAgentChat, VeniceCleaner, VeniceGenerator,
-    VeniceModelCatalog, WebhookIssueReportSink, default_client, jwks_client,
+    JwksTokenVerifier, LogIssueReportSink, LogSurveySink, MultiFormatDurationProbe,
+    OsAccountsHttpClient, OsPlatformIssueReportSink, PostHogSurveySink, RoutingTranscriber,
+    VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog, WebhookIssueReportSink,
+    WebhookSurveySink, default_client, jwks_client,
 };
 use scribe_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps,
@@ -115,6 +116,16 @@ fn build_router(
         tracing::info!("no issue report sink configured; reports will be logged only");
         Arc::new(LogIssueReportSink)
     };
+    let surveys: Arc<dyn scribe_domain::SurveySink> =
+        if let Some(sink) = PostHogSurveySink::from_config(http.clone(), &config.surveys) {
+            tracing::info!("survey answers will be captured in PostHog");
+            Arc::new(sink)
+        } else if let Some(sink) = WebhookSurveySink::from_config(http.clone(), &config.surveys) {
+            Arc::new(sink)
+        } else {
+            tracing::info!("no survey sink configured; survey answers will be logged only");
+            Arc::new(LogSurveySink)
+        };
 
     let flat_estimate_credits = config.os_accounts.flat_estimate_credits;
 
@@ -161,6 +172,7 @@ fn build_router(
         agent_chat,
         dictate,
         issue_reports,
+        surveys,
         limits: ApiLimits {
             max_audio_bytes: config.server.max_audio_bytes,
             max_json_bytes: config.server.max_json_bytes,

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -103,29 +103,8 @@ fn build_router(
     let token_verifier: Arc<dyn scribe_domain::TokenVerifier> = Arc::new(
         JwksTokenVerifier::from_config(jwks_client(), &config.os_accounts),
     );
-    let issue_reports: Arc<dyn scribe_domain::IssueReportSink> = if let Some(sink) =
-        OsPlatformIssueReportSink::from_config(http.clone(), &config.issue_reports)
-    {
-        tracing::info!("issue reports will be filed as os-platform issues");
-        Arc::new(sink)
-    } else if let Some(sink) =
-        WebhookIssueReportSink::from_config(http.clone(), &config.issue_reports)
-    {
-        Arc::new(sink)
-    } else {
-        tracing::info!("no issue report sink configured; reports will be logged only");
-        Arc::new(LogIssueReportSink)
-    };
-    let surveys: Arc<dyn scribe_domain::SurveySink> =
-        if let Some(sink) = PostHogSurveySink::from_config(http.clone(), &config.surveys) {
-            tracing::info!("survey answers will be captured in PostHog");
-            Arc::new(sink)
-        } else if let Some(sink) = WebhookSurveySink::from_config(http.clone(), &config.surveys) {
-            Arc::new(sink)
-        } else {
-            tracing::info!("no survey sink configured; survey answers will be logged only");
-            Arc::new(LogSurveySink)
-        };
+    let issue_reports = build_issue_report_sink(config, http);
+    let surveys = build_survey_sink(config, http);
 
     let flat_estimate_credits = config.os_accounts.flat_estimate_credits;
 
@@ -186,6 +165,39 @@ fn build_router(
         },
     });
     scribe_api::router(state)
+}
+
+fn build_issue_report_sink(
+    config: &AppConfig,
+    http: &reqwest::Client,
+) -> Arc<dyn scribe_domain::IssueReportSink> {
+    if let Some(sink) = OsPlatformIssueReportSink::from_config(http.clone(), &config.issue_reports)
+    {
+        tracing::info!("issue reports will be filed as os-platform issues");
+        Arc::new(sink)
+    } else if let Some(sink) =
+        WebhookIssueReportSink::from_config(http.clone(), &config.issue_reports)
+    {
+        Arc::new(sink)
+    } else {
+        tracing::info!("no issue report sink configured; reports will be logged only");
+        Arc::new(LogIssueReportSink)
+    }
+}
+
+fn build_survey_sink(
+    config: &AppConfig,
+    http: &reqwest::Client,
+) -> Arc<dyn scribe_domain::SurveySink> {
+    if let Some(sink) = PostHogSurveySink::from_config(http.clone(), &config.surveys) {
+        tracing::info!("survey answers will be captured in PostHog");
+        Arc::new(sink)
+    } else if let Some(sink) = WebhookSurveySink::from_config(http.clone(), &config.surveys) {
+        Arc::new(sink)
+    } else {
+        tracing::info!("no survey sink configured; survey answers will be logged only");
+        Arc::new(LogSurveySink)
+    }
 }
 
 fn init_tracing() {

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -124,15 +124,15 @@ impl Debug for IssueReportsConfig {
     }
 }
 
-/// Where onboarding attribution answers get forwarded. With no PostHog or
+/// Where onboarding attribution answers get forwarded. With no `PostHog` or
 /// webhook configured, answers become structured log lines.
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct SurveysConfig {
-    /// PostHog capture API host, e.g. `https://us.i.posthog.com`.
+    /// `PostHog` capture API host, e.g. `https://us.i.posthog.com`.
     /// `SCRIBE__SURVEYS__POSTHOG_API_HOST`.
     #[serde(default)]
     pub posthog_api_host: String,
-    /// PostHog project API key (`phc_...`). Redacted Debug.
+    /// `PostHog` project API key (`phc_...`). Redacted Debug.
     /// `SCRIBE__SURVEYS__POSTHOG_PROJECT_KEY`.
     #[serde(default)]
     pub posthog_project_key: String,

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -19,6 +19,8 @@ pub struct AppConfig {
     pub attestation: AttestationConfig,
     #[serde(default)]
     pub issue_reports: IssueReportsConfig,
+    #[serde(default)]
+    pub surveys: SurveysConfig,
     pub pricing: BTreeMap<String, ModelPriceConfig>,
 }
 
@@ -31,6 +33,7 @@ impl Debug for AppConfig {
             .field("upstreams", &self.upstreams)
             .field("attestation", &self.attestation)
             .field("issue_reports", &self.issue_reports)
+            .field("surveys", &self.surveys)
             .field("pricing", &self.pricing)
             .finish()
     }
@@ -117,6 +120,50 @@ impl Debug for IssueReportsConfig {
             .field("os_platform_project", &self.os_platform_project)
             .field("os_platform_label", &self.os_platform_label)
             .field("os_platform_reward_asset", &self.os_platform_reward_asset)
+            .finish()
+    }
+}
+
+/// Where onboarding attribution answers get forwarded. With no PostHog or
+/// webhook configured, answers become structured log lines.
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct SurveysConfig {
+    /// PostHog capture API host, e.g. `https://us.i.posthog.com`.
+    /// `SCRIBE__SURVEYS__POSTHOG_API_HOST`.
+    #[serde(default)]
+    pub posthog_api_host: String,
+    /// PostHog project API key (`phc_...`). Redacted Debug.
+    /// `SCRIBE__SURVEYS__POSTHOG_PROJECT_KEY`.
+    #[serde(default)]
+    pub posthog_project_key: String,
+    /// Receives each survey answer as a JSON POST. Often embeds a secret
+    /// token, hence the redacted Debug. Set via
+    /// `SCRIBE__SURVEYS__WEBHOOK_URL`.
+    #[serde(default)]
+    pub webhook_url: String,
+}
+
+impl Debug for SurveysConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SurveysConfig")
+            .field("posthog_api_host", &self.posthog_api_host)
+            .field(
+                "posthog_project_key",
+                if self.posthog_project_key.is_empty() {
+                    &"<unset>"
+                } else {
+                    &REDACTED
+                },
+            )
+            .field(
+                "webhook_url",
+                if self.webhook_url.is_empty() {
+                    &"<unset>"
+                } else {
+                    &REDACTED
+                },
+            )
             .finish()
     }
 }
@@ -431,6 +478,7 @@ impl Default for AppConfig {
                         .to_string(),
             },
             issue_reports: IssueReportsConfig::default(),
+            surveys: SurveysConfig::default(),
             pricing: default_pricing(),
         }
     }

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -219,6 +219,57 @@ pub struct IssueReport {
     pub platform: Option<String>,
 }
 
+/// A first-run onboarding attribution answer from the desktop app.
+#[derive(Clone, Debug)]
+pub struct OnboardingSurvey {
+    pub user_id: UserId,
+    pub source: OnboardingSurveySource,
+    pub app_version: Option<String>,
+    pub platform: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OnboardingSurveySource {
+    Friend,
+    XTwitter,
+    YouTube,
+    InstagramTikTok,
+    PodcastNewsletter,
+    AiChat,
+    Search,
+    Other,
+}
+
+impl OnboardingSurveySource {
+    pub fn from_slug(slug: &str) -> Option<Self> {
+        match slug {
+            "friend" => Some(Self::Friend),
+            "x-twitter" => Some(Self::XTwitter),
+            "youtube" => Some(Self::YouTube),
+            "instagram-tiktok" => Some(Self::InstagramTikTok),
+            "podcast-newsletter" => Some(Self::PodcastNewsletter),
+            "ai-chat" => Some(Self::AiChat),
+            "search" => Some(Self::Search),
+            "other" => Some(Self::Other),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Friend => "friend",
+            Self::XTwitter => "x-twitter",
+            Self::YouTube => "youtube",
+            Self::InstagramTikTok => "instagram-tiktok",
+            Self::PodcastNewsletter => "podcast-newsletter",
+            Self::AiChat => "ai-chat",
+            Self::Search => "search",
+            Self::Other => "other",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct IssueReportAttachment {
     pub name: String,
@@ -295,6 +346,11 @@ pub trait TokenVerifier: Send + Sync {
 #[async_trait]
 pub trait IssueReportSink: Send + Sync {
     async fn deliver(&self, report: IssueReport) -> Result<(), DomainError>;
+}
+
+#[async_trait]
+pub trait SurveySink: Send + Sync {
+    async fn deliver(&self, survey: OnboardingSurvey) -> Result<(), DomainError>;
 }
 
 pub trait AudioDurationProbe: Send + Sync {

--- a/scribe-api/crates/providers/src/lib.rs
+++ b/scribe-api/crates/providers/src/lib.rs
@@ -8,6 +8,7 @@ pub mod m4a_probe;
 pub mod openai;
 pub mod os_accounts;
 pub mod routing;
+pub mod surveys;
 pub mod venice;
 pub mod wav_probe;
 
@@ -22,6 +23,7 @@ pub use m4a_probe::{M4aDurationProbe, M4aProbeError};
 pub use openai::OpenAiTranscriber;
 pub use os_accounts::OsAccountsHttpClient;
 pub use routing::RoutingTranscriber;
+pub use surveys::{LogSurveySink, PostHogSurveySink, WebhookSurveySink};
 pub use venice::{
     VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog, VeniceTranscriber,
 };

--- a/scribe-api/crates/providers/src/surveys.rs
+++ b/scribe-api/crates/providers/src/surveys.rs
@@ -1,0 +1,336 @@
+use async_trait::async_trait;
+use scribe_config::SurveysConfig;
+use scribe_domain::{DomainError, OnboardingSurvey, SurveySink};
+use serde::Serialize;
+
+/// Forwards onboarding survey answers as a JSON POST to the configured webhook.
+pub struct WebhookSurveySink {
+    http: reqwest::Client,
+    webhook_url: String,
+}
+
+pub struct PostHogSurveySink {
+    http: reqwest::Client,
+    api_host: String,
+    project_key: String,
+}
+
+impl PostHogSurveySink {
+    pub fn from_config(http: reqwest::Client, config: &SurveysConfig) -> Option<Self> {
+        let api_host = config.posthog_api_host.trim().trim_end_matches('/');
+        let project_key = config.posthog_project_key.trim();
+        if api_host.is_empty() || project_key.is_empty() {
+            return None;
+        }
+        Some(Self {
+            http,
+            api_host: api_host.to_string(),
+            project_key: project_key.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl SurveySink for PostHogSurveySink {
+    async fn deliver(&self, survey: OnboardingSurvey) -> Result<(), DomainError> {
+        let body = PostHogCaptureWire::from_survey(&self.project_key, &survey);
+        let response = self
+            .http
+            .post(format!("{}/capture", self.api_host))
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, "surveys: PostHog transport error");
+                DomainError::UpstreamProvider
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            tracing::error!(%status, body_bytes = body.len(), "surveys: PostHog rejected answer");
+            return Err(DomainError::UpstreamProvider);
+        }
+        tracing::info!(
+            user_id = %survey.user_id.0,
+            source = survey.source.as_str(),
+            app_version = survey.app_version.as_deref().unwrap_or(""),
+            platform = survey.platform.as_deref().unwrap_or(""),
+            "surveys: answer captured in PostHog"
+        );
+        Ok(())
+    }
+}
+
+impl WebhookSurveySink {
+    /// `None` when no webhook is configured. The caller falls back to the
+    /// log sink so survey answers are never dropped silently.
+    pub fn from_config(http: reqwest::Client, config: &SurveysConfig) -> Option<Self> {
+        let webhook_url = config.webhook_url.trim();
+        if webhook_url.is_empty() {
+            return None;
+        }
+        Some(Self {
+            http,
+            webhook_url: webhook_url.to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl SurveySink for WebhookSurveySink {
+    async fn deliver(&self, survey: OnboardingSurvey) -> Result<(), DomainError> {
+        let body = OnboardingSurveyWire::from(&survey);
+        let response = self
+            .http
+            .post(&self.webhook_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, "surveys: webhook transport error");
+                DomainError::UpstreamProvider
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            tracing::error!(%status, body_bytes = body.len(), "surveys: webhook rejected answer");
+            return Err(DomainError::UpstreamProvider);
+        }
+        tracing::info!(
+            user_id = %survey.user_id.0,
+            source = survey.source.as_str(),
+            app_version = survey.app_version.as_deref().unwrap_or(""),
+            platform = survey.platform.as_deref().unwrap_or(""),
+            "surveys: answer forwarded to webhook"
+        );
+        Ok(())
+    }
+}
+
+/// Fallback sink when no webhook is configured: the answer becomes a
+/// structured log line, so it still reaches whoever reads deploy logs.
+pub struct LogSurveySink;
+
+#[async_trait]
+impl SurveySink for LogSurveySink {
+    async fn deliver(&self, survey: OnboardingSurvey) -> Result<(), DomainError> {
+        tracing::warn!(
+            user_id = %survey.user_id.0,
+            source = survey.source.as_str(),
+            app_version = survey.app_version.as_deref().unwrap_or(""),
+            platform = survey.platform.as_deref().unwrap_or(""),
+            "surveys: no webhook configured; answer logged only"
+        );
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OnboardingSurveyWire<'a> {
+    user_id: &'a str,
+    source: &'a str,
+    app_version: Option<&'a str>,
+    platform: Option<&'a str>,
+}
+
+impl<'a> From<&'a OnboardingSurvey> for OnboardingSurveyWire<'a> {
+    fn from(survey: &'a OnboardingSurvey) -> Self {
+        Self {
+            user_id: &survey.user_id.0,
+            source: survey.source.as_str(),
+            app_version: survey.app_version.as_deref(),
+            platform: survey.platform.as_deref(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PostHogCaptureWire<'a> {
+    api_key: &'a str,
+    event: &'static str,
+    distinct_id: &'a str,
+    properties: PostHogCaptureProperties<'a>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PostHogCaptureProperties<'a> {
+    source: &'a str,
+    app_version: Option<&'a str>,
+    platform: Option<&'a str>,
+}
+
+impl<'a> PostHogCaptureWire<'a> {
+    fn from_survey(project_key: &'a str, survey: &'a OnboardingSurvey) -> Self {
+        Self {
+            api_key: project_key,
+            event: "onboarding discovery source submitted",
+            distinct_id: &survey.user_id.0,
+            properties: PostHogCaptureProperties {
+                source: survey.source.as_str(),
+                app_version: survey.app_version.as_deref(),
+                platform: survey.platform.as_deref(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scribe_domain::{OnboardingSurveySource, UserId};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path},
+    };
+
+    fn survey() -> OnboardingSurvey {
+        OnboardingSurvey {
+            user_id: UserId("usr_test".to_string()),
+            source: OnboardingSurveySource::AiChat,
+            app_version: Some("0.0.8".to_string()),
+            platform: Some("macos".to_string()),
+        }
+    }
+
+    #[test]
+    fn webhook_sink_is_disabled_without_url() {
+        let config = SurveysConfig::default();
+        assert!(WebhookSurveySink::from_config(reqwest::Client::new(), &config).is_none());
+    }
+
+    #[test]
+    fn posthog_sink_requires_host_and_project_key() {
+        assert!(
+            PostHogSurveySink::from_config(reqwest::Client::new(), &SurveysConfig::default())
+                .is_none()
+        );
+        assert!(
+            PostHogSurveySink::from_config(
+                reqwest::Client::new(),
+                &SurveysConfig {
+                    posthog_api_host: "https://us.i.posthog.com".to_string(),
+                    ..SurveysConfig::default()
+                }
+            )
+            .is_none()
+        );
+        assert!(
+            PostHogSurveySink::from_config(
+                reqwest::Client::new(),
+                &SurveysConfig {
+                    posthog_project_key: "phc_test".to_string(),
+                    ..SurveysConfig::default()
+                }
+            )
+            .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn posthog_sink_captures_the_survey_answer() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/capture"))
+            .and(body_json(serde_json::json!({
+                "api_key": "phc_test",
+                "event": "onboarding discovery source submitted",
+                "distinct_id": "usr_test",
+                "properties": {
+                    "source": "ai-chat",
+                    "appVersion": "0.0.8",
+                    "platform": "macos"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let config = SurveysConfig {
+            posthog_api_host: server.uri(),
+            posthog_project_key: "phc_test".to_string(),
+            ..SurveysConfig::default()
+        };
+        let sink =
+            PostHogSurveySink::from_config(reqwest::Client::new(), &config).expect("posthog sink");
+
+        sink.deliver(survey()).await.expect("survey captured");
+    }
+
+    #[tokio::test]
+    async fn posthog_sink_returns_upstream_error_when_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/capture"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let config = SurveysConfig {
+            posthog_api_host: server.uri(),
+            posthog_project_key: "phc_test".to_string(),
+            ..SurveysConfig::default()
+        };
+        let sink =
+            PostHogSurveySink::from_config(reqwest::Client::new(), &config).expect("posthog sink");
+
+        assert_eq!(
+            sink.deliver(survey()).await,
+            Err(DomainError::UpstreamProvider)
+        );
+    }
+
+    #[tokio::test]
+    async fn webhook_sink_posts_the_survey_answer() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/survey"))
+            .and(body_json(serde_json::json!({
+                "userId": "usr_test",
+                "source": "ai-chat",
+                "appVersion": "0.0.8",
+                "platform": "macos"
+            })))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let config = SurveysConfig {
+            webhook_url: format!("{}/survey", server.uri()),
+            ..SurveysConfig::default()
+        };
+        let sink =
+            WebhookSurveySink::from_config(reqwest::Client::new(), &config).expect("webhook sink");
+
+        sink.deliver(survey()).await.expect("survey delivered");
+    }
+
+    #[tokio::test]
+    async fn webhook_sink_returns_upstream_error_when_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/survey"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let config = SurveysConfig {
+            webhook_url: format!("{}/survey", server.uri()),
+            ..SurveysConfig::default()
+        };
+        let sink =
+            WebhookSurveySink::from_config(reqwest::Client::new(), &config).expect("webhook sink");
+
+        assert_eq!(
+            sink.deliver(survey()).await,
+            Err(DomainError::UpstreamProvider)
+        );
+    }
+
+    #[tokio::test]
+    async fn log_sink_accepts_survey_answers() {
+        LogSurveySink
+            .deliver(survey())
+            .await
+            .expect("survey logged");
+    }
+}

--- a/scribe-api/crates/providers/src/surveys.rs
+++ b/scribe-api/crates/providers/src/surveys.rs
@@ -3,6 +3,8 @@ use scribe_config::SurveysConfig;
 use scribe_domain::{DomainError, OnboardingSurvey, SurveySink};
 use serde::Serialize;
 
+const POSTHOG_ONBOARDING_DISCOVERY_EVENT: &str = "onboarding_discovery_source_submitted";
+
 /// Forwards onboarding survey answers as a JSON POST to the configured webhook.
 pub struct WebhookSurveySink {
     http: reqwest::Client,
@@ -159,18 +161,28 @@ struct PostHogCaptureProperties<'a> {
     source: &'a str,
     app_version: Option<&'a str>,
     platform: Option<&'a str>,
+    #[serde(rename = "$set")]
+    set: PostHogPersonProperties<'a>,
+}
+
+#[derive(Serialize)]
+struct PostHogPersonProperties<'a> {
+    discovery_source: &'a str,
 }
 
 impl<'a> PostHogCaptureWire<'a> {
     fn from_survey(project_key: &'a str, survey: &'a OnboardingSurvey) -> Self {
         Self {
             api_key: project_key,
-            event: "onboarding discovery source submitted",
+            event: POSTHOG_ONBOARDING_DISCOVERY_EVENT,
             distinct_id: &survey.user_id.0,
             properties: PostHogCaptureProperties {
                 source: survey.source.as_str(),
                 app_version: survey.app_version.as_deref(),
                 platform: survey.platform.as_deref(),
+                set: PostHogPersonProperties {
+                    discovery_source: survey.source.as_str(),
+                },
             },
         }
     }
@@ -235,12 +247,15 @@ mod tests {
             .and(path("/capture"))
             .and(body_json(serde_json::json!({
                 "api_key": "phc_test",
-                "event": "onboarding discovery source submitted",
+                "event": "onboarding_discovery_source_submitted",
                 "distinct_id": "usr_test",
                 "properties": {
                     "source": "ai-chat",
                     "appVersion": "0.0.8",
-                    "platform": "macos"
+                    "platform": "macos",
+                    "$set": {
+                        "discovery_source": "ai-chat"
+                    }
                 }
             })))
             .respond_with(ResponseTemplate::new(200))

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -33,7 +33,8 @@ use crate::{
             RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest, RenameFolderRequest,
             RetryProcessingRequest, SaveAgentAssistantMessageRequest,
             SaveAgentHermesSessionRequest, SendAgentMessageRequest, SessionFolderDto,
-            SessionRequest, SourceReadinessDto, StartRecordingRequest, SubmitIssueReportRequest,
+            SessionRequest, SourceReadinessDto, StartRecordingRequest,
+            SubmitDiscoverySourceRequest, SubmitDiscoverySourceResponse, SubmitIssueReportRequest,
             SubmitIssueReportResponse, SuggestAgentSessionTitleRequest,
             SuggestAgentSessionTitleResponse, UpdateDictionaryEntryRequest, UpdateNoteRequest,
         },
@@ -429,6 +430,15 @@ pub async fn submit_issue_report(
 ) -> Result<SubmitIssueReportResponse, AppError> {
     let app_version = app.package_info().version.to_string();
     crate::scribe_api::submit_issue_report(&request, &app_version).await
+}
+
+#[tauri::command]
+pub async fn submit_discovery_source(
+    app: AppHandle,
+    request: SubmitDiscoverySourceRequest,
+) -> Result<SubmitDiscoverySourceResponse, AppError> {
+    let app_version = app.package_info().version.to_string();
+    crate::scribe_api::submit_discovery_source(&request, &app_version).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -607,6 +607,18 @@ pub struct SubmitIssueReportResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SubmitDiscoverySourceRequest {
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitDiscoverySourceResponse {
+    pub received: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExplainAgentApprovalRequest {
     pub description: String,
     #[serde(default)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ pub fn run() {
             os_accounts::os_accounts_open_portal,
             os_accounts::os_accounts_prepare_trial_checkout,
             os_accounts::os_accounts_start_trial_checkout,
+            commands::submit_discovery_source,
             focus_main_window
         ])
         .manage(hermes_bridge::HermesBridge::default())

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -603,6 +603,25 @@ pub async fn submit_issue_report(
     post_multipart("/v1/issue-reports", form).await
 }
 
+pub async fn submit_discovery_source(
+    request: &crate::domain::types::SubmitDiscoverySourceRequest,
+    app_version: &str,
+) -> Result<crate::domain::types::SubmitDiscoverySourceResponse, AppError> {
+    let source = request.source.trim();
+    if source.is_empty() {
+        return Err(AppError::new(
+            "discovery_source_empty",
+            "Discovery source is required.",
+        ));
+    }
+    let body = serde_json::json!({
+        "source": source,
+        "appVersion": app_version,
+        "platform": std::env::consts::OS,
+    });
+    post_json("/v1/onboarding-surveys", &body).await
+}
+
 fn issue_attachment_mime(path: &str) -> &'static str {
     let extension = Path::new(path)
         .extension()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,32 +80,21 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$TEMP/os-scribe-dictation-*.m4a"
-        ]
+        "scope": ["$TEMP/os-scribe-dictation-*.m4a"]
       },
-      "capabilities": [
-        "main",
-        "hud",
-        "agent-hud",
-        "meeting-hud"
-      ]
+      "capabilities": ["main", "hud", "agent-hud", "meeting-hud"]
     }
   },
   "plugins": {
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "osscribe"
-          ],
+          "scheme": ["osscribe"],
           "appLink": false
         }
       ],
       "desktop": {
-        "schemes": [
-          "osscribe"
-        ]
+        "schemes": ["osscribe"]
       }
     },
     "updater": {
@@ -125,10 +114,7 @@
       "icons/icon.icns",
       "icons/icon.png"
     ],
-    "targets": [
-      "app",
-      "dmg"
-    ],
+    "targets": ["app", "dmg"],
     "resources": {
       "../.tauri-helper/June.app": "native/bin/June.app",
       "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app",

--- a/src/components/onboarding/steps/PracticeStep.tsx
+++ b/src/components/onboarding/steps/PracticeStep.tsx
@@ -1,6 +1,10 @@
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { useEffect, useRef, useState } from "react";
-import { discoverySource, setDiscoverySource } from "../../../lib/onboarding";
+import {
+  discoverySource,
+  reportPendingDiscoverySource,
+  setDiscoverySource,
+} from "../../../lib/onboarding";
 import { JuneMark } from "../../account/AccountGate";
 import { KeycapShortcut } from "../../shortcuts/KeycapShortcut";
 import { useShortcutCapture } from "../../shortcuts/use-shortcut-capture";
@@ -64,6 +68,11 @@ export function DictationPracticeStep({
     const timer = window.setTimeout(() => setGreeted(true), TYPING_MS);
     return () => window.clearTimeout(timer);
   }, []);
+
+  function continueFromPractice() {
+    reportPendingDiscoverySource({ force: true });
+    onContinue();
+  }
 
   return (
     <StepCard title="Talk to June" subtitle="Say what you want done." wide>
@@ -154,9 +163,9 @@ export function DictationPracticeStep({
       ) : null}
       <StepActions
         continueLabel="Start using June"
-        onContinue={onContinue}
+        onContinue={continueFromPractice}
         continueDisabled={!succeeded}
-        onSkip={onContinue}
+        onSkip={continueFromPractice}
       />
     </StepCard>
   );

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -157,7 +157,7 @@ export function Select({
           {options.map((option) => {
             const isSelected = option.value === value;
             return (
-              <li key={option.value}>
+              <li key={option.value} role="presentation">
                 <button
                   type="button"
                   role="option"

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -11,6 +11,10 @@ const COMPLETED_KEY = "june.onboarding.completedVersion";
 const RESUME_KEY = "june.onboarding.resumeStep";
 const AGENT_ACK_KEY = "june.agent.riskAcknowledged";
 const DISCOVERY_KEY = "june.onboarding.discoverySource";
+const DISCOVERY_REPORTED_KEY = "june.onboarding.discoveryReported";
+const DISCOVERY_PENDING_REPORT_KEY = "june.onboarding.discoveryPendingReport";
+
+const discoveryReportsInFlight = new Set<string>();
 
 type OnboardingReplayEnv = {
   readonly DEV?: boolean;
@@ -58,6 +62,8 @@ export function resetOnboardingForReplay() {
     // wizard shows the whole flow. Real version-bump replays don't come
     // through here and keep it.
     window.localStorage.removeItem(DISCOVERY_KEY);
+    window.localStorage.removeItem(DISCOVERY_REPORTED_KEY);
+    window.localStorage.removeItem(DISCOVERY_PENDING_REPORT_KEY);
   } catch {
     // Ignore; storage unavailable already behaves like a completed wizard.
   }
@@ -88,8 +94,8 @@ export function setOnboardingResumeStep(stepId: string) {
 /**
  * Where the user says they discovered June, asked once at the end of the
  * wizard. A non-null answer is never re-asked, even when a version bump
- * replays the wizard. Stored locally for now; reporting it home needs a
- * scribe-api endpoint, and this is the single place to hook that up.
+ * replays the wizard. Stored locally first, then reported only when the user
+ * leaves the final onboarding step.
  */
 export function discoverySource(): string | null {
   try {
@@ -102,8 +108,73 @@ export function discoverySource(): string | null {
 export function setDiscoverySource(source: string) {
   try {
     window.localStorage.setItem(DISCOVERY_KEY, source);
+    window.localStorage.removeItem(DISCOVERY_REPORTED_KEY);
+    window.localStorage.removeItem(DISCOVERY_PENDING_REPORT_KEY);
   } catch {
     // Ignore; worst case the question is asked again on a replay.
+  }
+}
+
+export function reportPendingDiscoverySource(options?: { force?: boolean }) {
+  const source = discoverySource();
+  if (source && (options?.force || discoveryPendingReport() === source)) {
+    reportDiscoverySource(source, { markPending: options?.force === true });
+  }
+}
+
+function reportDiscoverySource(
+  source: string,
+  options?: { markPending?: boolean },
+) {
+  const normalized = source.trim();
+  if (!normalized || discoveryReportStatus() === normalized) {
+    return;
+  }
+  if (options?.markPending) {
+    try {
+      window.localStorage.setItem(DISCOVERY_PENDING_REPORT_KEY, normalized);
+    } catch {
+      // Ignore; a best-effort in-flight send still happens.
+    }
+  }
+  if (discoveryReportsInFlight.has(normalized)) {
+    return;
+  }
+  discoveryReportsInFlight.add(normalized);
+  void import("./tauri")
+    .then(({ submitDiscoverySource }) =>
+      submitDiscoverySource({ source: normalized }),
+    )
+    .then((response) => {
+      if (!response.received) return;
+      try {
+        if (discoverySource() === normalized) {
+          window.localStorage.setItem(DISCOVERY_REPORTED_KEY, normalized);
+          window.localStorage.removeItem(DISCOVERY_PENDING_REPORT_KEY);
+        }
+      } catch {
+        // Ignore; retrying later is harmless.
+      }
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      discoveryReportsInFlight.delete(normalized);
+    });
+}
+
+function discoveryReportStatus(): string | null {
+  try {
+    return window.localStorage.getItem(DISCOVERY_REPORTED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function discoveryPendingReport(): string | null {
+  try {
+    return window.localStorage.getItem(DISCOVERY_PENDING_REPORT_KEY);
+  } catch {
+    return null;
   }
 }
 
@@ -137,6 +208,8 @@ export function replayOnboarding(stepId?: string) {
   try {
     window.localStorage.removeItem(COMPLETED_KEY);
     window.localStorage.removeItem(DISCOVERY_KEY);
+    window.localStorage.removeItem(DISCOVERY_REPORTED_KEY);
+    window.localStorage.removeItem(DISCOVERY_PENDING_REPORT_KEY);
     if (stepId) window.localStorage.setItem(RESUME_KEY, stepId);
     else window.localStorage.removeItem(RESUME_KEY);
   } catch {

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -107,9 +107,12 @@ export function discoverySource(): string | null {
 
 export function setDiscoverySource(source: string) {
   try {
+    const previousSource = window.localStorage.getItem(DISCOVERY_KEY);
     window.localStorage.setItem(DISCOVERY_KEY, source);
-    window.localStorage.removeItem(DISCOVERY_REPORTED_KEY);
-    window.localStorage.removeItem(DISCOVERY_PENDING_REPORT_KEY);
+    if (previousSource !== source) {
+      window.localStorage.removeItem(DISCOVERY_REPORTED_KEY);
+      window.localStorage.removeItem(DISCOVERY_PENDING_REPORT_KEY);
+    }
   } catch {
     // Ignore; worst case the question is asked again on a replay.
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -799,6 +799,22 @@ export async function submitIssueReport(request: SubmitIssueReportRequest) {
   return invoke<SubmitIssueReportResponse>("submit_issue_report", { request });
 }
 
+export type SubmitDiscoverySourceRequest = {
+  source: string;
+};
+
+export type SubmitDiscoverySourceResponse = {
+  received: boolean;
+};
+
+export async function submitDiscoverySource(
+  request: SubmitDiscoverySourceRequest,
+) {
+  return invoke<SubmitDiscoverySourceResponse>("submit_discovery_source", {
+    request,
+  });
+}
+
 export type ExplainAgentApprovalResponse = {
   explanation: string;
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { Agentation } from "agentation";
 import { App } from "./app/App";
-import { replayOnboarding } from "./lib/onboarding";
+import {
+  replayOnboarding,
+  reportPendingDiscoverySource,
+} from "./lib/onboarding";
 import { initTheme } from "./lib/theme";
 import "./styles/app.css";
 
@@ -20,6 +23,7 @@ if (import.meta.env.DEV) {
 }
 
 initTheme();
+reportPendingDiscoverySource();
 
 // Console driver for the agent HUD overlay window: __agentHud("demo") etc.
 // from this window's devtools. Emits on the Tauri bus only, so fake demo

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -9,6 +9,7 @@ import {
   isOnboardingComplete,
   markOnboardingComplete,
   onboardingResumeStep,
+  reportPendingDiscoverySource,
   resetOnboardingForReplay,
   setDiscoverySource,
   setOnboardingResumeStep,
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsStartTrialCheckout: vi.fn(),
   osAccountsOpenPortal: vi.fn(),
   focusMainWindow: vi.fn(),
+  submitDiscoverySource: vi.fn(),
   listen: vi.fn(),
 }));
 
@@ -44,6 +46,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsStartTrialCheckout: mocks.osAccountsStartTrialCheckout,
   osAccountsOpenPortal: mocks.osAccountsOpenPortal,
   focusMainWindow: mocks.focusMainWindow,
+  submitDiscoverySource: mocks.submitDiscoverySource,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -113,6 +116,7 @@ describe("OnboardingFlow", () => {
     });
     mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
     mocks.focusMainWindow.mockResolvedValue(undefined);
+    mocks.submitDiscoverySource.mockResolvedValue({ received: true });
     mocks.setDictationLanguage.mockResolvedValue(undefined);
     mocks.setDictationShortcut.mockResolvedValue(undefined);
     mocks.dictationSettings.mockResolvedValue({
@@ -627,11 +631,89 @@ describe("OnboardingFlow", () => {
     await user.click(screen.getByRole("option", { name: "YouTube" }));
 
     expect(discoverySource()).toBe("youtube");
+    expect(mocks.submitDiscoverySource).not.toHaveBeenCalled();
+    expect(
+      localStorage.getItem("june.onboarding.discoveryPendingReport"),
+    ).toBeNull();
     // The trigger keeps showing the choice, and answering never gates the
     // step: Continue still waits on the dictation rep, not the survey.
     expect(
       screen.getByRole("button", { name: "Where did you hear about June?" }),
     ).toHaveTextContent("YouTube");
+
+    await user.type(
+      screen.getByPlaceholderText(/Tell June what to do/i),
+      "hello there",
+    );
+    await user.click(screen.getByRole("button", { name: "Start using June" }));
+
+    await waitFor(() =>
+      expect(mocks.submitDiscoverySource).toHaveBeenCalledWith({
+        source: "youtube",
+      }),
+    );
+    expect(localStorage.getItem("june.onboarding.discoveryReported")).toBe(
+      "youtube",
+    );
+    expect(
+      localStorage.getItem("june.onboarding.discoveryPendingReport"),
+    ).toBeNull();
+  });
+
+  it("keeps discovery reporting pending when the backend is offline", async () => {
+    mocks.submitDiscoverySource.mockRejectedValueOnce(new Error("offline"));
+
+    setDiscoverySource("search");
+    expect(mocks.submitDiscoverySource).not.toHaveBeenCalled();
+
+    reportPendingDiscoverySource();
+    expect(mocks.submitDiscoverySource).not.toHaveBeenCalled();
+
+    reportPendingDiscoverySource({ force: true });
+
+    await waitFor(() =>
+      expect(mocks.submitDiscoverySource).toHaveBeenCalledWith({
+        source: "search",
+      }),
+    );
+    expect(discoverySource()).toBe("search");
+    expect(
+      localStorage.getItem("june.onboarding.discoveryReported"),
+    ).toBeNull();
+    expect(localStorage.getItem("june.onboarding.discoveryPendingReport")).toBe(
+      "search",
+    );
+  });
+
+  it("retries one pending discovery answer on launch and does not duplicate after delivery", async () => {
+    localStorage.setItem("june.onboarding.discoverySource", "friend");
+    localStorage.setItem("june.onboarding.discoveryPendingReport", "friend");
+
+    reportPendingDiscoverySource();
+    await waitFor(() =>
+      expect(mocks.submitDiscoverySource).toHaveBeenCalledWith({
+        source: "friend",
+      }),
+    );
+    expect(localStorage.getItem("june.onboarding.discoveryReported")).toBe(
+      "friend",
+    );
+    expect(
+      localStorage.getItem("june.onboarding.discoveryPendingReport"),
+    ).toBeNull();
+
+    mocks.submitDiscoverySource.mockClear();
+    reportPendingDiscoverySource();
+
+    expect(mocks.submitDiscoverySource).not.toHaveBeenCalled();
+  });
+
+  it("does not report a selected discovery answer on launch until the action button was clicked", () => {
+    localStorage.setItem("june.onboarding.discoverySource", "friend");
+
+    reportPendingDiscoverySource();
+
+    expect(mocks.submitDiscoverySource).not.toHaveBeenCalled();
   });
 
   it("never re-asks an answered discovery question", async () => {
@@ -658,6 +740,9 @@ describe("OnboardingFlow", () => {
     // The dev replay forgets the discovery answer (so the replayed wizard
     // shows the whole flow) but keeps the agent-risk acknowledgment.
     expect(discoverySource()).toBeNull();
+    expect(
+      localStorage.getItem("june.onboarding.discoveryReported"),
+    ).toBeNull();
     expect(isAgentRiskAcknowledged()).toBe(true);
   });
 

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -685,6 +685,39 @@ describe("OnboardingFlow", () => {
     );
   });
 
+  it("keeps pending discovery retry state when the same source is re-selected during an in-flight report", async () => {
+    let rejectReport!: (error: Error) => void;
+    mocks.submitDiscoverySource.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectReport = reject;
+      }),
+    );
+
+    setDiscoverySource("search");
+    reportPendingDiscoverySource({ force: true });
+
+    await waitFor(() =>
+      expect(mocks.submitDiscoverySource).toHaveBeenCalledWith({
+        source: "search",
+      }),
+    );
+    expect(localStorage.getItem("june.onboarding.discoveryPendingReport")).toBe(
+      "search",
+    );
+
+    setDiscoverySource("search");
+    rejectReport(new Error("offline"));
+
+    await waitFor(() =>
+      expect(
+        localStorage.getItem("june.onboarding.discoveryPendingReport"),
+      ).toBe("search"),
+    );
+    expect(
+      localStorage.getItem("june.onboarding.discoveryReported"),
+    ).toBeNull();
+  });
+
   it("retries one pending discovery answer on launch and does not duplicate after delivery", async () => {
     localStorage.setItem("june.onboarding.discoverySource", "friend");
     localStorage.setItem("june.onboarding.discoveryPendingReport", "friend");


### PR DESCRIPTION
## Summary
- Add a new onboarding-survey endpoint in `scribe-api` and wire it through the Tauri client.
- Forward discovery-source answers through PostHog when configured, with webhook and log fallbacks.
- Move reporting to the final onboarding action so changing the answer does not spam events.
- Add unit and boundary coverage for the new survey flow and duplicate prevention.

## Testing
- `pnpm test src/test/onboarding.test.tsx`
- `pnpm test`