### PR TITLE
Cut fixed latency from the push-to-talk start path

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1505,19 +1505,37 @@ final class DictationController {
         emitMicrophones()
     }
 
+    /// Invalidates pending dictation starts. `AVCaptureDevice.requestAccess`
+    /// can fire its callback long after the request — the user reading the
+    /// macOS permission prompt — and a graze's discard arrives in between:
+    /// without this, accepting the prompt later would open the microphone
+    /// with no key held. discard() bumps the generation; a stale callback
+    /// sees the mismatch and does nothing.
+    private var dictationStartGeneration = 0
+
     func start() {
         guard !listening else {
             emit("error", ["code": "already_listening", "message": "Dictation is already listening."])
             return
         }
 
+        dictationStartGeneration += 1
+        let generation = dictationStartGeneration
         AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
-            guard microphoneAllowed else {
-                emit("error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
-                emit("permission_status", permissionPayload())
-                return
+            // Hop to main: commands (including the discard that may have
+            // cancelled this start) are handled there, so the generation
+            // comparison is ordered against them.
+            DispatchQueue.main.async {
+                guard let self, self.dictationStartGeneration == generation else {
+                    return
+                }
+                guard microphoneAllowed else {
+                    emit("error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
+                    emit("permission_status", permissionPayload())
+                    return
+                }
+                self.startRecording(purpose: .dictation, durationSeconds: nil)
             }
-            self?.startRecording(purpose: .dictation, durationSeconds: nil)
         }
     }
 
@@ -1569,6 +1587,9 @@ final class DictationController {
     }
 
     func discard() {
+        // Cancel any start still waiting on the permission prompt — the
+        // graze is over, so a later grant must not open the microphone.
+        dictationStartGeneration += 1
         // The HUD shows on listening_started, so a discard that interrupts a
         // live recording (a grazed push-to-talk key, a signed-out session)
         // must announce itself or the HUD stays stuck on "Listening".

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -807,7 +807,23 @@ final class ShortcutKeyMonitor {
         }
 
         if let push = matches.first(where: { $0.0 == .pushToTalk && $0.1.pressCount == 1 }) {
-            schedulePushStart(identity: identity, shortcut: push.1)
+            if matches.contains(where: { $0.0 == .toggle }) {
+                // A toggle shares this trigger, so a fresh press is ambiguous:
+                // a tap is (or arms) the toggle, only a hold is the push. The
+                // hold threshold is what tells them apart.
+                schedulePushStart(identity: identity, shortcut: push.1)
+            } else {
+                // Unambiguous push-to-talk (the default config: bare fn with
+                // the toggle on a different trigger). The threshold used to
+                // tax every dictation with 160ms before the microphone even
+                // opened; start on the down edge instead. Grazes are handled
+                // on the app side now: it times the press and discards
+                // releases shorter than the old threshold, so a brushed key
+                // never pastes transcribed noise.
+                cancelPendingPush()
+                activePushIdentity = identity
+                emitShortcut(.pushToTalk, shortcut: push.1, isDown: true)
+            }
         }
     }
 
@@ -1553,7 +1569,14 @@ final class DictationController {
     }
 
     func discard() {
+        // The HUD shows on listening_started, so a discard that interrupts a
+        // live recording (a grazed push-to-talk key, a signed-out session)
+        // must announce itself or the HUD stays stuck on "Listening".
+        let wasListening = isListening
         resetRecordingState()
+        if wasListening {
+            emit("recording_discarded")
+        }
     }
 
     func shutdown() {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1478,8 +1478,7 @@ fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_l
         tauri::async_runtime::spawn(async move {
             if crate::os_accounts::access_token().await.is_err() {
                 forward_dictation_command(&app, DictationCommand::DiscardListening, &label);
-                emit_dictation_not_signed_in(&app);
-                focus_main_window(&app);
+                notify_dictation_not_signed_in(&app);
                 reset_shortcut_activation(&app);
             }
         });
@@ -1503,8 +1502,39 @@ fn forward_dictation_command(app: &AppHandle, command: DictationCommand, shortcu
     }
 }
 
-fn emit_dictation_not_signed_in(app: &AppHandle) {
+/// Instant (millis since the Unix epoch) of the last signed-out prompt.
+/// One press-release can hit two signed-out checks — the parallel
+/// fast-discard task on the down edge and the transcribe_recording_ready
+/// backstop on the up edge — and which of them fires (or both) depends on
+/// how far the recording got before the discard landed. Deduping here, at
+/// the notifier, collapses every ordering to a single prompt + focus pull
+/// without losing the prompt in the paths where only one check runs.
+static LAST_NOT_SIGNED_IN_AT_MS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+const NOT_SIGNED_IN_DEDUPE_MS: u64 = 2_000;
+
+/// Emits the signed-out prompt and pulls the app forward, unless the same
+/// prompt fired within the dedupe window. Owns the focus pull too, so
+/// callers can't split the prompt from it.
+fn notify_dictation_not_signed_in(app: &AppHandle) {
+    use std::sync::atomic::Ordering;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let last = LAST_NOT_SIGNED_IN_AT_MS.load(Ordering::Relaxed);
+    if now_ms.saturating_sub(last) < NOT_SIGNED_IN_DEDUPE_MS {
+        return;
+    }
+    if LAST_NOT_SIGNED_IN_AT_MS
+        .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        // Another path won the race within the same window.
+        return;
+    }
     emit_dictation_event_value(app, dictation_not_signed_in_event());
+    focus_main_window(app);
 }
 
 fn dictation_not_signed_in_event() -> serde_json::Value {
@@ -1761,8 +1791,7 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     if crate::os_accounts::access_token().await.is_err() {
         let state = app.state::<HelperState>();
         let _ = send_helper_command(&state, serde_json::json!({ "type": "discard_recording" }));
-        emit_dictation_not_signed_in(&app);
-        focus_main_window(&app);
+        notify_dictation_not_signed_in(&app);
         return;
     }
     let provider = match dictation_transcription_provider(configured_transcription_provider()) {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -16,7 +16,7 @@ use std::{
     process::{Child, ChildStdin, Command, Stdio},
     sync::{Mutex, OnceLock},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tauri::{
     AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, State, WebviewWindow, WindowEvent,
@@ -372,10 +372,18 @@ pub struct DictationSettingsResponse {
     pub settings: DictationSettings,
 }
 
+/// A push released faster than this is a graze or an aborted press, not a
+/// dictation: recording starts on the down edge now (the helper no longer
+/// holds unambiguous presses back), so quick releases must discard instead of
+/// transcribing a fraction of a second of noise. Mirrors the helper's old
+/// holdThreshold, which used to absorb these by delaying the start.
+const PUSH_TO_TALK_MIN_HOLD: Duration = Duration::from_millis(160);
+
 #[derive(Debug, Default)]
 struct ShortcutActivationController {
     active_mode: Option<DictationShortcutKind>,
     push_to_talk_is_down: bool,
+    push_started_at: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -388,6 +396,7 @@ enum ShortcutKeyEdge {
 enum DictationCommand {
     StartListening,
     StopAndPaste,
+    DiscardListening,
     ToggleListening,
 }
 
@@ -396,6 +405,7 @@ impl ShortcutActivationController {
         &mut self,
         edge: ShortcutKeyEdge,
         kind: DictationShortcutKind,
+        now: Instant,
     ) -> Option<DictationCommand> {
         match (kind, edge) {
             (DictationShortcutKind::PushToTalk, ShortcutKeyEdge::Down) => {
@@ -404,15 +414,23 @@ impl ShortcutActivationController {
                 }
                 self.active_mode = Some(DictationShortcutKind::PushToTalk);
                 self.push_to_talk_is_down = true;
+                self.push_started_at = Some(now);
                 Some(DictationCommand::StartListening)
             }
             (DictationShortcutKind::PushToTalk, ShortcutKeyEdge::Up) => {
+                let started_at = self.push_started_at.take();
                 if self.active_mode == Some(DictationShortcutKind::PushToTalk)
                     && self.push_to_talk_is_down
                 {
                     self.active_mode = None;
                     self.push_to_talk_is_down = false;
-                    Some(DictationCommand::StopAndPaste)
+                    let grazed =
+                        started_at.is_some_and(|at| now.duration_since(at) < PUSH_TO_TALK_MIN_HOLD);
+                    Some(if grazed {
+                        DictationCommand::DiscardListening
+                    } else {
+                        DictationCommand::StopAndPaste
+                    })
                 } else {
                     self.push_to_talk_is_down = false;
                     None
@@ -436,6 +454,7 @@ impl ShortcutActivationController {
     fn reset(&mut self) {
         self.active_mode = None;
         self.push_to_talk_is_down = false;
+        self.push_started_at = None;
     }
 }
 
@@ -444,6 +463,7 @@ impl DictationCommand {
         match self {
             Self::StartListening => serde_json::json!({ "type": "start_listening" }),
             Self::StopAndPaste => serde_json::json!({ "type": "stop_and_paste" }),
+            Self::DiscardListening => serde_json::json!({ "type": "discard_recording" }),
             Self::ToggleListening => serde_json::json!({
                 "type": "toggle_listening",
                 "shortcut": shortcut_label,
@@ -1400,7 +1420,7 @@ fn handle_shortcut_key_event(
                 .controller
                 .lock()
                 .ok()
-                .and_then(|mut state| state.handle_edge(edge, kind))
+                .and_then(|mut state| state.handle_edge(edge, kind, Instant::now()))
         });
 
     let shortcut = match kind {
@@ -1439,24 +1459,31 @@ fn reset_shortcut_activation(app: &AppHandle) {
 }
 
 fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_label: &str) {
-    // Gate the start path on a signed-in OS Accounts session. ToggleListening
-    // can also start, but we can't tell start-from-stop without extra state;
-    // transcribe_recording_ready acts as the backstop there.
+    // The start path needs a signed-in OS Accounts session for the
+    // transcription that follows, but the token check must not sit between
+    // the key press and the microphone: capture is local and the token is
+    // only consumed once the recording ends. Awaiting it here delayed every
+    // start by an executor hop, blocked on a network refresh whenever the
+    // cached token was stale, and could reorder a fast press-release so
+    // stop_and_paste reached the helper before start_listening. Start
+    // immediately and check in parallel; a signed-out session discards the
+    // moments-old local recording and lands on the same sign-in surface as
+    // before. ToggleListening can also start, but we can't tell
+    // start-from-stop without extra state; transcribe_recording_ready acts
+    // as the backstop there.
+    forward_dictation_command(app, command, shortcut_label);
     if matches!(command, DictationCommand::StartListening) {
         let app = app.clone();
         let label = shortcut_label.to_string();
         tauri::async_runtime::spawn(async move {
             if crate::os_accounts::access_token().await.is_err() {
+                forward_dictation_command(&app, DictationCommand::DiscardListening, &label);
                 emit_dictation_not_signed_in(&app);
                 focus_main_window(&app);
                 reset_shortcut_activation(&app);
-                return;
             }
-            forward_dictation_command(&app, command, &label);
         });
-        return;
     }
-    forward_dictation_command(app, command, shortcut_label);
 }
 
 fn forward_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_label: &str) {
@@ -3093,31 +3120,72 @@ mod tests {
     #[test]
     fn push_to_talk_starts_on_down_and_stops_on_up() {
         let mut controller = ShortcutActivationController::default();
+        let down = Instant::now();
+        let up = down + PUSH_TO_TALK_MIN_HOLD;
 
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::PushToTalk),
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                down
+            ),
             Some(DictationCommand::StartListening)
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk),
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk, up),
             Some(DictationCommand::StopAndPaste)
+        );
+    }
+
+    #[test]
+    fn push_to_talk_graze_discards_instead_of_transcribing() {
+        // Recording starts on the down edge now, so an accidental brush of
+        // the key produces a real (tiny) recording. Releasing inside the
+        // minimum hold must discard it rather than paste transcribed noise.
+        let mut controller = ShortcutActivationController::default();
+        let down = Instant::now();
+        let up = down + PUSH_TO_TALK_MIN_HOLD - Duration::from_millis(1);
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                down
+            ),
+            Some(DictationCommand::StartListening)
+        );
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk, up),
+            Some(DictationCommand::DiscardListening)
+        );
+
+        // The graze fully releases the press: the next hold is a fresh start.
+        let next_down = up + Duration::from_millis(5);
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                next_down
+            ),
+            Some(DictationCommand::StartListening)
         );
     }
 
     #[test]
     fn toggle_mode_toggles_on_down_and_ignores_up() {
         let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
 
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle),
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
             Some(DictationCommand::ToggleListening)
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::Toggle),
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::Toggle, now),
             None
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle),
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
             Some(DictationCommand::ToggleListening)
         );
     }
@@ -3125,17 +3193,22 @@ mod tests {
     #[test]
     fn shortcut_activation_ignores_push_while_toggle_active() {
         let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
 
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle),
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
             Some(DictationCommand::ToggleListening)
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::PushToTalk),
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                now
+            ),
             None
         );
         assert_eq!(
-            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk),
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk, now),
             None
         );
     }

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -667,6 +667,13 @@ async function handleDictationEventPayload(payload: unknown) {
     return;
   }
 
+  if (dictationEvent.type === "recording_discarded") {
+    // A grazed push-to-talk key or a signed-out session: the recording was
+    // dropped without transcription, so the listening HUD just goes away.
+    void hideHud();
+    return;
+  }
+
   if (dictationEvent.type === "agent_session_prompt") {
     void hideHud();
     return;


### PR DESCRIPTION
## Investigation

Follow-up to #246. Mapped the full chain from physical fn press to first captured audio sample. The hardware and framework costs are small (AVAudioRecorder spin-up ~10-25ms, first audio buffer ~10-20ms). The avoidable latency was two fixed costs at the front of the chain:

1. **The helper's 160ms hold threshold applied to every push-to-talk press.** `schedulePushStart` always deferred by `holdThreshold` (0.16s). The threshold exists to tell a tap from a hold, which only matters when a toggle shares the same trigger - and in the default config (bare fn push-to-talk, toggle on Ctrl+Opt+T) nothing shares it. Every dictation paid 160ms for a disambiguation that had nothing to disambiguate.
2. **The token gate sat in the hot path.** Rust awaited `os_accounts::access_token()` before forwarding `start_listening` to the helper: an executor hop on every press, and a blocking network refresh whenever the cached token was stale - a plausible source of occasional 1s+ starts. The token is only consumed after the recording ends (upload for transcription), so nothing about capture needs it up front. The await also had an ordering bug: a fast press-release could deliver `stop_and_paste` to the helper before the spawned task ever sent `start_listening`.

## Changes

- **Helper (`main.swift`):** when no toggle shares the push-to-talk trigger, the press fires on the down edge - no threshold. Shared-trigger configs keep the 160ms disambiguation exactly as before.
- **Rust (`dictation.rs`):** `start_listening` is forwarded immediately; the token check runs in parallel. On a signed-out session the moments-old local recording is discarded (`discard_recording`) and the user lands on the same sign-in surface as before. This also fixes the press-release reordering race.
- **Graze handling moves to the activation controller:** starting on the down edge means a brushed key now records, so the controller times the press and a release under the old 160ms threshold maps to `DiscardListening` instead of `StopAndPaste` - a graze never pastes transcribed noise. Net behavior for grazes matches today (nothing transcribes); the differences are a brief cue sound and HUD flash.
- **New `recording_discarded` helper event**, emitted when a discard interrupts a live recording, handled by the HUD - otherwise the graze/signed-out paths would leave it stuck on "Listening".

## Expected effect

Default config: dictation starts ~160ms sooner on every press, plus elimination of the token-check hop, plus elimination of occasional multi-hundred-ms stale-token stalls. Mic open and first buffer (~25-45ms total) are now the dominant remaining cost.

## Considered and deliberately not done

- **Pre-roll capture during the 160ms threshold** (shared-trigger configs): start the recorder silently at the physical down edge and commit or discard at the threshold. It would make even the ambiguous path instant and capture the first syllable, but it opens the microphone before any cue or indicator - for a privacy-forward product that needs a deliberate decision, not a drive-by. Flagged as follow-up.
- **Keeping the mic warm between dictations:** a persistent capture session means a permanent mic-in-use indicator. Not acceptable.

## Testing

- New Rust test pins the graze-discard path (release under the threshold discards, full hold pastes, a graze does not wedge the next press); existing activation tests updated for the injected clock. Full `cargo test` green.
- `swiftc -typecheck` clean; full frontend suite green (410 tests); `tsc` and formatters clean.
- Manual verification recommended: bare-fn push-to-talk should feel immediate; a quick fn brush should flash and discard without pasting; signed-out start should drop into the sign-in surface; fn+fn-style shared-trigger configs should behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (a2a5ab9)

- **Pending-permission graze (Codex P2):** dictation starts now carry a generation; `discard()` bumps it and a stale `requestAccess` callback no-ops, so accepting the macOS mic prompt after the key was released can no longer open the microphone. The callback hops to the main queue so the generation comparison is ordered against command handling.
- **Double sign-in prompt (Greptile P1):** deduped in the notifier (one prompt + focus pull per 2s window) rather than removing either call site — on a long hold the fast-discard task is the *only* path that runs (its discard means `recording_ready` never fires), so removing it outright would have lost the prompt there.