### PR TITLE
[codex] Fix sidebar drag collapse preview

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,7 +9,6 @@ import {
   useState,
 } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
-import { flushSync } from "react-dom";
 import { AccountGate } from "../components/account/AccountGate";
 import { TrialGate } from "../components/account/TrialGate";
 import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
@@ -124,6 +123,7 @@ import {
 import { shouldPollProcessingStatus } from "./processing-polling";
 import { attachScrollThumbFade } from "../lib/scroll-thumb-fade";
 import { createInitialState, notesReducer } from "./state/app-state";
+import { handleSidebarResizeStart } from "./sidebar-resize";
 import {
   checkForScribeUpdate,
   installScribeUpdate,
@@ -1704,14 +1704,15 @@ export function App() {
         aria-orientation="vertical"
         aria-label="Resize sidebar"
         onPointerDown={(event) =>
-          handleSidebarResizeStart(
-            event,
-            sidebarWidth,
-            () => {
+          handleSidebarResizeStart(event, sidebarWidth, {
+            collapseWidth: SIDEBAR_COLLAPSE_WIDTH,
+            minWidth: SIDEBAR_MIN_WIDTH,
+            maxWidth: sidebarMaxWidth,
+            onStart: () => {
               setSidebarResizing(true);
               setSidebarTransition("none");
             },
-            (finalWidth) => {
+            onEnd: (finalWidth) => {
               if (finalWidth <= SIDEBAR_COLLAPSE_WIDTH) {
                 setSidebarResizing(false);
                 setSidebarTransition("smooth");
@@ -1727,7 +1728,7 @@ export function App() {
               setSidebarCollapsed(false);
               setSidebarWidth(nextWidth);
             },
-          )
+          })
         }
       />
       <section className="main-panel">
@@ -2333,111 +2334,6 @@ function handleTitlebarPointerDown(event: ReactPointerEvent<HTMLDivElement>) {
     .catch((error: unknown) =>
       console.warn("Failed to start window drag", error),
     );
-}
-
-function handleSidebarResizeStart(
-  event: ReactPointerEvent<HTMLDivElement>,
-  currentWidth: number,
-  onStart: () => void,
-  onEnd: (width: number) => void,
-) {
-  if (event.button !== 0) return;
-  event.preventDefault();
-  onStart();
-  const handle = event.currentTarget;
-  const shell = handle.closest(".app-shell") as HTMLElement | null;
-  const mainPanel = shell?.querySelector(".main-panel") as HTMLElement | null;
-  const startX = event.clientX;
-  const startWidth = currentWidth;
-  let latestWidth = currentWidth;
-  let collapsed = currentWidth === 0;
-
-  // While dragging in the resizable range the panel tracks the cursor with no
-  // transition (snappy). But the snap between the min width and fully-closed
-  // is a discrete jump — animate *that* crossing so collapsing/reopening via
-  // drag tweens smoothly. The handle's `left` rides along so the drag line
-  // doesn't detach from the panel edge mid-tween, and the main panel's left
-  // margin eases to its collapsed gutter at the same time so the card lands on
-  // its padding instead of sliding to the window edge and snapping back.
-  function setSnapTransition(animate: boolean) {
-    const timing = "var(--t-med) var(--ease-out)";
-    if (shell)
-      shell.style.transition = animate
-        ? `grid-template-columns ${timing}`
-        : "none";
-    handle.style.transition = animate ? `left ${timing}` : "none";
-    if (mainPanel)
-      mainPanel.style.transition = animate ? `margin ${timing}` : "none";
-  }
-
-  function applyWidth(width: number) {
-    shell?.style.setProperty("--sidebar-w-current", `${width}px`);
-    // Expanded the card hugs grid column 2 (the sidebar supplies the gutter);
-    // collapsed it must carry its own left gutter. Drive it here so it tweens
-    // with the collapse rather than jumping when React commits on pointer-up.
-    // `--main-gutter` keeps the resize bar tracking the card's left edge (so it
-    // rides the white, not the gray) since the bar is positioned off it too.
-    if (mainPanel)
-      mainPanel.style.marginLeft = width === 0 ? "var(--sp-3)" : "0px";
-    shell?.style.setProperty(
-      "--main-gutter",
-      width === 0 ? "var(--sp-3)" : "0px",
-    );
-    latestWidth = width;
-  }
-
-  function onPointerMove(moveEvent: PointerEvent) {
-    const rawWidth = startWidth + moveEvent.clientX - startX;
-
-    if (rawWidth <= SIDEBAR_COLLAPSE_WIDTH) {
-      // Below the threshold: collapse to 0. Only kick the smooth transition on
-      // the *crossing* — subsequent moves must leave it alone so the tween
-      // isn't cancelled by the next pointermove a few ms later.
-      if (!collapsed) {
-        collapsed = true;
-        setSnapTransition(true);
-        applyWidth(0);
-      }
-      return;
-    }
-
-    const nextWidth = Math.min(
-      sidebarMaxWidth(),
-      Math.max(SIDEBAR_MIN_WIDTH, rawWidth),
-    );
-    if (collapsed) {
-      // Re-opening from collapsed: animate the 0 → min snap.
-      collapsed = false;
-      setSnapTransition(true);
-      applyWidth(nextWidth);
-      return;
-    }
-    // Live resize within range: snap-follow the cursor, but don't re-assert
-    // `none` (which would cancel an in-flight open tween) unless the width
-    // actually moves.
-    if (nextWidth !== latestWidth) {
-      setSnapTransition(false);
-      applyWidth(nextWidth);
-    }
-  }
-
-  function onPointerUp() {
-    window.removeEventListener("pointermove", onPointerMove);
-    window.removeEventListener("pointerup", onPointerUp);
-    // Hand control back to React-driven styling. Commit synchronously so the
-    // collapsed/expanded class (and its matching left margin) is in the DOM
-    // *before* we drop the inline margin — otherwise removing it would briefly
-    // expose the expanded margin and flash a jump.
-    shell?.style.removeProperty("transition");
-    handle.style.removeProperty("transition");
-    mainPanel?.style.removeProperty("transition");
-    flushSync(() => onEnd(latestWidth));
-    mainPanel?.style.removeProperty("margin-left");
-    shell?.style.removeProperty("--main-gutter");
-  }
-
-  window.addEventListener("pointermove", onPointerMove);
-  window.addEventListener("pointerup", onPointerUp, { once: true });
 }
 
 function isDeniedPermission(state?: string) {

--- a/src/app/sidebar-resize.ts
+++ b/src/app/sidebar-resize.ts
@@ -30,11 +30,20 @@ export function handleSidebarResizeStart(
   const handle = event.currentTarget;
   const shell = handle.closest(".app-shell") as HTMLElement | null;
   const mainPanel = shell?.querySelector(".main-panel") as HTMLElement | null;
+  // Fixed elements whose `left` rides the sidebar width. They must join the
+  // snap tween: with no transition of their own they teleport to the far
+  // offset at the threshold crossing while the grid is still mid-tween, which
+  // reads as a flash of misalignment.
+  const composer = shell?.querySelector(".agent-composer") as HTMLElement | null;
+  const editorFooter = shell?.querySelector(
+    ".editor-footer",
+  ) as HTMLElement | null;
   const startX = event.clientX;
   const startWidth = currentWidth;
   let latestWidth = currentWidth;
   let collapsed = currentWidth === 0;
   let opening = false;
+  let snapTweening = false;
 
   function setPreview(preview: SidebarResizePreview) {
     shell?.setAttribute("data-sidebar-preview", preview);
@@ -57,7 +66,25 @@ export function handleSidebarResizeStart(
     handle.style.transition = animate ? `left ${timing}` : "none";
     if (mainPanel)
       mainPanel.style.transition = animate ? `margin ${timing}` : "none";
+    for (const el of [composer, editorFooter])
+      if (el) el.style.transition = animate ? `left ${timing}` : "none";
   }
+
+  // Snap tweens end on the shell's own grid transition (margin/left tweens on
+  // the other elements bubble through here too — hence the target check).
+  // While one is in flight, pointermoves retarget it instead of switching back
+  // to transition-less tracking: killing it mid-flight teleports the sidebar
+  // from the interpolated width to the cursor in a single frame.
+  function onSnapTweenEnd(endEvent: TransitionEvent) {
+    if (
+      endEvent.target !== shell ||
+      endEvent.propertyName !== "grid-template-columns"
+    )
+      return;
+    snapTweening = false;
+    setSnapTransition(false);
+  }
+  shell?.addEventListener("transitionend", onSnapTweenEnd);
 
   function applyWidth(width: number) {
     shell?.style.setProperty("--sidebar-w-current", `${width}px`);
@@ -87,6 +114,7 @@ export function handleSidebarResizeStart(
         opening = false;
         setPreview("collapsed");
         setSnapTransition(true);
+        snapTweening = true;
         applyWidth(0);
       }
       return;
@@ -99,15 +127,16 @@ export function handleSidebarResizeStart(
       opening = true;
       setPreview("opening");
       setSnapTransition(true);
+      snapTweening = true;
       applyWidth(nextWidth);
       return;
     }
-    // Live resize within range: snap-follow the cursor, but don't re-assert
-    // `none` (which would cancel an in-flight open tween) unless the width
-    // actually moves.
+    // Live resize within range: snap-follow the cursor. While a snap tween is
+    // still in flight, keep it and retarget toward the cursor; transitionend
+    // hands back transition-less tracking.
     if (nextWidth !== latestWidth) {
       setPreview(opening ? "opening" : "expanded");
-      setSnapTransition(false);
+      if (!snapTweening) setSnapTransition(false);
       applyWidth(nextWidth);
     }
   }
@@ -115,6 +144,7 @@ export function handleSidebarResizeStart(
   function onPointerUp() {
     window.removeEventListener("pointermove", onPointerMove);
     window.removeEventListener("pointerup", onPointerUp);
+    shell?.removeEventListener("transitionend", onSnapTweenEnd);
     // Hand control back to React-driven styling. Commit synchronously so the
     // collapsed/expanded class (and its matching left margin) is in the DOM
     // before we drop the inline margin. Otherwise removing it would briefly
@@ -122,6 +152,8 @@ export function handleSidebarResizeStart(
     shell?.style.removeProperty("transition");
     handle.style.removeProperty("transition");
     mainPanel?.style.removeProperty("transition");
+    composer?.style.removeProperty("transition");
+    editorFooter?.style.removeProperty("transition");
     commit(() => onEnd(latestWidth));
     mainPanel?.style.removeProperty("margin-left");
     shell?.style.removeProperty("--main-gutter");

--- a/src/app/sidebar-resize.ts
+++ b/src/app/sidebar-resize.ts
@@ -1,0 +1,130 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { flushSync } from "react-dom";
+
+type SidebarResizePreview = "collapsed" | "expanded";
+
+type SidebarResizeConfig = {
+  collapseWidth: number;
+  minWidth: number;
+  maxWidth: () => number;
+  onStart: () => void;
+  onEnd: (width: number) => void;
+  commit?: (fn: () => void) => void;
+};
+
+export function handleSidebarResizeStart(
+  event: ReactPointerEvent<HTMLDivElement>,
+  currentWidth: number,
+  {
+    collapseWidth,
+    minWidth,
+    maxWidth,
+    onStart,
+    onEnd,
+    commit = flushSync,
+  }: SidebarResizeConfig,
+) {
+  if (event.button !== 0) return;
+  event.preventDefault();
+  onStart();
+  const handle = event.currentTarget;
+  const shell = handle.closest(".app-shell") as HTMLElement | null;
+  const mainPanel = shell?.querySelector(".main-panel") as HTMLElement | null;
+  const startX = event.clientX;
+  const startWidth = currentWidth;
+  let latestWidth = currentWidth;
+  let collapsed = currentWidth === 0;
+
+  function setPreview(preview: SidebarResizePreview) {
+    shell?.setAttribute("data-sidebar-preview", preview);
+  }
+
+  setPreview(collapsed ? "collapsed" : "expanded");
+
+  // While dragging in the resizable range the panel tracks the cursor with no
+  // transition (snappy). But the snap between the min width and fully-closed
+  // is a discrete jump: animate that crossing so collapsing/reopening via drag
+  // tweens smoothly. The transient data-sidebar-preview attribute keeps fixed
+  // agent UI on the same collapsed/expanded rules as the grid before React's
+  // committed sidebar state catches up on pointer-up.
+  function setSnapTransition(animate: boolean) {
+    const timing = "var(--t-med) var(--ease-out)";
+    if (shell)
+      shell.style.transition = animate
+        ? `grid-template-columns ${timing}`
+        : "none";
+    handle.style.transition = animate ? `left ${timing}` : "none";
+    if (mainPanel)
+      mainPanel.style.transition = animate ? `margin ${timing}` : "none";
+  }
+
+  function applyWidth(width: number) {
+    shell?.style.setProperty("--sidebar-w-current", `${width}px`);
+    // Expanded the card hugs grid column 2 (the sidebar supplies the gutter);
+    // collapsed it must carry its own left gutter. Drive it here so it tweens
+    // with the collapse rather than jumping when React commits on pointer-up.
+    // `--main-gutter` keeps the resize bar tracking the card's left edge (so it
+    // rides the white, not the gray) since the bar is positioned off it too.
+    if (mainPanel)
+      mainPanel.style.marginLeft = width === 0 ? "var(--sp-3)" : "0px";
+    shell?.style.setProperty(
+      "--main-gutter",
+      width === 0 ? "var(--sp-3)" : "0px",
+    );
+    latestWidth = width;
+  }
+
+  function onPointerMove(moveEvent: PointerEvent) {
+    const rawWidth = startWidth + moveEvent.clientX - startX;
+
+    if (rawWidth <= collapseWidth) {
+      // Below the threshold: collapse to 0. Only kick the smooth transition on
+      // the crossing, because reasserting it on every pointermove cancels the
+      // in-flight tween.
+      if (!collapsed) {
+        collapsed = true;
+        setPreview("collapsed");
+        setSnapTransition(true);
+        applyWidth(0);
+      }
+      return;
+    }
+
+    const nextWidth = Math.min(maxWidth(), Math.max(minWidth, rawWidth));
+    if (collapsed) {
+      // Re-opening from collapsed: animate the 0 to min snap.
+      collapsed = false;
+      setPreview("expanded");
+      setSnapTransition(true);
+      applyWidth(nextWidth);
+      return;
+    }
+    // Live resize within range: snap-follow the cursor, but don't re-assert
+    // `none` (which would cancel an in-flight open tween) unless the width
+    // actually moves.
+    if (nextWidth !== latestWidth) {
+      setPreview("expanded");
+      setSnapTransition(false);
+      applyWidth(nextWidth);
+    }
+  }
+
+  function onPointerUp() {
+    window.removeEventListener("pointermove", onPointerMove);
+    window.removeEventListener("pointerup", onPointerUp);
+    // Hand control back to React-driven styling. Commit synchronously so the
+    // collapsed/expanded class (and its matching left margin) is in the DOM
+    // before we drop the inline margin. Otherwise removing it would briefly
+    // expose the expanded margin and flash a jump.
+    shell?.style.removeProperty("transition");
+    handle.style.removeProperty("transition");
+    mainPanel?.style.removeProperty("transition");
+    commit(() => onEnd(latestWidth));
+    mainPanel?.style.removeProperty("margin-left");
+    shell?.style.removeProperty("--main-gutter");
+    shell?.removeAttribute("data-sidebar-preview");
+  }
+
+  window.addEventListener("pointermove", onPointerMove);
+  window.addEventListener("pointerup", onPointerUp, { once: true });
+}

--- a/src/app/sidebar-resize.ts
+++ b/src/app/sidebar-resize.ts
@@ -1,7 +1,7 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { flushSync } from "react-dom";
 
-type SidebarResizePreview = "collapsed" | "expanded";
+type SidebarResizePreview = "collapsed" | "expanded" | "opening";
 
 type SidebarResizeConfig = {
   collapseWidth: number;
@@ -34,6 +34,7 @@ export function handleSidebarResizeStart(
   const startWidth = currentWidth;
   let latestWidth = currentWidth;
   let collapsed = currentWidth === 0;
+  let opening = false;
 
   function setPreview(preview: SidebarResizePreview) {
     shell?.setAttribute("data-sidebar-preview", preview);
@@ -83,6 +84,7 @@ export function handleSidebarResizeStart(
       // in-flight tween.
       if (!collapsed) {
         collapsed = true;
+        opening = false;
         setPreview("collapsed");
         setSnapTransition(true);
         applyWidth(0);
@@ -94,7 +96,8 @@ export function handleSidebarResizeStart(
     if (collapsed) {
       // Re-opening from collapsed: animate the 0 to min snap.
       collapsed = false;
-      setPreview("expanded");
+      opening = true;
+      setPreview("opening");
       setSnapTransition(true);
       applyWidth(nextWidth);
       return;
@@ -103,7 +106,7 @@ export function handleSidebarResizeStart(
     // `none` (which would cancel an in-flight open tween) unless the width
     // actually moves.
     if (nextWidth !== latestWidth) {
-      setPreview("expanded");
+      setPreview(opening ? "opening" : "expanded");
       setSnapTransition(false);
       applyWidth(nextWidth);
     }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6380,6 +6380,12 @@ function AgentArtifactPanel({
   const [showSource, setShowSource] = useState(false);
   const [query, setQuery] = useState("");
   const [filterOpen, setFilterOpen] = useState(false);
+  // The slide-in entrance must run once per mount and never again. WebKit
+  // replays CSS animations whenever it recreates the renderer (it does this
+  // during the sidebar drag's per-frame relayout), which flashed the panel
+  // mid-gesture. Once the entrance finishes, data-entered switches the
+  // animation off entirely so a renderer rebuild has nothing to replay.
+  const [entered, setEntered] = useState(false);
   const panelRef = useRef<HTMLElement>(null);
 
   // Restore the remembered width once per panel mount. The property lives on
@@ -6531,7 +6537,16 @@ function AgentArtifactPanel({
         aria-label="Resize files panel"
         onPointerDown={startResize}
       />
-      <aside ref={panelRef} className="agent-artifact-panel" aria-label="Files">
+      <aside
+        ref={panelRef}
+        className="agent-artifact-panel"
+        aria-label="Files"
+        data-entered={entered ? "true" : undefined}
+        onAnimationEnd={(event) => {
+          if (event.animationName === "agent-artifact-panel-in")
+            setEntered(true);
+        }}
+      >
         <header className="agent-artifact-panel-bar">
           {artifact ? (
             <button

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -16,6 +16,7 @@ import { IconToolbox } from "central-icons/IconToolbox";
 import { IconTrashCan } from "central-icons/IconTrashCan";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
 import { IconAnonymous } from "central-icons/IconAnonymous";
 import { IconArrowUp } from "central-icons/IconArrowUp";
 import { IconCameraSparkle } from "central-icons/IconCameraSparkle";
@@ -3933,16 +3934,26 @@ export function AgentWorkspace({
               {composer}
             </section>
           </div>
-          {artifactPanel ? (
-            <AgentArtifactPanel
-              artifacts={surfacedArtifacts}
-              state={artifactPanel}
-              onShowList={() => setArtifactPanel({ view: "list" })}
-              onOpen={openArtifact}
-              onDownload={downloadArtifact}
-              onClose={() => setArtifactPanel(null)}
-            />
-          ) : null}
+          {/* Portaled out of .main-panel: WKWebView clips a composited fixed
+              element to an overflow-hidden ancestor, and the panel sits
+              entirely outside the card's box — so whenever the engine
+              transiently promoted its layer (animation replays, drag-time
+              renderer churn), the panel blinked out. As a direct child of
+              .app-shell nothing excludes its box, and the shell still carries
+              the CSS variables and data-attributes its rules read. */}
+          {artifactPanel
+            ? createPortal(
+                <AgentArtifactPanel
+                  artifacts={surfacedArtifacts}
+                  state={artifactPanel}
+                  onShowList={() => setArtifactPanel({ view: "list" })}
+                  onOpen={openArtifact}
+                  onDownload={downloadArtifact}
+                  onClose={() => setArtifactPanel(null)}
+                />,
+                document.querySelector(".app-shell") ?? document.body,
+              )
+            : null}
         </>
       )}
       <ModelPickerDialog

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2121,13 +2121,11 @@ button.agent-safety-badge:hover {
   animation: none;
 }
 
-/* Keep the panel on its own stable compositing layer for the duration of a
- * sidebar drag so the shell's per-frame grid relayout never re-rasterizes
- * (and so flashes) this fixed element. */
-.app-shell[data-sidebar-resizing="true"] .agent-artifact-panel {
-  will-change: transform;
-}
-
+/* No will-change/transform promotion on this panel: WKWebView clips a
+ * composited fixed element to its overflow-hidden ancestor (.main-panel),
+ * and the panel sits entirely outside the card's box, so promoting its
+ * layer hides it outright. The entrance animation is the one sanctioned
+ * promotion, and data-entered retires it after the first run. */
 @keyframes agent-artifact-panel-in {
   from {
     opacity: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -137,6 +137,13 @@ input:focus-visible,
     );
 }
 
+.app-shell[data-sidebar-preview="opening"] {
+  grid-template-columns: var(--sidebar-w-current, var(--sidebar-w)) minmax(
+      0,
+      1fr
+    );
+}
+
 .app-shell[data-sidebar-preview="collapsed"] {
   grid-template-columns: 0 minmax(0, 1fr);
 }
@@ -162,6 +169,11 @@ input:focus-visible,
 
 .app-shell[data-sidebar-preview="expanded"] .sidebar {
   display: flex;
+}
+
+.app-shell[data-sidebar-preview="opening"] .sidebar,
+.app-shell[data-sidebar-preview="collapsed"] .sidebar {
+  display: none;
 }
 
 .sidebar-resize-handle {
@@ -2708,6 +2720,7 @@ button.agent-safety-badge:hover {
   left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
+.app-shell[data-sidebar-preview="opening"] .agent-composer,
 .app-shell[data-sidebar-preview="collapsed"] .agent-composer {
   left: calc(var(--sp-3) + var(--sp-8));
 }
@@ -4782,6 +4795,7 @@ button.agent-safety-badge:hover {
   margin-left: 0;
 }
 
+.app-shell[data-sidebar-preview="opening"] .main-panel,
 .app-shell[data-sidebar-preview="collapsed"] .main-panel {
   margin-left: var(--sp-3);
 }
@@ -5797,6 +5811,7 @@ button.agent-safety-badge:hover {
   left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
+.app-shell[data-sidebar-preview="opening"] .editor-footer,
 .app-shell[data-sidebar-preview="collapsed"] .editor-footer {
   left: calc(var(--sp-3) + var(--sp-8));
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -169,11 +169,18 @@ input:focus-visible,
 
 .app-shell[data-sidebar-preview="expanded"] .sidebar {
   display: flex;
+  visibility: visible;
 }
 
-.app-shell[data-sidebar-preview="opening"] .sidebar,
+.app-shell[data-sidebar-preview="opening"] .sidebar {
+  display: flex;
+  visibility: visible;
+}
+
 .app-shell[data-sidebar-preview="collapsed"] .sidebar {
-  display: none;
+  display: flex;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .sidebar-resize-handle {
@@ -2720,9 +2727,12 @@ button.agent-safety-badge:hover {
   left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
-.app-shell[data-sidebar-preview="opening"] .agent-composer,
 .app-shell[data-sidebar-preview="collapsed"] .agent-composer {
   left: calc(var(--sp-3) + var(--sp-8));
+}
+
+.app-shell[data-sidebar-preview="opening"] .agent-composer {
+  left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
 .app-shell[data-sidebar-transition="smooth"] .agent-composer {
@@ -4795,9 +4805,12 @@ button.agent-safety-badge:hover {
   margin-left: 0;
 }
 
-.app-shell[data-sidebar-preview="opening"] .main-panel,
 .app-shell[data-sidebar-preview="collapsed"] .main-panel {
   margin-left: var(--sp-3);
+}
+
+.app-shell[data-sidebar-preview="opening"] .main-panel {
+  margin-left: 0;
 }
 
 .main-panel-body {
@@ -5811,9 +5824,12 @@ button.agent-safety-badge:hover {
   left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
-.app-shell[data-sidebar-preview="opening"] .editor-footer,
 .app-shell[data-sidebar-preview="collapsed"] .editor-footer {
   left: calc(var(--sp-3) + var(--sp-8));
+}
+
+.app-shell[data-sidebar-preview="opening"] .editor-footer {
+  left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
 /* The fixed recorder's `left` rides the card's left edge. During a smooth

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -130,6 +130,17 @@ input:focus-visible,
   grid-template-columns: 0 minmax(0, 1fr);
 }
 
+.app-shell[data-sidebar-preview="expanded"] {
+  grid-template-columns: var(--sidebar-w-current, var(--sidebar-w)) minmax(
+      0,
+      1fr
+    );
+}
+
+.app-shell[data-sidebar-preview="collapsed"] {
+  grid-template-columns: 0 minmax(0, 1fr);
+}
+
 /* Sidebar ------------------------------------------------------------ */
 
 .sidebar {
@@ -146,6 +157,14 @@ input:focus-visible,
 }
 
 .app-shell[data-sidebar="collapsed"] .sidebar {
+  display: none;
+}
+
+.app-shell[data-sidebar-preview="expanded"] .sidebar {
+  display: flex;
+}
+
+.app-shell[data-sidebar-preview="collapsed"] .sidebar {
   display: none;
 }
 
@@ -2689,6 +2708,14 @@ button.agent-safety-badge:hover {
   left: calc(var(--sp-3) + var(--sp-8));
 }
 
+.app-shell[data-sidebar-preview="expanded"] .agent-composer {
+  left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
+}
+
+.app-shell[data-sidebar-preview="collapsed"] .agent-composer {
+  left: calc(var(--sp-3) + var(--sp-8));
+}
+
 .app-shell[data-sidebar-transition="smooth"] .agent-composer {
   transition: left var(--t-med) var(--ease-out);
 }
@@ -4755,6 +4782,14 @@ button.agent-safety-badge:hover {
   margin-left: var(--sp-3);
 }
 
+.app-shell[data-sidebar-preview="expanded"] .main-panel {
+  margin-left: 0;
+}
+
+.app-shell[data-sidebar-preview="collapsed"] .main-panel {
+  margin-left: var(--sp-3);
+}
+
 .main-panel-body {
   display: flex;
   flex-direction: column;
@@ -5759,6 +5794,14 @@ button.agent-safety-badge:hover {
 }
 
 .app-shell[data-sidebar="collapsed"] .editor-footer {
+  left: calc(var(--sp-3) + var(--sp-8));
+}
+
+.app-shell[data-sidebar-preview="expanded"] .editor-footer {
+  left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
+}
+
+.app-shell[data-sidebar-preview="collapsed"] .editor-footer {
   left: calc(var(--sp-3) + var(--sp-8));
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2113,6 +2113,21 @@ button.agent-safety-badge:hover {
   animation: agent-artifact-panel-in var(--t-slow) var(--ease-spring);
 }
 
+/* Entrance is strictly once-per-mount: WebKit replays CSS animations when it
+ * recreates a renderer (which the sidebar drag's per-frame relayout can
+ * trigger), and a replay reads as the open panel flashing and sliding back
+ * in. React sets data-entered when the entrance completes. */
+.agent-artifact-panel[data-entered="true"] {
+  animation: none;
+}
+
+/* Keep the panel on its own stable compositing layer for the duration of a
+ * sidebar drag so the shell's per-frame grid relayout never re-rasterizes
+ * (and so flashes) this fixed element. */
+.app-shell[data-sidebar-resizing="true"] .agent-artifact-panel {
+  will-change: transform;
+}
+
 @keyframes agent-artifact-panel-in {
   from {
     opacity: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -164,10 +164,6 @@ input:focus-visible,
   display: flex;
 }
 
-.app-shell[data-sidebar-preview="collapsed"] .sidebar {
-  display: none;
-}
-
 .sidebar-resize-handle {
   position: fixed;
   top: calc(var(--titlebar-h) + var(--sp-2));

--- a/src/test/sidebar-resize.test.ts
+++ b/src/test/sidebar-resize.test.ts
@@ -1,6 +1,7 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { handleSidebarResizeStart } from "../app/sidebar-resize";
+import appCss from "../styles/app.css?raw";
 
 function setupResizeDom(sidebarState: "collapsed" | "expanded") {
   document.body.innerHTML = `
@@ -34,6 +35,12 @@ function reactPointerEvent(
 }
 
 describe("handleSidebarResizeStart", () => {
+  it("does not hide the sidebar element during collapsed drag preview", () => {
+    expect(appCss).not.toMatch(
+      /\.app-shell\[data-sidebar-preview="collapsed"\]\s+\.sidebar\s*\{[^}]*display:\s*none/,
+    );
+  });
+
   it("sets collapsed preview state as soon as a drag crosses the collapse threshold", () => {
     const { shell, handle, mainPanel } = setupResizeDom("expanded");
     const onStart = vi.fn();
@@ -57,6 +64,7 @@ describe("handleSidebarResizeStart", () => {
     expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("0px");
     expect(shell.style.getPropertyValue("--main-gutter")).toBe("var(--sp-3)");
     expect(mainPanel.style.marginLeft).toBe("var(--sp-3)");
+    expect(document.querySelector(".sidebar")).toBeInTheDocument();
 
     window.dispatchEvent(pointerEvent("pointerup", 100));
 

--- a/src/test/sidebar-resize.test.ts
+++ b/src/test/sidebar-resize.test.ts
@@ -1,0 +1,96 @@
+import type { PointerEvent as ReactPointerEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { handleSidebarResizeStart } from "../app/sidebar-resize";
+
+function setupResizeDom(sidebarState: "collapsed" | "expanded") {
+  document.body.innerHTML = `
+    <main class="app-shell" data-sidebar="${sidebarState}">
+      <aside class="sidebar"></aside>
+      <div class="sidebar-resize-handle"></div>
+      <section class="main-panel"></section>
+    </main>
+  `;
+  return {
+    shell: document.querySelector(".app-shell") as HTMLElement,
+    handle: document.querySelector(".sidebar-resize-handle") as HTMLElement,
+    mainPanel: document.querySelector(".main-panel") as HTMLElement,
+  };
+}
+
+function pointerEvent(type: string, clientX: number) {
+  return new MouseEvent(type, { clientX }) as unknown as PointerEvent;
+}
+
+function reactPointerEvent(
+  handle: HTMLElement,
+  clientX: number,
+): ReactPointerEvent<HTMLDivElement> {
+  return {
+    button: 0,
+    clientX,
+    currentTarget: handle,
+    preventDefault: vi.fn(),
+  } as unknown as ReactPointerEvent<HTMLDivElement>;
+}
+
+describe("handleSidebarResizeStart", () => {
+  it("sets collapsed preview state as soon as a drag crosses the collapse threshold", () => {
+    const { shell, handle, mainPanel } = setupResizeDom("expanded");
+    const onStart = vi.fn();
+    const onEnd = vi.fn();
+
+    handleSidebarResizeStart(reactPointerEvent(handle, 240), 240, {
+      collapseWidth: 160,
+      minWidth: 188,
+      maxWidth: () => 320,
+      onStart,
+      onEnd,
+      commit: (fn) => fn(),
+    });
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(shell.dataset.sidebarPreview).toBe("expanded");
+
+    window.dispatchEvent(pointerEvent("pointermove", 100));
+
+    expect(shell.dataset.sidebarPreview).toBe("collapsed");
+    expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("0px");
+    expect(shell.style.getPropertyValue("--main-gutter")).toBe("var(--sp-3)");
+    expect(mainPanel.style.marginLeft).toBe("var(--sp-3)");
+
+    window.dispatchEvent(pointerEvent("pointerup", 100));
+
+    expect(onEnd).toHaveBeenCalledWith(0);
+    expect(shell.dataset.sidebarPreview).toBeUndefined();
+    expect(shell.style.getPropertyValue("--main-gutter")).toBe("");
+    expect(mainPanel.style.marginLeft).toBe("");
+  });
+
+  it("sets expanded preview state when dragging back out of collapsed width", () => {
+    const { shell, handle, mainPanel } = setupResizeDom("collapsed");
+    const onEnd = vi.fn();
+
+    handleSidebarResizeStart(reactPointerEvent(handle, 0), 0, {
+      collapseWidth: 160,
+      minWidth: 188,
+      maxWidth: () => 320,
+      onStart: vi.fn(),
+      onEnd,
+      commit: (fn) => fn(),
+    });
+
+    expect(shell.dataset.sidebarPreview).toBe("collapsed");
+
+    window.dispatchEvent(pointerEvent("pointermove", 220));
+
+    expect(shell.dataset.sidebarPreview).toBe("expanded");
+    expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("220px");
+    expect(shell.style.getPropertyValue("--main-gutter")).toBe("0px");
+    expect(mainPanel.style.marginLeft).toBe("0px");
+
+    window.dispatchEvent(pointerEvent("pointerup", 220));
+
+    expect(onEnd).toHaveBeenCalledWith(220);
+    expect(shell.dataset.sidebarPreview).toBeUndefined();
+  });
+});

--- a/src/test/sidebar-resize.test.ts
+++ b/src/test/sidebar-resize.test.ts
@@ -7,13 +7,14 @@ function setupResizeDom(sidebarState: "collapsed" | "expanded") {
     <main class="app-shell" data-sidebar="${sidebarState}">
       <aside class="sidebar"></aside>
       <div class="sidebar-resize-handle"></div>
-      <section class="main-panel"></section>
+      <section class="main-panel"><div class="agent-composer"></div></section>
     </main>
   `;
   return {
     shell: document.querySelector(".app-shell") as HTMLElement,
     handle: document.querySelector(".sidebar-resize-handle") as HTMLElement,
     mainPanel: document.querySelector(".main-panel") as HTMLElement,
+    composer: document.querySelector(".agent-composer") as HTMLElement,
   };
 }
 
@@ -97,5 +98,48 @@ describe("handleSidebarResizeStart", () => {
 
     expect(onEnd).toHaveBeenCalledWith(240);
     expect(shell.dataset.sidebarPreview).toBeUndefined();
+  });
+
+  it("keeps the snap tween alive (retargeting) instead of killing it on the next move", () => {
+    const { shell, handle, composer } = setupResizeDom("expanded");
+
+    handleSidebarResizeStart(reactPointerEvent(handle, 240), 240, {
+      collapseWidth: 160,
+      minWidth: 188,
+      maxWidth: () => 320,
+      onStart: vi.fn(),
+      onEnd: vi.fn(),
+      commit: (fn) => fn(),
+    });
+
+    // Collapse, then drag straight back out past the min width.
+    window.dispatchEvent(pointerEvent("pointermove", 100));
+    window.dispatchEvent(pointerEvent("pointermove", 220));
+
+    const tween = "grid-template-columns var(--t-med) var(--ease-out)";
+    expect(shell.style.transition).toBe(tween);
+    // Fixed agent UI tweens in lockstep instead of teleporting to the far
+    // offset at the crossing.
+    expect(composer.style.transition).toBe("left var(--t-med) var(--ease-out)");
+
+    // Further moves while the tween is in flight retarget it (the width var
+    // updates) but must not reset the transition to "none" — that teleports
+    // the sidebar from the interpolated width to the cursor in one frame.
+    window.dispatchEvent(pointerEvent("pointermove", 260));
+    expect(shell.style.transition).toBe(tween);
+    expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("260px");
+
+    // Once the grid tween completes, tracking goes back to transition-less.
+    const end = new Event("transitionend") as TransitionEvent;
+    Object.defineProperty(end, "propertyName", {
+      value: "grid-template-columns",
+    });
+    shell.dispatchEvent(end);
+    expect(shell.style.transition).toBe("none");
+    expect(composer.style.transition).toBe("none");
+
+    window.dispatchEvent(pointerEvent("pointerup", 260));
+    expect(shell.style.transition).toBe("");
+    expect(composer.style.transition).toBe("");
   });
 });

--- a/src/test/sidebar-resize.test.ts
+++ b/src/test/sidebar-resize.test.ts
@@ -1,7 +1,6 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { handleSidebarResizeStart } from "../app/sidebar-resize";
-import appCss from "../styles/app.css?raw";
 
 function setupResizeDom(sidebarState: "collapsed" | "expanded") {
   document.body.innerHTML = `
@@ -35,12 +34,6 @@ function reactPointerEvent(
 }
 
 describe("handleSidebarResizeStart", () => {
-  it("does not hide the sidebar element during collapsed drag preview", () => {
-    expect(appCss).not.toMatch(
-      /\.app-shell\[data-sidebar-preview="collapsed"\]\s+\.sidebar\s*\{[^}]*display:\s*none/,
-    );
-  });
-
   it("sets collapsed preview state as soon as a drag crosses the collapse threshold", () => {
     const { shell, handle, mainPanel } = setupResizeDom("expanded");
     const onStart = vi.fn();
@@ -64,7 +57,6 @@ describe("handleSidebarResizeStart", () => {
     expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("0px");
     expect(shell.style.getPropertyValue("--main-gutter")).toBe("var(--sp-3)");
     expect(mainPanel.style.marginLeft).toBe("var(--sp-3)");
-    expect(document.querySelector(".sidebar")).toBeInTheDocument();
 
     window.dispatchEvent(pointerEvent("pointerup", 100));
 
@@ -74,7 +66,7 @@ describe("handleSidebarResizeStart", () => {
     expect(mainPanel.style.marginLeft).toBe("");
   });
 
-  it("sets expanded preview state when dragging back out of collapsed width", () => {
+  it("keeps an opening preview when dragging back out of collapsed width", () => {
     const { shell, handle, mainPanel } = setupResizeDom("collapsed");
     const onEnd = vi.fn();
 
@@ -91,14 +83,19 @@ describe("handleSidebarResizeStart", () => {
 
     window.dispatchEvent(pointerEvent("pointermove", 220));
 
-    expect(shell.dataset.sidebarPreview).toBe("expanded");
+    expect(shell.dataset.sidebarPreview).toBe("opening");
     expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("220px");
     expect(shell.style.getPropertyValue("--main-gutter")).toBe("0px");
     expect(mainPanel.style.marginLeft).toBe("0px");
 
+    window.dispatchEvent(pointerEvent("pointermove", 240));
+
+    expect(shell.dataset.sidebarPreview).toBe("opening");
+    expect(shell.style.getPropertyValue("--sidebar-w-current")).toBe("240px");
+
     window.dispatchEvent(pointerEvent("pointerup", 220));
 
-    expect(onEnd).toHaveBeenCalledWith(220);
+    expect(onEnd).toHaveBeenCalledWith(240);
     expect(shell.dataset.sidebarPreview).toBeUndefined();
   });
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,3 +8,8 @@ declare module "*.svg" {
   const src: string;
   export default src;
 }
+
+declare module "*?raw" {
+  const src: string;
+  export default src;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,8 +8,3 @@ declare module "*.svg" {
   const src: string;
   export default src;
 }
-
-declare module "*?raw" {
-  const src: string;
-  export default src;
-}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,4 +1,4 @@
 # Lessons
 
 - When a user says a spinner/name change happened elsewhere, honor the latest component name from main while preserving the intended behavior. In this session, the spinner behavior belongs in the trailing agent-session state slot, but the component is `DotSpinner`.
-- During drag-preview UI states, keep transient states coherent for the whole pointer gesture. If `display: none` is needed to protect adjacent panels, use a separate opening state instead of flipping the element visible on the next pointermove.
+- During drag-preview UI states, avoid `display` toggles for reversible pointer gestures. Hide collapsed preview with visibility/pointer-events so reopening can render immediately while related fixed panels stay mounted.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,4 +1,4 @@
 # Lessons
 
 - When a user says a spinner/name change happened elsewhere, honor the latest component name from main while preserving the intended behavior. In this session, the spinner behavior belongs in the trailing agent-session state slot, but the component is `DotSpinner`.
-- During drag-preview UI states, avoid toggling `display: none` on elements that may re-open during the same pointer gesture. Keep the element mounted and animate or clip via layout state so reversing direction does not flash.
+- During drag-preview UI states, keep transient states coherent for the whole pointer gesture. If `display: none` is needed to protect adjacent panels, use a separate opening state instead of flipping the element visible on the next pointermove.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,3 +1,4 @@
 # Lessons
 
 - When a user says a spinner/name change happened elsewhere, honor the latest component name from main while preserving the intended behavior. In this session, the spinner behavior belongs in the trailing agent-session state slot, but the component is `DotSpinner`.
+- During drag-preview UI states, avoid toggling `display: none` on elements that may re-open during the same pointer gesture. Keep the element mounted and animate or clip via layout state so reversing direction does not flash.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,9 +14,10 @@ The files panel remains mounted, while fixed agent UI now follows the same
 collapsed or expanded selectors during the drag threshold crossing instead of
 waiting for React's committed `data-sidebar` state on pointer-up.
 
-Follow-up fix: the collapsed drag preview no longer applies `display: none` to
-the sidebar itself. The zero-width grid track clips the mounted sidebar during
-the drag, avoiding a display toggle flash when the pointer reverses back out.
+Follow-up correction: the collapsed drag preview hides the main sidebar again
+so the files panel stays visible. Reverse-drag now uses a separate `opening`
+preview state that keeps the main sidebar hidden until the gesture commits,
+avoiding the mid-drag flash without regressing files.
 
 Verification:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,10 +14,11 @@ The files panel remains mounted, while fixed agent UI now follows the same
 collapsed or expanded selectors during the drag threshold crossing instead of
 waiting for React's committed `data-sidebar` state on pointer-up.
 
-Follow-up correction: the collapsed drag preview hides the main sidebar again
-so the files panel stays visible. Reverse-drag now uses a separate `opening`
-preview state that keeps the main sidebar hidden until the gesture commits,
-avoiding the mid-drag flash without regressing files.
+Follow-up correction: collapsed drag preview now keeps the sidebar element in
+layout but hides it with `visibility`, so the files panel stays visible without
+a display toggle. Reverse-drag uses an `opening` preview state with the normal
+expanded offsets, so the main sidenav renders correctly while the mouse is
+still down.
 
 Verification:
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,25 @@
+# Sidebar files collapse bug
+
+- [x] Locate the main sidenav resize/collapse logic and the agent sidebar files sidenav rendering.
+- [x] Reproduce or reason through why files temporarily disappear during drag collapse.
+- [x] Patch the state/layout path with the smallest scoped change.
+- [x] Add or update focused tests if the behavior is covered by component tests.
+- [x] Run relevant tests and document the rendered validation blocker.
+
+## Review
+
+Fixed by giving drag-collapse its own transient `data-sidebar-preview` state.
+The files panel remains mounted, while fixed agent UI now follows the same
+collapsed or expanded selectors during the drag threshold crossing instead of
+waiting for React's committed `data-sidebar` state on pointer-up.
+
+Verification:
+
+- `pnpm test -- src/test/sidebar-resize.test.ts`
+- `pnpm test -- src/test/agent-workspace.test.tsx`
+- `pnpm run lint`
+- `pnpm run build`
+
+Rendered validation note: the in-app Browser runtime was present, but the `iab`
+browser was unavailable in this Conductor session. The project also does not
+ship Playwright, so validation used focused unit/component coverage plus build.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,6 +5,7 @@
 - [x] Patch the state/layout path with the smallest scoped change.
 - [x] Add or update focused tests if the behavior is covered by component tests.
 - [x] Run relevant tests and document the rendered validation blocker.
+- [x] Fix the reverse drag flash after collapsing while the pointer stays down.
 
 ## Review
 
@@ -12,6 +13,10 @@ Fixed by giving drag-collapse its own transient `data-sidebar-preview` state.
 The files panel remains mounted, while fixed agent UI now follows the same
 collapsed or expanded selectors during the drag threshold crossing instead of
 waiting for React's committed `data-sidebar` state on pointer-up.
+
+Follow-up fix: the collapsed drag preview no longer applies `display: none` to
+the sidebar itself. The zero-width grid track clips the mounted sidebar during
+the drag, avoiding a display toggle flash when the pointer reverses back out.
 
 Verification:
 


### PR DESCRIPTION
Adds a tested sidebar resize helper that applies a transient data-sidebar-preview state while the main sidebar is dragged across the collapse threshold.
Updates collapsed and expanded CSS selectors so the agent files panel, composer, main panel, and recorder footer follow a coherent layout during the drag preview.
This fixes the files panel temporarily disappearing because fixed agent UI could observe a zero sidebar width before React committed the collapsed sidebar state.
Validated with pnpm test -- src/test/sidebar-resize.test.ts, pnpm test -- src/test/agent-workspace.test.tsx, pnpm run lint, and pnpm run build.