### PR TITLE
Control June from your phone: pair a device, drive the agent remotely

### DIFF
--- a/scribe-api/Cargo.lock
+++ b/scribe-api/Cargo.lock
@@ -116,6 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -135,8 +136,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -293,6 +296,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deadpool"
@@ -1200,7 +1209,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1243,12 +1252,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1258,7 +1288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1448,7 +1487,10 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
+ "futures-util",
  "pretty_assertions",
+ "rand 0.8.6",
+ "reqwest",
  "scribe-config",
  "scribe-domain",
  "scribe-services",
@@ -1456,6 +1498,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-http",
  "tracing",
@@ -1592,6 +1635,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1863,6 +1917,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2125,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2202,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/scribe-api/Cargo.toml
+++ b/scribe-api/Cargo.toml
@@ -18,7 +18,7 @@ scribe-providers = { path = "crates/providers" }
 scribe-services = { path = "crates/services" }
 
 async-trait = "0.1"
-axum = { version = "0.8", features = ["multipart"] }
+axum = { version = "0.8", features = ["multipart", "ws"] }
 base64 = "0.22"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
@@ -31,6 +31,8 @@ sha2 = "0.10"
 # path, where the desktop helper records AAC-in-MPEG-4. Hound is WAV-only.
 mp4 = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls", "stream"] }
+futures-util = "0.3"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/scribe-api/crates/api/Cargo.toml
+++ b/scribe-api/crates/api/Cargo.toml
@@ -15,6 +15,9 @@ axum.workspace = true
 scribe-config.workspace = true
 scribe-domain.workspace = true
 scribe-services.workspace = true
+futures-util.workspace = true
+rand.workspace = true
+tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -24,6 +27,9 @@ tracing.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+futures-util.workspace = true
 pretty_assertions.workspace = true
 tokio.workspace = true
+tokio-tungstenite = "0.24"
+reqwest.workspace = true
 tower = { workspace = true, features = ["util"] }

--- a/scribe-api/crates/api/src/envelope.rs
+++ b/scribe-api/crates/api/src/envelope.rs
@@ -1,6 +1,7 @@
 use axum::{Json, http::StatusCode, response::IntoResponse};
 use serde::Serialize;
 
+pub(crate) const ERR_NOT_FOUND: i32 = 1001;
 pub const ERR_BAD_REQUEST: i32 = 2001;
 pub const ERR_UNAUTHORIZED: i32 = 3001;
 pub const ERR_UNPROCESSABLE: i32 = 4201;

--- a/scribe-api/crates/api/src/error.rs
+++ b/scribe-api/crates/api/src/error.rs
@@ -1,6 +1,7 @@
 use crate::envelope::{
     ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_PAYLOAD_TOO_LARGE, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM, error_response,
+    ERR_NOT_FOUND, ERR_PAYLOAD_TOO_LARGE, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
+    error_response,
 };
 use axum::{http::StatusCode, response::IntoResponse};
 use scribe_domain::AuthError;
@@ -9,6 +10,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ApiError {
+    #[error("not_found")]
+    NotFound { code: i32, message: String },
     #[error("bad_request")]
     BadRequest { code: i32, message: String },
     #[error("unauthorized")]
@@ -28,6 +31,13 @@ pub enum ApiError {
 }
 
 impl ApiError {
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound {
+            code: ERR_NOT_FOUND,
+            message: message.into(),
+        }
+    }
+
     pub fn bad_request(message: impl Into<String>) -> Self {
         Self::BadRequest {
             code: ERR_BAD_REQUEST,
@@ -53,6 +63,9 @@ impl ApiError {
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
         match self {
+            Self::NotFound { code, message } => {
+                error_response(StatusCode::NOT_FOUND, code, &message)
+            }
             Self::BadRequest { code, message } => {
                 error_response(StatusCode::BAD_REQUEST, code, &message)
             }

--- a/scribe-api/crates/api/src/handlers/mod.rs
+++ b/scribe-api/crates/api/src/handlers/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod health;
 pub(crate) mod issues;
 pub(crate) mod models;
 pub(crate) mod notes;
+pub(crate) mod remote;
 pub(crate) mod verify;

--- a/scribe-api/crates/api/src/handlers/remote.rs
+++ b/scribe-api/crates/api/src/handlers/remote.rs
@@ -1,0 +1,190 @@
+use crate::{
+    auth::authenticated_user,
+    envelope::ApiResponse,
+    error::ApiError,
+    remote::{AttachError, LinkHandle, PEER_HERE_CONTROLLER, PEER_HERE_HOST, Role},
+    state::ApiState,
+};
+use axum::{
+    Json,
+    extract::{
+        Path, Query, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    http::{HeaderMap, StatusCode, header},
+    response::{Html, IntoResponse, Response},
+};
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CreatePairingResponse {
+    pairing_id: String,
+    code: String,
+    expires_in_seconds: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClaimPairingResponse {
+    pairing_id: String,
+    controller_token: String,
+}
+
+/// Host (desktop, authenticated) mints a pairing. The `code` is shown to the
+/// user to type on their phone; the desktop then opens the host WS with the
+/// returned `pairingId` and its own OS Accounts bearer.
+pub(crate) async fn create_pairing(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Result<Json<ApiResponse<CreatePairingResponse>>, ApiError> {
+    let user = authenticated_user(&state, &headers).await?;
+    let (pairing_id, code) = state.remote().create_pairing(
+        user,
+        crate::remote::now_unix(),
+        crate::remote::new_pairing_id(),
+    );
+    Ok(Json(ApiResponse::ok(CreatePairingResponse {
+        pairing_id,
+        code,
+        expires_in_seconds: crate::remote::PAIRING_TTL_SECONDS,
+    })))
+}
+
+/// Phone claims a pairing by code. Deliberately UNAUTHENTICATED: the code is
+/// the capability (shown only on the trusted desktop, single-use, short TTL).
+/// The phone gets a controller token scoped to that one pairing and never
+/// signs in.
+pub(crate) async fn claim_pairing(
+    State(state): State<ApiState>,
+    Path(code): Path<String>,
+) -> Result<Json<ApiResponse<ClaimPairingResponse>>, ApiError> {
+    let claim = state
+        .remote()
+        .claim_pairing(&code, crate::remote::now_unix())
+        .ok_or_else(|| ApiError::not_found("pairing_not_found"))?;
+    Ok(Json(ApiResponse::ok(ClaimPairingResponse {
+        pairing_id: claim.pairing_id,
+        controller_token: claim.controller_token,
+    })))
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LinkQuery {
+    #[serde(default)]
+    pairing: String,
+    role: String,
+}
+
+/// The relay socket. Both devices reach it outbound. The credential rides in
+/// the `Sec-WebSocket-Protocol` header (browsers can set it; query strings
+/// risk landing in logs): the host sends its OS Accounts bearer, the phone
+/// sends its controller token.
+pub(crate) async fn link(
+    State(state): State<ApiState>,
+    Query(query): Query<LinkQuery>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let Some(credential) = headers
+        .get(header::SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return (StatusCode::UNAUTHORIZED, "missing credential").into_response();
+    };
+    let credential = credential.to_string();
+
+    let (pairing, role, handle) = match query.role.as_str() {
+        "host" => {
+            let Ok(user) = state.token_verifier().verify(&credential).await else {
+                return (StatusCode::UNAUTHORIZED, "invalid token").into_response();
+            };
+            match state.remote().attach_host(&query.pairing, &user) {
+                Ok(handle) => (query.pairing.clone(), Role::Host, handle),
+                Err(error) => return attach_error_response(&error),
+            }
+        }
+        "controller" => match state.remote().attach_controller(&credential) {
+            Ok((pairing, handle)) => (pairing, Role::Controller, handle),
+            Err(error) => return attach_error_response(&error),
+        },
+        _ => return (StatusCode::BAD_REQUEST, "invalid role").into_response(),
+    };
+
+    // Echo the credential back as the negotiated subprotocol to complete the
+    // browser handshake.
+    ws.protocols([credential])
+        .on_upgrade(move |socket| run_link(state, LinkContext { pairing, role }, handle, socket))
+}
+
+/// Identifies one side of a live link, bundled so `run_link` stays under the
+/// argument-count lint.
+struct LinkContext {
+    pairing: String,
+    role: Role,
+}
+
+fn attach_error_response(error: &AttachError) -> Response {
+    match error {
+        AttachError::UnknownPairing => (StatusCode::NOT_FOUND, "unknown pairing").into_response(),
+        AttachError::RoleTaken => (StatusCode::CONFLICT, "role already connected").into_response(),
+    }
+}
+
+async fn run_link(state: ApiState, ctx: LinkContext, mut handle: LinkHandle, socket: WebSocket) {
+    let (mut sink, mut stream) = socket.split();
+
+    // First frame: tell this side whether its peer is already attached, so the
+    // phone shows "connected" the instant the desktop is online (and vice
+    // versa) without waiting for traffic.
+    if state.remote().peer_present(&ctx.pairing, ctx.role) {
+        let hello = match ctx.role {
+            Role::Host => PEER_HERE_CONTROLLER,
+            Role::Controller => PEER_HERE_HOST,
+        };
+        let _ = sink.send(Message::Text(hello.to_string().into())).await;
+    }
+
+    loop {
+        tokio::select! {
+            outbound = handle.recv() => {
+                match outbound {
+                    Some(text) => {
+                        if sink.send(Message::Text(text.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            incoming = stream.next() => {
+                match incoming {
+                    Some(Ok(Message::Text(text))) => {
+                        // A false return means the peer isn't attached; keep
+                        // the socket open so the phone can wait for the
+                        // desktop to (re)connect rather than dropping.
+                        let _ = handle.send_to_peer(text.to_string());
+                    }
+                    // Binary/ping/pong aren't part of the text-JSON relay; a
+                    // Close or stream end means this side is gone.
+                    Some(Ok(Message::Binary(_) | Message::Ping(_) | Message::Pong(_))) => {}
+                    None | Some(Ok(Message::Close(_)) | Err(_)) => break,
+                }
+            }
+        }
+    }
+    drop(handle); // fires the presence guard, notifying the peer
+    state.remote().release_if_idle(&ctx.pairing);
+}
+
+/// The phone client: one self-contained page. The user types the code shown
+/// on their desktop, the page claims it (no login) and opens the relay. Public
+/// and unauthenticated like /verify and /s.
+pub(crate) async fn mobile_page() -> Html<&'static str> {
+    Html(MOBILE_PAGE)
+}
+
+const MOBILE_PAGE: &str = include_str!("remote_mobile.html");

--- a/scribe-api/crates/api/src/handlers/remote_mobile.html
+++ b/scribe-api/crates/api/src/handlers/remote_mobile.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex">
+<title>Control June</title>
+<style>
+  :root { color-scheme: light dark; --fg:#1c1b18; --bg:#fdfdfc; --muted:#6f6c64; --line:#e7e5e0; --accent:#b4540a; --me:#ece7df; }
+  @media (prefers-color-scheme: dark){ :root{ --fg:#ece9e2; --bg:#161513; --muted:#97938a; --line:#2c2a26; --accent:#e8853d; --me:#2a2825; } }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body { background: var(--bg); color: var(--fg); font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; display: flex; flex-direction: column; }
+  header { padding: 1rem 1.1rem; border-bottom: 1px solid var(--line); display: flex; align-items: center; gap: .6rem; }
+  header h1 { font-size: 1rem; margin: 0; font-weight: 600; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted); }
+  .dot.on { background: #3aa35a; }
+  main { flex: 1; overflow-y: auto; padding: 1rem 1.1rem; -webkit-overflow-scrolling: touch; }
+  .pair { max-width: 22rem; margin: 2rem auto; }
+  .pair h2 { font-size: 1.25rem; }
+  .pair p { color: var(--muted); }
+  input[type=text] { width: 100%; padding: .8rem; font-size: 1.3rem; letter-spacing: .18em; text-transform: uppercase; text-align: center; border: 1px solid var(--line); border-radius: 10px; background: var(--bg); color: var(--fg); }
+  button { font: inherit; font-weight: 600; padding: .75rem 1rem; border: none; border-radius: 10px; background: var(--accent); color: #fff; cursor: pointer; width: 100%; margin-top: .8rem; }
+  button:disabled { opacity: .5; }
+  .err { color: #c4554d; font-size: .9rem; margin-top: .6rem; }
+  .msg { max-width: 85%; padding: .6rem .8rem; border-radius: 14px; margin: .5rem 0; white-space: pre-wrap; word-wrap: break-word; }
+  .msg.me { margin-left: auto; background: var(--me); }
+  .msg.june { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+  footer { border-top: 1px solid var(--line); padding: .7rem 1.1rem calc(.7rem + env(safe-area-inset-bottom)); display: flex; gap: .5rem; }
+  footer textarea { flex: 1; resize: none; border: 1px solid var(--line); border-radius: 12px; padding: .6rem .8rem; font: inherit; background: var(--bg); color: var(--fg); max-height: 8rem; }
+  footer button { width: auto; padding: .6rem 1rem; }
+  .hidden { display: none; }
+</style>
+</head>
+<body>
+<header>
+  <span class="dot" id="status-dot"></span>
+  <h1 id="status-text">Control June</h1>
+</header>
+
+<main id="main">
+  <section class="pair" id="pair-view">
+    <h2>Pair with your Mac</h2>
+    <p>Open June on your Mac, go to Settings and turn on "Control from your phone", then enter the code it shows.</p>
+    <input type="text" id="code" inputmode="latin" autocomplete="one-time-code" maxlength="8" placeholder="CODE" aria-label="Pairing code">
+    <button id="pair-btn">Connect</button>
+    <p class="err hidden" id="pair-err"></p>
+  </section>
+
+  <div id="chat-view" class="hidden"></div>
+</main>
+
+<footer id="composer" class="hidden">
+  <textarea id="input" rows="1" placeholder="Ask June to do something..." aria-label="Message"></textarea>
+  <button id="send-btn">Send</button>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+  var dot = document.getElementById("status-dot");
+  var statusText = document.getElementById("status-text");
+  var pairView = document.getElementById("pair-view");
+  var chatView = document.getElementById("chat-view");
+  var composer = document.getElementById("composer");
+  var main = document.getElementById("main");
+  var input = document.getElementById("input");
+
+  var socket = null;
+  var hostOnline = false;
+  var current = null; // the in-flight June message element
+
+  function setStatus(connected, online) {
+    dot.classList.toggle("on", connected && online);
+    statusText.textContent = !connected ? "Control June"
+      : online ? "Connected to your Mac" : "Waiting for your Mac...";
+  }
+
+  function bubble(role, text) {
+    var el = document.createElement("div");
+    el.className = "msg " + role;
+    el.textContent = text;
+    chatView.appendChild(el);
+    main.scrollTop = main.scrollHeight;
+    return el;
+  }
+
+  function showChat() {
+    pairView.classList.add("hidden");
+    chatView.classList.remove("hidden");
+    composer.classList.remove("hidden");
+  }
+
+  function handleFrame(frame) {
+    var data;
+    try { data = JSON.parse(frame); } catch (e) { return; }
+    switch (data.type) {
+      case "peer_here": if (data.peer === "host") { hostOnline = true; setStatus(true, true); } break;
+      case "peer_left": if (data.peer === "host") { hostOnline = false; setStatus(true, false); } break;
+      case "delta":
+        if (!current) current = bubble("june", "");
+        current.textContent += (data.text || "");
+        main.scrollTop = main.scrollHeight;
+        break;
+      case "message":
+        bubble("june", data.text || "");
+        current = null;
+        break;
+      case "done":
+        current = null;
+        break;
+      case "error":
+        bubble("june", "Error: " + (data.message || "something went wrong"));
+        current = null;
+        break;
+    }
+  }
+
+  function connect(token) {
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    // The controller token rides as the WS subprotocol (kept out of the URL).
+    socket = new WebSocket(proto + "//" + location.host + "/v1/remote/link?role=controller", [token]);
+    socket.onopen = function () { setStatus(true, hostOnline); showChat(); };
+    socket.onmessage = function (ev) { handleFrame(ev.data); };
+    socket.onclose = function () { setStatus(false, false); };
+    socket.onerror = function () { setStatus(false, false); };
+  }
+
+  document.getElementById("pair-btn").addEventListener("click", function () {
+    var code = document.getElementById("code").value.trim().toUpperCase();
+    var err = document.getElementById("pair-err");
+    err.classList.add("hidden");
+    if (!code) { return; }
+    fetch("/v1/remote/pairings/" + encodeURIComponent(code) + "/claim", { method: "POST" })
+      .then(function (r) { return r.json(); })
+      .then(function (body) {
+        if (!body || !body.success || !body.data) { throw new Error((body && body.message) || "That code didn't work. Check it and try again."); }
+        connect(body.data.controllerToken);
+      })
+      .catch(function (e) { err.textContent = e.message || "Could not connect."; err.classList.remove("hidden"); });
+  });
+
+  function send() {
+    var text = input.value.trim();
+    if (!text || !socket || socket.readyState !== WebSocket.OPEN) { return; }
+    socket.send(JSON.stringify({ type: "prompt", text: text }));
+    bubble("me", text);
+    input.value = "";
+    input.style.height = "auto";
+    current = null;
+  }
+
+  document.getElementById("send-btn").addEventListener("click", send);
+  input.addEventListener("input", function () {
+    input.style.height = "auto";
+    input.style.height = Math.min(input.scrollHeight, 128) + "px";
+  });
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+})();
+</script>
+</body>
+</html>

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -6,6 +6,7 @@ mod envelope;
 mod error;
 mod handlers;
 mod multipart;
+mod remote;
 mod state;
 mod validation;
 
@@ -13,7 +14,7 @@ use axum::{
     Router,
     extract::DefaultBodyLimit,
     http::StatusCode,
-    routing::{get, post},
+    routing::{any, get, post},
 };
 use std::time::Duration;
 use tower_http::{cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer};
@@ -43,6 +44,16 @@ pub fn router(state: ApiState) -> Router {
         .route("/readyz", get(handlers::health::readyz))
         .route("/healthz", get(handlers::health::healthz))
         .route("/verify", get(handlers::verify::verify))
+        .route("/m", get(handlers::remote::mobile_page))
+        .route(
+            "/v1/remote/pairings",
+            post(handlers::remote::create_pairing),
+        )
+        .route(
+            "/v1/remote/pairings/{code}/claim",
+            post(handlers::remote::claim_pairing),
+        )
+        .route("/v1/remote/link", any(handlers::remote::link))
         .route("/v1/models", get(handlers::models::list_models))
         .route(
             "/v1/notes/transcribe",

--- a/scribe-api/crates/api/src/remote.rs
+++ b/scribe-api/crates/api/src/remote.rs
@@ -1,0 +1,443 @@
+//! In-memory relay that lets a phone (controller) drive a desktop's June
+//! (host) without either device accepting inbound connections. Both reach
+//! scribe-api outbound; the relay pipes JSON frames between them.
+//!
+//! Trust model (deliberately phone-login-free, like the reference UX):
+//! - The desktop is authenticated as an OS Accounts user and mints a pairing.
+//!   That anchors the relay to a real identity on the host end.
+//! - The pairing **code** is a capability: shown only on the trusted desktop,
+//!   single-use, and short-lived. The phone exchanges it for a
+//!   **controller token** scoped to exactly that one pairing, and never signs
+//!   in. Whoever holds the code can drive that host until it is unpaired, so
+//!   the code is treated like a password: short TTL, one claim, never logged.
+//!
+//! Nothing is persisted: a link is live WebSocket state and a pairing is a
+//! few-minute handshake. A server restart drops both; devices reconnect and
+//! re-pair. No user content is ever at rest here.
+
+use rand::Rng;
+use scribe_domain::UserId;
+use std::collections::HashMap;
+use std::sync::{
+    Arc, Mutex, MutexGuard, PoisonError,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::mpsc;
+
+/// How long a pairing code is claimable before it expires, in seconds.
+pub(crate) const PAIRING_TTL_SECONDS: u64 = 180;
+
+/// Locks a mutex, recovering from poisoning. A panic elsewhere can't corrupt
+/// the relay's invariants (worst case a single frame is dropped), so taking
+/// the inner value is safe and keeps the lints' no-`unwrap`/`expect` rule.
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+/// Pairing code length. Crockford base32 (no ambiguous chars); 8 chars is
+/// ~40 bits, unguessable within the TTL while typeable on a phone.
+const CODE_LEN: usize = 8;
+/// Controller-token length. Longer (the phone's standing credential for the
+/// life of the link), still opaque base32.
+const TOKEN_LEN: usize = 32;
+const CODE_ALPHABET: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+pub(crate) type PairingId = String;
+
+#[derive(Clone)]
+struct Pairing {
+    id: PairingId,
+    code: String,
+    user_id: UserId,
+    expires_at_unix: u64,
+    /// Set on claim: the controller token the phone presents on its WS.
+    controller_token: Option<String>,
+}
+
+/// One paired conversation. Each role has a *current* inbox sender, replaced
+/// on every (re)attach, so a reconnecting side gets a fresh channel and a
+/// stale sender from a dropped peer simply has no receiver. Sending to the
+/// peer is a hub lookup, never a captured sender, which is what makes
+/// reconnection safe.
+struct Link {
+    host_inbox: Mutex<Option<mpsc::UnboundedSender<String>>>,
+    controller_inbox: Mutex<Option<mpsc::UnboundedSender<String>>>,
+    host_present: Arc<AtomicBool>,
+    controller_present: Arc<AtomicBool>,
+}
+
+impl Link {
+    fn inbox(&self, role: Role) -> &Mutex<Option<mpsc::UnboundedSender<String>>> {
+        match role {
+            Role::Host => &self.host_inbox,
+            Role::Controller => &self.controller_inbox,
+        }
+    }
+
+    fn present(&self, role: Role) -> &AtomicBool {
+        match role {
+            Role::Host => &self.host_present,
+            Role::Controller => &self.controller_present,
+        }
+    }
+
+    /// Best-effort send to `role`'s current connection. Returns false if that
+    /// role is not attached (no inbox) or its receiver is gone.
+    fn deliver(&self, role: Role, message: String) -> bool {
+        lock(self.inbox(role))
+            .as_ref()
+            .is_some_and(|tx| tx.send(message).is_ok())
+    }
+}
+
+fn peer_of(role: Role) -> Role {
+    match role {
+        Role::Host => Role::Controller,
+        Role::Controller => Role::Host,
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Role {
+    Host,
+    Controller,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AttachError {
+    UnknownPairing,
+    RoleTaken,
+}
+
+pub(crate) struct ClaimedPairing {
+    pub pairing_id: PairingId,
+    pub controller_token: String,
+}
+
+/// What a connected side holds. `recv` yields frames from its peer (and
+/// hub-injected presence frames); `send_to_peer` relays a frame to whoever is
+/// currently attached as the peer. Dropping it frees the role and notifies
+/// the peer (see `PresenceGuard`).
+pub(crate) struct LinkHandle {
+    link: Arc<Link>,
+    role: Role,
+    inbound: mpsc::UnboundedReceiver<String>,
+    _presence: PresenceGuard,
+}
+
+impl LinkHandle {
+    pub(crate) async fn recv(&mut self) -> Option<String> {
+        self.inbound.recv().await
+    }
+
+    /// Relays a frame to the peer. False if the peer is not attached.
+    pub(crate) fn send_to_peer(&self, message: String) -> bool {
+        self.link.deliver(peer_of(self.role), message)
+    }
+}
+
+struct PresenceGuard {
+    link: Arc<Link>,
+    role: Role,
+    leave_frame: &'static str,
+}
+
+impl Drop for PresenceGuard {
+    fn drop(&mut self) {
+        self.link.present(self.role).store(false, Ordering::SeqCst);
+        // Clear our inbox so a stale peer send can't queue into a dead socket.
+        *lock(self.link.inbox(self.role)) = None;
+        // Tell the peer we left.
+        self.link
+            .deliver(peer_of(self.role), self.leave_frame.to_string());
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct RemoteHub {
+    pairings: Mutex<HashMap<PairingId, Pairing>>,
+    links: Mutex<HashMap<PairingId, Arc<Link>>>,
+}
+
+impl RemoteHub {
+    /// Mints a pairing for the authenticated desktop user. `now_unix`/`new_id`
+    /// are injected so the hub is a pure, testable unit.
+    pub(crate) fn create_pairing(
+        &self,
+        user: UserId,
+        now_unix: u64,
+        new_id: PairingId,
+    ) -> (PairingId, String) {
+        self.prune(now_unix);
+        let pairing = Pairing {
+            id: new_id,
+            code: random_token(CODE_LEN),
+            user_id: user,
+            expires_at_unix: now_unix + PAIRING_TTL_SECONDS,
+            controller_token: None,
+        };
+        let result = (pairing.id.clone(), pairing.code.clone());
+        lock(&self.pairings).insert(pairing.id.clone(), pairing);
+        result
+    }
+
+    /// Claims a pairing by code (no auth: the code IS the capability). Returns
+    /// the pairing id and a freshly minted controller token. Single-use: a
+    /// claimed or expired code yields nothing.
+    pub(crate) fn claim_pairing(&self, code: &str, now_unix: u64) -> Option<ClaimedPairing> {
+        let code = code.trim().to_ascii_uppercase();
+        let mut pairings = lock(&self.pairings);
+        let entry = pairings.values_mut().find(|p| p.code == code)?;
+        if entry.controller_token.is_some() || entry.expires_at_unix <= now_unix {
+            return None;
+        }
+        let token = random_token(TOKEN_LEN);
+        entry.controller_token = Some(token.clone());
+        Some(ClaimedPairing {
+            pairing_id: entry.id.clone(),
+            controller_token: token,
+        })
+    }
+
+    /// Host attach: the desktop authenticated as `user`; the pairing must be
+    /// its own and already claimed by a phone.
+    pub(crate) fn attach_host(
+        &self,
+        pairing: &PairingId,
+        user: &UserId,
+    ) -> Result<LinkHandle, AttachError> {
+        {
+            let pairings = lock(&self.pairings);
+            let ok = pairings
+                .get(pairing)
+                .is_some_and(|p| &p.user_id == user && p.controller_token.is_some());
+            if !ok {
+                return Err(AttachError::UnknownPairing);
+            }
+        }
+        self.attach(pairing, Role::Host)
+    }
+
+    /// Controller attach: the phone presents its controller token, which the
+    /// hub resolves to a pairing. No OS Accounts identity needed.
+    pub(crate) fn attach_controller(
+        &self,
+        controller_token: &str,
+    ) -> Result<(PairingId, LinkHandle), AttachError> {
+        let pairing_id = {
+            let pairings = lock(&self.pairings);
+            pairings
+                .values()
+                .find(|p| p.controller_token.as_deref() == Some(controller_token))
+                .map(|p| p.id.clone())
+                .ok_or(AttachError::UnknownPairing)?
+        };
+        let handle = self.attach(&pairing_id, Role::Controller)?;
+        Ok((pairing_id, handle))
+    }
+
+    fn attach(&self, pairing: &PairingId, role: Role) -> Result<LinkHandle, AttachError> {
+        let mut links = lock(&self.links);
+        let link = links
+            .entry(pairing.clone())
+            .or_insert_with(|| {
+                Arc::new(Link {
+                    host_inbox: Mutex::new(None),
+                    controller_inbox: Mutex::new(None),
+                    host_present: Arc::new(AtomicBool::new(false)),
+                    controller_present: Arc::new(AtomicBool::new(false)),
+                })
+            })
+            .clone();
+
+        // Claim the role; a live connection for it is refused.
+        if link.present(role).swap(true, Ordering::SeqCst) {
+            return Err(AttachError::RoleTaken);
+        }
+        // Fresh inbox every attach, so a reconnecting side starts clean.
+        let (inbox_tx, inbox_rx) = mpsc::unbounded_channel();
+        *lock(link.inbox(role)) = Some(inbox_tx);
+
+        let leave_frame = match role {
+            Role::Host => PEER_LEFT_HOST,
+            Role::Controller => PEER_LEFT_CONTROLLER,
+        };
+        Ok(LinkHandle {
+            link: link.clone(),
+            role,
+            inbound: inbox_rx,
+            _presence: PresenceGuard {
+                link,
+                role,
+                leave_frame,
+            },
+        })
+    }
+
+    pub(crate) fn peer_present(&self, pairing: &PairingId, role: Role) -> bool {
+        let links = lock(&self.links);
+        let Some(link) = links.get(pairing) else {
+            return false;
+        };
+        link.present(peer_of(role)).load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn release_if_idle(&self, pairing: &PairingId) {
+        let mut links = lock(&self.links);
+        let idle = links.get(pairing).is_some_and(|link| {
+            !link.host_present.load(Ordering::SeqCst)
+                && !link.controller_present.load(Ordering::SeqCst)
+        });
+        if idle {
+            links.remove(pairing);
+        }
+    }
+
+    fn prune(&self, now_unix: u64) {
+        lock(&self.pairings)
+            .retain(|_, p| p.expires_at_unix > now_unix || p.controller_token.is_some());
+    }
+}
+
+pub(crate) const PEER_LEFT_HOST: &str = r#"{"type":"peer_left","peer":"host"}"#;
+pub(crate) const PEER_LEFT_CONTROLLER: &str = r#"{"type":"peer_left","peer":"controller"}"#;
+pub(crate) const PEER_HERE_HOST: &str = r#"{"type":"peer_here","peer":"host"}"#;
+pub(crate) const PEER_HERE_CONTROLLER: &str = r#"{"type":"peer_here","peer":"controller"}"#;
+
+/// Current wall-clock seconds. The one spot the relay needs real time; the
+/// hub stays clock-free for testing.
+pub(crate) fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// A fresh opaque pairing id (lowercase base36, distinct from the uppercase
+/// human-typed code).
+pub(crate) fn new_pairing_id() -> String {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut rng = rand::thread_rng();
+    (0..24)
+        .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
+        .collect()
+}
+
+fn random_token(len: usize) -> String {
+    let mut rng = rand::thread_rng();
+    (0..len)
+        .map(|_| CODE_ALPHABET[rng.gen_range(0..CODE_ALPHABET.len())] as char)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(id: &str) -> UserId {
+        UserId(id.to_string())
+    }
+
+    #[test]
+    fn pairing_claim_is_single_use_and_case_insensitive() {
+        let hub = RemoteHub::default();
+        let (id, code) = hub.create_pairing(user("usr_a"), 1000, "pair-1".into());
+        assert_eq!(code.len(), CODE_LEN);
+
+        let claim = hub
+            .claim_pairing(&code.to_ascii_lowercase(), 1001)
+            .expect("claim");
+        assert_eq!(claim.pairing_id, id);
+        assert_eq!(claim.controller_token.len(), TOKEN_LEN);
+        // Second claim of the same code fails.
+        assert!(hub.claim_pairing(&code, 1002).is_none());
+    }
+
+    #[test]
+    fn expired_code_cannot_be_claimed() {
+        let hub = RemoteHub::default();
+        let (_, code) = hub.create_pairing(user("usr_a"), 1000, "pair-1".into());
+        let after = 1000 + PAIRING_TTL_SECONDS + 1;
+        assert!(hub.claim_pairing(&code, after).is_none());
+    }
+
+    #[test]
+    fn host_attach_requires_own_claimed_pairing() {
+        let hub = RemoteHub::default();
+        let (id, code) = hub.create_pairing(user("usr_a"), 1000, "pair-1".into());
+
+        // Not claimed yet: host attach refused.
+        assert_eq!(
+            hub.attach_host(&id, &user("usr_a")).err(),
+            Some(AttachError::UnknownPairing)
+        );
+        hub.claim_pairing(&code, 1001);
+        // Wrong user: refused.
+        assert_eq!(
+            hub.attach_host(&id, &user("usr_b")).err(),
+            Some(AttachError::UnknownPairing)
+        );
+        // Owner: ok, and a second host is refused WHILE the first is alive.
+        let first = hub.attach_host(&id, &user("usr_a")).expect("first host");
+        assert_eq!(
+            hub.attach_host(&id, &user("usr_a")).err(),
+            Some(AttachError::RoleTaken)
+        );
+        // Dropping it frees the role: a reconnect succeeds (no panic).
+        drop(first);
+        assert!(hub.attach_host(&id, &user("usr_a")).is_ok());
+    }
+
+    #[test]
+    fn controller_attaches_by_token_only() {
+        let hub = RemoteHub::default();
+        let (id, code) = hub.create_pairing(user("usr_a"), 1000, "pair-1".into());
+        let claim = hub.claim_pairing(&code, 1001).expect("claim");
+
+        assert_eq!(
+            hub.attach_controller("wrong-token").err(),
+            Some(AttachError::UnknownPairing)
+        );
+        let (resolved, _handle) = hub
+            .attach_controller(&claim.controller_token)
+            .expect("controller attaches");
+        assert_eq!(resolved, id);
+    }
+
+    #[tokio::test]
+    async fn frames_relay_and_disconnect_notifies_peer() {
+        let hub = RemoteHub::default();
+        let (id, code) = hub.create_pairing(user("usr_a"), 1000, "pair-1".into());
+        let claim = hub.claim_pairing(&code, 1001).expect("claim");
+
+        let mut host = hub.attach_host(&id, &user("usr_a")).expect("host");
+        let (_, mut controller) = hub
+            .attach_controller(&claim.controller_token)
+            .expect("controller");
+
+        assert!(controller.send_to_peer("prompt".into()));
+        assert_eq!(host.recv().await.as_deref(), Some("prompt"));
+        assert!(host.send_to_peer("delta".into()));
+        assert_eq!(controller.recv().await.as_deref(), Some("delta"));
+
+        drop(host);
+        assert_eq!(controller.recv().await.as_deref(), Some(PEER_LEFT_HOST));
+    }
+
+    #[test]
+    fn peer_present_tracks_attach_and_release() {
+        let hub = RemoteHub::default();
+        let (id, code) = hub.create_pairing(user("usr_a"), 1000, "pair-1".into());
+        let claim = hub.claim_pairing(&code, 1001).expect("claim");
+
+        let host = hub.attach_host(&id, &user("usr_a")).expect("host");
+        assert!(!hub.peer_present(&id, Role::Host));
+        let (_, controller) = hub
+            .attach_controller(&claim.controller_token)
+            .expect("ctrl");
+        assert!(hub.peer_present(&id, Role::Host));
+
+        drop(controller);
+        assert!(!hub.peer_present(&id, Role::Host));
+        drop(host);
+        hub.release_if_idle(&id);
+    }
+}

--- a/scribe-api/crates/api/src/state.rs
+++ b/scribe-api/crates/api/src/state.rs
@@ -1,3 +1,4 @@
+use crate::remote::RemoteHub;
 use scribe_domain::{IssueReportSink, TokenVerifier};
 use scribe_services::{
     AgentChatService, DictateService, NoteGenerateService, NoteTranscribeService, PricingTable,
@@ -17,6 +18,7 @@ struct ApiStateInner {
     agent_chat: Arc<AgentChatService>,
     dictate: Arc<DictateService>,
     issue_reports: Arc<dyn IssueReportSink>,
+    remote: RemoteHub,
     limits: ApiLimits,
     attestation: AttestationInfo,
 }
@@ -62,6 +64,7 @@ impl ApiState {
                 agent_chat: params.agent_chat,
                 dictate: params.dictate,
                 issue_reports: params.issue_reports,
+                remote: RemoteHub::default(),
                 limits: params.limits,
                 attestation: params.attestation,
             }),
@@ -70,6 +73,10 @@ impl ApiState {
 
     pub(crate) fn pricing(&self) -> &PricingTable {
         &self.inner.pricing
+    }
+
+    pub(crate) fn remote(&self) -> &RemoteHub {
+        &self.inner.remote
     }
 
     pub(crate) fn token_verifier(&self) -> &dyn TokenVerifier {

--- a/scribe-api/crates/api/tests/http_boundary.rs
+++ b/scribe-api/crates/api/tests/http_boundary.rs
@@ -692,3 +692,149 @@ impl AgentChatCompleter for FakeChatCompleter {
         })
     }
 }
+
+// ---------------------------------------------------------------------------
+// Remote control relay (pairing + WebSocket).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_create_pairing_requires_auth() -> Result<(), Box<dyn Error>> {
+    let response = match test_router()
+        .oneshot(json_request(
+            "/v1/remote/pairings",
+            &serde_json::json!({}),
+            None,
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_claim_unknown_code_is_404() -> Result<(), Box<dyn Error>> {
+    // Claim is unauthenticated by design (the code is the capability), so the
+    // only failure here is "no such code".
+    let response = match test_router()
+        .oneshot(json_request(
+            "/v1/remote/pairings/NOPENOPE/claim",
+            &serde_json::json!({}),
+            None,
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_remote_relay_pairs_and_relays_both_directions() -> Result<(), Box<dyn Error>> {
+    use futures_util::SinkExt;
+    use tokio_tungstenite::tungstenite::{Message, client::IntoClientRequest};
+
+    // One served instance so pairing state is shared across every call.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let app = test_router();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app.into_make_service()).await;
+    });
+    let base = format!("http://{addr}");
+    let http = reqwest::Client::new();
+
+    // Host (authenticated) mints a pairing.
+    let body: serde_json::Value = http
+        .post(format!("{base}/v1/remote/pairings"))
+        .header("authorization", AUTHORIZATION)
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(body["success"], true);
+    let pairing_id = body["data"]["pairingId"]
+        .as_str()
+        .ok_or("no pairingId")?
+        .to_string();
+    let code = body["data"]["code"].as_str().ok_or("no code")?.to_string();
+
+    // Phone claims it (no auth) and gets a controller token.
+    let claim: serde_json::Value = http
+        .post(format!("{base}/v1/remote/pairings/{code}/claim"))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(claim["success"], true);
+    let controller_token = claim["data"]["controllerToken"]
+        .as_str()
+        .ok_or("no controllerToken")?
+        .to_string();
+
+    // Open the host WS (bearer as subprotocol, role=host).
+    let mut host_req = format!("ws://{addr}/v1/remote/link?role=host&pairing={pairing_id}")
+        .into_client_request()?;
+    host_req
+        .headers_mut()
+        .insert("sec-websocket-protocol", "valid-token".parse()?);
+    let (mut host_ws, _) = tokio_tungstenite::connect_async(host_req).await?;
+
+    // Open the controller WS (controller token as subprotocol).
+    let mut ctrl_req =
+        format!("ws://{addr}/v1/remote/link?role=controller").into_client_request()?;
+    ctrl_req
+        .headers_mut()
+        .insert("sec-websocket-protocol", controller_token.parse()?);
+    let (mut ctrl_ws, _) = tokio_tungstenite::connect_async(ctrl_req).await?;
+
+    // The controller, attaching second, is told the host is already present.
+    let hello = next_text(&mut ctrl_ws).await;
+    assert!(
+        hello.contains("peer_here"),
+        "expected presence, got {hello}"
+    );
+
+    // Phone -> desktop.
+    ctrl_ws
+        .send(Message::Text(
+            r#"{"type":"prompt","text":"summarize my day"}"#.into(),
+        ))
+        .await?;
+    let got = next_text(&mut host_ws).await;
+    assert!(got.contains("summarize my day"));
+
+    // Desktop -> phone.
+    host_ws
+        .send(Message::Text(r#"{"type":"delta","text":"On it."}"#.into()))
+        .await?;
+    let got = next_text(&mut ctrl_ws).await;
+    assert!(got.contains("On it."));
+
+    // Desktop drops: the phone is told its peer left.
+    host_ws.close(None).await?;
+    let left = next_text(&mut ctrl_ws).await;
+    assert!(left.contains("peer_left"), "expected peer_left, got {left}");
+    Ok(())
+}
+
+async fn next_text(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> String {
+    use futures_util::StreamExt;
+    loop {
+        match ws.next().await {
+            Some(Ok(tokio_tungstenite::tungstenite::Message::Text(text))) => {
+                return String::from(text.as_str());
+            }
+            Some(Ok(_)) => {}
+            other => unreachable!("expected a text frame, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -872,6 +872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,6 +3031,7 @@ dependencies = [
  "chrono",
  "cpal",
  "dotenvy",
+ "futures-util",
  "hound",
  "keyring",
  "objc2",
@@ -3046,6 +3053,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "urlencoding",
  "uuid",
@@ -5324,6 +5332,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5560,6 +5584,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ hound = "3.5"
 keyring = { version = "3", features = ["apple-native"] }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-native-roots", "connect"] }
+futures-util = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -564,6 +564,41 @@ pub fn scribe_open_verify_page() -> Result<(), AppError> {
     crate::os_accounts::open_in_browser(&crate::scribe_api::verify_url())
 }
 
+/// Starts "control from your phone": mints a pairing and opens the relay host
+/// socket. Returns the code to show the user (and the mobile URL for a QR).
+#[tauri::command]
+pub async fn remote_start_pairing(
+    app: tauri::AppHandle,
+    host: tauri::State<'_, crate::remote::RemoteHost>,
+) -> Result<crate::remote::RemotePairing, AppError> {
+    crate::remote::start(&app, &host).await
+}
+
+/// Stops remote control and tears down the host socket.
+#[tauri::command]
+pub fn remote_stop(host: tauri::State<'_, crate::remote::RemoteHost>) -> Result<(), AppError> {
+    crate::remote::stop(&host);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn remote_status(
+    host: tauri::State<'_, crate::remote::RemoteHost>,
+) -> crate::remote::RemoteStatus {
+    crate::remote::status(&host)
+}
+
+/// Relays one frame from the webview's agent stream out to the phone. The
+/// webview calls this with `{"type":"delta","text":...}`, `{"type":"done"}`,
+/// etc. as it streams an agent turn.
+#[tauri::command]
+pub fn remote_send(
+    host: tauri::State<'_, crate::remote::RemoteHost>,
+    frame: String,
+) -> Result<(), AppError> {
+    crate::remote::send_to_controller(&host, frame)
+}
+
 #[tauri::command]
 pub async fn open_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod meeting_hud;
 pub mod menu_bar;
 pub mod os_accounts;
 pub mod providers;
+pub mod remote;
 pub mod scribe_api;
 
 use tauri::Emitter;
@@ -116,6 +117,10 @@ pub fn run() {
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,
             commands::scribe_open_verify_page,
+            commands::remote_start_pairing,
+            commands::remote_stop,
+            commands::remote_status,
+            commands::remote_send,
             commands::start_recording,
             commands::pause_recording,
             commands::resume_recording,
@@ -164,6 +169,7 @@ pub fn run() {
         ])
         .manage(hermes_bridge::HermesBridge::default())
         .manage(os_accounts::LoginFlow::default())
+        .manage(remote::RemoteHost::default())
         .setup(|app| {
             setup_app_menu(app)?;
             menu_bar::setup(app)?;

--- a/src-tauri/src/remote.rs
+++ b/src-tauri/src/remote.rs
@@ -1,0 +1,352 @@
+//! Desktop host for "control June from your phone".
+//!
+//! This process is the **host**: it authenticates to scribe-api with the
+//! user's OS Accounts token (which never leaves Rust for the webview) and
+//! holds the relay WebSocket. Inbound controller frames are emitted to the
+//! webview as Tauri events; the webview runs each prompt through the existing
+//! agent session client and hands streamed output back via a command, which
+//! this module relays to the phone. Keeping the socket here is what lets the
+//! agent orchestration stay in the webview without the access token going
+//! with it.
+
+use crate::domain::types::AppError;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::{client::IntoClientRequest, http::header, Message};
+
+/// Emitted to the webview for each prompt the phone sends.
+pub const REMOTE_PROMPT_EVENT: &str = "remote-prompt";
+/// Emitted when the link's connection state changes (paired/connected/closed).
+pub const REMOTE_STATUS_EVENT: &str = "remote-status";
+
+#[derive(Default)]
+pub struct RemoteHost {
+    inner: Mutex<Option<HostSession>>,
+}
+
+struct HostSession {
+    /// Frames to send to the phone (from the webview's agent stream).
+    outbound: mpsc::UnboundedSender<String>,
+    /// Cancels the host WS task.
+    cancel: tokio::sync::watch::Sender<bool>,
+    code: String,
+    mobile_url: String,
+    controller_online: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RemotePairing {
+    pub code: String,
+    pub mobile_url: String,
+    pub expires_in_seconds: u64,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteStatus {
+    pub active: bool,
+    pub code: Option<String>,
+    pub mobile_url: Option<String>,
+    /// True once a phone has connected to the link.
+    pub controller_online: bool,
+}
+
+#[derive(Deserialize)]
+struct CreatePairingData {
+    #[serde(rename = "pairingId")]
+    pairing_id: String,
+    code: String,
+    #[serde(rename = "expiresInSeconds")]
+    expires_in_seconds: u64,
+}
+
+/// Frame the phone sends us. We only act on prompts; everything else is
+/// ignored so the protocol can grow without breaking older hosts.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ControllerFrame {
+    Prompt {
+        text: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+/// Starts (or restarts) the host: mints a pairing, opens the relay socket, and
+/// returns the code to show the user. Idempotent restart: an existing session
+/// is torn down first.
+pub async fn start(app: &AppHandle, host: &RemoteHost) -> Result<RemotePairing, AppError> {
+    stop(host);
+
+    let token = crate::os_accounts::access_token().await?;
+    let api = crate::scribe_api::scribe_api_url();
+    let pairing = mint_pairing(&api, &token).await?;
+    let mobile_url = mobile_url_for(&api);
+
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+    let controller_online = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    {
+        let mut guard = host
+            .inner
+            .lock()
+            .map_err(|_| AppError::new("remote_lock", "Remote host lock poisoned."))?;
+        *guard = Some(HostSession {
+            outbound: outbound_tx,
+            cancel: cancel_tx,
+            code: pairing.code.clone(),
+            mobile_url: mobile_url.clone(),
+            controller_online: controller_online.clone(),
+        });
+    }
+
+    let ws_url = host_ws_url(&api, &pairing.pairing_id);
+    let app = app.clone();
+    tauri::async_runtime::spawn(run_host_socket(RunArgs {
+        app,
+        ws_url,
+        token,
+        outbound_rx,
+        cancel_rx,
+        controller_online,
+    }));
+
+    Ok(RemotePairing {
+        code: pairing.code,
+        mobile_url,
+        expires_in_seconds: pairing.expires_in_seconds,
+    })
+}
+
+/// Tears down the active host session, if any.
+pub fn stop(host: &RemoteHost) {
+    if let Ok(mut guard) = host.inner.lock() {
+        if let Some(session) = guard.take() {
+            let _ = session.cancel.send(true);
+        }
+    }
+}
+
+pub fn status(host: &RemoteHost) -> RemoteStatus {
+    match host.inner.lock() {
+        Ok(guard) => match guard.as_ref() {
+            Some(session) => RemoteStatus {
+                active: true,
+                code: Some(session.code.clone()),
+                mobile_url: Some(session.mobile_url.clone()),
+                controller_online: session
+                    .controller_online
+                    .load(std::sync::atomic::Ordering::SeqCst),
+            },
+            None => RemoteStatus {
+                active: false,
+                code: None,
+                mobile_url: None,
+                controller_online: false,
+            },
+        },
+        Err(_) => RemoteStatus {
+            active: false,
+            code: None,
+            mobile_url: None,
+            controller_online: false,
+        },
+    }
+}
+
+/// Sends a frame from the webview's agent stream out to the phone.
+pub fn send_to_controller(host: &RemoteHost, frame: String) -> Result<(), AppError> {
+    let guard = host
+        .inner
+        .lock()
+        .map_err(|_| AppError::new("remote_lock", "Remote host lock poisoned."))?;
+    let session = guard
+        .as_ref()
+        .ok_or_else(|| AppError::new("remote_inactive", "Remote control is not active."))?;
+    session
+        .outbound
+        .send(frame)
+        .map_err(|_| AppError::new("remote_closed", "Remote link is closed."))
+}
+
+async fn mint_pairing(api: &str, token: &str) -> Result<CreatePairingData, AppError> {
+    let response = crate::scribe_api::http_client()
+        .post(format!("{api}/v1/remote/pairings"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|error| AppError::new("remote_pair_failed", error.to_string()))?;
+    if !response.status().is_success() {
+        return Err(AppError::new(
+            "remote_pair_failed",
+            format!("Pairing request failed with status {}.", response.status()),
+        ));
+    }
+    let envelope: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|error| AppError::new("remote_pair_failed", error.to_string()))?;
+    serde_json::from_value(envelope.get("data").cloned().unwrap_or_default())
+        .map_err(|error| AppError::new("remote_pair_failed", error.to_string()))
+}
+
+struct RunArgs {
+    app: AppHandle,
+    ws_url: String,
+    token: String,
+    outbound_rx: mpsc::UnboundedReceiver<String>,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+    controller_online: Arc<std::sync::atomic::AtomicBool>,
+}
+
+async fn run_host_socket(mut args: RunArgs) {
+    let socket = match connect_host(&args.ws_url, &args.token).await {
+        Ok(socket) => socket,
+        Err(error) => {
+            let _ = args.app.emit(
+                REMOTE_STATUS_EVENT,
+                serde_json::json!({ "active": false, "error": error.message }),
+            );
+            return;
+        }
+    };
+    let (mut sink, mut stream) = socket.split();
+
+    loop {
+        tokio::select! {
+            _ = args.cancel_rx.changed() => {
+                if *args.cancel_rx.borrow() { break; }
+            }
+            outbound = args.outbound_rx.recv() => {
+                match outbound {
+                    Some(text) => {
+                        if sink.send(Message::text(text)).await.is_err() {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            incoming = stream.next() => {
+                match incoming {
+                    Some(Ok(Message::Text(text))) => {
+                        handle_controller_frame(&args.app, &args.controller_online, text.as_str());
+                    }
+                    Some(Ok(Message::Close(_))) | None | Some(Err(_)) => break,
+                    Some(Ok(_)) => {}
+                }
+            }
+        }
+    }
+    let _ = args
+        .app
+        .emit(REMOTE_STATUS_EVENT, serde_json::json!({ "active": false }));
+}
+
+fn handle_controller_frame(
+    app: &AppHandle,
+    controller_online: &Arc<std::sync::atomic::AtomicBool>,
+    text: &str,
+) {
+    // Hub-injected presence frames flip the "phone connected" indicator.
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(text) {
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("peer_here") => {
+                controller_online.store(true, std::sync::atomic::Ordering::SeqCst);
+                let _ = app.emit(
+                    REMOTE_STATUS_EVENT,
+                    serde_json::json!({ "active": true, "controllerOnline": true }),
+                );
+                return;
+            }
+            Some("peer_left") => {
+                controller_online.store(false, std::sync::atomic::Ordering::SeqCst);
+                let _ = app.emit(
+                    REMOTE_STATUS_EVENT,
+                    serde_json::json!({ "active": true, "controllerOnline": false }),
+                );
+                return;
+            }
+            _ => {}
+        }
+    }
+    if let Ok(ControllerFrame::Prompt { text }) = serde_json::from_str::<ControllerFrame>(text) {
+        let _ = app.emit(REMOTE_PROMPT_EVENT, serde_json::json!({ "text": text }));
+    }
+}
+
+async fn connect_host(
+    ws_url: &str,
+    token: &str,
+) -> Result<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    AppError,
+> {
+    let mut request = ws_url
+        .into_client_request()
+        .map_err(|error| AppError::new("remote_ws_failed", error.to_string()))?;
+    // The OS Accounts bearer rides as the WS subprotocol, never the URL.
+    request.headers_mut().insert(
+        header::SEC_WEBSOCKET_PROTOCOL,
+        token
+            .parse()
+            .map_err(|_| AppError::new("remote_ws_failed", "Invalid token for subprotocol."))?,
+    );
+    let (socket, _) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|error| AppError::new("remote_ws_failed", error.to_string()))?;
+    Ok(socket)
+}
+
+fn host_ws_url(api: &str, pairing_id: &str) -> String {
+    let base = api
+        .replacen("https://", "wss://", 1)
+        .replacen("http://", "ws://", 1);
+    format!("{base}/v1/remote/link?role=host&pairing={pairing_id}")
+}
+
+fn mobile_url_for(api: &str) -> String {
+    format!("{api}/m")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_ws_url_upgrades_scheme_and_carries_role() {
+        assert_eq!(
+            host_ws_url("https://scribe-api.example.test", "pair-1"),
+            "wss://scribe-api.example.test/v1/remote/link?role=host&pairing=pair-1"
+        );
+        assert_eq!(
+            host_ws_url("http://127.0.0.1:8080", "pair-1"),
+            "ws://127.0.0.1:8080/v1/remote/link?role=host&pairing=pair-1"
+        );
+    }
+
+    #[test]
+    fn mobile_url_points_at_the_phone_page() {
+        assert_eq!(
+            mobile_url_for("https://scribe-api.example.test"),
+            "https://scribe-api.example.test/m"
+        );
+    }
+
+    #[test]
+    fn prompt_frames_parse_and_others_are_ignored() {
+        assert!(matches!(
+            serde_json::from_str::<ControllerFrame>(r#"{"type":"prompt","text":"hi"}"#),
+            Ok(ControllerFrame::Prompt { text }) if text == "hi"
+        ));
+        assert!(matches!(
+            serde_json::from_str::<ControllerFrame>(r#"{"type":"ping"}"#),
+            Ok(ControllerFrame::Other)
+        ));
+    }
+}

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -890,7 +890,7 @@ where
     ))
 }
 
-fn http_client() -> &'static reqwest::Client {
+pub(crate) fn http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .no_proxy()
@@ -932,7 +932,7 @@ fn title_or_placeholder(title: &str) -> String {
     }
 }
 
-fn scribe_api_url() -> String {
+pub(crate) fn scribe_api_url() -> String {
     crate::os_accounts::load_local_env();
     std::env::var("SCRIBE_API_URL")
         .ok()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -74,6 +74,7 @@ import {
   playRecordingSound,
   preloadRecordingSounds,
 } from "../lib/recording-sounds";
+import { startRemoteBridge } from "../lib/remote-bridge";
 import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_GALLERY_EVENT,
@@ -373,6 +374,14 @@ export function App() {
 
   useEffect(() => {
     preloadRecordingSounds();
+  }, []);
+
+  // The host-side bridge for "control from your phone": idle until a paired
+  // phone sends a prompt, then runs it through the local agent and streams
+  // the reply back. Cheap to keep mounted (it only listens).
+  useEffect(() => {
+    const bridge = startRemoteBridge();
+    return () => bridge.stop();
   }, []);
 
   // The card scroller's thumb fades in with scroll/pointer activity and back

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -48,6 +48,7 @@ import {
   chordFromKeyEvent,
   shortcutFromCapturePayload,
 } from "../shortcuts/use-shortcut-capture";
+import { RemoteControlSection } from "./RemoteControlSection";
 import {
   selectPopoverPlacement,
   selectPopoverStyle,
@@ -1207,6 +1208,8 @@ export function AppSettings({
                     </button>
                   </div>
                 </div>
+
+                <RemoteControlSection />
 
                 {onReportIssue ? (
                   <div className="settings-row">

--- a/src/components/settings/RemoteControlSection.tsx
+++ b/src/components/settings/RemoteControlSection.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  remoteStartPairing,
+  remoteStatus,
+  remoteStop,
+  type RemoteStatus,
+} from "../../lib/tauri";
+
+/**
+ * "Control from your phone": pair a phone to drive June remotely. Starting
+ * mints a code and opens the relay; the user opens the mobile URL on their
+ * phone and types the code. The row reflects live link state (waiting for the
+ * phone, then connected) from the `remote-status` event the host emits.
+ */
+export function RemoteControlSection() {
+  const [status, setStatus] = useState<RemoteStatus>({
+    active: false,
+    controllerOnline: false,
+  });
+  const [code, setCode] = useState<string>();
+  const [mobileUrl, setMobileUrl] = useState<string>();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await remoteStatus();
+      setStatus(next);
+      if (next.active) {
+        setCode(next.code);
+        setMobileUrl(next.mobileUrl);
+      }
+    } catch {
+      // Status is best-effort; leave the last known state.
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const unlisten = listen<RemoteStatus & { error?: string }>(
+      "remote-status",
+      (event) => {
+        const payload = event.payload;
+        if (payload.error) setError(payload.error);
+        // The event carries partial state; merge what it includes.
+        setStatus((current) => ({
+          active: payload.active,
+          code: payload.code ?? current.code,
+          mobileUrl: payload.mobileUrl ?? current.mobileUrl,
+          controllerOnline:
+            payload.controllerOnline ?? current.controllerOnline,
+        }));
+      },
+    );
+    return () => {
+      void unlisten.then((dispose) => dispose());
+    };
+  }, [refresh]);
+
+  async function start() {
+    setError(undefined);
+    setBusy(true);
+    try {
+      const pairing = await remoteStartPairing();
+      setCode(pairing.code);
+      setMobileUrl(pairing.mobileUrl);
+      setStatus({ active: true, code: pairing.code, controllerOnline: false });
+    } catch (caught) {
+      setError(messageFromError(caught));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stop() {
+    setBusy(true);
+    try {
+      await remoteStop();
+      setStatus({ active: false, controllerOnline: false });
+      setCode(undefined);
+    } catch (caught) {
+      setError(messageFromError(caught));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const host = mobileUrl ? hostOf(mobileUrl) : undefined;
+
+  return (
+    <div className="settings-row">
+      <div className="settings-row-info">
+        <h3 className="settings-row-title">Control from your phone</h3>
+        <p className="settings-row-description">
+          Pair your phone to send June tasks while you&apos;re away from your
+          Mac. The agent runs here; your phone just talks to it.
+        </p>
+        {status.active && code ? (
+          <div className="remote-pairing">
+            <p className="remote-pairing-step">
+              On your phone, open{" "}
+              {host ? <strong>{host}/m</strong> : <strong>the June phone page</strong>}{" "}
+              and enter this code:
+            </p>
+            <p className="remote-code" aria-label="Pairing code">
+              {code}
+            </p>
+            <p className="remote-pairing-status" role="status">
+              {status.controllerOnline
+                ? "Your phone is connected."
+                : "Waiting for your phone..."}
+            </p>
+          </div>
+        ) : null}
+        {error ? <p className="welcome-status">{error}</p> : null}
+      </div>
+      <div className="settings-row-control">
+        {status.active ? (
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={busy}
+            onClick={() => void stop()}
+          >
+            {busy ? "Stopping…" : "Stop sharing"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={busy}
+            onClick={() => void start()}
+          >
+            {busy ? "Starting…" : "Pair a phone"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+  }
+}
+
+function messageFromError(error: unknown) {
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}

--- a/src/lib/remote-bridge.ts
+++ b/src/lib/remote-bridge.ts
@@ -1,0 +1,142 @@
+import { listen } from "@tauri-apps/api/event";
+import { HermesGatewayClient } from "./hermes-gateway";
+import type { HermesGatewayEvent } from "./hermes-gateway";
+import {
+  hermesBridgeStatus,
+  remoteSend,
+  startHermesBridge,
+} from "./tauri";
+
+/**
+ * The host-side agent bridge for "control from your phone".
+ *
+ * The Rust host owns the relay socket (so the OS Accounts token stays out of
+ * the webview) and emits a `remote-prompt` event for each prompt the phone
+ * sends. This module runs that prompt through the local agent over the
+ * existing Hermes gateway and streams the agent's output back to the phone via
+ * the `remote_send` command, frame by frame. Reusing the gateway client keeps
+ * remote turns identical to in-app ones.
+ *
+ * One dedicated agent session is reused across remote prompts, so the phone
+ * holds a continuous conversation rather than a fresh context each time.
+ */
+
+type RemotePromptPayload = { text?: string };
+
+/** Maps a live gateway event to the frame the phone should receive, or null
+ * for events the phone doesn't render (tool steps, thinking, presence). Pure,
+ * so the protocol mapping is unit-tested without a live gateway. */
+export function agentEventToRemoteFrame(
+  event: HermesGatewayEvent,
+): string | null {
+  switch (event.type) {
+    case "message.delta": {
+      const text = deltaText(event);
+      return text ? JSON.stringify({ type: "delta", text }) : null;
+    }
+    case "message.complete":
+      return JSON.stringify({ type: "done" });
+    case "error":
+      return JSON.stringify({
+        type: "error",
+        message: deltaText(event) || "The agent hit an error.",
+      });
+    case "approval.request":
+      // Outward actions need a decision the phone can't safely make; tell the
+      // user to finish that step on their Mac rather than auto-approving.
+      return JSON.stringify({
+        type: "message",
+        text: "June needs your approval for the next step. Open June on your Mac to continue.",
+      });
+    default:
+      return null;
+  }
+}
+
+function deltaText(event: HermesGatewayEvent): string {
+  const payload = event.payload as Record<string, unknown> | undefined;
+  if (!payload) return "";
+  for (const key of ["text", "delta", "message", "content"]) {
+    const value = payload[key];
+    if (typeof value === "string" && value) return value;
+  }
+  return "";
+}
+
+export type RemoteBridge = { stop: () => void };
+
+/**
+ * Wires the host bridge: listens for `remote-prompt`, ensures a gateway
+ * connection and a dedicated remote session, and streams each turn back to
+ * the phone. Returns a handle whose `stop()` tears the bridge down.
+ */
+export function startRemoteBridge(): RemoteBridge {
+  let gateway: HermesGatewayClient | undefined;
+  let sessionId: string | undefined;
+  let unEvent: (() => void) | undefined;
+  let stopped = false;
+
+  async function ensureSession(): Promise<{
+    gateway: HermesGatewayClient;
+    sessionId: string;
+  }> {
+    const status = await hermesBridgeStatus();
+    const bridge = status.running ? status : await startHermesBridge();
+    const wsUrl = bridge.connection?.wsUrl;
+    if (!wsUrl) throw new Error("Hermes did not return a gateway URL.");
+    if (!gateway) gateway = new HermesGatewayClient();
+    await gateway.connect(wsUrl);
+    if (!unEvent) {
+      // One subscription forwards every event for our session to the phone.
+      unEvent = gateway.onEvent((event) => {
+        if (event.session_id && event.session_id !== sessionId) return;
+        const frame = agentEventToRemoteFrame(event);
+        if (frame) void remoteSend(frame).catch(() => undefined);
+      });
+    }
+    if (!sessionId) {
+      const created = await gateway.request<{ session_id: string }>(
+        "session.create",
+        {},
+      );
+      sessionId = created.session_id;
+    }
+    return { gateway, sessionId };
+  }
+
+  const promptListener = listen<RemotePromptPayload>(
+    "remote-prompt",
+    (event) => {
+      const text = event.payload?.text?.trim();
+      if (!text || stopped) return;
+      void (async () => {
+        try {
+          const { gateway, sessionId } = await ensureSession();
+          await gateway.request("prompt.submit", {
+            session_id: sessionId,
+            text,
+          });
+        } catch (error) {
+          void remoteSend(
+            JSON.stringify({
+              type: "error",
+              message:
+                error instanceof Error
+                  ? error.message
+                  : "Could not reach the agent.",
+            }),
+          ).catch(() => undefined);
+        }
+      })();
+    },
+  );
+
+  return {
+    stop() {
+      stopped = true;
+      unEvent?.();
+      gateway?.close();
+      void promptListener.then((dispose) => dispose());
+    },
+  };
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -828,6 +828,38 @@ export async function listAgentToolEvents(taskId: string) {
   });
 }
 
+export type RemotePairing = {
+  code: string;
+  mobileUrl: string;
+  expiresInSeconds: number;
+};
+
+export type RemoteStatus = {
+  active: boolean;
+  code?: string;
+  mobileUrl?: string;
+  controllerOnline: boolean;
+};
+
+/** Starts "control from your phone": mints a pairing and opens the relay host
+ * socket. Returns the code to show the user (and the mobile URL for a QR). */
+export async function remoteStartPairing() {
+  return invoke<RemotePairing>("remote_start_pairing");
+}
+
+export async function remoteStop() {
+  return invoke<void>("remote_stop");
+}
+
+export async function remoteStatus() {
+  return invoke<RemoteStatus>("remote_status");
+}
+
+/** Relays one frame from the agent stream out to the phone. */
+export async function remoteSend(frame: string) {
+  return invoke<void>("remote_send", { frame });
+}
+
 export async function hermesBridgeStatus() {
   return invoke<HermesBridgeStatus>("hermes_bridge_status");
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11637,3 +11637,30 @@ input:focus-visible,
   color: var(--success);
   animation: onboarding-rise var(--t-med) var(--ease-out);
 }
+
+/* Control from your phone: the pairing code and link state in Settings. */
+.remote-pairing {
+  margin-top: var(--sp-3);
+  display: grid;
+  gap: var(--sp-1);
+}
+
+.remote-pairing-step {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.remote-code {
+  margin: var(--sp-1) 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 1.6rem;
+  letter-spacing: 0.22em;
+  color: var(--foreground);
+}
+
+.remote-pairing-status {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--muted-foreground);
+}

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -44,6 +44,9 @@ const mocks = vi.hoisted(() => ({
   updateDictionaryEntry: vi.fn(),
   deleteDictionaryEntry: vi.fn(),
   scribeOpenVerifyPage: vi.fn(),
+  remoteStartPairing: vi.fn(),
+  remoteStop: vi.fn(),
+  remoteStatus: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
@@ -80,6 +83,9 @@ vi.mock("../lib/tauri", () => ({
   updateDictionaryEntry: mocks.updateDictionaryEntry,
   deleteDictionaryEntry: mocks.deleteDictionaryEntry,
   scribeOpenVerifyPage: mocks.scribeOpenVerifyPage,
+  remoteStartPairing: mocks.remoteStartPairing,
+  remoteStop: mocks.remoteStop,
+  remoteStatus: mocks.remoteStatus,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -143,6 +149,16 @@ describe("AppSettings", () => {
     }));
     mocks.listDictionaryEntries.mockResolvedValue([]);
     mocks.scribeOpenVerifyPage.mockResolvedValue(undefined);
+    mocks.remoteStatus.mockResolvedValue({
+      active: false,
+      controllerOnline: false,
+    });
+    mocks.remoteStartPairing.mockResolvedValue({
+      code: "AB12CD34",
+      mobileUrl: "https://scribe-api.example.test/m",
+      expiresInSeconds: 180,
+    });
+    mocks.remoteStop.mockResolvedValue(undefined);
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
         transcriptionProvider: "venice",
@@ -1307,6 +1323,35 @@ describe("AppSettings", () => {
       await screen.findByRole("button", { name: "Verify server" }),
     );
     expect(mocks.scribeOpenVerifyPage).toHaveBeenCalledOnce();
+  });
+
+  it("pairs a phone from About and shows the code", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "About" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Pair a phone" }),
+    );
+
+    expect(mocks.remoteStartPairing).toHaveBeenCalledOnce();
+    expect(await screen.findByLabelText("Pairing code")).toHaveTextContent(
+      "AB12CD34",
+    );
+    expect(screen.getByText(/Waiting for your phone/)).toBeInTheDocument();
+    // The mobile host the user opens is surfaced.
+    expect(screen.getByText("scribe-api.example.test/m")).toBeInTheDocument();
   });
 
   it("replays onboarding from About in dev builds", async () => {

--- a/src/test/remote-bridge.test.ts
+++ b/src/test/remote-bridge.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { agentEventToRemoteFrame } from "../lib/remote-bridge";
+import type { HermesGatewayEvent } from "../lib/hermes-gateway";
+
+function event(
+  type: HermesGatewayEvent["type"],
+  payload?: Record<string, unknown>,
+): HermesGatewayEvent {
+  return { type, payload };
+}
+
+describe("agentEventToRemoteFrame", () => {
+  it("streams assistant deltas as delta frames", () => {
+    expect(
+      agentEventToRemoteFrame(event("message.delta", { text: "Hello" })),
+    ).toBe(JSON.stringify({ type: "delta", text: "Hello" }));
+    // Empty deltas produce nothing to send.
+    expect(agentEventToRemoteFrame(event("message.delta", { text: "" }))).toBe(
+      null,
+    );
+  });
+
+  it("ends a turn with a done frame", () => {
+    expect(agentEventToRemoteFrame(event("message.complete"))).toBe(
+      JSON.stringify({ type: "done" }),
+    );
+  });
+
+  it("forwards errors with a message", () => {
+    expect(
+      agentEventToRemoteFrame(event("error", { message: "boom" })),
+    ).toBe(JSON.stringify({ type: "error", message: "boom" }));
+  });
+
+  it("tells the phone to finish approvals on the Mac", () => {
+    const frame = agentEventToRemoteFrame(event("approval.request"));
+    expect(frame).not.toBeNull();
+    const parsed = JSON.parse(frame as string);
+    expect(parsed.type).toBe("message");
+    expect(parsed.text).toMatch(/approval/i);
+  });
+
+  it("drops events the phone does not render", () => {
+    for (const type of [
+      "tool.start",
+      "thinking.delta",
+      "status.update",
+      "gateway.ready",
+    ] as const) {
+      expect(agentEventToRemoteFrame(event(type, { text: "x" }))).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
The "work with June from anywhere" feature from the Slack thread, modeled on Codex-from-anywhere: pair your phone, then send June tasks from it while the agent keeps running on your Mac. Cleaner than Codex's model because OS Accounts already gives both devices a shared identity.

## How it works

Neither device accepts inbound connections (no NAT punching). Both reach scribe-api outbound; the relay matches them.

1. **Mac** (Settings -> About -> "Control from your phone" -> Pair a phone): authenticates as your OS Accounts user, mints a pairing, shows an 8-char code + the mobile host.
2. **Phone**: opens `scribe-api.opensoftware.co/m` (a self-contained web page, no app store), types the code. No phone login: the code is a single-use, 3-minute capability shown only on your trusted Mac, exchanged for a relay-only controller token scoped to that one pairing.
3. **Relay**: pipes JSON frames between the two. Phone sends a prompt -> Mac runs it through the local agent -> streams the reply back token by token.

## Architecture

**scribe-api relay (new, the security boundary, fully tested):**
- In-memory pairing + WS relay (`crates/api/src/remote.rs`). State is inherently live (sockets) or ephemeral (a 3-min code), so nothing is persisted and no user content is at rest. Reconnection-safe: a dropped side's stale sender simply has no receiver, and sending to the peer is a hub lookup, never a captured handle (this fixed a real reconnection panic found in testing).
- Credential rides in `Sec-WebSocket-Protocol`, never the URL (query strings leak to logs). Host presents its OS Accounts bearer; phone presents its controller token.
- `GET /m` serves the mobile client; `POST /v1/remote/pairings` (auth), `POST .../{code}/claim` (no auth), `WS /v1/remote/link`.
- **6 hub unit tests + 3 HTTP/WS integration tests over real TCP sockets** (pair -> claim -> host WS -> controller WS -> bidirectional relay -> peer-left on disconnect). Workspace clippy-clean.

**Desktop host (new):**
- Rust owns the relay socket, so the OS Accounts token never enters the webview. Inbound prompts become `remote-prompt` Tauri events; the webview runs each through the existing Hermes gateway agent session (remote turns are identical to in-app ones) and streams output back via `remote_send`. The token stays in Rust; the agent orchestration stays in the webview.
- Settings pairing UI with live link status; pure agent-event -> phone-frame mapper, unit-tested.

## Trust model, stated plainly

The pairing code is a bearer capability: whoever holds it can drive that Mac until unpaired. It's mitigated like a password (shown only on the authenticated desktop, single-use, short TTL, never logged), and the host end is always anchored to a real OS Accounts identity. Approvals for outward agent actions are deliberately NOT delegated to the phone: the agent tells the phone user to finish those on the Mac.

## What's verified vs. needs a live round-trip

- **Verified in CI:** the entire relay (real-socket integration test), the desktop transport (pairing URL/scheme, frame parsing), the agent-event mapper, the pairing UI. 460+ tests across both stacks, both lint-clean.
- **Needs manual verification (no phone/live gateway in CI):** the end-to-end phone -> relay -> Mac -> agent -> phone loop on a real device. The relay half is proven over sockets; the desktop bridge compiles and its pure parts are tested, but the live prompt->agent->stream path wants a real run.

## Deploy + follow-ups

- Needs the scribe-api CVM redeployed (no new env or volume; just the new routes).
- Follow-ups: a QR code on the pairing screen (today it's code-entry), reconnect/backoff on the host socket, and rate-limiting claims per IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)