### PR TITLE
Mark new session active in sidebar

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -538,6 +538,7 @@ export function Sidebar({
   }
 
   function handleNewAgentSession() {
+    setSelectedAgentSessionId(undefined);
     markAgentNewSessionPending();
     onNewAgentSession();
     dispatchAgentEvent(AGENT_NEW_SESSION_EVENT);

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -793,6 +793,8 @@ export function Sidebar({
     menu?.kind === "agent-session"
       ? agentSessions.find((session) => session.id === menu.sessionId)
       : undefined;
+  const newAgentSessionActive =
+    activeView === "agent" && !selectedAgentSessionId;
 
   return (
     <aside
@@ -855,6 +857,8 @@ export function Sidebar({
             <button
               type="button"
               className="sidebar-nav-item"
+              data-active={newAgentSessionActive || undefined}
+              aria-current={newAgentSessionActive ? "page" : undefined}
               onClick={handleNewAgentSession}
             >
               <span className="sidebar-nav-icon">

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -155,6 +155,8 @@ describe("folders UI", () => {
   });
 
   it("marks new session active until an existing agent session is selected", async () => {
+    const user = userEvent.setup();
+    const onNewAgentSession = vi.fn();
     render(
       <Sidebar
         notes={notes}
@@ -164,7 +166,7 @@ describe("folders UI", () => {
         onDeleteNote={vi.fn()}
         onOpenMoveDialog={vi.fn()}
         onRemoveNoteFromFolder={vi.fn()}
-        onNewAgentSession={vi.fn()}
+        onNewAgentSession={onNewAgentSession}
         onSelectAgentSession={vi.fn()}
       />,
     );
@@ -197,6 +199,12 @@ describe("folders UI", () => {
     await screen.findByText("Researching Google");
     expect(newSessionButton).not.toHaveAttribute("data-active");
     expect(newSessionButton).not.toHaveAttribute("aria-current");
+
+    await user.click(newSessionButton);
+
+    expect(onNewAgentSession).toHaveBeenCalledTimes(1);
+    expect(newSessionButton).toHaveAttribute("data-active", "true");
+    expect(newSessionButton).toHaveAttribute("aria-current", "page");
   });
 
   it("pins agent sessions in a dedicated sidebar section", async () => {

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -154,6 +154,51 @@ describe("folders UI", () => {
     );
   });
 
+  it("marks new session active until an existing agent session is selected", async () => {
+    render(
+      <Sidebar
+        notes={notes}
+        activeView="agent"
+        onChangeView={vi.fn()}
+        onSelectNote={vi.fn()}
+        onDeleteNote={vi.fn()}
+        onOpenMoveDialog={vi.fn()}
+        onRemoveNoteFromFolder={vi.fn()}
+        onNewAgentSession={vi.fn()}
+        onSelectAgentSession={vi.fn()}
+      />,
+    );
+
+    const newSessionButton = screen.getByRole("button", {
+      name: "New session",
+    });
+    expect(newSessionButton).toHaveAttribute("data-active", "true");
+    expect(newSessionButton).toHaveAttribute("aria-current", "page");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, {
+          detail: {
+            sessions: [
+              {
+                id: "session-1",
+                title: "Researching Google",
+                preview: "Generate a PDF",
+                last_active: "2026-06-04T19:00:00Z",
+              },
+            ],
+            selectedSessionId: "session-1",
+            workingSessionIds: [],
+          },
+        }),
+      );
+    });
+
+    await screen.findByText("Researching Google");
+    expect(newSessionButton).not.toHaveAttribute("data-active");
+    expect(newSessionButton).not.toHaveAttribute("aria-current");
+  });
+
   it("pins agent sessions in a dedicated sidebar section", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
Marks the New session sidebar item active when the agent workspace is showing a fresh session with no selected existing conversation. Clears that active state once an existing agent session is selected, so session rows keep their normal selected styling. Adds a regression test for the fresh-session to selected-session transition. Validated with pnpm test -- src/test/folders.test.tsx and pnpm lint.