### PR TITLE
Shake the listening pill instead of showing the clipped already-listening toast

### DIFF
--- a/src/hud.ts
+++ b/src/hud.ts
@@ -681,6 +681,19 @@ async function handleDictationEventPayload(payload: unknown) {
       hideSoon(900);
       return;
     }
+    // Re-triggering dictation while the pill is already up listening: the
+    // wobble on the live pill says "already going" without a text toast —
+    // which would also replace the listening state and auto-hide while the
+    // recording is still running. Listening continues untouched (the helper
+    // keeps streaming audio levels, which also keeps Rust's post-error
+    // window-hide timer from firing).
+    if (
+      dictationEvent.payload?.code === "already_listening" &&
+      hud?.dataset.state === "listening"
+    ) {
+      triggerShake();
+      return;
+    }
     const message = String(
       dictationEvent.payload?.message ?? "Dictation failed.",
     ).trim();

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -253,6 +253,12 @@ body {
   /* Fixed cap, not vw-relative: the window is resized to fit the measured
    * pill, so a vw clamp would be circular (pill fits whatever it last was). */
   max-width: 460px;
+  /* Not shrinkable — same trap as .hud-meeting-text: overflow: hidden gives a
+   * flex child an automatic min-width of 0, so it shrinks to the stale window
+   * width and the pill measures the old size, never growing. flex-shrink: 0
+   * keeps the intrinsic width so syncWindowToPill measures the true size.
+   * max-width + ellipsis still cap pathological messages. */
+  flex-shrink: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -299,6 +299,43 @@ describe("meeting detection HUD", () => {
     expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
+  it("shakes the listening pill instead of toasting when dictation is already listening", async () => {
+    await loadHud();
+    await emit("dictation-event", { type: "listening_started" });
+    mocks.invoke.mockClear();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "already_listening",
+        message: "Dictation is already listening.",
+      },
+    });
+
+    // The pill stays in its listening state — no toast, no show/hide cycle.
+    expect(hudElement().dataset.state).toBe("listening");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent("");
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_shake", undefined);
+    expect(hudShowCalls()).toBe(0);
+  });
+
+  it("falls back to the error toast for already_listening outside the listening state", async () => {
+    await loadHud();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "already_listening",
+        message: "Dictation is already listening.",
+      },
+    });
+
+    expect(hudElement().dataset.state).toBe("error");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent(
+      "Dictation is already listening.",
+    );
+  });
+
   it("hides when a Hey June prompt starts an agent session", async () => {
     vi.useFakeTimers();
     await loadHud();

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -334,6 +334,7 @@ describe("meeting detection HUD", () => {
     expect(document.querySelector("#hud-error-text")).toHaveTextContent(
       "Dictation is already listening.",
     );
+    expect(hudShowCalls()).toBe(1);
   });
 
   it("hides when a Hey June prompt starts an agent session", async () => {


### PR DESCRIPTION
Triggering dictation while it was already listening showed an error toast clipped at the right edge ("Dictation is already listenin"), then auto-hid the HUD while the recording was still running.

- The HUD now intercepts the helper's `already_listening` error while the pill is in its listening state and wobbles it natively (`dictation_hud_shake`) instead of swapping to a text toast, leaving the recording and waveform untouched.
- The clipping itself is fixed for every error toast: `.hud-error-text` could shrink to fit a window still sized for a narrower previous state, so the measured pill never grew (the same circular-measurement trap documented on `.hud-meeting-text`); `flex-shrink: 0` makes it measure at intrinsic width, with the existing 460px cap for pathological messages.
- Adds two HUD tests covering the shake path and the toast fallback when the error arrives outside the listening state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)