### PR TITLE
[codex] Fix hero chat sidebar resize

### DIFF
--- a/src/app/sidebar-resize.ts
+++ b/src/app/sidebar-resize.ts
@@ -35,7 +35,7 @@ export function handleSidebarResizeStart(
   // offset at the threshold crossing while the grid is still mid-tween, which
   // reads as a flash of misalignment.
   const composer = shell?.querySelector(
-    ".agent-composer",
+    '.agent-composer:not([data-hero="true"])',
   ) as HTMLElement | null;
   const editorFooter = shell?.querySelector(
     ".editor-footer",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2688,23 +2688,27 @@ input:focus-visible,
   flex-shrink: 0;
 }
 
-.app-shell[data-sidebar="collapsed"] .agent-composer {
+.app-shell[data-sidebar="collapsed"] .agent-composer:not([data-hero="true"]) {
   left: calc(var(--sp-3) + var(--sp-8));
 }
 
-.app-shell[data-sidebar-preview="expanded"] .agent-composer {
+.app-shell[data-sidebar-preview="expanded"]
+  .agent-composer:not([data-hero="true"]) {
   left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
-.app-shell[data-sidebar-preview="collapsed"] .agent-composer {
+.app-shell[data-sidebar-preview="collapsed"]
+  .agent-composer:not([data-hero="true"]) {
   left: calc(var(--sp-3) + var(--sp-8));
 }
 
-.app-shell[data-sidebar-preview="opening"] .agent-composer {
+.app-shell[data-sidebar-preview="opening"]
+  .agent-composer:not([data-hero="true"]) {
   left: calc(var(--sidebar-w-current, var(--sidebar-w)) + var(--sp-8));
 }
 
-.app-shell[data-sidebar-transition="smooth"] .agent-composer {
+.app-shell[data-sidebar-transition="smooth"]
+  .agent-composer:not([data-hero="true"]) {
   transition: left var(--t-med) var(--ease-out);
 }
 
@@ -3421,6 +3425,10 @@ input:focus-visible,
 .agent-composer[data-hero="true"] {
   position: relative;
   inset: auto;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
   pointer-events: auto;
 }
 

--- a/src/test/sidebar-resize.test.ts
+++ b/src/test/sidebar-resize.test.ts
@@ -1,13 +1,17 @@
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { handleSidebarResizeStart } from "../app/sidebar-resize";
+import appCss from "../styles/app.css?raw";
 
-function setupResizeDom(sidebarState: "collapsed" | "expanded") {
+function setupResizeDom(
+  sidebarState: "collapsed" | "expanded",
+  composerAttrs = "",
+) {
   document.body.innerHTML = `
     <main class="app-shell" data-sidebar="${sidebarState}">
       <aside class="sidebar"></aside>
       <div class="sidebar-resize-handle"></div>
-      <section class="main-panel"><div class="agent-composer"></div></section>
+      <section class="main-panel"><div class="agent-composer" ${composerAttrs}></div></section>
     </main>
   `;
   return {
@@ -32,6 +36,12 @@ function reactPointerEvent(
     currentTarget: handle,
     preventDefault: vi.fn(),
   } as unknown as ReactPointerEvent<HTMLDivElement>;
+}
+
+function loadAppStyles() {
+  const style = document.createElement("style");
+  style.textContent = appCss.replace(/^@import[^\n]+\n/gm, "");
+  document.head.append(style);
 }
 
 describe("handleSidebarResizeStart", () => {
@@ -141,5 +151,44 @@ describe("handleSidebarResizeStart", () => {
     window.dispatchEvent(pointerEvent("pointerup", 260));
     expect(shell.style.transition).toBe("");
     expect(composer.style.transition).toBe("");
+  });
+
+  it("does not apply docked composer transitions to the new-session hero composer", () => {
+    const { shell, handle, composer } = setupResizeDom(
+      "expanded",
+      'data-hero="true"',
+    );
+
+    handleSidebarResizeStart(reactPointerEvent(handle, 240), 240, {
+      collapseWidth: 160,
+      minWidth: 188,
+      maxWidth: () => 320,
+      onStart: vi.fn(),
+      onEnd: vi.fn(),
+      commit: (fn) => fn(),
+    });
+
+    window.dispatchEvent(pointerEvent("pointermove", 100));
+
+    expect(shell.dataset.sidebarPreview).toBe("collapsed");
+    expect(composer.style.transition).toBe("");
+
+    window.dispatchEvent(pointerEvent("pointerup", 100));
+  });
+
+  it("keeps hero composer offsets auto under sidebar preview CSS", () => {
+    setupResizeDom("expanded", 'data-hero="true"');
+    const shell = document.querySelector(".app-shell") as HTMLElement;
+    const composer = document.querySelector(".agent-composer") as HTMLElement;
+
+    shell.dataset.sidebarPreview = "expanded";
+    loadAppStyles();
+
+    const styles = getComputedStyle(composer);
+    expect(styles.position).toBe("relative");
+    expect(styles.left).toBe("auto");
+    expect(styles.right).toBe("auto");
+    expect(styles.bottom).toBe("auto");
+    expect(styles.top).toBe("auto");
   });
 });


### PR DESCRIPTION
## Summary

Fixes the new-session chat layout drifting during sidebar resize. The resize helper now excludes the hero composer from docked composer transition handling, and the CSS sidebar preview rules only apply to docked composers. The hero composer also explicitly resets fixed offsets to keep it in normal document flow.

## Validation

- pnpm exec vitest run src/test/sidebar-resize.test.ts
- pnpm run lint
- pnpm exec prettier --check src/app/sidebar-resize.ts src/test/sidebar-resize.test.ts src/styles/app.css
- pnpm run build

## Notes

Live browser automation was unavailable in this workspace, so the regression coverage includes both resize helper behavior and the app.css cascade under sidebar preview state.