### PR TITLE
[codex] fix visible agent credit failures

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -43,6 +43,7 @@ const HERMES_IMAGE_PREVIEW_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const HERMES_TEXT_PREVIEW_MAX_BYTES: u64 = 2 * 1024 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_BODY_BYTES: usize = 512 * 1024;
+const SCRIBE_ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 
 /// Identity injected into every Hermes session via `SOUL.md`. Hermes loads
 /// this file from `HERMES_HOME` at prompt-build time; without it the runtime
@@ -2577,7 +2578,9 @@ async fn handle_scribe_provider_connection(
                     let status = response.status;
                     let content_type = response.content_type.clone();
                     let body = response.collect_body().await.unwrap_or_default();
-                    match translate_context_overflow_error(&body) {
+                    match translate_context_overflow_error(&body)
+                        .or_else(|| translate_insufficient_credits_error(&body))
+                    {
                         Some(rewritten) => {
                             write_json_response(&mut stream, status, rewritten).await?;
                         }
@@ -2723,6 +2726,38 @@ fn translate_context_overflow_error(body: &[u8]) -> Option<serde_json::Value> {
             .to_string(),
     );
     Some(value)
+}
+
+/// Rewrites Scribe's insufficient-credit envelope into the OpenAI-style error
+/// shape Hermes's provider client expects for chat-completions failures. The
+/// status code stays 402, but the runtime now has an `error.message` to emit
+/// and persist, so the desktop UI can render its out-of-credits notice.
+fn translate_insufficient_credits_error(body: &[u8]) -> Option<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    if value.get("error_code")?.as_i64()? != SCRIBE_ERR_INSUFFICIENT_CREDITS {
+        return None;
+    }
+    let raw_message = value
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .unwrap_or("insufficient_credits");
+    let message = if raw_message == "insufficient_credits" {
+        "insufficient_credits: Your balance is too low. Add funds to continue.".to_string()
+    } else {
+        raw_message.to_string()
+    };
+    Some(serde_json::json!({
+        "error": {
+            "message": message.clone(),
+            "type": "insufficient_credits",
+            "code": "insufficient_credits",
+        },
+        "success": false,
+        "error_code": SCRIBE_ERR_INSUFFICIENT_CREDITS,
+        "message": message,
+    }))
 }
 
 /// The proxy's `/v1/models` listing. Hermes resolves a custom provider's
@@ -2954,6 +2989,42 @@ mod tests {
         assert!(message.starts_with("prompt_too_long"));
         assert_eq!(rewritten["error_code"], 2001);
         assert_eq!(rewritten["success"], false);
+    }
+
+    #[test]
+    fn insufficient_credits_rejection_translates_to_openai_error() {
+        // Hermes's provider client expects chat-completions failures in the
+        // OpenAI error shape. The Scribe envelope alone can disappear before
+        // the gateway emits a visible event.
+        let body =
+            br#"{"data":null,"success":false,"error_code":4301,"message":"insufficient_credits"}"#;
+
+        let rewritten = translate_insufficient_credits_error(body).expect("translated");
+
+        let message = rewritten["error"]["message"].as_str().expect("message");
+        assert!(message.contains("insufficient_credits"));
+        assert!(message.contains("Add funds"));
+        assert_eq!(rewritten["error"]["type"], "insufficient_credits");
+        assert_eq!(rewritten["error"]["code"], "insufficient_credits");
+        assert_eq!(rewritten["error_code"], 4301);
+        assert_eq!(rewritten["success"], false);
+    }
+
+    #[test]
+    fn non_credit_errors_do_not_translate_to_openai_billing_error() {
+        for body in [
+            br#"{"data":null,"success":false,"error_code":2001,"message":"prompt_too_long"}"#
+                .as_slice(),
+            br#"{"error":{"message":"rate limited"}}"#.as_slice(),
+            b"not json at all".as_slice(),
+            br#"{"error_code":"4301","message":"insufficient_credits"}"#.as_slice(),
+        ] {
+            assert!(
+                translate_insufficient_credits_error(body).is_none(),
+                "must not rewrite: {}",
+                String::from_utf8_lossy(body),
+            );
+        }
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -160,7 +160,10 @@ import {
   pricingLabel,
   selectedModel as selectedModelOption,
 } from "../settings/ModelPickerDialog";
-import { messageFromError } from "../../lib/errors";
+import {
+  isInsufficientCreditsMessage,
+  messageFromError,
+} from "../../lib/errors";
 import {
   displayedUserMessageText,
   issueReportPrompt,
@@ -2072,6 +2075,12 @@ export function AgentWorkspace({
     }
   }
 
+  function topUpCredits() {
+    void osAccountsTopUp().catch((err: unknown) =>
+      setError(messageFromError(err)),
+    );
+  }
+
   // The "+" picker routes through the same bridge import as drag-drop so the
   // agent always gets a real, readable path.
   async function pickAttachments() {
@@ -2891,8 +2900,8 @@ export function AgentWorkspace({
     dispatchAgentSessionStatus({
       sessionId,
       title:
-        hermesSessionItems.find((session) => session.id === sessionId)
-          ?.title ?? "Agent session",
+        hermesSessionItems.find((session) => session.id === sessionId)?.title ??
+        "Agent session",
       status: "cancelled",
       summary: "Stopped.",
       ...activityCounts,
@@ -3745,11 +3754,7 @@ export function AgentWorkspace({
               sessionUnrestricted(selectedHermesSessionId),
             )
           }
-          onTopUp={() =>
-            void osAccountsTopUp().catch((err: unknown) =>
-              setError(messageFromError(err)),
-            )
-          }
+          onTopUp={topUpCredits}
           onClarify={(part, answer) =>
             void respondToClarify(
               selectedHermesSessionId,
@@ -3821,11 +3826,7 @@ export function AgentWorkspace({
             onThinkingOpenChange={setThinkingOpen}
             onDownloadArtifact={downloadArtifact}
             onOpenArtifact={openArtifact}
-            onTopUp={() =>
-              void osAccountsTopUp().catch((err: unknown) =>
-                setError(messageFromError(err)),
-              )
-            }
+            onTopUp={topUpCredits}
             onApproval={(part, choice) => {
               const sessionId = part.sessionId ?? selectedTask.hermesSessionId;
               if (!sessionId) return;
@@ -3905,15 +3906,19 @@ export function AgentWorkspace({
           data-hero-leaving={heroLeaving ? "true" : undefined}
         >
           {error ? (
-            <AgentErrorBanner
-              message={error}
-              onRetry={
-                GATEWAY_CONNECTION_ERROR.test(error)
-                  ? () => void retryGatewayConnection()
-                  : undefined
-              }
-              onDismiss={() => setError(null)}
-            />
+            isInsufficientCreditsMessage(error) ? (
+              <CreditsNoticePart onTopUp={topUpCredits} />
+            ) : (
+              <AgentErrorBanner
+                message={error}
+                onRetry={
+                  GATEWAY_CONNECTION_ERROR.test(error)
+                    ? () => void retryGatewayConnection()
+                    : undefined
+                }
+                onDismiss={() => setError(null)}
+              />
+            )
           ) : null}
           <div className="agent-hero-heading">
             <h2 className="agent-hero-title">{heroGreeting}</h2>
@@ -3967,15 +3972,19 @@ export function AgentWorkspace({
                   onDismiss={galleryNoop}
                 />
               ) : error ? (
-                <AgentErrorBanner
-                  message={error}
-                  onRetry={
-                    GATEWAY_CONNECTION_ERROR.test(error)
-                      ? () => void retryGatewayConnection()
-                      : undefined
-                  }
-                  onDismiss={() => setError(null)}
-                />
+                isInsufficientCreditsMessage(error) ? (
+                  <CreditsNoticePart onTopUp={topUpCredits} />
+                ) : (
+                  <AgentErrorBanner
+                    message={error}
+                    onRetry={
+                      GATEWAY_CONNECTION_ERROR.test(error)
+                        ? () => void retryGatewayConnection()
+                        : undefined
+                    }
+                    onDismiss={() => setError(null)}
+                  />
+                )
               ) : null}
               {detailContent}
               {composer}

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -260,7 +260,18 @@ function creditsNotice(text: string): AgentChatNoticePart | undefined {
 function creditsNoticeFromTurnText(
   text: string,
 ): AgentChatNoticePart | undefined {
-  return /^\s*error\b/i.test(text) ? creditsNotice(text) : undefined;
+  if (/^\s*error\b/i.test(text)) return creditsNotice(text);
+  return looksLikeCreditFailurePayload(text) ? creditsNotice(text) : undefined;
+}
+
+function looksLikeCreditFailurePayload(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (/^insufficient[-_\s]?credits[.!]?$/i.test(trimmed)) return true;
+  if (/^insufficient_available_balance[.!]?$/i.test(trimmed)) return true;
+  if (/^your balance is too low\b/i.test(trimmed)) return true;
+  if (/error_code['"]?\s*:\s*4301/i.test(trimmed)) return true;
+  return false;
 }
 
 function messageToTurn(message: AgentMessageDto): AgentChatTurn {
@@ -402,7 +413,8 @@ function appendLiveHermesEvents(
       const taskIndex =
         typeof taskIndexRaw === "number" ? taskIndexRaw : undefined;
       const key =
-        subagentId ?? (taskIndex !== undefined ? `task-${taskIndex}` : "subagent");
+        subagentId ??
+        (taskIndex !== undefined ? `task-${taskIndex}` : "subagent");
       const partId = `subagent:${key}`;
       const goal = stringValue(payload?.goal);
       const taskCountRaw = payload?.task_count;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -15,7 +15,7 @@ export function messageFromError(err: unknown) {
  * (`... 'error_code': 4301, 'message': 'insufficient_credits'`). */
 export function isInsufficientCreditsMessage(message?: string) {
   if (!message) return false;
-  return /out of credits|insufficient credits|insufficient_credits|balance is too low/i.test(
+  return /out of credits|insufficient[-_\s]?credits|insufficient_available_balance|balance is too low|error_code['"]?\s*:\s*4301/i.test(
     message,
   );
 }

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -831,6 +831,8 @@ describe("Agent chat runtime", () => {
   // exact shape reaches us as persisted assistant text and as live event text.
   const CREDITS_ERROR =
     "Error: Error code: 402 - {'data': None, 'success': False, 'error_code': 4301, 'message': 'insufficient_credits'}";
+  const CREDITS_ENVELOPE =
+    '{"data":null,"success":false,"error_code":4301,"message":"insufficient_credits"}';
 
   it("folds a live insufficient-credits error event into a credits notice", () => {
     const turns = buildAgentChatTurns(
@@ -862,6 +864,40 @@ describe("Agent chat runtime", () => {
 
     expect(turns[0]?.parts).toEqual([
       { type: "notice", kind: "credits", text: CREDITS_ERROR },
+    ]);
+  });
+
+  it("folds a persisted Scribe insufficient-credits envelope into a credits notice", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "assistant",
+        content: CREDITS_ENVELOPE,
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      { type: "notice", kind: "credits", text: "insufficient_credits" },
+    ]);
+  });
+
+  it("folds a persisted bare insufficient-credits message into a credits notice", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "assistant",
+        content: "Your balance is too low. Add funds to continue.",
+        timestamp: "2026-06-04T10:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "notice",
+        kind: "credits",
+        text: "Your balance is too low. Add funds to continue.",
+      },
     ]);
   });
 
@@ -949,12 +985,20 @@ describe("Agent chat runtime", () => {
         {
           type: "subagent.tool",
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { subagent_id: "sa-1", goal: "Write the privacy page", tool_preview: "edit privacy.tsx" },
+          payload: {
+            subagent_id: "sa-1",
+            goal: "Write the privacy page",
+            tool_preview: "edit privacy.tsx",
+          },
         },
         {
           type: "subagent.complete",
           receivedAt: "2026-06-04T10:00:02.000Z",
-          payload: { subagent_id: "sa-1", goal: "Write the privacy page", summary: "Done: 1 file written" },
+          payload: {
+            subagent_id: "sa-1",
+            goal: "Write the privacy page",
+            summary: "Done: 1 file written",
+          },
         },
       ],
     );
@@ -973,8 +1017,12 @@ describe("Agent chat runtime", () => {
       status: "running",
     });
     // The first subagent's row accumulated its activity then its summary.
-    expect((tools?.[0] as { text?: string }).text).toContain("edit privacy.tsx");
-    expect((tools?.[0] as { text?: string }).text).toContain("Done: 1 file written");
+    expect((tools?.[0] as { text?: string }).text).toContain(
+      "edit privacy.tsx",
+    );
+    expect((tools?.[0] as { text?: string }).text).toContain(
+      "Done: 1 file written",
+    );
   });
 
   it("keeps the goal label when a later subagent event omits it", () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2832,6 +2832,38 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Hermes gateway is not connected.")).toBeNull();
   });
 
+  it("renders an out-of-credits notice when prompt submit rejects before a transcript turn exists", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "prompt.submit") {
+        return Promise.reject(
+          new Error(
+            "Scribe agent provider failed: insufficient_credits: Your balance is too low. Add funds to continue.",
+          ),
+        );
+      }
+      return Promise.resolve({});
+    });
+
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Send a message"), "hello");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(
+      await screen.findByText(/June stopped because your balance ran out/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Scribe agent provider failed/)).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Add funds" }));
+    expect(mocks.osAccountsTopUp).toHaveBeenCalledOnce();
+  });
+
   it("renders an out-of-credits notice with a top-up action instead of the raw 402 error", async () => {
     const user = userEvent.setup();
     mocks.osAccountsTopUp.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- Rewrite Scribe `4301` chat-completions envelopes into OpenAI-style provider errors so Hermes can emit or persist the billing failure.
- Treat Scribe envelope, bare `insufficient_credits`, and friendly balance-low messages as agent credit notices.
- Show the existing out-of-credits card with `Add funds` when `prompt.submit` rejects before a transcript turn exists.

## Root cause
The agent path depended on Hermes surfacing a raw provider error string. Scribe insufficient-credit responses could pass through the local provider proxy as the app envelope shape, which Hermes did not reliably expose as a visible chat event or persisted assistant turn. Direct submit failures also used the generic error banner without a top-up action.

## Validation
- `pnpm exec vitest run src/test/agent-chat-runtime.test.ts src/test/agent-workspace.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml hermes_bridge::tests::`
- `pnpm run lint`
- `pnpm exec prettier --check src/lib/errors.ts src/lib/agent-chat-runtime.ts src/components/agent/AgentWorkspace.tsx src/test/agent-chat-runtime.test.ts src/test/agent-workspace.test.tsx`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`

Note: repo-wide `pnpm run format` still fails on pre-existing unrelated files: `src/components/onboarding/steps/PermissionSteps.tsx`, `src/test/onboarding.test.tsx`, and `src-tauri/tauri.conf.json`.