### PR TITLE
Ask for system audio on the onboarding permissions screen

### DIFF
--- a/onboarding-preview.html
+++ b/onboarding-preview.html
@@ -24,8 +24,9 @@
 
   URL params (for scripted screenshots): ?theme=dark, ?step=<step id>
   (a step jump implies a signed-in account), ?perms=missing|denied
-  (permissions start ungranted; the row actions then grant after a beat,
-  so ?step=permissions&perms=missing walks the real grant dance)
+  (permissions, including system audio, start ungranted; the row actions
+  then grant after a beat, so ?step=permissions&perms=missing walks the
+  real grant dance)
 -->
 <html lang="en">
   <head>
@@ -73,9 +74,9 @@
         const params = new URLSearchParams(location.search);
         const step = params.get("step");
 
-        // ?perms=missing starts both permissions ungranted; ?perms=denied
-        // starts the mic at the System Settings dead end. The row actions
-        // then grant after a beat, like the real TCC dance.
+        // ?perms=missing starts all permissions ungranted; ?perms=denied
+        // starts the mic and system audio at the System Settings dead end.
+        // The row actions then grant after a beat, like the real TCC dance.
         const permsMode = params.get("perms");
         const perms = {
           microphone:
@@ -85,6 +86,12 @@
                 ? "undetermined"
                 : "granted",
           accessibility: permsMode ? "missing" : "granted",
+          systemAudio:
+            permsMode === "denied"
+              ? "denied"
+              : permsMode
+                ? "undetermined"
+                : "granted",
         };
 
         // The wizard always replays in the preview.
@@ -195,13 +202,51 @@
                 return dictationSettings();
               case "open_privacy_settings": {
                 // Pretend the user flips the toggle in System Settings and
-                // comes back; the wizard's poll picks it up.
+                // comes back; the wizard's poll picks it up. System audio
+                // has no poll — the row re-probes on window focus, so fake
+                // the return-to-June focus too.
                 const pane = args.request && args.request.pane;
                 setTimeout(() => {
                   if (pane === "microphone") perms.microphone = "granted";
                   if (pane === "accessibility") perms.accessibility = "granted";
+                  if (pane === "systemAudio") {
+                    perms.systemAudio = "granted";
+                    window.dispatchEvent(new Event("focus"));
+                  }
                 }, 2500);
                 return null;
+              }
+              case "check_recording_source_readiness": {
+                // The real capture-helper probe blocks while macOS shows the
+                // TCC dialog; pretend the user clicks Allow after a beat.
+                await new Promise((resolve) => setTimeout(resolve, 1200));
+                if (perms.systemAudio === "undetermined") {
+                  perms.systemAudio = "granted";
+                }
+                const ready = perms.systemAudio === "granted";
+                return {
+                  sourceMode: "microphonePlusSystem",
+                  ready,
+                  sources: [
+                    {
+                      source: "microphone",
+                      required: true,
+                      ready: true,
+                      permissionState: "granted",
+                      deviceAvailable: true,
+                      captureAvailable: true,
+                    },
+                    {
+                      source: "system",
+                      required: true,
+                      ready,
+                      permissionState: ready ? "unknown" : "denied",
+                      deviceAvailable: ready,
+                      captureAvailable: ready,
+                      recoveryAction: "openSystemAudioSettings",
+                    },
+                  ],
+                };
               }
               case "dictation_helper_command": {
                 const type = args.command && args.command.type;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -877,8 +877,9 @@ export function App() {
   }, [appBlocked]);
 
   // Probe with "microphonePlusSystem" on mount so sourceReadiness always
-  // has the system source. The helper's preflight surfaces the native
-  // TCC prompt on first install as a side-effect of this call.
+  // has the system source. Onboarding's permissions screen normally fires
+  // the native TCC prompt in context; for users who skipped that step the
+  // helper preflight behind this call surfaces it here instead.
   useEffect(() => {
     if (appBlocked) return;
     let cancelled = false;

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -11,7 +11,10 @@ import { PermissionsStep } from "./steps/PermissionSteps";
 import { DictationPracticeStep } from "./steps/PracticeStep";
 import { SignInStep } from "./steps/SignInStep";
 import { TrialStep } from "./steps/TrialStep";
-import { usePermissionStatuses } from "./use-permission-status";
+import {
+  usePermissionStatuses,
+  useSystemAudioStatus,
+} from "./use-permission-status";
 
 type StepId = "sign-in" | "permissions" | "trial" | "dictation-practice";
 
@@ -101,6 +104,10 @@ export function OnboardingFlow({
 
   // Only poll the helper while the user is on the permissions screen.
   const permissionStatuses = usePermissionStatuses(stepId === "permissions");
+  // The probe behind this is also what fires the system-audio TCC prompt
+  // on a fresh install — deliberately run from the permissions screen, in
+  // context, instead of ambushing the user after onboarding.
+  const systemAudio = useSystemAudioStatus(stepId === "permissions");
 
   // Onboarding pitches the bare-fn default, but a version bump replays the
   // wizard for existing users, so it must not clobber a key they customized
@@ -185,7 +192,12 @@ export function OnboardingFlow({
             onContinue={goNext}
           />
         ) : stepId === "permissions" ? (
-          <PermissionsStep statuses={permissionStatuses} onContinue={goNext} />
+          <PermissionsStep
+            statuses={permissionStatuses}
+            systemAudioStatus={systemAudio.status}
+            onAllowSystemAudio={systemAudio.probe}
+            onContinue={goNext}
+          />
         ) : stepId === "trial" ? (
           <TrialStep
             account={account}

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconTextIndicator } from "central-icons/IconTextIndicator";
+import { IconVolumeFull } from "central-icons/IconVolumeFull";
 import {
   dictationHelperCommand,
   openPrivacySettings,
@@ -13,6 +14,7 @@ import {
   isMicrophoneDenied,
   isMicrophoneGranted,
   type PermissionStatuses,
+  type SystemAudioStatus,
 } from "../use-permission-status";
 
 function PermissionRow({
@@ -55,15 +57,26 @@ function PermissionRow({
 
 export function PermissionsStep({
   statuses,
+  systemAudioStatus,
+  onAllowSystemAudio,
   onContinue,
 }: {
   statuses: PermissionStatuses;
+  systemAudioStatus: SystemAudioStatus;
+  /** Re-runs the capture-helper probe; fires the TCC prompt while the
+   * permission is still undetermined. */
+  onAllowSystemAudio: () => void;
   onContinue: () => void;
 }) {
   const [showUnknownStatuses, setShowUnknownStatuses] = useState(false);
   const micGranted = isMicrophoneGranted(statuses);
   const micDenied = isMicrophoneDenied(statuses);
   const accessibilityGranted = isAccessibilityGranted(statuses);
+  const systemAudioGranted = systemAudioStatus === "granted";
+  const systemAudioDenied = systemAudioStatus === "denied";
+  // macOS < 14.2 (or a missing capture helper) can never grant; the row
+  // explains itself and stays out of the Continue gate.
+  const systemAudioUnsupported = systemAudioStatus === "unsupported";
   const showPermissionRows = statuses.checked || showUnknownStatuses;
 
   // Fire the native TCC prompt as soon as the screen shows — the user just
@@ -106,7 +119,7 @@ export function PermissionsStep({
   return (
     <StepCard
       title="Let June listen and type"
-      subtitle="Dictation needs two macOS permissions."
+      subtitle="Dictation and meeting notes need three macOS permissions."
       wide
     >
       <ul
@@ -141,11 +154,35 @@ export function PermissionsStep({
           detail="Types your words at your cursor, in any app."
           onAllow={showPermissionRows ? openAccessibilitySettings : undefined}
         />
+        <PermissionRow
+          icon={<IconVolumeFull size={15} />}
+          granted={showPermissionRows && systemAudioGranted}
+          title="System audio"
+          detail={
+            systemAudioDenied
+              ? "Turned off in System Settings. Flip the toggle and June will notice."
+              : systemAudioUnsupported
+                ? "Needs macOS 14.2 or later."
+                : "Hears your calls and meetings, only while you record."
+          }
+          onAllow={
+            showPermissionRows
+              ? systemAudioDenied
+                ? () => void openPrivacySettings("systemAudio")
+                : systemAudioStatus === "unknown"
+                  ? onAllowSystemAudio
+                  : undefined
+              : undefined
+          }
+        />
       </ul>
       <StepActions
         onContinue={onContinue}
         continueDisabled={
-          !showPermissionRows || !micGranted || !accessibilityGranted
+          !showPermissionRows ||
+          !micGranted ||
+          !accessibilityGranted ||
+          !(systemAudioGranted || systemAudioUnsupported)
         }
         onSkip={onContinue}
       />

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -20,12 +20,16 @@ import {
 function PermissionRow({
   icon,
   granted,
+  probing = false,
   title,
   detail,
   onAllow,
 }: {
   icon: ReactNode;
   granted: boolean;
+  /** A permission check is in flight (the macOS dialog is up or about to
+   * be); the row pulses so the wait reads as activity, not a stall. */
+  probing?: boolean;
   title: string;
   detail: string;
   /** Grant affordance — fires the TCC prompt or opens System Settings;
@@ -33,7 +37,7 @@ function PermissionRow({
   onAllow?: () => void;
 }) {
   return (
-    <li className="onboarding-perm" data-granted={granted}>
+    <li className="onboarding-perm" data-granted={granted} data-probing={probing}>
       <span className="onboarding-perm-icon" aria-hidden>
         {granted ? <IconCheckmark1Small size={15} /> : icon}
       </span>
@@ -157,13 +161,16 @@ export function PermissionsStep({
         <PermissionRow
           icon={<IconVolumeFull size={15} />}
           granted={showPermissionRows && systemAudioGranted}
+          probing={showPermissionRows && systemAudioStatus === "probing"}
           title="System audio"
           detail={
             systemAudioDenied
               ? "Turned off in System Settings. Flip the toggle and June will notice."
               : systemAudioUnsupported
                 ? "Needs macOS 14.2 or later."
-                : "Hears your calls and meetings, only while you record."
+                : systemAudioStatus === "probing"
+                  ? "Waiting for macOS. Approve the prompt when it appears."
+                  : "Hears your calls and meetings, only while you record."
           }
           onAllow={
             showPermissionRows

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -1,7 +1,10 @@
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
-import { dictationHelperCommand } from "../../lib/tauri";
+import {
+  checkRecordingSourceReadiness,
+  dictationHelperCommand,
+} from "../../lib/tauri";
 
 export type PermissionStatuses = {
   /** AVCaptureDevice vocabulary: "granted" | "denied" | "restricted" | "undetermined". */
@@ -37,6 +40,82 @@ export function isAccessibilityGranted(statuses: PermissionStatuses) {
  * screen the whole time, so the usual focus-refresh in App.tsx isn't
  * running yet.
  */
+export type SystemAudioStatus =
+  | "unknown"
+  | "probing"
+  | "granted"
+  | "denied"
+  | "unsupported";
+
+/**
+ * System-audio permission state for the onboarding wizard.
+ *
+ * There is no query-only macOS API for the system-audio TCC entry, so the
+ * only way to learn the state is to run the capture-helper preflight
+ * (checkRecordingSourceReadiness) — on a fresh install that probe is also
+ * what surfaces the native "record system audio" prompt. Running it here,
+ * on the permissions screen, is the point: the user just read why we're
+ * asking, instead of getting hit with the dialog after onboarding ends.
+ */
+export function useSystemAudioStatus(active: boolean): {
+  status: SystemAudioStatus;
+  probe: () => void;
+} {
+  const [status, setStatus] = useState<SystemAudioStatus>("unknown");
+  const statusRef = useRef(status);
+  statusRef.current = status;
+  const inflightRef = useRef(false);
+
+  const probe = useCallback(() => {
+    if (inflightRef.current) return;
+    inflightRef.current = true;
+    // Only the first probe shows the pending row; re-probes after a denial
+    // keep the settled state until the new verdict lands, so the System
+    // Settings hint doesn't flicker away on every window focus.
+    setStatus((prev) => (prev === "unknown" ? "probing" : prev));
+    checkRecordingSourceReadiness("microphonePlusSystem")
+      .then((readiness) => {
+        const system = readiness.sources.find(
+          (source) => source.source === "system",
+        );
+        if (!system || system.permissionState === "unsupported") {
+          setStatus("unsupported");
+        } else {
+          // The probe leaves permissionState "unknown" on success; ready is
+          // the granted signal.
+          setStatus(system.ready ? "granted" : "denied");
+        }
+      })
+      .catch(() => {
+        // IPC failure, not a TCC verdict; back to unknown so the row's
+        // Allow button can retry.
+        setStatus((prev) => (prev === "probing" ? "unknown" : prev));
+      })
+      .finally(() => {
+        inflightRef.current = false;
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!active || statusRef.current !== "unknown") return;
+    probe();
+  }, [active, probe]);
+
+  // A denial is recoverable in System Settings; re-probe when the user
+  // comes back to the window. TCC is determined by then, so this never
+  // re-prompts — it just notices a flipped toggle.
+  useEffect(() => {
+    if (!active) return;
+    function onFocus() {
+      if (statusRef.current === "denied") probe();
+    }
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [active, probe]);
+
+  return { status, probe };
+}
+
 export function usePermissionStatuses(active: boolean): PermissionStatuses {
   const [statuses, setStatuses] = useState<PermissionStatuses>({
     checked: false,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11326,6 +11326,29 @@ input:focus-visible,
   color: var(--warm-strong);
 }
 
+/* A permission check is in flight (the macOS dialog is up, or the capture
+   helper is still starting). Pulse the icon so the disabled Continue reads
+   as "waiting", not broken. */
+.onboarding-perm[data-probing="true"] .onboarding-perm-icon {
+  animation: onboarding-perm-probe 1.4s var(--ease-in-out) infinite;
+}
+
+@keyframes onboarding-perm-probe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-perm[data-probing="true"] .onboarding-perm-icon {
+    animation: none;
+  }
+}
+
 .onboarding-perm-copy h2 {
   margin: 0;
   font-size: var(--fs-lg);

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -13,11 +13,15 @@ import {
   setOnboardingResumeStep,
   subscribeToOnboardingComplete,
 } from "../lib/onboarding";
-import type { AccountStatus } from "../lib/tauri";
+import type {
+  AccountStatus,
+  RecordingSourceReadinessDto,
+} from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
   dictationHelperCommand: vi.fn(),
+  checkRecordingSourceReadiness: vi.fn(),
   openPrivacySettings: vi.fn(),
   setDictationLanguage: vi.fn(),
   setDictationShortcut: vi.fn(),
@@ -34,6 +38,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../lib/tauri", () => ({
   dictationSettings: mocks.dictationSettings,
   dictationHelperCommand: mocks.dictationHelperCommand,
+  checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
   openPrivacySettings: mocks.openPrivacySettings,
   setDictationLanguage: mocks.setDictationLanguage,
   setDictationShortcut: mocks.setDictationShortcut,
@@ -72,6 +77,35 @@ const signedOutAccount: AccountStatus = {
 
 type ListenHandler = (event: { payload: string }) => void;
 
+// What check_recording_source_readiness returns after the capture-helper
+// probe: a passing probe leaves the system permissionState at "unknown" and
+// signals the grant via ready; a denial flips both.
+function systemAudioReadiness(granted: boolean): RecordingSourceReadinessDto {
+  return {
+    sourceMode: "microphonePlusSystem",
+    ready: granted,
+    sources: [
+      {
+        source: "microphone",
+        required: true,
+        ready: true,
+        permissionState: "granted",
+        deviceAvailable: true,
+        captureAvailable: true,
+      },
+      {
+        source: "system",
+        required: true,
+        ready: granted,
+        permissionState: granted ? "unknown" : "denied",
+        deviceAvailable: granted,
+        captureAvailable: granted,
+        recoveryAction: "openSystemAudioSettings",
+      },
+    ],
+  };
+}
+
 function shortcut(label: string) {
   return {
     code: "Fn",
@@ -106,6 +140,9 @@ describe("OnboardingFlow", () => {
       },
     );
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(
+      systemAudioReadiness(true),
+    );
     mocks.openPrivacySettings.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
     mocks.osAccountsPrepareTrialCheckout.mockResolvedValue({
@@ -670,6 +707,62 @@ describe("OnboardingFlow", () => {
       expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
         type: "request_microphone_permission",
       }),
+    );
+  });
+
+  it("probes system audio when the permissions screen shows", async () => {
+    // The probe is what surfaces the system-audio TCC prompt on a fresh
+    // install; it must fire here, in context, not after onboarding.
+    await renderFlow();
+    await waitFor(() =>
+      expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledWith(
+        "microphonePlusSystem",
+      ),
+    );
+  });
+
+  it("keeps continue locked and falls back to settings when system audio is denied", async () => {
+    const user = userEvent.setup();
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(
+      systemAudioReadiness(false),
+    );
+    await renderFlow();
+    grantPermissions();
+
+    await screen.findByText(
+      "Turned off in System Settings. Flip the toggle and June will notice.",
+    );
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+
+    await user.click(
+      screen.getByRole("button", { name: "Allow system audio access" }),
+    );
+    expect(mocks.openPrivacySettings).toHaveBeenCalledWith("systemAudio");
+
+    // The user flips the toggle and comes back; the focus re-probe picks
+    // up the grant.
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(
+      systemAudioReadiness(true),
+    );
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+    );
+  });
+
+  it("does not block continue when system audio is unsupported", async () => {
+    const readiness = systemAudioReadiness(false);
+    readiness.sources[1] = {
+      ...readiness.sources[1],
+      permissionState: "unsupported",
+    };
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(readiness);
+    await renderFlow();
+    grantPermissions();
+
+    await screen.findByText("Needs macOS 14.2 or later.");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
     );
   });
 });

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -752,8 +752,9 @@ describe("OnboardingFlow", () => {
 
   it("does not block continue when system audio is unsupported", async () => {
     const readiness = systemAudioReadiness(false);
-    readiness.sources[1] = {
-      ...readiness.sources[1],
+    const sysIdx = readiness.sources.findIndex((s) => s.source === "system");
+    readiness.sources[sysIdx] = {
+      ...readiness.sources[sysIdx],
       permissionState: "unsupported",
     };
     mocks.checkRecordingSourceReadiness.mockResolvedValue(readiness);


### PR DESCRIPTION
The system-audio TCC prompt used to fire as a side effect of the readiness probe on the app's first mount, hitting users out of the blue right after onboarding. There is no query-only macOS API for this permission, so the capture-helper preflight is both the check and the prompt; this runs it from the onboarding permissions step instead, where the user has just read why June is asking. A new "System audio" row covers the granted, denied, and unsupported states, re-probes on window focus after a denial so a toggle flipped in System Settings gets noticed, and gates Continue (except on macOS versions that cannot grant). The mount-time probe in App.tsx is unchanged and now serves as the fallback for users who skip the step. Includes new tests for the probe, denial, and unsupported paths, plus an updated onboarding preview stub (?step=permissions&perms=missing walks the full grant dance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)