### PR TITLE
[codex] Clarify update relaunch copy

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2371,7 +2371,7 @@ function UpdateRelaunchCard({
   relaunching: boolean;
   onRelaunch: () => void;
 }) {
-  const meta = status ?? updateVersionLabel(payload.version);
+  const meta = status ?? updateReadyLabel(payload.version);
   const failed = status?.toLowerCase().includes("failed") ?? false;
 
   return (
@@ -2384,7 +2384,7 @@ function UpdateRelaunchCard({
         type="button"
         className="update-relaunch-card"
         disabled={relaunching}
-        aria-label={`Relaunch to update to June ${payload.version}`}
+        aria-label={`Relaunch June to finish updating to ${payload.version}`}
         onClick={onRelaunch}
       >
         <span className="update-relaunch-mark" aria-hidden>
@@ -2392,7 +2392,7 @@ function UpdateRelaunchCard({
         </span>
         <span className="update-relaunch-copy">
           <span className="update-relaunch-title">
-            {relaunching ? "Relaunching..." : "Relaunch to update"}
+            {relaunching ? "Relaunching..." : "Relaunch to finish update"}
           </span>
           <span className={status ? "update-relaunch-status" : undefined}>
             {meta}
@@ -2477,6 +2477,10 @@ function updateProgressPercent(progress: UpdateInstallProgress | null) {
 
 function updateVersionLabel(version: string) {
   return version.startsWith("v") ? version : `v${version}`;
+}
+
+function updateReadyLabel(version: string) {
+  return `Update ${updateVersionLabel(version)} is ready. June will reopen after relaunch.`;
 }
 
 // Sidebar toggle icon. One static panel with a single divider that animates:

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11049,12 +11049,10 @@ input:focus-visible,
 }
 
 .update-relaunch-copy > span:last-child {
-  overflow: hidden;
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
   line-height: 1.2;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .update-relaunch-copy > .update-relaunch-status {


### PR DESCRIPTION
## Summary

- Updates the ready update card to say `Relaunch to finish update` instead of `Relaunch to update`.
- Adds subtext that the update is ready and June will reopen after relaunch.
- Lets the secondary update-card line wrap so the explanation is visible.

## Validation

- `pnpm vitest run src/test/update-decision.test.ts`
- `pnpm lint`