### PR TITLE
[codex] Add Windows support and DeepSeek default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ OPENAI_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 
 # Initial chat model used to turn transcripts and manual notes into generated note content.
 # The Settings tab can override this with any text model returned by Scribe API.
-VENICE_GENERATION_MODEL=zai-org-glm-5
+VENICE_GENERATION_MODEL=deepseek-v4-flash
 
 # --- OS Accounts (Login with Open Software) ---------------------------------
 # Identity only in the desktop app. The App API key (osk_) is server-side only

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,6 +1,7 @@
 name: desktop
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/desktop.yml"
@@ -69,13 +70,16 @@ jobs:
   # Decides whether the macOS Rust job has anything to test. macOS minutes
   # bill at 10x Linux, and most changes here are frontend-only — `cargo test`
   # reads nothing outside src-tauri/, so a pure frontend diff doesn't need a
-  # macOS runner. Unknown diff bases (force pushes, branch creation) fail
+  # macOS runner. The Windows bundle job has a broader packaged-app diff scope
+  # because it verifies the built frontend, Tauri config, and installer shape
+  # on a native Windows host. Unknown diff bases (force pushes, branch creation) fail
   # open to "changed" so the suite can never be skipped by accident.
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.diff.outputs.rust }}
+      desktop_bundle: ${{ steps.diff.outputs.desktop_bundle }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,12 +93,19 @@ jobs:
           if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]] \
             || ! git cat-file -e "$BASE" 2>/dev/null; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "desktop_bundle=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "$BASE" HEAD -- src-tauri/ .github/workflows/desktop.yml | grep -q .; then
+          changed_files="$(git diff --name-only "$BASE" HEAD)"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(src-tauri/|\.github/workflows/desktop\.yml$)'; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"
+          fi
+          if printf '%s\n' "$changed_files" | grep -Eq '^(\.github/workflows/desktop\.yml$|hud\.html$|index\.html$|meeting-hud\.html$|package\.json$|pnpm-lock\.yaml$|public/|scripts/|src/|src-tauri/|tsconfig\.json$|vite\.config\.ts$)'; then
+            echo "desktop_bundle=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "desktop_bundle=false" >> "$GITHUB_OUTPUT"
           fi
 
   rust:
@@ -129,6 +140,97 @@ jobs:
 
       - name: Cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  windows-rust:
+    name: Tauri Windows build
+    needs: changes
+    if: needs.changes.outputs.desktop_bundle == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Windows packaging tools
+        shell: pwsh
+        run: |
+          choco install nsis 7zip -y --no-progress
+          "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: tauri-cargo-registry-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            tauri-cargo-registry-${{ runner.os }}-
+
+      - name: Cache cargo target
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/target
+          key: tauri-cargo-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            tauri-cargo-target-${{ runner.os }}-
+
+      - name: Tauri Windows bundle
+        run: node scripts/tauri-build.mjs --debug --no-sign
+
+      - name: Verify Windows bundle
+        shell: pwsh
+        run: |
+          $exe = Get-Item "src-tauri/target/debug/os-scribe.exe" -ErrorAction Stop
+          if ($exe.Length -le 0) {
+            throw "Windows app executable is empty."
+          }
+
+          $setup = Get-ChildItem "src-tauri/target/debug/bundle/nsis" -Filter "*-setup.exe" | Select-Object -First 1
+          if ($null -eq $setup) {
+            throw "NSIS setup.exe was not produced."
+          }
+          if ($setup.Length -le 0) {
+            throw "NSIS setup.exe is empty."
+          }
+
+          $sevenZip = "${env:ProgramFiles}\7-Zip\7z.exe"
+          if (!(Test-Path $sevenZip)) {
+            throw "7-Zip was not installed at $sevenZip."
+          }
+          $listing = & $sevenZip l $setup.FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect NSIS installer payload."
+          }
+          if (($listing -join "`n") -notmatch "WebView2Loader\.dll") {
+            throw "NSIS installer is missing WebView2Loader.dll."
+          }
+          if (($listing -join "`n") -notmatch "os-scribe\.exe") {
+            throw "NSIS installer is missing os-scribe.exe."
+          }
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: june-windows-debug-nsis
+          path: src-tauri/target/debug/bundle/nsis/*-setup.exe
 
 # Coverage reruns of these suites live in coverage.yml (manual-only). They
 # duplicated this workflow's jobs on a macOS runner for every push and PR

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ pnpm install
 pnpm tauri:dev
 ```
 
+`pnpm tauri:dev` starts Vite and a local Scribe API when their ports are free.
+If `127.0.0.1:1421` or `127.0.0.1:8080` is already listening, the dev script
+reuses the existing service. Set `VITE_PORT` or `SCRIBE_API_PORT` to use a
+different port.
+
 To replay first-run onboarding, clear the saved onboarding checkpoint, and log
 out of OS Accounts without wiping the rest of your local app data:
 
@@ -42,8 +47,8 @@ cp .env.example .env
 # edit SCRIBE_API_URL and OS Accounts client settings when needed
 ```
 
-Run the local Scribe API separately when pointing the desktop app at
-`http://127.0.0.1:8080`:
+To run the local Scribe API yourself instead of letting `pnpm tauri:dev` start
+it, use:
 
 ```sh
 cp scribe-api/.env.example scribe-api/.env
@@ -59,7 +64,7 @@ Optional initial model defaults:
 
 ```sh
 export VENICE_TRANSCRIPTION_MODEL=nvidia/parakeet-tdt-0.6b-v3
-export VENICE_GENERATION_MODEL=zai-org-glm-5
+export VENICE_GENERATION_MODEL=deepseek-v4-flash
 export VENICE_TITLE_SUGGESTION_MODEL=nvidia-nemotron-3-nano-30b-a3b
 ```
 
@@ -108,7 +113,10 @@ The `Microphone only` mode is the default. The `Microphone + system audio` mode 
 
 Dictation uses a separate macOS helper built into `.tauri-helper/June Dictation Helper.app`. It needs microphone permission for capture and Accessibility permission to post the paste shortcut into the previously focused app.
 
-Local `pnpm tauri:build` output is ad-hoc signed unless a signing identity is configured. To build a downloadable, Developer ID-signed and notarized DMG, set the signing environment and run:
+Local `pnpm tauri:build` output is platform-specific: app and DMG bundles on
+macOS, and an NSIS installer on Windows. macOS output is ad-hoc signed unless a
+signing identity is configured. To build a downloadable, Developer ID-signed
+and notarized DMG, set the signing environment and run:
 
 ```sh
 pnpm tauri:build:signed-dmg
@@ -179,6 +187,20 @@ tccutil reset Microphone co.opensoftware.scribe
 ```
 
 System-audio permission is checked when selecting `Microphone + system audio` and immediately before recording starts. If macOS blocks it, open Privacy & Security and allow audio capture for June or the June audio capture helper, then restart the app.
+
+## Windows Development
+
+Windows builds use the base Tauri config plus
+[`src-tauri/tauri.windows.conf.json`](src-tauri/tauri.windows.conf.json), which
+targets an NSIS installer and excludes the macOS helper app resources. Install
+the normal Tauri Windows prerequisites, including Rust, Node.js, pnpm, WebView2,
+and the Microsoft C++ build tools.
+
+The managed Hermes runtime fallback on Windows uses PowerShell and requires
+Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher. The app
+runs the generated `venv\Scripts\hermes.exe` command. macOS-only dictation,
+system-audio capture, and Seatbelt sandbox features report unavailable or run
+without that OS sandbox on Windows.
 
 ## Verification
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "vite --host 127.0.0.1",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",
-    "tauri:build": "tauri build --bundles app,dmg",
+    "tauri:build": "node scripts/tauri-build.mjs",
     "tauri:build:signed-dmg": "./scripts/build-signed-dmg.sh",
     "build": "tsc && vite build",
     "test": "vitest run",
@@ -21,7 +21,7 @@
     "test:scribe-api:coverage": "cargo llvm-cov --manifest-path scribe-api/Cargo.toml --workspace --all-features --html --output-dir scribe-api/target/llvm-cov/html",
     "version:bump": "node scripts/bump-version.mjs",
     "lint": "tsc --noEmit",
-    "format": "prettier --check \"src/**/*.{ts,tsx,css}\" \"src-tauri/tauri.conf.json\" \"package.json\" \"tsconfig.json\" \"vite.config.ts\" \"index.html\" \"README.md\""
+    "format": "prettier --check \"src/**/*.{ts,tsx,css}\" \"src-tauri/tauri*.conf.json\" \"package.json\" \"tsconfig.json\" \"vite.config.ts\" \"index.html\" \"README.md\""
   },
   "dependencies": {
     "@tauri-apps/api": "^2.9.0",

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -89,17 +89,17 @@ model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
 privacy = "private"
 
-# Fallback pricing for the default text model (zai-org-glm-5-1); the live
+# Fallback pricing for the default text model (deepseek-v4-flash); the live
 # Venice catalog overrides this on boot. Keep in sync with
 # DEFAULT_GENERATION_MODEL in the Tauri providers module.
-[pricing."zai-org-glm-5-1"]
+[pricing."deepseek-v4-flash"]
 unit = "tokens"
-input_credits_per_million_tokens = 1750
-output_credits_per_million_tokens = 5500
+input_credits_per_million_tokens = 170
+output_credits_per_million_tokens = 350
 provider = "venice"
 model_type = "text"
-display_name = "GLM 5.1"
-privacy = "private"
+display_name = "DeepSeek V4 Flash"
+privacy = "anonymized"
 
 [pricing."zai-org-glm-5"]
 unit = "tokens"

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -351,19 +351,19 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     // extends over this on every boot. Keep the first entry in sync with
     // DEFAULT_GENERATION_MODEL in the Tauri providers module.
     pricing.insert(
-        "zai-org-glm-5-1".to_string(),
+        "deepseek-v4-flash".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Tokens,
             credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(1_750),
-            output_credits_per_million_tokens: Some(5_500),
+            input_credits_per_million_tokens: Some(170),
+            output_credits_per_million_tokens: Some(350),
             provider: ModelProvider::Venice,
             model_type: ModelType::Text,
-            display_name: "GLM 5.1".to_string(),
+            display_name: "DeepSeek V4 Flash".to_string(),
             description: None,
-            privacy: Some("private".to_string()),
+            privacy: Some("anonymized".to_string()),
             pricing: None,
-            context_tokens: Some(200_000),
+            context_tokens: Some(1_000_000),
             traits: Vec::new(),
             capabilities: Vec::new(),
         },

--- a/scripts/tauri-before-dev.mjs
+++ b/scripts/tauri-before-dev.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const apiDir = path.join(rootDir, "scribe-api");
+const frontendPort = Number.parseInt(process.env.VITE_PORT ?? "1421", 10);
+const apiPort = Number.parseInt(process.env.SCRIBE_API_PORT ?? "8080", 10);
+const shell = process.platform === "win32";
+
+let apiChild = null;
+let frontendChild = null;
+let shuttingDown = false;
+
+function portIsOpen(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const done = (open) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(open);
+    };
+    socket.once("connect", () => done(true));
+    socket.once("error", () => done(false));
+    socket.setTimeout(300, () => done(false));
+  });
+}
+
+function spawnManaged(name, command, args, cwd) {
+  const child = spawn(command, args, {
+    cwd,
+    env: process.env,
+    shell,
+    stdio: "inherit",
+  });
+
+  child.on("error", (error) => {
+    console.error(`${name} failed to start: ${error.message}`);
+    cleanup();
+    process.exit(1);
+  });
+
+  return child;
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of [frontendChild, apiChild]) {
+    if (child && !child.killed) {
+      child.kill();
+    }
+  }
+}
+
+function exitFromChild(code, signal) {
+  cleanup();
+  process.exit(code ?? (signal ? 1 : 0));
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => exitFromChild(0, signal));
+}
+
+if (!fs.existsSync(path.join(apiDir, "Cargo.toml"))) {
+  console.error(`Could not find scribe-api/Cargo.toml under ${rootDir}`);
+  process.exit(1);
+}
+
+if (await portIsOpen(apiPort)) {
+  console.error(
+    `Scribe API port ${apiPort} is already in use. Reusing it for Tauri dev.`,
+  );
+} else {
+  apiChild = spawnManaged(
+    "scribe-api",
+    "cargo",
+    ["run", "-p", "scribe", "--", "serve"],
+    apiDir,
+  );
+  apiChild.on("exit", (code, signal) => {
+    if (shuttingDown) return;
+    console.error(`scribe-api exited with ${signal ?? code}`);
+    exitFromChild(code, signal);
+  });
+}
+
+if (await portIsOpen(frontendPort)) {
+  console.error(
+    `Vite port ${frontendPort} is already in use. Reusing it for Tauri dev.`,
+  );
+} else {
+  frontendChild = spawnManaged("Vite", "pnpm", ["run", "dev"], rootDir);
+  frontendChild.on("exit", exitFromChild);
+}
+
+if (!frontendChild) {
+  setInterval(() => {}, 60 * 60 * 1000);
+}

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const platformBundles = {
+  darwin: ["app", "dmg"],
+  win32: ["nsis"],
+};
+
+const platformConfigs = {
+  darwin: "src-tauri/tauri.macos.conf.json",
+  win32: "src-tauri/tauri.windows.conf.json",
+};
+
+const rawUserArgs = process.argv.slice(2);
+const userArgs = rawUserArgs[0] === "--" ? rawUserArgs.slice(1) : rawUserArgs;
+const target = optionValue(userArgs, "--target");
+const buildPlatform = platformForTarget(target) ?? process.platform;
+const bundles = platformBundles[buildPlatform];
+const config = platformConfigs[buildPlatform];
+const hasBundleOverride = userArgs.some(
+  (arg) => arg === "--bundles" || arg.startsWith("--bundles="),
+);
+const hasConfigOverride = userArgs.some(
+  (arg) => arg === "--config" || arg.startsWith("--config="),
+);
+const args = ["build"];
+if (config && !hasConfigOverride) {
+  args.push("--config", config);
+}
+if (bundles && !hasBundleOverride) {
+  args.push("--bundles", bundles.join(","));
+}
+args.push(...userArgs);
+
+const child = spawn("tauri", args, {
+  shell: process.platform === "win32",
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  process.exit(code ?? (signal ? 1 : 0));
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+function optionValue(args, option) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === option) {
+      return args[index + 1];
+    }
+    if (arg.startsWith(`${option}=`)) {
+      return arg.slice(option.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function platformForTarget(targetTriple) {
+  if (!targetTriple) {
+    return undefined;
+  }
+  if (targetTriple.includes("windows")) {
+    return "win32";
+  }
+  if (targetTriple.includes("apple-darwin")) {
+    return "darwin";
+  }
+  return undefined;
+}

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -3,11 +3,17 @@
 import { spawn } from "node:child_process";
 
 const REPLAY_ONBOARDING_FLAG = "--replay-onboarding";
+const platformConfigs = {
+  darwin: "src-tauri/tauri.macos.conf.json",
+  win32: "src-tauri/tauri.windows.conf.json",
+};
 
 let replayOnboarding = false;
 const tauriArgs = [];
+const rawUserArgs = process.argv.slice(2);
+const userArgs = rawUserArgs[0] === "--" ? rawUserArgs.slice(1) : rawUserArgs;
 
-for (const arg of process.argv.slice(2)) {
+for (const arg of userArgs) {
   if (arg === REPLAY_ONBOARDING_FLAG) {
     replayOnboarding = true;
   } else {
@@ -15,20 +21,25 @@ for (const arg of process.argv.slice(2)) {
   }
 }
 
+const config = platformConfigs[process.platform];
+const hasConfigOverride = tauriArgs.some(
+  (arg) => arg === "--config" || arg.startsWith("--config="),
+);
+if (config && !hasConfigOverride) {
+  tauriArgs.unshift("--config", config);
+}
+
 const child = spawn("tauri", ["dev", ...tauriArgs], {
   env: {
     ...process.env,
     ...(replayOnboarding ? { VITE_JUNE_REPLAY_ONBOARDING: "1" } : {}),
   },
+  shell: process.platform === "win32",
   stdio: "inherit",
 });
 
 child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
-  }
-  process.exit(code ?? 1);
+  process.exit(code ?? (signal ? 1 : 0));
 });
 
 child.on("error", (error) => {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,9 +2300,11 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.80.0"
 
 [lib]
 name = "os_scribe_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [[bin]]
 name = "os-scribe"
@@ -25,7 +25,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cpal = "0.15"
 dotenvy = "0.15"
 hound = "3.5"
-keyring = { version = "3", features = ["apple-native"] }
+keyring = "3"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -47,6 +47,7 @@ uuid = { version = "1.11", features = ["serde", "v4"] }
 zeroize = { version = "1", features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3", features = ["apple-native"] }
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
@@ -56,6 +57,9 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
     "objc2-core-foundation",
 ] }
 window-vibrancy = "0.6"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3", features = ["windows-native"] }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -45,7 +45,9 @@ fn ensure_bundled_hermes_dir() {
         return;
     };
     if hermes_dir.exists() {
-        if !hermes_dir.join("bin").join("hermes").exists() {
+        if !hermes_dir.join("bin").join("hermes").exists()
+            && !hermes_dir.join("bin").join("hermes.exe").exists()
+        {
             // Placeholder (or partial) dir: nothing to validate.
             return;
         }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -97,10 +97,22 @@ pub fn microphone_permission_state() -> (String, Option<String>) {
     if host.default_input_device().is_some() {
         ("granted".to_string(), None)
     } else {
-        (
-            "denied".to_string(),
-            Some("Enable microphone access in macOS Privacy & Security settings.".to_string()),
-        )
+        ("denied".to_string(), Some(microphone_permission_hint()))
+    }
+}
+
+fn microphone_permission_hint() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "Enable microphone access in macOS Privacy & Security settings.".to_string()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Enable microphone access in Windows privacy settings.".to_string()
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        "Enable microphone access in your system privacy settings.".to_string()
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -595,12 +595,28 @@ pub async fn open_privacy_settings(request: OpenPrivacySettingsRequest) -> Resul
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = request;
-        Err(AppError::new(
-            "settings_open_unsupported",
-            "Privacy settings shortcuts are only supported on macOS.",
-        ))
+        open_non_macos_privacy_settings(request)
     }
+}
+
+#[cfg(target_os = "windows")]
+fn open_non_macos_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
+    match request.pane.as_str() {
+        "microphone" => crate::os_accounts::open_in_browser("ms-settings:privacy-microphone"),
+        _ => Err(AppError::new(
+            "settings_open_unsupported",
+            "This privacy settings shortcut is only supported on macOS.",
+        )),
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn open_non_macos_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
+    let _ = request;
+    Err(AppError::new(
+        "settings_open_unsupported",
+        "Privacy settings shortcuts are only supported on macOS.",
+    ))
 }
 
 #[tauri::command]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -616,21 +616,17 @@ pub fn setup(app: &mut tauri::App) {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let settings = app
-            .state::<DictationSettingsState>()
-            .settings
-            .lock()
-            .map(|settings| settings.clone())
-            .unwrap_or_default();
-        let event = hotkey_ready_event(&settings);
-
-        app.manage(HotkeyStatus {
-            event: Mutex::new(event.clone()),
-        });
-        let _ = app.emit("dictation-event", event.to_string());
-    }
+    let settings = app
+        .state::<DictationSettingsState>()
+        .settings
+        .lock()
+        .map(|settings| settings.clone())
+        .unwrap_or_default();
+    let event = initial_hotkey_event(&settings);
+    app.manage(HotkeyStatus {
+        event: Mutex::new(event.clone()),
+    });
+    let _ = app.emit("dictation-event", event.to_string());
 }
 
 #[tauri::command]
@@ -707,6 +703,19 @@ pub fn set_dictation_shortcut(
 }
 
 #[tauri::command]
+#[cfg(not(target_os = "macos"))]
+pub fn set_dictation_shortcut(
+    kind: DictationShortcutKind,
+    shortcut: DictationShortcutInput,
+) -> Result<DictationSettings, AppError> {
+    let _ = (kind, shortcut);
+    Err(AppError::new(
+        "dictation_shortcut_unsupported",
+        "Dictation shortcuts are only supported on macOS.",
+    ))
+}
+
+#[tauri::command]
 pub fn set_dictation_microphone(
     state: State<'_, DictationSettingsState>,
     helper_state: State<'_, HelperState>,
@@ -716,6 +725,16 @@ pub fn set_dictation_microphone(
     let settings = update_settings(&state, |settings| {
         settings.microphone = DictationMicrophoneSetting { id, name };
     })?;
+    #[cfg(not(target_os = "macos"))]
+    if helper_state
+        .process
+        .lock()
+        .map(|process| process.is_none())
+        .unwrap_or(true)
+    {
+        return Ok(settings);
+    }
+
     apply_microphone_setting(&helper_state, &settings.microphone)?;
     Ok(settings)
 }
@@ -743,9 +762,23 @@ pub fn set_dictation_language(
 
 #[tauri::command]
 pub fn dictation_helper_command(
+    app: AppHandle,
     state: State<'_, HelperState>,
     command: serde_json::Value,
 ) -> Result<(), AppError> {
+    #[cfg(target_os = "macos")]
+    let _ = &app;
+
+    #[cfg(not(target_os = "macos"))]
+    if state
+        .process
+        .lock()
+        .map(|process| process.is_none())
+        .unwrap_or(true)
+    {
+        return handle_missing_helper_command(&app, &command);
+    }
+
     send_helper_command(&state, command)
 }
 
@@ -1334,6 +1367,58 @@ fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Resul
         .stdin
         .flush()
         .map_err(|error| AppError::new("dictation_helper_write_failed", error.to_string()))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn handle_missing_helper_command(
+    app: &AppHandle,
+    command: &serde_json::Value,
+) -> Result<(), AppError> {
+    match command.get("type").and_then(serde_json::Value::as_str) {
+        Some(
+            "get_permission_status"
+            | "request_microphone_permission"
+            | "request_accessibility_permission",
+        ) => {
+            emit_dictation_event_value(app, non_macos_permission_status_event());
+            Ok(())
+        }
+        Some("list_microphones") => {
+            emit_dictation_event_value(
+                app,
+                serde_json::json!({
+                    "type": "microphone_devices",
+                    "payload": {
+                        "devices": [],
+                        "selectedID": "",
+                    },
+                }),
+            );
+            Ok(())
+        }
+        Some(
+            "cancel_shortcut_capture"
+            | "start_shortcut_capture"
+            | "set_microphone"
+            | "discard_mic_test",
+        ) => Ok(()),
+        _ => Err(AppError::new(
+            "dictation_helper_unavailable",
+            "Dictation recording is only supported on macOS.",
+        )),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn non_macos_permission_status_event() -> serde_json::Value {
+    let (microphone, _) = crate::audio::capture::microphone_permission_state();
+    serde_json::json!({
+        "type": "permission_status",
+        "payload": {
+            "microphone": microphone,
+            "accessibility": "granted",
+        },
+    })
 }
 
 fn apply_microphone_setting(
@@ -2751,6 +2836,22 @@ fn hotkey_ready_event(settings: &DictationSettings) -> serde_json::Value {
             "pushToTalkShortcut": settings.push_to_talk_shortcut.label,
             "toggleShortcut": settings.toggle_shortcut.label,
             "shortcuts": shortcuts,
+        },
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn initial_hotkey_event(settings: &DictationSettings) -> serde_json::Value {
+    hotkey_ready_event(settings)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn initial_hotkey_event(_settings: &DictationSettings) -> serde_json::Value {
+    serde_json::json!({
+        "type": "hotkey_trigger_unavailable",
+        "payload": {
+            "reason": "unsupported",
+            "message": "Dictation shortcuts are only supported on macOS.",
         },
     })
 }

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1773,11 +1773,32 @@ async fn resolve_hermes_command(
 
 fn bundled_hermes_command(app: &AppHandle) -> Option<PathBuf> {
     let resource_dir = app.path().resource_dir().ok()?;
-    let candidates = [
-        resource_dir.join("native/hermes/hermes-agent/venv/bin/hermes"),
-        resource_dir.join("native/hermes/bin/hermes"),
-    ];
+    let candidates = bundled_hermes_command_candidates(&resource_dir);
     candidates.into_iter().find(|path| path.exists())
+}
+
+fn bundled_hermes_command_candidates(resource_dir: &Path) -> Vec<PathBuf> {
+    let hermes_root = resource_dir.join("native").join("hermes");
+    if cfg!(target_os = "windows") {
+        vec![
+            hermes_root
+                .join("hermes-agent")
+                .join("venv")
+                .join("Scripts")
+                .join("hermes.exe"),
+            hermes_root.join("bin").join("hermes.exe"),
+            hermes_root.join("hermes.exe"),
+        ]
+    } else {
+        vec![
+            hermes_root
+                .join("hermes-agent")
+                .join("venv")
+                .join("bin")
+                .join("hermes"),
+            hermes_root.join("bin").join("hermes"),
+        ]
+    }
 }
 
 fn managed_hermes_runtime_dir(app: &AppHandle) -> Result<PathBuf, AppError> {
@@ -1789,9 +1810,11 @@ fn managed_hermes_runtime_dir(app: &AppHandle) -> Result<PathBuf, AppError> {
 }
 
 fn managed_hermes_command(app: &AppHandle) -> Result<PathBuf, AppError> {
-    Ok(managed_hermes_runtime_dir(app)?
-        .join("hermes-agent")
-        .join("venv/bin/hermes"))
+    Ok(hermes_venv_command(
+        &managed_hermes_runtime_dir(app)?
+            .join("hermes-agent")
+            .join("venv"),
+    ))
 }
 
 fn managed_hermes_runtime_current(app: &AppHandle) -> Result<bool, AppError> {
@@ -1803,13 +1826,54 @@ fn managed_hermes_runtime_current(app: &AppHandle) -> Result<bool, AppError> {
 }
 
 fn user_local_hermes_command() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    [
-        PathBuf::from(&home).join(".hermes/hermes-agent/venv/bin/hermes"),
-        PathBuf::from(&home).join(".local/bin/hermes"),
-    ]
-    .into_iter()
-    .find(|path| path.exists())
+    let mut candidates = Vec::new();
+    for home in home_dir_candidates() {
+        candidates.push(hermes_venv_command(
+            &home.join(".hermes").join("hermes-agent").join("venv"),
+        ));
+        candidates.push(if cfg!(target_os = "windows") {
+            home.join(".local").join("bin").join("hermes.exe")
+        } else {
+            home.join(".local").join("bin").join("hermes")
+        });
+    }
+    candidates.into_iter().find(|path| path.exists())
+}
+
+fn hermes_venv_command(venv_dir: &Path) -> PathBuf {
+    if cfg!(target_os = "windows") {
+        venv_dir.join("Scripts").join("hermes.exe")
+    } else {
+        venv_dir.join("bin").join("hermes")
+    }
+}
+
+fn home_dir_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for name in ["HOME", "USERPROFILE"] {
+        if let Some(value) = std::env::var_os(name) {
+            if !value.is_empty() {
+                let path = PathBuf::from(value);
+                if !candidates.contains(&path) {
+                    candidates.push(path);
+                }
+            }
+        }
+    }
+    match (std::env::var_os("HOMEDRIVE"), std::env::var_os("HOMEPATH")) {
+        (Some(drive), Some(path)) if !drive.is_empty() && !path.is_empty() => {
+            let candidate = PathBuf::from(format!(
+                "{}{}",
+                drive.to_string_lossy(),
+                path.to_string_lossy()
+            ));
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+        _ => {}
+    }
+    candidates
 }
 
 fn hermes_runtime_available_for_auto_start(app: &AppHandle) -> bool {
@@ -1823,6 +1887,22 @@ fn hermes_runtime_available_for_auto_start(app: &AppHandle) -> bool {
 }
 
 async fn install_managed_hermes_runtime(
+    app: &AppHandle,
+    hermes_home: &Path,
+) -> Result<(), AppError> {
+    #[cfg(target_os = "windows")]
+    {
+        return install_managed_hermes_runtime_windows(app, hermes_home).await;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        install_managed_hermes_runtime_unix(app, hermes_home).await
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn install_managed_hermes_runtime_unix(
     app: &AppHandle,
     hermes_home: &Path,
 ) -> Result<(), AppError> {
@@ -1900,7 +1980,101 @@ async fn install_managed_hermes_runtime(
         ));
     }
 
-    if !install_dir.join("venv/bin/hermes").exists() {
+    if !hermes_venv_command(&install_dir.join("venv")).exists() {
+        return Err(AppError::new(
+            "hermes_runtime_install_failed",
+            format!(
+                "Hermes setup completed but the runtime command was not created. Install log: {}.",
+                install_log.display()
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+async fn install_managed_hermes_runtime_windows(
+    app: &AppHandle,
+    hermes_home: &Path,
+) -> Result<(), AppError> {
+    let runtime_dir = managed_hermes_runtime_dir(app)?;
+    let install_dir = runtime_dir.join("hermes-agent");
+    fs::create_dir_all(&runtime_dir)
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    if install_dir.exists() && !managed_hermes_runtime_current(app)? {
+        fs::remove_dir_all(&install_dir)
+            .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    }
+    let install_log = runtime_dir.join("install.log");
+
+    let log_file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&install_log)
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    let log_file_for_stderr = log_file
+        .try_clone()
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+
+    let status = {
+        let runtime_dir = runtime_dir.clone();
+        let install_dir = install_dir.clone();
+        let hermes_home = hermes_home.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            Command::new("powershell.exe")
+                .args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    WINDOWS_MANAGED_HERMES_INSTALL_SCRIPT,
+                ])
+                .env("SCRIBE_HERMES_RUNTIME_DIR", &runtime_dir)
+                .env("SCRIBE_HERMES_INSTALL_DIR", &install_dir)
+                .env("SCRIBE_HERMES_HOME", &hermes_home)
+                .env("SCRIBE_HERMES_INSTALL_COMMIT", HERMES_AGENT_INSTALL_COMMIT)
+                .env(
+                    "SCRIBE_HERMES_SOURCE_TARBALL_URL",
+                    HERMES_SOURCE_TARBALL_URL,
+                )
+                .env(
+                    "SCRIBE_HERMES_SOURCE_TARBALL_SHA256",
+                    HERMES_SOURCE_TARBALL_SHA256,
+                )
+                .env("HERMES_HOME", &hermes_home)
+                .stdin(Stdio::null())
+                .stdout(Stdio::from(log_file))
+                .stderr(Stdio::from(log_file_for_stderr))
+                .status()
+        })
+        .await
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?
+        .map_err(|error| {
+            AppError::new(
+                "hermes_runtime_install_failed",
+                format!(
+                    "Could not run the Windows Hermes runtime installer. Install log: {}. {error}",
+                    install_log.display()
+                ),
+            )
+        })?
+    };
+
+    if !status.success() {
+        return Err(AppError::new(
+            "hermes_runtime_install_failed",
+            format!(
+                "Could not set up the Scribe-managed Hermes runtime. Install log: {}.",
+                install_log.display()
+            ),
+        ));
+    }
+
+    if !hermes_venv_command(&install_dir.join("venv")).exists() {
         return Err(AppError::new(
             "hermes_runtime_install_failed",
             format!(
@@ -1982,6 +2156,157 @@ cat > "$runtime_dir/runtime.json" <<EOF
 {"source":"NousResearch/hermes-agent","commit":"$install_commit","installDir":"$install_dir"}
 EOF
 "#;
+
+#[cfg(target_os = "windows")]
+const WINDOWS_MANAGED_HERMES_INSTALL_SCRIPT: &str = r##"
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$runtimeDir = $env:SCRIBE_HERMES_RUNTIME_DIR
+$installDir = $env:SCRIBE_HERMES_INSTALL_DIR
+$hermesHome = $env:SCRIBE_HERMES_HOME
+$installCommit = $env:SCRIBE_HERMES_INSTALL_COMMIT
+$sourceTarballUrl = $env:SCRIBE_HERMES_SOURCE_TARBALL_URL
+$sourceTarballSha256 = ($env:SCRIBE_HERMES_SOURCE_TARBALL_SHA256).ToLowerInvariant()
+
+if ([string]::IsNullOrWhiteSpace($runtimeDir) -or
+    [string]::IsNullOrWhiteSpace($installDir) -or
+    [string]::IsNullOrWhiteSpace($hermesHome)) {
+  throw "Hermes installer paths were not provided."
+}
+
+New-Item -ItemType Directory -Force -Path $runtimeDir, $hermesHome | Out-Null
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [Parameter(Mandatory = $true)][string[]]$Arguments
+  )
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath exited with code $LASTEXITCODE"
+  }
+}
+
+function Resolve-Python {
+  $candidates = @(
+    @{ Exe = "py"; Args = @("-3.11") },
+    @{ Exe = "py"; Args = @("-3.12") },
+    @{ Exe = "py"; Args = @("-3.13") },
+    @{ Exe = "python"; Args = @() },
+    @{ Exe = "python3"; Args = @() }
+  )
+  foreach ($candidate in $candidates) {
+    try {
+      $args = @($candidate.Args + @(
+        "-c",
+        "import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)"
+      ))
+      & $candidate.Exe @args
+      if ($LASTEXITCODE -eq 0) {
+        return $candidate
+      }
+    } catch {
+    }
+  }
+  throw "Python 3.11, 3.12, or 3.13 is required to install the managed Hermes runtime on Windows."
+}
+
+if (!(Test-Path (Join-Path $installDir "pyproject.toml"))) {
+  $tmpDir = Join-Path $runtimeDir ("download-" + [guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+  try {
+    $archive = Join-Path $tmpDir "hermes-agent.tar.gz"
+    Invoke-WebRequest -Uri $sourceTarballUrl -OutFile $archive
+    $actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $sourceTarballSha256) {
+      throw "Hermes source archive checksum mismatch. Expected $sourceTarballSha256, got $actualSha256."
+    }
+    Invoke-Native "tar" @("-xzf", $archive, "-C", $tmpDir)
+    $unpacked = Get-ChildItem -Path $tmpDir -Directory |
+      Where-Object { $_.Name -like "hermes-agent-*" } |
+      Select-Object -First 1
+    if ($null -eq $unpacked) {
+      throw "Hermes source archive did not contain a hermes-agent directory."
+    }
+    if (Test-Path $installDir) {
+      Remove-Item -Recurse -Force -Path $installDir
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $installDir) | Out-Null
+    Move-Item -Path $unpacked.FullName -Destination $installDir
+  } finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -Path $tmpDir
+  }
+}
+
+$python = Resolve-Python
+$venvDir = Join-Path $installDir "venv"
+if (Test-Path $venvDir) {
+  Remove-Item -Recurse -Force -Path $venvDir
+}
+Invoke-Native $python.Exe @($python.Args + @("-m", "venv", $venvDir))
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+if (!(Test-Path $venvPython)) {
+  throw "Python virtual environment was not created at $venvDir."
+}
+
+Set-Location $installDir
+Invoke-Native $venvPython @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
+Invoke-Native $venvPython @("-m", "pip", "install", "-e", ".[all]")
+
+$homeDirs = @("cron", "sessions", "logs", "pairing", "hooks", "image_cache", "audio_cache", "memories", "skills")
+foreach ($dir in $homeDirs) {
+  New-Item -ItemType Directory -Force -Path (Join-Path $hermesHome $dir) | Out-Null
+}
+
+$envFile = Join-Path $hermesHome ".env"
+if (!(Test-Path $envFile)) {
+  $exampleEnv = Join-Path $installDir ".env.example"
+  if (Test-Path $exampleEnv) {
+    Copy-Item -Path $exampleEnv -Destination $envFile
+  } else {
+    New-Item -ItemType File -Path $envFile | Out-Null
+  }
+}
+
+$configFile = Join-Path $hermesHome "config.yaml"
+if (!(Test-Path $configFile)) {
+  $exampleConfig = Join-Path $installDir "cli-config.yaml.example"
+  if (Test-Path $exampleConfig) {
+    Copy-Item -Path $exampleConfig -Destination $configFile
+  }
+}
+
+$soulFile = Join-Path $hermesHome "SOUL.md"
+if (!(Test-Path $soulFile)) {
+  [System.IO.File]::WriteAllText($soulFile, "# Hermes Agent Persona`n", (New-Object System.Text.UTF8Encoding $false))
+}
+
+$skillsSync = Join-Path $installDir "tools\skills_sync.py"
+if (Test-Path $skillsSync) {
+  try {
+    Invoke-Native $venvPython @($skillsSync)
+  } catch {
+    $sourceSkills = Join-Path $installDir "skills"
+    $targetSkills = Join-Path $hermesHome "skills"
+    if (Test-Path $sourceSkills) {
+      Copy-Item -Path (Join-Path $sourceSkills "*") -Destination $targetSkills -Recurse -Force
+    }
+  }
+}
+
+$hermesExe = Join-Path $venvDir "Scripts\hermes.exe"
+if (!(Test-Path $hermesExe)) {
+  throw "Hermes executable was not created at $hermesExe."
+}
+
+$metadata = [ordered]@{
+  source = "NousResearch/hermes-agent"
+  commit = $installCommit
+  installDir = $installDir
+} | ConvertTo-Json -Compress
+[System.IO.File]::WriteAllText((Join-Path $runtimeDir "runtime.json"), $metadata, (New-Object System.Text.UTF8Encoding $false))
+"##;
 
 fn apply_isolated_hermes_env(
     cmd: &mut Command,
@@ -3011,6 +3336,43 @@ mod tests {
         let request: StartHermesBridgeRequest =
             serde_json::from_str(r#"{"fullMode":false}"#).expect("sandboxed request");
         assert_eq!(request.full_mode, Some(false));
+    }
+
+    #[test]
+    fn hermes_venv_command_uses_the_target_entrypoint() {
+        let command = hermes_venv_command(Path::new("venv"));
+
+        if cfg!(target_os = "windows") {
+            assert_eq!(
+                command,
+                PathBuf::from("venv").join("Scripts").join("hermes.exe")
+            );
+        } else {
+            assert_eq!(command, PathBuf::from("venv").join("bin").join("hermes"));
+        }
+    }
+
+    #[test]
+    fn bundled_command_candidates_include_target_specific_launchers() {
+        let candidates = bundled_hermes_command_candidates(Path::new("resources"));
+
+        if cfg!(target_os = "windows") {
+            assert!(candidates.contains(
+                &PathBuf::from("resources")
+                    .join("native")
+                    .join("hermes")
+                    .join("bin")
+                    .join("hermes.exe")
+            ));
+        } else {
+            assert!(candidates.contains(
+                &PathBuf::from("resources")
+                    .join("native")
+                    .join("hermes")
+                    .join("bin")
+                    .join("hermes")
+            ));
+        }
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,9 +13,7 @@ pub mod os_accounts;
 pub mod providers;
 pub mod scribe_api;
 
-use tauri::Emitter;
-#[cfg(target_os = "macos")]
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check_for_updates";
 const CHECK_FOR_UPDATES_EVENT: &str = "scribe://check-for-updates";

--- a/src-tauri/src/meeting_hud.rs
+++ b/src-tauri/src/meeting_hud.rs
@@ -48,7 +48,6 @@ const IDLE_TICK: Duration = Duration::from_millis(220);
 const PILL_SIZE: LogicalSize<f64> = LogicalSize::new(76.0, 32.0);
 /// Upright the pill carries less (4 bars instead of 7), so it runs shorter.
 /// Must agree with `.mhud[data-orient="vertical"]` in meeting-hud.css.
-#[cfg(target_os = "macos")]
 const VERTICAL_PILL_LENGTH: f64 = 62.0;
 /// The window is a fixed square the length of the pill (tauri.conf.json), so a
 /// quarter turn always fits without resizing the native frame — the transparent

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -1247,8 +1247,8 @@ fn random_b64url(bytes: usize) -> String {
 }
 
 pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
-    let mut child = std::process::Command::new("open")
-        .arg(url)
+    let mut command = browser_open_command(url);
+    let mut child = command
         .spawn()
         .map_err(|e| AppError::new("browser_open_failed", e.to_string()))?;
     // Reap the short-lived `open` process off-thread so it doesn't linger as
@@ -1257,4 +1257,25 @@ pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
         let _ = child.wait();
     });
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn browser_open_command(url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new("open");
+    command.arg(url);
+    command
+}
+
+#[cfg(target_os = "windows")]
+fn browser_open_command(url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new("explorer.exe");
+    command.arg(url);
+    command
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn browser_open_command(url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new("xdg-open");
+    command.arg(url);
+    command
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -14,7 +14,7 @@ use tauri::{AppHandle, Manager, State};
 pub const PROVIDER_OPENAI: &str = "openai";
 pub const PROVIDER_VENICE: &str = "venice";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
-pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-1";
+pub const DEFAULT_GENERATION_MODEL: &str = "deepseek-v4-flash";
 
 // Kept exported under the legacy names so existing callers compile until they
 // migrate to the names above.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.0.12",
   "identifier": "co.opensoftware.scribe",
   "build": {
-    "beforeDevCommand": "./scripts/tauri-before-dev.sh",
+    "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",
     "beforeBuildCommand": "pnpm run build",
     "devUrl": "http://127.0.0.1:1421",
     "frontendDist": "../dist"
@@ -80,32 +80,21 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$TEMP/os-scribe-dictation-*.m4a"
-        ]
+        "scope": ["$TEMP/os-scribe-dictation-*.m4a"]
       },
-      "capabilities": [
-        "main",
-        "hud",
-        "agent-hud",
-        "meeting-hud"
-      ]
+      "capabilities": ["main", "hud", "agent-hud", "meeting-hud"]
     }
   },
   "plugins": {
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "osscribe"
-          ],
+          "scheme": ["osscribe"],
           "appLink": false
         }
       ],
       "desktop": {
-        "schemes": [
-          "osscribe"
-        ]
+        "schemes": ["osscribe"]
       }
     },
     "updater": {
@@ -125,22 +114,8 @@
       "icons/icon.icns",
       "icons/icon.png"
     ],
-    "targets": [
-      "app",
-      "dmg"
-    ],
     "resources": {
-      "../.tauri-helper/June.app": "native/bin/June.app",
-      "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app",
       "../.tauri-hermes/hermes": "native/hermes"
-    },
-    "macOS": {
-      "bundleName": "June",
-      "entitlements": "Entitlements.plist",
-      "exceptionDomain": "",
-      "frameworks": [],
-      "infoPlist": "Info.plist",
-      "minimumSystemVersion": "14.0"
     }
   }
 }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,5 +1,21 @@
 {
   "build": {
     "runner": "../scripts/cargo-os-scribe-runner.sh"
+  },
+  "bundle": {
+    "targets": ["app", "dmg"],
+    "resources": {
+      "../.tauri-helper/June.app": "native/bin/June.app",
+      "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app",
+      "../.tauri-hermes/hermes": "native/hermes"
+    },
+    "macOS": {
+      "bundleName": "June",
+      "entitlements": "Entitlements.plist",
+      "exceptionDomain": "",
+      "frameworks": [],
+      "infoPlist": "Info.plist",
+      "minimumSystemVersion": "14.0"
+    }
   }
 }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,10 @@
+{
+  "bundle": {
+    "targets": ["nsis"],
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
+      }
+    }
+  }
+}

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -258,7 +258,7 @@ export const AgentSessionsList = forwardRef<
           label="Start your first session"
           icon={<IconBubble3 size={28} />}
           title="Put June to work"
-          description="Ask June to check on your Mac, dig through your files, or research a topic. Each session keeps one task's conversation and everything it produces in one place."
+          description="Ask June to check on your computer, dig through your files, or research a topic. Each session keeps one task's conversation and everything it produces in one place."
           action={
             <button
               type="button"

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -487,10 +487,10 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
   {
     key: "health-check",
     icon: <IconHeartBeat size={18} />,
-    title: "Check my Mac's health",
+    title: "Check my computer's health",
     description: "Disk, memory, and login items that need attention.",
     prompt:
-      "Give my Mac a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
+      "Give my computer a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
     action: "run",
   },
   {
@@ -498,7 +498,8 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     icon: <IconMagnifyingGlass size={18} />,
     title: "Find a file",
     description: "Describe what you remember; June tracks it down.",
-    prompt: "Find <a file I half-remember> on my Mac and tell me where it is.",
+    prompt:
+      "Find <a file I half-remember> on my computer and tell me where it is.",
     action: "prefill",
   },
   {
@@ -2891,8 +2892,8 @@ export function AgentWorkspace({
     dispatchAgentSessionStatus({
       sessionId,
       title:
-        hermesSessionItems.find((session) => session.id === sessionId)
-          ?.title ?? "Agent session",
+        hermesSessionItems.find((session) => session.id === sessionId)?.title ??
+        "Agent session",
       status: "cancelled",
       summary: "Stopped.",
       ...activityCounts,
@@ -3951,7 +3952,7 @@ export function AgentWorkspace({
               <p className="agent-hero-footnote">
                 {bridgeStarting
                   ? "Getting June ready…"
-                  : "June runs privately on your Mac."}
+                  : "June runs privately on your computer."}
               </p>
             </div>
           ) : null}

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -37,7 +37,11 @@ function PermissionRow({
   onAllow?: () => void;
 }) {
   return (
-    <li className="onboarding-perm" data-granted={granted} data-probing={probing}>
+    <li
+      className="onboarding-perm"
+      data-granted={granted}
+      data-probing={probing}
+    >
       <span className="onboarding-perm-icon" aria-hidden>
         {granted ? <IconCheckmark1Small size={15} /> : icon}
       </span>
@@ -82,6 +86,7 @@ export function PermissionsStep({
   // explains itself and stays out of the Continue gate.
   const systemAudioUnsupported = systemAudioStatus === "unsupported";
   const showPermissionRows = statuses.checked || showUnknownStatuses;
+  const macLikePlatform = isMacLikePlatform();
 
   // Fire the native TCC prompt as soon as the screen shows — the user just
   // read why we're asking, so the dialog lands in context. No-op when
@@ -123,7 +128,11 @@ export function PermissionsStep({
   return (
     <StepCard
       title="Let June listen and type"
-      subtitle="Dictation and meeting notes need three macOS permissions."
+      subtitle={
+        macLikePlatform
+          ? "Dictation and meeting notes need three macOS permissions."
+          : "Dictation and meeting notes need microphone access."
+      }
       wide
     >
       <ul
@@ -151,48 +160,66 @@ export function PermissionsStep({
               : undefined
           }
         />
-        <PermissionRow
-          icon={<IconTextIndicator size={15} />}
-          granted={showPermissionRows && accessibilityGranted}
-          title="Accessibility"
-          detail="Types your words at your cursor, in any app."
-          onAllow={showPermissionRows ? openAccessibilitySettings : undefined}
-        />
-        <PermissionRow
-          icon={<IconVolumeFull size={15} />}
-          granted={showPermissionRows && systemAudioGranted}
-          probing={showPermissionRows && systemAudioStatus === "probing"}
-          title="System audio"
-          detail={
-            systemAudioDenied
-              ? "Turned off in System Settings. Flip the toggle and June will notice."
-              : systemAudioUnsupported
-                ? "Needs macOS 14.2 or later."
-                : systemAudioStatus === "probing"
-                  ? "Waiting for macOS. Approve the prompt when it appears."
-                  : "Hears your calls and meetings, only while you record."
-          }
-          onAllow={
-            showPermissionRows
-              ? systemAudioDenied
-                ? () => void openPrivacySettings("systemAudio")
-                : systemAudioStatus === "unknown"
-                  ? onAllowSystemAudio
+        {macLikePlatform ? (
+          <>
+            <PermissionRow
+              icon={<IconTextIndicator size={15} />}
+              granted={showPermissionRows && accessibilityGranted}
+              title="Accessibility"
+              detail="Types your words at your cursor, in any app."
+              onAllow={
+                showPermissionRows ? openAccessibilitySettings : undefined
+              }
+            />
+            <PermissionRow
+              icon={<IconVolumeFull size={15} />}
+              granted={showPermissionRows && systemAudioGranted}
+              probing={showPermissionRows && systemAudioStatus === "probing"}
+              title="System audio"
+              detail={
+                systemAudioDenied
+                  ? "Turned off in System Settings. Flip the toggle and June will notice."
+                  : systemAudioUnsupported
+                    ? "Needs macOS 14.2 or later."
+                    : systemAudioStatus === "probing"
+                      ? "Waiting for macOS. Approve the prompt when it appears."
+                      : "Hears your calls and meetings, only while you record."
+              }
+              onAllow={
+                showPermissionRows
+                  ? systemAudioDenied
+                    ? () => void openPrivacySettings("systemAudio")
+                    : systemAudioStatus === "unknown"
+                      ? onAllowSystemAudio
+                      : undefined
                   : undefined
-              : undefined
-          }
-        />
+              }
+            />
+          </>
+        ) : null}
       </ul>
       <StepActions
         onContinue={onContinue}
         continueDisabled={
           !showPermissionRows ||
           !micGranted ||
-          !accessibilityGranted ||
-          !(systemAudioGranted || systemAudioUnsupported)
+          (macLikePlatform &&
+            (!accessibilityGranted ||
+              !(systemAudioGranted || systemAudioUnsupported)))
         }
         onSkip={onContinue}
       />
     </StepCard>
   );
+}
+
+function isMacLikePlatform() {
+  const platform =
+    typeof navigator === "undefined"
+      ? ""
+      : `${navigator.platform} ${navigator.userAgent}`;
+  if (/Windows|Win32|Win64|Linux|Android/i.test(platform)) {
+    return false;
+  }
+  return true;
 }

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -13,7 +13,7 @@ import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 const JUNE_POINTS = [
   {
     icon: IconSparkle,
-    title: "An agent on your Mac",
+    title: "An agent on your computer",
     detail: "Hand June real work. It runs the session and comes back done.",
   },
   {
@@ -25,7 +25,7 @@ const JUNE_POINTS = [
     icon: IconLock,
     title: "Private by default",
     detail:
-      "Prompts leave your Mac only for inference, on zero-retention models by default.",
+      "Prompts leave your device only for inference, on zero-retention models by default.",
   },
 ];
 

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -161,7 +161,7 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
   // Mirrors DEFAULT_GENERATION_MODEL in the Rust providers module and the
   // leading Suggested pick in lib/suggested-models.ts.
-  generationModel: "zai-org-glm-5-1",
+  generationModel: "deepseek-v4-flash",
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;
@@ -663,7 +663,7 @@ export function AppSettings({
     ? "Input device used for dictation."
     : defaultMicrophone?.name
       ? `Auto-detect uses ${defaultMicrophone.name}.`
-      : "Auto-detect uses the current macOS input.";
+      : "Auto-detect uses the current system input.";
   const microphoneOptions = [
     { id: undefined, name: "Auto-detect" },
     ...microphones,

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -35,7 +35,7 @@ export function dispatchProviderModelSettingsChanged(
 }
 
 export const E2EE_MODEL_DESCRIPTION =
-  "Private model with end-to-end encryption. Your prompt is encrypted on your Mac and only decrypted inside a hardware-secured enclave (TEE); the response is encrypted before it leaves the enclave. No prompt data is ever readable by the model provider or its infrastructure.";
+  "Private model with end-to-end encryption. Your prompt is encrypted on your device and only decrypted inside a hardware-secured enclave (TEE); the response is encrypted before it leaves the enclave. No prompt data is ever readable by the model provider or its infrastructure.";
 export const PRIVATE_MODEL_DESCRIPTION =
   "Private model with zero data retention. No prompt data is stored, shared with a third party, or trained on.";
 export const ANONYMOUS_MODEL_DESCRIPTION =

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -16,12 +16,12 @@ export type SuggestedModel = {
  * Curation snapshot (June 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
  * index):
- * - GLM 5.1: latest GLM flagship, top-tier agentic coding and tool use among
- *   open models, 200K context, $1.75/$5.50 per 1M tokens — June's default.
+ * - DeepSeek V4 Flash: latest DeepSeek efficiency flagship, 1M context,
+ *   $0.17/$0.35 per 1M tokens — June's new default, fast and capable.
+ * - GLM 5.1: top-tier agentic coding and tool use among open models, 200K
+ *   context, $1.75/$5.50 per 1M tokens.
  * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
  *   agentic tool runs, 256K context, $0.85/$4.66.
- * - GLM 4.7: Venice's own catalog default and "function calling default" —
- *   near-flagship quality at a fraction of the price, $0.55/$2.65.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
  * - Whisper Large v3: best multilingual accuracy at the same low price.
  *
@@ -35,9 +35,14 @@ export type SuggestedModel = {
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
+      id: "deepseek-v4-flash",
+      reason:
+        "Best value: the latest DeepSeek efficiency flagship with 1M context, strong reasoning and coding, anonymized inference, and the lowest price.",
+    },
+    {
       id: "zai-org-glm-5-1",
       reason:
-        "Best overall: the latest GLM flagship, with top-tier agentic coding and tool use among open models and zero data retention.",
+        "Best overall among open models: top-tier agentic coding and tool use, with private zero-retention inference.",
     },
     {
       id: "kimi-k2-6",
@@ -47,7 +52,7 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
     {
       id: "zai-org-glm-4.7",
       reason:
-        "Best value: near-flagship quality at a fraction of the price, and Venice's own default for tool calling, with zero data retention.",
+        "Best value classic pick: near-flagship quality at a fraction of the price, and Venice's own default for tool calling, with zero data retention.",
     },
   ],
   transcription: [

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -195,20 +195,20 @@ describe("AgentWorkspace", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5-1",
+        generationModel: "deepseek-v4-flash",
       },
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "deepseek-v4-flash",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5-1",
-          name: "GLM 5.1",
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
           modelType: "text",
-          privacy: "private",
+          privacy: "anonymized",
           traits: [],
           capabilities: [],
         },
@@ -539,14 +539,14 @@ describe("AgentWorkspace", () => {
 
     // The session composer carries the same model trigger as the hero.
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: DeepSeek V4 Flash" }),
     );
 
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
     });
     expect(
-      within(dialog).getByRole("option", { name: /GLM 5.1/ }),
+      within(dialog).getByRole("option", { name: /DeepSeek V4 Flash/ }),
     ).toBeInTheDocument();
   });
 
@@ -578,6 +578,13 @@ describe("AgentWorkspace", () => {
       modelType: "text",
       selectedModel: "zai-org-glm-5-1",
       models: catalog,
+    });
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "zai-org-glm-5-1",
+      },
     });
     mocks.setVeniceModel.mockResolvedValue(undefined);
     const user = userEvent.setup();
@@ -633,7 +640,7 @@ describe("AgentWorkspace", () => {
   it("refreshes the model privacy label when generation model settings change", async () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    expect(await screen.findByText("Private mode")).toBeInTheDocument();
+    expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
 
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
@@ -2450,14 +2457,14 @@ describe("AgentWorkspace", () => {
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "deepseek-v4-flash",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5-1",
-          name: "GLM 5.1",
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
           modelType: "text",
-          privacy: "private",
+          privacy: "anonymized",
           traits: [],
           capabilities: ["functionCalling"],
         },
@@ -2485,7 +2492,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: DeepSeek V4 Flash" }),
     );
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -147,7 +147,7 @@ describe("AppSettings", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5-1",
+        generationModel: "deepseek-v4-flash",
       },
     });
     mocks.listVeniceModels.mockImplementation(async (mode) => ({
@@ -156,7 +156,7 @@ describe("AppSettings", () => {
       selectedModel:
         mode === "transcription"
           ? "nvidia/parakeet-tdt-0.6b-v3"
-          : "zai-org-glm-5-1",
+          : "deepseek-v4-flash",
       models:
         mode === "transcription"
           ? [
@@ -199,6 +199,21 @@ describe("AppSettings", () => {
               },
             ]
           : [
+              {
+                provider: "venice",
+                id: "deepseek-v4-flash",
+                name: "DeepSeek V4 Flash",
+                modelType: "text",
+                description:
+                  "Efficiency-optimized 284B MoE model with 1M context.",
+                privacy: "anonymized",
+                priceUnit: "tokens",
+                inputCreditsPerMillionTokens: 170,
+                outputCreditsPerMillionTokens: 350,
+                contextTokens: 1000000,
+                traits: [],
+                capabilities: ["supportsFunctionCalling"],
+              },
               {
                 provider: "venice",
                 id: "zai-org-glm-5-1",
@@ -258,7 +273,7 @@ describe("AppSettings", () => {
           : "venice",
       transcriptionModel:
         mode === "transcription" ? modelId : "nvidia/parakeet-tdt-0.6b-v3",
-      generationModel: mode === "generation" ? modelId : "zai-org-glm-5-1",
+      generationModel: mode === "generation" ? modelId : "deepseek-v4-flash",
     }));
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
@@ -1145,7 +1160,7 @@ describe("AppSettings", () => {
         screen.getAllByText("$1.00 input / $3.20 output per 1M tokens").length,
       ).toBeGreaterThan(0);
       expect(screen.getAllByText("Private mode").length).toBeGreaterThan(0);
-      expect(screen.getByText("Anonymous mode")).toBeInTheDocument();
+      expect(screen.getAllByText("Anonymous mode").length).toBeGreaterThan(0);
       expect(screen.queryByText("Anon")).not.toBeInTheDocument();
       await user.click(
         await screen.findByRole("option", { name: /Venice Uncensored/ }),

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -13,10 +13,7 @@ import {
   setOnboardingResumeStep,
   subscribeToOnboardingComplete,
 } from "../lib/onboarding";
-import type {
-  AccountStatus,
-  RecordingSourceReadinessDto,
-} from "../lib/tauri";
+import type { AccountStatus, RecordingSourceReadinessDto } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
@@ -188,6 +185,34 @@ describe("OnboardingFlow", () => {
         payload: { microphone: "granted", accessibility: "granted" },
       }),
     });
+  }
+
+  function stubNavigatorPlatform(platform: string, userAgent: string) {
+    const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+    const ownUserAgent = Object.getOwnPropertyDescriptor(
+      navigator,
+      "userAgent",
+    );
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      get: () => platform,
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      get: () => userAgent,
+    });
+    return () => {
+      if (ownPlatform) {
+        Object.defineProperty(navigator, "platform", ownPlatform);
+      } else {
+        Reflect.deleteProperty(navigator, "platform");
+      }
+      if (ownUserAgent) {
+        Object.defineProperty(navigator, "userAgent", ownUserAgent);
+      } else {
+        Reflect.deleteProperty(navigator, "userAgent");
+      }
+    };
   }
 
   it("walks the full flow for a subscribed user", async () => {
@@ -708,6 +733,36 @@ describe("OnboardingFlow", () => {
         type: "request_microphone_permission",
       }),
     );
+  });
+
+  it("only requires microphone access on Windows", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      await renderFlow();
+
+      expect(
+        screen.getByText("Dictation and meeting notes need microphone access."),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Accessibility")).not.toBeInTheDocument();
+      expect(screen.queryByText("System audio")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+
+      emitDictationEvent?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("probes system audio when the permissions screen shows", async () => {


### PR DESCRIPTION
## Summary

- Add platform-specific Tauri dev/build wrappers plus Windows NSIS config and CI bundle verification.
- Make the desktop runtime compile and launch on Windows with Windows keyring deps, browser/privacy fallbacks, dictation permission fallbacks, and Hermes Windows install/discovery paths.
- Update Windows-facing onboarding and agent copy so installed builds do not refer to Mac-only behavior.
- Switch the default generation model and suggested model ordering to DeepSeek V4 Flash, including fallback pricing and tests.

## Validation

- `pnpm lint`
- `pnpm test` - 43 files, 479 tests
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml hermes_bridge -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml dictation -- --nocapture`
- `pnpm tauri:build -- --target x86_64-pc-windows-gnu --no-sign`
- Native Windows 11 Parallels VM: silent NSIS install exited 0, installed `os-scribe.exe` and `WebView2Loader.dll`, launched the installed app, process stayed running with main window title `June`, and screenshot verified the onboarding UI rendered with platform-neutral copy.

## Notes

- The Windows CI job uploads the debug NSIS installer artifact and verifies the installer payload contains `os-scribe.exe` and `WebView2Loader.dll`.
- The local Windows release installer is generated under `src-tauri/target/x86_64-pc-windows-gnu/release/bundle/nsis/`, but build outputs remain ignored by git.