### PR TITLE
[codex] seamless update relaunch

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,3 +1,6 @@
+import { IconArrowInbox } from "central-icons/IconArrowInbox";
+import { IconArrowRight } from "central-icons/IconArrowRight";
+import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -9,7 +12,7 @@ import {
   useState,
 } from "react";
 import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
-import { AccountGate } from "../components/account/AccountGate";
+import { AccountGate, JuneMark } from "../components/account/AccountGate";
 import { TrialGate } from "../components/account/TrialGate";
 import { OnboardingFlow } from "../components/onboarding/OnboardingFlow";
 import {
@@ -40,7 +43,6 @@ import {
 } from "../components/settings/AppSettings";
 import { Sidebar, type SidebarView } from "../components/sidebar/Sidebar";
 import { BreadcrumbBar } from "../components/ui/BreadcrumbBar";
-import { Dialog } from "../components/ui/Dialog";
 import {
   assignNoteToFolder,
   assignSessionToFolder,
@@ -135,7 +137,7 @@ import { createInitialState, notesReducer } from "./state/app-state";
 import { handleSidebarResizeStart } from "./sidebar-resize";
 import {
   checkForScribeUpdate,
-  installScribeUpdate,
+  prepareScribeUpdate,
   type UpdateInstallProgress,
   type UpdatePromptPayload,
 } from "./update-decision";
@@ -255,10 +257,11 @@ export function App() {
   const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
   const [accessibilityStatus, setAccessibilityStatus] = useState<string>();
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
-  const [pendingUpdate, setPendingUpdate] =
+  const [readyUpdate, setReadyUpdate] =
     useState<UpdatePromptPayload<ScribeUpdate> | null>(null);
   const [updateStatus, setUpdateStatus] = useState<string | null>(null);
-  const [installingUpdate, setInstallingUpdate] = useState(false);
+  const [preparingUpdate, setPreparingUpdate] = useState(false);
+  const [relaunchingUpdate, setRelaunchingUpdate] = useState(false);
   const [updateProgress, setUpdateProgress] =
     useState<UpdateInstallProgress | null>(null);
   const systemGranted = !!sourceReadiness?.sources.find(
@@ -415,32 +418,110 @@ export function App() {
     return attachScrollThumbFade(el);
   }, [noteDetailScrollerActive, selectedNoteId]);
 
-  // installingUpdate is read through a ref so runUpdateCheck keeps a stable
-  // identity across installs. Otherwise the launch effect and the manual-check
-  // listener below would tear down and re-fire every time installingUpdate
-  // toggles — re-triggering an unwanted launch-time check after an install.
-  const installingUpdateRef = useRef(false);
+  // Update state is read through refs so runUpdateCheck keeps a stable identity.
+  // Otherwise the launch effect and the manual-check listener below would tear
+  // down and re-fire every time a download or relaunch toggles state.
+  const preparingUpdateRef = useRef(false);
+  const readyUpdateRef = useRef<UpdatePromptPayload<ScribeUpdate> | null>(null);
+  const relaunchingUpdateRef = useRef(false);
+  const updateProgressHiddenRef = useRef(false);
   useEffect(() => {
-    installingUpdateRef.current = installingUpdate;
-  }, [installingUpdate]);
+    preparingUpdateRef.current = preparingUpdate;
+  }, [preparingUpdate]);
+  useEffect(() => {
+    readyUpdateRef.current = readyUpdate;
+  }, [readyUpdate]);
+  useEffect(() => {
+    relaunchingUpdateRef.current = relaunchingUpdate;
+  }, [relaunchingUpdate]);
 
-  const runUpdateCheck = useCallback((mode: "launch" | "manual") => {
-    if (installingUpdateRef.current) return;
-    setUpdateStatus(mode === "manual" ? "Checking for updates..." : null);
-    void checkForScribeUpdate(
-      {
-        check: checkScribeUpdate,
-        prompt: (payload) => {
-          setUpdateStatus(null);
-          setUpdateProgress(null);
-          setPendingUpdate(payload);
+  const prepareUpdate = useCallback(
+    (payload: UpdatePromptPayload<ScribeUpdate>, mode: "launch" | "manual") => {
+      if (
+        preparingUpdateRef.current ||
+        readyUpdateRef.current ||
+        relaunchingUpdateRef.current
+      ) {
+        return;
+      }
+
+      preparingUpdateRef.current = true;
+      updateProgressHiddenRef.current = false;
+      setPreparingUpdate(true);
+      setReadyUpdate(null);
+      setUpdateProgress(null);
+      setUpdateStatus(mode === "manual" ? "Downloading update..." : null);
+
+      void prepareScribeUpdate({
+        update: payload.update,
+        reportProgress: (progress) => {
+          setUpdateProgress(progress);
+          if (mode === "manual" && !updateProgressHiddenRef.current) {
+            setUpdateStatus(
+              progress.state === "installing"
+                ? "Preparing update..."
+                : "Downloading update...",
+            );
+          }
         },
-        reportNoUpdate: () => setUpdateStatus("June is up to date."),
-        reportFailure: (message) =>
-          setUpdateStatus(`Update check failed: ${message}`),
-      },
-      mode,
-    );
+        reportReady: (ready) => {
+          preparingUpdateRef.current = false;
+          readyUpdateRef.current = ready;
+          updateProgressHiddenRef.current = false;
+          setPreparingUpdate(false);
+          setReadyUpdate(ready);
+          setUpdateProgress(null);
+          setUpdateStatus(null);
+        },
+        reportFailure: (message) => {
+          preparingUpdateRef.current = false;
+          updateProgressHiddenRef.current = false;
+          setPreparingUpdate(false);
+          setUpdateProgress(null);
+          setUpdateStatus(`Update failed: ${message}`);
+        },
+      });
+    },
+    [],
+  );
+
+  const runUpdateCheck = useCallback(
+    (mode: "launch" | "manual") => {
+      if (readyUpdateRef.current || relaunchingUpdateRef.current) return;
+      if (preparingUpdateRef.current) {
+        if (mode === "manual") {
+          updateProgressHiddenRef.current = false;
+          setUpdateStatus("Downloading update...");
+        }
+        return;
+      }
+      setUpdateStatus(mode === "manual" ? "Checking for updates..." : null);
+      void checkForScribeUpdate(
+        {
+          check: checkScribeUpdate,
+          prompt: (payload) => {
+            prepareUpdate(payload, mode);
+          },
+          reportNoUpdate: () => setUpdateStatus("June is up to date."),
+          reportFailure: (message) =>
+            setUpdateStatus(`Update check failed: ${message}`),
+        },
+        mode,
+      );
+    },
+    [prepareUpdate],
+  );
+
+  const handleRelaunchUpdate = useCallback(() => {
+    if (!readyUpdateRef.current || relaunchingUpdateRef.current) return;
+    relaunchingUpdateRef.current = true;
+    setRelaunchingUpdate(true);
+    setUpdateStatus(null);
+    void relaunchScribe().catch((error) => {
+      relaunchingUpdateRef.current = false;
+      setRelaunchingUpdate(false);
+      setUpdateStatus(`Relaunch failed: ${messageFromError(error)}`);
+    });
   }, []);
 
   // Launch check: silent by design — a "no update" result shows nothing so it
@@ -2202,32 +2283,18 @@ export function App() {
         }
         onMoved={() => agentSessionsListRef.current?.resetSelection()}
       />
-      <UpdateDialog
-        payload={pendingUpdate}
+      <UpdateHub
+        readyUpdate={readyUpdate}
         status={updateStatus}
-        installing={installingUpdate}
+        preparing={preparingUpdate}
+        relaunching={relaunchingUpdate}
         progress={updateProgress}
-        onClose={() => {
-          if (installingUpdate) return;
-          setPendingUpdate(null);
+        onDismissStatus={() => {
+          if (preparingUpdate) updateProgressHiddenRef.current = true;
           setUpdateStatus(null);
-          setUpdateProgress(null);
+          if (!preparingUpdate) setUpdateProgress(null);
         }}
-        onInstall={() => {
-          if (!pendingUpdate || installingUpdate) return;
-          setInstallingUpdate(true);
-          setUpdateStatus(null);
-          void installScribeUpdate({
-            update: pendingUpdate.update,
-            relaunch: relaunchScribe,
-            reportProgress: setUpdateProgress,
-            reportFailure: (message) => {
-              setInstallingUpdate(false);
-              setUpdateProgress(null);
-              setUpdateStatus(`Update failed: ${message}`);
-            },
-          });
-        }}
+        onRelaunch={handleRelaunchUpdate}
       />
     </main>
   );
@@ -2254,102 +2321,162 @@ function updateMenuBarSessionStatus(
   }
 }
 
-function UpdateDialog({
+function UpdateHub({
+  readyUpdate,
+  status,
+  preparing,
+  relaunching,
+  progress,
+  onDismissStatus,
+  onRelaunch,
+}: {
+  readyUpdate: UpdatePromptPayload<ScribeUpdate> | null;
+  status: string | null;
+  preparing: boolean;
+  relaunching: boolean;
+  progress: UpdateInstallProgress | null;
+  onDismissStatus: () => void;
+  onRelaunch: () => void;
+}) {
+  if (readyUpdate) {
+    return (
+      <UpdateRelaunchCard
+        payload={readyUpdate}
+        status={status}
+        relaunching={relaunching}
+        onRelaunch={onRelaunch}
+      />
+    );
+  }
+
+  if (!status) return null;
+  return (
+    <UpdateStatusCard
+      status={status}
+      preparing={preparing}
+      progress={progress}
+      onDismiss={onDismissStatus}
+    />
+  );
+}
+
+function UpdateRelaunchCard({
   payload,
   status,
-  installing,
-  progress,
-  onClose,
-  onInstall,
+  relaunching,
+  onRelaunch,
 }: {
-  payload: UpdatePromptPayload<ScribeUpdate> | null;
+  payload: UpdatePromptPayload<ScribeUpdate>;
   status: string | null;
-  installing: boolean;
-  progress: UpdateInstallProgress | null;
-  onClose: () => void;
-  onInstall: () => void;
+  relaunching: boolean;
+  onRelaunch: () => void;
 }) {
-  const percent =
-    progress?.contentLength && progress.contentLength > 0
-      ? Math.min(
-          100,
-          Math.round(
-            ((progress.downloadedBytes ?? 0) / progress.contentLength) * 100,
-          ),
-        )
-      : undefined;
+  const meta = status ?? updateVersionLabel(payload.version);
+  const failed = status?.toLowerCase().includes("failed") ?? false;
 
   return (
-    <Dialog
-      open={!!payload || !!status}
-      onClose={onClose}
-      title={payload ? `June ${payload.version}` : "Software update"}
-      description={
-        payload
-          ? "A new version is available."
-          : (status ?? "Checking for updates...")
-      }
-      width={460}
-      disableBackdropClose={installing}
-      footer={
-        payload ? (
-          <>
-            <button
-              type="button"
-              className="primary-action"
-              disabled={installing}
-              onClick={onClose}
-            >
-              Later
-            </button>
-            <button
-              type="button"
-              className="primary-action primary-solid"
-              disabled={installing}
-              onClick={onInstall}
-            >
-              {installing ? "Installing..." : "Install & relaunch"}
-            </button>
-          </>
-        ) : (
-          <button type="button" className="primary-action" onClick={onClose}>
-            Close
-          </button>
-        )
-      }
+    <aside
+      className="update-popover"
+      role={failed ? "alert" : "status"}
+      aria-live="polite"
     >
-      {payload ? (
-        <div className="update-dialog-body">
-          {payload.notes ? (
-            <div className="update-release-notes">{payload.notes}</div>
-          ) : (
-            <p className="dialog-field-hint">No release notes were provided.</p>
-          )}
-          {progress ? (
-            <div className="update-progress" aria-live="polite">
-              <div className="update-progress-row">
-                <span>
-                  {progress.state === "installing"
-                    ? "Installing update..."
-                    : "Downloading update..."}
-                </span>
-                {percent !== undefined ? <span>{percent}%</span> : null}
-              </div>
-              <div className="update-progress-track">
-                <div
-                  className="update-progress-fill"
-                  style={{ width: `${percent ?? 0}%` }}
-                />
-              </div>
-            </div>
-          ) : null}
-          {status ? <p className="dialog-field-hint">{status}</p> : null}
-        </div>
-      ) : (
-        <div />
-      )}
-    </Dialog>
+      <button
+        type="button"
+        className="update-relaunch-card"
+        disabled={relaunching}
+        aria-label={`Relaunch to update to June ${payload.version}`}
+        onClick={onRelaunch}
+      >
+        <span className="update-relaunch-mark" aria-hidden>
+          <JuneMark />
+        </span>
+        <span className="update-relaunch-copy">
+          <span className="update-relaunch-title">
+            {relaunching ? "Relaunching..." : "Relaunch to update"}
+          </span>
+          <span className={status ? "update-relaunch-status" : undefined}>
+            {meta}
+          </span>
+        </span>
+        <IconArrowRight
+          className="update-relaunch-arrow"
+          size={18}
+          aria-hidden
+        />
+      </button>
+    </aside>
   );
+}
+
+function UpdateStatusCard({
+  status,
+  preparing,
+  progress,
+  onDismiss,
+}: {
+  status: string;
+  preparing: boolean;
+  progress: UpdateInstallProgress | null;
+  onDismiss: () => void;
+}) {
+  const percent = updateProgressPercent(progress);
+  const progressWidth =
+    progress?.state === "installing" && percent === undefined
+      ? "100%"
+      : `${percent ?? 0}%`;
+  const failed = status.toLowerCase().includes("failed");
+
+  return (
+    <aside
+      className="update-popover update-status-card"
+      role={failed ? "alert" : "status"}
+      aria-live="polite"
+    >
+      <div className="update-status-row">
+        <span className="update-status-icon" aria-hidden>
+          <IconArrowInbox size={15} />
+        </span>
+        <span className="update-status-text">{status}</span>
+        <button
+          type="button"
+          className="update-status-close"
+          aria-label={
+            preparing ? "Hide update progress" : "Dismiss update status"
+          }
+          onClick={onDismiss}
+        >
+          <IconCrossSmall size={12} aria-hidden />
+        </button>
+      </div>
+      {progress ? (
+        <div className="update-progress" aria-hidden>
+          <div className="update-progress-track">
+            <div
+              className="update-progress-fill"
+              style={{ width: progressWidth }}
+            />
+          </div>
+          {percent !== undefined ? (
+            <span className="update-progress-percent">{percent}%</span>
+          ) : null}
+        </div>
+      ) : null}
+    </aside>
+  );
+}
+
+function updateProgressPercent(progress: UpdateInstallProgress | null) {
+  if (!progress?.contentLength || progress.contentLength <= 0) return undefined;
+  return Math.min(
+    100,
+    Math.round(
+      ((progress.downloadedBytes ?? 0) / progress.contentLength) * 100,
+    ),
+  );
+}
+
+function updateVersionLabel(version: string) {
+  return version.startsWith("v") ? version : `v${version}`;
 }
 
 // Sidebar toggle icon. One static panel with a single divider that animates:

--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -33,6 +33,13 @@ export type InstallUpdateDeps<TUpdate extends UpdaterUpdate> = {
   reportFailure: (message: string) => void;
 };
 
+export type PrepareUpdateDeps<TUpdate extends UpdaterUpdate> = {
+  update: TUpdate;
+  reportProgress: (progress: UpdateInstallProgress) => void;
+  reportReady: (payload: UpdatePromptPayload<TUpdate>) => void;
+  reportFailure: (message: string) => void;
+};
+
 export type UpdateInstallProgress = {
   state: "downloading" | "installing";
   downloadedBytes?: number;
@@ -59,12 +66,42 @@ export async function checkForScribeUpdate<TUpdate extends UpdaterUpdate>(
   }
 }
 
+export async function prepareScribeUpdate<TUpdate extends UpdaterUpdate>({
+  update,
+  reportProgress,
+  reportReady,
+  reportFailure,
+}: PrepareUpdateDeps<TUpdate>) {
+  try {
+    await downloadAndInstallScribeUpdate(update, reportProgress);
+    reportReady({
+      update,
+      version: update.version,
+      notes: normalizeNotes(update.body),
+    });
+  } catch (error) {
+    reportFailure(messageFromUnknown(error));
+  }
+}
+
 export async function installScribeUpdate<TUpdate extends UpdaterUpdate>({
   update,
   relaunch,
   reportProgress,
   reportFailure,
 }: InstallUpdateDeps<TUpdate>) {
+  try {
+    await downloadAndInstallScribeUpdate(update, reportProgress);
+    await relaunch();
+  } catch (error) {
+    reportFailure(messageFromUnknown(error));
+  }
+}
+
+async function downloadAndInstallScribeUpdate<TUpdate extends UpdaterUpdate>(
+  update: TUpdate,
+  reportProgress: (progress: UpdateInstallProgress) => void,
+) {
   let downloadedBytes = 0;
   let contentLength: number | undefined;
   // A multi-MB DMG fires thousands of Progress events; surfacing each as a state
@@ -74,44 +111,40 @@ export async function installScribeUpdate<TUpdate extends UpdaterUpdate>({
   let lastPercent: number | undefined;
   let lastReportedBytes = 0;
   const UNKNOWN_LENGTH_STEP = 1_000_000;
-  try {
-    await update.downloadAndInstall((event) => {
-      if (event.event === "Started") {
-        downloadedBytes = 0;
-        contentLength = event.data.contentLength;
-        lastPercent = contentLength ? 0 : undefined;
-        lastReportedBytes = 0;
-        reportProgress({
-          state: "downloading",
-          downloadedBytes,
-          contentLength,
-        });
+
+  await update.downloadAndInstall((event) => {
+    if (event.event === "Started") {
+      downloadedBytes = 0;
+      contentLength = event.data.contentLength;
+      lastPercent = contentLength ? 0 : undefined;
+      lastReportedBytes = 0;
+      reportProgress({
+        state: "downloading",
+        downloadedBytes,
+        contentLength,
+      });
+      return;
+    }
+    if (event.event === "Progress") {
+      downloadedBytes += event.data.chunkLength;
+      if (contentLength && contentLength > 0) {
+        const percent = Math.round((downloadedBytes / contentLength) * 100);
+        if (percent === lastPercent) return;
+        lastPercent = percent;
+      } else if (downloadedBytes - lastReportedBytes < UNKNOWN_LENGTH_STEP) {
         return;
+      } else {
+        lastReportedBytes = downloadedBytes;
       }
-      if (event.event === "Progress") {
-        downloadedBytes += event.data.chunkLength;
-        if (contentLength && contentLength > 0) {
-          const percent = Math.round((downloadedBytes / contentLength) * 100);
-          if (percent === lastPercent) return;
-          lastPercent = percent;
-        } else if (downloadedBytes - lastReportedBytes < UNKNOWN_LENGTH_STEP) {
-          return;
-        } else {
-          lastReportedBytes = downloadedBytes;
-        }
-        reportProgress({
-          state: "downloading",
-          downloadedBytes,
-          contentLength,
-        });
-        return;
-      }
-      reportProgress({ state: "installing", downloadedBytes, contentLength });
-    });
-    await relaunch();
-  } catch (error) {
-    reportFailure(messageFromUnknown(error));
-  }
+      reportProgress({
+        state: "downloading",
+        downloadedBytes,
+        contentLength,
+      });
+      return;
+    }
+    reportProgress({ state: "installing", downloadedBytes, contentLength });
+  });
 }
 
 function normalizeNotes(notes?: string) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -10967,35 +10967,171 @@ input:focus-visible,
   gap: var(--sp-3);
 }
 
-.update-dialog-body {
-  display: grid;
-  gap: var(--sp-4);
+.update-popover {
+  position: fixed;
+  left: var(--sp-5);
+  bottom: calc(var(--sp-3) + var(--control-lg) + var(--sp-5));
+  z-index: 45;
+  width: min(312px, calc(100vw - var(--sp-8)));
+  color: var(--foreground);
+  -webkit-app-region: no-drag;
+  animation: update-popover-in var(--t-med) var(--ease-spring) both;
 }
 
-.update-release-notes {
-  max-height: 220px;
-  overflow: auto;
-  white-space: pre-wrap;
+.update-relaunch-card {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) 22px;
+  align-items: center;
+  gap: var(--sp-4);
+  width: 100%;
+  min-height: 70px;
+  padding: var(--sp-3);
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-md);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-lg);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--t-fast) var(--ease-out),
+    background-color var(--t-fast) var(--ease-out),
+    transform var(--t-fast) var(--ease-out);
+}
+
+.update-relaunch-card:hover:not(:disabled) {
+  border-color: var(--ring);
+  background: color-mix(in oklch, var(--popover) 90%, var(--muted));
+  transform: translateY(-1px);
+}
+
+.update-relaunch-card:focus-visible {
+  outline: none;
+  border-color: var(--ring-focus);
+  box-shadow:
+    var(--shadow-lg),
+    0 0 0 3px var(--focus-ring);
+}
+
+.update-relaunch-card:disabled {
+  cursor: default;
+}
+
+.update-relaunch-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--brand) 12%, transparent);
+  color: var(--brand);
+}
+
+.update-relaunch-mark svg {
+  width: 17px;
+  height: auto;
+}
+
+.update-relaunch-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.update-relaunch-title {
+  overflow: hidden;
   color: var(--foreground);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-medium);
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.update-relaunch-copy > span:last-child {
+  overflow: hidden;
+  color: var(--muted-foreground);
   font-size: var(--fs-sm);
-  line-height: 1.48;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.update-relaunch-copy > .update-relaunch-status {
+  color: color-mix(in oklch, var(--destructive) 70%, var(--foreground));
+}
+
+.update-relaunch-arrow {
+  justify-self: end;
+  color: var(--muted-foreground);
+}
+
+.update-status-card {
+  display: grid;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-md);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-md);
+}
+
+.update-status-row {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) 24px;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.update-status-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+}
+
+.update-status-text {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.update-status-close {
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.update-status-close:hover {
+  background: var(--surface-subtle);
+  color: var(--foreground);
 }
 
 .update-progress {
   display: grid;
-  gap: var(--sp-2);
-}
-
-.update-progress-row {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--sp-4);
-  color: var(--muted-foreground);
-  font-size: var(--fs-xs);
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp-3);
 }
 
 .update-progress-track {
-  height: 8px;
+  height: 5px;
   overflow: hidden;
   border-radius: var(--r-pill);
   background: var(--surface-subtle);
@@ -11003,11 +11139,50 @@ input:focus-visible,
 
 .update-progress-fill {
   height: 100%;
-  /* Floor so the bar stays visible at 0% / indeterminate (width can be 0). */
-  min-width: 8%;
+  min-width: 8px;
   border-radius: inherit;
   background: var(--foreground);
   transition: width var(--t-fast) var(--ease-out);
+}
+
+.update-progress-percent {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1;
+}
+
+@keyframes update-popover-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 560px) {
+  .update-popover {
+    left: var(--sp-3);
+    right: var(--sp-3);
+    bottom: var(--sp-3);
+    width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .update-popover {
+    animation: none;
+  }
+
+  .update-relaunch-card {
+    transition: none;
+  }
+
+  .update-relaunch-card:hover:not(:disabled) {
+    transform: none;
+  }
 }
 
 @keyframes dialog-backdrop-in {

--- a/src/test/update-decision.test.ts
+++ b/src/test/update-decision.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   checkForScribeUpdate,
   installScribeUpdate,
+  prepareScribeUpdate,
   type UpdaterUpdate,
 } from "../app/update-decision";
 
@@ -119,5 +120,37 @@ describe("installScribeUpdate", () => {
       contentLength: 100,
     });
     expect(relaunch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("prepareScribeUpdate", () => {
+  it("reports download progress and marks the update ready without relaunching", async () => {
+    const candidate = update(" Ready after relaunch. ");
+    const reportProgress = vi.fn();
+    const reportReady = vi.fn();
+
+    await prepareScribeUpdate({
+      update: candidate,
+      reportProgress,
+      reportReady,
+      reportFailure: vi.fn(),
+    });
+
+    expect(candidate.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(reportProgress).toHaveBeenCalledWith({
+      state: "downloading",
+      downloadedBytes: 40,
+      contentLength: 100,
+    });
+    expect(reportProgress).toHaveBeenCalledWith({
+      state: "installing",
+      downloadedBytes: 40,
+      contentLength: 100,
+    });
+    expect(reportReady).toHaveBeenCalledWith({
+      update: candidate,
+      version: "0.2.0",
+      notes: "Ready after relaunch.",
+    });
   });
 });


### PR DESCRIPTION
## What changed

- Update checks now optimistically download and install available updates in the background.
- Relaunch is split from update preparation, so June only restarts when the user clicks the new bottom-left relaunch card.
- Manual update checks show compact progress or status feedback instead of opening a blocking update dialog.
- Added updater tests for the prepare-without-relaunch path.

## Impact

Users can keep working while an update downloads. Once the update is ready, a persistent card appears near the bottom left with the target version and a single relaunch action.

## Validation

- `pnpm run lint`
- `pnpm test`
- `pnpm run build`

Note: the in-app browser connector was unavailable in this session, so I could not run an interactive browser visual check.