### PR TITLE
[codex] Retry startup agent session hydration

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -160,7 +160,10 @@ import {
   pricingLabel,
   selectedModel as selectedModelOption,
 } from "../settings/ModelPickerDialog";
-import { messageFromError } from "../../lib/errors";
+import {
+  isHermesSessionsStartupRequestError,
+  messageFromError,
+} from "../../lib/errors";
 import {
   displayedUserMessageText,
   issueReportPrompt,
@@ -198,6 +201,11 @@ const POLLED_STATUSES = new Set<AgentTaskStatus>([
   "waitingForUser",
 ]);
 const AGENT_TITLE_TIMEOUT_MS = 2500;
+const AGENT_WORKSPACE_SESSION_RETRY_DELAYS_MS = [250, 500, 1000, 2000];
+const AGENT_WORKSPACE_MAX_SESSION_RETRY_DELAY_MS =
+  AGENT_WORKSPACE_SESSION_RETRY_DELAYS_MS[
+    AGENT_WORKSPACE_SESSION_RETRY_DELAYS_MS.length - 1
+  ] ?? 2000;
 
 // What the user reads instead of the gateway's "session busy" rejection. No
 // action in the pill — the composer's send slot already shows stop while
@@ -811,6 +819,7 @@ export function AgentWorkspace({
   // items above only hold the mount seed (the clicked session, or nothing),
   // and broadcasting that would wipe the sidebar's already-loaded list.
   const [hermesSessionsHydrated, setHermesSessionsHydrated] = useState(false);
+  const hermesSessionsHydratedRef = useRef(false);
   // Mounting without an explicit target restores the last open conversation,
   // so app restarts and dev reloads land the user back in the session they
   // were working in instead of bouncing them to the newest one. A pending
@@ -1327,63 +1336,80 @@ export function AgentWorkspace({
     }
   }, []);
 
-  const loadHermesSessions = useCallback(async () => {
-    if (!bridge.running) return;
-    setHermesSessionsLoading(true);
-    try {
-      const sessions = applySessionTitleOverrides(await listHermesSessions());
-      setHermesSessionsHydrated(true);
-      const pendingMessages = pendingHermesMessagesRef.current;
-      const selectedSessionId = selectedHermesSessionIdRef.current;
-      const workingSessions = workingSessionIdsRef.current;
-      const waitingSessions = waitingSessionIdsRef.current;
-      setHermesSessionItems((current) =>
-        mergeActiveHermesSessions(sessions, current, {
-          selectedSessionId,
-          workingSessionIds: workingSessions,
-          waitingSessionIds: waitingSessions,
-          pendingMessages,
-        }),
-      );
-      setSelectedHermesSessionId((current) => {
-        if (newSessionModeRef.current) {
-          selectedHermesSessionIdRef.current = undefined;
-          return undefined;
-        }
+  const loadHermesSessions = useCallback(
+    async (options: { suppressStartupRequestError?: boolean } = {}) => {
+      if (!bridge.running) return "skipped";
+      let keepLoading = false;
+      setHermesSessionsLoading(true);
+      try {
+        const sessions = applySessionTitleOverrides(await listHermesSessions());
+        hermesSessionsHydratedRef.current = true;
+        setHermesSessionsHydrated(true);
+        const pendingMessages = pendingHermesMessagesRef.current;
+        const selectedSessionId = selectedHermesSessionIdRef.current;
+        const workingSessions = workingSessionIdsRef.current;
+        const waitingSessions = waitingSessionIdsRef.current;
+        setHermesSessionItems((current) =>
+          mergeActiveHermesSessions(sessions, current, {
+            selectedSessionId,
+            workingSessionIds: workingSessions,
+            waitingSessionIds: waitingSessions,
+            pendingMessages,
+          }),
+        );
+        setSelectedHermesSessionId((current) => {
+          if (newSessionModeRef.current) {
+            selectedHermesSessionIdRef.current = undefined;
+            return undefined;
+          }
+          if (
+            current &&
+            (sessions.some((session) => session.id === current) ||
+              shouldRetainHermesSessionId(current, {
+                selectedSessionId: current,
+                workingSessionIds: workingSessions,
+                waitingSessionIds: waitingSessions,
+                pendingMessages,
+              }))
+          ) {
+            selectedHermesSessionIdRef.current = current;
+            return current;
+          }
+          const taskSession = selectedTask?.hermesSessionId;
+          if (
+            taskSession &&
+            sessions.some((session) => session.id === taskSession)
+          ) {
+            selectedHermesSessionIdRef.current = taskSession;
+            return taskSession;
+          }
+          const nextSessionId = sessions[0]?.id;
+          selectedHermesSessionIdRef.current = nextSessionId;
+          return nextSessionId;
+        });
+        // Deliberately no setError(null) here: this runs from background polls,
+        // so a success would wipe an unrelated banner (e.g. a failed send)
+        // moments after it appeared. The banner is dismissable instead.
+        return "loaded";
+      } catch (err) {
         if (
-          current &&
-          (sessions.some((session) => session.id === current) ||
-            shouldRetainHermesSessionId(current, {
-              selectedSessionId: current,
-              workingSessionIds: workingSessions,
-              waitingSessionIds: waitingSessions,
-              pendingMessages,
-            }))
+          options.suppressStartupRequestError &&
+          !hermesSessionsHydratedRef.current &&
+          isHermesSessionsStartupRequestError(err)
         ) {
-          selectedHermesSessionIdRef.current = current;
-          return current;
+          keepLoading = true;
+          return "transient-startup-error";
         }
-        const taskSession = selectedTask?.hermesSessionId;
-        if (
-          taskSession &&
-          sessions.some((session) => session.id === taskSession)
-        ) {
-          selectedHermesSessionIdRef.current = taskSession;
-          return taskSession;
+        setError(messageFromError(err));
+        return "failed";
+      } finally {
+        if (!keepLoading) {
+          setHermesSessionsLoading(false);
         }
-        const nextSessionId = sessions[0]?.id;
-        selectedHermesSessionIdRef.current = nextSessionId;
-        return nextSessionId;
-      });
-      // Deliberately no setError(null) here: this runs from background polls,
-      // so a success would wipe an unrelated banner (e.g. a failed send)
-      // moments after it appeared. The banner is dismissable instead.
-    } catch (err) {
-      setError(messageFromError(err));
-    } finally {
-      setHermesSessionsLoading(false);
-    }
-  }, [bridge.running, selectedTask?.hermesSessionId]);
+      }
+    },
+    [bridge.running, selectedTask?.hermesSessionId],
+  );
 
   useEffect(() => {
     void loadTasks();
@@ -1465,7 +1491,29 @@ export function AgentWorkspace({
 
   useEffect(() => {
     if (!bridge.running) return;
-    void loadHermesSessions();
+    let cancelled = false;
+    let retryTimeout: number | undefined;
+
+    function load(attempt: number) {
+      void loadHermesSessions({ suppressStartupRequestError: true }).then(
+        (result) => {
+          if (cancelled || result !== "transient-startup-error") return;
+          const retryDelay =
+            AGENT_WORKSPACE_SESSION_RETRY_DELAYS_MS[attempt] ??
+            AGENT_WORKSPACE_MAX_SESSION_RETRY_DELAY_MS;
+          retryTimeout = window.setTimeout(() => load(attempt + 1), retryDelay);
+        },
+      );
+    }
+
+    load(0);
+    return () => {
+      cancelled = true;
+      if (retryTimeout != null) {
+        window.clearTimeout(retryTimeout);
+      }
+      setHermesSessionsLoading(false);
+    };
   }, [bridge.running, loadHermesSessions]);
 
   useEffect(() => {
@@ -2334,7 +2382,9 @@ export function AgentWorkspace({
         session_id: runtimeSessionId,
         text: content,
       });
-      await loadHermesSessions();
+      await loadHermesSessions({
+        suppressStartupRequestError: !hermesSessionsHydratedRef.current,
+      });
     } catch (err) {
       // A queued report must not outlive its failed prompt; submit() re-arms
       // issue-report mode so the retry files it again.
@@ -3263,6 +3313,8 @@ export function AgentWorkspace({
         selectedTask.toolEvents.length > 0 ||
         taskHistoryLoadedIdsRef.current.has(selectedTask.id)
       : false;
+  const startupSessionHydrationPending =
+    hermesSessionsLoading && !hermesSessionsHydrated;
 
   useEffect(() => {
     // The conversation scrolls in .agent-scroll, which sits below the sticky
@@ -3949,7 +4001,7 @@ export function AgentWorkspace({
                 ))}
               </div>
               <p className="agent-hero-footnote">
-                {bridgeStarting
+                {bridgeStarting || startupSessionHydrationPending
                   ? "Getting June ready…"
                   : heroPrivacyFootnote(generationModel, generationPrivacyBadge)}
               </p>

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -7,6 +7,12 @@ export function messageFromError(err: unknown) {
   return String(err);
 }
 
+export function isHermesSessionsStartupRequestError(err: unknown) {
+  return /error sending request for url \(http:\/\/127\.0\.0\.1:\d+\/api\/sessions(?:\?|[)/])/i.test(
+    messageFromError(err),
+  );
+}
+
 /** Whether an error message means the user's balance ran out. String match is
  * intentional and a known weakness — billing failures reach us as plain text
  * from several layers (Tauri commands, the Hermes runtime's provider errors),

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -298,6 +298,109 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
+  it("keeps retrying startup session loads until the API is ready", async () => {
+    mocks.listAgentTasks.mockResolvedValue({ items: [] });
+    const startupError = new Error(
+      "error sending request for url (http://127.0.0.1:65144/api/sessions?limit=100&offset=0&archived=exclude&min_messages=1&order=recent)",
+    );
+    mocks.listHermesSessions
+      .mockRejectedValueOnce(startupError)
+      .mockRejectedValueOnce(startupError)
+      .mockRejectedValueOnce(startupError)
+      .mockRejectedValueOnce(startupError)
+      .mockRejectedValueOnce(startupError)
+      .mockResolvedValueOnce([existingSession]);
+
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(mocks.listHermesSessions).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Getting June ready…")).toBeInTheDocument();
+      expect(screen.queryByText(/error sending request for url/i)).toBeNull();
+
+      for (const [delay, callCount] of [
+        [250, 2],
+        [500, 3],
+        [1000, 4],
+        [2000, 5],
+        [2000, 6],
+      ] as const) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delay);
+        });
+        expect(mocks.listHermesSessions).toHaveBeenCalledTimes(callCount);
+        expect(screen.queryByText(/June is still starting/i)).toBeNull();
+        expect(screen.queryByText(/error sending request for url/i)).toBeNull();
+      }
+
+      expect(screen.getByText("Existing session")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the session loading state when a new session starts during startup retries", async () => {
+    mocks.listAgentTasks.mockResolvedValue({ items: [] });
+    const startupError = new Error(
+      "error sending request for url (http://127.0.0.1:65144/api/sessions?limit=100&offset=0&archived=exclude&min_messages=1&order=recent)",
+    );
+    mocks.listHermesSessions
+      .mockRejectedValueOnce(startupError)
+      .mockRejectedValueOnce(startupError)
+      .mockResolvedValueOnce([
+        {
+          id: "session-2",
+          title: "Spin up a project brief",
+          preview: "spin up a project brief",
+          last_active: "2026-06-05T12:00:00Z",
+        },
+      ]);
+
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(mocks.listHermesSessions).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Getting June ready…")).toBeInTheDocument();
+
+      const composer = screen.getByPlaceholderText("Describe a task for June…");
+      await act(async () => {
+        fireEvent.change(composer, {
+          target: { value: "spin up a project brief" },
+        });
+      });
+      await act(async () => {
+        fireEvent.submit(composer.closest("form") as HTMLFormElement);
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "spin up a project brief",
+      });
+      expect(mocks.listHermesSessions).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("spin up a project brief")).toBeInTheDocument();
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+      expect(screen.queryByText(/error sending request for url/i)).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+
+      expect(mocks.listHermesSessions).toHaveBeenCalledTimes(3);
+      expect(screen.queryByText(/error sending request for url/i)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("never announces the restored session as selected while a New Session is pending", async () => {
     // Regression: "New session" from inside a project arms the pending marker
     // and remounts the workspace. Initializing from the last-open restore used


### PR DESCRIPTION
## Summary

- Detects the transient `http://127.0.0.1/.../api/sessions` request failure that can happen right after relaunch while the Hermes API is still coming up.
- Keeps initial agent workspace session hydration retrying with capped backoff until the API is ready, instead of falling back to a startup error.
- Keeps startup loading state active while hydration is pending, including when a user starts a new session during the retry window, so raw loopback request errors stay out of the UI.
- Adds regression coverage for repeated startup retries and the submit-during-retry edge case.

## Validation

- `pnpm vitest run src/test/agent-workspace.test.tsx`
- `pnpm lint`
