### PR TITLE
Add launch checklist specs (AI self-ID, Venice filter, Scribe consent)

### DIFF
--- a/docs/ai-self-identification.md
+++ b/docs/ai-self-identification.md
@@ -1,0 +1,69 @@
+# AI Self-Identification — Launch Checklist Spec
+
+**Created**: 2026-06-12
+**Status**: Draft
+**Source**: OpenSoftware Launch Checklist (Google Doc)
+
+---
+
+## Overview
+
+Every consumer-facing interaction that routes through Venice AI must begin with an explicit self-identification from the OS-Agent (June's AI). This is a launch requirement: the agent must identify itself as an AI powered by Venice at the start of every conversation, dictation cleanup, note generation, or other inference-backed interaction. The requirement applies across all modalities — chat, dictation, meeting notes, and agent tasks — wherever the user interacts with AI-generated output.
+
+## Requirements
+
+### REQ-1: Venice AI self-identification prompt in system message
+
+The OS-Agent system prompt must include a self-identification directive that causes the model to identify itself as an AI powered by Venice at the start of every consumer-facing interaction.
+
+**Acceptance Criteria**:
+
+1. The system prompt for every Venice-backed inference call includes a self-identification instruction.
+2. The model's first response in a new conversation session identifies itself as an AI powered by Venice.
+3. Self-identification is present in all consumer-facing modalities: agent chat, dictation cleanup, note generation, and any future Venice-backed features.
+4. Internal / non-consumer-facing calls (e.g., programmatic tool use with no user-visible output) are exempt.
+
+### REQ-2: Consistent identification language
+
+The identification must use consistent, predictable language so users can recognize it across sessions.
+
+**Acceptance Criteria**:
+
+1. The identification phrase is defined in a single, shared constant (not duplicated per modality).
+2. The language is plain and non-technical (e.g., "I'm June, your AI assistant powered by Venice" — exact wording TBD by product).
+3. The identification appears only once per session, not on every subsequent turn.
+
+### REQ-3: No degradation to latency or UX
+
+Self-identification must not meaningfully degrade the user experience.
+
+**Acceptance Criteria**:
+
+1. For dictation cleanup and note generation, the identification is included in the system prompt, not prepended to the output — the user sees only the cleaned text / generated note.
+2. For agent chat, the identification is part of the first assistant message and does not require a separate round-trip.
+3. No additional network call is introduced to satisfy this requirement.
+
+## Implementation Notes
+
+- **Where to add the prompt**: The self-identification instruction belongs in the system message template for each Venice-backed inference path. In the codebase, this means updating the system prompts in:
+  - Agent conversation (`src-tauri/src/` agent/chat modules)
+  - Dictation cleanup (`dictation.rs` / `scribe_api` cleanup path)
+  - Note generation (`scribe_api` generate path)
+- **Shared constant**: Define the identification instruction string once (e.g., in a shared prompt module or config) and import it in each system prompt builder. Avoid copy-paste across modules.
+- **Venice API consideration**: If Venice's API supports a `system` role or equivalent metadata field, prefer that over injecting the instruction into the user message. This keeps the identification out of the visible transcript unless the modality calls for it (chat).
+- **Modality-specific behavior**:
+  - **Agent chat**: The model's first reply includes the identification naturally as part of its greeting.
+  - **Dictation / note generation**: The identification is in the system prompt only; the user-facing output is the cleaned text or generated note without an AI preamble.
+- **Testing**: Verify that every Venice-backed call includes the self-identification instruction in its system message by checking the prompt construction in unit tests. For agent chat, also verify the model output includes the identification phrase on the first turn.
+
+## Out of Scope
+
+- Modifying the Venice API itself — this is a client-side prompt requirement only.
+- Adding identification to OpenAI-backed calls (only Venice is in scope per the launch checklist).
+- Persisting whether a session has already shown the identification (the system prompt always includes it; the model handles deduplication naturally in multi-turn chat).
+
+## References
+
+- OpenSoftware Launch Checklist (Google Doc) — "AI Self-Identification" section
+- [`/docs/scribe-api-prd.md`](./scribe-api-prd.md) — Scribe API inference paths
+- [`/docs/onboarding-design.md`](./onboarding-design.md) — Agent first-run and honesty screen

--- a/docs/scribe-recording-consent.md
+++ b/docs/scribe-recording-consent.md
@@ -1,0 +1,115 @@
+# Scribe Audio Recording Consent — Launch Checklist Spec
+
+**Created**: 2026-06-12
+**Status**: Draft
+**Source**: OpenSoftware Launch Checklist (Google Doc)
+
+---
+
+## Overview
+
+Scribe records audio from meetings and voice notes. When recording meetings — especially those involving multiple participants — consent is a legal and ethical requirement. This spec defines four consent mechanisms that Scribe must implement before public launch, drawn from the OpenSoftware Launch Checklist. The requirements draw on recognized industry safe-harbor practices for recording consent.
+
+## Requirements
+
+### REQ-1: Audible recording-start beep
+
+When Scribe begins recording a meeting, it must emit an audible beep that is captured in the recording itself and audible to all participants.
+
+**Acceptance Criteria**:
+
+1. An audible tone plays through the system audio output at the start of every meeting recording.
+2. The tone is also captured in the recorded audio stream, so it is present in the resulting transcript and audio file.
+3. The tone is distinct from notification sounds and is clearly recognizable as a recording indicator.
+4. The beep occurs before any meeting audio is captured (i.e., the first audio frame in the recording is the beep).
+5. The beep is not skippable or configurable by the user — it always plays.
+6. The beep duration and frequency are defined in a shared constant (not hardcoded per platform).
+
+**Rationale**: An audible beep at the start of a recording is a recognized industry safe-harbor for recording consent. It provides constructive notice to all participants, including those who may not see a screen or visual indicator.
+
+### REQ-2: Identify the transcription bot
+
+When Scribe joins or records a meeting, it must clearly identify itself as a transcription bot to all participants.
+
+**Acceptance Criteria**:
+
+1. When joining a meeting platform (Zoom, Google Meet, etc.), the bot's display name clearly indicates it is a transcription bot (e.g., "June (Recording)" or "June Notetaker").
+2. If the meeting platform supports a join message or bot profile, the description states that the bot is recording and transcribing the meeting.
+3. For in-person / system-audio recordings (no bot join), the audible beep (REQ-1) and visible indicator (REQ-3) serve as the identification mechanism.
+
+**Rationale**: Participants must know that a recording and transcription is taking place and who is performing it. Opaque or ambiguous bot names undermine informed consent.
+
+### REQ-3: Visible recording indicator throughout the session
+
+A persistent, visible indicator must be displayed for the entire duration of a meeting recording.
+
+**Acceptance Criteria**:
+
+1. A recording indicator is visible on screen whenever Scribe is actively recording a meeting.
+2. The indicator remains visible for the entire duration of the recording — it does not auto-hide or dismiss after a timeout.
+3. The indicator clearly communicates that recording is in progress (e.g., a red dot with "Recording" label, a pill in the menu bar, or an overlay).
+4. When recording stops, the indicator is removed.
+5. The indicator is visible regardless of which application has focus — it is not hidden behind other windows.
+6. The indicator is distinguishable from other status indicators in the June UI.
+
+**Rationale**: A persistent, always-visible indicator ensures that all participants in the same physical space can see that recording is active, even if they missed the initial beep. This is a standard practice in recording applications (Zoom, Otter.ai, etc.).
+
+### REQ-4: One-click consent language sharing
+
+Scribe must provide a one-click feature to send consent language to all meeting participants ahead of the meeting.
+
+**Acceptance Criteria**:
+
+1. When a user schedules or initiates a meeting recording, Scribe offers a one-click action to share consent language with participants.
+2. The consent language clearly states that the meeting will be recorded and transcribed by June, who owns the recording, and how it will be used.
+3. The sharing mechanism integrates with the user's calendar (e.g., adds a note to the calendar invite) or communication tool (e.g., sends a message via email or Slack).
+4. The consent language template is editable by the user in Settings.
+5. A default consent language template is provided out of the box.
+6. The one-click action is surfaced at the point of scheduling or starting a recording, not buried in settings.
+
+**Rationale**: Proactively sharing consent language before a meeting is a best practice that goes beyond the minimum legal requirement in many jurisdictions. It demonstrates good faith and reduces the risk that participants are unaware of the recording.
+
+## Implementation Notes
+
+### Audible beep
+
+- **Where to implement**: In the audio capture pipeline, before the first audio frame from the system/microphone is written to the recording buffer. The beep should be synthesized (not a file read) for reliability.
+- **Platform**: On macOS, use `AVAudioEngine` or the Tauri audio layer to play the beep through the active output device and simultaneously write it to the recording buffer.
+- **Shared constant**: Define beep frequency (e.g., 1000 Hz), duration (e.g., 500 ms), and waveform (sine) in a config module.
+
+### Bot identification
+
+- **Meeting platform integrations**: When joining via a bot (if/when supported), set the bot's display name and description through the platform's API.
+- **System audio recordings**: For local system-audio capture (the current architecture), the beep and visible indicator serve as the identification. No separate bot identity is needed.
+
+### Visible recording indicator
+
+- **Menu bar indicator**: June already has a menu bar presence. The recording indicator should be part of this — a red recording dot or pill in the menu bar icon or an overlay HUD.
+- **Always-on-top**: The indicator must not be obscured. A menu bar item is always visible on macOS. Alternatively, a floating HUD (like the existing `meeting-hud.html`) can serve this purpose.
+- **State management**: The recording state should be managed centrally so that any component can query whether recording is active and render the indicator accordingly.
+
+### Consent language sharing
+
+- **Calendar integration**: The most natural integration point is the calendar — add a note to the Google Calendar / Outlook invite when the user clicks "Share consent." This requires calendar API access, which may not be available at launch.
+- **Fallback — clipboard / share sheet**: If calendar integration is not yet available, the one-click action should copy the consent language to the clipboard with a "Copied!" confirmation, or open the system share sheet. This still qualifies as "one-click" if the user's next action is a paste into an invite.
+- **Template**: Store the default template in the app's configuration. Allow the user to edit it in Settings → Recording → Consent template.
+
+### Default consent language template
+
+Suggested default (editable by the user):
+
+> This meeting will be recorded and transcribed by June, an AI notetaker by Open Software. The recording and transcript will be stored on the host's device and used to generate meeting notes. By joining, you consent to being recorded. If you have concerns, please contact the meeting host before joining.
+
+## Out of Scope
+
+- **Legal review of consent language**: The default template is a starting point; users should have their legal counsel review it for their jurisdiction.
+- **Per-participant consent tracking**: Scribe does not track whether individual participants consented — the audible beep, visible indicator, and pre-meeting notice are the consent mechanisms.
+- **Automated consent collection (e.g., a consent form before joining)**: Out of scope for v1; the one-click share + beep + indicator approach is the launch requirement.
+- **Recording consent for dictation**: Dictation is a single-user feature (the user is recording their own voice); multi-party consent does not apply.
+
+## References
+
+- OpenSoftware Launch Checklist (Google Doc) — "Scribe Audio Recording Consent" section
+- [`/docs/scribe-api-prd.md`](./scribe-api-prd.md) — Scribe API architecture
+- [`/docs/onboarding-design.md`](./onboarding-design.md) — Meeting notes onboarding and permission flow
+- [`/specs/001-tauri-note-mvp/`](../specs/001-tauri-note-mvp/) — Note MVP spec (recording foundations)

--- a/docs/venice-content-filter.md
+++ b/docs/venice-content-filter.md
@@ -1,0 +1,64 @@
+# Venice Content Filter — Launch Checklist Spec
+
+**Created**: 2026-06-12
+**Status**: Implemented
+**Source**: OpenSoftware Launch Checklist (Google Doc)
+
+---
+
+## Overview
+
+Venice AI provides a content filter that screens inference requests and responses for illegal activities. The filter is already implemented and active in the June/Scribe inference pipeline. This spec documents the requirement, the implemented behavior, and the response mechanism for flagged content, to serve as a reference for the launch checklist and future audits.
+
+## Requirements
+
+### REQ-1: Content filter for illegal activities
+
+All Venice-backed inference calls must pass through Venice's content filter, which detects requests or responses involving illegal activities.
+
+**Acceptance Criteria**:
+
+1. Every inference request routed through Scribe API or directly to Venice includes the content filter (enabled by default in the Venice API).
+2. Requests flagged by the filter are blocked before the response reaches the user.
+3. The filter applies to all modalities: agent chat, dictation cleanup, note generation, and model listing.
+
+### REQ-2: Response mechanism for flagged content
+
+When the content filter flags a request or response, the system must handle it gracefully and, where applicable, trigger account-level actions.
+
+**Acceptance Criteria**:
+
+1. **User-facing response**: When a request is filtered, the user receives a clear, non-judgmental message indicating the request could not be completed (e.g., "I'm unable to help with that request"). No details about the filter or the specific policy violated are exposed to the user.
+2. **Logging**: Filtered requests are logged server-side with the user ID, timestamp, and a categorization of the filter trigger. Logs are not accessible to end users.
+3. **Reporting**: Repeated filter violations from the same account are reported to the platform moderation team for review.
+4. **Account suspension**: If the platform moderation team determines an account is systematically attempting to generate illegal content, the account may be suspended per the OS Accounts terms of service. Suspension is a manual, human-reviewed action — not automatic.
+
+### REQ-3: No bypass path
+
+There must be no supported way for a user to disable or bypass the content filter.
+
+**Acceptance Criteria**:
+
+1. The filter cannot be disabled via settings, environment variables, or API parameters.
+2. Direct API calls to Venice (bypassing Scribe API) from the client are not possible — the client holds no Venice API keys (see [`scribe-api-prd.md`](./scribe-api-prd.md)).
+
+## Implementation Notes
+
+- **Current state**: The Venice content filter is enabled by default on all Venice API endpoints. No client-side configuration is required; the filter runs on Venice's infrastructure.
+- **Error handling in Scribe API**: When Venice returns a content-filtered response, Scribe API maps it to an appropriate error code in the `ApiResponse` envelope. The Tauri client displays a user-friendly message and does not surface the raw error.
+- **Reporting pipeline**: Filtered-request events are emitted as structured `tracing` logs. A downstream alerting or reporting system consumes these logs to flag accounts for moderation review. The exact reporting infrastructure (dashboard, alerts) is out of scope for this spec but tracked as a follow-up.
+- **Suspension flow**: Account suspension is handled through OS Accounts, not through Scribe or Scribe API. Scribe API does not have the ability to suspend accounts; it can only report.
+- **OpenAI path**: OpenAI's moderation API provides equivalent filtering for requests routed through OpenAI. This spec focuses on the Venice path per the launch checklist, but the principle (filter + report + suspend) applies to all upstream providers.
+
+## Out of Scope
+
+- Building a custom content filter — Venice and OpenAI provide this; we use theirs.
+- Defining the specific categories of illegal content — that is determined by the upstream provider's policies.
+- Automated account suspension — suspension is a human-reviewed action.
+- Content filter for on-device / local inference (if ever added) — not part of the current architecture.
+
+## References
+
+- OpenSoftware Launch Checklist (Google Doc) — "Venice Content Filter" section
+- [`/docs/scribe-api-prd.md`](./scribe-api-prd.md) — Scribe API architecture and error mapping
+- [`/docs/os-accounts-backend.md`](./os-accounts-backend.md) — OS Accounts integration


### PR DESCRIPTION
## Summary

Adds three specification documents derived from the **OpenSoftware Launch Checklist** (Google Doc), covering the product requirements that must be met before public launch.

## Documents

| File | Requirement | Status |
|------|------------|--------|
| `docs/ai-self-identification.md` | OS-Agent must include a Venice AI self-identification prompt in its default behavior at the start of every consumer-facing interaction | Draft — not yet implemented |
| `docs/venice-content-filter.md` | Content filter for illegal activities + response mechanism (reporting and/or suspending accounts) | Already implemented — documenting for reference |
| `docs/scribe-recording-consent.md` | Four consent requirements for Scribe meeting recording | Draft — not yet implemented |

### AI Self-Identification (`docs/ai-self-identification.md`)
- REQ-1: Self-ID prompt in every Venice-backed system message
- REQ-2: Consistent, shared identification language (single constant)
- REQ-3: No degradation to latency or UX (system prompt only for non-chat)

### Venice Content Filter (`docs/venice-content-filter.md`)
- REQ-1: All Venice calls pass through the content filter (already active by default)
- REQ-2: Graceful user-facing response + logging + reporting + human-reviewed suspension
- REQ-3: No bypass path (client holds no Venice keys)

### Scribe Recording Consent (`docs/scribe-recording-consent.md`)
- REQ-1: Audible recording-start beep (industry safe-harbor)
- REQ-2: Identify the transcription bot to all participants
- REQ-3: Persistent visible recording indicator throughout the session
- REQ-4: One-click feature to send consent language to participants ahead of the meeting

Each doc follows the existing repo style (title, overview, requirements with acceptance criteria, implementation notes, references).

## References

- OpenSoftware Launch Checklist (Google Doc)
- Existing docs: `scribe-api-prd.md`, `onboarding-design.md`, `release-macos.md`