### PR TITLE
Let June request Agent CLI access in-chat with one-click approval

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -74,9 +74,16 @@ Your environment: sessions run by default inside a macOS kernel sandbox (Seatbel
 
 /// Appended after the sandbox section when the user has NOT enabled Agent
 /// CLI access: the agent must recognize CLI failures as sandbox-caused and
-/// say so instead of misdiagnosing them as the user's auth problem.
+/// say so instead of misdiagnosing them as the user's auth problem — and it
+/// can request the fix in-chat via a literal token the app turns into a
+/// one-click approval card. The agent itself can never flip the setting:
+/// the flag file lives outside every sandbox write root by design, so the
+/// jailed process cannot rewrite the policy that governs it.
+///
+/// `AGENT_CLI_ACCESS_REQUEST_TOKEN` in `src/lib/agent-cli-access.ts` must
+/// match the token spelled out below.
 const JUNE_SOUL_CLI_BLOCKED_MD: &str = r#"
-Agent CLIs (Claude Code, Codex, Gemini, opencode): in sandboxed sessions their state folders (~/.claude and ~/.claude.json, ~/.codex, ~/.gemini, opencode's config and state) are write-blocked like the rest of the user's files. Those tools then fail to save sessions or store refreshed logins, and often report "not logged in" even when the user is. When a CLI fails this way, name the sandbox as the cause first, then give the user their real options: enable "Agent CLI access" in Settings, Agent tab (covers new sessions), or start this work in an Unrestricted session. Interactive logins (for example `claude /login`) are browser flows you can never complete; the user runs those once in their own terminal.
+Agent CLIs (Claude Code, Codex, Gemini, opencode): in sandboxed sessions their state folders (~/.claude and ~/.claude.json, ~/.codex, ~/.gemini, opencode's config and state) are write-blocked like the rest of the user's files. Those tools then fail to save sessions or store refreshed logins, and often report "not logged in" even when the user is. When a CLI fails this way, name the sandbox as the cause first, then request the fix directly: put the literal token [REQUEST:AGENT_CLI_ACCESS] on its own line in your reply. The June app replaces that token with an approval card; one click enables "Agent CLI access" in Settings, restarts the sandboxed runtime with those folders writable, and prompts you to retry. Use the token only for this setting and at most once per reply. The user can instead flip it themselves in Settings, Agent tab, or run the work in an Unrestricted session. Interactive logins (for example `claude /login`) are browser flows you can never complete; the user runs those once in their own terminal.
 "#;
 
 /// Appended after the sandbox section when the user HAS enabled Agent CLI
@@ -2787,9 +2794,11 @@ mod tests {
         assert!(soul.contains("Seatbelt"));
         assert!(soul.contains("write-jail"));
         assert!(soul.contains("operation not permitted"));
-        // CLI access off: the soul teaches the failure mode and the remedy.
+        // CLI access off: the soul teaches the failure mode and the remedy,
+        // including the in-chat request token the app renders as a card.
         assert!(soul.contains("Agent CLI access"));
         assert!(soul.contains("name the sandbox as the cause"));
+        assert!(soul.contains("[REQUEST:AGENT_CLI_ACCESS]"));
         assert!(!soul.contains("first-class job"));
     }
 
@@ -2805,6 +2814,8 @@ mod tests {
         // Both variants tell June it can never complete interactive logins.
         assert!(soul.contains("claude /login"));
         assert!(!soul.contains("name the sandbox as the cause"));
+        // Access already granted: there is nothing to request.
+        assert!(!soul.contains("[REQUEST:AGENT_CLI_ACCESS]"));
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -10,6 +10,7 @@ import { IconCrossMedium } from "central-icons/IconCrossMedium";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconFolder1 } from "central-icons/IconFolder1";
 import { IconFolders } from "central-icons/IconFolders";
+import { IconConsole } from "central-icons/IconConsole";
 import { IconShieldCheck } from "central-icons/IconShieldCheck";
 import { IconStopCircle } from "central-icons/IconStopCircle";
 import { IconToolbox } from "central-icons/IconToolbox";
@@ -83,6 +84,7 @@ import {
   hermesBridgeMessagingPlatforms,
   hermesBridgeFilePreview,
   hermesBridgeFileText,
+  hermesAgentCliAccess,
   hermesBridgeSkills,
   hermesBridgeStatus,
   hermesBridgeToolsets,
@@ -95,6 +97,7 @@ import {
   providerModelSettings,
   retryAgentTask,
   sendAgentMessage,
+  setHermesAgentCliAccess,
   setVeniceModel,
   startHermesBridge,
   submitIssueReport,
@@ -169,6 +172,11 @@ import {
   rememberSessionMode,
   sessionUnrestricted,
 } from "../../lib/agent-session-modes";
+import {
+  AGENT_CLI_ACCESS_ENABLED_MESSAGE,
+  hasAgentCliAccessRequest,
+  stripAgentCliAccessRequest,
+} from "../../lib/agent-cli-access";
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
@@ -925,6 +933,26 @@ export function AgentWorkspace({
   const [clarifySubmitting, setClarifySubmitting] = useState<
     Record<string, string>
   >({});
+  // Whether "Agent CLI access" (Settings, Agent tab) is on — drives the
+  // in-chat request card June can raise via its soul token. undefined until
+  // the stored value loads, so a card never flashes the wrong state.
+  const [cliAccessEnabled, setCliAccessEnabled] = useState<boolean>();
+  const [cliAccessSubmitting, setCliAccessSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    hermesAgentCliAccess()
+      .then((status) => {
+        if (!cancelled) setCliAccessEnabled(status.enabled);
+      })
+      .catch(() => {
+        // Unknown stays unknown; the card keeps its actionable default.
+        if (!cancelled) setCliAccessEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Dev-tools response gallery: when set, the timeline is replaced by a labeled
   // catalog of every agent response part type. Toggled from the console via
   // window.__agentGallery() — see the effect below. The errors flag marks the
@@ -2698,6 +2726,26 @@ export function AgentWorkspace({
     }
   }
 
+  // One-click approval of June's in-chat [REQUEST:AGENT_CLI_ACCESS] card.
+  // The agent can never flip the setting itself (the flag lives outside the
+  // sandbox's write roots), so the click is the trust boundary: it persists
+  // the opt-in, which also retires the sandboxed runtime, and the follow-up
+  // send respawns it with the CLI state folders writable and hands the
+  // conversation back to June to retry.
+  async function enableCliAccessFromChat() {
+    setCliAccessSubmitting(true);
+    try {
+      await setHermesAgentCliAccess(true);
+      setCliAccessEnabled(true);
+      await submitHermesSession(AGENT_CLI_ACCESS_ENABLED_MESSAGE);
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setCliAccessSubmitting(false);
+    }
+  }
+
   function pushLiveEvent(key: string, event: HermesGatewayEvent) {
     const liveEvent = { ...event, receivedAt: new Date().toISOString() };
     const nextEvents = [...(liveEventsRef.current[key] ?? []), liveEvent].slice(
@@ -3683,6 +3731,11 @@ export function AgentWorkspace({
           artifacts={turnArtifacts.get(turn.id)}
           approvalSubmitting={approvalSubmitting}
           clarifySubmitting={clarifySubmitting}
+          cliAccess={{
+            enabled: cliAccessEnabled,
+            submitting: cliAccessSubmitting,
+            onEnable: () => void enableCliAccessFromChat(),
+          }}
           thinkingOpen={thinkingOpen}
           onThinkingOpenChange={setThinkingOpen}
           onDownloadArtifact={downloadArtifact}
@@ -3767,6 +3820,11 @@ export function AgentWorkspace({
             artifacts={turnArtifacts.get(turn.id)}
             approvalSubmitting={approvalSubmitting}
             clarifySubmitting={clarifySubmitting}
+            cliAccess={{
+              enabled: cliAccessEnabled,
+              submitting: cliAccessSubmitting,
+              onEnable: () => void enableCliAccessFromChat(),
+            }}
             thinkingOpen={thinkingOpen}
             onThinkingOpenChange={setThinkingOpen}
             onDownloadArtifact={downloadArtifact}
@@ -5546,6 +5604,7 @@ function AgentChatTurnRow({
   approvalSubmitting,
   artifacts,
   clarifySubmitting,
+  cliAccess,
   thinkingOpen,
   onApproval,
   onClarify,
@@ -5559,6 +5618,9 @@ function AgentChatTurnRow({
   approvalSubmitting: Partial<Record<string, AgentApprovalChoice>>;
   artifacts?: AgentArtifact[];
   clarifySubmitting: Record<string, string>;
+  /** State + handler for June's in-chat Agent CLI access request card.
+   * Optional so the dev gallery can render rows without the live setting. */
+  cliAccess?: AgentCliAccessCardProps;
   thinkingOpen: (key: string) => boolean;
   onApproval: (
     part: Extract<AgentChatPart, { type: "approval" }>,
@@ -5691,9 +5753,24 @@ function AgentChatTurnRow({
         ) : null}
         {turn.parts.map((part, index) =>
           part.type === "text" ? (
-            <div key={`${turn.id}:text:${index}`}>
-              <MarkdownContent markdown={part.text} repairProse />
-            </div>
+            hasAgentCliAccessRequest(part.text) ? (
+              // June's soul emits a literal token to request the Agent CLI
+              // access setting; the token renders as an approval card, never
+              // as text.
+              <div key={`${turn.id}:text:${index}`}>
+                {stripAgentCliAccessRequest(part.text) ? (
+                  <MarkdownContent
+                    markdown={stripAgentCliAccessRequest(part.text)}
+                    repairProse
+                  />
+                ) : null}
+                <AgentCliAccessCard cliAccess={cliAccess} />
+              </div>
+            ) : (
+              <div key={`${turn.id}:text:${index}`}>
+                <MarkdownContent markdown={part.text} repairProse />
+              </div>
+            )
           ) : part.type === "context" ? (
             <ContextCompactionPart
               key={`${turn.id}:context:${index}`}
@@ -5925,6 +6002,91 @@ function ClarifyPart({
             ) : null}
           </>
         ) : null}
+      </div>
+    </article>
+  );
+}
+
+type AgentCliAccessCardProps = {
+  /** undefined while the stored setting is still loading. */
+  enabled?: boolean;
+  submitting: boolean;
+  onEnable: () => void;
+};
+
+/** June asked to enable "Agent CLI access" via the literal token its soul
+ * teaches ([REQUEST:AGENT_CLI_ACCESS]). The agent can never flip the setting
+ * itself — the flag file sits outside every sandbox write root — so this
+ * card is the one-click, user-approved path. Resolution is derived from the
+ * live setting rather than stored per message: a revisited transcript shows
+ * "Enabled" once the grant is on, and re-offers the choice while it is off.
+ * Mirrors the approval card chrome. */
+function AgentCliAccessCard({
+  cliAccess,
+}: {
+  cliAccess?: AgentCliAccessCardProps;
+}) {
+  const [dismissed, setDismissed] = useState(false);
+  const enabled = cliAccess?.enabled === true;
+  const resolved = enabled || dismissed;
+  const busy = Boolean(cliAccess?.submitting);
+  return (
+    <article
+      className="agent-approval-card"
+      data-status={resolved ? "resolved" : "pending"}
+    >
+      <span className="agent-tool-icon">
+        <IconConsole size={14} />
+      </span>
+      <div>
+        <div className="agent-tool-title">
+          <span>Agent CLI access requested</span>
+          <span
+            className="agent-tool-live-status"
+            data-status={resolved ? "complete" : "running"}
+          >
+            {resolved ? "Resolved" : "Waiting"}
+          </span>
+        </div>
+        <p>
+          June wants write access to the state folders of your coding CLIs
+          (Claude Code, Codex, Gemini, opencode) so they stay logged in and
+          can save their work in sandboxed sessions. Those folders configure
+          software that also runs outside June's sandbox. Enabling turns on
+          "Agent CLI access" in Settings and restarts the sandboxed runtime.
+        </p>
+        {resolved ? (
+          <p
+            className="agent-approval-result"
+            data-choice={enabled ? "once" : "deny"}
+          >
+            {enabled ? (
+              <IconCheckmark1Small size={14} />
+            ) : (
+              <IconCrossMedium size={14} />
+            )}
+            {enabled ? "Agent CLI access enabled" : "Not now"}
+          </p>
+        ) : (
+          <div className="agent-approval-actions">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              disabled={busy || !cliAccess || cliAccess.enabled === undefined}
+              onClick={() => cliAccess?.onEnable()}
+            >
+              {busy ? "Enabling…" : "Enable Agent CLI access"}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost agent-approval-deny"
+              disabled={busy}
+              onClick={() => setDismissed(true)}
+            >
+              Not now
+            </button>
+          </div>
+        )}
       </div>
     </article>
   );

--- a/src/lib/agent-cli-access.ts
+++ b/src/lib/agent-cli-access.ts
@@ -1,0 +1,26 @@
+/** The literal token June's soul tells it to emit when an agent CLI fails
+ * because the sandbox blocks its state folders (JUNE_SOUL_CLI_BLOCKED_MD in
+ * src-tauri/src/hermes_bridge.rs — the two must stay in sync). The agent can
+ * never flip the setting itself: the flag file lives outside every sandbox
+ * write root by design, so the request is rendered as a card the user
+ * approves with one click. */
+export const AGENT_CLI_ACCESS_REQUEST_TOKEN = "[REQUEST:AGENT_CLI_ACCESS]";
+
+export function hasAgentCliAccessRequest(text: string) {
+  return text.includes(AGENT_CLI_ACCESS_REQUEST_TOKEN);
+}
+
+/** Removes the request token (and the blank line it sat on) from display
+ * text; the card renders in its place. */
+export function stripAgentCliAccessRequest(text: string) {
+  return text
+    .split(AGENT_CLI_ACCESS_REQUEST_TOKEN)
+    .join("")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Sent into the session after the user approves the request, so June knows
+ * the grant is live and retries on the freshly restarted runtime. */
+export const AGENT_CLI_ACCESS_ENABLED_MESSAGE =
+  "I enabled Agent CLI access. The session now has write access to the CLI state folders; try the CLI again.";

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -63,6 +63,8 @@ const mocks = vi.hoisted(() => ({
   updateHermesBridgeMessagingPlatform: vi.fn(),
   deleteHermesSession: vi.fn(),
   listHermesSessionMessages: vi.fn(),
+  hermesAgentCliAccess: vi.fn(),
+  setHermesAgentCliAccess: vi.fn(),
   listHermesSessions: vi.fn(),
   gatewayRequest: vi.fn(),
   gatewayEventHandlers: new Set<(event: Record<string, unknown>) => void>(),
@@ -94,6 +96,7 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeFilePreview: mocks.hermesBridgeFilePreview,
   hermesBridgeFileText: mocks.hermesBridgeFileText,
   hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
+  hermesAgentCliAccess: mocks.hermesAgentCliAccess,
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
@@ -105,6 +108,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsTopUp: mocks.osAccountsTopUp,
   providerModelSettings: mocks.providerModelSettings,
   retryAgentTask: mocks.retryAgentTask,
+  setHermesAgentCliAccess: mocks.setHermesAgentCliAccess,
   setVeniceModel: mocks.setVeniceModel,
   saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
   saveAgentHermesSession: mocks.saveAgentHermesSession,
@@ -229,6 +233,7 @@ describe("AgentWorkspace", () => {
     );
     mocks.listHermesSessions.mockResolvedValue([existingSession]);
     mocks.listHermesSessionMessages.mockResolvedValue([]);
+    mocks.hermesAgentCliAccess.mockResolvedValue({ enabled: false });
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
     mocks.hermesBridgeFilePreview.mockResolvedValue(null);
     mocks.hermesBridgeFileText.mockResolvedValue(null);
@@ -804,6 +809,108 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("CLI Run Tracking")).toBeInTheDocument();
+  });
+
+  it("renders June's CLI access request as a card and enables the setting", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "use the codex cli to say hi",
+        timestamp: "2026-06-12T10:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content:
+          "The sandbox blocks Codex's state folders.\n\n[REQUEST:AGENT_CLI_ACCESS]",
+        timestamp: "2026-06-12T10:00:05Z",
+      },
+    ]);
+    mocks.setHermesAgentCliAccess.mockResolvedValue({ enabled: true });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(
+      await screen.findByText("Agent CLI access requested"),
+    ).toBeInTheDocument();
+    // The token renders as the card, never as literal text.
+    expect(screen.queryByText(/REQUEST:AGENT_CLI_ACCESS/)).toBeNull();
+    expect(
+      screen.getByText(/sandbox blocks Codex's state folders/),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Enable Agent CLI access" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.setHermesAgentCliAccess).toHaveBeenCalledWith(true),
+    );
+    // June is told the grant is live, so it retries on the restarted runtime.
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: expect.stringContaining("I enabled Agent CLI access"),
+      }),
+    );
+    expect(
+      await screen.findByText("Agent CLI access enabled"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the CLI access request as already granted when the setting is on", async () => {
+    mocks.hermesAgentCliAccess.mockResolvedValue({ enabled: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "a1",
+        role: "assistant",
+        content: "[REQUEST:AGENT_CLI_ACCESS]",
+        timestamp: "2026-06-12T10:00:05Z",
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(
+      await screen.findByText("Agent CLI access requested"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Agent CLI access enabled"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Enable Agent CLI access" }),
+    ).toBeNull();
+  });
+
+  it("dismisses the CLI access request without changing the setting", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Codex is blocked.\n\n[REQUEST:AGENT_CLI_ACCESS]",
+        timestamp: "2026-06-12T10:00:05Z",
+      },
+    ]);
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Not now" }),
+    );
+
+    expect(mocks.setHermesAgentCliAccess).not.toHaveBeenCalled();
+    // The card resolves quietly; nothing is sent into the session.
+    expect(await screen.findByText("Not now")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Enable Agent CLI access" }),
+    ).toBeNull();
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "prompt.submit",
+      expect.anything(),
+    );
   });
 
   it("repairs gateway-glued contractions in assistant prose but not code or user text", async () => {

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -105,6 +105,7 @@ vi.mock("../lib/tauri", () => ({
   providerModelSettings: vi.fn(async () => ({
     settings: { generationModel: "" },
   })),
+  hermesAgentCliAccess: vi.fn(async () => ({ enabled: false })),
   listVeniceModels: vi.fn(async () => ({
     mode: "generation",
     modelType: "text",

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -106,6 +106,7 @@ vi.mock("../lib/tauri", () => ({
   providerModelSettings: vi.fn(async () => ({
     settings: { generationModel: "" },
   })),
+  hermesAgentCliAccess: vi.fn(async () => ({ enabled: false })),
   listVeniceModels: vi.fn(async () => ({
     mode: "generation",
     modelType: "text",

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -100,6 +100,7 @@ vi.mock("../lib/tauri", () => ({
   providerModelSettings: vi.fn(async () => ({
     settings: { generationModel: "" },
   })),
+  hermesAgentCliAccess: vi.fn(async () => ({ enabled: false })),
   listVeniceModels: vi.fn(async () => ({
     mode: "generation",
     modelType: "text",


### PR DESCRIPTION
Implements Gaut's request from the Slack thread: when an agent CLI hits the sandbox wall, June shouldn't just describe the Settings toggle — it should be able to ask for the change and have it applied, without the user leaving the conversation.

## How it works

**June asks.** The soul's CLI-blocked section now teaches a literal token: when a CLI fails on sandbox-blocked state folders, June names the sandbox as the cause and puts `[REQUEST:AGENT_CLI_ACCESS]` on its own line.

**The app turns the token into a card.** Assistant text containing the token never renders it literally; in its place the conversation shows an approval card (same chrome as the existing tool-approval cards): what June wants ("write access to the state folders of your coding CLIs..."), why it matters ("those folders configure software that also runs outside June's sandbox"), and two choices.

**One click applies it.** "Enable Agent CLI access" persists the existing Settings opt-in via the existing `set_hermes_agent_cli_access` command (which already retires the sandboxed runtime so the next spawn carries the new Seatbelt grants), then auto-sends "I enabled Agent CLI access... try the CLI again" into the session — that send respawns the runtime with the folders writable and hands the turn back to June to retry. "Not now" resolves the card quietly without touching anything.

## Why a user-approved card and not "June does it directly"

The flag file deliberately lives outside every sandbox write root — the jailed process must never be able to rewrite the policy that governs it. The card keeps the user as the trust boundary while collapsing the fix from "go find Settings -> Agent" to one click in place.

## Design notes

- Card resolution is derived from the live setting, not stored per message: a revisited transcript shows "Enabled" once the grant is on, and re-offers the choice while it's off. No schema or Hermes changes needed.
- The token is detected at render time (same exact-match approach as the cron-preamble handling), so it works for both live streaming and reloaded history.
- The soul instructs the token's use only for this setting, at most once per reply; when CLI access is already enabled, the soul section that mentions the token isn't present at all.
- `AGENT_CLI_ACCESS_REQUEST_TOKEN` (frontend) and `JUNE_SOUL_CLI_BLOCKED_MD` (Rust) cross-reference each other so the pair can't drift silently.

## Testing

- Rust: soul tests assert the token is taught when CLI access is off and absent once granted; full `cargo test` green.
- Frontend: new tests cover token-to-card rendering (token never visible as text), the full enable flow (setting persisted, retry message submitted to the session, card flips to "Agent CLI access enabled"), the already-granted state, and "Not now" (no setting change, no send). Full suite: 40 files, 414 tests, all passing; `tsc` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)