### PR TITLE
Build universal macOS releases

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -256,7 +256,7 @@ jobs:
           # `notes` as plain text, so GitHub's auto-generated markdown would show
           # raw (## headings, @-mentions). Keep notes = the plain releaseBody.
           generateReleaseNotes: false
-          args: --bundles app,dmg --target aarch64-apple-darwin
+          args: --bundles app,dmg --target universal-apple-darwin
           # v0.6.x input name (was uploadUpdaterJson/uploadUpdaterSignatures,
           # which this version ignores). Generates + uploads latest.json; the
           # .sig updater signatures are uploaded alongside it automatically.
@@ -269,7 +269,7 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           dmgs=(
-            src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
             src-tauri/target/release/bundle/dmg/*.dmg
           )
           if [ "${#dmgs[@]}" -ne 1 ]; then
@@ -282,9 +282,11 @@ jobs:
             fi
             exit 1
           fi
-          stable_dmg="$RUNNER_TEMP/June_aarch64.dmg"
+          stable_dmg="$RUNNER_TEMP/June_universal.dmg"
+          legacy_dmg="$RUNNER_TEMP/June_aarch64.dmg"
           cp "${dmgs[0]}" "$stable_dmg"
-          gh release upload "v$VERSION" "$stable_dmg" \
+          cp "${dmgs[0]}" "$legacy_dmg"
+          gh release upload "v$VERSION" "$stable_dmg" "$legacy_dmg" \
             --repo open-software-network/os-june-releases \
             --clobber
 
@@ -336,7 +338,7 @@ jobs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*Download:*\n<https://github.com/open-software-network/os-june-releases/releases/latest/download/June_aarch64.dmg|macOS DMG (Apple Silicon)>"
+                    "text": "*Download:*\n<https://github.com/open-software-network/os-june-releases/releases/latest/download/June_universal.dmg|macOS DMG (Apple Silicon and Intel)>"
                   }
                 ]
               },
@@ -373,5 +375,6 @@ jobs:
             echo "- Version: \`$VERSION\`"
             echo "- Release repo: \`open-software-network/os-june-releases\`"
             echo "- Update manifest: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/latest.json\`"
-            echo "- Marketing download: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/June_aarch64.dmg\`"
+            echo "- Marketing download: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/June_universal.dmg\`"
+            echo "- Legacy Apple Silicon alias: \`https://github.com/open-software-network/os-june-releases/releases/latest/download/June_aarch64.dmg\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/staging-desktop-dmg.yml
+++ b/.github/workflows/staging-desktop-dmg.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -104,13 +106,15 @@ jobs:
           OS_ACCOUNTS_API_URL: ${{ secrets.STAGING_OS_ACCOUNTS_API_URL }}
           OS_ACCOUNTS_CLIENT_ID: ${{ secrets.STAGING_OS_ACCOUNTS_CLIENT_ID }}
           SCRIBE_API_URL: ${{ secrets.STAGING_SCRIBE_API_URL }}
-        run: pnpm tauri:build:signed-dmg
+        run: pnpm tauri:build:signed-dmg --target universal-apple-darwin
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
           name: os-scribe-staging-dmg-${{ github.sha }}
-          path: src-tauri/target/release/bundle/dmg/*.dmg
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+            src-tauri/target/release/bundle/dmg/*.dmg
           if-no-files-found: error
 
       - name: Summary
@@ -118,7 +122,7 @@ jobs:
           {
             echo "### Staging macOS DMG"
             echo "This artifact is built against the staging OS Accounts and Scribe API environment."
-            for dmg in src-tauri/target/release/bundle/dmg/*.dmg; do
+            for dmg in src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg src-tauri/target/release/bundle/dmg/*.dmg; do
               [ -e "$dmg" ] || continue
               echo "- \`$dmg\`"
             done

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -3,13 +3,14 @@
 June ships signed, notarized macOS builds with in-app auto-updates through
 `tauri-plugin-updater`. The source repo stays private; update artifacts,
 signatures, the DMG, and `latest.json` are published to the public
-`open-software-network/os-scribe-releases` repo.
+`open-software-network/os-june-releases` repo.
 
 ## macOS support
 
-June supports macOS 14.0 and later, including macOS 15. System audio capture
-uses Core Audio process taps and is available only on macOS 14.2 and later. On
-macOS 14.0 or 14.1, recording falls back to microphone-only mode.
+June supports macOS 14.0 and later on Apple Silicon and Intel Macs, including
+macOS 15. Production and staging builds ship as universal macOS apps. System
+audio capture uses Core Audio process taps and is available only on macOS 14.2
+and later. On macOS 14.0 or 14.1, recording falls back to microphone-only mode.
 
 The first updater-capable build must be installed manually once — earlier builds
 ship without the updater, so they can't pull it in — and every release after that
@@ -20,7 +21,7 @@ workflow; don't hard-code a specific number in this runbook.
 
 Create or confirm these before cutting the first updater release:
 
-- Public GitHub repo: `open-software-network/os-scribe-releases`.
+- Public GitHub repo: `open-software-network/os-june-releases`.
 - Release GitHub App (org-owned) installed on the public releases repo with
   `contents:write`, exposed as `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.
   The workflow mints a short-lived, repo-scoped token from it at run time
@@ -75,16 +76,16 @@ The workflow performs the release steps in order:
    Python deps, and the prebuilt dashboard UI, signed Mach-O by Mach-O and
    shipped under `Resources/native/hermes` so first launch needs no network
    install. Adds roughly 110 MB compressed to the DMG.
-7. Builds the `aarch64-apple-darwin` app and DMG with `tauri-action`.
+7. Builds the `universal-apple-darwin` app and DMG with `tauri-action`.
 8. Signs with the Apple Developer ID cert, notarizes with Apple API key
    credentials, signs updater artifacts with the Ed25519 updater key, and
    publishes the release assets plus `latest.json` to
-   `open-software-network/os-scribe-releases`.
+   `open-software-network/os-june-releases`.
 
 The app polls:
 
 ```text
-https://github.com/open-software-network/os-scribe-releases/releases/latest/download/latest.json
+https://github.com/open-software-network/os-june-releases/releases/latest/download/latest.json
 ```
 
 That endpoint is baked into shipped builds. Keep it alive until every install
@@ -106,13 +107,12 @@ been installed over a previous updater-capable build and relaunched successfully
 ## First updater release validation
 
 After the workflow publishes a release, download the DMG from
-`open-software-network/os-scribe-releases`, install the app into
+`open-software-network/os-june-releases`, install the app into
 `/Applications`, and run:
 
 ```sh
-VERSION="0.2.0"
 APP="/Applications/June.app"
-DMG="$HOME/Downloads/June_${VERSION}_aarch64.dmg"
+DMG="$HOME/Downloads/June_universal.dmg"
 
 codesign --verify --deep --strict --verbose=2 "$APP"
 spctl --assess --type execute --verbose "$APP"
@@ -120,9 +120,13 @@ spctl --assess --type install --verbose "$DMG"
 xcrun stapler validate "$APP"
 xcrun stapler validate "$DMG"
 plutil -extract CFBundleURLTypes xml1 -o - "$APP/Contents/Info.plist"
+lipo -archs "$APP/Contents/MacOS/os-scribe"
+lipo -archs "$APP/Contents/Resources/native/bin/June Dictation Helper.app/Contents/MacOS/june-dictation-helper"
+lipo -archs "$APP/Contents/Resources/native/bin/June.app/Contents/MacOS/june-system-audio-recorder"
 ```
 
-Confirm `osscribe` appears in `CFBundleURLSchemes`.
+Confirm `osscribe` appears in `CFBundleURLSchemes` and each `lipo` command
+prints both `x86_64` and `arm64`.
 
 For the first updater-to-updater validation, install an older updater-capable
 build, run **June -> Check for updates…**, confirm the prompt shows the

--- a/scripts/build-signed-dmg.sh
+++ b/scripts/build-signed-dmg.sh
@@ -145,7 +145,10 @@ cd "$ROOT_DIR"
 pnpm tauri build --bundles dmg "$@"
 
 shopt -s nullglob
-dmgs=("$ROOT_DIR"/src-tauri/target/release/bundle/dmg/*.dmg)
+dmgs=(
+  "$ROOT_DIR"/src-tauri/target/*-apple-darwin/release/bundle/dmg/*.dmg
+  "$ROOT_DIR"/src-tauri/target/release/bundle/dmg/*.dmg
+)
 if [[ "${#dmgs[@]}" -eq 0 ]]; then
   echo "No DMG artifacts found after build." >&2
   exit 1

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -148,38 +148,24 @@ fn build_system_audio_helper() {
     std::fs::create_dir_all(&macos_dir).expect("system audio helper app dir should be created");
     let executable = macos_dir.join("june-system-audio-recorder");
 
-    let source_modified = std::fs::metadata(&source)
-        .and_then(|metadata| metadata.modified())
-        .ok();
-    let executable_current = executable.exists()
-        && source_modified
-            .and_then(|source_modified| {
-                std::fs::metadata(&executable)
-                    .and_then(|metadata| metadata.modified())
-                    .ok()
-                    .map(|executable_modified| executable_modified >= source_modified)
-            })
-            .unwrap_or(false);
+    let executable_current = swift_helper_executable_current(&source, &executable);
     let mut should_sign = false;
     if !executable_current {
-        let mut command = std::process::Command::new("swiftc");
-        configure_swift_command(&mut command, &manifest_dir, &system_audio_min_macos_version);
-        let status = command
-            .arg("-framework")
-            .arg("Foundation")
-            .arg("-framework")
-            .arg("AppKit")
-            .arg("-framework")
-            .arg("AVFoundation")
-            .arg("-framework")
-            .arg("CoreAudio")
-            .arg("-framework")
-            .arg("AudioToolbox")
-            .arg(&source)
-            .arg("-o")
-            .arg(&executable)
-            .status();
-        if !matches!(status, Ok(status) if status.success()) {
+        let built = build_universal_swift_executable(
+            "system audio helper",
+            &manifest_dir,
+            &source,
+            &executable,
+            &system_audio_min_macos_version,
+            &[
+                "Foundation",
+                "AppKit",
+                "AVFoundation",
+                "CoreAudio",
+                "AudioToolbox",
+            ],
+        );
+        if !built {
             println!("cargo:warning=system audio helper could not be built; dual-source mode will report unavailable");
             return;
         }
@@ -273,44 +259,25 @@ fn build_dictation_helper() {
         .expect("dictation helper resources dir should be created");
     let executable = macos_dir.join("june-dictation-helper");
 
-    let source_modified = std::fs::metadata(&source)
-        .and_then(|metadata| metadata.modified())
-        .ok();
-    let executable_current = executable.exists()
-        && source_modified
-            .and_then(|source_modified| {
-                std::fs::metadata(&executable)
-                    .and_then(|metadata| metadata.modified())
-                    .ok()
-                    .map(|executable_modified| executable_modified >= source_modified)
-            })
-            .unwrap_or(false);
+    let executable_current = swift_helper_executable_current(&source, &executable);
     let mut should_sign = false;
     if !executable_current {
-        let mut command = std::process::Command::new("swiftc");
-        configure_swift_command(
-            &mut command,
+        let built = build_universal_swift_executable(
+            "dictation helper",
             &manifest_dir,
+            &source,
+            &executable,
             DICTATION_HELPER_MIN_MACOS_VERSION,
+            &[
+                "Foundation",
+                "AppKit",
+                "AVFoundation",
+                "Carbon",
+                "CoreMedia",
+                "CoreGraphics",
+            ],
         );
-        let status = command
-            .arg("-framework")
-            .arg("Foundation")
-            .arg("-framework")
-            .arg("AppKit")
-            .arg("-framework")
-            .arg("AVFoundation")
-            .arg("-framework")
-            .arg("Carbon")
-            .arg("-framework")
-            .arg("CoreMedia")
-            .arg("-framework")
-            .arg("CoreGraphics")
-            .arg(&source)
-            .arg("-o")
-            .arg(&executable)
-            .status();
-        if !matches!(status, Ok(status) if status.success()) {
+        if !built {
             println!("cargo:warning=dictation helper could not be built; dictation will report unavailable");
             return;
         }
@@ -392,6 +359,105 @@ fn build_dictation_helper() {
     }
 }
 
+fn swift_helper_executable_current(source: &std::path::Path, executable: &std::path::Path) -> bool {
+    if !executable.exists() {
+        return false;
+    }
+
+    let source_modified = std::fs::metadata(source)
+        .and_then(|metadata| metadata.modified())
+        .ok();
+    let executable_fresh = source_modified
+        .and_then(|source_modified| {
+            std::fs::metadata(executable)
+                .and_then(|metadata| metadata.modified())
+                .ok()
+                .map(|executable_modified| executable_modified >= source_modified)
+        })
+        .unwrap_or(false);
+    executable_fresh && executable_has_arches(executable, &["arm64", "x86_64"])
+}
+
+fn executable_has_arches(executable: &std::path::Path, required_arches: &[&str]) -> bool {
+    let output = std::process::Command::new("lipo")
+        .arg("-archs")
+        .arg(executable)
+        .output();
+    let Ok(output) = output else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    required_arches
+        .iter()
+        .all(|required| stdout.split_whitespace().any(|arch| arch == *required))
+}
+
+fn build_universal_swift_executable(
+    helper_name: &str,
+    manifest_dir: &std::path::Path,
+    source: &std::path::Path,
+    executable: &std::path::Path,
+    macos_version: &str,
+    frameworks: &[&str],
+) -> bool {
+    let Some(executable_name) = executable.file_name().and_then(|name| name.to_str()) else {
+        println!("cargo:warning={helper_name} executable path has no file name");
+        return false;
+    };
+    let slice_dir = manifest_dir
+        .join("target")
+        .join("swift-helper-slices")
+        .join(format!("{executable_name}-{}", std::process::id()));
+    if let Err(error) = std::fs::create_dir_all(&slice_dir) {
+        println!("cargo:warning={helper_name} slice dir could not be created: {error}");
+        return false;
+    }
+
+    let mut slices = Vec::new();
+    for swift_arch in ["arm64", "x86_64"] {
+        let slice = slice_dir.join(format!("{executable_name}-{swift_arch}"));
+        let mut command = std::process::Command::new("swiftc");
+        configure_swift_command(&mut command, manifest_dir, swift_arch, macos_version);
+        for framework in frameworks {
+            command.arg("-framework").arg(framework);
+        }
+        let status = command.arg(source).arg("-o").arg(&slice).status();
+        if !matches!(status, Ok(status) if status.success()) {
+            println!("cargo:warning={helper_name} {swift_arch} slice could not be built");
+            let _ = std::fs::remove_dir_all(&slice_dir);
+            return false;
+        }
+        slices.push(slice);
+    }
+
+    let universal = slice_dir.join(format!("{executable_name}-universal"));
+    let mut lipo = std::process::Command::new("lipo");
+    lipo.arg("-create").arg("-output").arg(&universal);
+    for slice in &slices {
+        lipo.arg(slice);
+    }
+    let status = lipo.status();
+    if !matches!(status, Ok(status) if status.success()) {
+        println!("cargo:warning={helper_name} universal binary could not be created");
+        let _ = std::fs::remove_dir_all(&slice_dir);
+        return false;
+    }
+
+    if let Ok(permissions) = std::fs::metadata(&slices[0]).map(|metadata| metadata.permissions()) {
+        let _ = std::fs::set_permissions(&universal, permissions);
+    }
+    if let Err(error) = std::fs::rename(&universal, executable) {
+        println!("cargo:warning={helper_name} universal binary could not be installed: {error}");
+        let _ = std::fs::remove_dir_all(&slice_dir);
+        return false;
+    }
+    let _ = std::fs::remove_dir_all(&slice_dir);
+    true
+}
+
 fn has_signing_identity() -> bool {
     std::env::var("APPLE_SIGNING_IDENTITY")
         .ok()
@@ -427,20 +493,13 @@ fn sign_helper_app(manifest_dir: &std::path::Path, app_dir: &std::path::Path) {
 fn configure_swift_command(
     command: &mut std::process::Command,
     manifest_dir: &std::path::Path,
+    swift_arch: &str,
     macos_version: &str,
 ) {
-    if let Some(target) = swift_target(macos_version) {
-        command.arg("-target").arg(target);
-    }
+    command
+        .arg("-target")
+        .arg(format!("{swift_arch}-apple-macosx{macos_version}"));
     let module_cache = manifest_dir.join("target").join("swift-module-cache");
     std::fs::create_dir_all(&module_cache).expect("swift module cache dir should be created");
     command.arg("-module-cache-path").arg(module_cache);
-}
-
-fn swift_target(macos_version: &str) -> Option<String> {
-    match std::env::var("HOST").ok()?.as_str() {
-        "aarch64-apple-darwin" => Some(format!("arm64-apple-macosx{macos_version}")),
-        "x86_64-apple-darwin" => Some(format!("x86_64-apple-macosx{macos_version}")),
-        _ => None,
-    }
 }


### PR DESCRIPTION
## Summary
- Investigated the current macOS 14/15 failure path: the shipped v0.0.12 app has `LSMinimumSystemVersion=14.0`, but the binary is `arm64` only and `latest.json` only advertises `darwin-aarch64`. Intel Macs on macOS 14 or 15 cannot run or update it.
- Switch production and staging release builds to `universal-apple-darwin` and install both macOS Rust targets.
- Build the nested Swift dictation and system-audio helper apps as universal binaries too, instead of using the host architecture.
- Publish `June_universal.dmg` while keeping the old `June_aarch64.dmg` alias pointed at the same DMG for existing links.
- Update the macOS release runbook with universal support and `lipo` validation.

## Validation
- `pnpm exec tauri build --bundles app --target universal-apple-darwin --no-sign`
- `lipo -archs` on the built main binary, dictation helper, and system-audio helper all returned `x86_64 arm64`.
- `plutil` confirmed minimum OS values: app `14.0`, dictation helper `14.0`, system-audio helper `14.2`.
- `pnpm test:rust`
- Checked `tauri-action@v0.6.2` source: universal macOS updater JSON populates both `darwin-aarch64` and `darwin-x86_64` entries.