### PR TITLE
Recover the fn press when it overlaps a foreign modifier

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -377,6 +377,14 @@ final class ShortcutKeyMonitor {
     private var pendingPushShortcut: MonitoredShortcut?
     private var lastTapIdentity: ShortcutIdentity?
     private var lastTapAt: Date?
+    /// A modifier-only shortcut whose own key went down while a foreign
+    /// modifier was still held (fn pressed before Cmd from a cmd-tab fully
+    /// cleared). The press edge couldn't fire then — the flags weren't an
+    /// exact match — so it fires the moment the foreign modifiers clear.
+    /// Set only on the shortcut's own key-down with extras present, which is
+    /// what keeps the cmd-tab phantom dead: there fn's down already matched
+    /// (and was consumed) before the interruption, so nothing is pending.
+    private var pendingOverlapIdentity: ShortcutIdentity?
     private var isCapturingShortcut = false
     private var capturePressCount = 1
     private var pendingModifierOnlyCapture: DispatchWorkItem?
@@ -418,6 +426,13 @@ final class ShortcutKeyMonitor {
     /// modifier keys may create a press; foreign keys can still *end* one
     /// (adding Cmd mid-push releases it), but such an interruption is not a
     /// physical release and must not arm the double-press detector.
+    ///
+    /// One foreign-key exception, tracked by `pendingOverlapIdentity`: a
+    /// press whose own key went down while a foreign modifier was still held
+    /// (fn hit right after a cmd-tab, or while Shift from a capital was
+    /// settling) never matched exactly, so the foreign key's *release* is the
+    /// first moment the chord physically holds — fire it then, or the press
+    /// is swallowed for as long as fn stays down.
     fileprivate func handleFlagsChanged(_ current: ShortcutModifiers, changedKeyCode: UInt16) {
         if let identity = activeIdentity, identity.modifiers != current {
             handlePhysicalUp(
@@ -426,13 +441,66 @@ final class ShortcutKeyMonitor {
             )
         }
 
+        updatePendingOverlap(current, changedKeyCode: changedKeyCode)
+
         guard let identity = matchingModifierOnlyIdentity(current),
               modifierKeyCodes(for: identity.modifiers).contains(changedKeyCode)
+                  || pendingOverlapIdentity == identity
         else {
             return
         }
 
+        pendingOverlapIdentity = nil
         handlePhysicalDown(identity: identity)
+    }
+
+    /// Arms the overlap recovery when a modifier-only shortcut's own key goes
+    /// down under extra foreign modifiers, and disarms it when that key comes
+    /// back up before the chord ever held. Foreign keys never arm it — their
+    /// releases only consume it via the match in handleFlagsChanged.
+    private func updatePendingOverlap(_ current: ShortcutModifiers, changedKeyCode: UInt16) {
+        guard let keyIsDown = modifierBitIsDown(for: changedKeyCode, in: current) else {
+            return
+        }
+        if keyIsDown {
+            for shortcut in shortcuts.values where shortcut.isModifierOnly {
+                guard modifierKeyCodes(for: shortcut.modifiers).contains(changedKeyCode),
+                      shortcut.modifiers != current,
+                      modifiersContain(current, shortcut.modifiers)
+                else {
+                    continue
+                }
+                pendingOverlapIdentity = ShortcutIdentity(shortcut)
+                return
+            }
+        } else if let pending = pendingOverlapIdentity,
+                  modifierKeyCodes(for: pending.modifiers).contains(changedKeyCode),
+                  !modifiersContain(current, pending.modifiers) {
+            pendingOverlapIdentity = nil
+        }
+    }
+
+    /// Whether the modifier a flagsChanged keyCode belongs to is set after
+    /// the event — i.e. whether that key just went down (or, with paired
+    /// left/right keys, its sibling is still holding the bit). Nil for
+    /// non-modifier keyCodes.
+    private func modifierBitIsDown(for keyCode: UInt16, in current: ShortcutModifiers) -> Bool? {
+        switch keyCode {
+        case 0x36, 0x37: return current.command
+        case 0x38, 0x3C: return current.shift
+        case 0x3A, 0x3D: return current.option
+        case 0x3B, 0x3E: return current.control
+        case 0x3F: return current.function
+        default: return nil
+        }
+    }
+
+    private func modifiersContain(_ current: ShortcutModifiers, _ subset: ShortcutModifiers) -> Bool {
+        (!subset.command || current.command)
+            && (!subset.control || current.control)
+            && (!subset.option || current.option)
+            && (!subset.shift || current.shift)
+            && (!subset.function || current.function)
     }
 
     fileprivate func handle(type: CGEventType, event: CGEvent) {
@@ -466,6 +534,7 @@ final class ShortcutKeyMonitor {
         activePushIdentity = nil
         lastTapIdentity = nil
         lastTapAt = nil
+        pendingOverlapIdentity = nil
     }
 
     func startShortcutCapture(pressCount: Int = 1) {
@@ -473,6 +542,7 @@ final class ShortcutKeyMonitor {
         capturePressCount = 1
         cancelPendingPush()
         activeIdentity = nil
+        pendingOverlapIdentity = nil
         cancelPendingModifierOnlyCapture()
         emit("shortcut_capture_started")
     }


### PR DESCRIPTION
## Problem

de0e24a ("Stop cmd-tab from faking fn edges and triggering dictation") gated flagsChanged press edges on the event's changed keyCode. That killed the cmd-tab phantom, but the phantom and a legitimate path were the same code path, and both died:

1. A foreign modifier is still down (Cmd right after cmd-tabbing *into* the app to dictate, or Shift from a capital still settling - a 30-100ms overlap is normal).
2. fn goes down. Its event carries flags {cmd, fn}: not an exact match, no press.
3. The foreign modifier releases. The flags now read exactly {fn}, but the event names a foreign key, so the new gate drops it.

The press is swallowed for as long as fn stays held. Before de0e24a, step 3 fired the press (bit-only matching). After it, dictation reads as "fn detection regressed / takes 1s+": the first press silently misses and only a full release and re-press works. There is no added latency anywhere in the code (`holdThreshold` is unchanged at 0.16s); the perceived delay is the miss-notice-repress cycle.

## Fix

Track the overlap explicitly (`pendingOverlapIdentity`):

- **Armed** only when a modifier-only shortcut's own key goes down while its modifiers are present *plus extras* (the case that could never match exactly).
- **Disarmed** when that own key comes back up before the chord ever held (press abandoned), or consumed when the press fires.
- A foreign modifier's release that makes the flags exactly equal the shortcut may fire the press **only while the mark is armed**.

Why the cmd-tab phantom stays dead: in that flow fn's own down arrived clean, matched exactly, and was consumed as a press before the Cmd interruption - so nothing is pending when Cmd later releases, and the release fires nothing. The two cases differ precisely in whether fn's own down ever matched, which is what the mark records.

## Scenario trace (no test harness exists for the helper; verified by hand against the state machine)

| Scenario | de0e24a | This PR |
|---|---|---|
| Clean fn press/hold/release | works | works (identical path, no pending armed) |
| Cmd held, fn pressed, Cmd released | press swallowed while fn held | press fires on Cmd release |
| Cmd held, fn tapped and released, Cmd released | nothing (correct) | nothing (mark disarmed at fn-up) |
| fn held, cmd-tab away, Cmd released | no re-trigger (the de0e24a fix) | no re-trigger (nothing pending) |
| Quick Cmd press+release while fn held | no fn+fn misfire | no fn+fn misfire |
| Arrow/Home/End fn-bit events | ignored | ignored (non-modifier keyCodes never arm) |
| Multi-modifier-only chords (e.g. ctrl+option) with a foreign extra | swallowed | recovers on the extra's release; disarms if a chord key drops first |

Also resets the pending mark in `setShortcut` and `startShortcutCapture` alongside the rest of the monitor state.

## Testing

- `swiftc -typecheck` clean; full `cargo test` suite green (build.rs compiles the helper, so the Swift change is exercised by the build).
- Manual verification on hardware recommended before release: hold Cmd, press fn, release Cmd - dictation should start; then re-test the original de0e24a repro (dictate with fn held, cmd-tab away, release) - no re-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)