### PR TITLE
[codex] Hide native context menu

### DIFF
--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -32,6 +32,7 @@ import {
   agentHudSetLayout,
   agentHudShow,
 } from "./lib/tauri";
+import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import type { HermesSessionInfo } from "./lib/tauri";
 import "./styles/agent-hud.css";
 
@@ -71,6 +72,8 @@ const pillChevron = document.querySelector<HTMLElement>("#agent-hud-chevron");
 const stack = document.querySelector<HTMLElement>("#agent-hud-stack");
 const menu = document.querySelector<HTMLElement>("#agent-hud-menu");
 const hideHud = document.querySelector<HTMLButtonElement>("#agent-hud-hide");
+
+installNativeContextMenuGuard();
 
 const state = {
   enabled: getAgentHudEnabled(),

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -25,6 +25,7 @@ import {
   isOnboardingComplete,
   subscribeToOnboardingComplete,
 } from "./lib/onboarding";
+import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import "./styles/hud.css";
 
 type DictationHudEvent = {
@@ -47,6 +48,9 @@ const appWindow = (() => {
     return undefined;
   }
 })();
+
+installNativeContextMenuGuard();
+
 const hud = document.querySelector<HTMLDivElement>("#hud");
 const dragHandle = document.querySelector<HTMLElement>("#hud-handle");
 const bars = Array.from(document.querySelectorAll<HTMLElement>(".hud-bar"));

--- a/src/lib/native-context-menu.ts
+++ b/src/lib/native-context-menu.ts
@@ -1,0 +1,58 @@
+const EDITABLE_CONTEXT_MENU_SELECTOR =
+  "input, textarea, select, [contenteditable]:not([contenteditable='false'])";
+
+type NativeContextMenuGuardOptions = {
+  isDev?: boolean;
+  allowEditableFields?: boolean;
+};
+
+export function installNativeContextMenuGuard({
+  isDev = import.meta.env.DEV,
+  allowEditableFields = true,
+}: NativeContextMenuGuardOptions = {}) {
+  if (isDev) {
+    return () => {};
+  }
+
+  const handleContextMenu = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (allowEditableFields && isEditableContextMenuTarget(event.target)) {
+      return;
+    }
+
+    event.preventDefault();
+  };
+
+  window.addEventListener("contextmenu", handleContextMenu);
+
+  return () => {
+    window.removeEventListener("contextmenu", handleContextMenu);
+  };
+}
+
+export function isEditableContextMenuTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const editable = target.closest(EDITABLE_CONTEXT_MENU_SELECTOR);
+  if (!editable) {
+    return false;
+  }
+
+  if (
+    editable instanceof HTMLInputElement ||
+    editable instanceof HTMLTextAreaElement
+  ) {
+    return !editable.disabled && !editable.readOnly;
+  }
+
+  if (editable instanceof HTMLSelectElement) {
+    return !editable.disabled;
+  }
+
+  return editable instanceof HTMLElement && editable.isContentEditable;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { Agentation } from "agentation";
 import { App } from "./app/App";
+import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import { replayOnboarding } from "./lib/onboarding";
 import { initTheme } from "./lib/theme";
 import "./styles/app.css";
@@ -20,6 +21,7 @@ if (import.meta.env.DEV) {
 }
 
 initTheme();
+installNativeContextMenuGuard();
 
 // Console driver for the agent HUD overlay window: __agentHud("demo") etc.
 // from this window's devtools. Emits on the Tauri bus only, so fake demo

--- a/src/meeting-hud.ts
+++ b/src/meeting-hud.ts
@@ -12,11 +12,14 @@ import {
 } from "./lib/audio-meter";
 import { meterLevelForSources, visualPeakScale } from "./lib/recorder-levels";
 import type { RecordingStatusDto } from "./lib/tauri";
+import { installNativeContextMenuGuard } from "./lib/native-context-menu";
 import "./styles/meeting-hud.css";
 
 const appWindow = getCurrentWindow();
 const pill = document.querySelector<HTMLDivElement>("#mhud");
 const bars = Array.from(document.querySelectorAll<HTMLElement>(".mhud-bar"));
+
+installNativeContextMenuGuard();
 
 // Shares the dictation HUD's + recorder bar's synthesis, ballistics, and
 // travelling-wave motion so all waveforms move identically.

--- a/src/test/native-context-menu.test.ts
+++ b/src/test/native-context-menu.test.ts
@@ -59,9 +59,31 @@ describe("native context menu guard", () => {
     input.remove();
   });
 
+  it("suppresses editable-field native context menus when editable fields are not allowed", () => {
+    const cleanup = installNativeContextMenuGuard({
+      isDev: false,
+      allowEditableFields: false,
+    });
+    const input = document.createElement("input");
+    document.body.append(input);
+
+    const event = dispatchContextMenu(input);
+
+    expect(event.defaultPrevented).toBe(true);
+    cleanup();
+    input.remove();
+  });
+
   it("does not treat readonly inputs as editable context menu targets", () => {
     const input = document.createElement("input");
     input.readOnly = true;
+
+    expect(isEditableContextMenuTarget(input)).toBe(false);
+  });
+
+  it("does not treat disabled inputs as editable context menu targets", () => {
+    const input = document.createElement("input");
+    input.disabled = true;
 
     expect(isEditableContextMenuTarget(input)).toBe(false);
   });

--- a/src/test/native-context-menu.test.ts
+++ b/src/test/native-context-menu.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  installNativeContextMenuGuard,
+  isEditableContextMenuTarget,
+} from "../lib/native-context-menu";
+
+function dispatchContextMenu(target: Element) {
+  const event = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("native context menu guard", () => {
+  it("suppresses unhandled native context menus in production", () => {
+    const cleanup = installNativeContextMenuGuard({ isDev: false });
+
+    const event = dispatchContextMenu(document.body);
+
+    expect(event.defaultPrevented).toBe(true);
+    cleanup();
+  });
+
+  it("leaves development context menus alone", () => {
+    const cleanup = installNativeContextMenuGuard({ isDev: true });
+
+    const event = dispatchContextMenu(document.body);
+
+    expect(event.defaultPrevented).toBe(false);
+    cleanup();
+  });
+
+  it("does not override app-owned context menus", () => {
+    const cleanup = installNativeContextMenuGuard({ isDev: false });
+    const button = document.createElement("button");
+    document.body.append(button);
+    button.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+    });
+
+    const event = dispatchContextMenu(button);
+
+    expect(event.defaultPrevented).toBe(true);
+    cleanup();
+    button.remove();
+  });
+
+  it("allows editable-field native context menus", () => {
+    const cleanup = installNativeContextMenuGuard({ isDev: false });
+    const input = document.createElement("input");
+    document.body.append(input);
+
+    const event = dispatchContextMenu(input);
+
+    expect(event.defaultPrevented).toBe(false);
+    cleanup();
+    input.remove();
+  });
+
+  it("does not treat readonly inputs as editable context menu targets", () => {
+    const input = document.createElement("input");
+    input.readOnly = true;
+
+    expect(isEditableContextMenuTarget(input)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds a production-only context menu guard across the main app and HUD webviews so unhandled Mac/WebView right-click menus do not expose native browser actions. Existing app-owned context menus and editable-field menus are preserved, and development builds still allow native inspection. Validation: `pnpm vitest run src/test/native-context-menu.test.ts`, `pnpm run lint`, `pnpm test`, and `pnpm run build`.