### PR TITLE
Guard session delete paths while a deletion is in flight

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1064,6 +1064,7 @@ export function Sidebar({
       {menu?.kind === "agent-session" && menuAgentSession ? (
         <AgentSessionContextMenu
           pinned={pinnedAgentSessionIds.has(menuAgentSession.id)}
+          deleting={deletingAgentSessionIds.has(menuAgentSession.id)}
           right={menu.right}
           top={menu.top}
           onTogglePinned={() => togglePinnedAgentSession(menuAgentSession.id)}
@@ -1629,6 +1630,7 @@ function AgentSessionRow({
       onContextMenu={(event) => {
         event.preventDefault();
         event.stopPropagation();
+        if (deleting) return;
         if (menuRef.current) onOpenMenu(menuRef.current);
       }}
     >
@@ -1707,6 +1709,7 @@ function AgentSessionRow({
 
 function AgentSessionContextMenu({
   pinned,
+  deleting,
   right,
   top,
   onTogglePinned,
@@ -1714,6 +1717,7 @@ function AgentSessionContextMenu({
   onClose,
 }: {
   pinned: boolean;
+  deleting: boolean;
   right: number;
   top: number;
   onTogglePinned: () => void;
@@ -1743,6 +1747,7 @@ function AgentSessionContextMenu({
         type="button"
         role="menuitem"
         className="destructive"
+        disabled={deleting}
         onClick={() => {
           onDelete();
           onClose();


### PR DESCRIPTION
Follow-up to #261 addressing two review findings: right-clicking a session row mid-deletion no longer opens the overflow menu (the button itself was already disabled), and an already open menu now disables its "Delete session" item while that session's delete call is in flight. Together these prevent queueing a duplicate delete for the same session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)