### PR TITLE
feat: send Slack notification on production release

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -306,6 +306,66 @@ jobs:
           git pull --rebase origin main
           git push origin main
 
+      - name: Notify Slack on release
+        if: ${{ success() }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::SLACK_WEBHOOK_URL secret is not configured; skipping Slack notification."
+            exit 0
+          fi
+          payload=$(cat <<EOF
+          {
+            "text": ":rocket: *June v${VERSION} released*",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rocket: *June v${VERSION} released*"
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Version:*\nv${VERSION}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Download:*\n<https://github.com/open-software-network/os-june-releases/releases/latest/download/June_aarch64.dmg|macOS DMG (Apple Silicon)>"
+                  }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View release"
+                    },
+                    "url": "https://github.com/open-software-network/os-june-releases/releases/tag/v${VERSION}"
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          )
+          response=$(curl -sS -f -X POST \
+            -H "Content-Type: application/json" \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL" 2>&1) || {
+            echo "::warning::Slack notification failed: $response"
+            exit 0
+          }
+          echo "Slack notification sent successfully."
+
       - name: Summary
         run: |
           {


### PR DESCRIPTION
Adds a Slack webhook notification step to the production-desktop-dmg workflow that posts to #build when a prod release succeeds.

**What it does:**
- Posts a formatted Slack message with the version, DMG download link, and a View release button
- Runs after the version commit, only on success
- Gracefully skips (warning only) if the SLACK_WEBHOOK_URL secret is not configured

**Setup required:**
Add a SLACK_WEBHOOK_URL secret to the production environment in repo settings (point the webhook at #build).