### PR TITLE
[codex] Hide raw Scribe response parse errors

### DIFF
--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -22,6 +22,8 @@ const AGENT_PROXY_MAX_INSTRUCTION_MESSAGES: usize = 4;
 const AGENT_TITLE_MAX_CHARS: usize = 48;
 const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 const ERR_TOKEN_EXPIRED: i64 = 3001;
+const INVALID_SCRIBE_RESPONSE_MESSAGE: &str =
+    "The processing service returned an invalid response.";
 
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 static AGENT_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -864,8 +866,30 @@ where
 {
     let status = response.status();
     let body = response.text().await.map_err(network_error)?;
-    let envelope: ApiEnvelope<T> = serde_json::from_str(&body)
-        .map_err(|error| AppError::new("scribe_api_response_invalid", error.to_string()))?;
+    parse_response_body(path, status, &body)
+}
+
+fn parse_response_body<T>(
+    path: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> Result<T, AppError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let envelope: ApiEnvelope<T> = serde_json::from_str(body).map_err(|error| {
+        tracing::warn!(
+            path,
+            status = status.as_u16(),
+            body_bytes = body.len(),
+            %error,
+            "scribe api returned a non-json response"
+        );
+        AppError::new(
+            "scribe_api_response_invalid",
+            INVALID_SCRIBE_RESPONSE_MESSAGE,
+        )
+    })?;
     if envelope.success {
         return envelope
             .data
@@ -1025,6 +1049,21 @@ mod tests {
             Some("Create a Quarterly Planning Briefing With Follow")
         );
         assert_eq!(clean_agent_session_title("   "), None);
+    }
+
+    #[test]
+    fn invalid_scribe_response_hides_json_parser_error() {
+        let result = parse_response_body::<GenerateResponse>(
+            "/v1/notes/generate",
+            reqwest::StatusCode::BAD_GATEWAY,
+            "",
+        );
+
+        assert!(result.is_err());
+        let error = result.err().expect("invalid response should fail");
+        assert_eq!(error.code, "scribe_api_response_invalid");
+        assert_eq!(error.message, INVALID_SCRIBE_RESPONSE_MESSAGE);
+        assert!(!error.message.contains("expected value"));
     }
 
     #[test]

--- a/src/components/note-editor/NoteFailureBanner.tsx
+++ b/src/components/note-editor/NoteFailureBanner.tsx
@@ -40,10 +40,21 @@ function friendlyFailureSegment(message: string) {
   if (normalized.includes("no_speech") || normalized.includes("no speech")) {
     friendly =
       "No speech detected. Try speaking louder or moving closer to the microphone.";
+  } else if (isInvalidScribeResponseMessage(body)) {
+    friendly = "The processing service returned an invalid response.";
   } else if (normalized.includes("upstream_provider_failed")) {
     friendly = "The transcription provider could not process this audio.";
   }
   return source ? `${source}: ${friendly}` : friendly;
+}
+
+function isInvalidScribeResponseMessage(message: string) {
+  const normalized = message.trim().toLowerCase();
+  return (
+    normalized.includes("scribe_api_response_invalid") ||
+    normalized.includes("processing service returned an invalid response") ||
+    /^expected value at line \d+ column \d+$/.test(normalized)
+  );
 }
 
 export function NoteFailureBanner({

--- a/src/test/note-failure-banner.test.tsx
+++ b/src/test/note-failure-banner.test.tsx
@@ -34,6 +34,15 @@ describe("userFacingFailureMessage", () => {
       "Microphone: No speech detected. Try speaking louder or moving closer to the microphone.",
     );
   });
+
+  it("hides raw JSON parser failures from saved notes", () => {
+    expect(userFacingFailureMessage("expected value at line 1 column 1")).toBe(
+      "The processing service returned an invalid response.",
+    );
+    expect(
+      userFacingFailureMessage("Microphone: expected value at line 1 column 1"),
+    ).toBe("Microphone: The processing service returned an invalid response.");
+  });
 });
 
 describe("NoteFailureBanner", () => {


### PR DESCRIPTION
## Summary
- Replace raw serde parse failures from non-JSON Scribe API responses with a stable friendly message.
- Render already-persisted `expected value at line 1 column 1` note failures as friendly UI copy.
- Add regression coverage for the backend parser and note failure banner.

## Root cause
The desktop client parsed every Scribe API response as the expected JSON envelope. When the API or an upstream gateway returned an empty or non-JSON body, serde produced `expected value at line 1 column 1`. Processing then persisted that raw parser text as the note failure reason, so the banner displayed it directly.

## Validation
- `pnpm test src/test/note-failure-banner.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml scribe_api::tests::invalid_scribe_response_hides_json_parser_error`
- `pnpm run lint`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `pnpm exec prettier --check src/components/note-editor/NoteFailureBanner.tsx src/test/note-failure-banner.test.tsx`
- `git diff --check`