### PR TITLE
Dev builds: replay onboarding from Settings → About

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -23,6 +23,7 @@ import {
   setVeniceModel,
 } from "../../lib/tauri";
 import { LANGUAGE_OPTIONS, languageLabel } from "../../lib/dictation-languages";
+import { replayOnboarding } from "../../lib/onboarding";
 import type {
   AccountStatus,
   DictationHelperEvent,
@@ -1192,6 +1193,30 @@ export function AppSettings({
                         onClick={onReportIssue}
                       >
                         Report an issue
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+
+                {import.meta.env.DEV ? (
+                  // Dev builds only: same helper the devtools console exposes
+                  // as june.replayOnboarding() — clears completion and
+                  // reloads into the wizard.
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Replay onboarding</h3>
+                      <p className="settings-row-description">
+                        Dev only. Forget that onboarding finished and reload
+                        into the first-run wizard.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={() => replayOnboarding()}
+                      >
+                        Replay onboarding
                       </button>
                     </div>
                   </div>

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1246,6 +1246,48 @@ describe("AppSettings", () => {
     expect(mocks.scribeOpenVerifyPage).toHaveBeenCalledOnce();
   });
 
+  it("replays onboarding from About in dev builds", async () => {
+    // vitest runs with import.meta.env.DEV = true, so the dev-only row shows.
+    window.localStorage.setItem("june.onboarding.completedVersion", "99");
+    const reload = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+    try {
+      render(
+        <AppSettings
+          account={signedInAccount}
+          accountLoading={false}
+          sourceMode="microphoneOnly"
+          checkingSourceReadiness={false}
+          onAccountChanged={vi.fn()}
+          onAccountRefresh={vi.fn()}
+          onSourceModeChange={vi.fn()}
+          onEnableSystemAudio={vi.fn()}
+        />,
+      );
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("tab", { name: "About" }));
+      await user.click(
+        await screen.findByRole("button", { name: "Replay onboarding" }),
+      );
+
+      // The completion flag is gone and the app reloads into the wizard.
+      expect(
+        window.localStorage.getItem("june.onboarding.completedVersion"),
+      ).toBeNull();
+      expect(reload).toHaveBeenCalledOnce();
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it("shows agent workspace and memory files inside Agent settings", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Why

Re-running the first-run wizard in dev required knowing about `june.replayOnboarding()` in the devtools console or the `VITE_JUNE_REPLAY_ONBOARDING` env flag. A visible affordance beats tribal knowledge.

## What

A **Replay onboarding** row in Settings → About, shown only when `import.meta.env.DEV` is true (compiled out of release bundles entirely). The button calls the existing `replayOnboarding()` helper — clears the completion flag and resume step, then reloads into the wizard. No new mechanism, just a surface for the one that was already there.

## Tests

About-tab test asserting the button shows under vitest's dev env, clears `june.onboarding.completedVersion`, and triggers the reload (location stubbed and restored). Full suite passes; tsc and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)