### PR TITLE
[codex] Contain update prompt in sidebar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2290,6 +2290,21 @@ export function App() {
         }}
         recoverableNoteIds={recoverableNoteIds}
         collapsed={sidebarCollapsed}
+        footerAccessory={
+          <UpdateHub
+            readyUpdate={readyUpdate}
+            status={updateStatus}
+            preparing={preparingUpdate}
+            relaunching={relaunchingUpdate}
+            progress={updateProgress}
+            onDismissStatus={() => {
+              if (preparingUpdate) updateProgressHiddenRef.current = true;
+              setUpdateStatus(null);
+              if (!preparingUpdate) setUpdateProgress(null);
+            }}
+            onRelaunch={handleRelaunchUpdate}
+          />
+        }
       />
       <div
         className="sidebar-resize-handle"
@@ -2789,19 +2804,6 @@ export function App() {
           handleSetSessionFolder(sessionId, folderId)
         }
         onMoved={() => agentSessionsListRef.current?.resetSelection()}
-      />
-      <UpdateHub
-        readyUpdate={readyUpdate}
-        status={updateStatus}
-        preparing={preparingUpdate}
-        relaunching={relaunchingUpdate}
-        progress={updateProgress}
-        onDismissStatus={() => {
-          if (preparingUpdate) updateProgressHiddenRef.current = true;
-          setUpdateStatus(null);
-          if (!preparingUpdate) setUpdateProgress(null);
-        }}
-        onRelaunch={handleRelaunchUpdate}
       />
     </main>
   );

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -98,6 +98,7 @@ type SidebarProps = {
   onSelectAgentSession: (session: HermesSessionInfo) => void;
   recoverableNoteIds?: ReadonlySet<string>;
   collapsed?: boolean;
+  footerAccessory?: ReactNode;
 };
 
 type MenuState =
@@ -234,6 +235,7 @@ export function Sidebar({
   onSelectAgentSession,
   recoverableNoteIds,
   collapsed = false,
+  footerAccessory,
 }: SidebarProps) {
   const [query, setQuery] = useState("");
   const commandInputRef = useRef<HTMLInputElement>(null);
@@ -1047,6 +1049,7 @@ export function Sidebar({
       )}
 
       <footer className="sidebar-footer">
+        {footerAccessory}
         <SidebarIdentity
           account={account}
           menuOpen={identityMenuOpen}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4385,7 +4385,7 @@ input:focus-visible,
   display: flex;
   flex: 0 0 auto;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--sp-2);
   padding-top: 0;
   background: var(--sidebar);
 }
@@ -11708,11 +11708,8 @@ input:focus-visible,
 }
 
 .update-popover {
-  position: fixed;
-  left: var(--sp-5);
-  bottom: calc(var(--sp-3) + var(--control-lg) + var(--sp-5));
-  z-index: 45;
-  width: min(312px, calc(100vw - var(--sp-8)));
+  width: 100%;
+  min-width: 0;
   color: var(--foreground);
   -webkit-app-region: no-drag;
   animation: update-popover-in var(--t-med) var(--ease-spring) both;
@@ -11720,12 +11717,12 @@ input:focus-visible,
 
 .update-relaunch-card {
   display: grid;
-  grid-template-columns: 36px minmax(0, 1fr) 22px;
+  grid-template-columns: 34px minmax(0, 1fr) 18px;
   align-items: center;
-  gap: var(--sp-4);
+  gap: var(--sp-3);
   width: 100%;
-  min-height: 70px;
-  padding: var(--sp-3);
+  min-height: 64px;
+  padding: var(--sp-2);
   border: 1px solid var(--popover-border);
   border-radius: var(--r-md);
   background: var(--popover);
@@ -11760,8 +11757,8 @@ input:focus-visible,
 .update-relaunch-mark {
   display: inline-grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   border-radius: var(--r-md);
   background: color-mix(in oklch, var(--brand) 12%, transparent);
   color: var(--brand);
@@ -11781,7 +11778,7 @@ input:focus-visible,
 .update-relaunch-title {
   overflow: hidden;
   color: var(--foreground);
-  font-size: var(--fs-lg);
+  font-size: var(--fs-md);
   font-weight: var(--fw-medium);
   line-height: 1.2;
   text-overflow: ellipsis;
@@ -11809,6 +11806,7 @@ input:focus-visible,
 .update-status-card {
   display: grid;
   gap: var(--sp-3);
+  width: 100%;
   padding: var(--sp-3);
   border: 1px solid var(--popover-border);
   border-radius: var(--r-md);
@@ -11899,15 +11897,6 @@ input:focus-visible,
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
-  }
-}
-
-@media (max-width: 560px) {
-  .update-popover {
-    left: var(--sp-3);
-    right: var(--sp-3);
-    bottom: var(--sp-3);
-    width: auto;
   }
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4395,6 +4395,10 @@ input:focus-visible,
   border-top: 0;
 }
 
+.sidebar[data-collapsed="true"] .update-popover {
+  display: none;
+}
+
 /* Sidebar identity — the user's name doubles as the settings entry point.
  * Clicking it opens a small popover above the footer. */
 .sidebar-identity-wrap {


### PR DESCRIPTION
## What changed

- Moves the update ready/status UI into the sidebar footer instead of rendering it as a viewport-fixed popover.
- Sizes the relaunch card to the sidebar column with compact grid columns so it stays contained at the default sidebar width and while resizing.

## Why

The relaunch-to-update card had a fixed 312px width and a viewport left offset. On the default 240px sidebar, that made the card spill into the main content area.

## Validation

- `pnpm exec prettier --check src/app/App.tsx src/components/sidebar/Sidebar.tsx src/styles/app.css`
- `pnpm lint`
- `pnpm test`
- `git diff --check`
