### PR TITLE
Add native macOS Settings menu entries

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3028,6 +3028,7 @@ dependencies = [
  "hound",
  "keyring",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "rand 0.8.6",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,14 @@ zeroize = { version = "1", features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSApplication",
+    "NSImage",
+    "NSMenu",
+    "NSMenuItem",
+    "NSResponder",
+] }
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "NSString",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod db;
 pub mod dictation;
 pub mod domain;
 pub mod hermes_bridge;
+pub mod macos_menu_icons;
 pub mod meeting_detection;
 pub mod meeting_hud;
 pub mod menu_bar;
@@ -19,6 +20,8 @@ use tauri::Manager;
 
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check_for_updates";
 const CHECK_FOR_UPDATES_EVENT: &str = "scribe://check-for-updates";
+const OPEN_SETTINGS_MENU_ID: &str = "open_settings";
+const OPEN_SETTINGS_EVENT: &str = "scribe://open-settings";
 
 pub fn run() {
     providers::load_local_env();
@@ -56,6 +59,12 @@ pub fn run() {
         .on_menu_event(|app, event| {
             if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
                 let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());
+                return;
+            }
+            if event.id().as_ref() == OPEN_SETTINGS_MENU_ID {
+                #[cfg(target_os = "macos")]
+                show_main_window(app);
+                let _ = app.emit(OPEN_SETTINGS_EVENT, ());
             }
         })
         .invoke_handler(tauri::generate_handler![
@@ -225,19 +234,26 @@ fn setup_app_menu(app: &tauri::App) -> tauri::Result<()> {
         true,
         &[
             &PredefinedMenuItem::about(handle, None, Some(about_metadata))?,
-            &PredefinedMenuItem::separator(handle)?,
             &MenuItem::with_id(
                 handle,
                 CHECK_FOR_UPDATES_MENU_ID,
-                "Check for updates…",
+                "Check for Updates",
                 true,
-                Some("CmdOrCtrl+Shift+U"),
+                None::<&str>,
             )?,
             &PredefinedMenuItem::separator(handle)?,
+            &MenuItem::with_id(
+                handle,
+                OPEN_SETTINGS_MENU_ID,
+                "Settings...",
+                true,
+                Some("CmdOrCtrl+,"),
+            )?,
             &PredefinedMenuItem::services(handle, None)?,
             &PredefinedMenuItem::separator(handle)?,
             &PredefinedMenuItem::hide(handle, None)?,
             &PredefinedMenuItem::hide_others(handle, None)?,
+            &PredefinedMenuItem::show_all(handle, None)?,
             &PredefinedMenuItem::separator(handle)?,
             &PredefinedMenuItem::quit(handle, None)?,
         ],
@@ -295,6 +311,7 @@ fn setup_app_menu(app: &tauri::App) -> tauri::Result<()> {
         ],
     )?;
     app.set_menu(menu)?;
+    macos_menu_icons::install_settings_symbol_on_app_menu();
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -249,6 +249,7 @@ fn setup_app_menu(app: &tauri::App) -> tauri::Result<()> {
                 true,
                 Some("CmdOrCtrl+,"),
             )?,
+            &PredefinedMenuItem::separator(handle)?,
             &PredefinedMenuItem::services(handle, None)?,
             &PredefinedMenuItem::separator(handle)?,
             &PredefinedMenuItem::hide(handle, None)?,

--- a/src-tauri/src/macos_menu_icons.rs
+++ b/src-tauri/src/macos_menu_icons.rs
@@ -1,0 +1,59 @@
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{NSApplication, NSImage, NSMenu, NSMenuItem};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSInteger, NSSize, NSString};
+
+#[cfg(target_os = "macos")]
+pub fn install_settings_symbol_on_app_menu() {
+    use objc2::MainThreadMarker;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    let Some(main_menu) = app.mainMenu() else {
+        return;
+    };
+    let title = NSString::from_str("Settings...");
+    let Some(settings_item) = find_menu_item(&main_menu, &title) else {
+        eprintln!("Warning: Could not find Settings... menu item");
+        return;
+    };
+
+    let symbol_name = NSString::from_str("gearshape");
+    let description = NSString::from_str("settings");
+    let Some(symbol) = NSImage::imageWithSystemSymbolName_accessibilityDescription(
+        &symbol_name,
+        Some(&description),
+    ) else {
+        eprintln!("Warning: Could not load gearshape SF Symbol");
+        return;
+    };
+    symbol.setSize(NSSize::new(18.0, 18.0));
+    settings_item.setImage(Some(&symbol));
+}
+
+#[cfg(target_os = "macos")]
+fn find_menu_item(menu: &NSMenu, title: &NSString) -> Option<objc2::rc::Retained<NSMenuItem>> {
+    if let Some(item) = menu.itemWithTitle(title) {
+        return Some(item);
+    }
+
+    for index in 0..menu.numberOfItems() {
+        let index = index as NSInteger;
+        let Some(item) = menu.itemAtIndex(index) else {
+            continue;
+        };
+        let Some(submenu) = item.submenu() else {
+            continue;
+        };
+        if let Some(found) = find_menu_item(&submenu, title) {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn install_settings_symbol_on_app_menu() {}

--- a/src-tauri/src/menu_bar.rs
+++ b/src-tauri/src/menu_bar.rs
@@ -17,16 +17,16 @@ const AGENT_MENU_BAR_STATE_EVENT: &str = "scribe:menu-bar:agent-state";
 const AGENT_MENU_BAR_NEW_SESSION_EVENT: &str = "scribe:menu-bar:new-agent-session";
 const AGENT_MENU_BAR_OPEN_SESSION_EVENT: &str = "scribe:menu-bar:open-agent-session";
 const AGENT_MENU_BAR_SET_AGENT_HUD_EVENT: &str = "scribe:menu-bar:set-agent-hud";
+const AGENT_MENU_BAR_OPEN_SETTINGS_EVENT: &str = "scribe://open-settings";
 
 const MENU_SHOW_ID: &str = "agent_menu_bar_show";
+const MENU_SETTINGS_ID: &str = "agent_menu_bar_settings";
 const MENU_NEW_SESSION_ID: &str = "agent_menu_bar_new_session";
 const MENU_SHOW_AGENT_HUD_ID: &str = "agent_menu_bar_show_agent_hud";
 const MENU_HIDE_AGENT_HUD_ID: &str = "agent_menu_bar_hide_agent_hud";
 const MENU_QUIT_ID: &str = "agent_menu_bar_quit";
 const MENU_STATUS_ID: &str = "agent_menu_bar_status";
 const MENU_LAST_STATUS_ID: &str = "agent_menu_bar_last_status";
-const MENU_RECENT_SESSIONS_ID: &str = "agent_menu_bar_recent_sessions";
-const MENU_EMPTY_SESSIONS_ID: &str = "agent_menu_bar_empty_sessions";
 const MENU_SESSION_ID_PREFIX: &str = "agent_menu_bar_session:";
 
 #[derive(Clone, Debug, Deserialize)]
@@ -134,6 +134,11 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
         show_main_window(app);
         return;
     }
+    if id == MENU_SETTINGS_ID {
+        show_main_window(app);
+        let _ = app.emit(AGENT_MENU_BAR_OPEN_SETTINGS_EVENT, ());
+        return;
+    }
     if id == MENU_NEW_SESSION_ID {
         show_main_window(app);
         let _ = app.emit(AGENT_MENU_BAR_NEW_SESSION_EVENT, ());
@@ -165,6 +170,8 @@ where
     let menu = Menu::new(manager)?;
 
     let show_item = MenuItem::with_id(manager, MENU_SHOW_ID, "Open June", true, None::<&str>)?;
+    let settings_item =
+        MenuItem::with_id(manager, MENU_SETTINGS_ID, "Settings...", true, None::<&str>)?;
     let new_session_item = MenuItem::with_id(
         manager,
         MENU_NEW_SESSION_ID,
@@ -181,7 +188,6 @@ where
     )?;
 
     menu.append(&show_item)?;
-    menu.append(&new_session_item)?;
     let agent_hud_item = MenuItem::with_id(
         manager,
         if state.agent_hud_enabled {
@@ -200,6 +206,7 @@ where
     menu.append(&agent_hud_item)?;
     menu.append(&PredefinedMenuItem::separator(manager)?)?;
     menu.append(&status_item)?;
+    menu.append(&new_session_item)?;
 
     if let Some(last_status) = state.last_status.as_ref() {
         let last_status_item = MenuItem::with_id(
@@ -212,39 +219,19 @@ where
         menu.append(&last_status_item)?;
     }
 
-    menu.append(&PredefinedMenuItem::separator(manager)?)?;
-
-    let recent_label = MenuItem::with_id(
-        manager,
-        MENU_RECENT_SESSIONS_ID,
-        "Recent Agent Sessions",
-        false,
-        None::<&str>,
-    )?;
-    menu.append(&recent_label)?;
-
-    if state.sessions.is_empty() {
-        let empty_item = MenuItem::with_id(
+    for session in &state.sessions {
+        let session_item = MenuItem::with_id(
             manager,
-            MENU_EMPTY_SESSIONS_ID,
-            "No sessions yet",
-            false,
+            format!("{MENU_SESSION_ID_PREFIX}{}", session.id),
+            escape_menu_text(session_label(session)),
+            true,
             None::<&str>,
         )?;
-        menu.append(&empty_item)?;
-    } else {
-        for session in &state.sessions {
-            let session_item = MenuItem::with_id(
-                manager,
-                format!("{MENU_SESSION_ID_PREFIX}{}", session.id),
-                escape_menu_text(session_label(session)),
-                true,
-                None::<&str>,
-            )?;
-            menu.append(&session_item)?;
-        }
+        menu.append(&session_item)?;
     }
 
+    menu.append(&PredefinedMenuItem::separator(manager)?)?;
+    menu.append(&settings_item)?;
     menu.append(&PredefinedMenuItem::separator(manager)?)?;
 
     let quit_item = MenuItem::with_id(manager, MENU_QUIT_ID, "Quit June", true, None::<&str>)?;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -97,6 +97,7 @@ import {
   AGENT_MENU_BAR_NEW_SESSION_EVENT,
   AGENT_MENU_BAR_OPEN_SESSION_EVENT,
   AGENT_MENU_BAR_SET_AGENT_HUD_EVENT,
+  OPEN_SETTINGS_EVENT,
   buildAgentMenuBarState,
   emitAgentMenuBarState,
 } from "../lib/menu-bar";
@@ -237,6 +238,12 @@ export function App() {
   const [settingsReturnView, setSettingsReturnView] =
     useState<SidebarView>("notes");
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");
+  const openSettings = useCallback(() => {
+    if (activeView !== "settings") {
+      setSettingsReturnView(activeView);
+    }
+    setActiveView("settings");
+  }, [activeView]);
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
   // note shows the same back-arrow + breadcrumb chrome folders use. Cleared
@@ -549,6 +556,19 @@ export function App() {
       unlisten?.();
     };
   }, [runUpdateCheck]);
+
+  useEffect(() => {
+    let aborted = false;
+    let unlisten: (() => void) | undefined;
+    void listen(OPEN_SETTINGS_EVENT, openSettings).then((cleanup) => {
+      if (aborted) cleanup();
+      else unlisten = cleanup;
+    });
+    return () => {
+      aborted = true;
+      unlisten?.();
+    };
+  }, [openSettings]);
 
   useEffect(() => {
     function openAgentWorkspace(session?: HermesSessionInfo) {
@@ -1804,10 +1824,8 @@ export function App() {
         settingsTab={settingsTab}
         onSettingsTabChange={setSettingsTab}
         onChangeView={(view) => {
-          if (view === "settings" && activeView !== "settings") {
-            setSettingsReturnView(activeView);
-          }
-          setActiveView(view);
+          if (view === "settings") openSettings();
+          else setActiveView(view);
           setAgentOrigin(undefined);
           if (view !== "agent") {
             setActiveAgentSession(undefined);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -190,6 +190,8 @@ export function App() {
     markAgentNewSessionPending();
     return "agent";
   });
+  const activeViewRef = useRef<SidebarView>(activeView);
+  activeViewRef.current = activeView;
   const [activeAgentSession, setActiveAgentSession] =
     useState<HermesSessionInfo>();
   const [pendingAgentReply, setPendingAgentReply] =
@@ -239,11 +241,12 @@ export function App() {
     useState<SidebarView>("notes");
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");
   const openSettings = useCallback(() => {
-    if (activeView !== "settings") {
-      setSettingsReturnView(activeView);
+    const returnView = activeViewRef.current;
+    if (returnView !== "settings") {
+      setSettingsReturnView(returnView);
     }
     setActiveView("settings");
-  }, [activeView]);
+  }, []);
   const [originFolderId, setOriginFolderId] = useState<string | undefined>();
   // Tracks that the open note was drilled into from the All notes view, so the
   // note shows the same back-arrow + breadcrumb chrome folders use. Cleared

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1550,16 +1550,16 @@ function SidebarIdentity({
       </button>
       {menuOpen ? (
         <div className="sidebar-identity-menu" role="menu">
-          <button type="button" role="menuitem" onClick={onOpenSettings}>
-            <IconSettingsGear4 size={14} />
-            Settings
-          </button>
           {onReportIssue ? (
             <button type="button" role="menuitem" onClick={onReportIssue}>
               <IconBug size={14} />
               Report an issue
             </button>
           ) : null}
+          <button type="button" role="menuitem" onClick={onOpenSettings}>
+            <IconSettingsGear4 size={14} />
+            Settings
+          </button>
           {account.signedIn && onSignOut ? (
             <>
               <div className="context-menu-separator" role="separator" />

--- a/src/lib/menu-bar.ts
+++ b/src/lib/menu-bar.ts
@@ -8,6 +8,7 @@ export const AGENT_MENU_BAR_OPEN_SESSION_EVENT =
   "scribe:menu-bar:open-agent-session";
 export const AGENT_MENU_BAR_SET_AGENT_HUD_EVENT =
   "scribe:menu-bar:set-agent-hud";
+export const OPEN_SETTINGS_EVENT = "scribe://open-settings";
 
 export type AgentMenuBarSessionStatus = "idle" | "running" | "waitingForUser";
 

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
+import { OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
 import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
@@ -12,6 +13,7 @@ const HERO_GREETING = new RegExp(
 
 const mocks = vi.hoisted(() => ({
   listen: vi.fn(),
+  listeners: new Map<string, (event: { payload?: unknown }) => void>(),
   getCurrentWindow: vi.fn(),
   bootstrapApp: vi.fn(),
   createNote: vi.fn(),
@@ -180,6 +182,16 @@ describe("App shortcuts", () => {
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
     mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.listeners.clear();
+    mocks.listen.mockImplementation(
+      async (
+        event: string,
+        handler: (event: { payload?: unknown }) => void,
+      ) => {
+        mocks.listeners.set(event, handler);
+        return () => mocks.listeners.delete(event);
+      },
+    );
     mocks.updateNote.mockImplementation(async (input) => ({
       ...first,
       ...input,
@@ -199,6 +211,20 @@ describe("App shortcuts", () => {
     await waitFor(() =>
       expect(mocks.createNote).toHaveBeenCalledWith(undefined),
     );
+  });
+
+  it("opens settings from the native app menu event", async () => {
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true),
+    );
+
+    mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+
+    expect(
+      await screen.findByRole("heading", { name: "Appearance" }),
+    ).toBeInTheDocument();
   });
 
   it("returns to the note after opening its folder from the note header", async () => {


### PR DESCRIPTION
## Summary
- Add a standard macOS `Settings...` entry to the June app menu with `Cmd+,`.
- Patch the app menu's Settings item with Apple's `gearshape` SF Symbol directly on the native `NSMenuItem`, matching Conductor's approach without rasterizing to PNG.
- Add `Show All` to the app menu and align the menu structure with native macOS conventions.
- Add a text-only Settings entry to the menu-bar-extra dropdown below recent sessions, with separators before Quit.
- Wire native menu Settings events into the existing React settings view and add regression coverage.

## Validation
- `pnpm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `pnpm lint`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
