### PR TITLE
Move ⌘N to new session, rename Agents nav to Sessions

### DIFF
--- a/agent-hud.html
+++ b/agent-hud.html
@@ -51,7 +51,7 @@
         hidden
       >
         <button id="agent-hud-hide" type="button" role="menuitem">
-          Hide agent HUD
+          Hide sessions HUD
         </button>
       </div>
     </main>

--- a/src-tauri/src/menu_bar.rs
+++ b/src-tauri/src/menu_bar.rs
@@ -175,7 +175,7 @@ where
     let new_session_item = MenuItem::with_id(
         manager,
         MENU_NEW_SESSION_ID,
-        "New Agent Session...",
+        "New session...",
         true,
         None::<&str>,
     )?;
@@ -196,9 +196,9 @@ where
             MENU_SHOW_AGENT_HUD_ID
         },
         if state.agent_hud_enabled {
-            "Hide agent HUD"
+            "Hide sessions HUD"
         } else {
-            "Show agent HUD"
+            "Show sessions HUD"
         },
         true,
         None::<&str>,
@@ -284,7 +284,7 @@ fn status_label(state: &AgentMenuBarState) -> String {
             pluralize(state.active_count, "session", "sessions")
         );
     }
-    "No active agent sessions".to_string()
+    "No active sessions".to_string()
 }
 
 fn last_status_label(last_status: &AgentMenuBarLastStatus) -> String {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1256,15 +1256,21 @@ export function App() {
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
-      if (!isCreateNoteShortcut(event)) return;
       if (document.querySelector('[role="dialog"]')) return;
-      event.preventDefault();
-      void handleCreateNote(null);
+      if (isNewSessionShortcut(event)) {
+        event.preventDefault();
+        handleNewAgentSession();
+        return;
+      }
+      if (isCreateNoteShortcut(event)) {
+        event.preventDefault();
+        void handleCreateNote(null);
+      }
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [handleCreateNote]);
+  }, [handleCreateNote, handleNewAgentSession]);
 
   function handleSelectFolder(folderId?: string) {
     setFolderReturnTarget(undefined);
@@ -2006,11 +2012,11 @@ export function App() {
                           ],
                         }
                       : {
-                          backLabel: "Back to agents",
+                          backLabel: "Back to sessions",
                           onBack: handleReturnToAgentsList,
                           crumbs: [
                             {
-                              label: "Agents",
+                              label: "Sessions",
                               onClick: handleReturnToAgentsList,
                             },
                           ],
@@ -2560,8 +2566,23 @@ export function isAccessibilityBlocked(state?: string) {
   return state !== undefined && state !== "granted";
 }
 
-function isCreateNoteShortcut(event: KeyboardEvent) {
+function isNewSessionShortcut(event: KeyboardEvent) {
   return event.key.toLowerCase() === "n" && isPrimaryShortcut(event);
+}
+
+function isCreateNoteShortcut(event: KeyboardEvent) {
+  // Primary modifier + Shift + N. isPrimaryShortcut rejects Shift, so check
+  // the primary modifier with Shift masked off, then require Shift on top.
+  return (
+    event.key.toLowerCase() === "n" &&
+    event.shiftKey &&
+    isPrimaryShortcut({
+      metaKey: event.metaKey,
+      ctrlKey: event.ctrlKey,
+      altKey: event.altKey,
+      shiftKey: false,
+    })
+  );
 }
 
 function stringPayloadValue(value: unknown) {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1234,6 +1234,22 @@ export function App() {
     [state.selectedFolderId],
   );
 
+  // Mirrors the sidebar's "New session" button so the agent sessions list
+  // can start a fresh chat with the same pending-session handshake. Memoized
+  // so the ⌘N keydown listener below subscribes once instead of every render.
+  const handleNewAgentSession = useCallback(() => {
+    pendingSessionProjectRef.current = null;
+    setAgentOrigin(undefined);
+    markAgentNewSessionPending();
+    setActiveAgentSession(undefined);
+    setActiveView("agent");
+    window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent<AgentNewSessionDetail>(AGENT_NEW_SESSION_EVENT),
+      );
+    }, 0);
+  }, []);
+
   useEffect(() => {
     if (
       appBlocked ||
@@ -1408,21 +1424,6 @@ export function App() {
     } catch (err) {
       setError(messageFromError(err));
     }
-  }
-
-  // Mirrors the sidebar's "New session" button so the agent sessions list
-  // can start a fresh chat with the same pending-session handshake.
-  function handleNewAgentSession() {
-    pendingSessionProjectRef.current = null;
-    setAgentOrigin(undefined);
-    markAgentNewSessionPending();
-    setActiveAgentSession(undefined);
-    setActiveView("agent");
-    window.setTimeout(() => {
-      window.dispatchEvent(
-        new CustomEvent<AgentNewSessionDetail>(AGENT_NEW_SESSION_EVENT),
-      );
-    }, 0);
   }
 
   // "Report an issue": the fresh-chat handshake in issue-report mode. The

--- a/src/components/agent/AgentSessionsList.tsx
+++ b/src/components/agent/AgentSessionsList.tsx
@@ -26,6 +26,7 @@ import {
 import { AGENT_DELETE_SESSION_EVENT } from "../../lib/agent-events";
 import { messageFromError } from "../../lib/errors";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
+import { primaryShortcutLabel } from "../../lib/platform";
 import type { FolderDto, HermesSessionInfo } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
@@ -73,6 +74,7 @@ export const AgentSessionsList = forwardRef<
   // install would see it, real data untouched underneath.
   const sessions = useForcedEmptyStates() ? NO_SESSIONS : allSessions;
   const [query, setQuery] = useState("");
+  const newSessionShortcut = primaryShortcutLabel("N");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const [bulkDeleteError, setBulkDeleteError] = useState<string | null>(null);
@@ -218,12 +220,12 @@ export const AgentSessionsList = forwardRef<
   return (
     <section
       className="all-notes-workspace agent-sessions-workspace"
-      aria-label="Agents"
+      aria-label="Sessions"
     >
       <header className="folders-header">
         <div className="folders-heading">
           <h1>
-            Agents
+            Sessions
             {sessions.length > 0 ? (
               <span className="folders-count">{sessions.length}</span>
             ) : null}
@@ -236,6 +238,9 @@ export const AgentSessionsList = forwardRef<
         >
           <IconPlusMedium size={13} />
           New session
+          <kbd className="primary-action-kbd" aria-hidden>
+            {newSessionShortcut}
+          </kbd>
         </button>
       </header>
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3919,7 +3919,7 @@ export function AgentWorkspace({
   return (
     <section
       className="agent-workspace"
-      aria-label="Agent"
+      aria-label="Session"
       data-artifact-panel={artifactPanel ? "open" : undefined}
       data-hero={heroMode ? "true" : undefined}
     >
@@ -4778,7 +4778,7 @@ function AgentSessionBar({
             ))
           ) : (
             <li>
-              <span className="detail-breadcrumb-label">Agent</span>
+              <span className="detail-breadcrumb-label">Session</span>
             </li>
           )}
           {title !== undefined ? (

--- a/src/components/folders/FoldersWorkspace.tsx
+++ b/src/components/folders/FoldersWorkspace.tsx
@@ -820,7 +820,7 @@ function FolderDetail({
             {folderSessions.length > 0 ? (
               <>
                 <div className="folder-actions-row">
-                  <h2 className="folder-notes-title">Agents</h2>
+                  <h2 className="folder-notes-title">Sessions</h2>
                 </div>
                 <FolderSessionList
                   folder={folder}

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 import type { NoteListItemDto } from "../../lib/tauri";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
-import { primaryShortcutLabel } from "../../lib/platform";
+import { primaryShiftShortcutLabel } from "../../lib/platform";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
 
@@ -77,7 +77,7 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(
     // moment the selection drops to zero, keep the bar mounted with data-exit,
     // and unmount when its animation finishes.
     const [exit, setExit] = useState<null | "slide" | "fade">(null);
-    const createNoteShortcut = primaryShortcutLabel("N");
+    const createNoteShortcut = primaryShiftShortcutLabel("N");
     // The cause of the *next* empty transition, latched by the call sites.
     // Toggling a row can't know it's the last box until the set settles, so
     // unchecking defaults to fade unless a dismiss intent was latched first.

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -278,10 +278,10 @@ export function AgentSettingsSection() {
         <div className="settings-rows">
           <div className="settings-row">
             <div className="settings-row-info">
-              <h3 className="settings-row-title">Agent HUD</h3>
+              <h3 className="settings-row-title">Sessions HUD</h3>
               <p className="settings-row-description">
                 Show a small pill at the top right of your screen with live
-                agent session status.
+                session status.
               </p>
             </div>
             <div className="settings-row-control">
@@ -290,7 +290,7 @@ export function AgentSettingsSection() {
                 onCheckedChange={(enabled) =>
                   void handleAgentHudEnabledChange(enabled)
                 }
-                aria-label="Show agent HUD"
+                aria-label="Show sessions HUD"
               />
             </div>
           </div>

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { IconArrowBoxRight } from "central-icons/IconArrowBoxRight";
 import { IconZap } from "central-icons/IconZap";
 import { IconBubble3 } from "central-icons/IconBubble3";
+import { IconRobot2 } from "central-icons/IconRobot2";
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
 import { IconAudio } from "central-icons/IconAudio";
 import { IconBrain2 } from "central-icons/IconBrain2";
@@ -203,7 +204,7 @@ const SETTINGS_SIDEBAR_GROUPS: {
     title: "AI",
     items: [
       { id: "models", label: "Models", icon: <IconBrain2 size={16} /> },
-      { id: "agent", label: "Agent", icon: <IconBubble3 size={16} /> },
+      { id: "agent", label: "Agent", icon: <IconRobot2 size={16} /> },
     ],
   },
   {
@@ -241,6 +242,7 @@ export function Sidebar({
   const [menu, setMenu] = useState<MenuState | null>(null);
   const [identityMenuOpen, setIdentityMenuOpen] = useState(false);
   const searchShortcut = primaryShortcutLabel("K");
+  const newSessionShortcut = primaryShortcutLabel("N");
   const inSettings = activeView === "settings";
   const [allAgentSessions, setAgentSessions] = useState<HermesSessionInfo[]>(
     [],
@@ -374,7 +376,7 @@ export function Sidebar({
         return {
           id: `agent:${session.id}`,
           label: title,
-          meta: "Agent",
+          meta: "Session",
           icon: <IconBubble3 size={15} />,
           searchText: normalizeCommandQuery(
             `${title} ${session.preview ?? ""} agent session`,
@@ -877,6 +879,9 @@ export function Sidebar({
                 <IconPlusMedium size={15} />
               </span>
               <span className="sidebar-nav-label">New session</span>
+              <kbd className="sidebar-nav-shortcut" aria-hidden="true">
+                {newSessionShortcut}
+              </kbd>
             </button>
             <button
               type="button"
@@ -974,7 +979,7 @@ export function Sidebar({
 
           <section
             className="sidebar-section sidebar-agent-section"
-            aria-label="Agent sessions"
+            aria-label="Sessions"
             data-active={
               activeView === "agent" || activeView === "agent-sessions"
             }
@@ -985,7 +990,7 @@ export function Sidebar({
                 className="section-title-label section-title-open"
                 onClick={() => onChangeView("agent-sessions")}
               >
-                Agent
+                Sessions
               </button>
               {/* Same destination as the header — the hover affordance just
                * makes the "this opens a list" behavior legible. */}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -10,11 +10,13 @@ export function isMacLikePlatform() {
 }
 
 export function primaryShortcutLabel(key: string) {
-  return isMacLikePlatform() ? `⌘ ${key}` : `Ctrl ${key}`;
+  // No space after the ⌘ glyph (it reads tight), but keep one after the
+  // "Ctrl" word so Windows labels don't run together as "CtrlN".
+  return isMacLikePlatform() ? `⌘${key}` : `Ctrl ${key}`;
 }
 
 export function primaryShiftShortcutLabel(key: string) {
-  return isMacLikePlatform() ? `⌘ ⇧ ${key}` : `Ctrl Shift ${key}`;
+  return isMacLikePlatform() ? `⌘⇧${key}` : `Ctrl Shift ${key}`;
 }
 
 export function isPrimaryShortcut(

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -13,6 +13,10 @@ export function primaryShortcutLabel(key: string) {
   return isMacLikePlatform() ? `⌘ ${key}` : `Ctrl ${key}`;
 }
 
+export function primaryShiftShortcutLabel(key: string) {
+  return isMacLikePlatform() ? `⌘ ⇧ ${key}` : `Ctrl Shift ${key}`;
+}
+
 export function isPrimaryShortcut(
   event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
 ) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4139,6 +4139,22 @@ input:focus-visible,
   white-space: nowrap;
 }
 
+.sidebar-nav-shortcut {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--r-xs);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
 .sidebar[data-collapsed="true"] .sidebar-nav-label {
   display: none;
 }

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -693,7 +693,7 @@ describe("agent HUD", () => {
 
     expect(menuElement().hidden).toBe(false);
     expect(menuElement()).toHaveAttribute("aria-hidden", "false");
-    expect(hideHudButton()).toHaveTextContent("Hide agent HUD");
+    expect(hideHudButton()).toHaveTextContent("Hide sessions HUD");
 
     hideHudButton().click();
     await flushPromises();
@@ -872,7 +872,7 @@ function agentHudMarkup() {
         hidden
       >
         <button id="agent-hud-hide" type="button" role="menuitem">
-          Hide agent HUD
+          Hide sessions HUD
         </button>
       </div>
     </main>

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1582,7 +1582,7 @@ describe("AppSettings", () => {
 
     await user.click(screen.getByRole("tab", { name: "Agent" }));
     const hudSwitch = await screen.findByRole("switch", {
-      name: "Show agent HUD",
+      name: "Show sessions HUD",
     });
 
     expect(hudSwitch).toHaveAttribute("aria-checked", "true");

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -271,25 +271,33 @@ describe("App shortcuts", () => {
     ).toBeInTheDocument();
   });
 
-  it("creates a loose note with Ctrl-N on Windows", async () => {
+  it("starts a session with Ctrl-N and creates a note with Ctrl-Shift-N on Windows", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
     );
+    const onNewSession = vi.fn();
+    window.addEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
     try {
       render(<App />);
 
       await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
+      // The Cmd key does nothing on Windows — Ctrl is the primary modifier.
       fireEvent.keyDown(window, { key: "n", metaKey: true });
+      expect(onNewSession).not.toHaveBeenCalled();
       expect(mocks.createNote).not.toHaveBeenCalled();
 
       fireEvent.keyDown(window, { key: "n", ctrlKey: true });
+      await waitFor(() => expect(onNewSession).toHaveBeenCalled());
+      expect(mocks.createNote).not.toHaveBeenCalled();
 
+      fireEvent.keyDown(window, { key: "n", ctrlKey: true, shiftKey: true });
       await waitFor(() =>
         expect(mocks.createNote).toHaveBeenCalledWith(undefined),
       );
     } finally {
+      window.removeEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
       restoreNavigator();
     }
   });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
+import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
 import { OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
 import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
@@ -223,7 +224,25 @@ describe("App shortcuts", () => {
     }));
   });
 
-  it("creates a loose note with Command-N but ignores bare n", async () => {
+  it("starts a new session with Command-N", async () => {
+    const onNewSession = vi.fn();
+    window.addEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
+
+    try {
+      render(<App />);
+
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      fireEvent.keyDown(window, { key: "n", metaKey: true });
+
+      await waitFor(() => expect(onNewSession).toHaveBeenCalled());
+      expect(mocks.createNote).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
+    }
+  });
+
+  it("creates a loose note with Command-Shift-N but ignores bare n", async () => {
     render(<App />);
 
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
@@ -231,7 +250,7 @@ describe("App shortcuts", () => {
     fireEvent.keyDown(window, { key: "n" });
     expect(mocks.createNote).not.toHaveBeenCalled();
 
-    fireEvent.keyDown(window, { key: "n", metaKey: true });
+    fireEvent.keyDown(window, { key: "n", metaKey: true, shiftKey: true });
 
     await waitFor(() =>
       expect(mocks.createNote).toHaveBeenCalledWith(undefined),

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -139,7 +139,7 @@ describe("Sidebar primary navigation", () => {
       />,
     );
 
-    expect(screen.getByText("⌘ K")).toBeInTheDocument();
+    expect(screen.getByText("⌘K")).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "k", metaKey: true });
 

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -92,7 +92,9 @@ describe("folders UI", () => {
       screen.getByRole("button", { name: "Meeting notes" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Folders" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Agent" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sessions" }),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Meeting notes" }));
     await user.click(screen.getByRole("button", { name: "New session" }));


### PR DESCRIPTION
## What

Shifts the product away from the word "agent" in the navigation and migrates the new-item keyboard shortcut.

**Shortcuts**
- `⌘N` now starts a new session (previously created a new note).
- New note moves to `⌘⇧N` (avoids clashing with the native macOS `⌘M` minimize accelerator).
- The `⌘N` hint is shown on the sidebar "New session" item and the sessions-view header button.
- All keyboard badges tightened to the native no-space form: `⌘K`, `⌘N`, `⌘⇧N`.

**"Agent" → "Session" relabeling**
- Sidebar section, main view heading, breadcrumbs, project sub-heading, command-palette tag, and the tray menu ("New session...", "No active sessions").
- HUD renamed to "Sessions HUD" across the tray menu, settings row, and the HUD window's own hide button.
- The settings tab stays labeled "Agent" (per design intent) but its icon is now `IconRobot2`.

## Why

Move away from the word "agent" in user-facing surfaces, and give "new session" the primary `⌘N` shortcut now that sessions are the main entry point.

## Tests

`tsc` clean, full vitest suite green (485 passed); shortcut/HUD/settings/folders tests updated to the new strings.