### PR TITLE
Prefer heading-based generated titles and ignore stale polling updates

### DIFF
--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -2194,11 +2194,47 @@ fn is_replaceable_generated_title(title: &str) -> bool {
 }
 
 fn generated_title_from_content(content: &str) -> Option<String> {
+    let heading_title = title_from_generated_headings(content);
+    if heading_title.is_some() {
+        return heading_title;
+    }
+
     content
         .lines()
         .map(clean_generated_title_line)
         .find(|line| !line.is_empty() && !is_replaceable_generated_title(line))
         .map(|line| truncate_title(&line, 72))
+}
+
+fn title_from_generated_headings(content: &str) -> Option<String> {
+    let mut headings = Vec::new();
+    for heading in content.lines().filter_map(markdown_heading_text) {
+        let heading = clean_generated_title_line(heading);
+        if heading.is_empty()
+            || is_replaceable_generated_title(&heading)
+            || headings
+                .iter()
+                .any(|existing: &String| existing.eq_ignore_ascii_case(&heading))
+        {
+            continue;
+        }
+        headings.push(heading);
+    }
+
+    title_from_parts(&headings)
+}
+
+fn title_from_parts(parts: &[String]) -> Option<String> {
+    match parts {
+        [] => None,
+        [only] => Some(truncate_title(only, 72)),
+        [first, second] => Some(truncate_title(&format!("{first} and {second}"), 72)),
+        _ => {
+            let last = parts.last()?;
+            let prefix = parts[..parts.len() - 1].join(", ");
+            Some(truncate_title(&format!("{prefix}, and {last}"), 72))
+        }
+    }
 }
 
 fn clean_generated_title_line(line: &str) -> String {

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -136,6 +136,27 @@ async fn generated_note_derives_title_when_provider_returns_placeholder() {
 }
 
 #[tokio::test]
+async fn generated_note_derives_title_from_all_section_headings() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+
+    let generated = repos
+        .set_generated_note(
+            &note.id,
+            Some("Untitled note".to_string()),
+            "# Budget review\n\n- Costs are rising\n\n# Hiring plan\n\n- Open roles are approved\n\n# Product launch\n\n- The team is keeping the launch date"
+                .to_string(),
+        )
+        .await
+        .expect("generated note");
+
+    assert_eq!(
+        generated.title,
+        "Budget review, Hiring plan, and Product launch"
+    );
+}
+
+#[tokio::test]
 async fn generated_note_appends_to_existing_generated_content() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src/app/state/app-state.ts
+++ b/src/app/state/app-state.ts
@@ -188,6 +188,12 @@ function mergeNoteUpdate(state: NotesState, note: NoteDto): NoteDto {
     note.processingStatus,
   );
   if (processingStatus === note.processingStatus) return note;
+  if (
+    isTerminalProcessingStatus(current.processingStatus) &&
+    !isTerminalProcessingStatus(note.processingStatus)
+  ) {
+    return current;
+  }
 
   return {
     ...note,

--- a/src/test/app-state.test.ts
+++ b/src/test/app-state.test.ts
@@ -204,6 +204,37 @@ describe("notesReducer", () => {
     expect(state.notes[0].processingStatus).toBe("ready");
   });
 
+  it("does not let stale active polling overwrite a ready title", () => {
+    const initial = notesReducer(createInitialState(), {
+      type: "noteLoaded",
+      note: note({
+        id: "note-1",
+        title: "Budget review, Hiring plan, and Product launch",
+        processingStatus: "ready",
+        generatedContent: "Finished notes",
+      }),
+    });
+
+    const state = notesReducer(initial, {
+      type: "noteUpdated",
+      note: note({
+        id: "note-1",
+        title: "New note",
+        processingStatus: "transcribing",
+        generatedContent: "",
+      }),
+    });
+
+    expect(state.selectedNote?.title).toBe(
+      "Budget review, Hiring plan, and Product launch",
+    );
+    expect(state.selectedNote?.generatedContent).toBe("Finished notes");
+    expect(state.selectedNote?.processingStatus).toBe("ready");
+    expect(state.notes[0].title).toBe(
+      "Budget review, Hiring plan, and Product launch",
+    );
+  });
+
   it("keeps source transcript rows on authoritative processing updates", () => {
     const initial = notesReducer(createInitialState(), {
       type: "noteLoaded",


### PR DESCRIPTION
## Summary
- Derive generated note titles from markdown section headings before falling back to content lines
- Join multiple unique headings into a natural title and skip placeholder headings
- Ignore stale non-terminal polling updates after a note is already ready so the title and content stay stable
- Add regression coverage for repository title derivation and app-state merge behavior

## Testing
- Added unit and integration-level regressions for heading-based title generation and stale update handling
- Not run (not requested)