### PR TITLE
Move session row actions into an overflow menu and tighten sidebar rows

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -94,11 +94,9 @@ type SidebarProps = {
   collapsed?: boolean;
 };
 
-type MenuState = {
-  noteId: string;
-  right: number;
-  top: number;
-};
+type MenuState =
+  | { kind: "note"; noteId: string; right: number; top: number }
+  | { kind: "agent-session"; sessionId: string; right: number; top: number };
 
 type CommandPaletteItem = {
   id: string;
@@ -709,13 +707,28 @@ export function Sidebar({
   // below — keeps it tucked next to the trigger rather than flying off to
   // the right. Clicking the same button again toggles it closed.
   function openMenuForNote(noteId: string, anchor: HTMLElement) {
-    if (menu?.noteId === noteId) {
+    if (menu?.kind === "note" && menu.noteId === noteId) {
       setMenu(null);
       return;
     }
     const rect = anchor.getBoundingClientRect();
     setMenu({
+      kind: "note",
       noteId,
+      right: window.innerWidth - rect.right,
+      top: rect.bottom + 4,
+    });
+  }
+
+  function openMenuForAgentSession(sessionId: string, anchor: HTMLElement) {
+    if (menu?.kind === "agent-session" && menu.sessionId === sessionId) {
+      setMenu(null);
+      return;
+    }
+    const rect = anchor.getBoundingClientRect();
+    setMenu({
+      kind: "agent-session",
+      sessionId,
       right: window.innerWidth - rect.right,
       top: rect.bottom + 4,
     });
@@ -771,6 +784,11 @@ export function Sidebar({
       });
     }
   }
+
+  const menuAgentSession =
+    menu?.kind === "agent-session"
+      ? agentSessions.find((session) => session.id === menu.sessionId)
+      : undefined;
 
   return (
     <aside
@@ -913,20 +931,21 @@ export function Sidebar({
                       activeView === "agent" &&
                       selectedAgentSessionId === session.id
                     }
-                    pinned
                     working={workingAgentSessionIds.has(session.id)}
                     waiting={waitingAgentSessionIds.has(session.id)}
                     unread={unreadAgentSessionIds.has(session.id)}
                     deleting={deletingAgentSessionIds.has(session.id)}
+                    menuOpen={
+                      menu?.kind === "agent-session" &&
+                      menu.sessionId === session.id
+                    }
                     onSelect={() => {
                       setSelectedAgentSessionId(session.id);
                       onSelectAgentSession(session);
                     }}
-                    onTogglePinned={() => togglePinnedAgentSession(session.id)}
-                    onDelete={() => {
-                      setAgentSessionDeleteError(null);
-                      setAgentSessionToDelete(session);
-                    }}
+                    onOpenMenu={(anchor) =>
+                      openMenuForAgentSession(session.id, anchor)
+                    }
                   />
                 ))}
               </div>
@@ -969,20 +988,21 @@ export function Sidebar({
                         activeView === "agent" &&
                         selectedAgentSessionId === session.id
                       }
-                      pinned={pinnedAgentSessionIds.has(session.id)}
                       working={workingAgentSessionIds.has(session.id)}
                       waiting={waitingAgentSessionIds.has(session.id)}
                       unread={unreadAgentSessionIds.has(session.id)}
                       deleting={deletingAgentSessionIds.has(session.id)}
+                      menuOpen={
+                        menu?.kind === "agent-session" &&
+                        menu.sessionId === session.id
+                      }
                       onSelect={() => {
                         setSelectedAgentSessionId(session.id);
                         onSelectAgentSession(session);
                       }}
-                      onTogglePinned={() => togglePinnedAgentSession(session.id)}
-                      onDelete={() => {
-                        setAgentSessionDeleteError(null);
-                        setAgentSessionToDelete(session);
-                      }}
+                      onOpenMenu={(anchor) =>
+                        openMenuForAgentSession(session.id, anchor)
+                      }
                     />
                   ))
                 ) : (
@@ -1029,7 +1049,7 @@ export function Sidebar({
         />
       </footer>
 
-      {menu ? (
+      {menu?.kind === "note" ? (
         <NoteContextMenu
           noteId={menu.noteId}
           right={menu.right}
@@ -1038,6 +1058,19 @@ export function Sidebar({
           onOpenMoveDialog={onOpenMoveDialog}
           onRemoveNoteFromFolder={onRemoveNoteFromFolder}
           onDeleteNote={onDeleteNote}
+          onClose={() => setMenu(null)}
+        />
+      ) : null}
+      {menu?.kind === "agent-session" && menuAgentSession ? (
+        <AgentSessionContextMenu
+          pinned={pinnedAgentSessionIds.has(menuAgentSession.id)}
+          right={menu.right}
+          top={menu.top}
+          onTogglePinned={() => togglePinnedAgentSession(menuAgentSession.id)}
+          onDelete={() => {
+            setAgentSessionDeleteError(null);
+            setAgentSessionToDelete(menuAgentSession);
+          }}
           onClose={() => setMenu(null)}
         />
       ) : null}
@@ -1565,34 +1598,39 @@ function pinnedSessionOrder(ids: ReadonlySet<string>, sessionId: string) {
 function AgentSessionRow({
   session,
   selected,
-  pinned,
   working,
   waiting,
   unread,
   deleting,
+  menuOpen,
   onSelect,
-  onTogglePinned,
-  onDelete,
+  onOpenMenu,
 }: {
   session: HermesSessionInfo;
   selected: boolean;
-  pinned: boolean;
   working: boolean;
   waiting: boolean;
   unread: boolean;
   deleting: boolean;
+  menuOpen: boolean;
   onSelect: () => void;
-  onTogglePinned: () => void;
-  onDelete: () => void;
+  onOpenMenu: (anchor: HTMLElement) => void;
 }) {
   const title = session.title || session.preview || "Untitled session";
   const status = waiting ? "waitingForUser" : working ? "running" : undefined;
   const time = formatSessionTime(sessionTimestamp(session));
+  const menuRef = useRef<HTMLButtonElement>(null);
   return (
     <article
       className="note-row agent-sidebar-row"
       data-selected={selected}
       data-status={status}
+      data-menu-open={menuOpen || undefined}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (menuRef.current) onOpenMenu(menuRef.current);
+      }}
     >
       <div
         className="note-row-main"
@@ -1647,35 +1685,73 @@ function AgentSessionRow({
       ) : null}
       <span className="agent-session-actions">
         <button
+          ref={menuRef}
           type="button"
-          className="note-row-menu agent-session-pin"
-          aria-label={pinned ? "Unpin session" : "Pin session"}
-          title={pinned ? "Unpin session" : "Pin session"}
-          aria-pressed={pinned}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onTogglePinned();
-          }}
-        >
-          {pinned ? <IconUnpin size={14} /> : <IconPin size={14} />}
-        </button>
-        <button
-          type="button"
-          className="note-row-menu agent-session-delete"
-          aria-label="Delete session"
-          title="Delete session"
+          className="note-row-menu agent-session-row-menu"
+          aria-label={`Actions for ${title}`}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
           disabled={deleting}
           onClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            onDelete();
+            onOpenMenu(event.currentTarget);
           }}
         >
-          <IconTrashCan size={14} />
+          <IconDotGrid1x3Vertical size={14} />
         </button>
       </span>
     </article>
+  );
+}
+
+function AgentSessionContextMenu({
+  pinned,
+  right,
+  top,
+  onTogglePinned,
+  onDelete,
+  onClose,
+}: {
+  pinned: boolean;
+  right: number;
+  top: number;
+  onTogglePinned: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="context-menu"
+      style={{ right, top }}
+      role="menu"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => {
+          onTogglePinned();
+          onClose();
+        }}
+      >
+        {pinned ? <IconUnpin size={14} /> : <IconPin size={14} />}
+        {pinned ? "Unpin session" : "Pin session"}
+      </button>
+      <div className="context-menu-separator" role="separator" />
+      <button
+        type="button"
+        role="menuitem"
+        className="destructive"
+        onClick={() => {
+          onDelete();
+          onClose();
+        }}
+      >
+        <IconTrashCan size={14} />
+        Delete session
+      </button>
+    </div>
   );
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4238,32 +4238,32 @@ button.agent-safety-badge:hover {
   flex: 1;
   min-height: 0;
   flex-direction: column;
-  gap: var(--sp-2);
+  gap: var(--sp-1);
 }
 
 .sidebar-pinned-section {
   flex: 0 0 auto;
-  gap: var(--sp-1);
 }
 
-.sidebar-pinned-section .section-title {
-  min-height: 22px;
-}
-
-.sidebar-pinned-list {
+/* Doubled class so these beat the later .notes-nav rule, whose height: 100%
+ * and 16px fade padding are meant for the open-ended agent list — the pinned
+ * list hugs its rows instead. */
+.notes-nav.sidebar-pinned-list {
   height: auto;
-  max-height: 154px;
+  max-height: 134px;
   overflow-y: auto;
   padding-bottom: 0;
 }
 
+/* Section headers share one height so the Pinned and Agent groups sit on the
+ * same vertical rhythm as the primary nav. */
 .section-title {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--sp-2);
   padding: 0 var(--sp-2);
-  min-height: var(--control-md);
+  min-height: 22px;
   color: var(--muted-foreground);
   font-size: var(--fs-md);
   font-weight: 500;
@@ -4559,29 +4559,24 @@ button.agent-safety-badge:hover {
   opacity: 0.45;
 }
 
-.agent-session-delete:hover:not(:disabled) {
-  color: var(--destructive);
-}
-
-.agent-session-pin:hover:not(:disabled) {
-  color: var(--foreground);
-}
-
 /* Agent rows drop the reserved menu column: the title spans (nearly) the full
  * row and fades out under the trailing overlay — a relative timestamp (or the
- * needs-you dot), swapped for the delete button on hover. */
+ * needs-you dot), swapped for the overflow menu button on hover. Session lists
+ * grow long, so these rows run denser than the primary nav. */
 .agent-sidebar-row {
   grid-template-columns: minmax(0, 1fr);
 }
 
 .agent-sidebar-row .note-row-main {
   grid-template-columns: minmax(0, 1fr);
+  min-height: 26px;
+  padding: var(--sp-1) var(--sp-3);
 }
 
 /* Titles ellipsize short of the trailing slot so they never collide with the
- * timestamp / dot or the two hover actions. */
+ * timestamp / dot or the hover menu button. */
 .agent-sidebar-row .note-row-title {
-  padding-right: 62px;
+  padding-right: 48px;
 }
 
 /* Trailing meta on agent rows: the relative timestamp or a compact status dot.
@@ -4610,14 +4605,15 @@ button.agent-safety-badge:hover {
 }
 
 .agent-sidebar-row:hover .agent-session-meta,
-.agent-sidebar-row:has(.agent-session-delete:focus-visible)
+.agent-sidebar-row[data-menu-open="true"] .agent-session-meta,
+.agent-sidebar-row:has(.agent-session-row-menu:focus-visible)
   .agent-session-meta {
   opacity: 0;
 }
 
-/* Row actions overlay the meta slot rather than holding a grid column of their
- * own, and reveal on hover only — a selected row keeps showing its timestamp
- * until pointed at. */
+/* The menu button overlays the meta slot rather than holding a grid column of
+ * its own, and reveals on hover only — a selected row keeps showing its
+ * timestamp until pointed at. It stays put while its menu is open. */
 .agent-session-actions {
   position: absolute;
   top: 50%;
@@ -4625,14 +4621,20 @@ button.agent-safety-badge:hover {
   translate: 0 -50%;
   display: inline-flex;
   align-items: center;
-  gap: 1px;
   opacity: 0;
   transition: opacity var(--t-fast) var(--ease-out);
 }
 
 .agent-sidebar-row:hover .agent-session-actions,
+.agent-sidebar-row[data-menu-open="true"] .agent-session-actions,
 .agent-session-actions:focus-within {
   opacity: 1;
+}
+
+.agent-sidebar-row[data-menu-open="true"] .agent-session-row-menu {
+  opacity: 1;
+  background: oklch(0% 0 none / 6%);
+  color: var(--foreground);
 }
 
 /* Needs-you dot: terracotta, matching the live-status accent used across the

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -145,7 +145,7 @@ describe("folders UI", () => {
     expect(screen.getByLabelText("Working")).toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: /Researching Google/ }),
+      screen.getByRole("button", { name: "Researching Google" }),
     );
 
     expect(onChangeView).not.toHaveBeenCalled();
@@ -200,7 +200,12 @@ describe("folders UI", () => {
     ) as HTMLElement;
     expect(row).not.toBeNull();
 
-    await user.click(within(row).getByRole("button", { name: "Pin session" }));
+    await user.click(
+      within(row).getByRole("button", {
+        name: "Actions for Fetch os platform issues",
+      }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Pin session" }));
 
     expect(
       screen.getByRole("region", { name: "Pinned agent sessions" }),
@@ -213,7 +218,12 @@ describe("folders UI", () => {
       '["session-1"]',
     );
 
-    await user.click(screen.getByRole("button", { name: "Unpin session" }));
+    await user.click(
+      within(
+        screen.getByRole("region", { name: "Pinned agent sessions" }),
+      ).getByRole("button", { name: "Actions for Fetch os platform issues" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Unpin session" }));
 
     expect(
       screen.queryByRole("region", { name: "Pinned agent sessions" }),
@@ -441,7 +451,10 @@ describe("folders UI", () => {
 
     expect(await screen.findByText("Researching Google")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Delete session" }));
+    await user.click(
+      screen.getByRole("button", { name: "Actions for Researching Google" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: "Delete session" }));
     const dialog = await screen.findByRole("dialog", {
       name: 'Delete "Researching Google"?',
     });


### PR DESCRIPTION
Replaces the hover pin/delete buttons on sidebar agent session rows with a single overflow menu button (also opens on right-click) offering pin/unpin and delete, reusing the existing context-menu popover. Session rows are denser now (26px min-height) and the Pinned and Agent section headers share one 22px height, so the three sidebar groups sit on a consistent rhythm that scales with many sessions. Also fixes the phantom gap under the pinned list: its padding-bottom: 0 override was losing the specificity tie to .notes-nav's 16px scroll-fade padding, and the new button class avoids a collision with the existing .agent-session-menu popover style. Tests updated to drive pin/unpin/delete through the new menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)