### PR TITLE
Stop the release build from mass-upgrading the Rust lockfile

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -158,7 +158,15 @@ jobs:
         run: |
           set -euo pipefail
           pnpm version:bump "$VERSION"
-          cargo generate-lockfile --manifest-path src-tauri/Cargo.toml
+          # Record ONLY the app's new version in Cargo.lock. The previous
+          # `cargo generate-lockfile` rebuilt the lockfile from scratch,
+          # silently mass-upgrading every dependency to the latest compatible
+          # release at build time - so a same-day upstream release could (and
+          # did: time 0.3.48 vs tauri-utils 2.9.2, 2026-06-12) break the
+          # release build with dependency versions no CI run ever tested.
+          # `--workspace` re-locks workspace members only and leaves every
+          # dependency exactly as committed.
+          cargo update --workspace --manifest-path src-tauri/Cargo.toml
 
       - name: Run release checks
         run: |


### PR DESCRIPTION
The v0.0.9 desktop release run failed in its release checks with E0119 in `tauri-utils 2.9.2` — while main was green. Root cause: after the version bump, the workflow ran `cargo generate-lockfile`, which rebuilds `Cargo.lock` from scratch and silently upgrades **every** dependency to the latest compatible release at build time. `time 0.3.48` was published this morning (2026-06-12 08:14 UTC) and fails to compile against `tauri-utils 2.9.2`; the committed lockfile pins `time 0.3.47` and builds fine.

Beyond today's breakage, this meant every shipped release was built with dependency versions that no CI run ever tested.

The fix: `cargo update --workspace` re-locks workspace members only (recording the app's bumped version) and leaves every dependency exactly as committed. Verified locally — after bumping to 0.0.9 it changes one line in `Cargo.lock`:

```
    Updating os-scribe v0.0.8 (.../src-tauri) -> v0.0.9
 src-tauri/Cargo.lock | 2 +-
```

The v0.0.9 release will be re-dispatched from this branch's workflow file (it still checks out and builds `main`), so the release isn't blocked on the merge; merging then fixes all future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)