### PR TITLE
[codex] Warn when credits are low

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
 import { AccountGate, JuneMark } from "../components/account/AccountGate";
+import { CreditBalanceBanner } from "../components/account/CreditBalanceBanner";
 import { TrialGate } from "../components/account/TrialGate";
 import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
 import {
@@ -394,6 +395,14 @@ export function App() {
     try {
       await osAccountsLogout();
       handleAccountChanged({ signedIn: false, configured: account.configured });
+    } catch (err) {
+      setError(messageFromError(err));
+    }
+  }
+
+  async function handleTopUpCredits() {
+    try {
+      await osAccountsTopUp();
     } catch (err) {
       setError(messageFromError(err));
     }
@@ -1881,6 +1890,12 @@ export function App() {
       />
       <section className="main-panel">
         {accessibilityBlocked ? <PermissionBanner /> : null}
+        {!accessibilityBlocked ? (
+          <CreditBalanceBanner
+            account={account}
+            onTopUp={() => void handleTopUpCredits()}
+          />
+        ) : null}
         <div
           ref={mainPanelBodyRef}
           className="main-panel-body"
@@ -2210,11 +2225,7 @@ export function App() {
                         throw err;
                       }
                     }}
-                    onTopUp={() =>
-                      void osAccountsTopUp().catch((err: unknown) =>
-                        setError(messageFromError(err)),
-                      )
-                    }
+                    onTopUp={() => void handleTopUpCredits()}
                     onAssignFolder={(folderId) =>
                       void handleSetNoteFolder(selectedNote.id, folderId)
                     }

--- a/src/components/account/CreditBalanceBanner.tsx
+++ b/src/components/account/CreditBalanceBanner.tsx
@@ -1,0 +1,63 @@
+import { IconWallet3 } from "central-icons/IconWallet3";
+import type { AccountStatus } from "../../lib/tauri";
+
+// Mirrors scribe-api's flat metered estimate. Users below this floor can pass
+// the subscription gates but still fail when dictation, recording processing,
+// or agent work attempts to reserve credits.
+export const METERED_USAGE_CREDIT_FLOOR = 250;
+
+type Props = {
+  account: AccountStatus;
+  onTopUp: () => void;
+};
+
+export function CreditBalanceBanner({ account, onTopUp }: Props) {
+  if (!shouldShowLowCreditBanner(account)) return null;
+
+  return (
+    <section
+      className="message-card credit-balance-banner"
+      role="alert"
+      aria-label="Low credit balance"
+    >
+      <p className="credit-balance-banner-message">
+        <span className="credit-balance-banner-eyebrow">
+          <IconWallet3 size={14} aria-hidden />
+          Low balance
+        </span>
+        <span className="credit-balance-banner-body">
+          Your balance is below the amount needed to start dictation,
+          recordings, or agent work.
+        </span>
+      </p>
+      <div className="credit-balance-banner-actions">
+        <button type="button" className="btn btn-ghost" onClick={onTopUp}>
+          Add funds
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export function shouldShowLowCreditBanner(account: AccountStatus) {
+  if (!hasMeteredAccess(account)) return false;
+  const creditBalance = accountCreditBalance(account);
+  return (
+    creditBalance !== undefined &&
+    Number.isFinite(creditBalance) &&
+    creditBalance < METERED_USAGE_CREDIT_FLOOR
+  );
+}
+
+export function accountCreditBalance(account: AccountStatus) {
+  return account.balance?.credits ?? account.balance?.usdMillis;
+}
+
+function hasMeteredAccess(account: AccountStatus) {
+  const status = account.subscription?.status;
+  return (
+    account.signedIn &&
+    account.subscription?.subscribed === true &&
+    (status === "trialing" || status === "active")
+  );
+}

--- a/src/components/account/CreditBalanceBanner.tsx
+++ b/src/components/account/CreditBalanceBanner.tsx
@@ -17,7 +17,7 @@ export function CreditBalanceBanner({ account, onTopUp }: Props) {
   return (
     <section
       className="message-card credit-balance-banner"
-      role="alert"
+      role="status"
       aria-label="Low credit balance"
     >
       <p className="credit-balance-banner-message">
@@ -50,7 +50,7 @@ export function shouldShowLowCreditBanner(account: AccountStatus) {
 }
 
 export function accountCreditBalance(account: AccountStatus) {
-  return account.balance?.credits ?? account.balance?.usdMillis;
+  return account.balance?.credits;
 }
 
 function hasMeteredAccess(account: AccountStatus) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6439,7 +6439,8 @@ input:focus-visible,
   }
 }
 
-.permission-banner-message {
+.permission-banner-message,
+.credit-balance-banner-message {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -6449,7 +6450,8 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
-.permission-banner-eyebrow {
+.permission-banner-eyebrow,
+.credit-balance-banner-eyebrow {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-2);
@@ -6458,11 +6460,13 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-.permission-banner-body {
+.permission-banner-body,
+.credit-balance-banner-body {
   color: var(--muted-foreground);
 }
 
-.permission-banner-actions {
+.permission-banner-actions,
+.credit-balance-banner-actions {
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);

--- a/src/test/credit-balance-banner.test.tsx
+++ b/src/test/credit-balance-banner.test.tsx
@@ -52,13 +52,13 @@ describe("shouldShowLowCreditBanner", () => {
     ).toBe(false);
   });
 
-  it("falls back to usdMillis when older payloads omit credits", () => {
+  it("stays hidden when older payloads omit credit units", () => {
     const account = activeAccount({
       balance: { usdMillis: METERED_USAGE_CREDIT_FLOOR - 1 },
     });
 
-    expect(accountCreditBalance(account)).toBe(METERED_USAGE_CREDIT_FLOOR - 1);
-    expect(shouldShowLowCreditBanner(account)).toBe(true);
+    expect(accountCreditBalance(account)).toBeUndefined();
+    expect(shouldShowLowCreditBanner(account)).toBe(false);
   });
 
   it("prefers credits when both balance fields are present", () => {
@@ -108,7 +108,7 @@ describe("CreditBalanceBanner", () => {
     render(<CreditBalanceBanner account={activeAccount()} onTopUp={onTopUp} />);
 
     expect(
-      screen.getByRole("alert", { name: "Low credit balance" }),
+      screen.getByRole("status", { name: "Low credit balance" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Low balance")).toBeInTheDocument();
     expect(

--- a/src/test/credit-balance-banner.test.tsx
+++ b/src/test/credit-balance-banner.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CreditBalanceBanner,
+  METERED_USAGE_CREDIT_FLOOR,
+  accountCreditBalance,
+  shouldShowLowCreditBanner,
+} from "../components/account/CreditBalanceBanner";
+import type { AccountStatus } from "../lib/tauri";
+
+function activeAccount(overrides: Partial<AccountStatus> = {}): AccountStatus {
+  return {
+    signedIn: true,
+    configured: true,
+    user: { id: "usr_1", handle: "junho" },
+    balance: {
+      credits: METERED_USAGE_CREDIT_FLOOR - 1,
+      usdMillis: METERED_USAGE_CREDIT_FLOOR - 1,
+    },
+    subscription: { subscribed: true, status: "active" },
+    ...overrides,
+  };
+}
+
+describe("shouldShowLowCreditBanner", () => {
+  it("shows for active members below the metered usage floor", () => {
+    expect(shouldShowLowCreditBanner(activeAccount())).toBe(true);
+  });
+
+  it("does not show at or above the metered usage floor", () => {
+    expect(
+      shouldShowLowCreditBanner(
+        activeAccount({
+          balance: {
+            credits: METERED_USAGE_CREDIT_FLOOR,
+            usdMillis: METERED_USAGE_CREDIT_FLOOR,
+          },
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldShowLowCreditBanner(
+        activeAccount({
+          balance: {
+            credits: METERED_USAGE_CREDIT_FLOOR + 1,
+            usdMillis: METERED_USAGE_CREDIT_FLOOR + 1,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to usdMillis when older payloads omit credits", () => {
+    const account = activeAccount({
+      balance: { usdMillis: METERED_USAGE_CREDIT_FLOOR - 1 },
+    });
+
+    expect(accountCreditBalance(account)).toBe(METERED_USAGE_CREDIT_FLOOR - 1);
+    expect(shouldShowLowCreditBanner(account)).toBe(true);
+  });
+
+  it("prefers credits when both balance fields are present", () => {
+    expect(
+      shouldShowLowCreditBanner(
+        activeAccount({
+          balance: {
+            credits: METERED_USAGE_CREDIT_FLOOR,
+            usdMillis: METERED_USAGE_CREDIT_FLOOR - 1,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("stays hidden for users outside the active app membership path", () => {
+    expect(
+      shouldShowLowCreditBanner({ signedIn: false, configured: true }),
+    ).toBe(false);
+    expect(
+      shouldShowLowCreditBanner(
+        activeAccount({
+          subscription: { subscribed: false },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowLowCreditBanner(
+        activeAccount({
+          subscription: { subscribed: true, status: "past_due" },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowLowCreditBanner(
+        activeAccount({
+          balance: undefined,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("CreditBalanceBanner", () => {
+  it("notifies low-balance users and opens top-up", async () => {
+    const onTopUp = vi.fn();
+    render(<CreditBalanceBanner account={activeAccount()} onTopUp={onTopUp} />);
+
+    expect(
+      screen.getByRole("alert", { name: "Low credit balance" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Low balance")).toBeInTheDocument();
+    expect(
+      screen.getByText(/below the amount needed to start dictation/i),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add funds" }));
+    expect(onTopUp).toHaveBeenCalledOnce();
+  });
+
+  it("renders nothing when the account has enough credits", () => {
+    const { container } = render(
+      <CreditBalanceBanner
+        account={activeAccount({
+          balance: {
+            credits: METERED_USAGE_CREDIT_FLOOR,
+            usdMillis: METERED_USAGE_CREDIT_FLOOR,
+          },
+        })}
+        onTopUp={() => undefined}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a proactive low-credit banner for signed-in trialing or active users below the 250 credit metered usage floor.
- Wire the banner into the main panel with an Add funds action that opens OS Accounts.
- Share the existing floating banner styling and keep the accessibility banner as the higher-priority floating notice.

## Validation
- `pnpm exec vitest run src/test/credit-balance-banner.test.tsx`
- `pnpm exec vitest run src/test/app-notes-reliability.test.tsx`
- `pnpm run lint`
- `pnpm exec prettier --check src/components/account/CreditBalanceBanner.tsx src/app/App.tsx src/styles/app.css src/test/credit-balance-banner.test.tsx`
- `git diff --check`
- Staged secret scan for `osk_`, `access_token`, `refresh_token`, `PRIVY_APP_SECRET`, `GITHUB_TOKEN`, `password`: no matches

Repo-wide `pnpm run format` still fails on unrelated existing files: `src/components/agent/AgentWorkspace.tsx`, `src/components/onboarding/steps/PermissionSteps.tsx`, `src/lib/agent-chat-runtime.ts`, `src/test/agent-chat-runtime.test.ts`, `src/test/onboarding.test.tsx`, and `src-tauri/tauri.conf.json`.