### PR TITLE
Fix managed Hermes runtime install: quote $UV_CMD against the Application Support space

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1804,6 +1804,18 @@ if [ ! -f "$install_dir/pyproject.toml" ] || [ ! -f "$install_dir/scripts/instal
   mv "$unpacked_dir" "$install_dir"
 fi
 
+# Upstream's install.sh (v2026.6.5) runs $UV_CMD unquoted in the venv-create,
+# uv-sync, and pip-install-tier calls. The managed uv it installs lives under
+# the app data dir — "Application Support" on macOS — so the space word-splits
+# the path and every one of those calls fails with "/Users/…/Library/
+# Application: No such file or directory". Quote the bare uses after
+# extraction. Idempotent (an already-quoted $UV_CMD is preceded by a quote,
+# which the pattern excludes) and applied outside the download guard so a
+# previously extracted tree gets patched on retry too.
+sed -e 's/\([^"]\)\$UV_CMD/\1"$UV_CMD"/g' "$install_dir/scripts/install.sh" \
+  > "$install_dir/scripts/install.sh.quoted"
+mv "$install_dir/scripts/install.sh.quoted" "$install_dir/scripts/install.sh"
+
 run_stage() {
   local stage="$1"
   HERMES_HOME="$hermes_home" HERMES_INSTALL_DIR="$install_dir" \

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1812,7 +1812,8 @@ fi
 # extraction. Idempotent (an already-quoted $UV_CMD is preceded by a quote,
 # which the pattern excludes) and applied outside the download guard so a
 # previously extracted tree gets patched on retry too.
-sed -e 's/\([^"]\)\$UV_CMD/\1"$UV_CMD"/g' "$install_dir/scripts/install.sh" \
+sed -e 's/^\$UV_CMD/"$UV_CMD"/g' \
+  -e 's/\([^"]\)\$UV_CMD/\1"$UV_CMD"/g' "$install_dir/scripts/install.sh" \
   > "$install_dir/scripts/install.sh.quoted"
 mv "$install_dir/scripts/install.sh.quoted" "$install_dir/scripts/install.sh"
 


### PR DESCRIPTION
## Problem

After the bundled Hermes runtime bump to v2026.6.5 (#259), the Scribe-managed runtime fails to install on macOS:

> Could not set up the Scribe-managed Hermes runtime. Install log: ~/Library/Application Support/co.opensoftware.scribe/hermes-runtime/install.log.

The install log shows every dependency tier failing with:

```
install.sh: line 1209: /Users/andrew/Library/Application: No such file or directory
...
{"ok":false,"stage":"python-deps","skipped":false,"reason":"exit code 1"}
```

## Root cause

Upstream's `install.sh` at the new pin runs `$UV_CMD` **unquoted** in the venv-create, `uv sync`, and pip-install-tier calls (it quotes it correctly elsewhere, e.g. the `uv python` calls). The managed uv binary it installs lives under our app data dir:

```
~/Library/Application Support/co.opensoftware.scribe/hermes/bin/uv
```

The space in "Application Support" word-splits the unquoted path, so every uv invocation executes `/Users/<user>/Library/Application` and fails. The venv stage happens to report success anyway, then python-deps exhausts all four fallback tiers and exits 1.

## Fix

`MANAGED_HERMES_INSTALL_SCRIPT` now patches the extracted script before running it, quoting every bare `$UV_CMD`:

```sh
sed -e 's/\([^"]\)\$UV_CMD/\1"$UV_CMD"/g' …/scripts/install.sh
```

- Idempotent: an already-quoted `$UV_CMD` is preceded by a quote, which the pattern excludes.
- Applied outside the download guard, so a previously extracted broken tree is repaired on the next attempt. Affected machines self-heal on next launch: the failed install never wrote `runtime.json`, so the installer re-runs automatically.
- Worth filing upstream against NousResearch/hermes-agent; this patch can be dropped once a fixed release is pinned.

## Not affected

- The DMG bundle path: `bundle-hermes-runtime.sh` drives uv directly rather than through `install.sh`.
- The state.db / config surfaces audited in #259 — this is purely the installer.

## Verification

- Ran the sed against the actual broken install on a real machine: `bash -n` passes and all `$UV_CMD` uses end up quoted (assignments and already-quoted calls untouched).
- Extracted the embedded heredoc script from the Rust constant and `bash -n`'d it.
- `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)