### PR TITLE
Allow dragging empty tab chrome

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2332,6 +2332,7 @@ export function App() {
           onClose={closeTab}
           onCloseOthers={closeOtherTabs}
           onNew={openNewChatTab}
+          onDragRegionPointerDown={handleTitlebarPointerDown}
         />
         <section className="main-panel">
           {accessibilityBlocked ? <PermissionBanner /> : null}

--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -2,7 +2,7 @@ import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconPlusMedium } from "central-icons/IconPlusMedium";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
+import type { KeyboardEvent, MouseEvent, PointerEvent, ReactNode } from "react";
 import { HoverTip } from "../ui/HoverTip";
 import { primaryShortcutLabel } from "../../lib/platform";
 
@@ -19,6 +19,7 @@ type TabBarProps = {
   onClose: (id: string) => void;
   onCloseOthers: (id: string) => void;
   onNew: () => void;
+  onDragRegionPointerDown?: (event: PointerEvent<HTMLDivElement>) => void;
 };
 
 type TabMenu = { tabId: string; x: number; y: number };
@@ -91,6 +92,7 @@ export function TabBar({
   onClose,
   onCloseOthers,
   onNew,
+  onDragRegionPointerDown,
 }: TabBarProps) {
   const stripRef = useRef<HTMLDivElement>(null);
   const [available, setAvailable] = useState(Number.POSITIVE_INFINITY);
@@ -180,6 +182,11 @@ export function TabBar({
     });
   }
 
+  function handleDragRegionPointerDown(event: PointerEvent<HTMLDivElement>) {
+    if (event.target !== event.currentTarget) return;
+    onDragRegionPointerDown?.(event);
+  }
+
   function renderTab(tab: TabItem) {
     const active = tab.id === activeTabId;
     return (
@@ -219,8 +226,20 @@ export function TabBar({
   }
 
   return (
-    <div className="tab-bar" role="tablist" aria-label="Open tabs">
-      <div className="tab-strip" ref={stripRef} data-size={size}>
+    <div
+      className="tab-bar"
+      role="tablist"
+      aria-label="Open tabs"
+      data-tauri-drag-region
+      onPointerDown={handleDragRegionPointerDown}
+    >
+      <div
+        className="tab-strip"
+        ref={stripRef}
+        data-size={size}
+        data-tauri-drag-region
+        onPointerDown={handleDragRegionPointerDown}
+      >
         {visible.map(renderTab)}
         {hidden.length > 0 ? (
           <button

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TabBar } from "../components/tabs/TabBar";
+
+const tabs = [
+  { id: "tab-1", title: "New session", icon: <span aria-hidden /> },
+  { id: "tab-2", title: "Notes", icon: <span aria-hidden /> },
+];
+
+function renderTabBar(overrides = {}) {
+  const props = {
+    tabs,
+    activeTabId: "tab-1",
+    onActivate: vi.fn(),
+    onClose: vi.fn(),
+    onCloseOthers: vi.fn(),
+    onNew: vi.fn(),
+    onDragRegionPointerDown: vi.fn(),
+    ...overrides,
+  };
+
+  const view = render(<TabBar {...props} />);
+  return { ...view, props };
+}
+
+describe("TabBar", () => {
+  it("starts a window drag from empty tab-strip space", () => {
+    const { container, props } = renderTabBar();
+    const strip = container.querySelector(".tab-strip");
+
+    expect(strip).not.toBeNull();
+    fireEvent.pointerDown(strip!);
+
+    expect(props.onDragRegionPointerDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a window drag from tab controls", () => {
+    const { props } = renderTabBar();
+
+    fireEvent.pointerDown(screen.getByRole("tab", { name: "New session" }));
+    fireEvent.pointerDown(screen.getByRole("button", { name: "New tab" }));
+
+    expect(props.onDragRegionPointerDown).not.toHaveBeenCalled();
+  });
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,8 @@
 # Lessons
 
+- When a custom chrome layer sits above the base titlebar drag layer, empty
+  space in that layer must forward pointerdown to the explicit native
+  `startDragging()` path while child controls guard themselves by target.
 - When a user says a spinner/name change happened elsewhere, honor the latest component name from main while preserving the intended behavior. In this session, the spinner behavior belongs in the trailing agent-session state slot, but the component is `DotSpinner`.
 - During drag-preview UI states, avoid `display` toggles for reversible pointer gestures. Hide collapsed preview with visibility/pointer-events so reopening can render immediately while related fixed panels stay mounted.
 - For tiny native HUDs, verify both the final steady state and the first visible frames after a hidden or interrupted show. A correct final size can still hitch if the native window animates from a stale frame while visible; fresh shows should be pre-sized while hidden, with animation reserved for visible state-to-state morphs.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Window Drag With Hidden Tabs
+
+- [x] Inspect the screenshot and existing titlebar drag implementation.
+- [x] Locate the tab strip and titlebar layering.
+- [x] Patch tab strip background drag handling without making controls draggable.
+- [x] Add focused regression coverage.
+- [x] Run targeted tests and practical build checks.
+
+## Notes
+
+The screenshot points at the main window chrome around the tab strip. The app
+already has a full-window `.titlebar-drag` layer under the tab bar, but the tab
+bar is above it, so empty tab-strip space needs the same explicit
+`startDragging()` pointer path used by the base titlebar region.
+
+## Verification
+
+- `pnpm test -- src/test/tab-bar.test.tsx`
+- `pnpm run lint`
+- `pnpm run build`
+- `curl http://127.0.0.1:1422/` against a temporary Vite server returned
+  `200 OK`
+- `pnpm test`
+
+## Previous Work
+
 # Dictation HUD second-run visual stability
 
 - [x] Read the attached transcript and screenshot.
@@ -34,7 +60,7 @@
       animation so the processing HUD appears seamlessly.
 - [x] Compare dictation HUD transparency with the agent HUD surface.
 
-## Notes
+## Previous Notes
 
 The screenshot shows the right side of the dictation pill cut by the window
 edge. The report says the issue heals on the next transition, which points at
@@ -44,7 +70,7 @@ listening show becomes visible while the native frame is still resizing from a
 stale width. Fresh shows now set native alpha to zero, snap-size the window,
 then reveal; visible state-to-state transitions still use the morph.
 
-## Verification
+## Previous Verification
 
 - `pnpm test -- src/test/hud-meeting.test.ts`
 - `pnpm test`


### PR DESCRIPTION
## Summary

- Forward direct pointerdown events from empty tab-bar/tab-strip space to the existing native window drag handler
- Preserve normal tab, close, overflow, and new-tab control behavior by ignoring bubbled child events
- Add focused TabBar regression coverage for empty-strip drag vs. real tab controls

## Verification

- pnpm test -- src/test/tab-bar.test.tsx
- pnpm run lint
- pnpm run build
- pnpm test