### PR TITLE
Stop re-processing the whole recording for every meeting turn

### DIFF
--- a/src-tauri/src/audio/turns.rs
+++ b/src-tauri/src/audio/turns.rs
@@ -110,7 +110,6 @@ pub fn write_turn_wav(turn: &AudioTurn, output_path: &Path) -> Result<(), AppErr
     let sample_rate = spec.sample_rate.max(1) as i64;
     let start_frame = ((turn.start_ms.max(0) * sample_rate) / 1000) as usize;
     let end_frame = ((turn.end_ms.max(turn.start_ms) * sample_rate) / 1000) as usize;
-    let start_sample = start_frame.saturating_mul(channels);
     let sample_count = end_frame
         .saturating_sub(start_frame)
         .saturating_mul(channels);
@@ -120,11 +119,16 @@ pub fn write_turn_wav(turn: &AudioTurn, output_path: &Path) -> Result<(), AppErr
     }
     let mut writer = WavWriter::create(output_path, spec)
         .map_err(|error| AppError::new("audio_turn_failed", error.to_string()))?;
-    for sample in reader
-        .samples::<i16>()
-        .skip(start_sample)
-        .take(sample_count)
-    {
+    // seek() repositions by byte offset. The previous .skip() pulled every
+    // sample before the turn through the decoder, so extracting turn N
+    // re-decoded the recording from its start each time — across a meeting's
+    // worth of turns that is quadratic in the recording length.
+    let start_frame = u32::try_from(start_frame)
+        .map_err(|error| AppError::new("audio_turn_failed", error.to_string()))?;
+    reader
+        .seek(start_frame)
+        .map_err(|error| AppError::new("audio_turn_failed", error.to_string()))?;
+    for sample in reader.samples::<i16>().take(sample_count) {
         writer
             .write_sample(sample.unwrap_or(0))
             .map_err(|error| AppError::new("audio_turn_failed", error.to_string()))?;
@@ -532,6 +536,35 @@ mod tests {
         let spec = reader.spec();
         assert_eq!(spec.channels, 1);
         assert_eq!(spec.sample_rate, 16_000);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn turn_extraction_cuts_the_exact_segment() {
+        // Pins the seek-based extraction: the segment must start at the
+        // turn's first frame and contain exactly the turn's samples, byte
+        // offsets and decoder state agreeing with the old skip-based path.
+        let dir =
+            std::env::temp_dir().join(format!("os-scribe-turn-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("source.wav");
+        let output = dir.join("turn.wav");
+        // 16 kHz mono: 1 ms = 16 frames. A ramp makes every frame unique.
+        let samples = (0..480).map(|value| value as i16).collect::<Vec<_>>();
+        write_samples(&input, &samples);
+
+        let turn = AudioTurn {
+            artifact_id: "artifact".to_string(),
+            source: "microphone".to_string(),
+            source_path: input.clone(),
+            start_ms: 10,
+            end_ms: 20,
+            turn_index: 0,
+        };
+        write_turn_wav(&turn, &output).unwrap();
+
+        let extracted = read_samples(&output);
+        assert_eq!(extracted, (160..320).map(|v| v as i16).collect::<Vec<_>>());
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -16,7 +16,7 @@ use crate::{
 use std::{
     collections::{HashMap, VecDeque},
     future::Future,
-    path::PathBuf,
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     time::{Duration, Instant},
@@ -452,6 +452,7 @@ pub async fn process_saved_source_audio(
         .collect::<HashMap<_, _>>();
     let mut transcription_jobs = Vec::new();
     let mut cached_candidates = Vec::new();
+    let mut normalized_sources: HashMap<PathBuf, PathBuf> = HashMap::new();
     for turn in turns {
         if let Some(existing) = existing_by_turn.get(&turn_cache_key(&turn.source, turn.turn_index))
         {
@@ -479,12 +480,11 @@ pub async fn process_saved_source_audio(
             "{:04}-{}-{}-{}.wav",
             turn.turn_index, turn.source, turn.start_ms, turn.end_ms
         ));
-        let source_audio_path = normalize_wav_for_transcription(
+        let source_audio_path = normalized_full_source(
+            &mut normalized_sources,
+            &segment_dir,
+            &turn.source,
             &turn.source_path,
-            &segment_dir.join(format!(
-                "{:04}-{}-source-normalized.wav",
-                turn.turn_index, turn.source
-            )),
         )?;
         let covers_full_source = turn.end_ms <= turn.start_ms;
         let raw_audio_path = if covers_full_source {
@@ -853,6 +853,32 @@ struct TranscribePreparedAudioRequest {
     start_ms: Option<i64>,
     end_ms: Option<i64>,
     turn_index: Option<i64>,
+}
+
+/// Full-source normalized audio, prepared once per source. The per-turn job
+/// loop used to normalize the WHOLE source recording again for every turn —
+/// the output name carried the turn index, so nothing was ever reused — and
+/// an hour of meeting audio was decoded, resampled, and rewritten dozens of
+/// times before the first transcription request even left the machine. The
+/// normalized copy only exists to serve as the full-source fallback when
+/// every turn of a source fails, so one per source is all there is to make.
+fn normalized_full_source(
+    cache: &mut HashMap<PathBuf, PathBuf>,
+    segment_dir: &Path,
+    source: &str,
+    source_path: &Path,
+) -> Result<PathBuf, AppError> {
+    if let Some(prepared) = cache.get(source_path) {
+        return Ok(prepared.clone());
+    }
+    let output = segment_dir.join(format!(
+        "{}-{:02}-source-normalized.wav",
+        source,
+        cache.len()
+    ));
+    let prepared = normalize_wav_for_transcription(source_path, &output)?;
+    cache.insert(source_path.to_path_buf(), prepared.clone());
+    Ok(prepared)
 }
 
 async fn transcribe_prepared_audio(
@@ -1534,6 +1560,49 @@ mod tests {
         },
         time::Duration,
     };
+
+    #[test]
+    fn full_source_normalization_runs_once_per_source() {
+        // Every turn of a source shares one normalized full-source copy; the
+        // job loop used to produce a fresh one per turn (a full decode,
+        // resample, and rewrite of the entire recording each time).
+        let dir = std::env::temp_dir().join(format!(
+            "os-scribe-normalize-cache-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("microphone.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&source, spec).unwrap();
+        // Quiet samples force a real normalization pass with an output file.
+        for sample in [100i16, -120, 90, -80] {
+            writer.write_sample(sample).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let mut cache = HashMap::new();
+        let first = normalized_full_source(&mut cache, &dir, "microphone", &source).unwrap();
+        let second = normalized_full_source(&mut cache, &dir, "microphone", &source).unwrap();
+
+        assert_eq!(first, second);
+        let normalized_outputs = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .contains("source-normalized")
+            })
+            .count();
+        assert_eq!(normalized_outputs, 1);
+        let _ = std::fs::remove_dir_all(dir);
+    }
 
     #[test]
     fn session_temp_dir_sanitizes_untrusted_session_ids() {


### PR DESCRIPTION
## Context

From the os-june Slack thread: a 10-minute dictation transcribes and summarizes in seconds, but meetings are far slower. Traced both pipelines. Dictation is one upload of one file. Meetings detect speaker turns and transcribe each turn - that part is fine (turn requests already run 4-way concurrent with best-effort context) - but the local preparation in front of those requests was **quadratic in recording length, twice**:

1. **Full-source normalization ran once per turn** (`process_saved_source_audio`, the job-building loop). Each turn called `normalize_wav_for_transcription(&turn.source_path, ...)` on the *entire* source recording with a turn-indexed output name, so nothing was ever reused: a full decode of every sample into memory, downmix, peak scan, resample to 16k, and rewrite to disk - per turn. For an hour-long 48kHz stereo recording (~690 MB of PCM) with a few dozen turns, that's tens of gigabytes of redundant I/O and minutes of CPU before the first transcription request even leaves the machine. The normalized full-source copy exists only as the fallback input used when every turn of a source fails, so one per source is all that's ever needed.
2. **Turn extraction positioned with `.skip()`** (`write_turn_wav`). hound's sample iterator decodes everything it skips, so extracting turn N re-decoded the recording from its start to the turn boundary, every time - on average half the meeting per turn.

## Changes

- `normalized_full_source()`: the full-source normalized copy is computed once per source path and cached for all of that source's turns (keyed by path, so multi-artifact edge cases stay correct).
- `write_turn_wav` repositions with `WavReader::seek()` - a plain byte-offset seek (verified against hound 3.5.1's implementation) - making extraction O(turn length) instead of O(position in recording).

No change to the transcription requests, concurrency, context building, ordering, or output formats. The per-turn segment normalization (which operates on just the turn's audio and provides per-speaker gain) is untouched.

## Expected effect

Local preparation drops from O(turns x recording length) to O(recording length). For long meetings with many turns this removes minutes of dead time between "Transcribing" appearing and the first request going out; short meetings with few turns see proportionally less. The `turn_wav_extraction` checkpoint (already logged per session with `durationMs`) makes the before/after directly measurable on a real meeting.

## Testing

- New test pins seek-based extraction against exact sample boundaries (ramp samples, mid-file turn) - the same result the old skip path produced, byte for byte.
- New test pins one-normalize-per-source (same path twice -> same output, exactly one normalized file on disk).
- Full `cargo test` green (133 lib tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)