### PR TITLE
Teach the agent to recognize a CLI blocked by the sandbox (not flail with --sandbox)

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -85,7 +85,9 @@ Your environment: sessions run by default inside a macOS kernel sandbox (Seatbel
 /// `AGENT_CLI_ACCESS_REQUEST_TOKEN` in `src/lib/agent-cli-access.ts` must
 /// match the token spelled out below.
 const JUNE_SOUL_CLI_BLOCKED_MD: &str = r#"
-Agent CLIs (Claude Code, Codex, Gemini, opencode): in sandboxed sessions their state folders (~/.claude and ~/.claude.json, ~/.codex, ~/.gemini, opencode's config and state) are write-blocked like the rest of the user's files. Those tools then fail to save sessions or store refreshed logins, and often report "not logged in" even when the user is. When a CLI fails this way, name the sandbox as the cause first, then request the fix directly: put the literal token [REQUEST:AGENT_CLI_ACCESS] on its own line in your reply. The June app replaces that token with an approval card; one click enables "Agent CLI access" in Settings, restarts the sandboxed runtime with those folders writable, and prompts you to retry. Use the token only for this setting and at most once per reply. The user can instead flip it themselves in Settings, Agent tab, or run the work in an Unrestricted session. Interactive logins (for example `claude /login`) are browser flows you can never complete; the user runs those once in their own terminal.
+Agent CLIs (Claude Code, Codex, Gemini, opencode): in sandboxed sessions their state folders (~/.claude and ~/.claude.json, ~/.codex, ~/.gemini, opencode's config and state) are write-blocked like the rest of the user's files. This breaks them in two ways. The milder one: they save no sessions and lose refreshed logins, often reporting "not logged in" even when the user is. The harder one: some CLIs will not even start when their state folder is unwritable. Codex is the clearest case: it fails immediately with "Operation not permitted (os error 1)", "could not create PATH aliases", or "failed to initialize in-process app-server client". Treat any "Operation not permitted" or "os error 1" from a coding CLI as June's write-jail denying its state folder, not a fault in the CLI or its arguments.
+Critically, this is NOT the CLI's own sandbox. Codex's `--sandbox`, Claude's permission mode, and similar flags control how the CLI sandboxes the work it does; they have no effect on June's outer Seatbelt jail and cannot lift it. Do not retry with different CLI sandbox flags, that is the wrong layer and only wastes turns. The one fix is granting the CLI's state folder write access.
+When a CLI fails either way, name the sandbox as the cause first, then request the fix directly: put the literal token [REQUEST:AGENT_CLI_ACCESS] on its own line in your reply. The June app replaces that token with an approval card; one click enables "Agent CLI access" in Settings, restarts the sandboxed runtime with those folders writable, and prompts you to retry. Use the token only for this setting and at most once per reply. The user can instead flip it themselves in Settings, Agent tab, or run the work in an Unrestricted session. Interactive logins (for example `claude /login`) are browser flows you can never complete; the user runs those once in their own terminal.
 "#;
 
 /// Appended after the sandbox section when the user HAS enabled Agent CLI
@@ -3180,6 +3182,13 @@ mod tests {
         assert!(soul.contains("name the sandbox as the cause"));
         assert!(soul.contains("[REQUEST:AGENT_CLI_ACCESS]"));
         assert!(!soul.contains("first-class job"));
+        // Teaches the hard startup-failure signature (a blocked Codex dies
+        // with EPERM before it does anything) so the agent recognizes it...
+        assert!(soul.contains("os error 1"));
+        assert!(soul.contains("in-process app-server"));
+        // ...and warns not to confuse it with the CLI's own sandbox flag,
+        // which is the wrong layer (what the screenshot agent got wrong).
+        assert!(soul.contains("NOT the CLI's own sandbox"));
     }
 
     #[test]

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -300,11 +300,11 @@ export function AgentSettingsSection() {
               <p className="settings-row-description">
                 Let June drive the coding CLIs you already use (Claude Code,
                 Codex, Gemini, opencode). Sandboxed sessions gain write access
-                to those tools' own settings and session folders so they stay
-                logged in and can save their work. Those folders configure
-                software that also runs outside June's sandbox, so leave this
-                off unless you want June operating your CLIs. Applies to new
-                sessions.
+                to those tools' own settings and session folders. Some CLIs
+                (Codex among them) will not even start without it; others lose
+                their login. Those folders configure software that also runs
+                outside June's sandbox, so leave this off unless you want June
+                operating your CLIs. Applies to new sessions.
               </p>
             </div>
             <div className="settings-row-control">


### PR DESCRIPTION
Fixes the screenshot: in a sandboxed session the agent tries to run Codex, it dies with "Operation not permitted (os error 1)", and the agent flails, retrying `codex exec --sandbox workspace-write` (the wrong layer) instead of surfacing the fix.

## What I verified empirically (not guessed)

Reproduced it under June's actual generated sandbox profile:
- **Agent CLI access OFF** (the user's case, confirmed from the live `hermes-sandbox.sb`): `codex exec` fails immediately with the exact reported errors, because the write-jail denies `~/.codex`.
- **`~/.codex` granted** (what enabling Agent CLI access already does): the identical `codex exec "say hi"` runs and returns "hi".

So the grant machinery is **correct and sufficient** - codex 0.139.0 works fine under the jail once its state folder is writable. This was never a missing-grant bug. It's a discoverability bug:

1. The agent didn't recognize the EPERM as June's outer Seatbelt jail. It assumed it was Codex's own sandbox and retried `--sandbox workspace-write` - a flag that tells Codex how to sandbox *itself*, with no effect on June's jail. Wasted turns, never fixed.
2. The blocked-CLI SOUL guidance only described the *milder* symptom ("reports not logged in"), not the *hard* one where a CLI won't even start.
3. So the agent never emitted `[REQUEST:AGENT_CLI_ACCESS]` - the token that renders a one-click "enable Agent CLI access" card, which restarts the runtime with `~/.codex` writable and actually fixes it.

## The fix

- **SOUL (blocked-CLI guidance):** name the concrete hard-failure signatures ("Operation not permitted", "os error 1", "could not create PATH aliases", "failed to initialize in-process app-server client"); tell the agent to treat any such error from a coding CLI as June's write-jail; and warn explicitly that the CLI's own `--sandbox`/permission flags are the wrong layer and cannot lift the jail. The agent then names the cause and emits the request token, surfacing the one-click enable.
- **Settings copy:** "Agent CLI access" no longer reads as mere login persistence; it now states some CLIs (Codex) will not start at all without it.

No grant change needed (verified sufficient). Two SOUL assertions added to the existing tests; 478 frontend tests and the hermes_bridge Rust suite pass; lint clean (one pre-existing needless-borrow warning untouched).

## On "shouldn't enabling agent CLIs just mean unrestricted access?"

That intuition is right in spirit, and the existing design already delivers it safely: enabling Agent CLI access grants exactly the dirs the CLIs need (verified), without lifting the whole jail. It's gated behind one explicit consent (the card / the Settings toggle) because those folders configure software that also runs *outside* June later, so silently granting on first CLI use would write to the user's `~/.codex`/`~/.claude` without asking. This PR makes that consent reliably appear at the moment a CLI is blocked, rather than changing the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)