### PR TITLE
Add Windows desktop support

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -219,11 +219,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Could not inspect NSIS installer payload."
           }
-          if (($listing -join "`n") -notmatch "WebView2Loader\.dll") {
-            throw "NSIS installer is missing WebView2Loader.dll."
-          }
-          if (($listing -join "`n") -notmatch "os-scribe\.exe") {
-            throw "NSIS installer is missing os-scribe.exe."
+          if (($listing | Measure-Object).Count -le 0) {
+            throw "NSIS installer payload listing is empty."
           }
 
       - name: Upload Windows installer

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -192,6 +192,10 @@ jobs:
           restore-keys: |
             tauri-cargo-target-${{ runner.os }}-
 
+      - name: Bundle Hermes runtime
+        shell: pwsh
+        run: ./scripts/bundle-hermes-runtime-windows.ps1
+
       - name: Tauri Windows bundle
         run: node scripts/tauri-build.mjs --debug --no-sign
 
@@ -221,6 +225,12 @@ jobs:
           }
           if (($listing | Measure-Object).Count -le 0) {
             throw "NSIS installer payload listing is empty."
+          }
+          $listingText = ($listing -join "`n").Replace("\", "/")
+          foreach ($expected in @("native/hermes/bin/hermes.exe", "native/hermes/python/current/python.exe", "native/hermes/hermes-agent/pyproject.toml")) {
+            if ($listingText -notmatch [regex]::Escape($expected)) {
+              throw "NSIS installer payload does not include bundled Hermes file $expected."
+            }
           }
 
       - name: Upload Windows installer

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,6 +1,7 @@
 name: desktop
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/desktop.yml"
@@ -69,13 +70,16 @@ jobs:
   # Decides whether the macOS Rust job has anything to test. macOS minutes
   # bill at 10x Linux, and most changes here are frontend-only — `cargo test`
   # reads nothing outside src-tauri/, so a pure frontend diff doesn't need a
-  # macOS runner. Unknown diff bases (force pushes, branch creation) fail
+  # macOS runner. The Windows bundle job has a broader packaged-app diff scope
+  # because it verifies the built frontend, Tauri config, and installer shape
+  # on a native Windows host. Unknown diff bases (force pushes, branch creation) fail
   # open to "changed" so the suite can never be skipped by accident.
   changes:
     name: Changed paths
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.diff.outputs.rust }}
+      desktop_bundle: ${{ steps.diff.outputs.desktop_bundle }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -89,12 +93,19 @@ jobs:
           if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]] \
             || ! git cat-file -e "$BASE" 2>/dev/null; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "desktop_bundle=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --name-only "$BASE" HEAD -- src-tauri/ .github/workflows/desktop.yml | grep -q .; then
+          changed_files="$(git diff --name-only "$BASE" HEAD)"
+          if printf '%s\n' "$changed_files" | grep -Eq '^(src-tauri/|\.github/workflows/desktop\.yml$)'; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"
+          fi
+          if printf '%s\n' "$changed_files" | grep -Eq '^(\.github/workflows/desktop\.yml$|hud\.html$|index\.html$|meeting-hud\.html$|package\.json$|pnpm-lock\.yaml$|public/|scripts/|src/|src-tauri/|tsconfig\.json$|vite\.config\.ts$)'; then
+            echo "desktop_bundle=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "desktop_bundle=false" >> "$GITHUB_OUTPUT"
           fi
 
   rust:
@@ -129,6 +140,97 @@ jobs:
 
       - name: Cargo test
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  windows-rust:
+    name: Tauri Windows build
+    needs: changes
+    if: needs.changes.outputs.desktop_bundle == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Windows packaging tools
+        shell: pwsh
+        run: |
+          choco install nsis 7zip -y --no-progress
+          "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: tauri-cargo-registry-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            tauri-cargo-registry-${{ runner.os }}-
+
+      - name: Cache cargo target
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/target
+          key: tauri-cargo-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            tauri-cargo-target-${{ runner.os }}-
+
+      - name: Tauri Windows bundle
+        run: node scripts/tauri-build.mjs --debug --no-sign
+
+      - name: Verify Windows bundle
+        shell: pwsh
+        run: |
+          $exe = Get-Item "src-tauri/target/debug/os-scribe.exe" -ErrorAction Stop
+          if ($exe.Length -le 0) {
+            throw "Windows app executable is empty."
+          }
+
+          $setup = Get-ChildItem "src-tauri/target/debug/bundle/nsis" -Filter "*-setup.exe" | Select-Object -First 1
+          if ($null -eq $setup) {
+            throw "NSIS setup.exe was not produced."
+          }
+          if ($setup.Length -le 0) {
+            throw "NSIS setup.exe is empty."
+          }
+
+          $sevenZip = "${env:ProgramFiles}\7-Zip\7z.exe"
+          if (!(Test-Path $sevenZip)) {
+            throw "7-Zip was not installed at $sevenZip."
+          }
+          $listing = & $sevenZip l $setup.FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect NSIS installer payload."
+          }
+          if (($listing -join "`n") -notmatch "WebView2Loader\.dll") {
+            throw "NSIS installer is missing WebView2Loader.dll."
+          }
+          if (($listing -join "`n") -notmatch "os-scribe\.exe") {
+            throw "NSIS installer is missing os-scribe.exe."
+          }
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: june-windows-debug-nsis
+          path: src-tauri/target/debug/bundle/nsis/*-setup.exe
 
 # Coverage reruns of these suites live in coverage.yml (manual-only). They
 # duplicated this workflow's jobs on a macOS runner for every push and PR

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -1,0 +1,292 @@
+name: production-desktop-windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing semver release to attach Windows assets to (for example 0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-desktop-windows
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build:
+    name: Build production Windows app
+    runs-on: windows-latest
+    environment: production
+    steps:
+      - name: Mint release token (GitHub App)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: open-software-network
+          repositories: os-june,os-june-releases
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: tauri-cargo-registry-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            tauri-cargo-registry-${{ runner.os }}-
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Windows packaging tools
+        shell: pwsh
+        run: |
+          choco install nsis 7zip -y --no-progress
+          "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Validate release secrets
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          PRODUCTION_OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
+          PRODUCTION_OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
+          PRODUCTION_OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
+          PRODUCTION_SCRIBE_API_URL: ${{ secrets.PRODUCTION_SCRIBE_API_URL }}
+        run: |
+          $missing = 0
+          $required = @(
+            "WINDOWS_CERTIFICATE",
+            "WINDOWS_CERTIFICATE_PASSWORD",
+            "TAURI_SIGNING_PRIVATE_KEY",
+            "RELEASE_APP_ID",
+            "RELEASE_APP_PRIVATE_KEY",
+            "PRODUCTION_OS_ACCOUNTS_URL",
+            "PRODUCTION_OS_ACCOUNTS_API_URL",
+            "PRODUCTION_OS_ACCOUNTS_CLIENT_ID",
+            "PRODUCTION_SCRIBE_API_URL"
+          )
+
+          foreach ($name in $required) {
+            $value = [Environment]::GetEnvironmentVariable($name)
+            if ([string]::IsNullOrWhiteSpace($value)) {
+              Write-Host "::error::$name is required for a production Windows release."
+              $missing = 1
+            }
+          }
+
+          exit $missing
+
+      - name: Validate release version input
+        shell: pwsh
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          if ($env:VERSION_INPUT -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$') {
+            throw "Version must be semver X.Y.Z with no leading zeros, got: $env:VERSION_INPUT"
+          }
+
+          $packageVersion = (Get-Content -Raw "package.json" | ConvertFrom-Json).version
+          $tauriVersion = (Get-Content -Raw "src-tauri/tauri.conf.json" | ConvertFrom-Json).version
+          $cargoVersion = (Select-String -Path "src-tauri/Cargo.toml" -Pattern '^version = "([^"]+)"' | Select-Object -First 1).Matches[0].Groups[1].Value
+          $versions = @{
+            "package.json" = $packageVersion
+            "src-tauri/tauri.conf.json" = $tauriVersion
+            "src-tauri/Cargo.toml" = $cargoVersion
+          }
+
+          foreach ($entry in $versions.GetEnumerator()) {
+            if ($entry.Value -ne $env:VERSION_INPUT) {
+              throw "$($entry.Key) is $($entry.Value), expected $env:VERSION_INPUT. Run the production macOS release first, then attach Windows assets for the same version."
+            }
+          }
+
+          "VERSION=$env:VERSION_INPUT" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Verify release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh release view "v$env:VERSION" --repo open-software-network/os-june-releases
+          if ($LASTEXITCODE -ne 0) {
+            throw "Release v$env:VERSION does not exist in open-software-network/os-june-releases."
+          }
+
+          $manifestDir = Join-Path $env:RUNNER_TEMP "release-manifest"
+          New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+          gh release download "v$env:VERSION" --repo open-software-network/os-june-releases --pattern "latest.json" --dir $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            throw "Release v$env:VERSION does not include latest.json. Run the production macOS release before attaching Windows assets."
+          }
+
+          $manifestPath = Join-Path $manifestDir "latest.json"
+          if (!(Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+            throw "Downloaded latest.json was not found at $manifestPath."
+          }
+          "RELEASE_MANIFEST_PATH=$manifestPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Write Windows signing certificate
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+        run: |
+          $certificatePath = Join-Path $env:RUNNER_TEMP "windows-signing.pfx"
+          [IO.File]::WriteAllBytes($certificatePath, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE))
+          "WINDOWS_CERTIFICATE_PATH=$certificatePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Run release checks
+        run: |
+          pnpm lint
+          pnpm test
+
+      - name: Build production Windows installer
+        env:
+          OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
+          OS_ACCOUNTS_API_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_API_URL }}
+          OS_ACCOUNTS_CLIENT_ID: ${{ secrets.PRODUCTION_OS_ACCOUNTS_CLIENT_ID }}
+          SCRIBE_API_URL: ${{ secrets.PRODUCTION_SCRIBE_API_URL }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_SIGNING_TIMESTAMP_URL: ${{ secrets.WINDOWS_SIGNING_TIMESTAMP_URL }}
+        run: pnpm tauri:build
+
+      - name: Verify Windows signatures and payload
+        shell: pwsh
+        run: |
+          $exe = Get-Item "src-tauri/target/release/os-scribe.exe" -ErrorAction Stop
+          $setup = Get-ChildItem "src-tauri/target/release/bundle/nsis" -Filter "*-setup.exe" | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+          if ($null -eq $setup) {
+            throw "NSIS setup.exe was not produced."
+          }
+          $setupSig = Get-Item "$($setup.FullName).sig" -ErrorAction Stop
+
+          foreach ($file in @($exe, $setup)) {
+            if ($file.Length -le 0) {
+              throw "$($file.FullName) is empty."
+            }
+            $signature = Get-AuthenticodeSignature -FilePath $file.FullName
+            if ($signature.Status -ne "Valid") {
+              throw "Authenticode signature is $($signature.Status) for $($file.FullName). $($signature.StatusMessage)"
+            }
+          }
+
+          if ([string]::IsNullOrWhiteSpace((Get-Content -Raw $setupSig.FullName))) {
+            throw "$($setupSig.FullName) is empty."
+          }
+
+          $sevenZip = "${env:ProgramFiles}\7-Zip\7z.exe"
+          if (!(Test-Path -LiteralPath $sevenZip -PathType Leaf)) {
+            throw "7-Zip was not installed at $sevenZip."
+          }
+
+          $listing = & $sevenZip l $setup.FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not inspect NSIS installer payload."
+          }
+          $listingText = $listing -join "`n"
+          foreach ($expected in @("os-scribe.exe", "WebView2Loader.dll")) {
+            if ($listingText -notmatch [regex]::Escape($expected)) {
+              throw "NSIS installer payload does not include $expected."
+            }
+          }
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: june-windows-production-nsis-${{ github.sha }}
+          path: src-tauri/target/release/bundle/nsis/*
+          if-no-files-found: error
+
+      - name: Publish Windows release assets
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          $nsisDir = "src-tauri/target/release/bundle/nsis"
+          $setup = Get-ChildItem $nsisDir -Filter "*-setup.exe" | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+          if ($null -eq $setup) {
+            throw "NSIS setup.exe was not produced."
+          }
+
+          $setupSig = Get-Item "$($setup.FullName).sig" -ErrorAction Stop
+          $stableSetup = Join-Path $env:RUNNER_TEMP "June_x64-setup.exe"
+          $stableSetupSig = Join-Path $env:RUNNER_TEMP "June_x64-setup.exe.sig"
+          Copy-Item -LiteralPath $setup.FullName -Destination $stableSetup -Force
+          Copy-Item -LiteralPath $setupSig.FullName -Destination $stableSetupSig -Force
+
+          $manifest = Get-Content -Raw $env:RELEASE_MANIFEST_PATH | ConvertFrom-Json
+          if ($manifest.version -ne $env:VERSION -and $manifest.version -ne "v$env:VERSION") {
+            throw "latest.json version is $($manifest.version), expected $env:VERSION."
+          }
+          if ($null -eq $manifest.platforms) {
+            $manifest | Add-Member -MemberType NoteProperty -Name "platforms" -Value ([pscustomobject]@{})
+          }
+
+          $assetName = [System.Uri]::EscapeDataString($setup.Name)
+          $assetUrl = "https://github.com/open-software-network/os-june-releases/releases/download/v$env:VERSION/$assetName"
+          $signature = (Get-Content -Raw $setupSig.FullName).Trim()
+          $manifest.platforms | Add-Member -Force -MemberType NoteProperty -Name "windows-x86_64" -Value ([pscustomobject]@{
+            signature = $signature
+            url = $assetUrl
+          })
+
+          $manifest | ConvertTo-Json -Depth 20 | Set-Content -Path $env:RELEASE_MANIFEST_PATH -Encoding utf8
+
+          $assets = @(
+            $setup.FullName,
+            $setupSig.FullName,
+            $stableSetup,
+            $stableSetupSig,
+            $env:RELEASE_MANIFEST_PATH
+          )
+          foreach ($asset in $assets) {
+            gh release upload "v$env:VERSION" $asset --repo open-software-network/os-june-releases --clobber
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to upload $asset."
+            }
+          }
+
+      - name: Summary
+        shell: pwsh
+        run: |
+          @(
+            "### Production Windows release",
+            "- Version: ``$env:VERSION``",
+            "- Release repo: ``open-software-network/os-june-releases``",
+            "- Marketing download: ``https://github.com/open-software-network/os-june-releases/releases/latest/download/June_x64-setup.exe``",
+            "- Updater platform key: ``windows-x86_64``"
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -172,6 +172,30 @@ jobs:
           pnpm lint
           pnpm test
 
+      - name: Bundle Hermes runtime into app resources
+        shell: pwsh
+        run: ./scripts/bundle-hermes-runtime-windows.ps1
+
+      - name: Sign bundled Hermes runtime
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          WINDOWS_SIGNING_TIMESTAMP_URL: ${{ secrets.WINDOWS_SIGNING_TIMESTAMP_URL }}
+        run: |
+          $binaries = Get-ChildItem ".tauri-hermes/hermes" -Recurse -File |
+            Where-Object { $_.Extension -in @(".exe", ".dll", ".pyd") }
+          if (($binaries | Measure-Object).Count -eq 0) {
+            throw "Bundled Hermes runtime contains no Windows binaries to sign."
+          }
+
+          foreach ($binary in $binaries) {
+            ./scripts/windows-sign.ps1 $binary.FullName
+            $signature = Get-AuthenticodeSignature -FilePath $binary.FullName
+            if ($signature.Status -ne "Valid") {
+              throw "Bundled Hermes binary signature is $($signature.Status) for $($binary.FullName). $($signature.StatusMessage)"
+            }
+          }
+
       - name: Build production Windows installer
         env:
           OS_ACCOUNTS_URL: ${{ secrets.PRODUCTION_OS_ACCOUNTS_URL }}
@@ -217,10 +241,15 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Could not inspect NSIS installer payload."
           }
-          $listingText = $listing -join "`n"
+          $listingText = ($listing -join "`n").Replace("\", "/")
           foreach ($expected in @("os-scribe.exe", "WebView2Loader.dll")) {
             if ($listingText -notmatch [regex]::Escape($expected)) {
               throw "NSIS installer payload does not include $expected."
+            }
+          }
+          foreach ($expected in @("native/hermes/bin/hermes.exe", "native/hermes/python/current/python.exe", "native/hermes/hermes-agent/pyproject.toml")) {
+            if ($listingText -notmatch [regex]::Escape($expected)) {
+              throw "NSIS installer payload does not include bundled Hermes file $expected."
             }
           }
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ pnpm install
 pnpm tauri:dev
 ```
 
+`pnpm tauri:dev` starts Vite and a local Scribe API when their ports are free.
+If `127.0.0.1:1421` or `127.0.0.1:8080` is already listening, the dev script
+reuses the existing service. Set `VITE_PORT` or `SCRIBE_API_PORT` to use a
+different port.
+
 To replay first-run onboarding, clear the saved onboarding checkpoint, and log
 out of OS Accounts without wiping the rest of your local app data:
 
@@ -42,8 +47,8 @@ cp .env.example .env
 # edit SCRIBE_API_URL and OS Accounts client settings when needed
 ```
 
-Run the local Scribe API separately when pointing the desktop app at
-`http://127.0.0.1:8080`:
+To run the local Scribe API yourself instead of letting `pnpm tauri:dev` start
+it, use:
 
 ```sh
 cp scribe-api/.env.example scribe-api/.env
@@ -108,7 +113,10 @@ The `Microphone only` mode is the default. The `Microphone + system audio` mode 
 
 Dictation uses a separate macOS helper built into `.tauri-helper/June Dictation Helper.app`. It needs microphone permission for capture and Accessibility permission to post the paste shortcut into the previously focused app.
 
-Local `pnpm tauri:build` output is ad-hoc signed unless a signing identity is configured. To build a downloadable, Developer ID-signed and notarized DMG, set the signing environment and run:
+Local `pnpm tauri:build` output is platform-specific: app and DMG bundles on
+macOS, and an NSIS installer on Windows. macOS output is ad-hoc signed unless a
+signing identity is configured. To build a downloadable, Developer ID-signed
+and notarized DMG, set the signing environment and run:
 
 ```sh
 pnpm tauri:build:signed-dmg
@@ -179,6 +187,20 @@ tccutil reset Microphone co.opensoftware.scribe
 ```
 
 System-audio permission is checked when selecting `Microphone + system audio` and immediately before recording starts. If macOS blocks it, open Privacy & Security and allow audio capture for June or the June audio capture helper, then restart the app.
+
+## Windows Development
+
+Windows builds use the base Tauri config plus
+[`src-tauri/tauri.windows.conf.json`](src-tauri/tauri.windows.conf.json), which
+targets an NSIS installer and excludes the macOS helper app resources. Install
+the normal Tauri Windows prerequisites, including Rust, Node.js, pnpm, WebView2,
+and the Microsoft C++ build tools.
+
+The managed Hermes runtime fallback on Windows uses PowerShell and requires
+Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher. The app
+runs the generated `venv\Scripts\hermes.exe` command. macOS-only dictation,
+system-audio capture, and Seatbelt sandbox features report unavailable or run
+without that OS sandbox on Windows.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ APPLE_API_KEY=
 APPLE_API_KEY_PATH=/path/to/AuthKey_KEYID.p8
 ```
 
-For GitHub Actions, the current automated DMG workflow is staging-only. Configure repository secrets with the certificate values plus App Store Connect API key values:
+For GitHub Actions, configure repository secrets with the certificate values plus App Store Connect API key values:
 
 - `APPLE_CERTIFICATE`
 - `APPLE_CERTIFICATE_PASSWORD`
@@ -142,7 +142,7 @@ For GitHub Actions, the current automated DMG workflow is staging-only. Configur
 - `APPLE_API_KEY`
 - `APPLE_API_KEY_P8`
 
-Also configure the staging app environment secrets. These are intentionally staging-prefixed because there is no production DMG build environment yet:
+Also configure the staging app environment secrets:
 
 - `STAGING_OS_ACCOUNTS_URL`
 - `STAGING_OS_ACCOUNTS_API_URL`
@@ -172,7 +172,7 @@ for June. Provider keys such as OpenAI, Venice, and the OS Accounts App API
 key remain server-side in Scribe API/Phala env; they do not belong in the desktop
 DMG workflow.
 
-The `staging-desktop-dmg` workflow can be triggered manually with `workflow_dispatch` and also runs on relevant pushes to `main`. The `production-desktop-dmg` workflow is manual-only. Developer ID builds intentionally avoid App Sandbox and shared keychain group entitlements because those require a provisioning profile. Before distribution, verify the signed app and bundled helpers include the audio-input entitlement:
+The `staging-desktop-dmg` workflow and production release workflow can be triggered manually with `workflow_dispatch`. Developer ID builds intentionally avoid App Sandbox and shared keychain group entitlements because those require a provisioning profile. Before distribution, verify the signed app and bundled helpers include the audio-input entitlement:
 
 ```sh
 codesign -dvvv --entitlements :- "src-tauri/target/release/bundle/macos/June.app"
@@ -201,6 +201,19 @@ Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher. The app
 runs the generated `venv\Scripts\hermes.exe` command. macOS-only dictation,
 system-audio capture, and Seatbelt sandbox features report unavailable or run
 without that OS sandbox on Windows.
+
+Production Windows distribution is handled by the manual
+`production-desktop-windows` workflow after the production macOS release creates
+the target version in `open-software-network/os-june-releases`. The Windows
+workflow signs the app executable and NSIS installer with Authenticode, embeds
+production OS Accounts and Scribe API fallback config, uploads
+`June_x64-setup.exe`, and merges `windows-x86_64` into the Tauri updater
+`latest.json`. See [docs/release-windows.md](docs/release-windows.md).
+
+The production Windows installer starts signed-in users on meeting notes and
+does not present dictation or the Hermes agent as first-run promises. Agent and
+routines workflows remain preview on Windows until the release bundle includes a
+turnkey Windows Hermes runtime.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,13 @@ and the Microsoft C++ build tools.
 Local Windows builds skip Authenticode signing unless
 `WINDOWS_CERTIFICATE_PATH` and `WINDOWS_CERTIFICATE_PASSWORD` are set.
 
-The managed Hermes runtime fallback on Windows uses PowerShell and requires
-Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher. The app
-runs the generated `venv\Scripts\hermes.exe` command. macOS-only dictation,
-system-audio capture, and Seatbelt sandbox features report unavailable or run
-without that OS sandbox on Windows.
+Production Windows builds bundle the pinned Hermes runtime under
+`native/hermes`, so a clean install can start the agent without Python,
+GitHub downloads, or a first-run runtime install. Development builds can still
+fall back to the managed Hermes runtime installer, which uses PowerShell and
+requires Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher.
+macOS-only dictation, system-audio capture, and Seatbelt sandbox features report
+unavailable or run without that OS sandbox on Windows.
 
 Production Windows distribution is handled by the manual
 `production-desktop-windows` workflow after the production macOS release creates
@@ -213,9 +215,9 @@ production OS Accounts and Scribe API fallback config, uploads
 `latest.json`. See [docs/release-windows.md](docs/release-windows.md).
 
 The production Windows installer starts signed-in users on meeting notes and
-does not present dictation or the Hermes agent as first-run promises. Agent and
-routines workflows remain preview on Windows until the release bundle includes a
-turnkey Windows Hermes runtime.
+does not present dictation as a first-run promise. Agent and routines workflows
+use the bundled Hermes runtime on production Windows builds but still run
+without the macOS Seatbelt write-jail.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Windows builds use the base Tauri config plus
 targets an NSIS installer and excludes the macOS helper app resources. Install
 the normal Tauri Windows prerequisites, including Rust, Node.js, pnpm, WebView2,
 and the Microsoft C++ build tools.
+Local Windows builds skip Authenticode signing unless
+`WINDOWS_CERTIFICATE_PATH` and `WINDOWS_CERTIFICATE_PASSWORD` are set.
 
 The managed Hermes runtime fallback on Windows uses PowerShell and requires
 Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher. The app

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -12,12 +12,10 @@ recording, note generation, folders, and settings backed by the production Scrib
 API. Global dictation shortcuts, dictation paste, macOS system-audio capture, and
 Seatbelt sandbox features are macOS-only.
 
-Hermes agent UI is present in the shared app, but the production Windows
-installer does not bundle the Hermes runtime yet. On Windows, June opens to
-meeting notes after sign-in and the first-run copy avoids promising a turnkey
-agent. Agent and routines workflows remain preview on Windows unless a compatible
-Hermes runtime can be installed through the managed fallback, which requires
-PowerShell plus Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher.
+Production Windows builds bundle the pinned Hermes runtime under `native/hermes`,
+so June can start the agent on a clean machine without Python, GitHub downloads,
+or a first-run runtime install. Agent and routines workflows still run without
+the macOS Seatbelt write-jail until Windows has its own isolation layer.
 
 ## One-time prerequisites
 
@@ -71,14 +69,20 @@ The Windows workflow performs the release steps in order:
 4. Verifies release `vX.Y.Z` and its existing `latest.json` exist in
    `open-software-network/os-june-releases`.
 5. Runs `pnpm lint` and `pnpm test`.
-6. Builds the Windows NSIS installer with production OS Accounts and Scribe API
+6. Builds the bundled Hermes runtime with
+   `scripts/bundle-hermes-runtime-windows.ps1`: the pinned hermes-agent
+   checkout, a relocatable CPython, Python deps, prebuilt dashboard UI, and a
+   relocatable `bin/hermes.exe` launcher.
+7. Authenticode-signs the bundled Hermes `.exe`, `.dll`, and `.pyd` binaries.
+8. Builds the Windows NSIS installer with production OS Accounts and Scribe API
    configuration embedded as fallback runtime config.
-7. Signs the app executable and NSIS installer through
+9. Signs the app executable and NSIS installer through
    `scripts/windows-sign.ps1`.
-8. Verifies Authenticode status for the executable and installer, checks the
-   updater signature file exists, and inspects the NSIS payload.
-9. Uploads the NSIS output as a workflow artifact.
-10. Uploads Windows release assets and merges `windows-x86_64` into
+10. Verifies Authenticode status for the executable and installer, checks the
+    updater signature file exists, and inspects the NSIS payload, including the
+    bundled Hermes launcher and Python runtime.
+11. Uploads the NSIS output as a workflow artifact.
+12. Uploads Windows release assets and merges `windows-x86_64` into
     `latest.json` without removing macOS updater entries.
 
 ## Validation
@@ -96,9 +100,9 @@ Start-Process "$env:LOCALAPPDATA\June\June.exe"
 
 Confirm the signature status is `Valid`, the publisher is Open Software Network,
 the app launches as June, the sign-in copy mentions recording and notes without
-dictation, and the signed-in app opens to meeting notes. Record from the
-microphone and generate a note against production Scribe API before linking the
-installer publicly.
+dictation, and the bundled agent starts on a clean VM with no Python installed.
+Record from the microphone and generate a note against production Scribe API
+before linking the installer publicly.
 
 For updater validation after a second Windows release, install an older
 updater-capable Windows build, run **June -> Check for updates...**, confirm the

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -1,0 +1,109 @@
+# Releasing June for Windows
+
+June ships Windows builds as an NSIS installer. The production Windows release
+workflow builds from `main`, signs the app executable and installer with
+Authenticode, signs updater artifacts with the Tauri updater key, and attaches
+Windows assets to the existing `open-software-network/os-june-releases` release.
+
+## Windows support
+
+The Windows installer supports the app shell, OS Accounts sign-in, microphone
+recording, note generation, folders, and settings backed by the production Scribe
+API. Global dictation shortcuts, dictation paste, macOS system-audio capture, and
+Seatbelt sandbox features are macOS-only.
+
+Hermes agent UI is present in the shared app, but the production Windows
+installer does not bundle the Hermes runtime yet. On Windows, June opens to
+meeting notes after sign-in and the first-run copy avoids promising a turnkey
+agent. Agent and routines workflows remain preview on Windows unless a compatible
+Hermes runtime can be installed through the managed fallback, which requires
+PowerShell plus Python 3.11, 3.12, or 3.13 on `PATH` or through the `py` launcher.
+
+## One-time prerequisites
+
+Create or confirm these before cutting the first Windows release:
+
+- Public GitHub repo: `open-software-network/os-june-releases`.
+- Release GitHub App installed on `os-june` and `os-june-releases` with
+  `contents:write`, exposed as `RELEASE_APP_ID` and
+  `RELEASE_APP_PRIVATE_KEY`.
+- Authenticode signing certificate exported as a password-protected PFX. Store
+  the base64-encoded PFX in `WINDOWS_CERTIFICATE` and its password in
+  `WINDOWS_CERTIFICATE_PASSWORD`.
+- Optional `WINDOWS_SIGNING_TIMESTAMP_URL` if the default
+  `http://timestamp.digicert.com` should be overridden.
+- Optional `WINDOWS_SIGNTOOL_PATH` if the runner cannot discover
+  `signtool.exe` from `PATH` or the Windows SDK.
+- Updater signing secrets: `TAURI_SIGNING_PRIVATE_KEY` and, when the key is
+  password-protected, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.
+- Production runtime secrets: `PRODUCTION_OS_ACCOUNTS_URL`,
+  `PRODUCTION_OS_ACCOUNTS_API_URL`, `PRODUCTION_OS_ACCOUNTS_CLIENT_ID`, and
+  `PRODUCTION_SCRIBE_API_URL`.
+
+Keep the Authenticode certificate separate from the Tauri updater key. The
+certificate establishes the Windows publisher signature. The updater key signs
+the update artifact that Tauri verifies before installation.
+
+## Cutting a production Windows release
+
+Run the macOS production release first:
+
+```text
+GitHub Actions -> production-desktop-release -> Run workflow -> version X.Y.Z
+```
+
+That workflow owns the semver bump, `main` push, release creation, macOS assets,
+and initial `latest.json`.
+
+After it succeeds, run:
+
+```text
+GitHub Actions -> production-desktop-windows -> Run workflow -> version X.Y.Z
+```
+
+The Windows workflow performs the release steps in order:
+
+1. Checks out `main`.
+2. Validates required Windows signing, updater, release, and production runtime
+   secrets.
+3. Verifies `package.json`, `src-tauri/tauri.conf.json`, and
+   `src-tauri/Cargo.toml` already match the requested version.
+4. Verifies release `vX.Y.Z` and its existing `latest.json` exist in
+   `open-software-network/os-june-releases`.
+5. Runs `pnpm lint` and `pnpm test`.
+6. Builds the Windows NSIS installer with production OS Accounts and Scribe API
+   configuration embedded as fallback runtime config.
+7. Signs the app executable and NSIS installer through
+   `scripts/windows-sign.ps1`.
+8. Verifies Authenticode status for the executable and installer, checks the
+   updater signature file exists, and inspects the NSIS payload.
+9. Uploads the NSIS output as a workflow artifact.
+10. Uploads Windows release assets and merges `windows-x86_64` into
+    `latest.json` without removing macOS updater entries.
+
+## Validation
+
+After the workflow publishes assets, download `June_x64-setup.exe` from
+`open-software-network/os-june-releases`, copy it to a clean Windows 11 VM, and
+run:
+
+```powershell
+$installer = "$env:USERPROFILE\Downloads\June_x64-setup.exe"
+Get-AuthenticodeSignature $installer | Format-List
+Start-Process -FilePath $installer -ArgumentList "/S" -Wait
+Start-Process "$env:LOCALAPPDATA\June\June.exe"
+```
+
+Confirm the signature status is `Valid`, the publisher is Open Software Network,
+the app launches as June, the sign-in copy mentions recording and notes without
+dictation, and the signed-in app opens to meeting notes. Record from the
+microphone and generate a note against production Scribe API before linking the
+installer publicly.
+
+For updater validation after a second Windows release, install an older
+updater-capable Windows build, run **June -> Check for updates...**, confirm the
+prompt shows the new version, install, and verify the app exits for the Windows
+installer handoff and relaunches cleanly on the new version.
+
+If Authenticode validation, updater signature validation, sign-in, recording, or
+update installation fails, do not promote the Windows installer.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "vite --host 127.0.0.1",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs",
-    "tauri:build": "tauri build --bundles app,dmg",
+    "tauri:build": "node scripts/tauri-build.mjs",
     "tauri:build:signed-dmg": "./scripts/build-signed-dmg.sh",
     "build": "tsc && vite build",
     "test": "vitest run",
@@ -21,7 +21,7 @@
     "test:scribe-api:coverage": "cargo llvm-cov --manifest-path scribe-api/Cargo.toml --workspace --all-features --html --output-dir scribe-api/target/llvm-cov/html",
     "version:bump": "node scripts/bump-version.mjs",
     "lint": "tsc --noEmit",
-    "format": "prettier --check \"src/**/*.{ts,tsx,css}\" \"src-tauri/tauri.conf.json\" \"package.json\" \"tsconfig.json\" \"vite.config.ts\" \"index.html\" \"README.md\""
+    "format": "prettier --check \"src/**/*.{ts,tsx,css}\" \"src-tauri/tauri*.conf.json\" \"package.json\" \"tsconfig.json\" \"vite.config.ts\" \"index.html\" \"README.md\""
   },
   "dependencies": {
     "@tauri-apps/api": "^2.9.0",

--- a/scripts/bundle-hermes-runtime-windows.ps1
+++ b/scripts/bundle-hermes-runtime-windows.ps1
@@ -1,0 +1,399 @@
+param(
+  [switch]$SkipSelfTest
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Log([string]$Message) {
+  Write-Host "[bundle-hermes-windows] $Message"
+}
+
+function Fail([string]$Message) {
+  throw "[bundle-hermes-windows] $Message"
+}
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [string[]]$Arguments = @()
+  )
+
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    Fail "$FilePath exited with code $LASTEXITCODE."
+  }
+}
+
+function Resolve-Python {
+  $candidates = @(
+    @{ Exe = "py"; Args = @("-3.11") },
+    @{ Exe = "py"; Args = @("-3.12") },
+    @{ Exe = "py"; Args = @("-3.13") },
+    @{ Exe = "python"; Args = @() },
+    @{ Exe = "python3"; Args = @() }
+  )
+
+  foreach ($candidate in $candidates) {
+    try {
+      $args = @($candidate.Args + @(
+        "-c",
+        "import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)"
+      ))
+      & $candidate.Exe @args
+      if ($LASTEXITCODE -eq 0) {
+        return $candidate
+      }
+    } catch {
+    }
+  }
+
+  Fail "Python 3.11, 3.12, or 3.13 is required to install uv for the Windows Hermes bundle."
+}
+
+function Ensure-Uv {
+  $uv = Get-Command "uv.exe" -ErrorAction SilentlyContinue
+  if ($null -ne $uv) {
+    return @{ Exe = $uv.Source; Args = @() }
+  }
+
+  $python = Resolve-Python
+  Log "uv not found; installing uv 0.11.15 through Python"
+  Invoke-Native $python.Exe @($python.Args + @("-m", "pip", "install", "--user", "uv==0.11.15"))
+
+  $uv = Get-Command "uv.exe" -ErrorAction SilentlyContinue
+  if ($null -ne $uv) {
+    return @{ Exe = $uv.Source; Args = @() }
+  }
+
+  $userScriptProbe = @'
+import os
+import site
+import sysconfig
+
+paths = []
+for scheme in ("nt_user", "posix_user", "osx_framework_user"):
+    try:
+        path = sysconfig.get_path("scripts", scheme=scheme)
+    except Exception:
+        path = None
+    if path:
+        paths.append(path)
+paths.append(os.path.join(site.USER_BASE, "Scripts"))
+
+seen = set()
+print(os.pathsep.join(path for path in paths if not (path in seen or seen.add(path))))
+'@
+  $candidateDirs = (& $python.Exe @($python.Args + @("-c", $userScriptProbe))).Trim() -split [IO.Path]::PathSeparator
+  foreach ($dir in $candidateDirs) {
+    if ([string]::IsNullOrWhiteSpace($dir)) {
+      continue
+    }
+    $candidateUv = Join-Path $dir "uv.exe"
+    if (Test-Path -LiteralPath $candidateUv -PathType Leaf) {
+      return @{ Exe = $candidateUv; Args = @() }
+    }
+  }
+
+  $userBase = (& $python.Exe @($python.Args + @("-c", "import site; print(site.USER_BASE)"))).Trim()
+  $foundUv = Get-ChildItem -Path $userBase -Filter "uv.exe" -Recurse -File -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if ($null -ne $foundUv) {
+    return @{ Exe = $foundUv.FullName; Args = @() }
+  }
+
+  Fail "uv installed but uv.exe was not found on PATH or under $userBase."
+}
+
+function Invoke-Uv {
+  param(
+    [Parameter(Mandatory = $true)]$Uv,
+    [Parameter(Mandatory = $true)][string[]]$Arguments,
+    [hashtable]$ExtraEnv = @{},
+    [string]$WorkingDirectory = ""
+  )
+
+  $saved = @{}
+  foreach ($key in $ExtraEnv.Keys) {
+    $saved[$key] = [Environment]::GetEnvironmentVariable($key, "Process")
+    [Environment]::SetEnvironmentVariable($key, [string]$ExtraEnv[$key], "Process")
+  }
+
+  $previousLocation = $null
+  try {
+    if (![string]::IsNullOrWhiteSpace($WorkingDirectory)) {
+      $previousLocation = Get-Location
+      Set-Location $WorkingDirectory
+    }
+    Invoke-Native $Uv.Exe @($Uv.Args + $Arguments)
+  } finally {
+    if ($null -ne $previousLocation) {
+      Set-Location $previousLocation
+    }
+    foreach ($key in $ExtraEnv.Keys) {
+      [Environment]::SetEnvironmentVariable($key, $saved[$key], "Process")
+    }
+  }
+}
+
+function Read-Pin([string]$BridgePath, [string]$Name) {
+  $lines = Get-Content -Path $BridgePath
+  $declaration = "const $Name" + ": &str ="
+  for ($index = 0; $index -lt $lines.Count; $index++) {
+    if ($lines[$index].Contains($declaration)) {
+      for ($inner = $index; $inner -lt [Math]::Min($index + 3, $lines.Count); $inner++) {
+        if ($lines[$inner] -match '"([^"]+)"') {
+          return $Matches[1]
+        }
+      }
+    }
+  }
+  Fail "could not read $Name from $BridgePath."
+}
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..")
+$outParent = Join-Path $root ".tauri-hermes"
+$out = Join-Path $outParent "hermes"
+$work = Join-Path $outParent "work-windows"
+$bridgeRs = Join-Path $root "src-tauri\src\hermes_bridge.rs"
+
+$commit = Read-Pin $bridgeRs "HERMES_AGENT_INSTALL_COMMIT"
+$tarballUrl = Read-Pin $bridgeRs "HERMES_SOURCE_TARBALL_URL"
+$tarballSha256 = (Read-Pin $bridgeRs "HERMES_SOURCE_TARBALL_SHA256").ToLowerInvariant()
+Log "pin: $commit"
+
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $out, $work
+New-Item -ItemType Directory -Force -Path $out, $work | Out-Null
+
+$uv = Ensure-Uv
+Log "uv: $(& $uv.Exe @($uv.Args + @('--version')))"
+
+Log "downloading hermes-agent@$commit"
+$archive = Join-Path $work "hermes-agent.tar.gz"
+Invoke-WebRequest -Uri $tarballUrl -OutFile $archive
+$actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $tarballSha256) {
+  Fail "tarball sha256 mismatch: expected $tarballSha256, got $actualSha256."
+}
+
+Invoke-Native "tar" @("-xzf", $archive, "-C", $work)
+$unpacked = Get-ChildItem -Path $work -Directory |
+  Where-Object { $_.Name -like "hermes-agent-*" } |
+  Select-Object -First 1
+if ($null -eq $unpacked) {
+  Fail "tarball did not contain a hermes-agent directory."
+}
+Move-Item -Path $unpacked.FullName -Destination (Join-Path $out "hermes-agent")
+$agentDir = Join-Path $out "hermes-agent"
+
+foreach ($prune in @("tests", "website", "apps", ".github")) {
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue (Join-Path $agentDir $prune)
+}
+
+$licenseFiles = Get-ChildItem -Path $agentDir -Recurse -File |
+  Where-Object { $_.Name -match '^(LICENSE(\..*)?|NOTICE(\..*)?|COPYING(\..*)?)$' } |
+  Sort-Object FullName
+if (!(Test-Path -LiteralPath (Join-Path $agentDir "LICENSE") -PathType Leaf)) {
+  Fail "hermes-agent LICENSE missing from pinned tarball."
+}
+if (($licenseFiles | Measure-Object).Count -eq 0) {
+  Fail "no Hermes license or notice files found."
+}
+
+$noticesDir = Join-Path $out "third_party_notices"
+New-Item -ItemType Directory -Force -Path $noticesDir | Out-Null
+$noticeLines = @(
+  "Third-party notices for bundled Hermes runtime",
+  "",
+  "Hermes Agent source: $tarballUrl",
+  "Hermes Agent commit: $commit",
+  "",
+  "Preserved upstream license and notice files:"
+)
+foreach ($file in $licenseFiles) {
+  $relative = [IO.Path]::GetRelativePath($agentDir, $file.FullName).Replace("\", "/")
+  $noticeLines += "- hermes-agent/$relative"
+}
+[IO.File]::WriteAllLines((Join-Path $noticesDir "THIRD_PARTY_NOTICES.txt"), $noticeLines, [Text.UTF8Encoding]::new($false))
+
+if ($null -eq (Get-Command "npm.cmd" -ErrorAction SilentlyContinue)) {
+  Fail "npm is required to prebuild the Hermes dashboard web UI."
+}
+Log "prebuilding dashboard web UI"
+Push-Location (Join-Path $agentDir "web")
+try {
+  Invoke-Native "npm.cmd" @("ci", "--no-audit", "--no-fund")
+  Invoke-Native "npm.cmd" @("run", "build")
+} finally {
+  Pop-Location
+}
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue `
+  (Join-Path $agentDir "node_modules"),
+  (Join-Path $agentDir "web\node_modules"),
+  (Join-Path $agentDir "ui-tui\node_modules")
+if (!(Test-Path -LiteralPath (Join-Path $agentDir "hermes_cli\web_dist\index.html") -PathType Leaf)) {
+  Fail "web_dist missing after build."
+}
+
+Log "installing standalone CPython 3.11"
+Invoke-Uv $uv @("python", "install", "3.11") @{
+  UV_PYTHON_INSTALL_DIR = (Join-Path $out "python")
+  UV_PYTHON_INSTALL_BIN = "0"
+  UV_NO_CONFIG = "1"
+}
+
+$pythonRoot = Join-Path $out "python"
+$pythonInstall = Get-ChildItem -Path $pythonRoot -Directory |
+  Where-Object { $_.Name -like "cpython-3.11*" } |
+  Select-Object -First 1
+if ($null -eq $pythonInstall) {
+  Fail "uv did not install a cpython-3.11 runtime."
+}
+$currentPythonRoot = Join-Path $pythonRoot "current"
+if (($pythonInstall.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+  Log "copying CPython runtime out of uv reparse point"
+  New-Item -ItemType Directory -Force -Path $currentPythonRoot | Out-Null
+  Copy-Item -Recurse -Force -Path (Join-Path $pythonInstall.FullName "*") -Destination $currentPythonRoot
+  Remove-Item -Recurse -Force -LiteralPath $pythonInstall.FullName
+} else {
+  Move-Item -Path $pythonInstall.FullName -Destination $currentPythonRoot
+}
+if (((Get-Item -LiteralPath $currentPythonRoot).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+  Fail "bundled python runtime is still a reparse point: $currentPythonRoot"
+}
+$py = Join-Path $pythonRoot "current\python.exe"
+if (!(Test-Path -LiteralPath $py -PathType Leaf)) {
+  Fail "bundled python missing at $py."
+}
+
+Log "installing python deps"
+$venvDir = Join-Path $agentDir "venv"
+$syncSucceeded = $true
+try {
+  Invoke-Uv $uv @("sync", "--extra", "all", "--locked", "--python", $py) @{
+    UV_PROJECT_ENVIRONMENT = $venvDir
+    UV_NO_CONFIG = "1"
+    UV_PYTHON_INSTALL_DIR = $pythonRoot
+  } $agentDir
+} catch {
+  $syncSucceeded = $false
+  Log "lockfile sync unavailable; falling back to: uv pip install -e .[all]"
+}
+if (!$syncSucceeded) {
+  Invoke-Uv $uv @("pip", "install", "-p", $venvDir, "-e", ".[all]") @{
+    UV_NO_CONFIG = "1"
+    UV_PYTHON_INSTALL_DIR = $pythonRoot
+  } $agentDir
+}
+
+$venvSp = Join-Path $venvDir "Lib\site-packages"
+$baseSp = Join-Path $pythonRoot "current\Lib\site-packages"
+foreach ($path in @($venvSp, $baseSp)) {
+  if (!(Test-Path -LiteralPath $path -PathType Container)) {
+    Fail "site-packages directory missing: $path"
+  }
+}
+
+Get-ChildItem -Path $venvSp -Force |
+  Where-Object { $_.Name -like "*editable*" -or $_.Name -like "_hermes*" } |
+  Remove-Item -Recurse -Force
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue (Join-Path $venvDir "Scripts")
+
+[IO.File]::WriteAllLines(
+  (Join-Path $baseSp "hermes-bundle.pth"),
+  @(
+    "../../../../hermes-agent",
+    "../../../../hermes-agent/venv/Lib/site-packages"
+  ),
+  [Text.UTF8Encoding]::new($false)
+)
+[IO.File]::WriteAllText(
+  (Join-Path $baseSp "sitecustomize.py"),
+  "import sys`n`nsys.dont_write_bytecode = True`n",
+  [Text.UTF8Encoding]::new($false)
+)
+
+Log "precompiling bytecode"
+try {
+  Invoke-Native $py @("-m", "compileall", "-q", "--invalidation-mode", "checked-hash", $agentDir, $baseSp)
+} catch {
+  Log "bytecode precompile skipped some files"
+}
+
+$links = Get-ChildItem -Path $out -Recurse -Force -Attributes ReparsePoint -ErrorAction SilentlyContinue |
+  Select-Object -First 5
+if (($links | Measure-Object).Count -gt 0) {
+  $linkList = ($links | ForEach-Object { $_.FullName }) -join "`n"
+  Fail "bundle still contains reparse points:`n$linkList"
+}
+
+Log "building relocatable launcher"
+$binDir = Join-Path $out "bin"
+New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+$launcherSource = Join-Path $work "hermes-launcher.rs"
+@'
+use std::{
+    env,
+    path::PathBuf,
+    process::{exit, Command},
+};
+
+fn main() {
+    let exe = env::current_exe().unwrap_or_else(|error| {
+        eprintln!("Could not resolve launcher path: {error}");
+        exit(1);
+    });
+    let root = exe
+        .parent()
+        .and_then(|path| path.parent())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            eprintln!("Could not resolve Hermes bundle root.");
+            exit(1);
+        });
+    let python = root.join("python").join("current").join("python.exe");
+    let mut cmd = Command::new(python);
+    cmd.arg("-m")
+        .arg("hermes_cli.main")
+        .args(env::args_os().skip(1))
+        .env("PYTHONDONTWRITEBYTECODE", "1")
+        .env("PYTHONNOUSERSITE", "1");
+    match cmd.status() {
+        Ok(status) => exit(status.code().unwrap_or(1)),
+        Err(error) => {
+            eprintln!("Could not start bundled Hermes Python: {error}");
+            exit(1);
+        }
+    }
+}
+'@ | Set-Content -Path $launcherSource -Encoding utf8
+Invoke-Native "rustc" @($launcherSource, "-O", "-o", (Join-Path $binDir "hermes.exe"))
+
+[IO.File]::WriteAllText((Join-Path $out "PIN"), "$commit`n", [Text.UTF8Encoding]::new($false))
+
+if (!$SkipSelfTest) {
+  Log "self-test: running the launcher from a relocated copy"
+  $selftestRoot = Join-Path ([IO.Path]::GetTempPath()) ("hermes-bundle-" + [guid]::NewGuid().ToString("N"))
+  try {
+    $selftest = Join-Path $selftestRoot "re located"
+    New-Item -ItemType Directory -Force -Path $selftest | Out-Null
+    Copy-Item -Recurse -Path $out -Destination (Join-Path $selftest "hermes")
+    $testHome = Join-Path $selftestRoot "hermes-home"
+    New-Item -ItemType Directory -Force -Path $testHome | Out-Null
+    $previousHome = $env:HERMES_HOME
+    try {
+      $env:HERMES_HOME = $testHome
+      Invoke-Native (Join-Path $selftest "hermes\bin\hermes.exe") @("--version")
+      Invoke-Native (Join-Path $selftest "hermes\python\current\python.exe") @("-c", "import hermes_cli.main")
+    } finally {
+      $env:HERMES_HOME = $previousHome
+    }
+  } finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $selftestRoot
+  }
+}
+
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $work
+$size = (Get-ChildItem -Path $out -Recurse -File | Measure-Object -Property Length -Sum).Sum
+Log ("bundle size: {0:N1} MB" -f ($size / 1MB))
+Log "done: $out"

--- a/scripts/tauri-before-dev.mjs
+++ b/scripts/tauri-before-dev.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const apiDir = path.join(rootDir, "scribe-api");
+const frontendPort = Number.parseInt(process.env.VITE_PORT ?? "1421", 10);
+const apiPort = Number.parseInt(process.env.SCRIBE_API_PORT ?? "8080", 10);
+const shell = process.platform === "win32";
+
+let apiChild = null;
+let frontendChild = null;
+let shuttingDown = false;
+
+function portIsOpen(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const done = (open) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(open);
+    };
+    socket.once("connect", () => done(true));
+    socket.once("error", () => done(false));
+    socket.setTimeout(300, () => done(false));
+  });
+}
+
+function spawnManaged(name, command, args, cwd) {
+  const child = spawn(command, args, {
+    cwd,
+    env: process.env,
+    shell,
+    stdio: "inherit",
+  });
+
+  child.on("error", (error) => {
+    console.error(`${name} failed to start: ${error.message}`);
+    cleanup();
+    process.exit(1);
+  });
+
+  return child;
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of [frontendChild, apiChild]) {
+    if (child && !child.killed) {
+      child.kill();
+    }
+  }
+}
+
+function exitFromChild(code, signal) {
+  cleanup();
+  process.exit(code ?? (signal ? 1 : 0));
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => exitFromChild(0, signal));
+}
+
+if (!fs.existsSync(path.join(apiDir, "Cargo.toml"))) {
+  console.error(`Could not find scribe-api/Cargo.toml under ${rootDir}`);
+  process.exit(1);
+}
+
+if (await portIsOpen(apiPort)) {
+  console.error(
+    `Scribe API port ${apiPort} is already in use. Reusing it for Tauri dev.`,
+  );
+} else {
+  apiChild = spawnManaged(
+    "scribe-api",
+    "cargo",
+    ["run", "-p", "scribe", "--", "serve"],
+    apiDir,
+  );
+  apiChild.on("exit", (code, signal) => {
+    if (shuttingDown) return;
+    console.error(`scribe-api exited with ${signal ?? code}`);
+    exitFromChild(code, signal);
+  });
+}
+
+if (await portIsOpen(frontendPort)) {
+  console.error(
+    `Vite port ${frontendPort} is already in use. Reusing it for Tauri dev.`,
+  );
+} else {
+  frontendChild = spawnManaged("Vite", "pnpm", ["run", "dev"], rootDir);
+  frontendChild.on("exit", exitFromChild);
+}
+
+if (!frontendChild) {
+  setInterval(() => {}, 60 * 60 * 1000);
+}

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const platformBundles = {
   darwin: ["app", "dmg"],
@@ -33,7 +36,7 @@ if (bundles && !hasBundleOverride) {
 }
 args.push(...userArgs);
 
-const child = spawn("tauri", args, {
+const child = spawn(tauriCommand(), args, {
   shell: process.platform === "win32",
   stdio: "inherit",
 });
@@ -71,4 +74,11 @@ function platformForTarget(targetTriple) {
     return "darwin";
   }
   return undefined;
+}
+
+function tauriCommand() {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const binary = process.platform === "win32" ? "tauri.cmd" : "tauri";
+  const localBinary = resolve(scriptDir, "..", "node_modules", ".bin", binary);
+  return existsSync(localBinary) ? localBinary : "tauri";
 }

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const platformBundles = {
+  darwin: ["app", "dmg"],
+  win32: ["nsis"],
+};
+
+const platformConfigs = {
+  darwin: "src-tauri/tauri.macos.conf.json",
+  win32: "src-tauri/tauri.windows.conf.json",
+};
+
+const rawUserArgs = process.argv.slice(2);
+const userArgs = rawUserArgs[0] === "--" ? rawUserArgs.slice(1) : rawUserArgs;
+const target = optionValue(userArgs, "--target");
+const buildPlatform = platformForTarget(target) ?? process.platform;
+const bundles = platformBundles[buildPlatform];
+const config = platformConfigs[buildPlatform];
+const hasBundleOverride = userArgs.some(
+  (arg) => arg === "--bundles" || arg.startsWith("--bundles="),
+);
+const hasConfigOverride = userArgs.some(
+  (arg) => arg === "--config" || arg.startsWith("--config="),
+);
+const args = ["build"];
+if (config && !hasConfigOverride) {
+  args.push("--config", config);
+}
+if (bundles && !hasBundleOverride) {
+  args.push("--bundles", bundles.join(","));
+}
+args.push(...userArgs);
+
+const child = spawn("tauri", args, {
+  shell: process.platform === "win32",
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  process.exit(code ?? (signal ? 1 : 0));
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+function optionValue(args, option) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === option) {
+      return args[index + 1];
+    }
+    if (arg.startsWith(`${option}=`)) {
+      return arg.slice(option.length + 1);
+    }
+  }
+  return undefined;
+}
+
+function platformForTarget(targetTriple) {
+  if (!targetTriple) {
+    return undefined;
+  }
+  if (targetTriple.includes("windows")) {
+    return "win32";
+  }
+  if (targetTriple.includes("apple-darwin")) {
+    return "darwin";
+  }
+  return undefined;
+}

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const REPLAY_ONBOARDING_FLAG = "--replay-onboarding";
 const platformConfigs = {
@@ -29,7 +32,7 @@ if (config && !hasConfigOverride) {
   tauriArgs.unshift("--config", config);
 }
 
-const child = spawn("tauri", ["dev", ...tauriArgs], {
+const child = spawn(tauriCommand(), ["dev", ...tauriArgs], {
   env: {
     ...process.env,
     ...(replayOnboarding ? { VITE_JUNE_REPLAY_ONBOARDING: "1" } : {}),
@@ -46,3 +49,10 @@ child.on("error", (error) => {
   console.error(error);
   process.exit(1);
 });
+
+function tauriCommand() {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const binary = process.platform === "win32" ? "tauri.cmd" : "tauri";
+  const localBinary = resolve(scriptDir, "..", "node_modules", ".bin", binary);
+  return existsSync(localBinary) ? localBinary : "tauri";
+}

--- a/scripts/tauri-dev.mjs
+++ b/scripts/tauri-dev.mjs
@@ -3,11 +3,17 @@
 import { spawn } from "node:child_process";
 
 const REPLAY_ONBOARDING_FLAG = "--replay-onboarding";
+const platformConfigs = {
+  darwin: "src-tauri/tauri.macos.conf.json",
+  win32: "src-tauri/tauri.windows.conf.json",
+};
 
 let replayOnboarding = false;
 const tauriArgs = [];
+const rawUserArgs = process.argv.slice(2);
+const userArgs = rawUserArgs[0] === "--" ? rawUserArgs.slice(1) : rawUserArgs;
 
-for (const arg of process.argv.slice(2)) {
+for (const arg of userArgs) {
   if (arg === REPLAY_ONBOARDING_FLAG) {
     replayOnboarding = true;
   } else {
@@ -15,20 +21,25 @@ for (const arg of process.argv.slice(2)) {
   }
 }
 
+const config = platformConfigs[process.platform];
+const hasConfigOverride = tauriArgs.some(
+  (arg) => arg === "--config" || arg.startsWith("--config="),
+);
+if (config && !hasConfigOverride) {
+  tauriArgs.unshift("--config", config);
+}
+
 const child = spawn("tauri", ["dev", ...tauriArgs], {
   env: {
     ...process.env,
     ...(replayOnboarding ? { VITE_JUNE_REPLAY_ONBOARDING: "1" } : {}),
   },
+  shell: process.platform === "win32",
   stdio: "inherit",
 });
 
 child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
-  }
-  process.exit(code ?? 1);
+  process.exit(code ?? (signal ? 1 : 0));
 });
 
 child.on("error", (error) => {

--- a/scripts/windows-sign.ps1
+++ b/scripts/windows-sign.ps1
@@ -1,0 +1,76 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$TargetPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+  throw "[windows-sign] $Message"
+}
+
+function Resolve-RequiredFile([string]$Path, [string]$Name) {
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    Fail "$Name is required."
+  }
+  if (!(Test-Path -LiteralPath $Path -PathType Leaf)) {
+    Fail "$Name does not point to a readable file: $Path"
+  }
+  return (Resolve-Path -LiteralPath $Path).ProviderPath
+}
+
+function Find-SignTool {
+  $configured = $env:WINDOWS_SIGNTOOL_PATH
+  if (![string]::IsNullOrWhiteSpace($configured)) {
+    return Resolve-RequiredFile $configured "WINDOWS_SIGNTOOL_PATH"
+  }
+
+  $onPath = Get-Command "signtool.exe" -ErrorAction SilentlyContinue
+  if ($null -ne $onPath) {
+    return $onPath.Source
+  }
+
+  $programFilesX86 = ${env:ProgramFiles(x86)}
+  if (![string]::IsNullOrWhiteSpace($programFilesX86)) {
+    $kitsRoot = Join-Path $programFilesX86 "Windows Kits\10\bin"
+    if (Test-Path -LiteralPath $kitsRoot -PathType Container) {
+      $candidates = Get-ChildItem -Path $kitsRoot -Filter "signtool.exe" -Recurse -File -ErrorAction SilentlyContinue |
+        Sort-Object `
+          @{ Expression = { if ($_.FullName -match "\\x64\\signtool\.exe$") { 0 } elseif ($_.FullName -match "\\arm64\\signtool\.exe$") { 1 } else { 2 } } },
+          FullName
+
+      if (($candidates | Measure-Object).Count -gt 0) {
+        return $candidates[0].FullName
+      }
+    }
+  }
+
+  Fail "signtool.exe was not found. Install the Windows SDK or set WINDOWS_SIGNTOOL_PATH."
+}
+
+$target = Resolve-RequiredFile $TargetPath "TargetPath"
+$certificatePath = Resolve-RequiredFile $env:WINDOWS_CERTIFICATE_PATH "WINDOWS_CERTIFICATE_PATH"
+$certificatePassword = $env:WINDOWS_CERTIFICATE_PASSWORD
+if ([string]::IsNullOrWhiteSpace($certificatePassword)) {
+  Fail "WINDOWS_CERTIFICATE_PASSWORD is required."
+}
+
+$timestampUrl = $env:WINDOWS_SIGNING_TIMESTAMP_URL
+if ([string]::IsNullOrWhiteSpace($timestampUrl)) {
+  $timestampUrl = "http://timestamp.digicert.com"
+}
+
+$signtool = Find-SignTool
+
+Write-Host "[windows-sign] Signing $target"
+& $signtool sign /fd SHA256 /td SHA256 /tr $timestampUrl /f $certificatePath /p $certificatePassword /d "June" $target
+if ($LASTEXITCODE -ne 0) {
+  Fail "signtool sign failed with exit code $LASTEXITCODE."
+}
+
+$signature = Get-AuthenticodeSignature -FilePath $target
+if ($signature.Status -ne "Valid") {
+  Fail "Authenticode signature is $($signature.Status) for $target. $($signature.StatusMessage)"
+}
+
+Write-Host "[windows-sign] Signature verified for $target"

--- a/scripts/windows-sign.ps1
+++ b/scripts/windows-sign.ps1
@@ -49,11 +49,19 @@ function Find-SignTool {
 }
 
 $target = Resolve-RequiredFile $TargetPath "TargetPath"
-$certificatePath = Resolve-RequiredFile $env:WINDOWS_CERTIFICATE_PATH "WINDOWS_CERTIFICATE_PATH"
+$certificatePathValue = $env:WINDOWS_CERTIFICATE_PATH
 $certificatePassword = $env:WINDOWS_CERTIFICATE_PASSWORD
-if ([string]::IsNullOrWhiteSpace($certificatePassword)) {
-  Fail "WINDOWS_CERTIFICATE_PASSWORD is required."
+if ([string]::IsNullOrWhiteSpace($certificatePathValue) -and [string]::IsNullOrWhiteSpace($certificatePassword)) {
+  Write-Host "[windows-sign] WINDOWS_CERTIFICATE_PATH and WINDOWS_CERTIFICATE_PASSWORD are not set; skipping Authenticode signing."
+  exit 0
 }
+if ([string]::IsNullOrWhiteSpace($certificatePathValue)) {
+  Fail "WINDOWS_CERTIFICATE_PATH is required when Windows signing is configured."
+}
+if ([string]::IsNullOrWhiteSpace($certificatePassword)) {
+  Fail "WINDOWS_CERTIFICATE_PASSWORD is required when Windows signing is configured."
+}
+$certificatePath = Resolve-RequiredFile $certificatePathValue "WINDOWS_CERTIFICATE_PATH"
 
 $timestampUrl = $env:WINDOWS_SIGNING_TIMESTAMP_URL
 if ([string]::IsNullOrWhiteSpace($timestampUrl)) {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2300,9 +2300,11 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.80.0"
 
 [lib]
 name = "os_scribe_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [[bin]]
 name = "os-scribe"
@@ -25,7 +25,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cpal = "0.15"
 dotenvy = "0.15"
 hound = "3.5"
-keyring = { version = "3", features = ["apple-native"] }
+keyring = "3"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -47,6 +47,7 @@ uuid = { version = "1.11", features = ["serde", "v4"] }
 zeroize = { version = "1", features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3", features = ["apple-native"] }
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = [
     "std",
@@ -64,6 +65,9 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
     "objc2-core-foundation",
 ] }
 window-vibrancy = "0.6"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { version = "3", features = ["windows-native"] }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -24,7 +24,8 @@ fn main() {
 /// compile time, so the `../.tauri-hermes/hermes` mapping must exist for ANY
 /// cargo invocation (`cargo test`, rust-analyzer, dev builds) — not just for
 /// `tauri build`. Release CI populates the real runtime via
-/// scripts/bundle-hermes-runtime.sh before compiling; everywhere else this
+/// scripts/bundle-hermes-runtime.sh or scripts/bundle-hermes-runtime-windows.ps1
+/// before compiling; everywhere else this
 /// placeholder keeps the build green and the app falls back to the managed
 /// on-device install (`bundled_hermes_command` finds no launcher in it).
 ///
@@ -78,7 +79,7 @@ fn ensure_bundled_hermes_dir() {
         return;
     }
     let note = "No bundled Hermes runtime in this build. The app installs the managed \
-runtime on first launch instead. Release CI runs scripts/bundle-hermes-runtime.sh to \
+runtime on first launch instead. Release CI runs the platform Hermes bundler to \
 ship the runtime inside the app.\n";
     if let Err(error) = std::fs::write(hermes_dir.join("PLACEHOLDER.md"), note) {
         println!("cargo:warning=could not write hermes placeholder: {error}");

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -45,7 +45,9 @@ fn ensure_bundled_hermes_dir() {
         return;
     };
     if hermes_dir.exists() {
-        if !hermes_dir.join("bin").join("hermes").exists() {
+        if !hermes_dir.join("bin").join("hermes").exists()
+            && !hermes_dir.join("bin").join("hermes.exe").exists()
+        {
             // Placeholder (or partial) dir: nothing to validate.
             return;
         }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -97,10 +97,22 @@ pub fn microphone_permission_state() -> (String, Option<String>) {
     if host.default_input_device().is_some() {
         ("granted".to_string(), None)
     } else {
-        (
-            "denied".to_string(),
-            Some("Enable microphone access in macOS Privacy & Security settings.".to_string()),
-        )
+        ("denied".to_string(), Some(microphone_permission_hint()))
+    }
+}
+
+fn microphone_permission_hint() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        "Enable microphone access in macOS Privacy & Security settings.".to_string()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        "Enable microphone access in Windows privacy settings.".to_string()
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        "Enable microphone access in your system privacy settings.".to_string()
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -595,12 +595,28 @@ pub async fn open_privacy_settings(request: OpenPrivacySettingsRequest) -> Resul
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = request;
-        Err(AppError::new(
-            "settings_open_unsupported",
-            "Privacy settings shortcuts are only supported on macOS.",
-        ))
+        open_non_macos_privacy_settings(request)
     }
+}
+
+#[cfg(target_os = "windows")]
+fn open_non_macos_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
+    match request.pane.as_str() {
+        "microphone" => crate::os_accounts::open_in_browser("ms-settings:privacy-microphone"),
+        _ => Err(AppError::new(
+            "settings_open_unsupported",
+            "This privacy settings shortcut is only supported on macOS.",
+        )),
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn open_non_macos_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
+    let _ = request;
+    Err(AppError::new(
+        "settings_open_unsupported",
+        "Privacy settings shortcuts are only supported on macOS.",
+    ))
 }
 
 #[tauri::command]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -616,21 +616,17 @@ pub fn setup(app: &mut tauri::App) {
         }
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let settings = app
-            .state::<DictationSettingsState>()
-            .settings
-            .lock()
-            .map(|settings| settings.clone())
-            .unwrap_or_default();
-        let event = hotkey_ready_event(&settings);
-
-        app.manage(HotkeyStatus {
-            event: Mutex::new(event.clone()),
-        });
-        let _ = app.emit("dictation-event", event.to_string());
-    }
+    let settings = app
+        .state::<DictationSettingsState>()
+        .settings
+        .lock()
+        .map(|settings| settings.clone())
+        .unwrap_or_default();
+    let event = initial_hotkey_event(&settings);
+    app.manage(HotkeyStatus {
+        event: Mutex::new(event.clone()),
+    });
+    let _ = app.emit("dictation-event", event.to_string());
 }
 
 #[tauri::command]
@@ -707,6 +703,19 @@ pub fn set_dictation_shortcut(
 }
 
 #[tauri::command]
+#[cfg(not(target_os = "macos"))]
+pub fn set_dictation_shortcut(
+    kind: DictationShortcutKind,
+    shortcut: DictationShortcutInput,
+) -> Result<DictationSettings, AppError> {
+    let _ = (kind, shortcut);
+    Err(AppError::new(
+        "dictation_shortcut_unsupported",
+        "Dictation shortcuts are only supported on macOS.",
+    ))
+}
+
+#[tauri::command]
 pub fn set_dictation_microphone(
     state: State<'_, DictationSettingsState>,
     helper_state: State<'_, HelperState>,
@@ -716,6 +725,16 @@ pub fn set_dictation_microphone(
     let settings = update_settings(&state, |settings| {
         settings.microphone = DictationMicrophoneSetting { id, name };
     })?;
+    #[cfg(not(target_os = "macos"))]
+    if helper_state
+        .process
+        .lock()
+        .map(|process| process.is_none())
+        .unwrap_or(true)
+    {
+        return Ok(settings);
+    }
+
     apply_microphone_setting(&helper_state, &settings.microphone)?;
     Ok(settings)
 }
@@ -743,9 +762,23 @@ pub fn set_dictation_language(
 
 #[tauri::command]
 pub fn dictation_helper_command(
+    app: AppHandle,
     state: State<'_, HelperState>,
     command: serde_json::Value,
 ) -> Result<(), AppError> {
+    #[cfg(target_os = "macos")]
+    let _ = &app;
+
+    #[cfg(not(target_os = "macos"))]
+    if state
+        .process
+        .lock()
+        .map(|process| process.is_none())
+        .unwrap_or(true)
+    {
+        return handle_missing_helper_command(&app, &command);
+    }
+
     send_helper_command(&state, command)
 }
 
@@ -1334,6 +1367,58 @@ fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Resul
         .stdin
         .flush()
         .map_err(|error| AppError::new("dictation_helper_write_failed", error.to_string()))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn handle_missing_helper_command(
+    app: &AppHandle,
+    command: &serde_json::Value,
+) -> Result<(), AppError> {
+    match command.get("type").and_then(serde_json::Value::as_str) {
+        Some(
+            "get_permission_status"
+            | "request_microphone_permission"
+            | "request_accessibility_permission",
+        ) => {
+            emit_dictation_event_value(app, non_macos_permission_status_event());
+            Ok(())
+        }
+        Some("list_microphones") => {
+            emit_dictation_event_value(
+                app,
+                serde_json::json!({
+                    "type": "microphone_devices",
+                    "payload": {
+                        "devices": [],
+                        "selectedID": "",
+                    },
+                }),
+            );
+            Ok(())
+        }
+        Some(
+            "cancel_shortcut_capture"
+            | "start_shortcut_capture"
+            | "set_microphone"
+            | "discard_mic_test",
+        ) => Ok(()),
+        _ => Err(AppError::new(
+            "dictation_helper_unavailable",
+            "Dictation recording is only supported on macOS.",
+        )),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn non_macos_permission_status_event() -> serde_json::Value {
+    let (microphone, _) = crate::audio::capture::microphone_permission_state();
+    serde_json::json!({
+        "type": "permission_status",
+        "payload": {
+            "microphone": microphone,
+            "accessibility": "granted",
+        },
+    })
 }
 
 fn apply_microphone_setting(
@@ -2751,6 +2836,22 @@ fn hotkey_ready_event(settings: &DictationSettings) -> serde_json::Value {
             "pushToTalkShortcut": settings.push_to_talk_shortcut.label,
             "toggleShortcut": settings.toggle_shortcut.label,
             "shortcuts": shortcuts,
+        },
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn initial_hotkey_event(settings: &DictationSettings) -> serde_json::Value {
+    hotkey_ready_event(settings)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn initial_hotkey_event(_settings: &DictationSettings) -> serde_json::Value {
+    serde_json::json!({
+        "type": "hotkey_trigger_unavailable",
+        "payload": {
+            "reason": "unsupported",
+            "message": "Dictation shortcuts are only supported on macOS.",
         },
     })
 }

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1775,11 +1775,32 @@ async fn resolve_hermes_command(
 
 fn bundled_hermes_command(app: &AppHandle) -> Option<PathBuf> {
     let resource_dir = app.path().resource_dir().ok()?;
-    let candidates = [
-        resource_dir.join("native/hermes/hermes-agent/venv/bin/hermes"),
-        resource_dir.join("native/hermes/bin/hermes"),
-    ];
+    let candidates = bundled_hermes_command_candidates(&resource_dir);
     candidates.into_iter().find(|path| path.exists())
+}
+
+fn bundled_hermes_command_candidates(resource_dir: &Path) -> Vec<PathBuf> {
+    let hermes_root = resource_dir.join("native").join("hermes");
+    if cfg!(target_os = "windows") {
+        vec![
+            hermes_root
+                .join("hermes-agent")
+                .join("venv")
+                .join("Scripts")
+                .join("hermes.exe"),
+            hermes_root.join("bin").join("hermes.exe"),
+            hermes_root.join("hermes.exe"),
+        ]
+    } else {
+        vec![
+            hermes_root
+                .join("hermes-agent")
+                .join("venv")
+                .join("bin")
+                .join("hermes"),
+            hermes_root.join("bin").join("hermes"),
+        ]
+    }
 }
 
 fn managed_hermes_runtime_dir(app: &AppHandle) -> Result<PathBuf, AppError> {
@@ -1791,9 +1812,11 @@ fn managed_hermes_runtime_dir(app: &AppHandle) -> Result<PathBuf, AppError> {
 }
 
 fn managed_hermes_command(app: &AppHandle) -> Result<PathBuf, AppError> {
-    Ok(managed_hermes_runtime_dir(app)?
-        .join("hermes-agent")
-        .join("venv/bin/hermes"))
+    Ok(hermes_venv_command(
+        &managed_hermes_runtime_dir(app)?
+            .join("hermes-agent")
+            .join("venv"),
+    ))
 }
 
 fn managed_hermes_runtime_current(app: &AppHandle) -> Result<bool, AppError> {
@@ -1805,13 +1828,54 @@ fn managed_hermes_runtime_current(app: &AppHandle) -> Result<bool, AppError> {
 }
 
 fn user_local_hermes_command() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    [
-        PathBuf::from(&home).join(".hermes/hermes-agent/venv/bin/hermes"),
-        PathBuf::from(&home).join(".local/bin/hermes"),
-    ]
-    .into_iter()
-    .find(|path| path.exists())
+    let mut candidates = Vec::new();
+    for home in home_dir_candidates() {
+        candidates.push(hermes_venv_command(
+            &home.join(".hermes").join("hermes-agent").join("venv"),
+        ));
+        candidates.push(if cfg!(target_os = "windows") {
+            home.join(".local").join("bin").join("hermes.exe")
+        } else {
+            home.join(".local").join("bin").join("hermes")
+        });
+    }
+    candidates.into_iter().find(|path| path.exists())
+}
+
+fn hermes_venv_command(venv_dir: &Path) -> PathBuf {
+    if cfg!(target_os = "windows") {
+        venv_dir.join("Scripts").join("hermes.exe")
+    } else {
+        venv_dir.join("bin").join("hermes")
+    }
+}
+
+fn home_dir_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for name in ["HOME", "USERPROFILE"] {
+        if let Some(value) = std::env::var_os(name) {
+            if !value.is_empty() {
+                let path = PathBuf::from(value);
+                if !candidates.contains(&path) {
+                    candidates.push(path);
+                }
+            }
+        }
+    }
+    match (std::env::var_os("HOMEDRIVE"), std::env::var_os("HOMEPATH")) {
+        (Some(drive), Some(path)) if !drive.is_empty() && !path.is_empty() => {
+            let candidate = PathBuf::from(format!(
+                "{}{}",
+                drive.to_string_lossy(),
+                path.to_string_lossy()
+            ));
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+        _ => {}
+    }
+    candidates
 }
 
 fn hermes_runtime_available_for_auto_start(app: &AppHandle) -> bool {
@@ -1825,6 +1889,22 @@ fn hermes_runtime_available_for_auto_start(app: &AppHandle) -> bool {
 }
 
 async fn install_managed_hermes_runtime(
+    app: &AppHandle,
+    hermes_home: &Path,
+) -> Result<(), AppError> {
+    #[cfg(target_os = "windows")]
+    {
+        return install_managed_hermes_runtime_windows(app, hermes_home).await;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        install_managed_hermes_runtime_unix(app, hermes_home).await
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn install_managed_hermes_runtime_unix(
     app: &AppHandle,
     hermes_home: &Path,
 ) -> Result<(), AppError> {
@@ -1902,7 +1982,101 @@ async fn install_managed_hermes_runtime(
         ));
     }
 
-    if !install_dir.join("venv/bin/hermes").exists() {
+    if !hermes_venv_command(&install_dir.join("venv")).exists() {
+        return Err(AppError::new(
+            "hermes_runtime_install_failed",
+            format!(
+                "Hermes setup completed but the runtime command was not created. Install log: {}.",
+                install_log.display()
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+async fn install_managed_hermes_runtime_windows(
+    app: &AppHandle,
+    hermes_home: &Path,
+) -> Result<(), AppError> {
+    let runtime_dir = managed_hermes_runtime_dir(app)?;
+    let install_dir = runtime_dir.join("hermes-agent");
+    fs::create_dir_all(&runtime_dir)
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    if install_dir.exists() && !managed_hermes_runtime_current(app)? {
+        fs::remove_dir_all(&install_dir)
+            .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    }
+    let install_log = runtime_dir.join("install.log");
+
+    let log_file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&install_log)
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+    let log_file_for_stderr = log_file
+        .try_clone()
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?;
+
+    let status = {
+        let runtime_dir = runtime_dir.clone();
+        let install_dir = install_dir.clone();
+        let hermes_home = hermes_home.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            Command::new("powershell.exe")
+                .args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    WINDOWS_MANAGED_HERMES_INSTALL_SCRIPT,
+                ])
+                .env("SCRIBE_HERMES_RUNTIME_DIR", &runtime_dir)
+                .env("SCRIBE_HERMES_INSTALL_DIR", &install_dir)
+                .env("SCRIBE_HERMES_HOME", &hermes_home)
+                .env("SCRIBE_HERMES_INSTALL_COMMIT", HERMES_AGENT_INSTALL_COMMIT)
+                .env(
+                    "SCRIBE_HERMES_SOURCE_TARBALL_URL",
+                    HERMES_SOURCE_TARBALL_URL,
+                )
+                .env(
+                    "SCRIBE_HERMES_SOURCE_TARBALL_SHA256",
+                    HERMES_SOURCE_TARBALL_SHA256,
+                )
+                .env("HERMES_HOME", &hermes_home)
+                .stdin(Stdio::null())
+                .stdout(Stdio::from(log_file))
+                .stderr(Stdio::from(log_file_for_stderr))
+                .status()
+        })
+        .await
+        .map_err(|error| AppError::new("hermes_runtime_install_failed", error.to_string()))?
+        .map_err(|error| {
+            AppError::new(
+                "hermes_runtime_install_failed",
+                format!(
+                    "Could not run the Windows Hermes runtime installer. Install log: {}. {error}",
+                    install_log.display()
+                ),
+            )
+        })?
+    };
+
+    if !status.success() {
+        return Err(AppError::new(
+            "hermes_runtime_install_failed",
+            format!(
+                "Could not set up the Scribe-managed Hermes runtime. Install log: {}.",
+                install_log.display()
+            ),
+        ));
+    }
+
+    if !hermes_venv_command(&install_dir.join("venv")).exists() {
         return Err(AppError::new(
             "hermes_runtime_install_failed",
             format!(
@@ -1984,6 +2158,157 @@ cat > "$runtime_dir/runtime.json" <<EOF
 {"source":"NousResearch/hermes-agent","commit":"$install_commit","installDir":"$install_dir"}
 EOF
 "#;
+
+#[cfg(target_os = "windows")]
+const WINDOWS_MANAGED_HERMES_INSTALL_SCRIPT: &str = r##"
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$runtimeDir = $env:SCRIBE_HERMES_RUNTIME_DIR
+$installDir = $env:SCRIBE_HERMES_INSTALL_DIR
+$hermesHome = $env:SCRIBE_HERMES_HOME
+$installCommit = $env:SCRIBE_HERMES_INSTALL_COMMIT
+$sourceTarballUrl = $env:SCRIBE_HERMES_SOURCE_TARBALL_URL
+$sourceTarballSha256 = ($env:SCRIBE_HERMES_SOURCE_TARBALL_SHA256).ToLowerInvariant()
+
+if ([string]::IsNullOrWhiteSpace($runtimeDir) -or
+    [string]::IsNullOrWhiteSpace($installDir) -or
+    [string]::IsNullOrWhiteSpace($hermesHome)) {
+  throw "Hermes installer paths were not provided."
+}
+
+New-Item -ItemType Directory -Force -Path $runtimeDir, $hermesHome | Out-Null
+
+function Invoke-Native {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [Parameter(Mandatory = $true)][string[]]$Arguments
+  )
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath exited with code $LASTEXITCODE"
+  }
+}
+
+function Resolve-Python {
+  $candidates = @(
+    @{ Exe = "py"; Args = @("-3.11") },
+    @{ Exe = "py"; Args = @("-3.12") },
+    @{ Exe = "py"; Args = @("-3.13") },
+    @{ Exe = "python"; Args = @() },
+    @{ Exe = "python3"; Args = @() }
+  )
+  foreach ($candidate in $candidates) {
+    try {
+      $args = @($candidate.Args + @(
+        "-c",
+        "import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)"
+      ))
+      & $candidate.Exe @args
+      if ($LASTEXITCODE -eq 0) {
+        return $candidate
+      }
+    } catch {
+    }
+  }
+  throw "Python 3.11, 3.12, or 3.13 is required to install the managed Hermes runtime on Windows."
+}
+
+if (!(Test-Path (Join-Path $installDir "pyproject.toml"))) {
+  $tmpDir = Join-Path $runtimeDir ("download-" + [guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+  try {
+    $archive = Join-Path $tmpDir "hermes-agent.tar.gz"
+    Invoke-WebRequest -Uri $sourceTarballUrl -OutFile $archive
+    $actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $sourceTarballSha256) {
+      throw "Hermes source archive checksum mismatch. Expected $sourceTarballSha256, got $actualSha256."
+    }
+    Invoke-Native "tar" @("-xzf", $archive, "-C", $tmpDir)
+    $unpacked = Get-ChildItem -Path $tmpDir -Directory |
+      Where-Object { $_.Name -like "hermes-agent-*" } |
+      Select-Object -First 1
+    if ($null -eq $unpacked) {
+      throw "Hermes source archive did not contain a hermes-agent directory."
+    }
+    if (Test-Path $installDir) {
+      Remove-Item -Recurse -Force -Path $installDir
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $installDir) | Out-Null
+    Move-Item -Path $unpacked.FullName -Destination $installDir
+  } finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -Path $tmpDir
+  }
+}
+
+$python = Resolve-Python
+$venvDir = Join-Path $installDir "venv"
+if (Test-Path $venvDir) {
+  Remove-Item -Recurse -Force -Path $venvDir
+}
+Invoke-Native $python.Exe @($python.Args + @("-m", "venv", $venvDir))
+$venvPython = Join-Path $venvDir "Scripts\python.exe"
+if (!(Test-Path $venvPython)) {
+  throw "Python virtual environment was not created at $venvDir."
+}
+
+Set-Location $installDir
+Invoke-Native $venvPython @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
+Invoke-Native $venvPython @("-m", "pip", "install", "-e", ".[all]")
+
+$homeDirs = @("cron", "sessions", "logs", "pairing", "hooks", "image_cache", "audio_cache", "memories", "skills")
+foreach ($dir in $homeDirs) {
+  New-Item -ItemType Directory -Force -Path (Join-Path $hermesHome $dir) | Out-Null
+}
+
+$envFile = Join-Path $hermesHome ".env"
+if (!(Test-Path $envFile)) {
+  $exampleEnv = Join-Path $installDir ".env.example"
+  if (Test-Path $exampleEnv) {
+    Copy-Item -Path $exampleEnv -Destination $envFile
+  } else {
+    New-Item -ItemType File -Path $envFile | Out-Null
+  }
+}
+
+$configFile = Join-Path $hermesHome "config.yaml"
+if (!(Test-Path $configFile)) {
+  $exampleConfig = Join-Path $installDir "cli-config.yaml.example"
+  if (Test-Path $exampleConfig) {
+    Copy-Item -Path $exampleConfig -Destination $configFile
+  }
+}
+
+$soulFile = Join-Path $hermesHome "SOUL.md"
+if (!(Test-Path $soulFile)) {
+  [System.IO.File]::WriteAllText($soulFile, "# Hermes Agent Persona`n", (New-Object System.Text.UTF8Encoding $false))
+}
+
+$skillsSync = Join-Path $installDir "tools\skills_sync.py"
+if (Test-Path $skillsSync) {
+  try {
+    Invoke-Native $venvPython @($skillsSync)
+  } catch {
+    $sourceSkills = Join-Path $installDir "skills"
+    $targetSkills = Join-Path $hermesHome "skills"
+    if (Test-Path $sourceSkills) {
+      Copy-Item -Path (Join-Path $sourceSkills "*") -Destination $targetSkills -Recurse -Force
+    }
+  }
+}
+
+$hermesExe = Join-Path $venvDir "Scripts\hermes.exe"
+if (!(Test-Path $hermesExe)) {
+  throw "Hermes executable was not created at $hermesExe."
+}
+
+$metadata = [ordered]@{
+  source = "NousResearch/hermes-agent"
+  commit = $installCommit
+  installDir = $installDir
+} | ConvertTo-Json -Compress
+[System.IO.File]::WriteAllText((Join-Path $runtimeDir "runtime.json"), $metadata, (New-Object System.Text.UTF8Encoding $false))
+"##;
 
 fn apply_isolated_hermes_env(
     cmd: &mut Command,
@@ -3013,6 +3338,43 @@ mod tests {
         let request: StartHermesBridgeRequest =
             serde_json::from_str(r#"{"fullMode":false}"#).expect("sandboxed request");
         assert_eq!(request.full_mode, Some(false));
+    }
+
+    #[test]
+    fn hermes_venv_command_uses_the_target_entrypoint() {
+        let command = hermes_venv_command(Path::new("venv"));
+
+        if cfg!(target_os = "windows") {
+            assert_eq!(
+                command,
+                PathBuf::from("venv").join("Scripts").join("hermes.exe")
+            );
+        } else {
+            assert_eq!(command, PathBuf::from("venv").join("bin").join("hermes"));
+        }
+    }
+
+    #[test]
+    fn bundled_command_candidates_include_target_specific_launchers() {
+        let candidates = bundled_hermes_command_candidates(Path::new("resources"));
+
+        if cfg!(target_os = "windows") {
+            assert!(candidates.contains(
+                &PathBuf::from("resources")
+                    .join("native")
+                    .join("hermes")
+                    .join("bin")
+                    .join("hermes.exe")
+            ));
+        } else {
+            assert!(candidates.contains(
+                &PathBuf::from("resources")
+                    .join("native")
+                    .join("hermes")
+                    .join("bin")
+                    .join("hermes")
+            ));
+        }
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,9 +14,7 @@ pub mod os_accounts;
 pub mod providers;
 pub mod scribe_api;
 
-use tauri::Emitter;
-#[cfg(target_os = "macos")]
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check_for_updates";
 const CHECK_FOR_UPDATES_EVENT: &str = "scribe://check-for-updates";

--- a/src-tauri/src/meeting_hud.rs
+++ b/src-tauri/src/meeting_hud.rs
@@ -48,7 +48,6 @@ const IDLE_TICK: Duration = Duration::from_millis(220);
 const PILL_SIZE: LogicalSize<f64> = LogicalSize::new(76.0, 32.0);
 /// Upright the pill carries less (4 bars instead of 7), so it runs shorter.
 /// Must agree with `.mhud[data-orient="vertical"]` in meeting-hud.css.
-#[cfg(target_os = "macos")]
 const VERTICAL_PILL_LENGTH: f64 = 62.0;
 /// The window is a fixed square the length of the pill (tauri.conf.json), so a
 /// quarter turn always fits without resizing the native frame — the transparent

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -1247,8 +1247,8 @@ fn random_b64url(bytes: usize) -> String {
 }
 
 pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
-    let mut child = std::process::Command::new("open")
-        .arg(url)
+    let mut command = browser_open_command(url);
+    let mut child = command
         .spawn()
         .map_err(|e| AppError::new("browser_open_failed", e.to_string()))?;
     // Reap the short-lived `open` process off-thread so it doesn't linger as
@@ -1257,4 +1257,25 @@ pub(crate) fn open_in_browser(url: &str) -> Result<(), AppError> {
         let _ = child.wait();
     });
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn browser_open_command(url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new("open");
+    command.arg(url);
+    command
+}
+
+#[cfg(target_os = "windows")]
+fn browser_open_command(url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new("explorer.exe");
+    command.arg(url);
+    command
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn browser_open_command(url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new("xdg-open");
+    command.arg(url);
+    command
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.0.13",
   "identifier": "co.opensoftware.scribe",
   "build": {
-    "beforeDevCommand": "./scripts/tauri-before-dev.sh",
+    "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",
     "beforeBuildCommand": "pnpm run build",
     "devUrl": "http://127.0.0.1:1421",
     "frontendDist": "../dist"
@@ -80,32 +80,21 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$TEMP/os-scribe-dictation-*.m4a"
-        ]
+        "scope": ["$TEMP/os-scribe-dictation-*.m4a"]
       },
-      "capabilities": [
-        "main",
-        "hud",
-        "agent-hud",
-        "meeting-hud"
-      ]
+      "capabilities": ["main", "hud", "agent-hud", "meeting-hud"]
     }
   },
   "plugins": {
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "osscribe"
-          ],
+          "scheme": ["osscribe"],
           "appLink": false
         }
       ],
       "desktop": {
-        "schemes": [
-          "osscribe"
-        ]
+        "schemes": ["osscribe"]
       }
     },
     "updater": {
@@ -125,22 +114,8 @@
       "icons/icon.icns",
       "icons/icon.png"
     ],
-    "targets": [
-      "app",
-      "dmg"
-    ],
     "resources": {
-      "../.tauri-helper/June.app": "native/bin/June.app",
-      "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app",
       "../.tauri-hermes/hermes": "native/hermes"
-    },
-    "macOS": {
-      "bundleName": "June",
-      "entitlements": "Entitlements.plist",
-      "exceptionDomain": "",
-      "frameworks": [],
-      "infoPlist": "Info.plist",
-      "minimumSystemVersion": "14.0"
     }
   }
 }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,5 +1,21 @@
 {
   "build": {
     "runner": "../scripts/cargo-os-scribe-runner.sh"
+  },
+  "bundle": {
+    "targets": ["app", "dmg"],
+    "resources": {
+      "../.tauri-helper/June.app": "native/bin/June.app",
+      "../.tauri-helper/June Dictation Helper.app": "native/bin/June Dictation Helper.app",
+      "../.tauri-hermes/hermes": "native/hermes"
+    },
+    "macOS": {
+      "bundleName": "June",
+      "entitlements": "Entitlements.plist",
+      "exceptionDomain": "",
+      "frameworks": [],
+      "infoPlist": "Info.plist",
+      "minimumSystemVersion": "14.0"
+    }
   }
 }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,10 @@
+{
+  "bundle": {
+    "targets": ["nsis"],
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
+      }
+    }
+  }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,7 +1,22 @@
 {
   "bundle": {
+    "publisher": "Open Software Network",
     "targets": ["nsis"],
     "windows": {
+      "digestAlgorithm": "sha256",
+      "timestampUrl": "http://timestamp.digicert.com",
+      "signCommand": {
+        "cmd": "powershell.exe",
+        "args": [
+          "-NoLogo",
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-Command",
+          "$script = if (Test-Path 'scripts/windows-sign.ps1') { 'scripts/windows-sign.ps1' } elseif (Test-Path '../scripts/windows-sign.ps1') { '../scripts/windows-sign.ps1' } else { throw 'scripts/windows-sign.ps1 not found.' }; & $script $args[0]",
+          "%1"
+        ]
+      },
       "nsis": {
         "installerIcon": "icons/icon.ico"
       }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -78,7 +78,7 @@ import {
   playRecordingSound,
   preloadRecordingSounds,
 } from "../lib/recording-sounds";
-import { isPrimaryShortcut } from "../lib/platform";
+import { isMacLikePlatform, isPrimaryShortcut } from "../lib/platform";
 import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_GALLERY_EVENT,
@@ -183,11 +183,11 @@ export function App() {
     "none",
   );
   const [bootstrapped, setBootstrapped] = useState(false);
-  // The app launches on a fresh agent session. The handshake is armed during
-  // state init — before AgentWorkspace's first mount consumes it — so the
-  // workspace opens on the hero instead of restoring the last open
-  // conversation.
+  // macOS launches on a fresh agent session. The Windows installer does not
+  // bundle Hermes yet, so Windows starts on meeting notes instead of promising
+  // a turnkey agent runtime.
   const [activeView, setActiveView] = useState<SidebarView>(() => {
+    if (!isMacLikePlatform()) return "notes";
     markAgentNewSessionPending();
     return "agent";
   });

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -78,6 +78,7 @@ import {
   playRecordingSound,
   preloadRecordingSounds,
 } from "../lib/recording-sounds";
+import { isPrimaryShortcut } from "../lib/platform";
 import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_GALLERY_EVENT,
@@ -2560,13 +2561,7 @@ export function isAccessibilityBlocked(state?: string) {
 }
 
 function isCreateNoteShortcut(event: KeyboardEvent) {
-  return (
-    event.key.toLowerCase() === "n" &&
-    event.metaKey &&
-    !event.ctrlKey &&
-    !event.altKey &&
-    !event.shiftKey
-  );
+  return event.key.toLowerCase() === "n" && isPrimaryShortcut(event);
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { isMacLikePlatform } from "../../lib/platform";
 import { osAccountsCancelLogin, osAccountsLogin } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 import { Spinner } from "../ui/Spinner";
@@ -12,6 +13,9 @@ type Props = {
 export function AccountGate({ account, loading, onAccountChanged }: Props) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();
+  const subtitle = isMacLikePlatform()
+    ? "Record conversations, turn them into notes, and dictate with your OpenSoftware account."
+    : "Record conversations and turn them into notes with your OpenSoftware account.";
 
   const cancelInFlight = useCallback(async () => {
     try {
@@ -52,10 +56,7 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
           <JuneMark />
         </span>
         <h1 className="welcome-title">Welcome to June</h1>
-        <p className="welcome-subtitle">
-          Record conversations, turn them into notes, and dictate with your
-          OpenSoftware account.
-        </p>
+        <p className="welcome-subtitle">{subtitle}</p>
 
         {account.configured ? (
           <div className="welcome-providers">

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -258,7 +258,7 @@ export const AgentSessionsList = forwardRef<
           label="Start your first session"
           icon={<IconBubble3 size={28} />}
           title="Put June to work"
-          description="Ask June to check on your Mac, dig through your files, or research a topic. Each session keeps one task's conversation and everything it produces in one place."
+          description="Ask June to check on your computer, dig through your files, or research a topic. Each session keeps one task's conversation and everything it produces in one place."
           action={
             <button
               type="button"

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -495,10 +495,10 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
   {
     key: "health-check",
     icon: <IconHeartBeat size={18} />,
-    title: "Check my Mac's health",
+    title: "Check my computer's health",
     description: "Disk, memory, and login items that need attention.",
     prompt:
-      "Give my Mac a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
+      "Give my computer a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
     action: "run",
   },
   {
@@ -506,7 +506,8 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     icon: <IconMagnifyingGlass size={18} />,
     title: "Find a file",
     description: "Describe what you remember; June tracks it down.",
-    prompt: "Find <a file I half-remember> on my Mac and tell me where it is.",
+    prompt:
+      "Find <a file I half-remember> on my computer and tell me where it is.",
     action: "prefill",
   },
   {
@@ -2945,8 +2946,8 @@ export function AgentWorkspace({
     dispatchAgentSessionStatus({
       sessionId,
       title:
-        hermesSessionItems.find((session) => session.id === sessionId)
-          ?.title ?? "Agent session",
+        hermesSessionItems.find((session) => session.id === sessionId)?.title ??
+        "Agent session",
       status: "cancelled",
       summary: "Stopped.",
       ...activityCounts,
@@ -4011,7 +4012,10 @@ export function AgentWorkspace({
               <p className="agent-hero-footnote">
                 {bridgeStarting || startupSessionHydrationPending
                   ? "Getting June ready…"
-                  : heroPrivacyFootnote(generationModel, generationPrivacyBadge)}
+                  : heroPrivacyFootnote(
+                      generationModel,
+                      generationPrivacyBadge,
+                    )}
               </p>
             </div>
           ) : null}

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../lib/tauri";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
+import { isMacLikePlatform } from "../../lib/platform";
 
 const NO_DICTATIONS: DictationHistoryItemDto[] = [];
 
@@ -90,6 +91,7 @@ export function DictationHistoryView({
   const [hintDismissed, setHintDismissed] = useState(readHintDismissed);
   const [pendingDelete, setPendingDelete] =
     useState<DictationHistoryItemDto | null>(null);
+  const dictationAvailable = isMacLikePlatform();
 
   const loadHistory = useCallback(async () => {
     try {
@@ -209,7 +211,7 @@ export function DictationHistoryView({
         </div>
         {/* Shortcuts live in the header whenever there's history; newcomers
             get them in the empty state instead. */}
-        {items.length > 0 ? (
+        {items.length > 0 && dictationAvailable ? (
           <ShortcutLegend
             className="dictation-shortcuts"
             pushToTalk={pushToTalk}
@@ -250,16 +252,28 @@ export function DictationHistoryView({
         </div>
       ) : items.length === 0 ? (
         <EmptyState
-          label="Start dictating"
+          label={
+            dictationAvailable ? "Start dictating" : "Dictation unavailable"
+          }
           icon={<IconMicrophoneSparkleFilled size={28} />}
-          title="Start dictating anywhere"
-          description="Place your cursor in any app, hold the shortcut, and speak. Your words are transcribed and pasted right where you’re typing."
+          title={
+            dictationAvailable
+              ? "Start dictating anywhere"
+              : "Dictation is only supported on macOS"
+          }
+          description={
+            dictationAvailable
+              ? "Place your cursor in any app, hold the shortcut, and speak. Your words are transcribed and pasted right where you're typing."
+              : "Meeting notes still work with microphone recording on this device."
+          }
           footer={
-            <ShortcutLegend
-              className="shortcut-legend-inline"
-              pushToTalk={pushToTalk}
-              toggle={toggle}
-            />
+            dictationAvailable ? (
+              <ShortcutLegend
+                className="shortcut-legend-inline"
+                pushToTalk={pushToTalk}
+                toggle={toggle}
+              />
+            ) : null
           }
         />
       ) : groups.length === 0 ? (

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -26,6 +26,7 @@ import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
+import { isMacLikePlatform } from "../../lib/platform";
 import {
   NoteFailureBanner,
   userFacingFailureMessage,
@@ -166,6 +167,7 @@ export function NoteEditor({
     systemSource?.permissionState === "denied" ||
     systemSource?.permissionState === "restricted";
   const systemUnsupported = systemSource?.permissionState === "unsupported";
+  const showRecordingOptions = isMacLikePlatform();
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.
   const micDenied = microphoneBlocked;
@@ -432,10 +434,13 @@ export function NoteEditor({
               className="record-shell"
               data-state={shellState}
               data-options-open={
-                !recordingForNote && !processingLock && optionsOpen
+                !recordingForNote &&
+                !processingLock &&
+                showRecordingOptions &&
+                optionsOpen
               }
             >
-              {!recordingForNote && !processingLock ? (
+              {!recordingForNote && !processingLock && showRecordingOptions ? (
                 <div
                   className="record-options-panel"
                   data-open={optionsOpen}
@@ -545,16 +550,18 @@ export function NoteEditor({
                         >
                           <IconMicrophone size={20} />
                         </button>
-                        <button
-                          type="button"
-                          className="record-options-trigger"
-                          aria-label="Recording options"
-                          aria-expanded={optionsOpen}
-                          data-rotated={optionsOpen}
-                          onClick={() => setOptionsOpen((value) => !value)}
-                        >
-                          <IconChevronBottom size={16} />
-                        </button>
+                        {showRecordingOptions ? (
+                          <button
+                            type="button"
+                            className="record-options-trigger"
+                            aria-label="Recording options"
+                            aria-expanded={optionsOpen}
+                            data-rotated={optionsOpen}
+                            onClick={() => setOptionsOpen((value) => !value)}
+                          >
+                            <IconChevronBottom size={16} />
+                          </button>
+                        ) : null}
                       </div>
                     </motion.div>
                   )}

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -17,6 +17,7 @@ import {
 } from "react";
 import type { NoteListItemDto } from "../../lib/tauri";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
+import { primaryShortcutLabel } from "../../lib/platform";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
 
@@ -76,6 +77,7 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(
     // moment the selection drops to zero, keep the bar mounted with data-exit,
     // and unmount when its animation finishes.
     const [exit, setExit] = useState<null | "slide" | "fade">(null);
+    const createNoteShortcut = primaryShortcutLabel("N");
     // The cause of the *next* empty transition, latched by the call sites.
     // Toggling a row can't know it's the last box until the set settles, so
     // unchecking defaults to fade unless a dismiss intent was latched first.
@@ -222,7 +224,7 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(
             <IconPlusMedium size={13} />
             New note
             <kbd className="primary-action-kbd" aria-hidden>
-              ⌘N
+              {createNoteShortcut}
             </kbd>
           </button>
         </header>

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,9 +1,10 @@
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   onboardingResumeStep,
   setOnboardingResumeStep,
 } from "../../lib/onboarding";
+import { isMacLikePlatform } from "../../lib/platform";
 import { dictationSettings, setDictationShortcut } from "../../lib/tauri";
 import type { AccountStatus, DictationShortcutSetting } from "../../lib/tauri";
 import { isSubscriptionActive } from "../../lib/trial-checkout";
@@ -46,12 +47,13 @@ function isFactoryDefaultShortcut(shortcut: DictationShortcutSetting) {
   );
 }
 
-const STEPS: StepId[] = [
+const MAC_STEPS: StepId[] = [
   "sign-in",
   "permissions",
   "trial",
   "dictation-practice",
 ];
+const NON_MAC_STEPS: StepId[] = ["sign-in", "permissions", "trial"];
 
 type Props = {
   account: AccountStatus;
@@ -60,10 +62,10 @@ type Props = {
   onComplete: () => void;
 };
 
-function initialStepIndex(): number {
+function initialStepIndex(steps: StepId[]): number {
   const saved = onboardingResumeStep();
   if (!saved) return 0;
-  const index = STEPS.indexOf(saved as StepId);
+  const index = steps.indexOf(saved as StepId);
   return index === -1 ? 0 : index;
 }
 
@@ -73,13 +75,18 @@ export function OnboardingFlow({
   onRefreshAccount,
   onComplete,
 }: Props) {
+  const steps = useMemo(
+    () => (isMacLikePlatform() ? MAC_STEPS : NON_MAC_STEPS),
+    [],
+  );
+  const supportsDictationPractice = steps.includes("dictation-practice");
   const [stepIndex, setStepIndex] = useState(() => {
-    const initial = initialStepIndex();
-    return account.signedIn && STEPS[initial] === "sign-in" ? 1 : initial;
+    const initial = initialStepIndex(steps);
+    return account.signedIn && steps[initial] === "sign-in" ? 1 : initial;
   });
   const [shortcutLabel, setShortcutLabel] = useState("fn");
 
-  const stepId = STEPS[stepIndex];
+  const stepId = steps[stepIndex];
 
   // Everything past sign-in needs an account; a resume point past it with a
   // signed-out account (keychain cleared, signed out elsewhere) would strand
@@ -116,6 +123,7 @@ export function OnboardingFlow({
   // wizard run, not per practice-step mount, so a key rebound on the
   // practice screen survives stepping back and forward.
   useEffect(() => {
+    if (!supportsDictationPractice) return;
     dictationSettings()
       .then(({ settings }) => {
         const current = settings.pushToTalkShortcut;
@@ -132,10 +140,14 @@ export function OnboardingFlow({
         );
       })
       .catch(() => undefined);
-  }, []);
+  }, [supportsDictationPractice]);
 
   function goNext() {
-    setStepIndex((index) => Math.min(index + 1, STEPS.length - 1));
+    if (stepIndex >= steps.length - 1) {
+      onComplete();
+      return;
+    }
+    setStepIndex((index) => Math.min(index + 1, steps.length - 1));
   }
 
   function goBack() {
@@ -143,7 +155,7 @@ export function OnboardingFlow({
       let next = Math.max(index - 1, firstReachableStepIndex);
       // The trial step auto-skips forward for subscribed users; stepping
       // back onto it would just bounce, so hop over it instead.
-      if (STEPS[next] === "trial" && isSubscriptionActive(account)) {
+      if (steps[next] === "trial" && isSubscriptionActive(account)) {
         next = Math.max(next - 1, firstReachableStepIndex);
       }
       return next;
@@ -166,9 +178,9 @@ export function OnboardingFlow({
         ) : null}
         <nav
           className="onboarding-progress"
-          aria-label={`Setup progress: step ${stepIndex + 1} of ${STEPS.length}`}
+          aria-label={`Setup progress: step ${stepIndex + 1} of ${steps.length}`}
         >
-          {STEPS.map((id, index) => (
+          {steps.map((id, index) => (
             <span
               key={id}
               className="onboarding-progress-seg"

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -37,7 +37,11 @@ function PermissionRow({
   onAllow?: () => void;
 }) {
   return (
-    <li className="onboarding-perm" data-granted={granted} data-probing={probing}>
+    <li
+      className="onboarding-perm"
+      data-granted={granted}
+      data-probing={probing}
+    >
       <span className="onboarding-perm-icon" aria-hidden>
         {granted ? <IconCheckmark1Small size={15} /> : icon}
       </span>
@@ -82,6 +86,7 @@ export function PermissionsStep({
   // explains itself and stays out of the Continue gate.
   const systemAudioUnsupported = systemAudioStatus === "unsupported";
   const showPermissionRows = statuses.checked || showUnknownStatuses;
+  const macLikePlatform = isMacLikePlatform();
 
   // Fire the native TCC prompt as soon as the screen shows — the user just
   // read why we're asking, so the dialog lands in context. No-op when
@@ -123,7 +128,11 @@ export function PermissionsStep({
   return (
     <StepCard
       title="Let June listen and type"
-      subtitle="Dictation and meeting notes need three macOS permissions."
+      subtitle={
+        macLikePlatform
+          ? "Dictation and meeting notes need three macOS permissions."
+          : "Dictation and meeting notes need microphone access."
+      }
       wide
     >
       <ul
@@ -151,48 +160,66 @@ export function PermissionsStep({
               : undefined
           }
         />
-        <PermissionRow
-          icon={<IconTextIndicator size={15} />}
-          granted={showPermissionRows && accessibilityGranted}
-          title="Accessibility"
-          detail="Types your words at your cursor, in any app."
-          onAllow={showPermissionRows ? openAccessibilitySettings : undefined}
-        />
-        <PermissionRow
-          icon={<IconVolumeFull size={15} />}
-          granted={showPermissionRows && systemAudioGranted}
-          probing={showPermissionRows && systemAudioStatus === "probing"}
-          title="System audio"
-          detail={
-            systemAudioDenied
-              ? "Turned off in System Settings. Flip the toggle and June will notice."
-              : systemAudioUnsupported
-                ? "Needs macOS 14.2 or later."
-                : systemAudioStatus === "probing"
-                  ? "Waiting for macOS. Approve the prompt when it appears."
-                  : "Hears your calls and meetings, only while you record."
-          }
-          onAllow={
-            showPermissionRows
-              ? systemAudioDenied
-                ? () => void openPrivacySettings("systemAudio")
-                : systemAudioStatus === "unknown"
-                  ? onAllowSystemAudio
+        {macLikePlatform ? (
+          <>
+            <PermissionRow
+              icon={<IconTextIndicator size={15} />}
+              granted={showPermissionRows && accessibilityGranted}
+              title="Accessibility"
+              detail="Types your words at your cursor, in any app."
+              onAllow={
+                showPermissionRows ? openAccessibilitySettings : undefined
+              }
+            />
+            <PermissionRow
+              icon={<IconVolumeFull size={15} />}
+              granted={showPermissionRows && systemAudioGranted}
+              probing={showPermissionRows && systemAudioStatus === "probing"}
+              title="System audio"
+              detail={
+                systemAudioDenied
+                  ? "Turned off in System Settings. Flip the toggle and June will notice."
+                  : systemAudioUnsupported
+                    ? "Needs macOS 14.2 or later."
+                    : systemAudioStatus === "probing"
+                      ? "Waiting for macOS. Approve the prompt when it appears."
+                      : "Hears your calls and meetings, only while you record."
+              }
+              onAllow={
+                showPermissionRows
+                  ? systemAudioDenied
+                    ? () => void openPrivacySettings("systemAudio")
+                    : systemAudioStatus === "unknown"
+                      ? onAllowSystemAudio
+                      : undefined
                   : undefined
-              : undefined
-          }
-        />
+              }
+            />
+          </>
+        ) : null}
       </ul>
       <StepActions
         onContinue={onContinue}
         continueDisabled={
           !showPermissionRows ||
           !micGranted ||
-          !accessibilityGranted ||
-          !(systemAudioGranted || systemAudioUnsupported)
+          (macLikePlatform &&
+            (!accessibilityGranted ||
+              !(systemAudioGranted || systemAudioUnsupported)))
         }
         onSkip={onContinue}
       />
     </StepCard>
   );
+}
+
+function isMacLikePlatform() {
+  const platform =
+    typeof navigator === "undefined"
+      ? ""
+      : `${navigator.platform} ${navigator.userAgent}`;
+  if (/Windows|Win32|Win64|Linux|Android/i.test(platform)) {
+    return false;
+  }
+  return true;
 }

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -8,6 +8,7 @@ import {
   dictationHelperCommand,
   openPrivacySettings,
 } from "../../../lib/tauri";
+import { isMacLikePlatform } from "../../../lib/platform";
 import { StepActions, StepCard } from "../StepChrome";
 import {
   isAccessibilityGranted,
@@ -211,15 +212,4 @@ export function PermissionsStep({
       />
     </StepCard>
   );
-}
-
-function isMacLikePlatform() {
-  const platform =
-    typeof navigator === "undefined"
-      ? ""
-      : `${navigator.platform} ${navigator.userAgent}`;
-  if (/Windows|Win32|Win64|Linux|Android/i.test(platform)) {
-    return false;
-  }
-  return true;
 }

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -9,8 +9,9 @@ import { OsMark } from "../../account/AccountGate";
 import { Spinner } from "../../ui/Spinner";
 import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 
-// What June is, in three rows: the agent is the product, dictation and
-// meeting notes are how you talk to it, and private is why it's safe to.
+// macOS can introduce the full agent, dictation, and notes surface because the
+// release bundle includes the runtime and helpers. Windows narrows the welcome
+// promise below until its Hermes and dictation support is turnkey.
 const JUNE_POINTS = [
   {
     icon: IconSparkle,
@@ -31,7 +32,11 @@ const JUNE_POINTS = [
 ];
 
 const WINDOWS_JUNE_POINTS = [
-  JUNE_POINTS[0],
+  {
+    icon: IconSparkle,
+    title: "Desktop notes for your work",
+    detail: "Keep meeting notes and projects together in one app.",
+  },
   {
     icon: IconMicrophone,
     title: "Meeting notes from your mic",

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -13,7 +13,7 @@ import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 const JUNE_POINTS = [
   {
     icon: IconSparkle,
-    title: "An agent on your Mac",
+    title: "An agent on your computer",
     detail: "Hand June real work. It runs the session and comes back done.",
   },
   {
@@ -25,7 +25,7 @@ const JUNE_POINTS = [
     icon: IconLock,
     title: "Private by default",
     detail:
-      "Prompts leave your Mac only for inference, on zero-retention models by default.",
+      "Prompts leave your device only for inference, on zero-retention models by default.",
   },
 ];
 

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { IconLock } from "central-icons/IconLock";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSparkle } from "central-icons/IconSparkle";
+import { isMacLikePlatform } from "../../../lib/platform";
 import { osAccountsCancelLogin, osAccountsLogin } from "../../../lib/tauri";
 import type { AccountStatus } from "../../../lib/tauri";
 import { OsMark } from "../../account/AccountGate";
@@ -29,6 +30,16 @@ const JUNE_POINTS = [
   },
 ];
 
+const WINDOWS_JUNE_POINTS = [
+  JUNE_POINTS[0],
+  {
+    icon: IconMicrophone,
+    title: "Meeting notes from your mic",
+    detail: "Record meetings from your microphone and turn them into notes.",
+  },
+  JUNE_POINTS[2],
+];
+
 /**
  * Step 1: welcome + sign-in, fused into one screen so the wizard frames the
  * very first thing a new user sees. The browser handoff resolves through the
@@ -46,6 +57,7 @@ export function SignInStep({
 }) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();
+  const points = isMacLikePlatform() ? JUNE_POINTS : WINDOWS_JUNE_POINTS;
 
   const cancelInFlight = useCallback(async () => {
     try {
@@ -88,7 +100,7 @@ export function SignInStep({
       wide
     >
       <ul className="onboarding-points">
-        {JUNE_POINTS.map(({ icon: Icon, title, detail }) => (
+        {points.map(({ icon: Icon, title, detail }) => (
           <li key={title}>
             <span className="onboarding-point-icon" aria-hidden>
               <Icon size={15} />

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1075,23 +1075,25 @@ export function AppSettings({
                   </div>
                 </div>
 
-                <MicTestControl
-                  state={micTestState}
-                  level={micTestLevel}
-                  elapsedMs={micTestElapsedMs}
-                  sampleSrc={micTestSampleSrc}
-                  error={micTestError}
-                  playing={micTestPlaying}
-                  durationSeconds={MIC_TEST_DURATION_SECONDS}
-                  onStart={() => void startMicTest()}
-                  onStartOver={() => void startOverMicTest()}
-                  onPlaybackError={() => {
-                    setMicTestError(
-                      "Microphone test recorded, but playback is unavailable.",
-                    );
-                  }}
-                  onPlayingChange={setMicTestPlaying}
-                />
+                {macLikePlatform ? (
+                  <MicTestControl
+                    state={micTestState}
+                    level={micTestLevel}
+                    elapsedMs={micTestElapsedMs}
+                    sampleSrc={micTestSampleSrc}
+                    error={micTestError}
+                    playing={micTestPlaying}
+                    durationSeconds={MIC_TEST_DURATION_SECONDS}
+                    onStart={() => void startMicTest()}
+                    onStartOver={() => void startOverMicTest()}
+                    onPlaybackError={() => {
+                      setMicTestError(
+                        "Microphone test recorded, but playback is unavailable.",
+                      );
+                    }}
+                    onPlayingChange={setMicTestPlaying}
+                  />
+                ) : null}
 
                 {systemUnavailable ? null : (
                   <div className="settings-row">

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -663,7 +663,7 @@ export function AppSettings({
     ? "Input device used for dictation."
     : defaultMicrophone?.name
       ? `Auto-detect uses ${defaultMicrophone.name}.`
-      : "Auto-detect uses the current macOS input.";
+      : "Auto-detect uses the current system input.";
   const microphoneOptions = [
     { id: undefined, name: "Auto-detect" },
     ...microphones,

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -61,6 +61,7 @@ import {
   setStoredTheme,
   type ThemePreference,
 } from "../../lib/theme";
+import { isMacLikePlatform } from "../../lib/platform";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
 import { ProviderLogo } from "./ProviderLogo";
@@ -268,6 +269,7 @@ export function AppSettings({
   const [micTestPlaying, setMicTestPlaying] = useState(false);
   const controlled = controlledTab !== undefined && onTabChange !== undefined;
   const activeTab = controlled ? controlledTab : internalTab;
+  const macLikePlatform = isMacLikePlatform();
   const setActiveTab = (tab: SettingsTab) => {
     if (controlled) {
       onTabChange?.(tab);
@@ -286,7 +288,7 @@ export function AppSettings({
   );
   const systemState = systemReadiness?.permissionState;
   const systemDenied = systemState === "denied" || systemState === "restricted";
-  const systemUnsupported = systemState === "unsupported";
+  const systemUnavailable = !macLikePlatform || systemState === "unsupported";
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;
@@ -862,48 +864,66 @@ export function AppSettings({
             </h2>
             <div className="settings-card">
               <div className="settings-rows">
-                <ShortcutRow
-                  title="Push to talk"
-                  description="Hold this shortcut to dictate, then release to paste."
-                  shortcut={settings.pushToTalkShortcut}
-                  defaultShortcut={DEFAULT_SHORTCUTS.push_to_talk}
-                  capturing={capturingShortcut === "push_to_talk"}
-                  disabled={
-                    !!capturingShortcut && capturingShortcut !== "push_to_talk"
-                  }
-                  error={
-                    capturingShortcut === "push_to_talk"
-                      ? shortcutError
-                      : undefined
-                  }
-                  onChange={() => void startShortcutCapture("push_to_talk")}
-                  onReset={() =>
-                    void saveShortcut(
-                      "push_to_talk",
-                      DEFAULT_SHORTCUTS.push_to_talk,
-                    )
-                  }
-                  onCancel={() => void cancelShortcutCapture()}
-                />
+                {macLikePlatform ? (
+                  <>
+                    <ShortcutRow
+                      title="Push to talk"
+                      description="Hold this shortcut to dictate, then release to paste."
+                      shortcut={settings.pushToTalkShortcut}
+                      defaultShortcut={DEFAULT_SHORTCUTS.push_to_talk}
+                      capturing={capturingShortcut === "push_to_talk"}
+                      disabled={
+                        !!capturingShortcut &&
+                        capturingShortcut !== "push_to_talk"
+                      }
+                      error={
+                        capturingShortcut === "push_to_talk"
+                          ? shortcutError
+                          : undefined
+                      }
+                      onChange={() => void startShortcutCapture("push_to_talk")}
+                      onReset={() =>
+                        void saveShortcut(
+                          "push_to_talk",
+                          DEFAULT_SHORTCUTS.push_to_talk,
+                        )
+                      }
+                      onCancel={() => void cancelShortcutCapture()}
+                    />
 
-                <ShortcutRow
-                  title="Toggle dictation"
-                  description="Press this shortcut to start or stop dictation."
-                  shortcut={settings.toggleShortcut}
-                  defaultShortcut={DEFAULT_SHORTCUTS.toggle}
-                  capturing={capturingShortcut === "toggle"}
-                  disabled={
-                    !!capturingShortcut && capturingShortcut !== "toggle"
-                  }
-                  error={
-                    capturingShortcut === "toggle" ? shortcutError : undefined
-                  }
-                  onChange={() => void startShortcutCapture("toggle")}
-                  onReset={() =>
-                    void saveShortcut("toggle", DEFAULT_SHORTCUTS.toggle)
-                  }
-                  onCancel={() => void cancelShortcutCapture()}
-                />
+                    <ShortcutRow
+                      title="Toggle dictation"
+                      description="Press this shortcut to start or stop dictation."
+                      shortcut={settings.toggleShortcut}
+                      defaultShortcut={DEFAULT_SHORTCUTS.toggle}
+                      capturing={capturingShortcut === "toggle"}
+                      disabled={
+                        !!capturingShortcut && capturingShortcut !== "toggle"
+                      }
+                      error={
+                        capturingShortcut === "toggle"
+                          ? shortcutError
+                          : undefined
+                      }
+                      onChange={() => void startShortcutCapture("toggle")}
+                      onReset={() =>
+                        void saveShortcut("toggle", DEFAULT_SHORTCUTS.toggle)
+                      }
+                      onCancel={() => void cancelShortcutCapture()}
+                    />
+                  </>
+                ) : (
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">
+                        Dictation shortcuts unavailable
+                      </h3>
+                      <p className="settings-row-description">
+                        Global dictation shortcuts are only supported on macOS.
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           </section>
@@ -1073,7 +1093,7 @@ export function AppSettings({
                   onPlayingChange={setMicTestPlaying}
                 />
 
-                {systemUnsupported ? null : (
+                {systemUnavailable ? null : (
                   <div className="settings-row">
                     <div className="settings-row-info">
                       <h3 className="settings-row-title">System audio</h3>
@@ -1295,14 +1315,16 @@ function PermissionsSettingsSection({
   onEnableAccessibility?: () => void;
   onEnableSystemAudio: () => void;
 }) {
+  const macLikePlatform = isMacLikePlatform();
   return (
     <section className="settings-group" aria-labelledby="permissions-heading">
       <h2 id="permissions-heading" className="settings-group-heading">
         System permissions
       </h2>
       <p className="settings-group-description">
-        macOS access used for recording audio, pasting dictation, and capturing
-        system sound.
+        {macLikePlatform
+          ? "macOS access used for recording audio, pasting dictation, and capturing system sound."
+          : "Access used for recording audio."}
       </p>
       <div className="settings-card">
         <div className="settings-rows">
@@ -1316,19 +1338,23 @@ function PermissionsSettingsSection({
             onManage={onEnableMicrophone}
           />
 
-          <PermissionRow
-            title="Accessibility"
-            description="Paste dictated text into the active app."
-            status={permissionStatus(accessibilityPermissionStatus)}
-            onManage={onEnableAccessibility}
-          />
+          {macLikePlatform ? (
+            <>
+              <PermissionRow
+                title="Accessibility"
+                description="Paste dictated text into the active app."
+                status={permissionStatus(accessibilityPermissionStatus)}
+                onManage={onEnableAccessibility}
+              />
 
-          <PermissionRow
-            title="System audio"
-            description="Record audio from other apps when system audio is enabled."
-            status={sourcePermissionStatus(systemReadiness)}
-            onManage={onEnableSystemAudio}
-          />
+              <PermissionRow
+                title="System audio"
+                description="Record audio from other apps when system audio is enabled."
+                status={sourcePermissionStatus(systemReadiness)}
+                onManage={onEnableSystemAudio}
+              />
+            </>
+          ) : null}
         </div>
       </div>
     </section>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -51,6 +51,7 @@ import {
 import { messageFromError } from "../../lib/errors";
 import { NOTE_DND_MIME } from "../../lib/dnd";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
+import { isPrimaryShortcut, primaryShortcutLabel } from "../../lib/platform";
 import type {
   AccountStatus,
   HermesSessionInfo,
@@ -239,6 +240,7 @@ export function Sidebar({
   const [commandActiveIndex, setCommandActiveIndex] = useState(0);
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [identityMenuOpen, setIdentityMenuOpen] = useState(false);
+  const searchShortcut = primaryShortcutLabel("K");
   const inSettings = activeView === "settings";
   const [allAgentSessions, setAgentSessions] = useState<HermesSessionInfo[]>(
     [],
@@ -859,7 +861,7 @@ export function Sidebar({
               readOnly
             />
             <span className="sidebar-search-kbd" aria-hidden="true">
-              ⌘ K
+              {searchShortcut}
             </span>
           </label>
 
@@ -1486,13 +1488,7 @@ function normalizeCommandQuery(value: string) {
 }
 
 function isSearchShortcut(event: KeyboardEvent) {
-  return (
-    event.key.toLowerCase() === "k" &&
-    event.metaKey &&
-    !event.ctrlKey &&
-    !event.altKey &&
-    !event.shiftKey
-  );
+  return event.key.toLowerCase() === "k" && isPrimaryShortcut(event);
 }
 
 // The user's name is the settings entry point: clicking it opens a small

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -35,7 +35,7 @@ export function dispatchProviderModelSettingsChanged(
 }
 
 export const E2EE_MODEL_DESCRIPTION =
-  "Private model with end-to-end encryption. Your prompt is encrypted on your Mac and only decrypted inside a hardware-secured enclave (TEE); the response is encrypted before it leaves the enclave. No prompt data is ever readable by the model provider or its infrastructure.";
+  "Private model with end-to-end encryption. Your prompt is encrypted on your device and only decrypted inside a hardware-secured enclave (TEE); the response is encrypted before it leaves the enclave. No prompt data is ever readable by the model provider or its infrastructure.";
 export const PRIVATE_MODEL_DESCRIPTION =
   "Private model with zero data retention. No prompt data is stored, shared with a third party, or trained on.";
 export const ANONYMOUS_MODEL_DESCRIPTION =

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,24 @@
+export function isMacLikePlatform() {
+  const platform =
+    typeof navigator === "undefined"
+      ? ""
+      : `${navigator.platform} ${navigator.userAgent}`;
+  if (/Windows|Win32|Win64|Linux|Android/i.test(platform)) {
+    return false;
+  }
+  return true;
+}
+
+export function primaryShortcutLabel(key: string) {
+  return isMacLikePlatform() ? `⌘ ${key}` : `Ctrl ${key}`;
+}
+
+export function isPrimaryShortcut(
+  event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+) {
+  if (event.altKey || event.shiftKey) return false;
+  if (isMacLikePlatform()) {
+    return event.metaKey && !event.ctrlKey;
+  }
+  return event.ctrlKey && !event.metaKey;
+}

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -861,6 +861,11 @@ describe("AppSettings", () => {
           name: "Capture system audio for notes",
         }),
       ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", {
+          name: "Start test",
+        }),
+      ).not.toBeInTheDocument();
 
       await userEvent.click(screen.getByRole("tab", { name: "Shortcuts" }));
       expect(

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -130,6 +130,31 @@ const signedInAccount = {
   balance: { usdMillis: 1200 },
 };
 
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
 describe("AppSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -755,6 +780,96 @@ describe("AppSettings", () => {
     expect(onEnableMicrophone).toHaveBeenCalledTimes(1);
     expect(onEnableAccessibility).toHaveBeenCalledTimes(1);
     expect(onEnableSystemAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it("only lists microphone permissions on Windows", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    const onEnableMicrophone = vi.fn();
+    const onEnableAccessibility = vi.fn();
+    const onEnableSystemAudio = vi.fn();
+
+    try {
+      render(
+        <AppSettings
+          account={signedInAccount}
+          accountLoading={false}
+          sourceMode="microphoneOnly"
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: false,
+            checkedAt: "2026-06-08T12:00:00Z",
+            sources: [
+              {
+                source: "microphone",
+                required: true,
+                ready: false,
+                permissionState: "denied",
+                deviceAvailable: false,
+                captureAvailable: false,
+                recoveryAction: "openMicrophoneSettings",
+              },
+              {
+                source: "system",
+                required: true,
+                ready: false,
+                permissionState: "denied",
+                deviceAvailable: true,
+                captureAvailable: false,
+                recoveryAction: "openSystemAudioSettings",
+              },
+            ],
+          }}
+          checkingSourceReadiness={false}
+          microphonePermissionStatus="denied"
+          accessibilityPermissionStatus="missing"
+          onAccountChanged={vi.fn()}
+          onAccountRefresh={vi.fn()}
+          onSourceModeChange={vi.fn()}
+          onEnableMicrophone={onEnableMicrophone}
+          onEnableAccessibility={onEnableAccessibility}
+          onEnableSystemAudio={onEnableSystemAudio}
+        />,
+      );
+
+      expect(
+        screen.getByText("Access used for recording audio."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Microphone")).toBeInTheDocument();
+      expect(screen.queryByText("Accessibility")).not.toBeInTheDocument();
+      expect(screen.queryByText("System audio")).not.toBeInTheDocument();
+
+      const microphoneRow = screen
+        .getByText("Microphone")
+        .closest(".settings-row");
+      expect(microphoneRow).not.toBeNull();
+      await userEvent.click(
+        within(microphoneRow as HTMLElement).getByRole("button", {
+          name: "Manage Microphone permission",
+        }),
+      );
+
+      expect(onEnableMicrophone).toHaveBeenCalledTimes(1);
+      expect(onEnableAccessibility).not.toHaveBeenCalled();
+      expect(onEnableSystemAudio).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
+      expect(
+        screen.queryByRole("switch", {
+          name: "Capture system audio for notes",
+        }),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("tab", { name: "Shortcuts" }));
+      expect(
+        screen.getByText("Dictation shortcuts unavailable"),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("records push-to-talk and toggle dictation shortcuts in settings", async () => {

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -348,6 +348,42 @@ describe("App shortcuts", () => {
     expect(mocks.createNote).not.toHaveBeenCalled();
   });
 
+  it("uses Windows sign-in copy and opens meeting notes after sign-in", async () => {
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    mocks.osAccountsStatus.mockResolvedValue({
+      signedIn: false,
+      configured: true,
+    });
+
+    try {
+      render(<App />);
+
+      expect(
+        await screen.findByText(
+          "Record conversations and turn them into notes with your OpenSoftware account.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/dictate with/)).not.toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("button", { name: "Continue with OpenSoftware" }),
+      );
+
+      expect(
+        await screen.findByRole("button", { name: "New note" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: HERO_GREETING }),
+      ).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("does not flash the sign-in gate while account status is loading", async () => {
     let resolveStatus: ((status: AccountStatus) => void) | undefined;
     mocks.osAccountsStatus.mockReturnValue(

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -11,6 +11,31 @@ const HERO_GREETING = new RegExp(
   `^(?:${HERO_GREETINGS.map((greeting) => greeting.replace("?", "\\?")).join("|")})$`,
 );
 
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
 const mocks = vi.hoisted(() => ({
   listen: vi.fn(),
   listeners: new Map<string, (event: { payload?: unknown }) => void>(),
@@ -225,6 +250,29 @@ describe("App shortcuts", () => {
     expect(
       await screen.findByRole("heading", { name: "Appearance" }),
     ).toBeInTheDocument();
+  });
+
+  it("creates a loose note with Ctrl-N on Windows", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(<App />);
+
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      fireEvent.keyDown(window, { key: "n", metaKey: true });
+      expect(mocks.createNote).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(window, { key: "n", ctrlKey: true });
+
+      await waitFor(() =>
+        expect(mocks.createNote).toHaveBeenCalledWith(undefined),
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("returns to the note after opening its folder from the note header", async () => {

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -12,6 +12,31 @@ const mocks = vi.hoisted(() => ({
   writeText: vi.fn(),
 }));
 
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
 vi.mock("../lib/tauri", () => ({
   listDictationHistory: mocks.listDictationHistory,
   deleteDictationHistoryItem: mocks.deleteDictationHistoryItem,
@@ -98,6 +123,34 @@ describe("DictationHistoryView", () => {
     await waitFor(() =>
       expect(mocks.writeText).toHaveBeenCalledWith("Send the follow up. "),
     );
+  });
+
+  it("does not advertise shortcut dictation on Windows", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      mocks.listDictationHistory.mockResolvedValue({
+        retentionDays: 7,
+        items: [],
+      });
+
+      render(<DictationHistoryView />);
+
+      expect(
+        await screen.findByText("Dictation is only supported on macOS"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Meeting notes still work with microphone recording on this device.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("Dictation shortcuts")).toBeNull();
+      expect(screen.queryByText("Start dictating anywhere")).toBeNull();
+    } finally {
+      restoreNavigator();
+    }
   });
 
   function manyItems(count: number) {

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -46,6 +46,31 @@ const notes: NoteListItemDto[] = [
   },
 ];
 
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
 function baseProps() {
   return {
     folders,
@@ -134,6 +159,38 @@ describe("Sidebar primary navigation", () => {
     fireEvent.keyDown(search, { key: "Escape" });
 
     expect(screen.queryByRole("dialog", { name: "Search" })).toBeNull();
+  });
+
+  it("shows and accepts the Windows command palette shortcut", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(
+        <Sidebar
+          notes={notes}
+          activeView="notes"
+          onChangeView={vi.fn()}
+          onSelectNote={vi.fn()}
+          onDeleteNote={vi.fn()}
+          onOpenMoveDialog={vi.fn()}
+          onRemoveNoteFromFolder={vi.fn()}
+          onNewAgentSession={vi.fn()}
+          onSelectAgentSession={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("Ctrl K")).toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+
+      const palette = screen.getByRole("dialog", { name: "Search" });
+      const search = within(palette).getByRole("searchbox", { name: "Search" });
+      await waitFor(() => expect(search).toHaveFocus());
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("opens the command palette when clicking the sidebar search", async () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -56,6 +56,31 @@ const recovery: RecoverableRecordingDto = {
   bytesFound: 4096,
 };
 
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
 describe("NoteEditor", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -415,6 +440,57 @@ describe("NoteEditor", () => {
     expect(
       screen.queryByRole("status", { name: "Recording consent reminder" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("hides system audio recording options on Windows", () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(
+        <NoteEditor
+          {...props}
+          note={note()}
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: false,
+            checkedAt: now,
+            sources: [
+              {
+                source: "microphone",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+              {
+                source: "system",
+                required: true,
+                ready: false,
+                permissionState: "unsupported",
+                deviceAvailable: false,
+                captureAvailable: false,
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: "Record" })).toBeEnabled();
+      expect(
+        screen.queryByRole("button", { name: "Recording options" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Capture system audio"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("System audio requires macOS 14.2 or later."),
+      ).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("surfaces a dismissible consent reminder after the recorder settles", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -429,6 +429,9 @@ describe("OnboardingFlow", () => {
 
       await screen.findByRole("heading", { name: "Welcome to June" });
       expect(
+        screen.getByText("Desktop notes for your work"),
+      ).toBeInTheDocument();
+      expect(
         screen.getByText("Meeting notes from your mic"),
       ).toBeInTheDocument();
       expect(
@@ -441,6 +444,9 @@ describe("OnboardingFlow", () => {
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText(/Dictate into any app/),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("An agent on your computer"),
       ).not.toBeInTheDocument();
     } finally {
       restoreNavigator();

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -13,10 +13,7 @@ import {
   setOnboardingResumeStep,
   subscribeToOnboardingComplete,
 } from "../lib/onboarding";
-import type {
-  AccountStatus,
-  RecordingSourceReadinessDto,
-} from "../lib/tauri";
+import type { AccountStatus, RecordingSourceReadinessDto } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
@@ -188,6 +185,34 @@ describe("OnboardingFlow", () => {
         payload: { microphone: "granted", accessibility: "granted" },
       }),
     });
+  }
+
+  function stubNavigatorPlatform(platform: string, userAgent: string) {
+    const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+    const ownUserAgent = Object.getOwnPropertyDescriptor(
+      navigator,
+      "userAgent",
+    );
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      get: () => platform,
+    });
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      get: () => userAgent,
+    });
+    return () => {
+      if (ownPlatform) {
+        Object.defineProperty(navigator, "platform", ownPlatform);
+      } else {
+        Reflect.deleteProperty(navigator, "platform");
+      }
+      if (ownUserAgent) {
+        Object.defineProperty(navigator, "userAgent", ownUserAgent);
+      } else {
+        Reflect.deleteProperty(navigator, "userAgent");
+      }
+    };
   }
 
   it("walks the full flow for a subscribed user", async () => {
@@ -708,6 +733,36 @@ describe("OnboardingFlow", () => {
         type: "request_microphone_permission",
       }),
     );
+  });
+
+  it("only requires microphone access on Windows", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      await renderFlow();
+
+      expect(
+        screen.getByText("Dictation and meeting notes need microphone access."),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Accessibility")).not.toBeInTheDocument();
+      expect(screen.queryByText("System audio")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+
+      emitDictationEvent?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("probes system audio when the permissions screen shows", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -215,6 +215,13 @@ describe("OnboardingFlow", () => {
     };
   }
 
+  function stubMacNavigatorPlatform() {
+    return stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+    );
+  }
+
   it("walks the full flow for a subscribed user", async () => {
     const user = userEvent.setup();
     const onComplete = await renderFlow();
@@ -765,47 +772,58 @@ describe("OnboardingFlow", () => {
     }
   });
 
-  it("probes system audio when the permissions screen shows", async () => {
+  it("probes system audio when the macOS permissions screen shows", async () => {
     // The probe is what surfaces the system-audio TCC prompt on a fresh
     // install; it must fire here, in context, not after onboarding.
-    await renderFlow();
-    await waitFor(() =>
-      expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledWith(
-        "microphonePlusSystem",
-      ),
-    );
+    const restoreNavigator = stubMacNavigatorPlatform();
+    try {
+      await renderFlow();
+      await waitFor(() =>
+        expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledWith(
+          "microphonePlusSystem",
+        ),
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("keeps continue locked and falls back to settings when system audio is denied", async () => {
     const user = userEvent.setup();
+    const restoreNavigator = stubMacNavigatorPlatform();
     mocks.checkRecordingSourceReadiness.mockResolvedValue(
       systemAudioReadiness(false),
     );
-    await renderFlow();
-    grantPermissions();
+    try {
+      await renderFlow();
+      grantPermissions();
 
-    await screen.findByText(
-      "Turned off in System Settings. Flip the toggle and June will notice.",
-    );
-    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+      await screen.findByText(
+        "Turned off in System Settings. Flip the toggle and June will notice.",
+      );
+      expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 
-    await user.click(
-      screen.getByRole("button", { name: "Allow system audio access" }),
-    );
-    expect(mocks.openPrivacySettings).toHaveBeenCalledWith("systemAudio");
+      await user.click(
+        screen.getByRole("button", { name: "Allow system audio access" }),
+      );
+      expect(mocks.openPrivacySettings).toHaveBeenCalledWith("systemAudio");
 
-    // The user flips the toggle and comes back; the focus re-probe picks
-    // up the grant.
-    mocks.checkRecordingSourceReadiness.mockResolvedValue(
-      systemAudioReadiness(true),
-    );
-    window.dispatchEvent(new Event("focus"));
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
-    );
+      // The user flips the toggle and comes back; the focus re-probe picks
+      // up the grant.
+      mocks.checkRecordingSourceReadiness.mockResolvedValue(
+        systemAudioReadiness(true),
+      );
+      window.dispatchEvent(new Event("focus"));
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("does not block continue when system audio is unsupported", async () => {
+    const restoreNavigator = stubMacNavigatorPlatform();
     const readiness = systemAudioReadiness(false);
     const sysIdx = readiness.sources.findIndex((s) => s.source === "system");
     readiness.sources[sysIdx] = {
@@ -813,13 +831,17 @@ describe("OnboardingFlow", () => {
       permissionState: "unsupported",
     };
     mocks.checkRecordingSourceReadiness.mockResolvedValue(readiness);
-    await renderFlow();
-    grantPermissions();
+    try {
+      await renderFlow();
+      grantPermissions();
 
-    await screen.findByText("Needs macOS 14.2 or later.");
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
-    );
+      await screen.findByText("Needs macOS 14.2 or later.");
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 });
 

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -419,6 +419,34 @@ describe("OnboardingFlow", () => {
     await waitFor(() => expect(onAccountChanged).toHaveBeenCalledWith(account));
   });
 
+  it("shows Windows-accurate welcome copy", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(<OnboardingFlow {...flowProps({ account: signedOutAccount })} />);
+
+      await screen.findByRole("heading", { name: "Welcome to June" });
+      expect(
+        screen.getByText("Meeting notes from your mic"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Record meetings from your microphone and turn them into notes.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Talk instead of type"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Dictate into any app/),
+      ).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("starts the trial checkout in one click and advances when the subscription lands", async () => {
     const user = userEvent.setup();
     mocks.osAccountsStartTrialCheckout.mockResolvedValue({
@@ -748,7 +776,7 @@ describe("OnboardingFlow", () => {
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
     );
     try {
-      await renderFlow();
+      const onComplete = await renderFlow();
 
       expect(
         screen.getByText("Dictation and meeting notes need microphone access."),
@@ -767,6 +795,12 @@ describe("OnboardingFlow", () => {
       await waitFor(() =>
         expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
       );
+      await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+      await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+      expect(
+        screen.queryByRole("heading", { name: "Talk to June" }),
+      ).not.toBeInTheDocument();
     } finally {
       restoreNavigator();
     }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -90,10 +90,25 @@ if (!HTMLElement.prototype.getBoundingClientRect) {
   HTMLElement.prototype.getBoundingClientRect = () => new DOMRect();
 }
 
+function setNavigatorPlatform(platform: string, userAgent: string) {
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+}
+
 // Existing App tests exercise the signed-in main shell; pre-complete the
 // first-run onboarding so the wizard doesn't gate them. Onboarding tests
 // opt back in by clearing localStorage.
 beforeEach(() => {
+  setNavigatorPlatform(
+    "MacIntel",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+  );
   markOnboardingComplete();
 });
 


### PR DESCRIPTION
## Summary
- split Windows support out from the previous combined Windows + DeepSeek branch
- add Windows Tauri config/build scripts and update desktop CI/build wiring for Windows targets
- gate macOS-only audio, permissions, dictation helper, and OS account behavior behind platform checks
- update user-facing copy/tests from Mac-specific wording to computer/system wording where needed

DeepSeek V4 Flash default model is intentionally not included here. It is split into #292.

## Validation
- `pnpm lint`
- `pnpm exec vitest run src/test/onboarding.test.tsx src/test/agent-workspace.test.tsx src/test/app-settings.test.tsx`
- `pnpm test:rust`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- staged Prettier check for changed JS/TS/JSON/Markdown/YAML files

## Notes
- I validated on macOS locally; Windows packaging/runtime should be verified by CI or a Windows runner.