### PR TITLE
Stop the agent instantly: don't block the stopped UI on the interrupt RPC

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2877,6 +2877,27 @@ export function AgentWorkspace({
   async function stopHermesSession(sessionId: string) {
     if (stoppingSessionIds.has(sessionId)) return;
     setStoppingSessionIds((current) => new Set(current).add(sessionId));
+
+    // Stop the UI FIRST, synchronously, before the interrupt RPC. Stopping
+    // must feel instant: the moment the user clicks, the session reads as
+    // stopped (the Stop control gives way to Send) rather than staying
+    // "working" until the gateway round-trip acks. Tearing down the
+    // per-session listener here also means a straggler "running" event
+    // arriving while the interrupt is in flight can't flip the session back
+    // to working (and on a gateway drop no terminal event ever comes to do
+    // it). The interrupt then fires below to actually halt the runtime agent.
+    sessionGatewayUnlistenRef.current.get(sessionId)?.();
+    const activityCounts = clearSessionActivity(sessionId);
+    dispatchAgentSessionStatus({
+      sessionId,
+      title:
+        hermesSessionItems.find((session) => session.id === sessionId)
+          ?.title ?? "Agent session",
+      status: "cancelled",
+      summary: "Stopped.",
+      ...activityCounts,
+    });
+
     try {
       const runtimeSessionId = runtimeSessionIds[sessionId];
       if (runtimeSessionId) {
@@ -2888,23 +2909,9 @@ export function AgentWorkspace({
         });
       }
     } catch {
-      // Fall through to the local cleanup below.
+      // The UI already reflects stopped; a failed interrupt (gateway down)
+      // must not leave the session reading as working.
     } finally {
-      // Tear down the per-session gateway listener along with the flags —
-      // a straggler "running" event arriving after the interrupt would
-      // otherwise flip the session straight back to working (and on a
-      // gateway drop no terminal event ever comes to unregister it).
-      sessionGatewayUnlistenRef.current.get(sessionId)?.();
-      const activityCounts = clearSessionActivity(sessionId);
-      dispatchAgentSessionStatus({
-        sessionId,
-        title:
-          hermesSessionItems.find((session) => session.id === sessionId)
-            ?.title ?? "Agent session",
-        status: "cancelled",
-        summary: "Stopped.",
-        ...activityCounts,
-      });
       setStoppingSessionIds((current) => {
         const next = new Set(current);
         next.delete(sessionId);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1113,6 +1113,68 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayEventHandlers.size).toBe(0);
   });
 
+  it("stops instantly even when the interrupt request hasn't resolved", async () => {
+    // Immediacy regression: the stopped UI must not wait on the gateway
+    // round-trip. Make session.interrupt hang forever and assert the Stop
+    // control still gives way to Send right away.
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "summarize the current page",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "summarize the current page",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      // The interrupt never settles — the UI must still reflect stopped.
+      if (method === "session.interrupt") {
+        return new Promise(() => {});
+      }
+      return Promise.resolve({});
+    });
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "summarize the current page",
+      }),
+    );
+
+    const stop = await screen.findByRole("button", { name: "Stop June" });
+    await userEvent.click(stop);
+
+    // The interrupt request was fired (and never resolves)...
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.interrupt", {
+        session_id: "runtime-session-2",
+      }),
+    );
+    // ...yet the Stop control is already gone and the listener torn down,
+    // proving the stop did not block on the RPC.
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Stop June" })).toBeNull(),
+    );
+    expect(mocks.gatewayEventHandlers.size).toBe(0);
+  });
+
   it("keeps an opened thinking disclosure open while reasoning streams", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(


### PR DESCRIPTION
Fixes stopping an agent session not feeling immediate.

## Root cause

`stopHermesSession` did its optimistic cleanup - clearing the working flag (which is what hides the Stop control), tearing down the per-session gateway listener, and marking the session `cancelled` - inside the `finally` block. That block runs only **after** `await gateway.request("session.interrupt", ...)` settles. So between the click and the gateway ack, the Stop control stayed up and the session kept reading as "working". On a slow gateway or a busy runtime, that lag is exactly what felt inelegant.

## Fix

Move the optimistic stop to run **synchronously the moment the user clicks**, before firing the interrupt RPC:

- Tear down the per-session listener and clear the working/waiting flags immediately -> the Stop control gives way to Send instantly.
- Dispatch the `cancelled` status immediately.
- Then fire `session.interrupt` (still awaited for error handling, but the UI no longer depends on it). A failed interrupt (gateway down) can no longer leave the session stuck reading as working, because the UI already reflects stopped.

The interrupt still reaches the runtime and halts the agent; only the **UI's** dependence on the round-trip is removed.

## Testing

New test makes `session.interrupt` a promise that never resolves and asserts the Stop control disappears and the per-session listener is torn down regardless - proving the stop doesn't block on the RPC. The existing stop test (which also checks the interrupt is sent and the listener removed) still passes. 429/429 frontend tests, lint clean.

## Known follow-up (server-side, out of scope here)

`session.interrupt` signals the parent agent's interrupt flag but not its running **subagents** - they're separate worker threads, and the runtime's subagent registry (`delegation.status`) isn't scoped by session, so cascading interrupts from the client could collaterally kill another session's subagents. So a stop with parallel subagents in flight may still have those finish their current step. True per-session subagent cascade belongs in the Hermes runtime. Flagging it; not attempting it from the client where it isn't safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)