### PR TITLE
Drop Input Monitoring: Carbon hot keys + DOM capture replace key taps

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -690,16 +690,6 @@ final class ShortcutKeyMonitor {
         pendingModifierOnlyModifiers = nil
     }
 
-    private func matchingIdentity(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> ShortcutIdentity? {
-        for shortcut in shortcuts.values where !shortcut.isModifierOnly {
-            guard keyCode == shortcut.keyCode, modifiersMatch(flags, shortcut.modifiers) else {
-                continue
-            }
-            return ShortcutIdentity(shortcut)
-        }
-        return nil
-    }
-
     private func matchingModifierOnlyIdentity(_ current: ShortcutModifiers) -> ShortcutIdentity? {
         for shortcut in shortcuts.values where shortcut.isModifierOnly {
             guard shortcut.modifiers == current else {
@@ -828,14 +818,6 @@ final class ShortcutKeyMonitor {
             "shortcut": shortcut.label,
         ])
     }
-}
-
-private func modifiersMatch(_ flags: NSEvent.ModifierFlags, _ modifiers: ShortcutModifiers) -> Bool {
-    flags.contains(.command) == modifiers.command
-        && flags.contains(.control) == modifiers.control
-        && flags.contains(.option) == modifiers.option
-        && flags.contains(.shift) == modifiers.shift
-        && flags.contains(.function) == modifiers.function
 }
 
 private func shortcutModifiers(from flags: NSEvent.ModifierFlags) -> ShortcutModifiers {

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -519,12 +519,17 @@ final class ShortcutKeyMonitor {
         activeIdentity = nil
         pendingOverlapIdentity = nil
         cancelPendingModifierOnlyCapture()
+        // A registered hot key consumes its chord system-wide, so the rebind
+        // UI's DOM would never see the user's current shortcut. Suspend them
+        // for the duration of the capture.
+        unregisterCarbonHotKeys()
         emit("shortcut_capture_started")
     }
 
     func cancelShortcutCapture() {
         isCapturingShortcut = false
         cancelPendingModifierOnlyCapture()
+        registerCarbonHotKeys()
         emit("shortcut_capture_cancelled")
     }
 
@@ -551,11 +556,15 @@ final class ShortcutKeyMonitor {
         InstallEventHandler(GetEventDispatcherTarget(), carbonHotKeyCallback, 2, &specs, userInfo, &carbonHandlerRef)
     }
 
-    private func registerCarbonHotKeys() {
+    private func unregisterCarbonHotKeys() {
         for entry in carbonHotKeys.values {
             UnregisterEventHotKey(entry.ref)
         }
         carbonHotKeys.removeAll()
+    }
+
+    private func registerCarbonHotKeys() {
+        unregisterCarbonHotKeys()
 
         for shortcut in shortcuts.values {
             guard !shortcut.isModifierOnly else {
@@ -667,6 +676,9 @@ final class ShortcutKeyMonitor {
 
         isCapturingShortcut = false
         cancelPendingModifierOnlyCapture()
+        // Resume the previous hot keys now; set_shortcut re-registers with
+        // the new chord once the frontend persists it.
+        registerCarbonHotKeys()
         emitJSON("shortcut_captured", [
             "shortcut": nextShortcut.payload,
         ])
@@ -855,9 +867,10 @@ private let carbonHotKeyCallback: EventHandlerUPP = { _, eventRef, userInfo in
     }
     let monitor = Unmanaged<ShortcutKeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
     let pressed = GetEventKind(eventRef) == UInt32(kEventHotKeyPressed)
-    DispatchQueue.main.async {
-        monitor.handleCarbonHotKey(id: hotKeyId.id, pressed: pressed)
-    }
+    // GetEventDispatcherTarget delivers on the main thread already; calling
+    // synchronously avoids a run-loop hop during which re-registration
+    // (setShortcut) could clear the hot-key table and drop this press.
+    monitor.handleCarbonHotKey(id: hotKeyId.id, pressed: pressed)
     return noErr
 }
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -358,8 +358,13 @@ final class ShortcutKeyMonitor {
     private static let doublePressWindow: TimeInterval = 0.34
 
     private var globalMonitor: Any?
-    private var eventTap: CFMachPort?
-    private var eventTapRunLoopSource: CFRunLoopSource?
+    private var carbonHandlerRef: EventHandlerRef?
+    /// Registered Carbon hot keys by their EventHotKeyID.id. Carbon's
+    /// RegisterEventHotKey delivers pressed/released edges for key chords
+    /// with NO permission prompt, unlike keyDown monitors and event taps,
+    /// which both summon the Input Monitoring ("keylogger") dialog.
+    private var carbonHotKeys: [UInt32: (identity: ShortcutIdentity, ref: EventHotKeyRef)] = [:]
+    private var nextCarbonHotKeyId: UInt32 = 1
     private var shortcuts: [ShortcutKind: MonitoredShortcut] = [
         .pushToTalk: .defaultPushToTalk,
         .toggle: MonitoredShortcut(
@@ -393,26 +398,19 @@ final class ShortcutKeyMonitor {
     private init() {}
 
     func start() {
-        guard globalMonitor == nil, eventTap == nil else {
+        guard globalMonitor == nil else {
             return
         }
 
         startGlobalMonitor()
-        startEventTap()
+        installCarbonHotKeyHandler()
+        registerCarbonHotKeys()
 
-        if globalMonitor == nil, eventTap == nil {
+        if globalMonitor == nil {
             emit("fn_monitor_unavailable", [
                 "message": "Could not monitor global shortcut key events.",
             ])
         }
-    }
-
-    fileprivate func enableEventTap() {
-        guard let eventTap else {
-            return
-        }
-
-        CGEvent.tapEnable(tap: eventTap, enable: true)
     }
 
     /// A flagsChanged event names the key that changed (`keyCode`), and the
@@ -503,32 +501,9 @@ final class ShortcutKeyMonitor {
             && (!subset.function || current.function)
     }
 
-    fileprivate func handle(type: CGEventType, event: CGEvent) {
-        if isCapturingShortcut {
-            handleCapture(type: type, keyCode: keyCode(from: event), flags: event.flags)
-            return
-        }
-
-        switch type {
-        case .keyDown:
-            guard let identity = matchingIdentity(keyCode: keyCode(from: event), flags: event.flags) else {
-                return
-            }
-            handlePhysicalDown(identity: identity)
-        case .keyUp:
-            guard let identity = activeIdentity, keyCode(from: event) == identity.keyCode else {
-                return
-            }
-            handlePhysicalUp(identity: identity)
-        case .flagsChanged:
-            handleFlagsChanged(shortcutModifiers(from: event.flags), changedKeyCode: keyCode(from: event))
-        default:
-            break
-        }
-    }
-
     func setShortcut(_ nextShortcut: MonitoredShortcut, kind: ShortcutKind) {
         shortcuts[kind] = nextShortcut
+        registerCarbonHotKeys()
         cancelPendingPush()
         activeIdentity = nil
         activePushIdentity = nil
@@ -553,93 +528,100 @@ final class ShortcutKeyMonitor {
         emit("shortcut_capture_cancelled")
     }
 
+    /// flagsChanged ONLY, deliberately: modifier traffic is visible to a
+    /// global monitor under the Accessibility permission June already holds,
+    /// while .keyDown/.keyUp in this mask is what made macOS demand Input
+    /// Monitoring on first launch. Key chords are watched by Carbon hot keys
+    /// instead (registerCarbonHotKeys), which need no permission at all.
     private func startGlobalMonitor() {
-        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.flagsChanged, .keyDown, .keyUp], handler: { [weak self] event in
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.flagsChanged], handler: { [weak self] event in
             self?.handle(event: event)
         })
     }
 
-    private func startEventTap() {
-        let mask = CGEventMask(
-            (1 << CGEventType.flagsChanged.rawValue)
-                | (1 << CGEventType.keyDown.rawValue)
-                | (1 << CGEventType.keyUp.rawValue)
-        )
-        let userInfo = Unmanaged.passUnretained(self).toOpaque()
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .tailAppendEventTap,
-            options: .listenOnly,
-            eventsOfInterest: mask,
-            callback: shortcutEventTapCallback,
-            userInfo: userInfo
-        ) else {
+    private func installCarbonHotKeyHandler() {
+        guard carbonHandlerRef == nil else {
             return
         }
+        var specs = [
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed)),
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyReleased)),
+        ]
+        let userInfo = Unmanaged.passUnretained(self).toOpaque()
+        InstallEventHandler(GetEventDispatcherTarget(), carbonHotKeyCallback, 2, &specs, userInfo, &carbonHandlerRef)
+    }
 
-        eventTap = tap
-        eventTapRunLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        if let eventTapRunLoopSource {
-            CFRunLoopAddSource(CFRunLoopGetMain(), eventTapRunLoopSource, .commonModes)
+    private func registerCarbonHotKeys() {
+        for entry in carbonHotKeys.values {
+            UnregisterEventHotKey(entry.ref)
         }
-        CGEvent.tapEnable(tap: tap, enable: true)
+        carbonHotKeys.removeAll()
+
+        for shortcut in shortcuts.values {
+            guard !shortcut.isModifierOnly else {
+                continue // flagsChanged path handles modifier-only chords.
+            }
+            guard !shortcut.modifiers.function else {
+                // Carbon has no fn modifier bit, and nothing permission-free
+                // can watch fn+key chords. Say so instead of silently dying.
+                emit("fn_monitor_unavailable", [
+                    "message": "The shortcut \(shortcut.label) combines Fn with another key, which is no longer supported. Pick a different shortcut in Settings.",
+                ])
+                continue
+            }
+            var carbonModifiers: UInt32 = 0
+            if shortcut.modifiers.command { carbonModifiers |= UInt32(cmdKey) }
+            if shortcut.modifiers.control { carbonModifiers |= UInt32(controlKey) }
+            if shortcut.modifiers.option { carbonModifiers |= UInt32(optionKey) }
+            if shortcut.modifiers.shift { carbonModifiers |= UInt32(shiftKey) }
+
+            var ref: EventHotKeyRef?
+            let hotKeyId = EventHotKeyID(signature: OSType(0x4A_44_48_4B), id: nextCarbonHotKeyId) // "JDHK"
+            let status = RegisterEventHotKey(
+                UInt32(shortcut.keyCode),
+                carbonModifiers,
+                hotKeyId,
+                GetEventDispatcherTarget(),
+                0,
+                &ref
+            )
+            if status == noErr, let ref {
+                carbonHotKeys[nextCarbonHotKeyId] = (ShortcutIdentity(shortcut), ref)
+            } else {
+                emit("fn_monitor_unavailable", [
+                    "message": "Could not register the shortcut \(shortcut.label).",
+                ])
+            }
+            nextCarbonHotKeyId += 1
+        }
+    }
+
+    fileprivate func handleCarbonHotKey(id: UInt32, pressed: Bool) {
+        guard !isCapturingShortcut, let entry = carbonHotKeys[id] else {
+            return
+        }
+        if pressed {
+            handlePhysicalDown(identity: entry.identity)
+        } else {
+            handlePhysicalUp(identity: entry.identity)
+        }
     }
 
     private func handle(event: NSEvent) {
-        if isCapturingShortcut {
-            handleCapture(type: event.type, keyCode: UInt16(event.keyCode), flags: event.modifierFlags)
+        guard event.type == .flagsChanged else {
             return
         }
-
-        switch event.type {
-        case .keyDown:
-            guard let identity = matchingIdentity(keyCode: UInt16(event.keyCode), flags: event.modifierFlags) else {
-                return
-            }
-            handlePhysicalDown(identity: identity)
-        case .keyUp:
-            guard let identity = activeIdentity, UInt16(event.keyCode) == identity.keyCode else {
-                return
-            }
-            handlePhysicalUp(identity: identity)
-        case .flagsChanged:
-            handleFlagsChanged(
-                shortcutModifiers(from: event.modifierFlags),
-                changedKeyCode: UInt16(event.keyCode)
-            )
-        default:
-            break
+        if isCapturingShortcut {
+            // Modifier-only chords (fn included) are captured here; key
+            // chords are captured by the focused June window's DOM, which
+            // sees ordinary keystrokes without any permission.
+            handleCapture(modifiers: shortcutModifiers(from: event.modifierFlags))
+            return
         }
-    }
-
-    private func handleCapture(type: CGEventType, keyCode: UInt16, flags: CGEventFlags) {
-        switch type {
-        case .keyDown:
-            captureShortcut(keyCode: keyCode, modifiers: shortcutModifiers(from: flags))
-        case .flagsChanged:
-            handleCapture(flags: flags)
-        default:
-            break
-        }
-    }
-
-    private func handleCapture(type: NSEvent.EventType, keyCode: UInt16, flags: NSEvent.ModifierFlags) {
-        switch type {
-        case .keyDown:
-            captureShortcut(keyCode: keyCode, modifiers: shortcutModifiers(from: flags))
-        case .flagsChanged:
-            handleCapture(flags: flags)
-        default:
-            break
-        }
-    }
-
-    private func handleCapture(flags: CGEventFlags) {
-        handleCapture(modifiers: shortcutModifiers(from: flags))
-    }
-
-    private func handleCapture(flags: NSEvent.ModifierFlags) {
-        handleCapture(modifiers: shortcutModifiers(from: flags))
+        handleFlagsChanged(
+            shortcutModifiers(from: event.modifierFlags),
+            changedKeyCode: UInt16(event.keyCode)
+        )
     }
 
     private func handleCapture(modifiers: ShortcutModifiers) {
@@ -648,32 +630,6 @@ final class ShortcutKeyMonitor {
         } else {
             cancelPendingModifierOnlyCapture()
         }
-    }
-
-    private func captureShortcut(keyCode: UInt16, modifiers: ShortcutModifiers) {
-        cancelPendingModifierOnlyCapture()
-        guard let (code, label) = keyCodeMetadata[keyCode] else {
-            emit("shortcut_capture_error", [
-                "message": "That key is not supported for global shortcuts.",
-            ])
-            return
-        }
-        guard modifiers.hasAny else {
-            emit("shortcut_capture_error", [
-                "message": "Shortcut must include Cmd, Ctrl, Opt, Shift, or Fn.",
-            ])
-            return
-        }
-
-        finishCapture(
-            MonitoredShortcut(
-                keyCode: keyCode,
-                code: code,
-                label: (modifiers.labelParts + [label]).joined(separator: "+"),
-                modifiers: modifiers,
-                pressCount: capturePressCount
-            )
-        )
     }
 
     private func scheduleModifierOnlyCapture(modifiers: ShortcutModifiers) {
@@ -720,16 +676,6 @@ final class ShortcutKeyMonitor {
         pendingModifierOnlyCapture?.cancel()
         pendingModifierOnlyCapture = nil
         pendingModifierOnlyModifiers = nil
-    }
-
-    private func matchingIdentity(keyCode: UInt16, flags: CGEventFlags) -> ShortcutIdentity? {
-        for shortcut in shortcuts.values where !shortcut.isModifierOnly {
-            guard keyCode == shortcut.keyCode, modifiersMatch(flags, shortcut.modifiers) else {
-                continue
-            }
-            return ShortcutIdentity(shortcut)
-        }
-        return nil
     }
 
     private func matchingIdentity(keyCode: UInt16, flags: NSEvent.ModifierFlags) -> ShortcutIdentity? {
@@ -872,34 +818,12 @@ final class ShortcutKeyMonitor {
     }
 }
 
-private func keyCode(from event: CGEvent) -> UInt16 {
-    UInt16(event.getIntegerValueField(.keyboardEventKeycode))
-}
-
-private func modifiersMatch(_ flags: CGEventFlags, _ modifiers: ShortcutModifiers) -> Bool {
-    flags.contains(.maskCommand) == modifiers.command
-        && flags.contains(.maskControl) == modifiers.control
-        && flags.contains(.maskAlternate) == modifiers.option
-        && flags.contains(.maskShift) == modifiers.shift
-        && flags.contains(.maskSecondaryFn) == modifiers.function
-}
-
 private func modifiersMatch(_ flags: NSEvent.ModifierFlags, _ modifiers: ShortcutModifiers) -> Bool {
     flags.contains(.command) == modifiers.command
         && flags.contains(.control) == modifiers.control
         && flags.contains(.option) == modifiers.option
         && flags.contains(.shift) == modifiers.shift
         && flags.contains(.function) == modifiers.function
-}
-
-private func shortcutModifiers(from flags: CGEventFlags) -> ShortcutModifiers {
-    ShortcutModifiers(
-        command: flags.contains(.maskCommand),
-        control: flags.contains(.maskControl),
-        option: flags.contains(.maskAlternate),
-        shift: flags.contains(.maskShift),
-        function: flags.contains(.maskSecondaryFn)
-    )
 }
 
 private func shortcutModifiers(from flags: NSEvent.ModifierFlags) -> ShortcutModifiers {
@@ -912,80 +836,29 @@ private func shortcutModifiers(from flags: NSEvent.ModifierFlags) -> ShortcutMod
     )
 }
 
-private let keyCodeMetadata: [UInt16: (code: String, label: String)] = [
-    0x00: ("KeyA", "A"),
-    0x01: ("KeyS", "S"),
-    0x02: ("KeyD", "D"),
-    0x03: ("KeyF", "F"),
-    0x04: ("KeyH", "H"),
-    0x05: ("KeyG", "G"),
-    0x06: ("KeyZ", "Z"),
-    0x07: ("KeyX", "X"),
-    0x08: ("KeyC", "C"),
-    0x09: ("KeyV", "V"),
-    0x0b: ("KeyB", "B"),
-    0x0c: ("KeyQ", "Q"),
-    0x0d: ("KeyW", "W"),
-    0x0e: ("KeyE", "E"),
-    0x0f: ("KeyR", "R"),
-    0x10: ("KeyY", "Y"),
-    0x11: ("KeyT", "T"),
-    0x12: ("Digit1", "1"),
-    0x13: ("Digit2", "2"),
-    0x14: ("Digit3", "3"),
-    0x15: ("Digit4", "4"),
-    0x16: ("Digit6", "6"),
-    0x17: ("Digit5", "5"),
-    0x18: ("Equal", "="),
-    0x19: ("Digit9", "9"),
-    0x1a: ("Digit7", "7"),
-    0x1b: ("Minus", "-"),
-    0x1c: ("Digit8", "8"),
-    0x1d: ("Digit0", "0"),
-    0x1e: ("BracketRight", "]"),
-    0x1f: ("KeyO", "O"),
-    0x20: ("KeyU", "U"),
-    0x21: ("BracketLeft", "["),
-    0x22: ("KeyI", "I"),
-    0x23: ("KeyP", "P"),
-    0x24: ("Enter", "Return"),
-    0x25: ("KeyL", "L"),
-    0x26: ("KeyJ", "J"),
-    0x27: ("Quote", "'"),
-    0x28: ("KeyK", "K"),
-    0x29: ("Semicolon", ";"),
-    0x2a: ("Backslash", "\\"),
-    0x2b: ("Comma", ","),
-    0x2c: ("Slash", "/"),
-    0x2d: ("KeyN", "N"),
-    0x2e: ("KeyM", "M"),
-    0x2f: ("Period", "."),
-    0x30: ("Tab", "Tab"),
-    0x31: ("Space", "Space"),
-    0x32: ("Backquote", "`"),
-    0x33: ("Backspace", "Delete"),
-    0x35: ("Escape", "Esc"),
-    0x7a: ("F1", "F1"),
-    0x7b: ("ArrowLeft", "Left"),
-    0x7c: ("ArrowRight", "Right"),
-    0x7d: ("ArrowDown", "Down"),
-    0x7e: ("ArrowUp", "Up"),
-]
-
-private let shortcutEventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
-    guard let userInfo else {
-        return Unmanaged.passUnretained(event)
+private let carbonHotKeyCallback: EventHandlerUPP = { _, eventRef, userInfo in
+    guard let eventRef, let userInfo else {
+        return OSStatus(eventNotHandledErr)
     }
-
+    var hotKeyId = EventHotKeyID()
+    let status = GetEventParameter(
+        eventRef,
+        EventParamName(kEventParamDirectObject),
+        EventParamType(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &hotKeyId
+    )
+    guard status == noErr else {
+        return status
+    }
     let monitor = Unmanaged<ShortcutKeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
-    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-        monitor.enableEventTap()
-        return Unmanaged.passUnretained(event)
+    let pressed = GetEventKind(eventRef) == UInt32(kEventHotKeyPressed)
+    DispatchQueue.main.async {
+        monitor.handleCarbonHotKey(id: hotKeyId.id, pressed: pressed)
     }
-
-    monitor.handle(type: type, event: event)
-
-    return Unmanaged.passUnretained(event)
+    return noErr
 }
 
 final class FocusTargetController {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -375,6 +375,14 @@ export function AppSettings({
     };
   }, [languageOpen]);
 
+  // The capture effect below must call the latest saveShortcut, not the one
+  // from the render in which capturing began (it is a plain function,
+  // redefined every render). Same ref pattern as use-shortcut-capture.
+  const saveShortcutRef = useRef(saveShortcut);
+  useEffect(() => {
+    saveShortcutRef.current = saveShortcut;
+  });
+
   useEffect(() => {
     if (!capturingShortcut) return;
     const kind = capturingShortcut;
@@ -401,7 +409,7 @@ export function AppSettings({
       void dictationHelperCommand({ type: "cancel_shortcut_capture" }).catch(
         () => undefined,
       );
-      void saveShortcut(kind, result.shortcut);
+      void saveShortcutRef.current(kind, result.shortcut);
     }
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -43,7 +43,11 @@ import {
   BillingSettingsSection,
 } from "../account/AccountSettings";
 import { KeycapShortcut } from "../shortcuts/KeycapShortcut";
-import { shortcutFromCapturePayload } from "../shortcuts/use-shortcut-capture";
+import {
+  MODIFIER_REQUIRED_MESSAGE,
+  chordFromKeyEvent,
+  shortcutFromCapturePayload,
+} from "../shortcuts/use-shortcut-capture";
 import {
   selectPopoverPlacement,
   selectPopoverStyle,
@@ -373,14 +377,34 @@ export function AppSettings({
 
   useEffect(() => {
     if (!capturingShortcut) return;
+    const kind = capturingShortcut;
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
         void cancelShortcutCapture();
+        return;
       }
+      // Key chords are read here in the DOM (the window is focused during a
+      // rebind); the helper's flagsChanged monitor only contributes fn and
+      // bare-modifier chords. This split is what lets the helper run without
+      // the Input Monitoring permission.
+      const result = chordFromKeyEvent(event);
+      if (result.kind === "ignore") return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (result.kind === "needsModifier") {
+        setShortcutError(MODIFIER_REQUIRED_MESSAGE);
+        setStatus(MODIFIER_REQUIRED_MESSAGE);
+        return;
+      }
+      setShortcutError(undefined);
+      void dictationHelperCommand({ type: "cancel_shortcut_capture" }).catch(
+        () => undefined,
+      );
+      void saveShortcut(kind, result.shortcut);
     }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [capturingShortcut]);
 
   async function requestMicrophones() {

--- a/src/components/shortcuts/use-shortcut-capture.ts
+++ b/src/components/shortcuts/use-shortcut-capture.ts
@@ -14,15 +14,19 @@ export type CapturedShortcut = Pick<
 >;
 
 /**
- * Native record-a-shortcut flow: `start()` puts the dictation helper into
- * capture mode (it owns the event tap, so fn and bare modifiers work — DOM
- * keydown can't see those), the captured chord comes back as a
- * `shortcut_captured` helper event, and the hook persists it through
- * `setDictationShortcut` before reporting back. Escape cancels.
+ * Record-a-shortcut flow with two capture sources, neither of which needs
+ * the Input Monitoring permission:
  *
- * Settings grew this flow first (inline in AppSettings); the onboarding
- * practice step uses this hook. Both speak the same helper protocol, so a
- * capture started here is indistinguishable from one started in Settings.
+ * - Key chords are read from DOM keydown right here: the rebind UI only
+ *   runs while June's window is focused, so ordinary keystrokes reach the
+ *   webview without any global monitoring.
+ * - fn and bare-modifier chords never reach the DOM, so `start()` also puts
+ *   the dictation helper into capture mode; its flagsChanged-only monitor
+ *   (covered by the Accessibility permission June already holds) reports
+ *   them back as a `shortcut_captured` event.
+ *
+ * Both paths persist through `setDictationShortcut`, whose backend rejects
+ * unsupported keys with a clear error. Escape cancels.
  */
 export function useShortcutCapture({
   kind,
@@ -93,6 +97,10 @@ export function useShortcutCapture({
         setCapturing(false);
         return;
       }
+      persistCaptured(captured);
+    });
+
+    function persistCaptured(captured: CapturedShortcut) {
       const current = callbacksRef.current;
       setDictationShortcut(current.kind, captured)
         .then((saved) => {
@@ -105,19 +113,33 @@ export function useShortcutCapture({
           setCapturing(false);
           setError(messageFromError(caught));
         });
-    });
+    }
 
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
         void cancel();
+        return;
       }
+      const result = chordFromKeyEvent(event);
+      if (result.kind === "ignore") return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (result.kind === "needsModifier") {
+        setError(MODIFIER_REQUIRED_MESSAGE);
+        return;
+      }
+      // Stop the helper's capture before persisting: the chord is decided.
+      void dictationHelperCommand({ type: "cancel_shortcut_capture" }).catch(
+        () => undefined,
+      );
+      persistCaptured(result.shortcut);
     }
-    window.addEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
 
     return () => {
       active = false;
-      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("keydown", onKey, true);
       void unlisten.then((fn) => fn());
     };
   }, [capturing, cancel]);
@@ -172,6 +194,55 @@ export function shortcutFromCapturePayload(
     modifiers,
     pressCount,
   };
+}
+
+/** What a keydown means for an in-progress capture. Bare modifier presses
+ * are ignored here (the helper's flagsChanged monitor owns those, since the
+ * DOM cannot see fn); a real key either completes a chord or, without any
+ * modifier, asks the user for one. */
+export type CaptureKeyResult =
+  | { kind: "ignore" }
+  | { kind: "needsModifier" }
+  | { kind: "chord"; shortcut: CapturedShortcut };
+
+export const MODIFIER_REQUIRED_MESSAGE =
+  "Shortcut must include Cmd, Ctrl, Opt, Shift, or Fn.";
+
+export function chordFromKeyEvent(event: KeyboardEvent): CaptureKeyResult {
+  if (["Shift", "Control", "Alt", "Meta"].includes(event.key)) {
+    return { kind: "ignore" };
+  }
+  if (!event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+    return { kind: "needsModifier" };
+  }
+  const modifiers = {
+    command: event.metaKey,
+    control: event.ctrlKey,
+    option: event.altKey,
+    shift: event.shiftKey,
+    function: false,
+  };
+  const label = [
+    modifiers.command ? "Cmd" : undefined,
+    modifiers.control ? "Ctrl" : undefined,
+    modifiers.option ? "Opt" : undefined,
+    modifiers.shift ? "Shift" : undefined,
+    keyLabel(event.code),
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join("+");
+  return {
+    kind: "chord",
+    shortcut: { code: event.code, modifiers, label, pressCount: 1 },
+  };
+}
+
+/** Friendly key name from a DOM `code`: "KeyD" -> "D", "Digit5" -> "5";
+ * anything else (F5, Space, ArrowUp) already reads fine as-is. */
+function keyLabel(code: string) {
+  if (code.startsWith("Key") && code.length === 4) return code.slice(3);
+  if (code.startsWith("Digit") && code.length === 6) return code.slice(5);
+  return code;
 }
 
 function messageFromError(error: unknown) {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppSettings } from "../components/settings/AppSettings";
@@ -892,6 +892,63 @@ describe("AppSettings", () => {
         pressCount: 1,
       }),
     );
+  });
+
+  it("captures a key chord from DOM keydown without the helper seeing keys", async () => {
+    // Key chords are read from the focused window's DOM: that is what lets
+    // the helper drop its keyDown monitors, whose presence triggered the
+    // macOS Input Monitoring ("keylogger") prompt on first launch.
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
+    const changeButtons = await screen.findAllByRole("button", {
+      name: "Change",
+    });
+    await user.click(changeButtons[0]);
+    await waitFor(() =>
+      expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+        type: "start_shortcut_capture",
+        pressCount: 1,
+      }),
+    );
+
+    fireEvent.keyDown(window, {
+      key: "p",
+      code: "KeyP",
+      ctrlKey: true,
+      altKey: true,
+    });
+
+    await waitFor(() =>
+      expect(mocks.setDictationShortcut).toHaveBeenCalledWith("push_to_talk", {
+        code: "KeyP",
+        label: "Ctrl+Opt+P",
+        modifiers: {
+          command: false,
+          control: true,
+          option: true,
+          shift: false,
+          function: false,
+        },
+        pressCount: 1,
+      }),
+    );
+    // The chord was decided in the DOM, so the helper capture gets cancelled.
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "cancel_shortcut_capture",
+    });
   });
 
   it("resets customized dictation shortcuts and hides reset for defaults", async () => {


### PR DESCRIPTION
Fixes the regression Manu hit installing from the DMG: macOS prompting for **Input Monitoring** - the "keylogger" permission this app was deliberately architected to avoid.

## Root cause

`918510b` (shortcut edge monitoring in the helper) introduced two things that each independently summon the Input Monitoring prompt on first launch:

1. `NSEvent.addGlobalMonitorForEvents(matching: [.flagsChanged, **.keyDown, .keyUp**], ...)` - global key monitors require Input Monitoring; flagsChanged alone is covered by Accessibility (which June already requires for typing).
2. A `CGEventTap` on the same events - any listening event tap requires Input Monitoring, full stop.

Both ran unconditionally at helper startup, so every fresh install prompted regardless of the configured shortcut.

## The fix - back to the permission-free architecture

The pre-918510b code used Carbon `RegisterEventHotKey` (zero permissions); this restores that approach while keeping everything the helper rework added (edge state machine, double-press, overlap handling, capture protocol):

| Concern | Before this PR | Now |
|---|---|---|
| fn / bare-modifier hold | keyDown monitor + tap | flagsChanged-only monitor (Accessibility, already granted) |
| Key-chord shortcuts (Ctrl+Opt+D etc.) | keyDown monitor + tap | Carbon hot keys: pressed/released events drive the same `handlePhysicalDown/Up` machine, **no permission** |
| Rebind capture, key chords | helper keyDown monitor | DOM keydown in the focused June window (rebinding implies focus), feeding the existing `setDictationShortcut` path - Rust's `key_code_for_code` already validates and maps DOM codes |
| Rebind capture, fn / modifiers | helper monitor | unchanged (flagsChanged) |

Settings' inline capture flow and the onboarding hook now share one `chordFromKeyEvent` builder, so both surfaces behave identically.

**Known narrowing:** Carbon has no fn modifier bit, so an fn+key chord (e.g. "Fn+D") can no longer be monitored or captured. These were never the default and the new capture UI cannot produce them; a persisted one now emits `fn_monitor_unavailable` naming the shortcut instead of silently dying.

**Behavior note:** Carbon hot keys consume the chord system-wide while registered (other apps don't see Ctrl+Opt+D) - identical to the pre-918510b behavior, slightly different from the listen-only tap.

## Verification

- `grep -cE "CGEventTap|keyDown|keyUp|IOHID"` on the helper now matches only comments and the existing CGEvent *synthesis* (typing, Accessibility-covered). No listening APIs remain - nothing left can trigger the Input Monitoring prompt.
- New test: DOM chord capture in Settings persists the right `{code, modifiers, label}` and cancels the helper capture. 419/419 frontend tests, 17/17 Rust suites, helper compiles clean via build.rs, lint clean.
- Reviewer-reproducible check for the actual prompt: `tccutil reset ListenEvent` + launch a built app from this branch - the dictation rebind and fn hold should work with Accessibility alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)