### PR TITLE
Make DeepSeek V4 Flash the default text model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ OPENAI_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 
 # Initial chat model used to turn transcripts and manual notes into generated note content.
 # The Settings tab can override this with any text model returned by Scribe API.
-VENICE_GENERATION_MODEL=zai-org-glm-5
+VENICE_GENERATION_MODEL=deepseek-v4-flash
 
 # --- OS Accounts (Login with Open Software) ---------------------------------
 # Identity only in the desktop app. The App API key (osk_) is server-side only

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Optional initial model defaults:
 
 ```sh
 export VENICE_TRANSCRIPTION_MODEL=nvidia/parakeet-tdt-0.6b-v3
-export VENICE_GENERATION_MODEL=zai-org-glm-5
+export VENICE_GENERATION_MODEL=deepseek-v4-flash
 export VENICE_TITLE_SUGGESTION_MODEL=nvidia-nemotron-3-nano-30b-a3b
 ```
 

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -89,17 +89,17 @@ model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
 privacy = "private"
 
-# Fallback pricing for the default text model (zai-org-glm-5-1); the live
+# Fallback pricing for the default text model (deepseek-v4-flash); the live
 # Venice catalog overrides this on boot. Keep in sync with
 # DEFAULT_GENERATION_MODEL in the Tauri providers module.
-[pricing."zai-org-glm-5-1"]
+[pricing."deepseek-v4-flash"]
 unit = "tokens"
-input_credits_per_million_tokens = 1750
-output_credits_per_million_tokens = 5500
+input_credits_per_million_tokens = 170
+output_credits_per_million_tokens = 350
 provider = "venice"
 model_type = "text"
-display_name = "GLM 5.1"
-privacy = "private"
+display_name = "DeepSeek V4 Flash"
+privacy = "anonymized"
 
 [pricing."zai-org-glm-5"]
 unit = "tokens"

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -351,19 +351,19 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     // extends over this on every boot. Keep the first entry in sync with
     // DEFAULT_GENERATION_MODEL in the Tauri providers module.
     pricing.insert(
-        "zai-org-glm-5-1".to_string(),
+        "deepseek-v4-flash".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Tokens,
             credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(1_750),
-            output_credits_per_million_tokens: Some(5_500),
+            input_credits_per_million_tokens: Some(170),
+            output_credits_per_million_tokens: Some(350),
             provider: ModelProvider::Venice,
             model_type: ModelType::Text,
-            display_name: "GLM 5.1".to_string(),
+            display_name: "DeepSeek V4 Flash".to_string(),
             description: None,
-            privacy: Some("private".to_string()),
+            privacy: Some("anonymized".to_string()),
             pricing: None,
-            context_tokens: Some(200_000),
+            context_tokens: Some(1_000_000),
             traits: Vec::new(),
             capabilities: Vec::new(),
         },

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -14,7 +14,7 @@ use tauri::{AppHandle, Manager, State};
 pub const PROVIDER_OPENAI: &str = "openai";
 pub const PROVIDER_VENICE: &str = "venice";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
-pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-1";
+pub const DEFAULT_GENERATION_MODEL: &str = "deepseek-v4-flash";
 
 // Kept exported under the legacy names so existing callers compile until they
 // migrate to the names above.

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -161,7 +161,7 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
   // Mirrors DEFAULT_GENERATION_MODEL in the Rust providers module and the
   // leading Suggested pick in lib/suggested-models.ts.
-  generationModel: "zai-org-glm-5-1",
+  generationModel: "deepseek-v4-flash",
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -16,8 +16,10 @@ export type SuggestedModel = {
  * Curation snapshot (June 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
  * index):
- * - GLM 5.1: latest GLM flagship, top-tier agentic coding and tool use among
- *   open models, 200K context, $1.75/$5.50 per 1M tokens — June's default.
+ * - DeepSeek V4 Flash: latest DeepSeek efficiency flagship, 1M context,
+ *   $0.17/$0.35 per 1M tokens, June's default.
+ * - GLM 5.1: top-tier agentic coding and tool use among open models, 200K
+ *   context, $1.75/$5.50 per 1M tokens.
  * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
  *   agentic tool runs, 256K context, $0.85/$4.66.
  * - GLM 4.7: Venice's own catalog default and "function calling default" —
@@ -35,9 +37,14 @@ export type SuggestedModel = {
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
+      id: "deepseek-v4-flash",
+      reason:
+        "Best value: DeepSeek's efficiency flagship with 1M context, strong reasoning and coding, anonymized inference, and the lowest price.",
+    },
+    {
       id: "zai-org-glm-5-1",
       reason:
-        "Best overall: the latest GLM flagship, with top-tier agentic coding and tool use among open models and zero data retention.",
+        "Best overall among open models: top-tier agentic coding and tool use, with private zero-retention inference.",
     },
     {
       id: "kimi-k2-6",
@@ -47,7 +54,7 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
     {
       id: "zai-org-glm-4.7",
       reason:
-        "Best value: near-flagship quality at a fraction of the price, and Venice's own default for tool calling, with zero data retention.",
+        "Best value classic pick: near-flagship quality at a fraction of the price, and Venice's own default for tool calling, with zero data retention.",
     },
   ],
   transcription: [

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -195,20 +195,20 @@ describe("AgentWorkspace", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5-1",
+        generationModel: "deepseek-v4-flash",
       },
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "deepseek-v4-flash",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5-1",
-          name: "GLM 5.1",
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
           modelType: "text",
-          privacy: "private",
+          privacy: "anonymized",
           traits: [],
           capabilities: [],
         },
@@ -539,14 +539,14 @@ describe("AgentWorkspace", () => {
 
     // The session composer carries the same model trigger as the hero.
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: DeepSeek V4 Flash" }),
     );
 
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
     });
     expect(
-      within(dialog).getByRole("option", { name: /GLM 5.1/ }),
+      within(dialog).getByRole("option", { name: /DeepSeek V4 Flash/ }),
     ).toBeInTheDocument();
   });
 
@@ -578,6 +578,13 @@ describe("AgentWorkspace", () => {
       modelType: "text",
       selectedModel: "zai-org-glm-5-1",
       models: catalog,
+    });
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "zai-org-glm-5-1",
+      },
     });
     mocks.setVeniceModel.mockResolvedValue(undefined);
     const user = userEvent.setup();
@@ -633,7 +640,7 @@ describe("AgentWorkspace", () => {
   it("refreshes the model privacy label when generation model settings change", async () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
-    expect(await screen.findByText("Private mode")).toBeInTheDocument();
+    expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
 
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
@@ -2450,14 +2457,14 @@ describe("AgentWorkspace", () => {
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "deepseek-v4-flash",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5-1",
-          name: "GLM 5.1",
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
           modelType: "text",
-          privacy: "private",
+          privacy: "anonymized",
           traits: [],
           capabilities: ["functionCalling"],
         },
@@ -2485,7 +2492,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: DeepSeek V4 Flash" }),
     );
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -147,7 +147,7 @@ describe("AppSettings", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5-1",
+        generationModel: "deepseek-v4-flash",
       },
     });
     mocks.listVeniceModels.mockImplementation(async (mode) => ({
@@ -156,7 +156,7 @@ describe("AppSettings", () => {
       selectedModel:
         mode === "transcription"
           ? "nvidia/parakeet-tdt-0.6b-v3"
-          : "zai-org-glm-5-1",
+          : "deepseek-v4-flash",
       models:
         mode === "transcription"
           ? [
@@ -199,6 +199,21 @@ describe("AppSettings", () => {
               },
             ]
           : [
+              {
+                provider: "venice",
+                id: "deepseek-v4-flash",
+                name: "DeepSeek V4 Flash",
+                modelType: "text",
+                description:
+                  "Efficiency-optimized 284B MoE model with 1M context.",
+                privacy: "anonymized",
+                priceUnit: "tokens",
+                inputCreditsPerMillionTokens: 170,
+                outputCreditsPerMillionTokens: 350,
+                contextTokens: 1000000,
+                traits: [],
+                capabilities: ["supportsFunctionCalling"],
+              },
               {
                 provider: "venice",
                 id: "zai-org-glm-5-1",
@@ -258,7 +273,7 @@ describe("AppSettings", () => {
           : "venice",
       transcriptionModel:
         mode === "transcription" ? modelId : "nvidia/parakeet-tdt-0.6b-v3",
-      generationModel: mode === "generation" ? modelId : "zai-org-glm-5-1",
+      generationModel: mode === "generation" ? modelId : "deepseek-v4-flash",
     }));
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
@@ -1145,7 +1160,7 @@ describe("AppSettings", () => {
         screen.getAllByText("$1.00 input / $3.20 output per 1M tokens").length,
       ).toBeGreaterThan(0);
       expect(screen.getAllByText("Private mode").length).toBeGreaterThan(0);
-      expect(screen.getByText("Anonymous mode")).toBeInTheDocument();
+      expect(screen.getAllByText("Anonymous mode").length).toBeGreaterThan(0);
       expect(screen.queryByText("Anon")).not.toBeInTheDocument();
       await user.click(
         await screen.findByRole("option", { name: /Venice Uncensored/ }),
@@ -1193,19 +1208,19 @@ describe("AppSettings", () => {
     // Suggested is the default view: only the curated picks present in the
     // catalog show, each with its recommendation reason.
     expect(
-      await screen.findByRole("option", { name: /GLM 5\.1/ }),
+      await screen.findByRole("option", { name: /DeepSeek V4 Flash/ }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: /Venice Uncensored/ }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/Best overall/)).toBeInTheDocument();
+    expect(screen.getByText(/Best value/)).toBeInTheDocument();
 
     // All shows the full catalog, without recommendation copy.
     await user.click(screen.getByRole("tab", { name: "All" }));
     expect(
       screen.getByRole("option", { name: /Venice Uncensored/ }),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/Best overall/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Best value/)).not.toBeInTheDocument();
 
     // Searching looks across the whole catalog even from Suggested, and a
     // suggested pick stays selectable.
@@ -1215,10 +1230,10 @@ describe("AppSettings", () => {
       screen.getByRole("option", { name: /Venice Uncensored/ }),
     ).toBeInTheDocument();
     await user.clear(screen.getByLabelText("Search models"));
-    await user.click(screen.getByRole("option", { name: /GLM 5\.1/ }));
+    await user.click(screen.getByRole("option", { name: /DeepSeek V4 Flash/ }));
     expect(mocks.setVeniceModel).toHaveBeenCalledWith(
       "generation",
-      "zai-org-glm-5-1",
+      "deepseek-v4-flash",
     );
   });
 


### PR DESCRIPTION
## Summary
- make `deepseek-v4-flash` the default generation/text model in desktop provider settings
- update Scribe API fallback pricing/config and local env docs to match the new default
- move DeepSeek V4 Flash to the front of suggested text models and update settings/agent tests

## Validation
- `pnpm exec vitest run src/test/app-settings.test.tsx src/test/agent-workspace.test.tsx src/test/model-privacy.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml providers::tests:: --lib`
- `cargo test -p scribe-config` from `scribe-api`
- `pnpm exec prettier --check README.md src/components/settings/AppSettings.tsx src/lib/suggested-models.ts src/test/app-settings.test.tsx src/test/agent-workspace.test.tsx`