### PR TITLE
Render delegated subagents in the agent chat (they were dropped)

### DIFF
--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -384,6 +384,60 @@ function appendLiveHermesEvents(
       continue;
     }
 
+    if (event.type.startsWith("subagent.")) {
+      // Delegated subagents (the model's `delegate_task`) stream their own
+      // lifecycle: subagent.start / .tool / .progress / .thinking / .complete,
+      // each carrying the subagent's goal and identity. The gateway forwards
+      // them over the same socket as everything else; without this branch they
+      // were silently dropped and the spawn never appeared in the chat. Render
+      // each subagent as a tool-style row keyed by its id, so N parallel
+      // subagents show as N live rows that resolve as they finish.
+      if (!currentAssistant) {
+        currentAssistant = createAssistantTurn(turns, event.receivedAt);
+        toolCreatedTurns.add(currentAssistant);
+      }
+      const payload = event.payload as Record<string, unknown> | undefined;
+      const subagentId = stringValue(payload?.subagent_id);
+      const taskIndexRaw = payload?.task_index;
+      const taskIndex =
+        typeof taskIndexRaw === "number" ? taskIndexRaw : undefined;
+      const key = subagentId ?? (taskIndex !== undefined ? `task-${taskIndex}` : "subagent");
+      const goal = stringValue(payload?.goal);
+      const taskCountRaw = payload?.task_count;
+      const taskCount =
+        typeof taskCountRaw === "number" ? taskCountRaw : undefined;
+      const label = goal
+        ? `Subagent: ${goal}`
+        : taskCount && taskCount > 1 && taskIndex !== undefined
+          ? `Subagent ${taskIndex + 1} of ${taskCount}`
+          : "Subagent";
+      const completed = event.type === "subagent.complete";
+      const reportedStatus = stringValue(payload?.status)?.toLowerCase();
+      const status: AgentChatToolPart["status"] = completed
+        ? reportedStatus && /fail|error|interrupt/.test(reportedStatus)
+          ? "failed"
+          : "complete"
+        : "running";
+      if (status === "running") {
+        currentAssistant.status = "running";
+      } else if (toolCreatedTurns.has(currentAssistant)) {
+        currentAssistant.status = "complete";
+      }
+      // The live line: a completion summary, else whatever the subagent is
+      // doing now (its latest tool preview).
+      const activity =
+        stringValue(payload?.summary) ??
+        stringValue(payload?.tool_preview) ??
+        (event.type === "subagent.complete" ? undefined : stringValue(payload?.text));
+      upsertToolPart(currentAssistant.parts, {
+        id: `subagent:${key}`,
+        name: label,
+        text: activity ?? "",
+        status,
+      });
+      continue;
+    }
+
     if (event.type.startsWith("tool.")) {
       if (isClarifyToolEvent(event)) {
         if (event.type.includes("complete") || event.type.includes("fail")) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -401,20 +401,39 @@ function appendLiveHermesEvents(
       const taskIndexRaw = payload?.task_index;
       const taskIndex =
         typeof taskIndexRaw === "number" ? taskIndexRaw : undefined;
-      const key = subagentId ?? (taskIndex !== undefined ? `task-${taskIndex}` : "subagent");
+      const key =
+        subagentId ?? (taskIndex !== undefined ? `task-${taskIndex}` : "subagent");
+      const partId = `subagent:${key}`;
       const goal = stringValue(payload?.goal);
       const taskCountRaw = payload?.task_count;
       const taskCount =
         typeof taskCountRaw === "number" ? taskCountRaw : undefined;
+      // Keep the richest label we have seen for this subagent: progress and
+      // tool events often omit the goal, and downgrading to the generic
+      // "Subagent" would make the row flicker. Prefer the goal, else the name
+      // already shown, else a task-position label.
+      const existingName = currentAssistant.parts.find(
+        (part): part is AgentChatToolPart =>
+          part.type === "tool" && part.id === partId,
+      )?.name;
       const label = goal
         ? `Subagent: ${goal}`
-        : taskCount && taskCount > 1 && taskIndex !== undefined
-          ? `Subagent ${taskIndex + 1} of ${taskCount}`
-          : "Subagent";
-      const completed = event.type === "subagent.complete";
-      const reportedStatus = stringValue(payload?.status)?.toLowerCase();
+        : (existingName ??
+          (taskCount && taskCount > 1 && taskIndex !== undefined
+            ? `Subagent ${taskIndex + 1} of ${taskCount}`
+            : "Subagent"));
+      // Terminal on `subagent.complete` or any failure-flavored subtype the
+      // gateway might add (fail/cancel/timeout/abort/interrupt). Keyed off the
+      // subtype, not a fixed allow-list, so a new terminal event can't strand
+      // a row as "running" forever.
+      const subtype = event.type.slice("subagent.".length).toLowerCase();
+      const reportedStatus = stringValue(payload?.status)?.toLowerCase() ?? "";
+      const failurePattern = /fail|error|cancel|timeout|abort|interrupt/;
+      const failed =
+        failurePattern.test(subtype) || failurePattern.test(reportedStatus);
+      const completed = subtype === "complete" || subtype === "done" || failed;
       const status: AgentChatToolPart["status"] = completed
-        ? reportedStatus && /fail|error|interrupt/.test(reportedStatus)
+        ? failed
           ? "failed"
           : "complete"
         : "running";
@@ -428,9 +447,9 @@ function appendLiveHermesEvents(
       const activity =
         stringValue(payload?.summary) ??
         stringValue(payload?.tool_preview) ??
-        (event.type === "subagent.complete" ? undefined : stringValue(payload?.text));
+        (completed ? undefined : stringValue(payload?.text));
       upsertToolPart(currentAssistant.parts, {
-        id: `subagent:${key}`,
+        id: partId,
         name: label,
         text: activity ?? "",
         status,

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -14,6 +14,11 @@ export type HermesGatewayEventName =
   | "clarify.response"
   | "approval.request"
   | "approval.response"
+  | "subagent.start"
+  | "subagent.tool"
+  | "subagent.progress"
+  | "subagent.thinking"
+  | "subagent.complete"
   | "error"
   | (string & {});
 

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -977,6 +977,57 @@ describe("Agent chat runtime", () => {
     expect((tools?.[0] as { text?: string }).text).toContain("Done: 1 file written");
   });
 
+  it("keeps the goal label when a later subagent event omits it", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "subagent.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { subagent_id: "sa-1", goal: "Write the privacy page" },
+        },
+        // A tool event carrying only the id + preview, no goal.
+        {
+          type: "subagent.tool",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { subagent_id: "sa-1", tool_preview: "edit privacy.tsx" },
+        },
+      ],
+    );
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    // The richer label must survive the goal-less follow-up (no flicker).
+    expect(tool).toMatchObject({
+      name: "Subagent: Write the privacy page",
+      status: "running",
+    });
+  });
+
+  it("resolves a failure-flavored terminal subtype instead of staying running", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "subagent.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { subagent_id: "sa-1", goal: "Write the privacy page" },
+        },
+        // A subtype not in the documented union; must still terminate the row.
+        {
+          type: "subagent.timeout",
+          receivedAt: "2026-06-04T10:00:05.000Z",
+          payload: { subagent_id: "sa-1" },
+        },
+      ],
+    );
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    expect(tool).toMatchObject({
+      name: "Subagent: Write the privacy page",
+      status: "failed",
+    });
+  });
+
   it("labels a goal-less subagent by its task position and marks failures", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -920,4 +920,85 @@ describe("Agent chat runtime", () => {
       { type: "text", text: prose, status: "complete" },
     ]);
   });
+
+  it("renders delegated subagents as live tool rows (regression: silently dropped)", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "subagent.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            subagent_id: "sa-1",
+            task_index: 0,
+            task_count: 2,
+            goal: "Write the privacy page",
+          },
+        },
+        {
+          type: "subagent.start",
+          receivedAt: "2026-06-04T10:00:00.050Z",
+          payload: {
+            subagent_id: "sa-2",
+            task_index: 1,
+            task_count: 2,
+            goal: "Write the terms page",
+          },
+        },
+        {
+          type: "subagent.tool",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { subagent_id: "sa-1", goal: "Write the privacy page", tool_preview: "edit privacy.tsx" },
+        },
+        {
+          type: "subagent.complete",
+          receivedAt: "2026-06-04T10:00:02.000Z",
+          payload: { subagent_id: "sa-1", goal: "Write the privacy page", summary: "Done: 1 file written" },
+        },
+      ],
+    );
+
+    const tools = turns[0]?.parts.filter((part) => part.type === "tool");
+    expect(tools).toHaveLength(2);
+    // Two parallel subagents, keyed by id, each labeled by its goal.
+    expect(tools?.[0]).toMatchObject({
+      id: "subagent:sa-1",
+      name: "Subagent: Write the privacy page",
+      status: "complete",
+    });
+    expect(tools?.[1]).toMatchObject({
+      id: "subagent:sa-2",
+      name: "Subagent: Write the terms page",
+      status: "running",
+    });
+    // The first subagent's row accumulated its activity then its summary.
+    expect((tools?.[0] as { text?: string }).text).toContain("edit privacy.tsx");
+    expect((tools?.[0] as { text?: string }).text).toContain("Done: 1 file written");
+  });
+
+  it("labels a goal-less subagent by its task position and marks failures", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "subagent.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { task_index: 2, task_count: 5 },
+        },
+        {
+          type: "subagent.complete",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: { task_index: 2, task_count: 5, status: "failed" },
+        },
+      ],
+    );
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    expect(tool).toMatchObject({
+      id: "subagent:task-2",
+      name: "Subagent 3 of 5",
+      status: "failed",
+    });
+  });
 });


### PR DESCRIPTION
Fixes the screenshot: the agent says "Let me use subagents to write all 5 pages in parallel" and then nothing renders.

## Root cause (traced into the runtime, not guessed)

When the agent delegates to parallel subagents (`delegate_task`), the Hermes gateway streams `subagent.start` / `.tool` / `.progress` / `.thinking` / `.complete` events over the **same `/api/ws` socket** June's chat already consumes (confirmed at `tui_gateway/server.py:1871`, which emits each with a payload of `goal`, `subagent_id`, `task_index`, `task_count`, `status`, `summary`, ...). 

But the chat reducer (`agent-chat-runtime.ts`) only matched `message.*`, `thinking/reasoning.delta`, `tool.*`, `clarify.*`, `approval.*`, and `error` - with **no fallback branch**. Every `subagent.*` event fell through the loop and was silently discarded. The events were arriving; the client was throwing them away.

So this is entirely a frontend fix - no change to the bundled Python runtime.

## The fix

Add a `subagent.*` branch to the reducer that maps each subagent onto the existing, already-rendered tool-part model, keyed by `subagent_id` (falling back to `task-<index>`):

- `subagent.start` -> a live row labeled by the goal ("Subagent: Write the privacy page"), or "Subagent N of M" when no goal is given.
- `subagent.tool` / `.progress` / `.thinking` -> the row stays running and accumulates its activity (the latest tool preview).
- `subagent.complete` -> resolves to **complete**, or **failed** when the payload status says so, appending the summary.

Five parallel subagents now show as five live rows that resolve as each finishes. No new component, no new part type - it reuses the tool-row rendering every other tool call already uses, so it inherits the existing styling and collapse behavior.

## Testing

- Two reducer tests: the parallel-spawn case (two subagents keyed by id, one streaming-then-complete with accumulated activity + summary, one still running) and the goal-less/failed case ("Subagent 3 of 5", status failed).
- Also added the `subagent.*` names to the `HermesGatewayEventName` union for documentation.
- 430/430 frontend tests pass, lint clean.

Worth a live confirmation once merged: spawn subagents in a real session and watch the rows appear - the reducer is verified against the runtime's actual event shape, but a real delegate_task run is the final proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)