### PR TITLE
[codex] Allow custom local model selection

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1406,7 +1406,11 @@ export function AgentWorkspace({
         setGenerationModels(modelsResponse.models);
         setGenerationModel(
           selectedModelId
-            ? selectedModelOption(modelsResponse.models, selectedModelId)
+            ? selectedModelOption(
+                modelsResponse.models,
+                selectedModelId,
+                "generation",
+              )
             : undefined,
         );
       }
@@ -3616,7 +3620,11 @@ export function AgentWorkspace({
           <ComposerModelPopover
             flyout={composerModelFlyout}
             model={generationModel}
-            options={modelOptions(generationModels, generationModel?.id ?? "")}
+            options={modelOptions(
+              generationModels,
+              generationModel?.id ?? "",
+              "generation",
+            )}
             search={modelSearch}
             popoverRef={composerModelPopoverRef}
             searchRef={composerModelSearchRef}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -683,10 +683,12 @@ export function AppSettings({
   const transcriptionOptions = modelOptions(
     veniceModels.transcription,
     providerSettings.transcriptionModel,
+    "transcription",
   );
   const generationOptions = modelOptions(
     veniceModels.generation,
     providerSettings.generationModel,
+    "generation",
   );
   const pickerOptions = pickerMode ? modelOptionsForMode(pickerMode) : [];
   const pickerValue = pickerMode ? modelValueForMode(pickerMode) : "";
@@ -1137,6 +1139,7 @@ export function AppSettings({
                   <ModelRow
                     title="Transcription"
                     description="Speech-to-text for note recordings and dictation."
+                    mode="transcription"
                     value={providerSettings.transcriptionModel}
                     options={transcriptionOptions}
                     onOpen={() => openModelPicker("transcription")}
@@ -1144,6 +1147,7 @@ export function AppSettings({
                   <ModelRow
                     title="Text"
                     description="Used for generated notes and agent responses."
+                    mode="generation"
                     value={providerSettings.generationModel}
                     options={generationOptions}
                     onOpen={() => openModelPicker("generation")}
@@ -1427,17 +1431,19 @@ function numericPayload(value: unknown) {
 function ModelRow({
   title,
   description,
+  mode,
   value,
   options,
   onOpen,
 }: {
   title: string;
   description: string;
+  mode: ProviderModelMode;
   value: string;
   options: VeniceModelDto[];
   onOpen: () => void;
 }) {
-  const model = selectedModel(options, value);
+  const model = selectedModel(options, value, mode);
   return (
     <div className="settings-row">
       <div className="settings-row-info">

--- a/src/components/settings/ModelPickerDialog.tsx
+++ b/src/components/settings/ModelPickerDialog.tsx
@@ -4,6 +4,7 @@ import { IconFire1 } from "central-icons/IconFire1";
 import { IconGhost2 } from "central-icons/IconGhost2";
 import { IconLock } from "central-icons/IconLock";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
+import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import {
@@ -106,8 +107,12 @@ export function ModelPickerDialog({
   // looks across the whole catalog, since three curated rows aren't worth
   // searching.
   const [tab, setTab] = useState<"suggested" | "all">("suggested");
+  const [localModelId, setLocalModelId] = useState("");
   useEffect(() => {
-    if (open) setTab("suggested");
+    if (open) {
+      setTab("suggested");
+      setLocalModelId("");
+    }
   }, [open, mode]);
   const suggested = useMemo(
     () => suggestedModelsForMode(mode, options),
@@ -144,6 +149,15 @@ export function ModelPickerDialog({
   }, [options, query, searching, suggested, tab]);
   const showReasons = !searching && tab === "suggested" && suggested.length > 0;
   const title = mode === "transcription" ? "Transcription model" : "Text model";
+  const localModelIdValue = localModelId.trim();
+  const localModelLabel =
+    mode === "transcription" ? "Local ASR model ID" : "Local text model ID";
+  const localModelPlaceholder =
+    mode === "transcription" ? "local-whisper" : "ollama/qwen3:30b";
+  const localModelDescription =
+    mode === "transcription"
+      ? "Enter the model ID exposed by your local Scribe API. It will be used for recordings and dictation."
+      : "Enter the model ID exposed by your local Scribe API. Local text models should support tool calls for the agent.";
 
   return (
     <Dialog
@@ -164,6 +178,37 @@ export function ModelPickerDialog({
           aria-label="Search models"
         />
       </label>
+      <form
+        className="model-picker-local"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (localModelIdValue) onSelect(localModelIdValue);
+        }}
+      >
+        <div className="model-picker-local-copy">
+          <p className="model-picker-local-title">Use local model</p>
+          <p className="model-picker-local-description">
+            {localModelDescription}
+          </p>
+        </div>
+        <div className="model-picker-local-controls">
+          <input
+            className="model-picker-local-input"
+            value={localModelId}
+            onChange={(event) => setLocalModelId(event.currentTarget.value)}
+            placeholder={localModelPlaceholder}
+            aria-label={localModelLabel}
+          />
+          <button
+            type="submit"
+            className="btn btn-secondary model-picker-local-submit"
+            disabled={!localModelIdValue}
+          >
+            <IconPlusMedium size={14} aria-hidden />
+            Use
+          </button>
+        </div>
+      </form>
       {!searching && suggested.length > 0 ? (
         <div
           className="model-picker-tabs"
@@ -246,17 +291,12 @@ export function ModelPickerDialog({
   );
 }
 
-export function selectedModel(options: VeniceModelDto[], value: string) {
-  return (
-    options.find((model) => model.id === value) ?? {
-      provider: "",
-      id: value,
-      name: value,
-      modelType: "",
-      traits: [],
-      capabilities: [],
-    }
-  );
+export function selectedModel(
+  options: VeniceModelDto[],
+  value: string,
+  mode?: ProviderModelMode,
+) {
+  return options.find((model) => model.id === value) ?? localModel(value, mode);
 }
 
 export function pricingLabel(model: VeniceModelDto) {
@@ -351,19 +391,34 @@ function trimNumber(value: number) {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
 }
 
-export function modelOptions(models: VeniceModelDto[], selectedModel: string) {
-  if (models.some((model) => model.id === selectedModel)) {
+export function modelOptions(
+  models: VeniceModelDto[],
+  selectedModel: string,
+  mode?: ProviderModelMode,
+) {
+  const modelId = selectedModel.trim();
+  if (!modelId || models.some((model) => model.id === modelId)) {
     return models;
   }
-  return [
-    {
-      provider: "",
-      id: selectedModel,
-      name: selectedModel,
-      modelType: "",
-      traits: [],
-      capabilities: [],
-    },
-    ...models,
-  ];
+  return [localModel(modelId, mode), ...models];
+}
+
+function localModel(modelId: string, mode?: ProviderModelMode): VeniceModelDto {
+  const trimmed = modelId.trim();
+  const modelType =
+    mode === "transcription" ? "asr" : mode === "generation" ? "text" : "";
+  return {
+    provider: "local",
+    id: trimmed,
+    name: trimmed,
+    modelType,
+    description:
+      mode === "transcription"
+        ? "Custom speech-to-text model."
+        : "Custom text model.",
+    priceUnit: "local",
+    priceDescription: "Custom model",
+    traits: ["custom"],
+    capabilities: mode === "generation" ? ["supportsFunctionCalling"] : [],
+  };
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7580,6 +7580,79 @@ input:focus-visible,
   outline: 0;
 }
 
+.model-picker-local {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.72fr);
+  align-items: end;
+  gap: var(--sp-4);
+  padding: var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--surface-subtle);
+}
+
+.model-picker-local-copy {
+  min-width: 0;
+}
+
+.model-picker-local-title {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.model-picker-local-description {
+  margin: var(--sp-1) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+}
+
+.model-picker-local-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+.model-picker-local-input {
+  min-width: 0;
+  height: var(--control-md);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: var(--fs-sm);
+  outline: 0;
+}
+
+.model-picker-local-input:focus-visible {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.model-picker-local-submit {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .model-picker-local,
+  .model-picker-local-controls {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .model-picker-local-submit {
+    justify-content: center;
+    width: 100%;
+  }
+}
+
 .model-picker-list {
   display: grid;
   gap: var(--sp-2);

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1183,6 +1183,62 @@ describe("AppSettings", () => {
     }
   });
 
+  it("accepts local model IDs for transcription and text selection", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Change transcription model",
+      }),
+    );
+    let dialog = await screen.findByRole("dialog", {
+      name: "Transcription model",
+    });
+    await user.type(
+      within(dialog).getByRole("textbox", { name: "Local ASR model ID" }),
+      "local-whisper",
+    );
+    await user.click(within(dialog).getByRole("button", { name: /Use/i }));
+
+    expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+      "transcription",
+      "local-whisper",
+    );
+    expect(await screen.findByText("local-whisper")).toBeInTheDocument();
+    expect(screen.getAllByText("Custom model").length).toBeGreaterThan(0);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Change text model",
+      }),
+    );
+    dialog = await screen.findByRole("dialog", { name: "Text model" });
+    await user.type(
+      within(dialog).getByRole("textbox", { name: "Local text model ID" }),
+      "ollama/qwen3:30b",
+    );
+    await user.click(within(dialog).getByRole("button", { name: /Use/i }));
+
+    expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+      "generation",
+      "ollama/qwen3:30b",
+    );
+    expect(await screen.findByText("ollama/qwen3:30b")).toBeInTheDocument();
+  });
+
   it("defaults the model picker to curated suggestions", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary

- Adds a local model entry section to the shared model picker for transcription and text models.
- Lets users type a custom local model ID and persist it through the existing model settings command.
- Keeps selected IDs that are not in the remote catalog visible as custom model rows in Settings and the agent composer.
- Adds settings coverage for custom ASR and text model selection.

## Impact

Users can bring a local ASR or text model exposed by their local Scribe API/provider proxy without waiting for it to appear in the hosted model catalog. Custom text models are treated as tool-capable in the picker because the desktop app cannot inspect local provider capabilities before selection.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm exec vitest run src/test/app-settings.test.tsx`
- `pnpm exec prettier --check src/components/settings/ModelPickerDialog.tsx src/components/settings/AppSettings.tsx src/styles/app.css src/test/app-settings.test.tsx`
- `git diff --check`