### PR TITLE
Reveal full model description on hover in catalog card

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4094,6 +4094,26 @@ function ComposerModelPopover({
     [cancelHoverIntent],
   );
   useEffect(() => cancelHoverIntent, [cancelHoverIntent]);
+  // The catalog hover card is interactive (its description carries its own
+  // hover tip for the full, untruncated text), so it cannot vanish the instant
+  // the pointer leaves a row — it has to survive the trip across the gap onto
+  // the card. A short close debounce bridges that gap; entering the card or a
+  // fresh row cancels it.
+  const closeTimerRef = useRef<number | null>(null);
+  const cancelCatalogClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+  const scheduleCatalogClose = useCallback(() => {
+    cancelCatalogClose();
+    closeTimerRef.current = window.setTimeout(
+      () => setCatalogHover(null),
+      MODEL_HOVER_INTENT_MS,
+    );
+  }, [cancelCatalogClose]);
+  useEffect(() => cancelCatalogClose, [cancelCatalogClose]);
   // Position-aware scroll fades on the catalog list, same treatment as the
   // artifact panel body: only when it overflows, only on edges with hidden
   // content.
@@ -4178,6 +4198,7 @@ function ComposerModelPopover({
       : undefined;
 
   function showCatalogHover(option: VeniceModelDto, row: HTMLElement) {
+    cancelCatalogClose();
     const panel = flyoutRef.current;
     if (!panel) return;
     const rowRect = row.getBoundingClientRect();
@@ -4323,7 +4344,7 @@ function ComposerModelPopover({
           aria-label="All text models"
           onMouseLeave={() => {
             cancelHoverIntent();
-            setCatalogHover(null);
+            scheduleCatalogClose();
           }}
         >
           <div className="agent-composer-model-surface">
@@ -4361,6 +4382,7 @@ function ComposerModelPopover({
                       selected={option.id === model.id}
                       onSelect={onSelect}
                       onHover={(hoverModel, row, immediate) => {
+                        cancelCatalogClose();
                         if (immediate) {
                           cancelHoverIntent();
                           showCatalogHover(hoverModel, row);
@@ -4384,6 +4406,8 @@ function ComposerModelPopover({
         <div
           className="agent-composer-model-hovercard agent-composer-model-detail"
           data-side={catalogHover.side}
+          onMouseEnter={cancelCatalogClose}
+          onMouseLeave={scheduleCatalogClose}
           style={
             catalogHover.side === "right"
               ? { top: catalogHover.top, left: catalogHover.x }
@@ -4445,9 +4469,35 @@ function ComposerModelCardContent({
         <p className="agent-composer-model-detail-values">{values}</p>
       ) : null}
       {withDescription && model.description ? (
-        <p className="agent-composer-model-detail-desc">{model.description}</p>
+        <ComposerModelDescription text={model.description} />
       ) : null}
     </>
+  );
+}
+
+// The catalog card clamps the description to two lines so it stays compact.
+// When that clamp actually hides text, the row becomes its own hover tip
+// carrying the full copy — hover the truncated blurb to read the rest. The tip
+// only attaches when the text is clipped, so short descriptions don't get a
+// redundant repeat of what's already fully visible.
+function ComposerModelDescription({ text }: { text: string }) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const [clamped, setClamped] = useState(false);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el) setClamped(el.scrollHeight - el.clientHeight > 1);
+  }, [text]);
+  const body = (
+    <span ref={ref} className="agent-composer-model-detail-desc">
+      {text}
+    </span>
+  );
+  return clamped ? (
+    <HoverTip tip={text} className="agent-composer-model-detail-desc-tip">
+      {body}
+    </HoverTip>
+  ) : (
+    body
   );
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2968,15 +2968,23 @@ input:focus-visible,
   line-height: 1.4;
 }
 
+/* When the description is clamped it's wrapped in a HoverTip; the wrapper span
+ * must stretch so the clamped text keeps the card's full width (an inline span
+ * would shrink-wrap and throw off the two-line measurement). */
+.agent-composer-model-detail-desc-tip {
+  display: block;
+}
+
 /* The catalog rows' hover card — same body as the suggested-model detail
  * card, but fixed-positioned beside the hovered row (set from JS) so it can
  * escape the panel's clipping and tracks the pointer like Codex's item
- * tooltips. Non-interactive on purpose. */
+ * tooltips. Interactive so the pointer can reach its (clamped) description and
+ * its hover tip; a close debounce keeps it alive across the gap from the row. */
 .agent-composer-model-hovercard {
   position: fixed;
   z-index: 3;
   display: block;
-  pointer-events: none;
+  pointer-events: auto;
   color: var(--popover-foreground);
   /* Keep the hover card above the panel so the panel shadow/fade cannot wash
    * over the card. Clip only the side facing the panel; the other three sides


### PR DESCRIPTION
The third-level catalog hover card in the composer's model picker clamps each model's description to two lines, so longer blurbs were cut off with no way to read the rest. This makes the card interactive (it was `pointer-events: none`) and attaches a `HoverTip` carrying the full untruncated text, but only when the clamp actually hides content so short descriptions don't get a redundant repeat. A short close debounce keeps the card alive as the pointer crosses the gap from the row onto the card, and a CSS tweak keeps the wrapped description at full width so the two-line measurement stays correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)