### PR TITLE
Advertise the generation model's context window on /v1/models

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -108,10 +108,7 @@ const JUNE_HINT_UNRESTRICTED: &str = "Sandbox status for this session: Unrestric
 /// engages on this machine (non-macOS, sandbox-exec missing, or disabled by
 /// env): SOUL.md then carries no sandbox section, and a status line about a
 /// nonexistent jail would only confuse the agent.
-fn environment_hint_for_spawn(
-    full_mode: bool,
-    sandbox_available: bool,
-) -> Option<&'static str> {
+fn environment_hint_for_spawn(full_mode: bool, sandbox_available: bool) -> Option<&'static str> {
     if !sandbox_available {
         return None;
     }
@@ -2403,16 +2400,10 @@ async fn handle_scribe_provider_connection(
     }
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", "/v1/models") => {
-            let model = crate::providers::generation_model();
-            let body = serde_json::json!({
-                "object": "list",
-                "data": [{
-                    "id": model,
-                    "object": "model",
-                    "created": 0,
-                    "owned_by": "scribe"
-                }]
-            });
+            let body = provider_models_body(
+                crate::providers::generation_model(),
+                crate::providers::generation_model_context_tokens().await,
+            );
             write_json_response(&mut stream, 200, body).await?;
         }
         ("POST", "/v1/chat/completions") => {
@@ -2572,6 +2563,27 @@ fn translate_context_overflow_error(body: &[u8]) -> Option<serde_json::Value> {
             .to_string(),
     );
     Some(value)
+}
+
+/// The proxy's `/v1/models` listing. Hermes resolves a custom provider's
+/// context window by fetching `{base_url}/models` and reading any of its
+/// `_CONTEXT_LENGTH_KEYS` from the model entry (`context_length` included),
+/// then sizes its history compression to that window. Advertising the real
+/// window makes the agent trim proactively instead of discovering the limit
+/// by bouncing off the backend's prompt_too_long rejection. When the window
+/// is unknown the field is omitted and Hermes falls back to its own probing,
+/// exactly the previous behavior.
+fn provider_models_body(model: String, context_tokens: Option<i64>) -> serde_json::Value {
+    let mut entry = serde_json::json!({
+        "id": model,
+        "object": "model",
+        "created": 0,
+        "owned_by": "scribe"
+    });
+    if let Some(context_tokens) = context_tokens {
+        entry["context_length"] = serde_json::json!(context_tokens);
+    }
+    serde_json::json!({ "object": "list", "data": [entry] })
 }
 
 fn provider_proxy_authorized(request: &HttpRequest, token: &str) -> bool {
@@ -2802,6 +2814,29 @@ mod tests {
     }
 
     #[test]
+    fn models_listing_advertises_the_context_window_when_known() {
+        let body = provider_models_body("zai-org-glm-5".to_string(), Some(202_752));
+
+        let entry = &body["data"][0];
+        assert_eq!(entry["id"], "zai-org-glm-5");
+        // The key hermes-agent's _CONTEXT_LENGTH_KEYS reads; renaming it
+        // silently puts the agent back on reactive overflow recovery.
+        assert_eq!(entry["context_length"], 202_752);
+    }
+
+    #[test]
+    fn models_listing_omits_the_context_window_when_unknown() {
+        // Offline or signed out: the listing must still serve (hermes needs
+        // it to enumerate the model at all) and just skip the window, which
+        // returns hermes to its own probing.
+        let body = provider_models_body("zai-org-glm-5".to_string(), None);
+
+        let entry = &body["data"][0];
+        assert_eq!(entry["id"], "zai-org-glm-5");
+        assert!(entry.get("context_length").is_none());
+    }
+
+    #[test]
     fn start_request_full_mode_is_opt_in_and_defaults_to_no_preference() {
         // Background callers (auto-start, routines, older frontends) send no
         // fullMode — that must deserialize as "no preference", never as an
@@ -2910,7 +2945,9 @@ mod tests {
             Some(JUNE_HINT_UNRESTRICTED),
         );
         assert_eq!(
-            envs_of(&hinted).get("HERMES_ENVIRONMENT_HINT").map(String::as_str),
+            envs_of(&hinted)
+                .get("HERMES_ENVIRONMENT_HINT")
+                .map(String::as_str),
             Some(JUNE_HINT_UNRESTRICTED)
         );
 

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -150,6 +150,43 @@ pub fn generation_model() -> String {
     current_settings().generation_model
 }
 
+/// Context window (tokens) of the configured generation model, looked up in
+/// the backend's model catalog and cached per model id. The agent provider
+/// proxy advertises it on `/v1/models` so Hermes sizes its history to the
+/// real window and compresses proactively, instead of discovering the limit
+/// by bouncing off the backend's prompt_too_long rejection. Returns `None`
+/// when the catalog is unreachable (offline, signed out) or doesn't report a
+/// window for the model — callers degrade by omitting the field, which puts
+/// Hermes back on its own probing, exactly the pre-advertisement behavior.
+pub async fn generation_model_context_tokens() -> Option<i64> {
+    let model_id = generation_model();
+    if let Ok(cache) = context_tokens_cache().lock() {
+        if let Some((cached_id, tokens)) = cache.as_ref() {
+            if *cached_id == model_id {
+                return Some(*tokens);
+            }
+        }
+    }
+    let models = crate::scribe_api::list_models(ModelMode::Generation.api_type())
+        .await
+        .ok()?;
+    let tokens = models
+        .into_iter()
+        .find(|model| model.id == model_id)?
+        .context_tokens?;
+    if let Ok(mut cache) = context_tokens_cache().lock() {
+        *cache = Some((model_id, tokens));
+    }
+    Some(tokens)
+}
+
+/// One entry only: the generation model changes rarely, and a stale entry
+/// for the previous model would otherwise outlive a settings switch.
+fn context_tokens_cache() -> &'static Mutex<Option<(String, i64)>> {
+    static CACHE: OnceLock<Mutex<Option<(String, i64)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
 // Legacy name kept for callers we haven't migrated yet.
 pub fn venice_generation_model() -> String {
     generation_model()


### PR DESCRIPTION
## Context

Follow-up to #250, which made the backend's `prompt_too_long` rejection recognizable so hermes's compression recovery kicks in *reactively*. This PR adds the proactive half: tell the agent the model's real context window up front so it trims before ever hitting the backend cap.

## How it works

Hermes resolves a custom provider's context window by fetching `{base_url}/models` and reading the model entry's metadata - its `_CONTEXT_LENGTH_KEYS` list includes `context_length` (`agent/model_metadata.py` in the bundled runtime). Once known, its compressor sizes the conversation to the window and compresses proactively. The proxy's `/v1/models` listing previously carried only `id`/`object`/`owned_by`, so the agent ran blind until the first overflow.

## Changes

- `providers::generation_model_context_tokens()`: looks up the configured generation model's `context_tokens` in the backend's model catalog, cached per model id (one entry, replaced when the model setting changes).
- The proxy's `/v1/models` entry now carries `context_length` when the window is known. When the catalog is unreachable (offline, signed out) or reports no window, the field is omitted and the listing still serves - hermes falls back to its own probing, exactly the previous behavior.
- Body construction extracted into a pure `provider_models_body` with tests pinning both shapes (the `context_length` key name is what hermes matches; renaming it would silently return the agent to reactive-only recovery).

## Notes

- Composes with #250: this prevents most overflows, #250 recovers the ones that still happen (e.g. the backend's character-based request cap can be hit before the token window, and a single giant tool output can blow past any window mid-turn). Both PRs add code adjacent to the same helper block, so whichever merges second needs a trivial conflict resolution.
- No behavior change when the window is unknown.

## Testing

- New unit tests for both listing shapes; full `cargo test` green (130 lib tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)