### PR TITLE
[codex] Make Kimi K2.6 the default text model

### DIFF
--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -89,16 +89,16 @@ model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
 privacy = "private"
 
-# Fallback pricing for the default text model (zai-org-glm-5-1); the live
+# Fallback pricing for the default text model (kimi-k2-6); the live
 # Venice catalog overrides this on boot. Keep in sync with
 # DEFAULT_GENERATION_MODEL in the Tauri providers module.
-[pricing."zai-org-glm-5-1"]
+[pricing."kimi-k2-6"]
 unit = "tokens"
-input_credits_per_million_tokens = 1750
-output_credits_per_million_tokens = 5500
+input_credits_per_million_tokens = 850
+output_credits_per_million_tokens = 4660
 provider = "venice"
 model_type = "text"
-display_name = "GLM 5.1"
+display_name = "Kimi K2.6"
 privacy = "private"
 
 [pricing."zai-org-glm-5"]

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -351,19 +351,19 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     // extends over this on every boot. Keep the first entry in sync with
     // DEFAULT_GENERATION_MODEL in the Tauri providers module.
     pricing.insert(
-        "zai-org-glm-5-1".to_string(),
+        "kimi-k2-6".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Tokens,
             credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(1_750),
-            output_credits_per_million_tokens: Some(5_500),
+            input_credits_per_million_tokens: Some(850),
+            output_credits_per_million_tokens: Some(4_660),
             provider: ModelProvider::Venice,
             model_type: ModelType::Text,
-            display_name: "GLM 5.1".to_string(),
+            display_name: "Kimi K2.6".to_string(),
             description: None,
             privacy: Some("private".to_string()),
             pricing: None,
-            context_tokens: Some(200_000),
+            context_tokens: Some(256_000),
             traits: Vec::new(),
             capabilities: Vec::new(),
         },

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -14,7 +14,7 @@ use tauri::{AppHandle, Manager, State};
 pub const PROVIDER_OPENAI: &str = "openai";
 pub const PROVIDER_VENICE: &str = "venice";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
-pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-1";
+pub const DEFAULT_GENERATION_MODEL: &str = "kimi-k2-6";
 
 // Kept exported under the legacy names so existing callers compile until they
 // migrate to the names above.

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -161,7 +161,7 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
   // Mirrors DEFAULT_GENERATION_MODEL in the Rust providers module and the
   // leading Suggested pick in lib/suggested-models.ts.
-  generationModel: "zai-org-glm-5-1",
+  generationModel: "kimi-k2-6",
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -16,10 +16,10 @@ export type SuggestedModel = {
  * Curation snapshot (June 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
  * index):
- * - GLM 5.1: latest GLM flagship, top-tier agentic coding and tool use among
- *   open models, 200K context, $1.75/$5.50 per 1M tokens — June's default.
  * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
- *   agentic tool runs, 256K context, $0.85/$4.66.
+ *   agentic tool runs, 256K context, $0.85/$4.66 — June's default.
+ * - GLM 5.1: latest GLM flagship, top-tier agentic coding and tool use among
+ *   open models, 200K context, $1.75/$5.50 per 1M tokens.
  * - GLM 4.7: Venice's own catalog default and "function calling default" —
  *   near-flagship quality at a fraction of the price, $0.55/$2.65.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
@@ -35,14 +35,14 @@ export type SuggestedModel = {
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
-      id: "zai-org-glm-5-1",
-      reason:
-        "Best overall: the latest GLM flagship, with top-tier agentic coding and tool use among open models and zero data retention.",
-    },
-    {
       id: "kimi-k2-6",
       reason:
-        "Most capable open-weights model: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
+        "Best overall: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
+    },
+    {
+      id: "zai-org-glm-5-1",
+      reason:
+        "Best GLM pick: latest GLM flagship, with top-tier agentic coding and tool use among open models and zero data retention.",
     },
     {
       id: "zai-org-glm-4.7",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -195,18 +195,18 @@ describe("AgentWorkspace", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5-1",
+        generationModel: "kimi-k2-6",
       },
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "kimi-k2-6",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5-1",
-          name: "GLM 5.1",
+          id: "kimi-k2-6",
+          name: "Kimi K2.6",
           modelType: "text",
           privacy: "private",
           traits: [],
@@ -539,14 +539,14 @@ describe("AgentWorkspace", () => {
 
     // The session composer carries the same model trigger as the hero.
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
     );
 
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
     });
     expect(
-      within(dialog).getByRole("option", { name: /GLM 5.1/ }),
+      within(dialog).getByRole("option", { name: /Kimi K2.6/ }),
     ).toBeInTheDocument();
   });
 
@@ -556,8 +556,8 @@ describe("AgentWorkspace", () => {
     const catalog = [
       {
         provider: "venice",
-        id: "zai-org-glm-5-1",
-        name: "GLM 5.1",
+        id: "kimi-k2-6",
+        name: "Kimi K2.6",
         modelType: "text",
         privacy: "private",
         traits: [],
@@ -565,8 +565,8 @@ describe("AgentWorkspace", () => {
       },
       {
         provider: "venice",
-        id: "kimi-k2",
-        name: "Kimi K2",
+        id: "anonymous-only",
+        name: "Anonymous Only",
         modelType: "text",
         privacy: "anonymous",
         traits: [],
@@ -576,7 +576,7 @@ describe("AgentWorkspace", () => {
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "kimi-k2-6",
       models: catalog,
     });
     mocks.setVeniceModel.mockResolvedValue(undefined);
@@ -585,7 +585,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
     );
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
@@ -596,16 +596,16 @@ describe("AgentWorkspace", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "kimi-k2",
+        generationModel: "anonymous-only",
       },
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "kimi-k2",
+      selectedModel: "anonymous-only",
       models: catalog,
     });
-    // The popover opens on the suggested picks (GLM 5.1 is curated); the
+    // The popover opens on the suggested picks (Kimi K2.6 is curated); the
     // switch target only exists in the full catalog behind All models.
     await user.click(
       within(dialog).getByRole("button", { name: "All models" }),
@@ -613,18 +613,20 @@ describe("AgentWorkspace", () => {
     const panel = await screen.findByRole("group", {
       name: "All text models",
     });
-    await user.click(within(panel).getByRole("option", { name: /Kimi K2/ }));
+    await user.click(
+      within(panel).getByRole("option", { name: /Anonymous Only/ }),
+    );
 
     await waitFor(() =>
       expect(mocks.setVeniceModel).toHaveBeenCalledWith(
         "generation",
-        "kimi-k2",
+        "anonymous-only",
       ),
     );
     // The composer trigger reflects the new model and the session bar badge
     // its privacy mode.
     expect(
-      await screen.findByRole("button", { name: "Model: Kimi K2" }),
+      await screen.findByRole("button", { name: "Model: Anonymous Only" }),
     ).toBeInTheDocument();
     expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
     expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
@@ -2450,12 +2452,12 @@ describe("AgentWorkspace", () => {
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "zai-org-glm-5-1",
+      selectedModel: "kimi-k2-6",
       models: [
         {
           provider: "venice",
-          id: "zai-org-glm-5-1",
-          name: "GLM 5.1",
+          id: "kimi-k2-6",
+          name: "Kimi K2.6",
           modelType: "text",
           privacy: "private",
           traits: [],
@@ -2463,10 +2465,10 @@ describe("AgentWorkspace", () => {
         },
         {
           provider: "venice",
-          id: "kimi-k2",
-          name: "Kimi K2",
+          id: "zai-org-glm-5-1",
+          name: "GLM 5.1",
           modelType: "text",
-          privacy: "anonymous",
+          privacy: "private",
           traits: [],
           capabilities: ["functionCalling"],
         },
@@ -2485,7 +2487,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Model: GLM 5.1" }),
+      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
     );
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
@@ -2500,7 +2502,7 @@ describe("AgentWorkspace", () => {
       within(panel).getByRole("textbox", { name: "Search models" }),
     ).toBeInTheDocument();
     expect(
-      within(panel).getByRole("option", { name: /Kimi K2/ }),
+      within(panel).getByRole("option", { name: /GLM 5.1/ }),
     ).toBeInTheDocument();
     expect(
       within(panel).queryByRole("option", { name: /Tool-less model/ }),

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -147,16 +147,14 @@ describe("AppSettings", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "zai-org-glm-5-1",
+        generationModel: "kimi-k2-6",
       },
     });
     mocks.listVeniceModels.mockImplementation(async (mode) => ({
       mode,
       modelType: mode === "transcription" ? "asr" : "text",
       selectedModel:
-        mode === "transcription"
-          ? "nvidia/parakeet-tdt-0.6b-v3"
-          : "zai-org-glm-5-1",
+        mode === "transcription" ? "nvidia/parakeet-tdt-0.6b-v3" : "kimi-k2-6",
       models:
         mode === "transcription"
           ? [
@@ -199,6 +197,21 @@ describe("AppSettings", () => {
               },
             ]
           : [
+              {
+                provider: "venice",
+                id: "kimi-k2-6",
+                name: "Kimi K2.6",
+                modelType: "text",
+                description:
+                  "Open-weights model built for long tool-driven tasks.",
+                privacy: "private",
+                priceUnit: "tokens",
+                inputCreditsPerMillionTokens: 850,
+                outputCreditsPerMillionTokens: 4660,
+                contextTokens: 256000,
+                traits: [],
+                capabilities: ["supportsFunctionCalling"],
+              },
               {
                 provider: "venice",
                 id: "zai-org-glm-5-1",
@@ -258,7 +271,7 @@ describe("AppSettings", () => {
           : "venice",
       transcriptionModel:
         mode === "transcription" ? modelId : "nvidia/parakeet-tdt-0.6b-v3",
-      generationModel: mode === "generation" ? modelId : "zai-org-glm-5-1",
+      generationModel: mode === "generation" ? modelId : "kimi-k2-6",
     }));
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- Switch the desktop default generation model from GLM 5.1 to Kimi K2.6.
- Move Kimi K2.6 to the top of the Suggested generation models list and keep GLM 5.1 as the next suggested option.
- Update Scribe API fallback pricing/default model metadata for `kimi-k2-6` so metering still has a safe local fallback before the live Venice catalog loads.
- Update settings and agent workspace tests to expect Kimi K2.6 as the default text model.

## Validation

- `pnpm lint`
- `pnpm test` - 43 files, 480 tests
- `pnpm vitest run src/test/app-settings.test.tsx src/test/agent-workspace.test.tsx src/test/model-privacy.test.ts`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo test --manifest-path src-tauri/Cargo.toml providers -- --nocapture`
- `cargo +1.95.0 test --manifest-path scribe-api/Cargo.toml -p scribe-config`

## Notes

- `cargo test --manifest-path scribe-api/Cargo.toml -p scribe-config` fails with the default local Rust 1.93.1 because `scribe-config` requires Rust 1.95. Re-running with the installed `1.95.0` toolchain passes.