### PR TITLE
Unwedge agent sessions stuck on prompt_too_long

### DIFF
--- a/scribe-api/crates/api/src/validation.rs
+++ b/scribe-api/crates/api/src/validation.rs
@@ -84,7 +84,16 @@ fn validate_json_shape(
             }
             *total_string_chars = total_string_chars.saturating_add(chars);
             if *total_string_chars > MAX_AGENT_TOTAL_STRING_CHARS {
-                return Err(ApiError::bad_request("prompt_too_long"));
+                // Agent clients recover from context overflow automatically
+                // (compress the history, retry), but they classify by the
+                // provider error TEXT: hermes-agent's overflow patterns match
+                // phrases like "maximum context" and "context length", not
+                // the bare token. Keep `prompt_too_long` first for clients
+                // keying on it; the rest of the sentence is what unwedges an
+                // agent whose conversation outgrew the model.
+                return Err(ApiError::bad_request(
+                    "prompt_too_long: the request exceeds the model's maximum context length",
+                ));
             }
         }
         Value::Array(items) => {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -2366,6 +2366,22 @@ async fn handle_scribe_provider_connection(
             let body = serde_json::from_slice::<serde_json::Value>(&request.body)
                 .unwrap_or_else(|_| serde_json::json!({}));
             match crate::scribe_api::proxy_agent_chat_completions(body).await {
+                Ok(response) if response.status >= 400 => {
+                    // Error bodies are small enough to buffer whole, and
+                    // buffering is what makes the overflow translation
+                    // below possible. Success responses keep streaming.
+                    let status = response.status;
+                    let content_type = response.content_type.clone();
+                    let body = response.collect_body().await.unwrap_or_default();
+                    match translate_context_overflow_error(&body) {
+                        Some(rewritten) => {
+                            write_json_response(&mut stream, status, rewritten).await?;
+                        }
+                        None => {
+                            write_raw_response(&mut stream, status, &content_type, &body).await?;
+                        }
+                    }
+                }
                 Ok(response) => {
                     write_streaming_response(&mut stream, response).await?;
                 }
@@ -2476,6 +2492,33 @@ async fn read_http_request(stream: &mut tokio::net::TcpStream) -> io::Result<Htt
         headers,
         body,
     })
+}
+
+/// Rewrites the backend's `prompt_too_long` rejection into wording the agent
+/// recognizes as a context overflow. The backend answers an over-long
+/// conversation with its envelope (`{"success": false, "error_code": 2001,
+/// "message": "prompt_too_long"}`). Hermes recovers from overflow on its own
+/// (compress the history, retry) but only when it recognizes the provider's
+/// error TEXT, and the bare `prompt_too_long` token is not in its
+/// `_CONTEXT_OVERFLOW_PATTERNS` list — so the agent treated the rejection as
+/// a generic error and re-sent the same oversized prompt forever, wedging the
+/// session. The rewritten message keeps the stable `prompt_too_long` token
+/// first and adds the "maximum context length" phrasing that list matches
+/// ("context length", "maximum context"); everything else in the envelope
+/// passes through untouched. Returns `None` for every other body, including
+/// non-JSON.
+fn translate_context_overflow_error(body: &[u8]) -> Option<serde_json::Value> {
+    let mut value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let message = value.get("message")?.as_str()?;
+    if !message.contains("prompt_too_long") {
+        return None;
+    }
+    value["message"] = serde_json::Value::String(
+        "prompt_too_long: the request exceeds the model's maximum context length. \
+         Reduce the length of the messages and retry."
+            .to_string(),
+    );
+    Some(value)
 }
 
 fn provider_proxy_authorized(request: &HttpRequest, token: &str) -> bool {
@@ -2665,6 +2708,44 @@ mod tests {
         assert!(!provider_proxy_authorized(&missing, "proxy-secret"));
         assert!(!provider_proxy_authorized(&basic, "proxy-secret"));
         assert!(!provider_proxy_authorized(&extra, "proxy-secret"));
+    }
+
+    #[test]
+    fn prompt_too_long_rejection_translates_to_a_recognized_overflow() {
+        // The session in this state was wedged: the agent never recognized
+        // the backend's bare `prompt_too_long` as a context overflow, so it
+        // retried the same oversized prompt forever instead of compressing.
+        let body =
+            br#"{"data":null,"success":false,"error_code":2001,"message":"prompt_too_long"}"#;
+
+        let rewritten = translate_context_overflow_error(body).expect("translated");
+
+        let message = rewritten["message"].as_str().expect("message");
+        // The phrases hermes-agent's _CONTEXT_OVERFLOW_PATTERNS matches on;
+        // losing them silently re-wedges sessions.
+        assert!(message.contains("maximum context"));
+        assert!(message.contains("context length"));
+        // Clients keying on the stable token and the envelope still work.
+        assert!(message.starts_with("prompt_too_long"));
+        assert_eq!(rewritten["error_code"], 2001);
+        assert_eq!(rewritten["success"], false);
+    }
+
+    #[test]
+    fn unrelated_error_bodies_pass_through_untranslated() {
+        for body in [
+            br#"{"data":null,"success":false,"error_code":2001,"message":"string_too_long"}"#
+                .as_slice(),
+            br#"{"error":{"message":"rate limited"}}"#.as_slice(),
+            b"not json at all".as_slice(),
+            br#"{"message":42}"#.as_slice(),
+        ] {
+            assert!(
+                translate_context_overflow_error(body).is_none(),
+                "must not rewrite: {}",
+                String::from_utf8_lossy(body),
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The stuck state

A session whose conversation outgrows the model's context window gets permanently wedged (screenshot in the report): every send - including bare "continue" - produces `Error code: 400 - {'data': None, 'success': False, 'error_code': 2001, 'message': 'prompt_too_long'}` and nothing ever recovers.

## Root cause

Three facts line up:

1. The backend's agent proxy validation rejects an over-long request body with `ApiError::bad_request("prompt_too_long")` (`scribe-api/crates/api/src/validation.rs`), serialized through the standard envelope with the generic bad-request code 2001.
2. The bundled hermes-agent has a full recovery path for exactly this situation - classify the provider error as a context overflow, compress the history, retry (`agent/conversation_loop.py`, `agent/error_classifier.py`). It classifies by **matching the provider's error text** against `_CONTEXT_OVERFLOW_PATTERNS` ("context length", "maximum context", "prompt is too long", ...).
3. The bare token `prompt_too_long` matches none of those patterns.

So the agent treats the rejection as a generic error, never compresses, and re-sends the same oversized conversation on every turn. The proxy's existing message-count cap (64 messages) doesn't help because the overflow is driven by message size, not count.

## Fix (both layers)

- **App provider proxy (`hermes_bridge.rs`):** error responses (status >= 400) are now buffered instead of streamed - they're tiny - and a `prompt_too_long` envelope message is rewritten to `"prompt_too_long: the request exceeds the model's maximum context length. Reduce the length of the messages and retry."`. That wording matches hermes's overflow patterns, so its compression recovery kicks in and the session unwedges on its next message. The stable `prompt_too_long` token stays first, `error_code`/`success` and every other field pass through untouched, and non-matching error bodies are forwarded byte-for-byte. Success responses keep streaming exactly as before.
- **Backend (`scribe-api/crates/api/src/validation.rs`):** the validation message now carries the recognizable wording at the source. Once deployed this also covers app builds that predate the proxy translation.

Already-wedged sessions (like the one in the screenshot) recover by sending any message after updating: the next 400 gets classified as overflow, hermes compresses, and the turn proceeds.

## Testing

- New proxy tests: the exact envelope from the screenshot translates to a message containing the hermes-matched phrases (pinned so copy edits can't silently re-wedge sessions) with the envelope preserved; unrelated errors, non-JSON, and non-string messages pass through untranslated.
- Full `cargo test` green in both workspaces (src-tauri 126+, scribe-api on its pinned 1.95.0 toolchain, 106 tests).

## Worth knowing

Hermes caps compression attempts; a conversation that cannot compress below the backend's total-size cap will still fail, but now with hermes's explicit "try /new to start fresh" guidance instead of a silent retry loop. A deeper follow-up would be advertising the model's real context window through the proxy's `/v1/models` response so hermes trims proactively instead of reactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)