### PR TITLE
Bump bundled Hermes runtime to v2026.6.5

### DIFF
--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -133,7 +133,15 @@ if ! (cd "$out/hermes-agent/web" && npm ci --no-audit --no-fund && npm run build
   tail -40 "$web_log" >&2
   die "web UI build failed (full log: $web_log)"
 fi
-rm -rf "$out/hermes-agent/web/node_modules"
+# npm workspaces (root package.json lists web/, ui-tui/, apps/*) hoist the
+# install to the REPO ROOT, so pruning web/node_modules alone leaves a root
+# node_modules full of .bin symlinks — which the no-symlinks gate below
+# rejects. None of it is needed at runtime: the dashboard serves the
+# prebuilt web_dist, and the Node TUI is an interactive-terminal surface
+# June never launches.
+rm -rf "$out/hermes-agent/node_modules" \
+  "$out/hermes-agent/web/node_modules" \
+  "$out/hermes-agent/ui-tui/node_modules"
 [ -f "$out/hermes-agent/hermes_cli/web_dist/index.html" ] || die "web_dist missing after build"
 
 # ---- relocatable CPython + hash-verified deps --------------------------------

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -30,11 +30,12 @@ const SCRIBE_HERMES_DISABLE_SANDBOX_ENV: &str = "SCRIBE_HERMES_DISABLE_SANDBOX";
 // Referenced by the spawn match arm on every target; only ever reached when
 // `prepare_sandbox` returns a profile, which it only does on macOS.
 const SANDBOX_EXEC_PATH: &str = "/usr/bin/sandbox-exec";
-const HERMES_AGENT_INSTALL_COMMIT: &str = "31c40c72c03cb11d5e596d015d61e7dd118cecee";
+// v2026.6.5 — see the bump PR for the audited pin→tag compatibility delta.
+const HERMES_AGENT_INSTALL_COMMIT: &str = "3c231eb3979ab9c57d5cd6d02f1d577a3b718b43";
 const HERMES_SOURCE_TARBALL_URL: &str =
-    "https://github.com/NousResearch/hermes-agent/archive/31c40c72c03cb11d5e596d015d61e7dd118cecee.tar.gz";
+    "https://github.com/NousResearch/hermes-agent/archive/3c231eb3979ab9c57d5cd6d02f1d577a3b718b43.tar.gz";
 const HERMES_SOURCE_TARBALL_SHA256: &str =
-    "287ead740a444d7e8c8e00a6d6e073d9b3329034f649a07b42e0a3f5b14686e4";
+    "c36c4b4a205b09673a6bc742c2c4361bac6e92139e795378a4335422458c3a43";
 const FILESYSTEM_MAX_DEPTH: usize = 2;
 const FILESYSTEM_MAX_ENTRIES_PER_DIR: usize = 80;
 const HERMES_IMPORT_MAX_BYTES: u64 = 50 * 1024 * 1024;
@@ -571,10 +572,12 @@ async fn start_hermes_bridge_inner(
         );
     }
     let port_string = port.to_string();
-    let hermes_args: [&str; 7] = [
+    // No --tui: upstream removed the flag from the dashboard subcommand in
+    // v2026.6.5 (cae6b5486) — the embedded chat gateway (/api/ws) is always
+    // enabled now, and passing the flag is an argparse error.
+    let hermes_args: [&str; 6] = [
         "dashboard",
         "--no-open",
-        "--tui",
         "--host",
         "127.0.0.1",
         "--port",


### PR DESCRIPTION
## Why

The Hermes pin sat at a Jun 2 commit (`31c40c72`), ~1,180 commits behind upstream. This audits the full delta against every surface June integrates with and bumps to the **v2026.6.5 release tag** (`3c231eb3`).

## Compatibility audit (pin → v2026.6.5)

Verified unchanged by diffing the upstream sources June depends on:

- **Gateway WS protocol** — `session.create/resume`, `prompt.submit`, `approval.respond`, `clarify.respond`, `session.interrupt`, `session.active_list`, event shapes: identical (new optional `profile` param on create/resume is additive).
- **Dashboard HTTP API** — `/api/ws` token auth, `/api/sessions`, skills/toolsets/messaging endpoints, `/api/status` (`gateway_running`): identical.
- **`config.yaml`** — every key June writes (`model.*`, `agent.max_turns`, `display.skin`): identical; new keys are all optional.
- **Install contract** — `install.sh --dir/--hermes-home/--stage venv|python-deps/--json/--non-interactive` and the `uv sync --extra all --locked` tier: identical.
- **Storage** — `state.db` SCHEMA_VERSION still 14 → no migration runs on user machines; SOUL.md handling unchanged.

Two real breaks, both fixed here:

1. **`dashboard --tui` is gone** (upstream `cae6b548`): the embedded chat gateway June drives over `/api/ws` is now *always* enabled, and the flag is a hard argparse error. Removed from the spawn args. (Upstream's motivation is telling — flag-gated `/api/ws` was the root cause of "desktop app connects but chat is dead" reports.)
2. **npm workspaces hoist `node_modules` to the repo root** during the dashboard web prebuild; the bundle script pruned only `web/node_modules`, and the leftover root `.bin` symlinks tripped the bundle's no-symlinks gate (Tauri/signing requirement). The script now prunes root + `ui-tui` trees too — nothing in them is needed at runtime; the dashboard serves the prebuilt `web_dist`.

## What June gains

Resumed sessions restore their original working directory; multi-profile session support (optional `profile` param we can adopt later); `HERMES_MAX_TOKENS` output-limit control; corrupt `config.yaml` auto-backup instead of silent loss; WAL truncate-on-checkpoint (bounds `state.db` growth); hermes-managed `uv` for deterministic installs. Upstream now caps Python at `<3.14` — June bundles CPython 3.11, no action needed.

## Validation

- Full bundle built from the new pin via `scripts/bundle-hermes-runtime.sh` — self-test passes from a relocated copy (376M).
- The bundled runtime booted with June's exact spawn args (`dashboard --no-open --host … --port …` + token env): `/api/status` answers with `release_date: 2026.6.5`.
- New tarball SHA256 pinned; `cargo check` + full Rust suite (212) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)