### PR TITLE
Defer the system audio permission prompt to the first record action

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -550,9 +550,11 @@ pub async fn check_recording_source_readiness(
     // The system-audio permission probe can block for over a minute while the
     // helper waits on a CoreAudio permission grant; keep that work off the
     // async runtime so other commands stay responsive.
-    tokio::task::spawn_blocking(move || recording_source_readiness(request.source_mode))
-        .await
-        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
+    tokio::task::spawn_blocking(move || {
+        recording_source_readiness(request.source_mode, request.probe_system_permission)
+    })
+    .await
+    .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
 }
 
 /// Opens the scribe-api `/verify` page (enclave attestation, routing,
@@ -614,9 +616,10 @@ pub async fn start_recording(
     let source_mode = request.source_mode.unwrap_or_default();
     // Readiness probing and capture startup both wait on the system-audio
     // helper (up to tens of seconds); run them off the async runtime.
-    let readiness = tokio::task::spawn_blocking(move || recording_source_readiness(source_mode))
-        .await
-        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))?;
+    let readiness =
+        tokio::task::spawn_blocking(move || recording_source_readiness(source_mode, true))
+            .await
+            .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))?;
     if !readiness.ready {
         let message = readiness
             .sources
@@ -974,7 +977,10 @@ async fn finish_recording_session(
     })
 }
 
-fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSourceReadinessDto {
+fn recording_source_readiness(
+    source_mode: RecordingSourceMode,
+    probe_system_permission: bool,
+) -> RecordingSourceReadinessDto {
     let (microphone_state, microphone_hint) = microphone_permission_state();
     let microphone_ready = microphone_state == "granted";
     let mut sources = vec![SourceReadinessDto {
@@ -991,7 +997,11 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
         let mut system = crate::audio::system_macos::system_audio_readiness();
-        if should_probe_system_audio_permission(system.ready, is_capture_active()) {
+        if should_probe_system_audio_permission(
+            probe_system_permission,
+            system.ready,
+            is_capture_active(),
+        ) {
             if let Err(error) = crate::audio::system_macos::helper_permission_check() {
                 system.ready = false;
                 system.permission_state = "denied".to_string();
@@ -1012,8 +1022,16 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     }
 }
 
-fn should_probe_system_audio_permission(system_ready: bool, capture_active: bool) -> bool {
-    system_ready && !capture_active
+// Launching the helper is what surfaces the native TCC prompt, so it only
+// runs when the caller explicitly asked for it (user-initiated actions, not
+// passive readiness reads) — and never mid-capture, where a second helper
+// instance would fight the active one.
+fn should_probe_system_audio_permission(
+    probe_requested: bool,
+    system_ready: bool,
+    capture_active: bool,
+) -> bool {
+    probe_requested && system_ready && !capture_active
 }
 
 #[tauri::command]
@@ -1545,12 +1563,17 @@ mod tests {
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
-        assert!(!should_probe_system_audio_permission(true, true));
+        assert!(!should_probe_system_audio_permission(true, true, true));
     }
 
     #[test]
     fn probes_system_audio_permission_only_when_available_and_idle() {
-        assert!(should_probe_system_audio_permission(true, false));
-        assert!(!should_probe_system_audio_permission(false, false));
+        assert!(should_probe_system_audio_permission(true, true, false));
+        assert!(!should_probe_system_audio_permission(true, false, false));
+    }
+
+    #[test]
+    fn skips_system_audio_permission_probe_unless_requested() {
+        assert!(!should_probe_system_audio_permission(false, true, false));
     }
 }

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -294,6 +294,13 @@ pub struct MicrophonePermissionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct CheckRecordingSourceReadinessRequest {
     pub source_mode: RecordingSourceMode,
+    /// When true, launch the system-audio helper to verify the TCC grant —
+    /// this surfaces the native permission prompt on first run, so callers
+    /// must only set it on an explicit user action (starting a recording,
+    /// retrying after a denial). Passive callers get device/version
+    /// readiness with permission_state "unknown".
+    #[serde(default)]
+    pub probe_system_permission: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -876,9 +876,12 @@ export function App() {
       .catch((err: unknown) => setError(messageFromError(err)));
   }, [appBlocked]);
 
-  // Probe with "microphonePlusSystem" on mount so sourceReadiness always
-  // has the system source. The helper's preflight surfaces the native
-  // TCC prompt on first install as a side-effect of this call.
+  // Passive check with "microphonePlusSystem" on mount so sourceReadiness
+  // always has the system source. Deliberately not a permission probe: the
+  // probe launches the helper, which fires the native "record system audio"
+  // TCC prompt out of the blue on first launch after onboarding. The prompt
+  // belongs to the moment the user starts a recording (handleStartRecording
+  // probes for real).
   useEffect(() => {
     if (appBlocked) return;
     let cancelled = false;
@@ -917,6 +920,16 @@ export function App() {
   // common case where the user flipped a toggle in System Settings and
   // returns to June. The helper poll is what surfaces fresh mic /
   // accessibility state via the dictation-event listener above.
+  // System audio only probes (helper launch) after an observed denial:
+  // that's the one state a passive check can't move past, and a denied TCC
+  // entry never re-prompts, so the probe stays invisible. Everywhere else
+  // the check is passive, so app focus never pops the permission dialog.
+  const systemPermissionBlocked = sourceReadiness?.sources.some(
+    (source) =>
+      source.source === "system" &&
+      (source.permissionState === "denied" ||
+        source.permissionState === "restricted"),
+  );
   useEffect(() => {
     if (appBlocked) return;
     const recordingState = state.recordingStatus?.state;
@@ -930,13 +943,15 @@ export function App() {
         () => undefined,
       );
       if (captureActive) return;
-      void checkRecordingSourceReadiness("microphonePlusSystem")
+      void checkRecordingSourceReadiness("microphonePlusSystem", {
+        probeSystemPermission: systemPermissionBlocked,
+      })
         .then(setSourceReadiness)
         .catch(() => undefined);
     }
     window.addEventListener("focus", refresh);
     return () => window.removeEventListener("focus", refresh);
-  }, [appBlocked, state.recordingStatus?.state]);
+  }, [appBlocked, state.recordingStatus?.state, systemPermissionBlocked]);
 
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");
@@ -1423,7 +1438,12 @@ export function App() {
     });
     try {
       setCheckingSourceReadiness(true);
-      const readiness = await checkRecordingSourceReadiness(sourceMode);
+      // The probe is what surfaces the system-audio TCC prompt on first
+      // use — it lives here, on the user's explicit record action, rather
+      // than at app launch.
+      const readiness = await checkRecordingSourceReadiness(sourceMode, {
+        probeSystemPermission: true,
+      });
       setSourceReadiness(readiness);
 
       const micSource = readiness.sources.find(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1013,11 +1013,23 @@ export async function updateNote(input: {
 
 export async function checkRecordingSourceReadiness(
   sourceMode: RecordingSourceMode,
+  options?: {
+    /**
+     * Launches the system-audio helper to verify the TCC grant, which
+     * surfaces the native permission prompt on first run. Only set this on
+     * an explicit user action (starting a recording, retrying after a
+     * denial) — passive readiness reads must leave it off.
+     */
+    probeSystemPermission?: boolean;
+  },
 ) {
   return invoke<RecordingSourceReadinessDto>(
     "check_recording_source_readiness",
     {
-      request: { sourceMode },
+      request: {
+        sourceMode,
+        probeSystemPermission: options?.probeSystemPermission ?? false,
+      },
     },
   );
 }

--- a/src/test/tauri-contract.test.ts
+++ b/src/test/tauri-contract.test.ts
@@ -47,20 +47,39 @@ describe("Tauri command contracts", () => {
 
   it("sends recording lifecycle commands with stable request shapes", async () => {
     await checkRecordingSourceReadiness("microphonePlusSystem");
+    await checkRecordingSourceReadiness("microphonePlusSystem", {
+      probeSystemPermission: true,
+    });
     await startRecording("note-1", "microphonePlusSystem");
     await finishRecording("session-1");
 
+    // The readiness check defaults to passive — probing launches the
+    // system-audio helper and fires the native TCC prompt, so it has to be
+    // opted into per call.
     expect(mocks.invoke).toHaveBeenNthCalledWith(
       1,
       "check_recording_source_readiness",
       {
-        request: { sourceMode: "microphonePlusSystem" },
+        request: {
+          sourceMode: "microphonePlusSystem",
+          probeSystemPermission: false,
+        },
       },
     );
-    expect(mocks.invoke).toHaveBeenNthCalledWith(2, "start_recording", {
+    expect(mocks.invoke).toHaveBeenNthCalledWith(
+      2,
+      "check_recording_source_readiness",
+      {
+        request: {
+          sourceMode: "microphonePlusSystem",
+          probeSystemPermission: true,
+        },
+      },
+    );
+    expect(mocks.invoke).toHaveBeenNthCalledWith(3, "start_recording", {
       request: { noteId: "note-1", sourceMode: "microphonePlusSystem" },
     });
-    expect(mocks.invoke).toHaveBeenNthCalledWith(3, "finish_recording", {
+    expect(mocks.invoke).toHaveBeenNthCalledWith(4, "finish_recording", {
       request: { sessionId: "session-1" },
     });
   });


### PR DESCRIPTION
## Problem

> when a user first opens June after the onboarding, they get hit with "June would like to record system audio" permission out of the blue

The post-onboarding mount effect in `App.tsx` called `check_recording_source_readiness("microphonePlusSystem")`, and that command unconditionally launched the system-audio capture helper to verify the TCC grant. Launching the helper is what fires the native permission prompt, so fresh installs saw it at app open instead of when they actually tried to record. The window-focus refresh had the same side effect.

## Fix

`check_recording_source_readiness` now takes a `probeSystemPermission` flag (default `false`, serde-defaulted so older callers are unaffected):

- **Passive** (startup mount, focus refresh): reads device and macOS-version readiness only; system permission state stays `unknown` and no helper launches, so no prompt.
- **Probe** (`handleStartRecording` in the frontend, `start_recording` preflight in Rust): launches the helper as before, surfacing the TCC prompt at the moment the user starts a recording.

One nuance kept intact: after an observed denial, the focus refresh still probes so that a user who flips the toggle in System Settings and returns to June gets the system-audio toggle back without recording first. That path never shows a dialog, since macOS does not re-prompt a denied TCC entry.

Behavior summary:
- Fresh install: no prompt at launch. First click of record asks for system audio in context; deny falls back to mic-only for that take (existing fallback), grant records everything.
- Previously denied: the blocked strip appears after the first record attempt, and granting in System Settings is picked up on refocus as before.

## Testing

- `cargo test --lib`: 135 passed, including new gate test `skips_system_audio_permission_probe_unless_requested`
- `bun run test`: 428 passed; contract test now pins both the passive and probing request shapes
- `tsc --noEmit` clean; clippy warning count unchanged from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)