### PR TITLE
[codex] Fix dictation HUD transitions

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -34,13 +34,11 @@
           <span class="hud-bar"></span>
         </div>
         <span id="hud-braille" class="hud-braille" aria-hidden="true"></span>
-        <span class="hud-error-mark" aria-hidden="true"></span>
       </div>
-      <span
-        id="hud-error-text"
-        class="hud-error-text"
-        aria-hidden="true"
-      ></span>
+      <span class="hud-error-icon" aria-hidden="true"></span>
+      <span class="hud-error-layer" aria-hidden="true">
+        <span id="hud-error-text" class="hud-error-message"></span>
+      </span>
       <span class="hud-meeting-body">
         <span class="hud-meeting-mark" aria-hidden="true"></span>
         <span class="hud-meeting-text">

--- a/scripts/tauri-before-dev.sh
+++ b/scripts/tauri-before-dev.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+CONDUCTOR_REPO_WORKSPACES_DIR=""
+if [[ "$ROOT_DIR" == */conductor/workspaces/*/* ]]; then
+  CONDUCTOR_REPO_WORKSPACES_DIR="$(dirname "$ROOT_DIR")"
+fi
 FRONTEND_PORT="${VITE_PORT:-1421}"
 API_PID=""
 
@@ -36,7 +40,7 @@ if [[ -n "$existing_frontend_pids" ]]; then
       exit $?
     fi
 
-    if [[ "$command" == *"vite"* && "$cwd" == */conductor/workspaces/os-scribe/* ]]; then
+    if [[ -n "$CONDUCTOR_REPO_WORKSPACES_DIR" && "$command" == *"vite"* && "$cwd" == "$CONDUCTOR_REPO_WORKSPACES_DIR"/* ]]; then
       echo "Stopping Vite from another workspace: $cwd (pid $pid)" >&2
       kill "$pid" 2>/dev/null || true
       continue

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -825,6 +825,39 @@ pub fn dictation_hud_set_record_bounds(
     }
 }
 
+#[tauri::command]
+pub fn dictation_hud_preferred_error_placement(app: AppHandle) -> String {
+    let Some(hud) = app.get_webview_window("hud") else {
+        return "below".to_string();
+    };
+    let Ok(window_size) = hud.outer_size() else {
+        return "below".to_string();
+    };
+    let Some(position) = current_or_next_hud_position(&app, &hud, window_size) else {
+        return "below".to_string();
+    };
+
+    let center_x = position.x as f64 + window_size.width as f64 / 2.0;
+    let center_y = position.y as f64 + window_size.height as f64 / 2.0;
+    let monitor = hud
+        .monitor_from_point(center_x, center_y)
+        .ok()
+        .flatten()
+        .or_else(|| hud.current_monitor().ok().flatten())
+        .or_else(|| hud.primary_monitor().ok().flatten());
+    let Some(monitor) = monitor else {
+        return "below".to_string();
+    };
+
+    let work_area = monitor.work_area();
+    let work_mid_y = work_area.position.y as f64 + work_area.size.height as f64 / 2.0;
+    if center_y > work_mid_y {
+        "above".to_string()
+    } else {
+        "below".to_string()
+    }
+}
+
 /// Serializes window-frame motion (resize morphs, the error shake) so two
 /// concurrent commands never fight over the window's position.
 pub struct HudFrameLock(Mutex<()>);
@@ -1028,34 +1061,20 @@ pub fn dictation_hud_show(app: AppHandle, enter: Option<bool>, animate: Option<b
 /// and exit motion.
 const HUD_ENTER_OFFSET_LOGICAL: f64 = 8.0;
 
-/// Swap the HUD window between its two chromes. The dictation pill uses
-/// native vibrancy frost + the NSWindow shadow, with the window sized
-/// exactly to the pill. The meeting card instead paints its own surface
-/// and CSS shadow into a transparent, click-through gutter (the webview
-/// adds it to the window size) so the corner dismiss can overhang the
-/// card's edge — impossible while the frost fills the window.
+/// Keep the HUD window on frostless chrome. The webview paints its own CSS
+/// surface and shadow into a transparent, click-through gutter, matching the
+/// agent HUD and avoiding native vibrancy rims or end-of-exit repaint flashes.
 #[tauri::command]
-pub fn dictation_hud_set_chrome(app: AppHandle, meeting: bool) {
+pub fn dictation_hud_set_chrome(app: AppHandle, _frostless: bool) {
     let Some(hud) = app.get_webview_window("hud") else {
         return;
     };
-    let _ = hud.set_shadow(!meeting);
+    let _ = hud.set_shadow(false);
     #[cfg(target_os = "macos")]
     {
-        use window_vibrancy::{
-            apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
-        };
-        if meeting {
-            if let Err(error) = clear_vibrancy(&hud) {
-                tracing::warn!(%error, "failed to clear dictation HUD vibrancy");
-            }
-        } else if let Err(error) = apply_vibrancy(
-            &hud,
-            NSVisualEffectMaterial::HudWindow,
-            Some(NSVisualEffectState::Active),
-            Some(10.0),
-        ) {
-            tracing::warn!(%error, "failed to re-apply dictation HUD vibrancy");
+        use window_vibrancy::clear_vibrancy;
+        if let Err(error) = clear_vibrancy(&hud) {
+            tracing::warn!(%error, "failed to clear dictation HUD vibrancy");
         }
     }
 }
@@ -2558,6 +2577,33 @@ fn position_hud_window(app: &AppHandle, hud: &WebviewWindow) {
     }
 }
 
+fn current_or_next_hud_position(
+    app: &AppHandle,
+    hud: &WebviewWindow,
+    window_size: PhysicalSize<u32>,
+) -> Option<PhysicalPosition<i32>> {
+    if hud.is_visible().unwrap_or(false)
+        && !HUD_WOKEN_FADED.load(std::sync::atomic::Ordering::Relaxed)
+    {
+        if let Ok(position) = hud.outer_position() {
+            return Some(position);
+        }
+    }
+
+    if let Some(state) = app.try_state::<HudPosition>() {
+        let saved = state.inner.lock().ok().and_then(|guard| *guard);
+        if let Some((x, y)) = saved {
+            if hud_position_is_visible(hud, x, y, window_size) {
+                return Some(PhysicalPosition::new(x, y));
+            }
+        }
+    }
+
+    default_hud_position(hud, window_size)
+        .map(|(x, y)| PhysicalPosition::new(x, y))
+        .or_else(|| hud.outer_position().ok())
+}
+
 /// Meeting prompts always enter at the default top-center spot. They're
 /// transient notifications, not the user's parked dictation pill, so the
 /// saved drag position doesn't apply to them.
@@ -2627,24 +2673,17 @@ fn configure_hud_window(app: &AppHandle) -> Result<(), String> {
             .map_err(|error| error.to_string())?;
         hud.set_skip_taskbar(true)
             .map_err(|error| error.to_string())?;
-        // The window is exactly the pill; depth comes from the native window
-        // shadow instead of a CSS one painted into a transparent gutter.
-        hud.set_shadow(true).map_err(|error| error.to_string())?;
+        // The webview paints the HUD surface and shadow into a transparent
+        // gutter, matching the agent HUD. Keep native shadow/vibrancy off so
+        // no frosted rim or large repaint can appear during transitions.
+        hud.set_shadow(false).map_err(|error| error.to_string())?;
 
         #[cfg(target_os = "macos")]
         {
             make_hud_nonactivating(&hud);
-            // Real behind-window blur (CSS backdrop-filter can't sample other
-            // apps' pixels). The radius must match the pill's CSS
-            // border-radius (--r-lg, 10px). Mirrors the meeting HUD.
-            use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
-            if let Err(error) = apply_vibrancy(
-                &hud,
-                NSVisualEffectMaterial::HudWindow,
-                Some(NSVisualEffectState::Active),
-                Some(10.0),
-            ) {
-                tracing::warn!(%error, "failed to apply dictation HUD vibrancy");
+            use window_vibrancy::clear_vibrancy;
+            if let Err(error) = clear_vibrancy(&hud) {
+                tracing::warn!(%error, "failed to clear dictation HUD vibrancy");
             }
         }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,7 @@ pub fn run() {
             dictation::dictation_hud_set_stop_bounds,
             dictation::dictation_hud_set_dismiss_bounds,
             dictation::dictation_hud_set_record_bounds,
+            dictation::dictation_hud_preferred_error_placement,
             dictation::dictation_hud_set_size,
             dictation::dictation_hud_set_alpha,
             dictation::dictation_hud_show,

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
+import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
 import { IconMicrophone } from "central-icons-filled/IconMicrophone";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -56,6 +57,8 @@ const dragHandle = document.querySelector<HTMLElement>("#hud-handle");
 const bars = Array.from(document.querySelectorAll<HTMLElement>(".hud-bar"));
 const brailleNode = document.querySelector<HTMLElement>("#hud-braille");
 const errorText = document.querySelector<HTMLElement>("#hud-error-text");
+const errorIcon = document.querySelector<HTMLElement>(".hud-error-icon");
+const errorLayer = document.querySelector<HTMLElement>(".hud-error-layer");
 const stopButton = document.querySelector<HTMLButtonElement>("#hud-stop");
 const meetingStartButton =
   document.querySelector<HTMLButtonElement>("#hud-meeting-start");
@@ -70,6 +73,15 @@ if (meetingDismissButton) {
   meetingDismissButton.innerHTML = renderToStaticMarkup(
     createElement(IconCrossSmall, {
       size: 12,
+      ariaHidden: true,
+      focusable: false,
+    }),
+  );
+}
+if (errorIcon) {
+  errorIcon.innerHTML = renderToStaticMarkup(
+    createElement(IconExclamationCircle, {
+      size: 16,
       ariaHidden: true,
       focusable: false,
     }),
@@ -95,20 +107,29 @@ let brailleFrame = 0;
 let meetingPromptSuppressed = false;
 let pendingMeetingPrompt: DictationHudEvent | undefined;
 let hideRequestId = 0;
+let showRequestId = 0;
+let showQueue: Promise<void> = Promise.resolve();
 
 // waverows shows multiple horizontal rows of dots flowing across — reads as a
 // "thinking/processing" texture rather than a single dot bouncing.
 const brailleWave = spinners.waverows;
 
-// Matches the .hud[data-state="exiting"] transition in hud.css.
-const EXIT_TRANSITION_MS = 160;
+// Matches the .hud[data-state="exiting"] transition in hud.css. Long
+// enough to read as a deliberate dissolve rather than a blink-out.
+const EXIT_TRANSITION_MS = 240;
 // Matches the .hud.is-morphing fade (60ms) plus a frame of slack.
 const MORPH_FADE_MS = 80;
-// Transparent, click-through margin around the meeting card. Its CSS
-// shadow paints here and the corner dismiss overhangs into it — the card
-// runs without the native frost (dictation_hud_set_chrome), so the window
-// can be bigger than the surface, agent-HUD style.
-const MEETING_WINDOW_GUTTER = 16;
+// Transparent, click-through margin around the frostless HUD surface. Its
+// CSS shadow paints here and the meeting dismiss can overhang the card's
+// edge. This is the agent HUD model: transparent native window, CSS-painted
+// surface, no native vibrancy rim.
+const WINDOW_GUTTER = 16;
+// Gap between the error pill and the message layer that draws above/below it
+// — must match the .hud-error-layer margin in hud.css.
+const ERROR_LAYER_GAP = 8;
+// The error message layer's reveal / retract — must track the
+// .hud-error-layer grid-template-rows transition (--t-med) in hud.css.
+const ERROR_REVEAL_MS = 160;
 const MEETING_PROMPT_TIMEOUT_MS = 30_000;
 
 function invokeBestEffort(command: string, args?: Record<string, unknown>) {
@@ -158,14 +179,29 @@ const HUD_WHISPER_FLOOR = 0.06;
 // The idle pulse + speech wave live in the shared meter (IDLE_PULSE_*,
 // SPEECH_WAVE_*, withWaveLayers) so the HUD and recorder move identically.
 
-function setHud(state: string, status: string) {
-  if (!hud || !statusText) return;
+type HudTransition = {
+  changed: boolean;
+  previous?: string;
+};
+
+function setHud(state: string, status: string): HudTransition {
+  if (!hud || !statusText) return { changed: false };
   const previous = hud.dataset.state;
-  const sizeBefore = hud.getBoundingClientRect();
   hud.dataset.state = state;
   statusText.textContent = status;
-  if (errorText) {
+  // Keep the error message through "exiting" so it dissolves with the
+  // window's native alpha fade instead of vanishing a frame early; the
+  // post-hide flip to "idle" clears it.
+  if (errorText && state !== "exiting") {
     errorText.textContent = state === "error" ? status : "";
+  }
+  // The error draw-out collapse class is owned by the reveal/retract
+  // sequence (see playErrorReveal, retractErrorLayer). Leave it alone for
+  // "error" (the reveal manages it) and "exiting" (the retract must hold
+  // through the fade); clear it for any other state so a stray collapse
+  // can't follow into the next pill.
+  if (state !== "error" && state !== "exiting") {
+    hud.classList.remove("hud-reveal-collapsed");
   }
   if (state === "transcribing" || state === "pasting") {
     startBraille();
@@ -180,30 +216,30 @@ function setHud(state: string, status: string) {
   } else if (previous === "listening") {
     clearStopHover();
   }
-  // Pill size varies by state and the window must track it exactly (the
-  // frosted surface is a window-filling native vibrancy view). When the size
-  // actually changes, morph: contents crossfade while the glass eases over —
-  // also what keeps a bigger pill from painting clipped before the resize.
-  // The meeting card is taller as well as wider, so height counts too.
   if (state !== previous && hud) {
-    if ((previous === "meeting") !== (state === "meeting")) {
-      // Crossing the meeting boundary swaps the window chrome: the card
-      // paints its own shadow into a gutter; every other state restores
-      // the vibrancy pill (see MEETING_WINDOW_GUTTER).
+    if (usesFrostlessChrome(previous) !== usesFrostlessChrome(state)) {
+      // Kept for compatibility with older native windows; in normal builds
+      // every state is frostless and this branch does not run.
       invokeBestEffort("dictation_hud_set_chrome", {
-        meeting: state === "meeting",
+        frostless: usesFrostlessChrome(state),
       });
     }
     if (state === "meeting") clearStopHover();
-    if (state === "exiting") return;
-    hud.offsetWidth;
-    const sizeAfter = hud.getBoundingClientRect();
-    void syncWindowToPill({
-      morph:
-        Math.ceil(sizeAfter.width) !== Math.ceil(sizeBefore.width) ||
-        Math.ceil(sizeAfter.height) !== Math.ceil(sizeBefore.height),
-    });
   }
+  return { changed: state !== previous, previous };
+}
+
+async function updateErrorPlacement() {
+  if (!hud) return;
+  let placement: unknown;
+  try {
+    placement = await Promise.resolve(
+      invoke("dictation_hud_preferred_error_placement"),
+    );
+  } catch {
+    placement = undefined;
+  }
+  hud.dataset.errorPlacement = placement === "above" ? "above" : "below";
 }
 
 function startBarLoop() {
@@ -389,13 +425,50 @@ function pushStopBoundsToNative() {
   });
 }
 
+// The native window size the current state wants. getBoundingClientRect
+// includes transforms, and the exit leaves one in play: "exiting" eases the
+// pill to scale(0.94), and when the window hides mid-flight the suspended
+// webview freezes that transition wherever it stood until the next show. A
+// fresh show measured through the frozen scale baked a too-narrow frame
+// into the window — the pill came up clipped flat at the right edge, then
+// visibly snapped to full width when the settle pass healed it. Kill
+// in-flight transitions for the measurement so every property sits at its
+// end value.
+function measureWindowSize() {
+  if (!hud) return { width: 0, height: 0 };
+  hud.classList.add("hud-snap");
+  hud.offsetWidth;
+  let { width, height } = hud.getBoundingClientRect();
+  if (hud.dataset.state === "error" && errorLayer) {
+    // The message layer is centered above/below the pill (.hud-snap forces
+    // it to its full drawn-out height for this measurement). Mirror its slot
+    // on the opposite vertical side so the center-anchored native resize
+    // leaves the pill dead centre while the layer reveals vertically.
+    const layer = errorLayer.getBoundingClientRect();
+    width = Math.max(width, layer.width);
+    height += 2 * (ERROR_LAYER_GAP + layer.height);
+  }
+  if (usesFrostlessChrome(hud.dataset.state)) {
+    // The frostless HUD includes the transparent gutter its CSS shadow (and
+    // the meeting card's overhanging dismiss) paint into. The center-anchored
+    // native resize splits it evenly, so the surface stays put.
+    width += WINDOW_GUTTER * 2;
+    height += WINDOW_GUTTER * 2;
+  }
+  hud.classList.remove("hud-snap");
+  return { width, height };
+}
+
 // Resize the native window to the pill's measured size (Rust re-anchors so
 // the pill center stays put), then refresh the stop-button rect once layout
 // has settled at the new size — the pill's client position shifts when the
 // window around it changes. With `morph` the contents fade out while the
 // glass eases to its new frame, then fade back in (the invoke resolves when
 // the native motion finishes).
-async function syncWindowToPill(options?: { morph?: boolean }) {
+async function syncWindowToPill(options?: {
+  animate?: boolean;
+  morph?: boolean;
+}) {
   if (!hud) return;
   // ABC Diatype may still be loading on the window's first show; measuring
   // with the fallback font bakes the wrong width into the window frame.
@@ -409,14 +482,6 @@ async function syncWindowToPill(options?: { morph?: boolean }) {
       }
     }
   }
-  hud.offsetWidth;
-  let { width, height } = hud.getBoundingClientRect();
-  // The meeting card's window includes the transparent gutter its CSS
-  // shadow and overhanging dismiss paint into.
-  if (hud.dataset.state === "meeting") {
-    width += MEETING_WINDOW_GUTTER * 2;
-    height += MEETING_WINDOW_GUTTER * 2;
-  }
   if (options?.morph) {
     hud.classList.add("is-morphing");
     // Let the contents finish fading before the glass starts moving: the
@@ -427,13 +492,14 @@ async function syncWindowToPill(options?: { morph?: boolean }) {
       await new Promise((resolve) => window.setTimeout(resolve, MORPH_FADE_MS));
     }
   }
+  const { width, height } = measureWindowSize();
   // Exact floats — Rust rounds at physical pixels. Ceiling here oversized
   // the window by up to a point, leaving a bright sliver of bare frost
   // around the dark card.
   await invokeBestEffortAsync("dictation_hud_set_size", {
     width,
     height,
-    animate: !prefersReducedMotion(),
+    animate: options?.animate ?? !prefersReducedMotion(),
   });
   window.requestAnimationFrame(() => {
     window.requestAnimationFrame(() => {
@@ -444,8 +510,8 @@ async function syncWindowToPill(options?: { morph?: boolean }) {
   });
 }
 
-// The native window alpha drives the exit dissolve — CSS opacity can't fade
-// the vibrancy frost or the native shadow behind the webview.
+// The native window alpha drives the exit dissolve so the CSS surface, shadow,
+// and transparent gutter fade as one unit.
 function setWindowAlpha(alpha: number) {
   invokeBestEffort("dictation_hud_set_alpha", { alpha });
 }
@@ -526,15 +592,26 @@ function startMeetingPromptTimer() {
 
 async function hideHud() {
   const requestId = ++hideRequestId;
+  showRequestId += 1;
   clearHideTimer();
+  clearFrameSettleTimer();
   clearMeetingPromptTimer();
   clearStopHover();
   clearDismissHover();
+  const exitState = hud?.dataset.state;
+  const exitingError = exitState === "error";
+  if (exitingError) {
+    hud?.classList.remove("hud-reveal-collapsed");
+  }
   let nativeExit = false;
   if (hud) {
     const meetingExit =
       hud.dataset.state === "meeting" && !prefersReducedMotion();
     hud.classList.toggle("hud-exit-up", meetingExit);
+    hud.classList.toggle("hud-error-exit", exitingError);
+    if (exitState) {
+      hud.dataset.exitState = exitState;
+    }
     setHud("exiting", statusText?.textContent || "Idle");
     stopBraille();
     if (meetingExit) {
@@ -549,9 +626,9 @@ async function hideHud() {
       }
     }
     if (!nativeExit) {
-      // CSS dissolves the content; the native alpha ramp fades the frost +
-      // shadow with it. The timeout race guards against rAF stalling if the
-      // window is already occluded/hidden.
+      // CSS dissolves the content; the native alpha ramp fades the whole
+      // transparent window with it. The timeout race guards against rAF
+      // stalling if the window is already occluded/hidden.
       await Promise.race([
         fadeWindowAlpha(requestId),
         new Promise((resolve) =>
@@ -569,19 +646,63 @@ async function hideHud() {
   // window is ever shown again without new content, a pill stuck in that
   // state renders as a bare, undraggable gray bar.
   if (hud?.dataset.state === "exiting" && requestId === hideRequestId) {
+    hud.classList.remove("hud-error-exit");
+    delete hud.dataset.exitState;
     setHud("idle", "Idle");
   }
 }
 
-async function showHud() {
+function shouldMorphTransition(transition: HudTransition) {
+  return (
+    transition.changed &&
+    transition.previous !== undefined &&
+    !pillIsBlank(transition.previous) &&
+    !pillIsBlank(hud?.dataset.state)
+  );
+}
+
+function showOptionsForTransition(transition: HudTransition) {
+  const current = hud?.dataset.state;
+  const processingContinuation =
+    (transition.previous === "listening" && current === "transcribing") ||
+    (transition.previous === "transcribing" && current === "pasting") ||
+    (transition.previous === "pasting" && current === "pasting");
+  const morph = !processingContinuation && shouldMorphTransition(transition);
+  return {
+    fresh: transition.changed && pillIsBlank(transition.previous),
+    morph,
+  };
+}
+
+function showHud(options?: { fresh?: boolean; morph?: boolean }) {
+  const requestId = ++showRequestId;
   hideRequestId += 1;
   clearHideTimer();
+  clearFrameSettleTimer();
+
+  const run = showQueue.then(() => showHudNow(requestId, options));
+  showQueue = run.catch(() => {});
+  return run;
+}
+
+async function showHudNow(
+  requestId: number,
+  options?: { fresh?: boolean; morph?: boolean },
+) {
+  if (requestId !== showRequestId) return;
+  if (options?.fresh) {
+    setWindowAlpha(0);
+  }
   // Size the window to the pill before it appears, then let Rust position
   // and show it (dictation_hud_show also restores the native alpha an
   // interrupted exit fade may have left low). Showing only after the resize
   // is what keeps the pill from flashing up as a bare gray bar, or clipped
   // at a stale width from a previous state.
-  await syncWindowToPill();
+  await syncWindowToPill({
+    animate: options?.morph ? !prefersReducedMotion() : false,
+    morph: options?.morph,
+  });
+  if (requestId !== showRequestId) return;
   // A fresh meeting prompt always enters at the top-center default spot,
   // and (motion permitting) slides down from the top edge while the
   // window alpha ramps up. The motion is native (the invoke resolves when
@@ -598,6 +719,7 @@ async function showHud() {
     // No bridge (standalone page): fall back to the CSS entrance.
     if (meetingEntrance && animate) replayCssEntrance();
   }
+  if (requestId !== showRequestId) return;
   // Force a layout flush before reading rects.
   hud?.offsetWidth;
   if (hud?.dataset.state === "meeting") {
@@ -620,22 +742,30 @@ async function showHud() {
 const FRAME_SETTLE_DELAY_MS = 120;
 let frameSettleTimer: number | undefined;
 
+function clearFrameSettleTimer() {
+  if (frameSettleTimer !== undefined) {
+    window.clearTimeout(frameSettleTimer);
+    frameSettleTimer = undefined;
+  }
+}
+
 function assertWindowMatchesPill() {
   // Standalone browser page: the viewport is the whole tab, never the pill.
   if (!appWindow) return;
-  if (frameSettleTimer !== undefined) window.clearTimeout(frameSettleTimer);
+  clearFrameSettleTimer();
   frameSettleTimer = window.setTimeout(() => {
     frameSettleTimer = undefined;
     const state = hud?.dataset.state;
     if (!hud || !state || state === "idle" || state === "exiting") return;
-    const gutter = state === "meeting" ? MEETING_WINDOW_GUTTER * 2 : 0;
-    const rect = hud.getBoundingClientRect();
+    const expected = measureWindowSize();
     const drift = Math.max(
-      Math.abs(window.innerWidth - (rect.width + gutter)),
-      Math.abs(window.innerHeight - (rect.height + gutter)),
+      Math.abs(window.innerWidth - expected.width),
+      Math.abs(window.innerHeight - expected.height),
     );
     // Rust rounds the frame at physical pixels; allow a point of slack.
-    if (drift > 1.5) void syncWindowToPill();
+    // Snap, don't ease: this corrects a pill the user already sees as
+    // settled, and easing it reads as the window morphing on its own.
+    if (drift > 1.5) void syncWindowToPill({ animate: false });
   }, FRAME_SETTLE_DELAY_MS);
 }
 
@@ -652,8 +782,8 @@ async function handleDictationEventPayload(payload: unknown) {
 
   if (dictationEvent.type === "listening_started") {
     resetBars();
-    setHud("listening", "Listening");
-    await showHud();
+    const transition = setHud("listening", "Listening");
+    await showHud(showOptionsForTransition(transition));
     return;
   }
 
@@ -679,23 +809,23 @@ async function handleDictationEventPayload(payload: unknown) {
   }
 
   if (dictationEvent.type === "finalizing_transcript") {
-    setHud("transcribing", "Transcribing");
-    await showHud();
+    const transition = setHud("transcribing", "Transcribing");
+    await showHud(showOptionsForTransition(transition));
     return;
   }
 
   if (dictationEvent.type === "final_transcript") {
-    setHud("pasting", "Pasting");
-    await showHud();
+    const transition = setHud("pasting", "Pasting");
+    await showHud(showOptionsForTransition(transition));
     return;
   }
 
   if (dictationEvent.type === "paste_target") {
-    setHud(
+    const transition = setHud(
       "pasting",
       `Pasting into ${dictationEvent.payload?.app || "previous app"}`,
     );
-    await showHud();
+    await showHud(showOptionsForTransition(transition));
     return;
   }
 
@@ -752,12 +882,32 @@ async function handleDictationEventPayload(payload: unknown) {
     const message = String(
       dictationEvent.payload?.message ?? "Dictation failed.",
     ).trim();
-    setHud("error", message || "Dictation failed.");
-    await showHud();
+    await updateErrorPlacement();
+    const transition = setHud("error", message || "Dictation failed.");
+    // Render the pill with the message layer drawn in, snap the window to
+    // the full (layer-included) size with no native motion, then draw the
+    // layer out in CSS — the pill never moves and nothing clips.
+    hud?.classList.add("hud-reveal-collapsed");
+    await showHud({ fresh: pillIsBlank(transition.previous) });
+    playErrorReveal();
     triggerShake();
     // Hold long enough for the shake to finish and the message to read.
     hideSoon(1800);
   }
+}
+
+// Drop the collapse so the message layer draws out of the pill. The pill was
+// rendered collapsed and the window already snapped to the full size, so
+// this is a pure CSS draw-out within the still window.
+function playErrorReveal() {
+  if (!hud) return;
+  if (prefersReducedMotion()) {
+    hud.classList.remove("hud-reveal-collapsed");
+    return;
+  }
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => hud?.classList.remove("hud-reveal-collapsed")),
+  );
 }
 
 async function handleMeetingDetectionEventPayload(payload: unknown) {
@@ -804,8 +954,8 @@ async function showMeetingPrompt(meetingEvent: DictationHudEvent) {
       meetingEvent.payload?.appLabels,
     );
   }
-  setHud("meeting", "Meeting detected");
-  await showHud();
+  const transition = setHud("meeting", "Meeting detected");
+  await showHud(showOptionsForTransition(transition));
   startMeetingPromptTimer();
 }
 
@@ -837,6 +987,14 @@ function meetingAppLine(labels: unknown) {
 
 function pillIsBlank(state: string | undefined) {
   return state === undefined || state === "idle" || state === "exiting";
+}
+
+// Every state runs without native frost or native shadow. The HUD paints the
+// same CSS surface and drop shadow as the agent HUD into a transparent gutter.
+// Keeping idle/exiting frostless prevents any chrome swap during hide.
+function usesFrostlessChrome(state: string | undefined) {
+  void state;
+  return true;
 }
 
 function canShowMeetingPrompt(state: string | undefined) {
@@ -886,7 +1044,8 @@ stopButton?.addEventListener("click", async (event) => {
   event.preventDefault();
   setStopHover(false);
   if (hud?.dataset.state === "listening") {
-    setHud("transcribing", "Transcribing");
+    const transition = setHud("transcribing", "Transcribing");
+    void showHud(showOptionsForTransition(transition));
   }
   try {
     await invoke("dictation_helper_command", {

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -195,11 +195,9 @@ function setHud(state: string, status: string): HudTransition {
   if (errorText && state !== "exiting") {
     errorText.textContent = state === "error" ? status : "";
   }
-  // The error draw-out collapse class is owned by the reveal/retract
-  // sequence (see playErrorReveal, retractErrorLayer). Leave it alone for
-  // "error" (the reveal manages it) and "exiting" (the retract must hold
-  // through the fade); clear it for any other state so a stray collapse
-  // can't follow into the next pill.
+  // The error reveal collapse class is owned by the reveal/exit sequence.
+  // Leave it alone for "error" and "exiting": the reveal removes it after
+  // sizing, and error exits clear it before fading the expanded HUD in place.
   if (state !== "error" && state !== "exiting") {
     hud.classList.remove("hud-reveal-collapsed");
   }

--- a/src/lib/dictation-hud-demo.ts
+++ b/src/lib/dictation-hud-demo.ts
@@ -115,7 +115,10 @@ export function registerDictationHudDemo({ local }: DictationHudDemoOptions) {
 
   function error() {
     cancelTimers();
-    emitDictation("error", { message: "Dictation failed." });
+    // A real-world message long enough to exercise the expanded error card.
+    emitDictation("error", {
+      message: "Dictation recorded no text. Try again.",
+    });
   }
 
   function silent() {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -6,19 +6,12 @@
  *
  * Forced dark regardless of system theme — the HUD is a transient overlay
  * that needs to read consistently against any wallpaper or app behind it.
- * Layout: [drag handle] [audio viz] [stop button], inside a frosted pill.
+ * Layout: [drag handle] [audio viz] [stop button], inside a compact
+ * frostless CSS surface.
  *
- * The window is sized exactly to the pill (dictation.rs resizes it to the
- * rect hud.ts measures per state): the frosted surface is a native
- * NSVisualEffectView behind the webview (CSS backdrop-filter can't sample
- * other apps' pixels) and depth comes from the native NSWindow shadow, so
- * there's no CSS shadow or blur here — just a translucent tint over vibrancy.
- * Mirrors the meeting HUD (meeting-hud.css).
- *
- * Platform note: the vibrancy/shadow path is macOS-only (cfg-gated in
- * dictation.rs) and there's deliberately no CSS blur fallback — the app
- * ships macOS-only, so on other platforms the pill would render as a solid
- * tint. If that ever changes, reintroduce a backdrop-filter fallback here.
+ * The native window is transparent and slightly larger than the pill so the
+ * CSS shadow can paint into its gutter. This matches the agent HUD: no native
+ * vibrancy, no NSVisualEffectView rim, no inset-looking frost edge.
  */
 
 :root {
@@ -65,9 +58,8 @@ body {
 
 .hud {
   /* The agent HUD's surface recipe — near-opaque dark glass doing the
-   * legibility work itself, with the vibrancy frost just warming the
-   * edges. One surface across every June overlay (agent HUD, this pill,
-   * the meeting card, the recording indicator). */
+   * legibility work itself. One surface across the agent HUD, this pill,
+   * the meeting card, and the error reveal. */
   --hud-bg: color-mix(in oklch, var(--popover) 92%, transparent);
   --hud-border: var(--border);
   --hud-bar: var(--foreground);
@@ -77,28 +69,25 @@ body {
    * same regardless of OS color scheme — --accent here would leak the
    * light-mode (near-white) value into the always-dark HUD. */
   --hud-stop-bg-hover: color-mix(in oklch, var(--foreground) 16%, transparent);
-  --hud-danger: var(--destructive);
-  --hud-alert: var(--hud-danger);
 
   position: relative;
   display: flex;
   align-items: center;
   gap: var(--sp-1);
   height: 32px;
-  /* Borderless, like the agent HUD: on the vibrancy surface a 1px hairline
-   * reads far harder than it does over the agent HUD's CSS glass, so the
-   * pills looked mismatched. The 4px inset (was 3px + 1px border) keeps the
-   * inner 6px-radius controls concentric inside the 10px outer radius. */
+  /* Borderless, like the agent HUD. The 4px inset keeps the inner
+   * 6px-radius controls concentric inside the 10px outer radius. */
   padding: 4px;
-  /* Must match the vibrancy view's corner radius set in dictation.rs so
-   * tint and frost trace the same curve. */
   border-radius: var(--r-lg);
   background: var(--hud-bg);
+  box-shadow: var(--shadow-md);
   color: var(--foreground);
   pointer-events: auto;
+  /* Paced for the exit dissolve — must track EXIT_TRANSITION_MS in hud.ts
+   * so the content fade and the native window alpha land together. */
   transition:
-    opacity 120ms var(--ease-out),
-    transform 160ms var(--ease-out);
+    opacity 200ms var(--ease-out),
+    transform 240ms var(--ease-out);
 }
 
 /* Resize morph: while the glass eases to a new frame the contents sit at
@@ -199,17 +188,13 @@ body {
   transition: height 22ms linear;
 }
 
-.hud-braille,
-.hud-error-mark {
+.hud-braille {
   position: absolute;
   inset: 0;
   display: none;
   align-items: center;
   justify-content: center;
   text-align: center;
-}
-
-.hud-braille {
   font-family: var(--font-mono);
   font-size: 14px;
   line-height: 1;
@@ -218,52 +203,111 @@ body {
   transform: translateY(-1px);
 }
 
-.hud-error-mark {
+/* Error reveal (Wispr-style): the pill itself stays put and a glass layer
+ * opens above or below it to show the message, then retracts on dismiss.
+ * The layer is absolutely positioned so it never moves the pill; the window
+ * is pre-sized to fit the layer mirrored vertically (see measureWindowSize
+ * in hud.ts) so the center-anchored resize keeps the pill centered. No
+ * native size animation and no content crossfade — the motion is entirely
+ * this CSS reveal, matching the agent HUD's 0fr -> 1fr expansion. */
+
+/* The error icon rides inside the pill (the fixed anchor), next to the
+ * handle, marking the state while the message layer is still drawn in. */
+.hud-error-icon {
+  display: none;
   width: 16px;
   height: 16px;
-  border: 1px solid color-mix(in oklch, var(--hud-alert) 70%, transparent);
-  border-radius: 999px;
+  color: var(--foreground);
 }
 
-.hud-error-mark::before,
-.hud-error-mark::after {
-  content: "";
+.hud[data-state="error"] .hud-error-icon {
+  display: grid;
+  place-items: center;
+  color: var(--destructive);
+}
+
+.hud.hud-error-exit[data-state="exiting"] .hud-error-icon {
+  display: grid;
+  place-items: center;
+  color: var(--destructive);
+}
+
+.hud-error-icon svg {
+  display: block;
+}
+
+/* The drawn-out message panel: its own glass surface, on top, attached to
+ * the pill's vertical edge. .hud-reveal-collapsed clips it back into the
+ * pill before the window fades. */
+.hud-error-layer {
   position: absolute;
-  top: 7px;
-  left: 4px;
-  width: 7px;
-  height: 1.5px;
-  border-radius: 999px;
-  background: var(--hud-alert);
-}
-
-.hud-error-mark::before {
-  transform: rotate(45deg);
-}
-
-.hud-error-mark::after {
-  transform: rotate(-45deg);
-}
-
-.hud-error-text {
+  left: 50%;
+  z-index: 1;
   display: none;
-  color: color-mix(in oklch, var(--foreground) 92%, var(--hud-alert));
-  font-size: var(--fs-sm);
-  font-weight: 500;
-  line-height: 1;
-  /* Fixed cap, not vw-relative: the window is resized to fit the measured
-   * pill, so a vw clamp would be circular (pill fits whatever it last was). */
-  max-width: 460px;
-  /* Not shrinkable — same trap as .hud-meeting-text: overflow: hidden gives a
-   * flex child an automatic min-width of 0, so it shrinks to the stale window
-   * width and the pill measures the old size, never growing. flex-shrink: 0
-   * keeps the intrinsic width so syncWindowToPill measures the true size.
-   * max-width + ellipsis still cap pathological messages. */
-  flex-shrink: 0;
+  grid-template-rows: 1fr;
+  width: max-content;
+  max-width: 360px;
   overflow: hidden;
-  text-overflow: ellipsis;
+  border-radius: var(--r-md);
+  background: var(--hud-bg);
+  box-shadow: var(--shadow-md);
+  pointer-events: none;
+  transition:
+    grid-template-rows var(--t-med) var(--ease-out),
+    opacity var(--t-fast) var(--ease-out);
+}
+
+.hud[data-state="error"] .hud-error-layer {
+  display: grid;
+}
+
+.hud.hud-error-exit[data-state="exiting"] .hud-error-layer {
+  display: grid;
+}
+
+.hud[data-error-placement="below"] .hud-error-layer,
+.hud:not([data-error-placement="above"]) .hud-error-layer {
+  top: 100%;
+  margin-top: var(--sp-2);
+  transform: translateX(-50%);
+  transform-origin: top center;
+}
+
+.hud[data-error-placement="above"] .hud-error-layer {
+  bottom: 100%;
+  margin-bottom: var(--sp-2);
+  transform: translateX(-50%);
+  transform-origin: bottom center;
+}
+
+/* Drawn in: the panel collapses to nothing at the pill's edge. hud.ts holds
+ * this while the window snaps to full size, then drops it so the panel draws
+ * out; on dismiss it is re-added so the panel retracts before the fade. */
+.hud.hud-reveal-collapsed .hud-error-layer {
+  grid-template-rows: 0fr;
+  opacity: 0;
+}
+
+/* The window measurement (taken under .hud-snap) always reads the panel at
+ * full height, never the collapsed start, so the window is sized to fit it. */
+.hud.hud-snap .hud-error-layer {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+/* Single line so the reveal is a clean vertical open with no reflow; the
+ * layer's overflow does the clipping, ellipsis catches a rare long one. */
+.hud-error-message {
+  display: block;
+  min-height: 0;
+  padding: 6px 11px;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  line-height: 1.35;
   white-space: nowrap;
-  transform: translateY(-0.5px);
+  text-overflow: ellipsis;
 }
 
 /* Meeting prompt card -------------------------------------------------- */
@@ -334,7 +378,8 @@ body {
 }
 
 .hud-meeting-app {
-  /* Fixed cap, not vw-relative — see .hud-error-text. */
+  /* Fixed cap, not vw-relative: the window is resized to fit the measured
+   * pill, so a vw clamp would be circular (pill fits whatever it last was). */
   max-width: 200px;
   overflow: hidden;
   color: var(--muted-foreground);
@@ -504,24 +549,18 @@ body {
 }
 
 /* State machine ------------------------------------------------------- */
-.hud[data-state="error"] .hud-handle {
-  display: none;
-}
-
-.hud[data-state="meeting"] {
-  /* The window chrome is swapped for this state (dictation_hud_set_chrome):
-   * no native frost or shadow — this CSS shadow paints into the
-   * transparent gutter around the card (see MEETING_WINDOW_GUTTER in
-   * hud.ts). */
+.hud[data-state="meeting"],
+.hud[data-state="exiting"][data-exit-state="meeting"] {
+  /* Same frostless CSS surface as the compact pill, with meeting-specific
+   * layout inside the transparent shadow gutter. */
   gap: 0;
   height: 54px;
   padding: 0 var(--sp-4) 0 0;
-  box-shadow: var(--shadow-md);
 }
 
 /* Entrance fallback for the standalone browser page only — in the app the
  * slide+fade is native window motion (dictation_hud_show with enter), so
- * the frost and shadow travel with the card instead of being left bare at
+ * the surface and shadow travel with the card instead of being left bare at
  * the window edges. hud.ts adds the class when the bridge is absent. */
 .hud.hud-enter[data-state="meeting"] {
   animation: hud-meeting-enter var(--t-slow) var(--ease-out);
@@ -529,18 +568,21 @@ body {
 
 /* The drag affordance is a single quiet grabber line spanning the card's
  * left edge — still the drag handle. */
-.hud[data-state="meeting"] > .hud-handle {
+.hud[data-state="meeting"] > .hud-handle,
+.hud[data-state="exiting"][data-exit-state="meeting"] > .hud-handle {
   width: 20px;
   height: 100%;
   margin-right: 0;
   border-radius: 0;
 }
 
-.hud[data-state="meeting"] .hud-handle svg {
+.hud[data-state="meeting"] .hud-handle svg,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-handle svg {
   display: none;
 }
 
-.hud[data-state="meeting"] .hud-handle::before {
+.hud[data-state="meeting"] .hud-handle::before,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-handle::before {
   content: "";
   width: 2px;
   height: 22px;
@@ -549,81 +591,108 @@ body {
 }
 
 .hud[data-state="meeting"] .hud-viz,
-.hud[data-state="meeting"] .hud-stop {
+.hud[data-state="meeting"] .hud-stop,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-viz,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-stop {
   display: none;
 }
 
-.hud[data-state="meeting"] .hud-meeting-body {
+.hud[data-state="meeting"] .hud-meeting-body,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-meeting-body {
   display: grid;
   margin-right: var(--sp-7);
 }
 
-.hud[data-state="meeting"] .hud-meeting-start {
+.hud[data-state="meeting"] .hud-meeting-start,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-meeting-start {
   display: inline-flex;
 }
 
-.hud[data-state="meeting"] .hud-meeting-dismiss {
+.hud[data-state="meeting"] .hud-meeting-dismiss,
+.hud[data-state="exiting"][data-exit-state="meeting"] .hud-meeting-dismiss {
   display: inline-flex;
 }
 
-/* Text-only pill for hard errors. The "not allowed" wobble is native now —
- * dictation_hud_shake jiggles the window itself, because a CSS translateX
- * would slide the tint off the stationary vibrancy frost. */
+/* Error pill (the fixed anchor): the compact handle + error-icon pill that
+ * the message layer draws out of. It uses the agent HUD's clean dark glass
+ * with no native vibrancy rim. The "not allowed" wobble is native
+ * (dictation_hud_shake jiggles the window itself). */
 .hud[data-state="error"] {
-  --hud-alert: var(--hud-danger);
+  justify-content: center;
   gap: var(--sp-2);
-  padding-inline: var(--sp-3) var(--sp-4);
-  /* The shared 92%-opacity surface, with the danger tint folded in (the
-   * pill is borderless now, so the error cue lives entirely in this tint). */
-  background: color-mix(in oklch, var(--popover) 78%, var(--hud-danger) 22%);
+  padding: 4px var(--sp-2);
+}
+
+/* The pill is its own centered cluster now, so the handle drops the
+ * push-everything-right margin. */
+.hud[data-state="error"] > .hud-handle {
+  margin-right: 0;
 }
 
 .hud[data-state="transcribing"] .hud-viz,
-.hud[data-state="pasting"] .hud-viz {
-  /* Braille replaces the bars + stop-button footprint while the handle stays
-   * available for moving the HUD during finalization. */
+.hud[data-state="pasting"] .hud-viz,
+.hud[data-state="exiting"][data-exit-state="transcribing"] .hud-viz,
+.hud[data-state="exiting"][data-exit-state="pasting"] .hud-viz {
+  /* Braille replaces the bars + stop-button footprint while the handle
+   * stays available for moving the HUD. */
   width: 88px;
 }
 
+/* The audio viz gives way entirely to the message body. */
 .hud[data-state="error"] .hud-viz {
+  display: none;
+}
+
+.hud.hud-error-exit[data-state="exiting"] .hud-viz {
   display: none;
 }
 
 .hud[data-state="transcribing"] .hud-bars,
 .hud[data-state="pasting"] .hud-bars,
-.hud[data-state="error"] .hud-bars {
+.hud[data-state="exiting"][data-exit-state="transcribing"] .hud-bars,
+.hud[data-state="exiting"][data-exit-state="pasting"] .hud-bars {
   display: none;
 }
 
 .hud[data-state="transcribing"] .hud-braille,
-.hud[data-state="pasting"] .hud-braille {
+.hud[data-state="pasting"] .hud-braille,
+.hud[data-state="exiting"][data-exit-state="transcribing"] .hud-braille,
+.hud[data-state="exiting"][data-exit-state="pasting"] .hud-braille {
   display: flex;
-}
-
-.hud[data-state="error"] .hud-error-text {
-  display: block;
 }
 
 /* Stop button only matters while we're still capturing audio. */
 .hud[data-state="transcribing"] .hud-stop,
 .hud[data-state="pasting"] .hud-stop,
-.hud[data-state="error"] .hud-stop {
+.hud[data-state="error"] .hud-stop,
+.hud[data-state="exiting"][data-exit-state="transcribing"] .hud-stop,
+.hud[data-state="exiting"][data-exit-state="pasting"] .hud-stop,
+.hud.hud-error-exit[data-state="exiting"] .hud-stop {
   display: none;
 }
 
 /* Rapid fade exit. Triggered by setting data-state="exiting" before the
- * window hides — the content dissolves while the native window alpha ramps
- * down with it. No blur: the window edge is the pill edge now, so the bleed
- * would clip (softness comes from the native alpha fade instead). */
+ * window hides. Keep the same frostless CSS surface through the fade; native
+ * alpha handles the whole transparent window. */
 .hud[data-state="exiting"] {
   opacity: 0;
   transform: scale(0.94);
   pointer-events: none;
 }
 
-/* The meeting card's exit is native window motion (dictation_hud_exit):
- * the whole window slides up and fades, frost included. Keep the content
- * put and opaque so CSS doesn't double the motion or strand bare frost. */
+/* Transition kill-switch, held by syncWindowToPill (hud.ts) across one
+ * forced reflow so every in-flight transition lands at its end value before
+ * the pill is measured. getBoundingClientRect includes transforms, and an
+ * exit frozen mid-fade by the hidden webview's suspended timeline would
+ * otherwise be measured at the exiting scale, baking a too-narrow frame
+ * into the window. */
+.hud.hud-snap,
+.hud.hud-snap > * {
+  transition: none !important;
+}
+
+/* The meeting card's exit is native window motion (dictation_hud_exit).
+ * Keep the content put and opaque so CSS doesn't double the motion. */
 .hud.hud-exit-up[data-state="exiting"] {
   opacity: 1;
   transform: none;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -220,12 +220,7 @@ body {
   color: var(--foreground);
 }
 
-.hud[data-state="error"] .hud-error-icon {
-  display: grid;
-  place-items: center;
-  color: var(--destructive);
-}
-
+.hud[data-state="error"] .hud-error-icon,
 .hud.hud-error-exit[data-state="exiting"] .hud-error-icon {
   display: grid;
   place-items: center;
@@ -617,7 +612,8 @@ body {
  * the message layer draws out of. It uses the agent HUD's clean dark glass
  * with no native vibrancy rim. The "not allowed" wobble is native
  * (dictation_hud_shake jiggles the window itself). */
-.hud[data-state="error"] {
+.hud[data-state="error"],
+.hud.hud-error-exit[data-state="exiting"] {
   justify-content: center;
   gap: var(--sp-2);
   padding: 4px var(--sp-2);
@@ -625,7 +621,8 @@ body {
 
 /* The pill is its own centered cluster now, so the handle drops the
  * push-everything-right margin. */
-.hud[data-state="error"] > .hud-handle {
+.hud[data-state="error"] > .hud-handle,
+.hud.hud-error-exit[data-state="exiting"] > .hud-handle {
   margin-right: 0;
 }
 

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -78,7 +78,7 @@ describe("meeting detection HUD", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_size", {
       width: 32,
       height: 32,
-      animate: true,
+      animate: false,
     });
   });
 
@@ -207,6 +207,34 @@ describe("meeting detection HUD", () => {
     expect(hudShowCalls()).toBe(1);
   });
 
+  it("preserves the meeting prompt layout during native meeting exit", async () => {
+    await loadHud();
+    await emit("meeting-detection-event", { type: "meeting_detected" });
+
+    let resolveExit: (() => void) | undefined;
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "dictation_hud_exit") {
+        return new Promise<void>((resolve) => {
+          resolveExit = resolve;
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    document.querySelector<HTMLButtonElement>("#hud-meeting-dismiss")?.click();
+    await Promise.resolve();
+
+    expect(hudElement().dataset.state).toBe("exiting");
+    expect(hudElement().dataset.exitState).toBe("meeting");
+    expect(hudElement().classList.contains("hud-exit-up")).toBe(true);
+
+    resolveExit?.();
+
+    await vi.waitFor(() => expect(mocks.hide).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(hudElement().dataset.state).toBe("idle"));
+    expect(hudElement().dataset.exitState).toBeUndefined();
+  });
+
   it("ignores a dismiss click outside the meeting prompt state", async () => {
     await loadHud();
     hudElement().dataset.state = "listening";
@@ -231,7 +259,7 @@ describe("meeting detection HUD", () => {
     // under the mocked invoke.
     expect(mocks.hide).toHaveBeenCalledOnce();
     expect(hudElement().dataset.state).toBe("idle");
-    expect(chromeCalls()).toEqual([true, false]);
+    expect(chromeCalls()).toEqual([]);
   });
 
   it("hides and suppresses the prompt after 30 seconds without a click", async () => {
@@ -341,7 +369,7 @@ describe("meeting detection HUD", () => {
     // Drain the in-flight exit. Its fallback timeout dies with the fake
     // clock, but the rAF alpha ramp keeps running on real time after this
     // test ends and would land its hide() inside the next test's counts.
-    await vi.advanceTimersByTimeAsync(220);
+    await vi.advanceTimersByTimeAsync(320);
     expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
@@ -364,8 +392,115 @@ describe("meeting detection HUD", () => {
     expect(hudElement().dataset.state).toBe("exiting");
     expect(document.querySelector("#hud-error-text")).toHaveTextContent("");
 
-    await vi.advanceTimersByTimeAsync(220);
+    await vi.advanceTimersByTimeAsync(320);
     expect(mocks.hide).toHaveBeenCalledOnce();
+  });
+
+  it("uses agent-style frostless chrome for the compact listening pill", async () => {
+    await loadHud();
+
+    await emit("dictation-event", { type: "listening_started" });
+
+    expect(hudElement().dataset.state).toBe("listening");
+    expect(chromeCalls()).toEqual([]);
+    expect(mocks.invoke).toHaveBeenCalledWith(
+      "dictation_hud_set_size",
+      expect.objectContaining({ width: 32, height: 32 }),
+    );
+  });
+
+  it("fades the processing HUD in place when paste completes", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("dictation-event", {
+      type: "paste_target",
+      payload: { app: "Notes" },
+    });
+    mocks.invoke.mockClear();
+
+    await emit("dictation-event", { type: "paste_completed" });
+
+    expect(hudElement().dataset.state).toBe("exiting");
+    expect(hudElement().dataset.exitState).toBe("pasting");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent("");
+
+    await vi.advanceTimersByTimeAsync(320);
+
+    expect(mocks.hide).toHaveBeenCalledOnce();
+    expect(hudElement().dataset.state).toBe("idle");
+    expect(hudElement().dataset.exitState).toBeUndefined();
+  });
+
+  it("switches from listening to transcribing without a morph flash", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("dictation-event", { type: "listening_started" });
+    mocks.invoke.mockClear();
+
+    let resolveResize: (() => void) | undefined;
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "dictation_hud_set_size") {
+        return new Promise<void>((resolve) => {
+          resolveResize = resolve;
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const finalizing = emit("dictation-event", {
+      type: "finalizing_transcript",
+    });
+    await Promise.resolve();
+    expect(sizeCalls()).toHaveLength(1);
+    expect(sizeCalls()[0]?.[1]).toMatchObject({ animate: false });
+    expect(hudShowCalls()).toBe(0);
+
+    resolveResize?.();
+    await finalizing;
+
+    expect(sizeCalls()).toHaveLength(1);
+    expect(hudShowCalls()).toBe(1);
+  });
+
+  it("snap-sizes an interrupted fresh listening show before revealing it", async () => {
+    await loadHud();
+    hudElement().dataset.state = "exiting";
+    mocks.invoke.mockClear();
+
+    await emit("dictation-event", { type: "listening_started" });
+
+    const setAlphaIndex = invokeCallIndex("dictation_hud_set_alpha");
+    const setSizeIndex = invokeCallIndex("dictation_hud_set_size");
+    const showIndex = invokeCallIndex("dictation_hud_show");
+
+    expect(setAlphaIndex).toBeGreaterThanOrEqual(0);
+    expect(setSizeIndex).toBeGreaterThan(setAlphaIndex);
+    expect(showIndex).toBeGreaterThan(setSizeIndex);
+    expect(sizeCalls()[0]?.[1]).toMatchObject({ animate: false });
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_alpha", {
+      alpha: 0,
+    });
+  });
+
+  it("measures the pill with in-flight transitions snapped to their end values", async () => {
+    await loadHud();
+    const hud = hudElement();
+    // Mid-exit: the scale(0.94)/opacity transition is still in play (or
+    // frozen by a hidden webview) when the next show measures the pill.
+    hud.dataset.state = "exiting";
+    const snappedAtMeasure: boolean[] = [];
+    const measure = hud.getBoundingClientRect.bind(hud);
+    vi.spyOn(hud, "getBoundingClientRect").mockImplementation(() => {
+      snappedAtMeasure.push(hud.classList.contains("hud-snap"));
+      return measure();
+    });
+
+    await emit("dictation-event", { type: "listening_started" });
+
+    // The window-sizing measurement reads the rect under .hud-snap
+    // (transition: none), so a frozen exit scale can't undersize the frame.
+    expect(snappedAtMeasure[0]).toBe(true);
+    expect(hud.classList.contains("hud-snap")).toBe(false);
   });
 
   it("shakes the listening pill instead of toasting when dictation is already listening", async () => {
@@ -406,6 +541,98 @@ describe("meeting detection HUD", () => {
     expect(hudShowCalls()).toBe(1);
   });
 
+  it("reveals the error message below the pill by default", async () => {
+    await loadHud();
+    await emit("dictation-event", { type: "finalizing_transcript" });
+    mocks.invoke.mockClear();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "transcription_failed",
+        message: "Dictation recorded no text. Try again.",
+      },
+    });
+
+    expect(hudElement().dataset.state).toBe("error");
+    const message = document.querySelector("#hud-error-text");
+    expect(message).toHaveTextContent("Dictation recorded no text. Try again.");
+    expect(hudElement().dataset.errorPlacement).toBe("below");
+    // The message lives inside the HUD window now (the layer opens from the
+    // pill), not as a detached caption sibling.
+    expect(document.querySelector("#hud #hud-error-text")).not.toBeNull();
+    // The HUD is frostless from native setup through every state, so this
+    // transition no longer swaps native chrome mid-flow.
+    expect(chromeCalls()).toEqual([]);
+    expect(mocks.invoke).not.toHaveBeenCalledWith(
+      "dictation_hud_caption_fits_below",
+      expect.anything(),
+    );
+    expect(mocks.invoke).toHaveBeenCalledWith(
+      "dictation_hud_preferred_error_placement",
+    );
+    // The window is sized to fit the message layer mirrored above/below the
+    // pill, plus the shadow gutter (jsdom rects are zero: 2 gaps tall and
+    // 2 gutters all round).
+    expect(mocks.invoke).toHaveBeenCalledWith(
+      "dictation_hud_set_size",
+      expect.objectContaining({ width: 32, height: 48 }),
+    );
+  });
+
+  it("reveals the error message above the pill when native placement asks for it", async () => {
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === "dictation_hud_preferred_error_placement") {
+        return Promise.resolve("above");
+      }
+      return Promise.resolve(undefined);
+    });
+    await loadHud();
+
+    await emit("dictation-event", {
+      type: "error",
+      payload: {
+        code: "transcription_failed",
+        message: "Dictation recorded no text. Try again.",
+      },
+    });
+
+    expect(hudElement().dataset.state).toBe("error");
+    expect(hudElement().dataset.errorPlacement).toBe("above");
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent(
+      "Dictation recorded no text. Try again.",
+    );
+  });
+
+  it("fades the expanded error in place when the error exits", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("dictation-event", {
+      type: "error",
+      payload: { message: "Dictation recorded no text. Try again." },
+    });
+    mocks.invoke.mockClear();
+
+    // Error exits by fading the expanded panel in place, not retracting it
+    // back into the compact recorder pill.
+    await vi.advanceTimersByTimeAsync(1800);
+    expect(hudElement().dataset.state).toBe("exiting");
+    expect(hudElement().classList.contains("hud-error-exit")).toBe(true);
+    expect(hudElement().classList.contains("hud-reveal-collapsed")).toBe(false);
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent(
+      "Dictation recorded no text. Try again.",
+    );
+
+    await vi.advanceTimersByTimeAsync(320);
+
+    expect(mocks.hide).toHaveBeenCalledOnce();
+    expect(hudElement().dataset.state).toBe("idle");
+    expect(chromeCalls()).toEqual([]);
+    // The message survives the exit fade (it dissolves with the window) and
+    // clears once the pill parks on idle.
+    expect(document.querySelector("#hud-error-text")).toHaveTextContent("");
+  });
+
   it("hides when a Hey June prompt starts an agent session", async () => {
     vi.useFakeTimers();
     await loadHud();
@@ -417,7 +644,7 @@ describe("meeting detection HUD", () => {
     });
 
     expect(hudElement().dataset.state).toBe("exiting");
-    await vi.advanceTimersByTimeAsync(220);
+    await vi.advanceTimersByTimeAsync(320);
     expect(mocks.hide).toHaveBeenCalledOnce();
   });
 
@@ -467,10 +694,22 @@ function hudShowCalls() {
   ).length;
 }
 
+function sizeCalls() {
+  return mocks.invoke.mock.calls.filter(
+    ([command]) => command === "dictation_hud_set_size",
+  );
+}
+
+function invokeCallIndex(commandName: string) {
+  return mocks.invoke.mock.calls.findIndex(
+    ([command]) => command === commandName,
+  );
+}
+
 function chromeCalls() {
   return mocks.invoke.mock.calls
     .filter(([command]) => command === "dictation_hud_set_chrome")
-    .map(([, args]) => (args as { meeting: boolean }).meeting);
+    .map(([, args]) => (args as { frostless: boolean }).frostless);
 }
 
 function hudElement() {
@@ -494,9 +733,11 @@ function hudMarkup() {
           <span class="hud-bar"></span>
         </div>
         <span id="hud-braille" class="hud-braille" aria-hidden="true"></span>
-        <span class="hud-error-mark" aria-hidden="true"></span>
       </div>
-      <span id="hud-error-text" class="hud-error-text" aria-hidden="true"></span>
+      <span class="hud-error-icon" aria-hidden="true"></span>
+      <span class="hud-error-layer" aria-hidden="true">
+        <span id="hud-error-text" class="hud-error-message"></span>
+      </span>
       <span class="hud-meeting-body">
         <span class="hud-meeting-mark" aria-hidden="true"></span>
         <span class="hud-meeting-text">

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2,3 +2,21 @@
 
 - When a user says a spinner/name change happened elsewhere, honor the latest component name from main while preserving the intended behavior. In this session, the spinner behavior belongs in the trailing agent-session state slot, but the component is `DotSpinner`.
 - During drag-preview UI states, avoid `display` toggles for reversible pointer gestures. Hide collapsed preview with visibility/pointer-events so reopening can render immediately while related fixed panels stay mounted.
+- For tiny native HUDs, verify both the final steady state and the first visible frames after a hidden or interrupted show. A correct final size can still hitch if the native window animates from a stale frame while visible; fresh shows should be pre-sized while hidden, with animation reserved for visible state-to-state morphs.
+- getBoundingClientRect includes CSS transforms, and a hidden WKWebView suspends its animation timeline. Any "measure the DOM to size a native window" path must neutralize in-flight transitions first (transition: none for one reflow), or a frozen exit transform (e.g. the HUD's scale 0.94) gets baked into the native frame and the window comes up clipped.
+- When an overlay can be dragged around the screen, expansion direction must be
+  position-aware. A one-sided reveal that looks clean at top-center can feel
+  broken near screen edges; query native monitor/work-area context and reveal
+  into available space.
+- Do not swap a native HUD back to vibrancy while an oversized transitional
+  window is still visible. Keep exit states on the same chrome as the visible
+  state, then restore idle chrome only after the window is hidden.
+- When a user says an error HUD should "just fade out", do not mirror the
+  entrance animation on exit. Keep the expanded error mounted and fade the
+  whole surface in place.
+- When a HUD uses `data-state="exiting"`, preserve the outgoing visual state
+  separately. Otherwise exit selectors can fall back to the default layout and
+  briefly repaint controls from a different state during fade-out.
+- For same-footprint HUD transitions, do not use the generic morph path. If
+  the layout is deliberately size-compatible, snap the native size and swap
+  content directly to avoid a perceptible flash.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,32 +1,53 @@
-# Sidebar files collapse bug
+# Dictation HUD second-run visual stability
 
-- [x] Locate the main sidenav resize/collapse logic and the agent sidebar files sidenav rendering.
-- [x] Reproduce or reason through why files temporarily disappear during drag collapse.
-- [x] Patch the state/layout path with the smallest scoped change.
-- [x] Add or update focused tests if the behavior is covered by component tests.
-- [x] Run relevant tests and document the rendered validation blocker.
-- [x] Fix the reverse drag flash after collapsing while the pointer stays down.
+- [x] Read the attached transcript and screenshot.
+- [x] Inspect the follow-up hitch video.
+- [x] Inspect the dictation HUD state and sizing flow.
+- [x] Identify the likely clipping race.
+- [x] Patch the HUD sizing path with a scoped fix.
+- [x] Patch fresh second-run shows to snap-size before reveal.
+- [x] Add focused regression coverage.
+- [x] Run targeted tests and lint/build checks as practical.
+- [x] Fix the residual second-run hitch: snap in-flight transitions before
+      measuring the pill, and make the settle-pass heal a non-animated snap.
+- [x] Lengthen the exit dissolve to a perceptible fade (240ms native alpha +
+      matching CSS).
+- [x] Float error messages in a caption line below/above the pill (frostless
+      chrome + dictation_hud_caption_fits_below) instead of stretching the
+      pill; pill shows the compact error mark.
+- [x] Rework the error reveal to attach above/below the HUD based on screen
+      position, using a CSS reveal while the native window stays pre-sized.
+- [x] Add focused regression coverage for above/below placement and sizing.
+- [x] Run targeted HUD tests and practical build checks.
+- [x] Make every visible dictation HUD state frostless to match the agent HUD
+      surface instead of using native vibrancy for compact states.
+- [x] Keep frostless chrome through exit so the oversized error window cannot
+      flash a native frosted rectangle while fading.
+- [x] Tint the compact error icon red and verify the HUD tests/build.
+- [x] Remove the error-layer retract on dismiss so expanded errors fade in
+      place instead of animating back into the recorder pill.
+- [x] Preserve the outgoing processing HUD layout during paste-complete fade
+      so it cannot flash back to the waveform recorder controls.
+- [x] Audit all `hideHud()` callers and preserve meeting prompt layout during
+      native meeting exit.
+- [x] Make listening to transcribing skip the content morph/native resize
+      animation so the processing HUD appears seamlessly.
+- [x] Compare dictation HUD transparency with the agent HUD surface.
 
-## Review
+## Notes
 
-Fixed by giving drag-collapse its own transient `data-sidebar-preview` state.
-The files panel remains mounted, while fixed agent UI now follows the same
-collapsed or expanded selectors during the drag threshold crossing instead of
-waiting for React's committed `data-sidebar` state on pointer-up.
+The screenshot shows the right side of the dictation pill cut by the window
+edge. The report says the issue heals on the next transition, which points at
+the native HUD window keeping a stale frame until a later resize/show pass.
+The follow-up video shows a related second-run hitch: the interrupted fresh
+listening show becomes visible while the native frame is still resizing from a
+stale width. Fresh shows now set native alpha to zero, snap-size the window,
+then reveal; visible state-to-state transitions still use the morph.
 
-Follow-up correction: collapsed drag preview now keeps the sidebar element in
-layout but hides it with `visibility`, so the files panel stays visible without
-a display toggle. Reverse-drag uses an `opening` preview state with the normal
-expanded offsets, so the main sidenav renders correctly while the mouse is
-still down.
+## Verification
 
-Verification:
-
-- `pnpm test -- src/test/sidebar-resize.test.ts`
-- `pnpm test -- src/test/agent-workspace.test.tsx`
+- `pnpm test -- src/test/hud-meeting.test.ts`
+- `pnpm test`
 - `pnpm run lint`
 - `pnpm run build`
-
-Rendered validation note: the in-app Browser runtime was present, but the `iab`
-browser was unavailable in this Conductor session. The project also does not
-ship Playwright, so validation used focused unit/component coverage plus build.
+- `cargo check --manifest-path src-tauri/Cargo.toml`


### PR DESCRIPTION
Fixes dictation HUD clipping, repaint, and transition flicker by moving the HUD to the same frostless CSS-painted surface model as the agent HUD and preserving outgoing layouts during fade-out.
The error state now reveals above or below the pill based on screen position, uses a red error icon, fades out in place, and keeps silent/no-speech outcomes hidden.
Normal recording completion, listening to transcribing, and meeting prompt exits now avoid flashing back to the waveform or another stale layout.
Also broadens Conductor workspace Vite cleanup and adds focused HUD regression coverage.
Validated with `pnpm test -- src/test/hud-meeting.test.ts`, `pnpm test`, `pnpm run lint`, `pnpm run build`, and `cargo check --manifest-path src-tauri/Cargo.toml`.
