### PR TITLE
[codex] Make Windows desktop CI manual

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -144,7 +144,7 @@ jobs:
   windows-rust:
     name: Tauri Windows build
     needs: changes
-    if: needs.changes.outputs.desktop_bundle == 'true'
+    if: github.event_name == 'workflow_dispatch' && needs.changes.outputs.desktop_bundle == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Gate the `desktop` workflow's `windows-rust` job so it only runs for `workflow_dispatch` events.
- Keep the frontend and macOS Rust checks automatic on PRs and pushes.

## Why

The Windows desktop bundle job uses a Windows runner and packaging steps, so running it automatically on every desktop-relevant PR or push is too slow and expensive. It can still be launched manually from the Actions UI when a Windows bundle check is needed.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/desktop.yml"); puts "desktop.yml parsed"'`
- `actionlint .github/workflows/desktop.yml`
