### PR TITLE
feat: add live transcript preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Useful validation docs:
 
 Architecture and product notes:
 
+- [docs/adr/0001-auto-updates-via-tauri-updater.md](docs/adr/0001-auto-updates-via-tauri-updater.md)
 - [docs/adr/0002-live-transcript-preview-strategy.md](docs/adr/0002-live-transcript-preview-strategy.md)
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Useful validation docs:
 - [specs/002-system-audio-source-mode/quickstart.md](specs/002-system-audio-source-mode/quickstart.md)
 - [specs/003-conversation-turns/quickstart.md](specs/003-conversation-turns/quickstart.md)
 
+Architecture and product notes:
+
+- [docs/adr/0002-live-transcript-preview-strategy.md](docs/adr/0002-live-transcript-preview-strategy.md)
+
 ## Release notes
 
 Production desktop releases are cut from GitHub Actions. macOS produces signed

--- a/docs/adr/0002-live-transcript-preview-strategy.md
+++ b/docs/adr/0002-live-transcript-preview-strategy.md
@@ -1,0 +1,252 @@
+# Live transcript preview for meeting notes
+
+## Status
+
+proposed
+
+## Context
+
+Users want to see words appear while June is taking meeting notes. The product
+question is whether we should build that as true real-time transcription or as a
+lower-risk live preview that later reconciles with June's existing saved-audio
+pipeline.
+
+The current meeting-notes architecture is deliberately saved-audio-first:
+
+- `src-tauri/src/audio/capture.rs` records microphone audio to local WAV files
+  and tracks live levels.
+- `src-tauri/src/audio/system_macos.rs` records system audio as a separate local
+  source on supported macOS versions.
+- `finish_recording` validates finalized source artifacts before starting
+  transcription.
+- `src-tauri/src/domain/processing.rs` detects microphone and system turns after
+  recording, transcribes saved turn WAVs, persists source transcripts, and only
+  then generates notes.
+- `src/components/note-editor/NoteEditor.tsx` already has a Transcription tab
+  that renders ordered `Microphone` and `System` turns.
+
+That reliability model matters. Saved audio is the retry source of truth, and
+the transcript that feeds note generation is built from validated audio rather
+than volatile UI text.
+
+Provider capabilities are uneven:
+
+- OpenAI supports realtime transcription sessions for live transcript deltas
+  from streaming audio. Its file-oriented speech-to-text guide explicitly points
+  microphone, call, and media-stream use cases to realtime transcription.
+- Google Cloud Speech-to-Text, Amazon Transcribe, and Azure Speech all document
+  cloud streaming speech-to-text paths.
+- Local Whisper-style systems can run a chunked or sliding-window preview, but
+  classic Whisper is not a native streaming ASR model. Implementations such as
+  `whisper.cpp` describe their stream example as sampling audio periodically and
+  running inference repeatedly. That can be useful, but latency, repetition,
+  battery use, and correction behavior are product constraints.
+
+So the decision is not "OpenAI or nothing." The decision is to separate the
+user-visible live transcript surface from the provider transport that produces
+preview text.
+
+## Decision
+
+Build **live transcript preview** as an optional recording companion, not as the
+source of truth for notes.
+
+The initial contract should be provider-neutral:
+
+```ts
+type LiveTranscriptSource = "microphone" | "system";
+type LiveTranscriptTransport = "chunked" | "streaming";
+type LiveTranscriptStability = "partial" | "final";
+
+type LiveTranscriptEvent = {
+  noteId: string;
+  sessionId: string;
+  source: LiveTranscriptSource;
+  segmentId: string;
+  sequence: number;
+  startMs: number;
+  endMs: number;
+  text: string;
+  stability: LiveTranscriptStability;
+  provider: string;
+  transport: LiveTranscriptTransport;
+  receivedAt: string;
+};
+```
+
+The event stream is ephemeral UI state:
+
+- It appears while a note is actively recording.
+- It may revise, replace, or drop partial text.
+- It is not copied into `transcripts` as the final record.
+- It is reconciled or discarded when final post-recording processing completes.
+- If preview fails, recording continues and the final transcript still runs from
+  saved local audio.
+
+Product copy should avoid promising exact realtime behavior. Use "Live preview"
+or "Live transcript preview" in the app unless we are specifically describing a
+provider-backed streaming implementation.
+
+## Architecture
+
+### Backend capture tap
+
+Add a non-blocking live-preview tap beside the existing file writer:
+
+1. The capture callback still prioritizes writing source audio to disk and
+   updating level stats.
+2. A bounded channel receives small PCM windows for preview.
+3. If the preview channel is full, drop preview audio and keep recording.
+4. Pause and resume follow the recorder state.
+5. Microphone and system audio stay in separate lanes.
+
+This should not hold the current `ACTIVE_RECORDING` mutex during provider work.
+Provider work belongs in a worker task that consumes preview chunks and emits
+Tauri events.
+
+### Frontend state
+
+The frontend should store live preview turns separately from `NoteDto`:
+
+- Key by `sessionId`, `source`, and `segmentId`.
+- Sort by `sequence`, then `startMs`.
+- Render partial text with a lighter treatment than final preview segments.
+- Clear the preview when the recording session ends and the persisted transcript
+  arrives.
+- If a new recording starts while another note is transcribing, show the normal
+  recording UI and the new session's preview, not the previous session's
+  pending processing state.
+
+The Transcription tab can reuse the existing source-turn layout, but it should
+make preview status clear:
+
+- While recording: show "Live preview" as quiet metadata.
+- After stop: show the existing transcribing or generating state until final
+  persisted turns are available.
+- If preview is delayed or unavailable: show a small status line and keep the
+  recorder controls usable.
+
+### Provider abstraction
+
+Introduce a capability boundary rather than a provider-specific UI path:
+
+```rust
+enum LiveTranscriptCapability {
+    Unsupported,
+    ChunkedPreview,
+    StreamingDeltas,
+}
+
+trait LiveTranscriptProvider {
+    fn capability(&self) -> LiveTranscriptCapability;
+    async fn run(&self, input: LiveTranscriptInput, sink: LiveTranscriptSink)
+        -> Result<(), AppError>;
+}
+```
+
+Provider implementations can differ internally:
+
+- `ChunkedPreview` can use short rolling WAV windows and the existing Scribe API
+  transcription path. It is less immediate, but it keeps the private,
+  saved-audio-first posture and avoids a proprietary realtime dependency.
+- `StreamingDeltas` can use OpenAI, Google, AWS, Azure, or another provider with
+  a true streaming API. It should normalize provider-specific partial and final
+  events into `LiveTranscriptEvent`.
+- `Unsupported` disables the preview while preserving recording and final
+  transcription.
+
+## Phased rollout
+
+### Phase 1: Chunked local/private preview
+
+Ship an experiment that provides useful live visibility without changing the
+final transcript contract.
+
+- Capture 5-10 second rolling windows per source.
+- Send windows to Scribe API using a new preview action or a constrained variant
+  of the current transcription endpoint.
+- Prompt each chunk with recent preview text to reduce repeated words.
+- Emit provisional `LiveTranscriptEvent` records to the frontend.
+- Drop stale chunks if transcription falls behind.
+- Do not bill users for both preview and final transcription without an explicit
+  product decision. The billing model must be resolved before broad rollout.
+
+Expected behavior: users see delayed live preview, usually a few seconds behind.
+This is not word-by-word realtime, but it answers "is June hearing this meeting"
+and gives users confidence during the recording.
+
+### Phase 2: Optional streaming providers
+
+Add a provider capability for true streaming deltas.
+
+- Gate cloud streaming behind explicit provider selection and privacy copy.
+- Keep raw audio inside the current Scribe API trust boundary when possible.
+- Prefer server-side WebSocket or gRPC bridges so provider keys stay out of the
+  desktop app.
+- Normalize every provider into the same frontend event shape.
+- Keep final persisted transcripts generated from saved local artifacts unless
+  we intentionally add an audited path for accepting streaming finals.
+
+Expected behavior: users who opt into a streaming-capable provider get lower
+latency. Users who stay on the private default still get chunked preview or no
+preview, depending on model support.
+
+### Phase 3: Local streaming ASR runtime
+
+Evaluate a dedicated local ASR runtime only after Phase 1 teaches us the product
+latency threshold.
+
+- Candidate engines must handle macOS and Windows packaging.
+- CPU, memory, battery, model download size, and update flow must be measured.
+- The local engine must support cancellation and backpressure.
+- A local model can power preview even if final transcript generation continues
+  through the existing provider path.
+
+Expected behavior: privacy-friendly live preview without sending raw audio to a
+new cloud provider, if runtime costs are acceptable.
+
+## Privacy and product guardrails
+
+- Do not silently route live audio to a new third-party provider.
+- Default to the current private path unless the user deliberately chooses a
+  streaming provider.
+- Make preview status honest. "Live preview delayed" is better than pretending
+  partial text is authoritative.
+- Never let preview failure fail the recording.
+- Never let preview backpressure block the file writer.
+- Keep consent reminders and recording indicators unchanged.
+- Preserve saved local audio as the retry source of truth.
+
+## Acceptance criteria for the first implementation PR
+
+- Recording and final note generation still work when live preview is disabled.
+- Preview failures do not change recorder state or processing status.
+- Partial preview text is visually distinct from persisted transcript text.
+- Stopping a recording clears preview state and transitions to the existing
+  transcribing or generating states.
+- A queued second recording shows its own live preview while the prior recording
+  continues background processing.
+- Microphone-only and microphone-plus-system modes both have deterministic
+  source lanes.
+- Tests cover frontend preview reconciliation and backend preview backpressure.
+
+## Open questions
+
+- What latency threshold feels valuable enough for Phase 1: 3 seconds, 5
+  seconds, or 10 seconds?
+- Do users expect preview to appear in the Notes tab, the Transcription tab, or
+  both?
+- Should preview be included in copied transcript text while recording?
+- How should preview usage be priced if it calls paid transcription models
+  before final transcription?
+- Does the product want a "use cloud realtime transcription" setting, or should
+  it be attached to model selection?
+
+## References checked on 2026-06-16
+
+- [OpenAI Realtime and audio guide](https://developers.openai.com/api/docs/guides/realtime)
+- [OpenAI Speech to text guide](https://developers.openai.com/api/docs/guides/speech-to-text)
+- [Google Cloud Speech-to-Text streaming audio guide](https://docs.cloud.google.com/speech-to-text/docs/v1/transcribe-streaming-audio)
+- [Amazon Transcribe streaming audio guide](https://docs.aws.amazon.com/transcribe/latest/dg/streaming.html)
+- [Azure Speech-to-text documentation](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/index-speech-to-text)
+- [whisper.cpp realtime audio input example](https://github.com/ggml-org/whisper.cpp?tab=readme-ov-file#real-time-audio-input-example)

--- a/docs/adr/0002-live-transcript-preview-strategy.md
+++ b/docs/adr/0002-live-transcript-preview-strategy.md
@@ -187,8 +187,8 @@ Implemented Phase 1 behavior:
 - Preview workers transcribe 8 second microphone chunks as `preview=true`
   Scribe API requests.
 - The API validates the model and audio, enforces a server-side preview duration
-  cap, authorizes a wallet hold, and returns a zero-credit receipt without
-  settling a wallet charge.
+  cap, authorizes a wallet hold, and settles it with a zero-credit charge before
+  returning the preview receipt.
 - React stores preview events outside `NoteDto`, renders them only in the
   Transcription tab, and clears them when recording stops.
 

--- a/docs/adr/0002-live-transcript-preview-strategy.md
+++ b/docs/adr/0002-live-transcript-preview-strategy.md
@@ -186,8 +186,9 @@ Implemented Phase 1 behavior:
   writer remains the priority.
 - Preview workers transcribe 8 second microphone chunks as `preview=true`
   Scribe API requests.
-- The API validates the model and audio but returns a zero-credit receipt for
-  preview requests. It does not authorize a hold or settle a wallet charge.
+- The API validates the model and audio, enforces a server-side preview duration
+  cap, authorizes a wallet hold, and returns a zero-credit receipt without
+  settling a wallet charge.
 - React stores preview events outside `NoteDto`, renders them only in the
   Transcription tab, and clears them when recording stops.
 

--- a/docs/adr/0002-live-transcript-preview-strategy.md
+++ b/docs/adr/0002-live-transcript-preview-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-proposed
+accepted - Phase 1 microphone preview implemented
 
 ## Context
 
@@ -61,18 +61,22 @@ type LiveTranscriptStability = "partial" | "final";
 type LiveTranscriptEvent = {
   noteId: string;
   sessionId: string;
+  sourceMode: "microphoneOnly" | "microphonePlusSystem";
   source: LiveTranscriptSource;
   segmentId: string;
-  sequence: number;
   startMs: number;
   endMs: number;
   text: string;
+  language?: string;
   stability: LiveTranscriptStability;
-  provider: string;
-  transport: LiveTranscriptTransport;
-  receivedAt: string;
 };
 ```
+
+Phase 1 ships the microphone chunked-preview subset of this contract through
+the `live-transcript-event` Tauri event. The system-audio lane remains part of
+the provider-neutral design, but live system-source preview requires extending
+the macOS helper process to expose preview PCM without weakening the finalized
+audio source-of-truth path.
 
 The event stream is ephemeral UI state:
 
@@ -144,6 +148,11 @@ trait LiveTranscriptProvider {
 }
 ```
 
+The project toolchain already satisfies the Rust 1.75+ requirement for direct
+`async fn` in traits (`scribe-api` pins Rust 1.95). If this boundary needs to be
+used as an object-safe trait, implement it with `async_trait` or an explicit
+boxed future instead of relying on direct `async fn` trait object dispatch.
+
 Provider implementations can differ internally:
 
 - `ChunkedPreview` can use short rolling WAV windows and the existing Scribe API
@@ -170,6 +179,17 @@ final transcript contract.
 - Drop stale chunks if transcription falls behind.
 - Do not bill users for both preview and final transcription without an explicit
   product decision. The billing model must be resolved before broad rollout.
+
+Implemented Phase 1 behavior:
+
+- The microphone capture callback feeds a bounded preview channel while the WAV
+  writer remains the priority.
+- Preview workers transcribe 8 second microphone chunks as `preview=true`
+  Scribe API requests.
+- The API validates the model and audio but returns a zero-credit receipt for
+  preview requests. It does not authorize a hold or settle a wallet charge.
+- React stores preview events outside `NoteDto`, renders them only in the
+  Transcription tab, and clears them when recording stops.
 
 Expected behavior: users see delayed live preview, usually a few seconds behind.
 This is not word-by-word realtime, but it answers "is June hearing this meeting"
@@ -229,6 +249,8 @@ new cloud provider, if runtime costs are acceptable.
 - Microphone-only and microphone-plus-system modes both have deterministic
   source lanes.
 - Tests cover frontend preview reconciliation and backend preview backpressure.
+- Phase 1 preview calls do not result in a separate user charge without a
+  product decision on billing.
 
 ## Open questions
 
@@ -244,6 +266,7 @@ new cloud provider, if runtime costs are acceptable.
 
 ## References checked on 2026-06-16
 
+- [OpenAI Realtime transcription guide](https://developers.openai.com/api/docs/guides/realtime-transcription)
 - [OpenAI Realtime and audio guide](https://developers.openai.com/api/docs/guides/realtime)
 - [OpenAI Speech to text guide](https://developers.openai.com/api/docs/guides/speech-to-text)
 - [Google Cloud Speech-to-Text streaming audio guide](https://docs.cloud.google.com/speech-to-text/docs/v1/transcribe-streaming-audio)

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -49,6 +49,7 @@ authorize_hold_ttl_note_transcribe_secs = 60
 authorize_hold_ttl_note_generate_secs = 300
 authorize_hold_ttl_dictate_transcribe_secs = 30
 authorize_hold_ttl_dictate_cleanup_secs = 30
+note_transcribe_preview_max_audio_secs = 30
 flat_estimate_credits = 250
 
 [upstreams.openai]

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -45,9 +45,10 @@ pub(crate) async fn transcribe(
         language.as_deref(),
         validation::MAX_LANGUAGE_CHARS,
     )?;
-    let preview = form
-        .optional_text("preview")
-        .is_some_and(|value| matches!(value.as_str(), "true" | "1"));
+    // This client field is not an authorization decision. It only requests
+    // live-preview semantics; NoteTranscribeService still probes duration,
+    // enforces the preview cap, and authorizes with OS Accounts before ASR.
+    let preview = parse_preview_flag(form.optional_text("preview").as_deref());
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;
     let filename = form
@@ -227,9 +228,13 @@ fn require_priced_model_kind(
     }
 }
 
+fn parse_preview_flag(value: Option<&str>) -> bool {
+    value.is_some_and(|value| matches!(value, "true" | "1"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::require_priced_model_kind;
+    use super::{parse_preview_flag, require_priced_model_kind};
     use crate::ApiError;
     use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
     use scribe_domain::ModelKind;
@@ -309,5 +314,14 @@ mod tests {
             error,
             ApiError::Unprocessable { message, .. } if message == "model_not_priced"
         ));
+    }
+
+    #[test]
+    fn parse_preview_flag_accepts_only_wire_true_values() {
+        assert!(parse_preview_flag(Some("true")));
+        assert!(parse_preview_flag(Some("1")));
+        assert!(!parse_preview_flag(None));
+        assert!(!parse_preview_flag(Some("false")));
+        assert!(!parse_preview_flag(Some("yes")));
     }
 }

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -45,6 +45,9 @@ pub(crate) async fn transcribe(
         language.as_deref(),
         validation::MAX_LANGUAGE_CHARS,
     )?;
+    let preview = form
+        .optional_text("preview")
+        .is_some_and(|value| matches!(value.as_str(), "true" | "1"));
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;
     let filename = form
@@ -60,6 +63,7 @@ pub(crate) async fn transcribe(
             context,
             language,
             model_id: ModelId(model_id),
+            preview,
         })
         .await?;
     Ok(Json(ApiResponse::ok(TranscribeResponse::from(output))))

--- a/scribe-api/crates/api/tests/http_boundary.rs
+++ b/scribe-api/crates/api/tests/http_boundary.rs
@@ -354,6 +354,7 @@ fn test_state_with_sinks(
             duration_probe: duration_probe.clone(),
             hold_ttl_seconds: 30,
             flat_estimate_credits: 1_000,
+            preview_max_audio_seconds: 30,
         })),
         note_generate: Arc::new(NoteGenerateService::new(NoteGenerateServiceDeps {
             pricing: pricing.clone(),

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -113,6 +113,7 @@ fn build_router(
         duration_probe: duration_probe.clone(),
         hold_ttl_seconds: config.os_accounts.authorize_hold_ttl_note_transcribe_secs,
         flat_estimate_credits,
+        preview_max_audio_seconds: config.os_accounts.note_transcribe_preview_max_audio_secs,
     }));
     let note_generate = Arc::new(NoteGenerateService::new(NoteGenerateServiceDeps {
         pricing: pricing.clone(),

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -155,6 +155,10 @@ pub struct OsAccountsConfig {
     pub authorize_hold_ttl_note_generate_secs: u64,
     pub authorize_hold_ttl_dictate_transcribe_secs: u64,
     pub authorize_hold_ttl_dictate_cleanup_secs: u64,
+    /// Maximum audio duration accepted by no-charge live preview requests.
+    /// Desktop chunks are shorter; this server cap prevents arbitrary-length
+    /// preview transcription if a client replays the public endpoint.
+    pub note_transcribe_preview_max_audio_secs: u64,
     /// Skip per-request estimation entirely and authorize this many credits
     /// for every metered action. Trades a bigger Hold (and thus a tighter
     /// max concurrency per user) for not needing to probe audio duration or
@@ -190,6 +194,10 @@ impl Debug for OsAccountsConfig {
             .field(
                 "authorize_hold_ttl_dictate_cleanup_secs",
                 &self.authorize_hold_ttl_dictate_cleanup_secs,
+            )
+            .field(
+                "note_transcribe_preview_max_audio_secs",
+                &self.note_transcribe_preview_max_audio_secs,
             )
             .field("flat_estimate_credits", &self.flat_estimate_credits)
             .finish()
@@ -454,6 +462,7 @@ impl Default for AppConfig {
                 authorize_hold_ttl_note_generate_secs: 300,
                 authorize_hold_ttl_dictate_transcribe_secs: 30,
                 authorize_hold_ttl_dictate_cleanup_secs: 30,
+                note_transcribe_preview_max_audio_secs: 30,
                 flat_estimate_credits: 250,
             },
             upstreams: UpstreamsConfig {
@@ -513,6 +522,10 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
         "os_accounts.app_api_key",
         &config.os_accounts.app_api_key,
         "osk_REPLACE_ME",
+    )?;
+    validate_positive_config(
+        "os_accounts.note_transcribe_preview_max_audio_secs",
+        config.os_accounts.note_transcribe_preview_max_audio_secs,
     )?;
 
     let uses_openai = config
@@ -604,6 +617,16 @@ fn validate_required_secret(
         return Err(ConfigError::InvalidRequired {
             field,
             reason: "placeholder value must be replaced",
+        });
+    }
+    Ok(())
+}
+
+fn validate_positive_config(field: &'static str, value: u64) -> Result<(), ConfigError> {
+    if value == 0 {
+        return Err(ConfigError::InvalidRequired {
+            field,
+            reason: "must be > 0",
         });
     }
     Ok(())
@@ -710,6 +733,16 @@ mod tests {
             pricing,
             ..valid_config()
         };
+
+        let result = validate(&config);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_preview_audio_cap() {
+        let mut config = valid_config();
+        config.os_accounts.note_transcribe_preview_max_audio_secs = 0;
 
         let result = validate(&config);
 

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -402,11 +402,54 @@ mod tests {
                 context: None,
                 language: None,
                 model_id: ModelId("audio-model".to_string()),
+                preview: false,
             })
             .await;
 
         assert!(matches!(result, Err(ServiceError::InvalidInput { .. })));
         assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_dispatches_asr_without_wallet_charge() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-session-1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: Some("Previous words".to_string()),
+                language: Some("en".to_string()),
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+            })
+            .await
+            .expect("preview transcription succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
+        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(
+            transcriber.last_context(),
+            Some("Previous words".to_string())
+        );
+        assert_eq!(transcriber.last_language(), Some("en".to_string()));
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -412,7 +412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_authorizes_dispatches_asr_without_wallet_charge() {
+    async fn note_transcribe_preview_authorizes_dispatches_asr_and_settles_zero_credits() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -447,12 +447,20 @@ mod tests {
         assert_eq!(output.receipt.credits_charged.0, 0);
         assert_eq!(
             os_accounts.events(),
-            vec![RecordedCall::Authorize {
-                user_id: "usr_123".to_string(),
-                action: "note_transcribe".to_string(),
-                estimate: 1024,
-                hold_ttl: 60,
-            }]
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
+                        .to_string(),
+                },
+            ]
         );
         assert_eq!(transcriber.call_count(), 1);
         assert_eq!(
@@ -460,6 +468,57 @@ mod tests {
             Some("Previous words".to_string())
         );
         assert_eq!(transcriber.last_language(), Some("en".to_string()));
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_settles_zero_credits_when_asr_fails() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FailingTranscriber),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-session-1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
+                        .to_string(),
+                },
+            ]
+        );
     }
 
     #[tokio::test]
@@ -819,6 +878,18 @@ mod tests {
                 language: Some("en".to_string()),
                 provider: "test".to_string(),
             })
+        }
+    }
+
+    struct FailingTranscriber;
+
+    #[async_trait]
+    impl Transcriber for FailingTranscriber {
+        async fn transcribe(
+            &self,
+            _request: TranscriptionRequest,
+        ) -> Result<Transcript, DomainError> {
+            Err(DomainError::UpstreamProvider)
         }
     }
 

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -391,6 +391,7 @@ mod tests {
             duration_probe: Arc::new(FailingDurationProbe),
             hold_ttl_seconds: 60,
             flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
         });
 
         let result = service
@@ -411,7 +412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_dispatches_asr_without_wallet_charge() {
+    async fn note_transcribe_preview_authorizes_dispatches_asr_without_wallet_charge() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -426,6 +427,7 @@ mod tests {
             duration_probe: Arc::new(FixedDurationProbe),
             hold_ttl_seconds: 60,
             flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
         });
 
         let output = service
@@ -443,13 +445,107 @@ mod tests {
             .expect("preview transcription succeeds");
 
         assert_eq!(output.receipt.credits_charged.0, 0);
-        assert_eq!(os_accounts.events(), Vec::new());
+        assert_eq!(
+            os_accounts.events(),
+            vec![RecordedCall::Authorize {
+                user_id: "usr_123".to_string(),
+                action: "note_transcribe".to_string(),
+                estimate: 1024,
+                hold_ttl: 60,
+            }]
+        );
         assert_eq!(transcriber.call_count(), 1);
         assert_eq!(
             transcriber.last_context(),
             Some("Previous words".to_string())
         );
         assert_eq!(transcriber.last_language(), Some("en".to_string()));
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_denied_authorization_does_not_dispatch_asr() {
+        let os_accounts = Arc::new(RecordingOsAccounts {
+            allow: false,
+            deny_reason: Some("insufficient_available_balance".to_string()),
+            ..RecordingOsAccounts::default()
+        });
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-session-1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::InsufficientCredits)));
+        assert_eq!(transcriber.call_count(), 0);
+        assert_eq!(
+            os_accounts.events(),
+            vec![RecordedCall::Authorize {
+                user_id: "usr_123".to_string(),
+                action: "note_transcribe".to_string(),
+                estimate: 1024,
+                hold_ttl: 60,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_rejects_audio_over_duration_cap() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 1,
+        });
+
+        let result = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-session-1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+            })
+            .await;
+
+        assert!(matches!(result, Err(ServiceError::InvalidInput { .. })));
+        assert_eq!(transcriber.call_count(), 0);
+        assert_eq!(os_accounts.events(), Vec::new());
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -66,6 +66,28 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
+        if params.preview {
+            tracing::info!(
+                note_id = %params.note_id,
+                model = %params.model_id.0,
+                seconds,
+                "note_transcribe: preview request is not charged"
+            );
+            let transcript = self
+                .transcriber
+                .transcribe(TranscriptionRequest {
+                    audio: params.audio,
+                    format,
+                    context: params.context,
+                    language: params.language,
+                    model: params.model_id.clone(),
+                })
+                .await?;
+            return Ok(NoteTranscribeOutput {
+                transcript,
+                receipt: uncharged_receipt(),
+            });
+        }
         // Flat-estimate mode: skip per-request estimation for the upfront
         // authorize. The Hold is bigger than necessary; the actual charge
         // below is what the user pays.
@@ -127,6 +149,13 @@ impl NoteTranscribeService {
     }
 }
 
+fn uncharged_receipt() -> Receipt {
+    Receipt {
+        credits_charged: Credits(0),
+        idempotent_replay: false,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct NoteTranscribeParams {
     pub user_id: UserId,
@@ -137,6 +166,7 @@ pub struct NoteTranscribeParams {
     pub context: Option<String>,
     pub language: Option<String>,
     pub model_id: ModelId,
+    pub preview: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -19,6 +19,7 @@ pub struct NoteTranscribeServiceDeps {
     pub duration_probe: Arc<dyn AudioDurationProbe>,
     pub hold_ttl_seconds: u64,
     pub flat_estimate_credits: u64,
+    pub preview_max_audio_seconds: u64,
 }
 
 pub struct NoteTranscribeService {
@@ -28,6 +29,7 @@ pub struct NoteTranscribeService {
     duration_probe: Arc<dyn AudioDurationProbe>,
     hold_ttl_seconds: u64,
     flat_estimate_credits: u64,
+    preview_max_audio_seconds: u64,
 }
 
 impl NoteTranscribeService {
@@ -39,6 +41,7 @@ impl NoteTranscribeService {
             duration_probe: deps.duration_probe,
             hold_ttl_seconds: deps.hold_ttl_seconds,
             flat_estimate_credits: deps.flat_estimate_credits,
+            preview_max_audio_seconds: deps.preview_max_audio_seconds.max(1),
         }
     }
 
@@ -66,12 +69,33 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
+        // Flat-estimate mode: skip per-request estimation for the upfront
+        // authorize. The Hold is bigger than necessary; the actual charge
+        // below is what the user pays.
+        let estimate = Credits(self.flat_estimate_credits);
         if params.preview {
+            if seconds > self.preview_max_audio_seconds {
+                return Err(ServiceError::InvalidInput {
+                    reason: format!(
+                        "live transcript preview chunks must be {} seconds or shorter",
+                        self.preview_max_audio_seconds
+                    ),
+                });
+            }
+            let _authorization = authorize_or_deny(AuthorizeParams {
+                os_accounts: self.os_accounts.as_ref(),
+                user_id: params.user_id.clone(),
+                action: ActionSlug::NoteTranscribe,
+                estimate,
+                hold_ttl_seconds: self.hold_ttl_seconds,
+            })
+            .await?;
             tracing::info!(
                 note_id = %params.note_id,
                 model = %params.model_id.0,
                 seconds,
-                "note_transcribe: preview request is not charged"
+                estimate_credits = estimate.0,
+                "note_transcribe: preview request authorized and not charged"
             );
             let transcript = self
                 .transcriber
@@ -88,10 +112,6 @@ impl NoteTranscribeService {
                 receipt: uncharged_receipt(),
             });
         }
-        // Flat-estimate mode: skip per-request estimation for the upfront
-        // authorize. The Hold is bigger than necessary; the actual charge
-        // below is what the user pays.
-        let estimate = Credits(self.flat_estimate_credits);
         tracing::info!(
             note_id = %params.note_id,
             estimate_credits = estimate.0,

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -113,7 +113,7 @@ impl NoteTranscribeService {
                 ),
             });
         }
-        authorize_or_deny(AuthorizeParams {
+        let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),
             action: ActionSlug::NoteTranscribe,
@@ -126,9 +126,13 @@ impl NoteTranscribeService {
             model = %params.model_id.0,
             seconds,
             estimate_credits = estimate.0,
-            "note_transcribe: preview request authorized and not charged"
+            "note_transcribe: preview request authorized"
         );
-        let transcript = self
+        let idempotency_key = format!(
+            "note_transcribe_preview:{}:{}",
+            params.user_id.0, params.note_id
+        );
+        let transcript_result = self
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
@@ -137,10 +141,23 @@ impl NoteTranscribeService {
                 language: params.language,
                 model: params.model_id.clone(),
             })
-            .await?;
+            .await
+            .map_err(ServiceError::from);
+        let receipt = charge(ChargeParams {
+            os_accounts: self.os_accounts.as_ref(),
+            action_token: authorization.action_token,
+            credits: Credits(0),
+            idempotency_key,
+        })
+        .await?;
+        let transcript = transcript_result?;
+        tracing::info!(
+            note_id = %params.note_id,
+            "note_transcribe: preview hold settled with zero credits"
+        );
         Ok(NoteTranscribeOutput {
             transcript,
-            receipt: uncharged_receipt(),
+            receipt,
         })
     }
 
@@ -209,13 +226,6 @@ impl NoteTranscribeService {
             transcript,
             receipt,
         })
-    }
-}
-
-fn uncharged_receipt() -> Receipt {
-    Receipt {
-        credits_charged: Credits(0),
-        idempotent_replay: false,
     }
 }
 

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -32,6 +32,14 @@ pub struct NoteTranscribeService {
     preview_max_audio_seconds: u64,
 }
 
+struct PreparedNoteTranscription {
+    params: NoteTranscribeParams,
+    format: AudioFormat,
+    seconds: u64,
+    actual: Credits,
+    estimate: Credits,
+}
+
 impl NoteTranscribeService {
     pub fn new(deps: NoteTranscribeServiceDeps) -> Self {
         Self {
@@ -73,45 +81,80 @@ impl NoteTranscribeService {
         // authorize. The Hold is bigger than necessary; the actual charge
         // below is what the user pays.
         let estimate = Credits(self.flat_estimate_credits);
-        if params.preview {
-            if seconds > self.preview_max_audio_seconds {
-                return Err(ServiceError::InvalidInput {
-                    reason: format!(
-                        "live transcript preview chunks must be {} seconds or shorter",
-                        self.preview_max_audio_seconds
-                    ),
-                });
-            }
-            let _authorization = authorize_or_deny(AuthorizeParams {
-                os_accounts: self.os_accounts.as_ref(),
-                user_id: params.user_id.clone(),
-                action: ActionSlug::NoteTranscribe,
-                estimate,
-                hold_ttl_seconds: self.hold_ttl_seconds,
-            })
-            .await?;
-            tracing::info!(
-                note_id = %params.note_id,
-                model = %params.model_id.0,
-                seconds,
-                estimate_credits = estimate.0,
-                "note_transcribe: preview request authorized and not charged"
-            );
-            let transcript = self
-                .transcriber
-                .transcribe(TranscriptionRequest {
-                    audio: params.audio,
-                    format,
-                    context: params.context,
-                    language: params.language,
-                    model: params.model_id.clone(),
-                })
-                .await?;
-            return Ok(NoteTranscribeOutput {
-                transcript,
-                receipt: uncharged_receipt(),
+        let prepared = PreparedNoteTranscription {
+            params,
+            format,
+            seconds,
+            actual,
+            estimate,
+        };
+        if prepared.params.preview {
+            return self.transcribe_preview(prepared).await;
+        }
+        self.transcribe_charged(prepared).await
+    }
+
+    async fn transcribe_preview(
+        &self,
+        prepared: PreparedNoteTranscription,
+    ) -> Result<NoteTranscribeOutput, ServiceError> {
+        let PreparedNoteTranscription {
+            params,
+            format,
+            seconds,
+            estimate,
+            ..
+        } = prepared;
+        if seconds > self.preview_max_audio_seconds {
+            return Err(ServiceError::InvalidInput {
+                reason: format!(
+                    "live transcript preview chunks must be {} seconds or shorter",
+                    self.preview_max_audio_seconds
+                ),
             });
         }
+        authorize_or_deny(AuthorizeParams {
+            os_accounts: self.os_accounts.as_ref(),
+            user_id: params.user_id.clone(),
+            action: ActionSlug::NoteTranscribe,
+            estimate,
+            hold_ttl_seconds: self.hold_ttl_seconds,
+        })
+        .await?;
+        tracing::info!(
+            note_id = %params.note_id,
+            model = %params.model_id.0,
+            seconds,
+            estimate_credits = estimate.0,
+            "note_transcribe: preview request authorized and not charged"
+        );
+        let transcript = self
+            .transcriber
+            .transcribe(TranscriptionRequest {
+                audio: params.audio,
+                format,
+                context: params.context,
+                language: params.language,
+                model: params.model_id.clone(),
+            })
+            .await?;
+        Ok(NoteTranscribeOutput {
+            transcript,
+            receipt: uncharged_receipt(),
+        })
+    }
+
+    async fn transcribe_charged(
+        &self,
+        prepared: PreparedNoteTranscription,
+    ) -> Result<NoteTranscribeOutput, ServiceError> {
+        let PreparedNoteTranscription {
+            params,
+            format,
+            seconds,
+            actual,
+            estimate,
+        } = prepared;
         tracing::info!(
             note_id = %params.note_id,
             estimate_credits = estimate.0,

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,6 +1,9 @@
 use crate::{
     app_paths::AppPaths,
-    audio::system_macos::SystemAudioCapture,
+    audio::{
+        live_preview::{start_live_transcript_preview, LivePreviewController, LivePreviewSink},
+        system_macos::SystemAudioCapture,
+    },
     domain::types::{
         AppError, AudioLevelDto, RecordingSessionDto, RecordingSource, RecordingSourceMode,
         RecordingState, RecordingStatusDto, SourceState, SourceStatusDto,
@@ -74,6 +77,7 @@ struct ActiveRecording {
     paused_flag: Arc<AtomicBool>,
     writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
     stats: Arc<Mutex<CaptureStats>>,
+    live_preview: Option<LivePreviewController>,
     _stream: cpal::Stream,
 }
 
@@ -117,6 +121,7 @@ fn microphone_permission_hint() -> String {
 }
 
 pub fn start_capture(
+    app: tauri::AppHandle,
     paths: &AppPaths,
     note_id: String,
     source_mode: RecordingSourceMode,
@@ -174,6 +179,20 @@ pub fn start_capture(
     let writer_for_callback = Arc::clone(&writer);
     let stats_for_callback = Arc::clone(&stats);
     let paused_for_callback = Arc::clone(&paused_flag);
+    let live_preview = if crate::scribe_api::configured() && crate::os_accounts::cached_signed_in()
+    {
+        Some(start_live_transcript_preview(
+            app,
+            note_id.clone(),
+            session_id.clone(),
+            source_mode,
+            sample_rate,
+            channels,
+        ))
+    } else {
+        None
+    };
+    let preview_for_callback = live_preview.as_ref().map(LivePreviewController::sink);
     let err_fn = |error| eprintln!("audio stream error: {error}");
 
     let stream = match config.sample_format() {
@@ -185,6 +204,7 @@ pub fn start_capture(
                     &writer_for_callback,
                     &stats_for_callback,
                     &paused_for_callback,
+                    preview_for_callback.as_ref(),
                 )
             },
             err_fn,
@@ -198,6 +218,7 @@ pub fn start_capture(
                     &writer_for_callback,
                     &stats_for_callback,
                     &paused_for_callback,
+                    preview_for_callback.as_ref(),
                 )
             },
             err_fn,
@@ -212,6 +233,7 @@ pub fn start_capture(
                     &writer_for_callback,
                     &stats_for_callback,
                     &paused_for_callback,
+                    preview_for_callback.as_ref(),
                 )
             },
             err_fn,
@@ -290,6 +312,7 @@ pub fn start_capture(
         paused_flag,
         writer,
         stats,
+        live_preview,
         _stream: stream,
     });
 
@@ -411,10 +434,14 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
         system_final_path,
         writer,
         paused_flag,
+        live_preview,
         _stream,
         ..
     } = recording;
     paused_flag.store(true, Ordering::Release);
+    if let Some(live_preview) = live_preview {
+        live_preview.cancel();
+    }
     drop(_stream);
     let microphone_finalized = (|| -> Result<(), AppError> {
         if let Some(writer) = writer
@@ -463,6 +490,7 @@ fn write_input_data<I>(
     writer: &Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
     stats: &Arc<Mutex<CaptureStats>>,
     paused: &Arc<AtomicBool>,
+    preview: Option<&LivePreviewSink>,
 ) where
     I: Iterator<Item = f32>,
 {
@@ -478,22 +506,34 @@ fn write_input_data<I>(
     let Ok(mut stats) = stats.lock() else {
         return;
     };
-    let mut callback_peak = 0.0_f32;
-    for sample in data {
-        let clamped = sample.clamp(-1.0, 1.0);
-        let normalized = clamped.abs();
-        callback_peak = callback_peak.max(normalized);
-        stats.peak = stats.peak.max(normalized);
-        stats.sum_square += (normalized as f64).powi(2);
-        stats.samples += 1;
-        stats.bytes_written += 2;
-        let _ = writer.write_sample((clamped * i16::MAX as f32) as i16);
-    }
-    if callback_peak > 0.0 {
-        if stats.recent_peaks.len() == 24 {
-            stats.recent_peaks.pop_front();
+    let mut preview_samples = preview.map(|_| Vec::new());
+    {
+        let mut callback_peak = 0.0_f32;
+        for sample in data {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let pcm_sample = (clamped * i16::MAX as f32) as i16;
+            let normalized = clamped.abs();
+            callback_peak = callback_peak.max(normalized);
+            stats.peak = stats.peak.max(normalized);
+            stats.sum_square += (normalized as f64).powi(2);
+            stats.samples += 1;
+            stats.bytes_written += 2;
+            let _ = writer.write_sample(pcm_sample);
+            if let Some(samples) = preview_samples.as_mut() {
+                samples.push(pcm_sample);
+            }
         }
-        stats.recent_peaks.push_back(callback_peak);
+        if callback_peak > 0.0 {
+            if stats.recent_peaks.len() == 24 {
+                stats.recent_peaks.pop_front();
+            }
+            stats.recent_peaks.push_back(callback_peak);
+        }
+    }
+    drop(stats);
+    drop(writer_guard);
+    if let (Some(preview), Some(samples)) = (preview, preview_samples) {
+        preview.try_send(samples);
     }
 }
 

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -5,6 +5,7 @@ use crate::{
 use hound::{SampleFormat, WavSpec, WavWriter};
 use serde::Serialize;
 use std::{
+    collections::VecDeque,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -19,6 +20,7 @@ pub const LIVE_TRANSCRIPT_EVENT: &str = "live-transcript-event";
 
 const PREVIEW_BATCH_BUFFER: usize = 512;
 const PREVIEW_CHUNK_MS: i64 = 8_000;
+const PREVIEW_CONTEXT_TURNS: usize = 3;
 const PREVIEW_SILENCE_RMS_FLOOR: f32 = 0.012;
 
 #[derive(Debug, Clone, Serialize)]
@@ -121,6 +123,7 @@ async fn run_live_preview_worker(
         return;
     }
     let mut buffer: Vec<i16> = Vec::with_capacity(chunk_samples * 2);
+    let mut recent_preview_text = VecDeque::with_capacity(PREVIEW_CONTEXT_TURNS);
     let mut next_start_ms = 0_i64;
     let mut segment_index = 0_i64;
 
@@ -140,6 +143,7 @@ async fn run_live_preview_worker(
                 continue;
             }
             let segment_id = format!("microphone-{segment_index}");
+            let context = preview_context(&recent_preview_text);
             if let Some(event) = transcribe_preview_chunk(
                 &note_id,
                 &session_id,
@@ -150,12 +154,14 @@ async fn run_live_preview_worker(
                 sample_rate,
                 channels,
                 &samples,
+                context,
             )
             .await
             {
                 if cancelled.load(Ordering::Acquire) {
                     return;
                 }
+                remember_preview_text(&mut recent_preview_text, &event.text);
                 let _ = app.emit(LIVE_TRANSCRIPT_EVENT, event);
             }
             segment_index += 1;
@@ -173,9 +179,11 @@ async fn transcribe_preview_chunk(
     sample_rate: u32,
     channels: u16,
     samples: &[i16],
+    context: Option<String>,
 ) -> Option<LiveTranscriptEventDto> {
     let temp_path = preview_chunk_path(session_id, segment_id);
     if let Err(error) = write_preview_wav(&temp_path, sample_rate, channels, samples) {
+        let _ = std::fs::remove_file(&temp_path);
         eprintln!("live transcript preview failed to write chunk: {error}");
         return None;
     }
@@ -184,7 +192,7 @@ async fn transcribe_preview_chunk(
         provider: crate::providers::configured_transcription_provider(),
         audio_path: temp_path.clone(),
         title: "Live transcript preview".to_string(),
-        context: None,
+        context,
         language: crate::dictation::configured_transcription_language(),
         operation_id: Some(format!("live-preview-{session_id}-{segment_id}")),
         preview: true,
@@ -272,9 +280,41 @@ fn is_effectively_silent(samples: &[i16]) -> bool {
     rms < PREVIEW_SILENCE_RMS_FLOOR
 }
 
+fn preview_context(recent_preview_text: &VecDeque<String>) -> Option<String> {
+    let text = recent_preview_text
+        .iter()
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "Previous live transcript preview segments:\n{text}\n\nUse this only as context. Do not repeat it."
+        ))
+    }
+}
+
+fn remember_preview_text(recent_preview_text: &mut VecDeque<String>, text: &str) {
+    let text = text.trim();
+    if text.is_empty() {
+        return;
+    }
+    recent_preview_text.push_back(text.to_string());
+    while recent_preview_text.len() > PREVIEW_CONTEXT_TURNS {
+        recent_preview_text.pop_front();
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{duration_ms, is_effectively_silent, samples_for_ms, LivePreviewSink};
+    use super::{
+        duration_ms, is_effectively_silent, preview_context, remember_preview_text, samples_for_ms,
+        LivePreviewSink,
+    };
+    use std::collections::VecDeque;
     use tokio::sync::mpsc;
 
     #[test]
@@ -297,5 +337,21 @@ mod tests {
 
         assert!(sink.try_send(vec![1]));
         assert!(!sink.try_send(vec![2]));
+    }
+
+    #[test]
+    fn preview_context_keeps_recent_nonempty_segments() {
+        let mut recent = VecDeque::new();
+
+        remember_preview_text(&mut recent, " first ");
+        remember_preview_text(&mut recent, "");
+        remember_preview_text(&mut recent, "second");
+        remember_preview_text(&mut recent, "third");
+        remember_preview_text(&mut recent, "fourth");
+
+        let context = preview_context(&recent).expect("context");
+        assert!(!context.contains("first"));
+        assert!(context.contains("second\nthird\nfourth"));
+        assert!(context.contains("Do not repeat it."));
     }
 }

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -1,0 +1,301 @@
+use crate::{
+    domain::types::{RecordingSource, RecordingSourceMode},
+    scribe_api::{transcribe_saved_audio, TranscriptionRequest},
+};
+use hound::{SampleFormat, WavSpec, WavWriter};
+use serde::Serialize;
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use tauri::{AppHandle, Emitter};
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+pub const LIVE_TRANSCRIPT_EVENT: &str = "live-transcript-event";
+
+const PREVIEW_BATCH_BUFFER: usize = 512;
+const PREVIEW_CHUNK_MS: i64 = 8_000;
+const PREVIEW_SILENCE_RMS_FLOOR: f32 = 0.012;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveTranscriptEventDto {
+    pub note_id: String,
+    pub session_id: String,
+    pub source_mode: RecordingSourceMode,
+    pub source: RecordingSource,
+    pub segment_id: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub text: String,
+    pub language: Option<String>,
+    pub stability: &'static str,
+}
+
+#[derive(Debug)]
+struct LivePreviewBatch {
+    samples: Vec<i16>,
+}
+
+#[derive(Clone)]
+pub struct LivePreviewSink {
+    sender: mpsc::Sender<LivePreviewBatch>,
+}
+
+impl LivePreviewSink {
+    pub fn try_send(&self, samples: Vec<i16>) -> bool {
+        if samples.is_empty() {
+            return false;
+        }
+        self.sender.try_send(LivePreviewBatch { samples }).is_ok()
+    }
+}
+
+pub struct LivePreviewController {
+    cancelled: Arc<AtomicBool>,
+    sink: LivePreviewSink,
+}
+
+impl LivePreviewController {
+    pub fn sink(&self) -> LivePreviewSink {
+        self.sink.clone()
+    }
+
+    pub fn cancel(self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
+impl Drop for LivePreviewController {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
+pub fn start_live_transcript_preview(
+    app: AppHandle,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    sample_rate: u32,
+    channels: u16,
+) -> LivePreviewController {
+    let (sender, receiver) = mpsc::channel(PREVIEW_BATCH_BUFFER);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = Arc::clone(&cancelled);
+    tauri::async_runtime::spawn(async move {
+        run_live_preview_worker(
+            app,
+            note_id,
+            session_id,
+            source_mode,
+            sample_rate.max(1),
+            channels.max(1),
+            receiver,
+            worker_cancelled,
+        )
+        .await;
+    });
+    LivePreviewController {
+        cancelled,
+        sink: LivePreviewSink { sender },
+    }
+}
+
+async fn run_live_preview_worker(
+    app: AppHandle,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    sample_rate: u32,
+    channels: u16,
+    mut receiver: mpsc::Receiver<LivePreviewBatch>,
+    cancelled: Arc<AtomicBool>,
+) {
+    let chunk_samples = samples_for_ms(sample_rate, channels, PREVIEW_CHUNK_MS);
+    if chunk_samples == 0 {
+        return;
+    }
+    let mut buffer: Vec<i16> = Vec::with_capacity(chunk_samples * 2);
+    let mut next_start_ms = 0_i64;
+    let mut segment_index = 0_i64;
+
+    while let Some(batch) = receiver.recv().await {
+        if cancelled.load(Ordering::Acquire) {
+            return;
+        }
+        buffer.extend(batch.samples);
+        while buffer.len() >= chunk_samples {
+            let samples = buffer.drain(..chunk_samples).collect::<Vec<_>>();
+            let start_ms = next_start_ms;
+            let duration_ms = duration_ms(samples.len(), sample_rate, channels);
+            let end_ms = start_ms + duration_ms;
+            next_start_ms = end_ms;
+            if is_effectively_silent(&samples) {
+                segment_index += 1;
+                continue;
+            }
+            let segment_id = format!("microphone-{segment_index}");
+            if let Some(event) = transcribe_preview_chunk(
+                &note_id,
+                &session_id,
+                source_mode,
+                &segment_id,
+                start_ms,
+                end_ms,
+                sample_rate,
+                channels,
+                &samples,
+            )
+            .await
+            {
+                if cancelled.load(Ordering::Acquire) {
+                    return;
+                }
+                let _ = app.emit(LIVE_TRANSCRIPT_EVENT, event);
+            }
+            segment_index += 1;
+        }
+    }
+}
+
+async fn transcribe_preview_chunk(
+    note_id: &str,
+    session_id: &str,
+    source_mode: RecordingSourceMode,
+    segment_id: &str,
+    start_ms: i64,
+    end_ms: i64,
+    sample_rate: u32,
+    channels: u16,
+    samples: &[i16],
+) -> Option<LiveTranscriptEventDto> {
+    let temp_path = preview_chunk_path(session_id, segment_id);
+    if let Err(error) = write_preview_wav(&temp_path, sample_rate, channels, samples) {
+        eprintln!("live transcript preview failed to write chunk: {error}");
+        return None;
+    }
+
+    let request = TranscriptionRequest {
+        provider: crate::providers::configured_transcription_provider(),
+        audio_path: temp_path.clone(),
+        title: "Live transcript preview".to_string(),
+        context: None,
+        language: crate::dictation::configured_transcription_language(),
+        operation_id: Some(format!("live-preview-{session_id}-{segment_id}")),
+        preview: true,
+    };
+    let result = transcribe_saved_audio(request).await;
+    let _ = std::fs::remove_file(&temp_path);
+    match result {
+        Ok(transcript) => {
+            let text = transcript.text.trim().to_string();
+            if text.is_empty() {
+                return None;
+            }
+            Some(LiveTranscriptEventDto {
+                note_id: note_id.to_string(),
+                session_id: session_id.to_string(),
+                source_mode,
+                source: RecordingSource::Microphone,
+                segment_id: segment_id.to_string(),
+                start_ms,
+                end_ms,
+                text,
+                language: transcript.language,
+                stability: "final",
+            })
+        }
+        Err(error) => {
+            eprintln!(
+                "live transcript preview transcription failed: {} ({})",
+                error.message, error.code
+            );
+            None
+        }
+    }
+}
+
+fn preview_chunk_path(session_id: &str, segment_id: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "os-scribe-live-preview-{}-{}-{}.wav",
+        session_id,
+        segment_id,
+        Uuid::new_v4()
+    ))
+}
+
+fn write_preview_wav(
+    path: &Path,
+    sample_rate: u32,
+    channels: u16,
+    samples: &[i16],
+) -> Result<(), hound::Error> {
+    let spec = WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec)?;
+    for sample in samples {
+        writer.write_sample(*sample)?;
+    }
+    writer.finalize()
+}
+
+fn samples_for_ms(sample_rate: u32, channels: u16, duration_ms: i64) -> usize {
+    ((u64::from(sample_rate) * u64::from(channels) * duration_ms.max(0) as u64) / 1000) as usize
+}
+
+fn duration_ms(sample_count: usize, sample_rate: u32, channels: u16) -> i64 {
+    let frames = sample_count as u64 / u64::from(channels.max(1));
+    ((frames * 1000) / u64::from(sample_rate.max(1))) as i64
+}
+
+fn is_effectively_silent(samples: &[i16]) -> bool {
+    if samples.is_empty() {
+        return true;
+    }
+    let sum_square = samples
+        .iter()
+        .map(|sample| {
+            let normalized = *sample as f64 / i16::MAX as f64;
+            normalized * normalized
+        })
+        .sum::<f64>();
+    let rms = (sum_square / samples.len() as f64).sqrt() as f32;
+    rms < PREVIEW_SILENCE_RMS_FLOOR
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{duration_ms, is_effectively_silent, samples_for_ms, LivePreviewSink};
+    use tokio::sync::mpsc;
+
+    #[test]
+    fn computes_chunk_sample_counts_for_interleaved_audio() {
+        assert_eq!(samples_for_ms(16_000, 1, 8_000), 128_000);
+        assert_eq!(samples_for_ms(48_000, 2, 1_000), 96_000);
+        assert_eq!(duration_ms(96_000, 48_000, 2), 1_000);
+    }
+
+    #[test]
+    fn silence_gate_skips_quiet_preview_chunks() {
+        assert!(is_effectively_silent(&[0; 128]));
+        assert!(!is_effectively_silent(&[2_000; 128]));
+    }
+
+    #[test]
+    fn preview_sink_drops_batches_when_buffer_is_full() {
+        let (sender, _receiver) = mpsc::channel(1);
+        let sink = LivePreviewSink { sender };
+
+        assert!(sink.try_send(vec![1]));
+        assert!(!sink.try_send(vec![2]));
+    }
+}

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -8,7 +8,7 @@ use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -19,6 +19,7 @@ use uuid::Uuid;
 pub const LIVE_TRANSCRIPT_EVENT: &str = "live-transcript-event";
 
 const PREVIEW_BATCH_BUFFER: usize = 512;
+const PREVIEW_STALE_BATCH_THRESHOLD: usize = PREVIEW_BATCH_BUFFER / 2;
 const PREVIEW_CHUNK_MS: i64 = 8_000;
 const PREVIEW_CONTEXT_TURNS: usize = 3;
 const PREVIEW_SILENCE_RMS_FLOOR: f32 = 0.012;
@@ -40,12 +41,14 @@ pub struct LiveTranscriptEventDto {
 
 #[derive(Debug)]
 struct LivePreviewBatch {
+    start_sample: u64,
     samples: Vec<i16>,
 }
 
 #[derive(Clone)]
 pub struct LivePreviewSink {
     sender: mpsc::Sender<LivePreviewBatch>,
+    next_sample_index: Arc<AtomicU64>,
 }
 
 impl LivePreviewSink {
@@ -53,13 +56,45 @@ impl LivePreviewSink {
         if samples.is_empty() {
             return false;
         }
-        self.sender.try_send(LivePreviewBatch { samples }).is_ok()
+        let start_sample = self
+            .next_sample_index
+            .fetch_add(samples.len() as u64, Ordering::Relaxed);
+        self.sender
+            .try_send(LivePreviewBatch {
+                start_sample,
+                samples,
+            })
+            .is_ok()
     }
 }
 
 pub struct LivePreviewController {
     cancelled: Arc<AtomicBool>,
     sink: LivePreviewSink,
+}
+
+struct LivePreviewWorkerParams {
+    app: AppHandle,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    sample_rate: u32,
+    channels: u16,
+    receiver: mpsc::Receiver<LivePreviewBatch>,
+    cancelled: Arc<AtomicBool>,
+}
+
+struct PreviewChunkRequest<'a> {
+    note_id: &'a str,
+    session_id: &'a str,
+    source_mode: RecordingSourceMode,
+    segment_id: &'a str,
+    start_ms: i64,
+    end_ms: i64,
+    sample_rate: u32,
+    channels: u16,
+    samples: &'a [i16],
+    context: Option<String>,
 }
 
 impl LivePreviewController {
@@ -90,72 +125,86 @@ pub fn start_live_transcript_preview(
     let cancelled = Arc::new(AtomicBool::new(false));
     let worker_cancelled = Arc::clone(&cancelled);
     tauri::async_runtime::spawn(async move {
-        run_live_preview_worker(
+        run_live_preview_worker(LivePreviewWorkerParams {
             app,
             note_id,
             session_id,
             source_mode,
-            sample_rate.max(1),
-            channels.max(1),
+            sample_rate: sample_rate.max(1),
+            channels: channels.max(1),
             receiver,
-            worker_cancelled,
-        )
+            cancelled: worker_cancelled,
+        })
         .await;
     });
     LivePreviewController {
         cancelled,
-        sink: LivePreviewSink { sender },
+        sink: LivePreviewSink {
+            sender,
+            next_sample_index: Arc::new(AtomicU64::new(0)),
+        },
     }
 }
 
-async fn run_live_preview_worker(
-    app: AppHandle,
-    note_id: String,
-    session_id: String,
-    source_mode: RecordingSourceMode,
-    sample_rate: u32,
-    channels: u16,
-    mut receiver: mpsc::Receiver<LivePreviewBatch>,
-    cancelled: Arc<AtomicBool>,
-) {
+async fn run_live_preview_worker(params: LivePreviewWorkerParams) {
+    let LivePreviewWorkerParams {
+        app,
+        note_id,
+        session_id,
+        source_mode,
+        sample_rate,
+        channels,
+        mut receiver,
+        cancelled,
+    } = params;
     let chunk_samples = samples_for_ms(sample_rate, channels, PREVIEW_CHUNK_MS);
     if chunk_samples == 0 {
         return;
     }
     let mut buffer: Vec<i16> = Vec::with_capacity(chunk_samples * 2);
+    let mut buffer_start_sample = 0_u64;
     let mut recent_preview_text = VecDeque::with_capacity(PREVIEW_CONTEXT_TURNS);
-    let mut next_start_ms = 0_i64;
     let mut segment_index = 0_i64;
 
     while let Some(batch) = receiver.recv().await {
         if cancelled.load(Ordering::Acquire) {
             return;
         }
+        let batch = if should_drop_stale_batches(receiver.len()) {
+            newest_preview_batch(batch, &mut receiver)
+        } else {
+            batch
+        };
+        let expected_start = buffer_start_sample.saturating_add(buffer.len() as u64);
+        if buffer.is_empty() || batch.start_sample != expected_start {
+            buffer.clear();
+            buffer_start_sample = batch.start_sample;
+        }
         buffer.extend(batch.samples);
         while buffer.len() >= chunk_samples {
+            let chunk_start_sample = buffer_start_sample;
             let samples = buffer.drain(..chunk_samples).collect::<Vec<_>>();
-            let start_ms = next_start_ms;
-            let duration_ms = duration_ms(samples.len(), sample_rate, channels);
-            let end_ms = start_ms + duration_ms;
-            next_start_ms = end_ms;
+            buffer_start_sample = buffer_start_sample.saturating_add(chunk_samples as u64);
+            let start_ms = sample_offset_ms(chunk_start_sample, sample_rate, channels);
+            let end_ms = sample_offset_ms(buffer_start_sample, sample_rate, channels);
             if is_effectively_silent(&samples) {
                 segment_index += 1;
                 continue;
             }
             let segment_id = format!("microphone-{segment_index}");
             let context = preview_context(&recent_preview_text);
-            if let Some(event) = transcribe_preview_chunk(
-                &note_id,
-                &session_id,
+            if let Some(event) = transcribe_preview_chunk(PreviewChunkRequest {
+                note_id: &note_id,
+                session_id: &session_id,
                 source_mode,
-                &segment_id,
+                segment_id: &segment_id,
                 start_ms,
                 end_ms,
                 sample_rate,
                 channels,
-                &samples,
+                samples: &samples,
                 context,
-            )
+            })
             .await
             {
                 if cancelled.load(Ordering::Acquire) {
@@ -169,18 +218,35 @@ async fn run_live_preview_worker(
     }
 }
 
+fn newest_preview_batch(
+    mut batch: LivePreviewBatch,
+    receiver: &mut mpsc::Receiver<LivePreviewBatch>,
+) -> LivePreviewBatch {
+    while let Ok(next) = receiver.try_recv() {
+        batch = next;
+    }
+    batch
+}
+
+fn should_drop_stale_batches(queued_batches: usize) -> bool {
+    queued_batches >= PREVIEW_STALE_BATCH_THRESHOLD
+}
+
 async fn transcribe_preview_chunk(
-    note_id: &str,
-    session_id: &str,
-    source_mode: RecordingSourceMode,
-    segment_id: &str,
-    start_ms: i64,
-    end_ms: i64,
-    sample_rate: u32,
-    channels: u16,
-    samples: &[i16],
-    context: Option<String>,
+    request: PreviewChunkRequest<'_>,
 ) -> Option<LiveTranscriptEventDto> {
+    let PreviewChunkRequest {
+        note_id,
+        session_id,
+        source_mode,
+        segment_id,
+        start_ms,
+        end_ms,
+        sample_rate,
+        channels,
+        samples,
+        context,
+    } = request;
     let temp_path = preview_chunk_path(session_id, segment_id);
     if let Err(error) = write_preview_wav(&temp_path, sample_rate, channels, samples) {
         let _ = std::fs::remove_file(&temp_path);
@@ -260,9 +326,19 @@ fn samples_for_ms(sample_rate: u32, channels: u16, duration_ms: i64) -> usize {
     ((u64::from(sample_rate) * u64::from(channels) * duration_ms.max(0) as u64) / 1000) as usize
 }
 
+#[cfg(test)]
 fn duration_ms(sample_count: usize, sample_rate: u32, channels: u16) -> i64 {
     let frames = sample_count as u64 / u64::from(channels.max(1));
     ((frames * 1000) / u64::from(sample_rate.max(1))) as i64
+}
+
+fn sample_offset_ms(sample_index: u64, sample_rate: u32, channels: u16) -> i64 {
+    let frames = sample_index / u64::from(channels.max(1));
+    let millis = frames
+        .saturating_mul(1000)
+        .checked_div(u64::from(sample_rate.max(1)))
+        .unwrap_or(0);
+    millis.min(i64::MAX as u64) as i64
 }
 
 fn is_effectively_silent(samples: &[i16]) -> bool {
@@ -311,10 +387,17 @@ fn remember_preview_text(recent_preview_text: &mut VecDeque<String>, text: &str)
 #[cfg(test)]
 mod tests {
     use super::{
-        duration_ms, is_effectively_silent, preview_context, remember_preview_text, samples_for_ms,
-        LivePreviewSink,
+        duration_ms, is_effectively_silent, newest_preview_batch, preview_context,
+        remember_preview_text, sample_offset_ms, samples_for_ms, should_drop_stale_batches,
+        LivePreviewBatch, LivePreviewSink, PREVIEW_STALE_BATCH_THRESHOLD,
     };
-    use std::collections::VecDeque;
+    use std::{
+        collections::VecDeque,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc,
+        },
+    };
     use tokio::sync::mpsc;
 
     #[test]
@@ -322,6 +405,7 @@ mod tests {
         assert_eq!(samples_for_ms(16_000, 1, 8_000), 128_000);
         assert_eq!(samples_for_ms(48_000, 2, 1_000), 96_000);
         assert_eq!(duration_ms(96_000, 48_000, 2), 1_000);
+        assert_eq!(sample_offset_ms(96_000, 48_000, 2), 1_000);
     }
 
     #[test]
@@ -333,10 +417,72 @@ mod tests {
     #[test]
     fn preview_sink_drops_batches_when_buffer_is_full() {
         let (sender, _receiver) = mpsc::channel(1);
-        let sink = LivePreviewSink { sender };
+        let sink = LivePreviewSink {
+            sender,
+            next_sample_index: Arc::new(AtomicU64::new(0)),
+        };
 
         assert!(sink.try_send(vec![1]));
         assert!(!sink.try_send(vec![2]));
+    }
+
+    #[test]
+    fn preview_sink_accounts_for_dropped_batches_in_sample_offsets() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let sink = LivePreviewSink {
+            sender,
+            next_sample_index: Arc::new(AtomicU64::new(0)),
+        };
+
+        assert!(sink.try_send(vec![1, 2]));
+        assert!(!sink.try_send(vec![3, 4, 5]));
+        let first = receiver.try_recv().expect("first batch");
+        assert_eq!(first.start_sample, 0);
+
+        assert!(sink.try_send(vec![6]));
+        let second = receiver.try_recv().expect("second batch");
+        assert_eq!(second.start_sample, 5);
+        assert_eq!(sink.next_sample_index.load(Ordering::Relaxed), 6);
+    }
+
+    #[test]
+    fn newest_preview_batch_drops_queued_stale_batches() {
+        let (sender, mut receiver) = mpsc::channel(4);
+        sender
+            .try_send(LivePreviewBatch {
+                start_sample: 0,
+                samples: vec![1],
+            })
+            .expect("send first");
+        sender
+            .try_send(LivePreviewBatch {
+                start_sample: 1,
+                samples: vec![2],
+            })
+            .expect("send second");
+        sender
+            .try_send(LivePreviewBatch {
+                start_sample: 2,
+                samples: vec![3],
+            })
+            .expect("send third");
+
+        let first = receiver.try_recv().expect("queued first");
+        let newest = newest_preview_batch(first, &mut receiver);
+
+        assert_eq!(newest.start_sample, 2);
+        assert_eq!(newest.samples, vec![3]);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn stale_preview_batches_are_dropped_only_after_real_backlog() {
+        assert!(!should_drop_stale_batches(0));
+        assert!(!should_drop_stale_batches(1));
+        assert!(!should_drop_stale_batches(
+            PREVIEW_STALE_BATCH_THRESHOLD - 1
+        ));
+        assert!(should_drop_stale_batches(PREVIEW_STALE_BATCH_THRESHOLD));
     }
 
     #[test]

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
+pub mod live_preview;
 pub mod recovery;
 pub mod system_macos;
 pub mod turns;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -645,7 +645,7 @@ pub async fn start_recording(
     let capture_paths = paths.clone();
     let capture_note_id = note.id.clone();
     let started = tokio::task::spawn_blocking(move || {
-        start_capture(&capture_paths, capture_note_id, source_mode)
+        start_capture(app, &capture_paths, capture_note_id, source_mode)
     })
     .await
     .map_err(|error| AppError::new("recording_start_failed", error.to_string()))??;

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -843,6 +843,7 @@ async fn transcribe_prepared_audio(
             context: request.base_context,
             language: request_language,
             operation_id: Some(request.operation_id),
+            preview: false,
         })
         .await;
     }
@@ -863,6 +864,7 @@ async fn transcribe_prepared_audio(
             context,
             language: request_language.clone(),
             operation_id: Some(format!("{}-chunk-{index}", request.operation_id)),
+            preview: false,
         })
         .await?;
         if language.is_none() {

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -36,6 +36,7 @@ pub struct TranscriptionRequest {
     pub context: Option<String>,
     pub language: Option<String>,
     pub operation_id: Option<String>,
+    pub preview: bool,
 }
 
 impl TranscriptionRequest {
@@ -219,6 +220,9 @@ pub async fn transcribe_saved_audio(
         .text("title", title_or_placeholder(&request.title))
         .text("model", crate::providers::transcription_model())
         .part("audio", audio_part(audio, &filename, &request.audio_path)?);
+    if request.preview {
+        form = form.text("preview", "true");
+    }
     if let Some(context) = request
         .context
         .as_deref()

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -80,6 +80,7 @@ import {
   finishRecording,
   getRecordingStatus,
   getNote,
+  LIVE_TRANSCRIPT_EVENT,
   listNotes,
   listSessionFolders,
   openPrivacySettings,
@@ -96,6 +97,7 @@ import {
   updateNote,
   agentHudHide,
   agentHudShow,
+  type LiveTranscriptEventDto,
 } from "../lib/tauri";
 import {
   playRecordingSound,
@@ -267,6 +269,28 @@ function tabMeta(
   }
 }
 
+function upsertLiveTranscriptEvent(
+  current: LiveTranscriptEventDto[],
+  next: LiveTranscriptEventDto,
+) {
+  const events = current.filter(
+    (event) =>
+      !(
+        event.sessionId === next.sessionId &&
+        event.source === next.source &&
+        event.segmentId === next.segmentId
+      ),
+  );
+  events.push(next);
+  events.sort(
+    (left, right) =>
+      left.startMs - right.startMs ||
+      left.endMs - right.endMs ||
+      left.segmentId.localeCompare(right.segmentId),
+  );
+  return events.slice(-32);
+}
+
 export function App() {
   const replayOnboarding = shouldReplayOnboarding();
   const [state, dispatch] = useReducer(
@@ -416,6 +440,9 @@ export function App() {
   >(undefined);
   const recordingStatusRef = useRef(state.recordingStatus);
   const recordingStartInFlightRef = useRef(false);
+  const [liveTranscriptEvents, setLiveTranscriptEvents] = useState<
+    LiveTranscriptEventDto[]
+  >([]);
   useEffect(() => {
     recordingStatusRef.current = state.recordingStatus;
   }, [state.recordingStatus]);
@@ -1647,6 +1674,42 @@ export function App() {
   }, [state.recordingStatus?.sessionId, state.recordingStatus?.state]);
 
   useEffect(() => {
+    if (!state.recordingStatus) {
+      setLiveTranscriptEvents([]);
+    }
+  }, [state.recordingStatus?.sessionId]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let aborted = false;
+    void listen<LiveTranscriptEventDto>(LIVE_TRANSCRIPT_EVENT, (event) => {
+      const payload = event.payload;
+      const activeRecording = recordingStatusRef.current;
+      if (!activeRecording || payload.sessionId !== activeRecording.sessionId) {
+        return;
+      }
+      if (
+        recordingNoteIdRef.current &&
+        payload.noteId !== recordingNoteIdRef.current
+      ) {
+        return;
+      }
+      const text = payload.text.trim();
+      if (!text) return;
+      setLiveTranscriptEvents((current) =>
+        upsertLiveTranscriptEvent(current, { ...payload, text }),
+      );
+    }).then((cleanup) => {
+      if (aborted) cleanup();
+      else unlisten = cleanup;
+    });
+    return () => {
+      aborted = true;
+      unlisten?.();
+    };
+  }, []);
+
+  useEffect(() => {
     if (
       !selectedNote ||
       !shouldPollProcessingStatus(selectedNote.processingStatus)
@@ -2082,6 +2145,7 @@ export function App() {
       if (!startAlreadyClaimed) {
         recordingStartInFlightRef.current = true;
       }
+      setLiveTranscriptEvents([]);
       setRecordingNote(noteId);
       const startingStatus = startingRecordingStatus(noteId, sourceMode);
       recordingStatusRef.current = startingStatus;
@@ -2236,6 +2300,7 @@ export function App() {
     // notes…") plus a queued count tell the user work is still in flight.
     const owningNoteId = recordingNoteIdRef.current;
     dispatch({ type: "recordingStatusCleared" });
+    setLiveTranscriptEvents([]);
     setRecordingNote(undefined);
     playRecordingSound("stop");
     // Optimistically flip the note that owns this recording to transcribing.
@@ -2870,8 +2935,14 @@ export function App() {
                           : undefined
                       }
                       recordingDisabled={Boolean(
-                        state.recordingStatus && selectedNoteId !== recordingNoteId,
+                        state.recordingStatus &&
+                        selectedNoteId !== recordingNoteId,
                       )}
+                      liveTranscript={
+                        selectedNoteId === recordingNoteId
+                          ? liveTranscriptEvents
+                          : []
+                      }
                       sourceMode={sourceMode}
                       sourceReadiness={sourceReadiness}
                       recovery={selectedRecovery}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -14,6 +14,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { Switch } from "../ui/Switch";
 import type {
   FolderDto,
+  LiveTranscriptEventDto,
   NoteDto,
   RecordingSourceMode,
   RecordingSourceReadinessDto,
@@ -38,6 +39,7 @@ type NoteEditorProps = {
   folders: FolderDto[];
   recordingStatus?: RecordingStatusDto;
   recordingDisabled?: boolean;
+  liveTranscript?: LiveTranscriptEventDto[];
   sourceMode: RecordingSourceMode;
   sourceReadiness?: RecordingSourceReadinessDto;
   recovery?: RecoverableRecordingDto;
@@ -79,6 +81,11 @@ function sourceKey(source?: string): "microphone" | "system" {
 
 type SourceFilter = "all" | "microphone" | "system";
 
+type RenderedTranscriptTurn = TranscriptDto & {
+  preview?: boolean;
+  stability?: LiveTranscriptEventDto["stability"];
+};
+
 const SOURCE_FILTERS = [
   { value: "all", label: "All" },
   { value: "microphone", label: "Microphone" },
@@ -105,6 +112,7 @@ export function NoteEditor({
   folders,
   recordingStatus,
   recordingDisabled = false,
+  liveTranscript = [],
   sourceMode,
   sourceReadiness,
   recovery,
@@ -131,6 +139,18 @@ export function NoteEditor({
   const content = note.editedContent ?? note.generatedContent ?? "";
   const activeTab = note.activeTab ?? "notes";
   const sourceTranscripts = orderedVisibleSourceTranscripts(note);
+  const liveTranscriptTurns = useMemo(
+    () => liveTranscript.map(liveTranscriptEventToTurn),
+    [liveTranscript],
+  );
+  const transcriptTurns = useMemo(
+    () =>
+      [...sourceTranscripts, ...liveTranscriptTurns]
+        .map((turn, index) => ({ turn, index }))
+        .sort(compareSourceTranscriptOrder)
+        .map(({ turn }) => turn),
+    [sourceTranscripts, liveTranscriptTurns],
+  );
   const recordingForNote = recordingStatus;
   const recordingActive = Boolean(recordingForNote);
   const [optionsOpen, setOptionsOpen] = useState(false);
@@ -148,19 +168,19 @@ export function NoteEditor({
   const hasBothSources = useMemo(() => {
     let mic = false;
     let system = false;
-    for (const turn of sourceTranscripts) {
+    for (const turn of transcriptTurns) {
       if (sourceKey(turn.source) === "system") system = true;
       else mic = true;
       if (mic && system) return true;
     }
     return false;
-  }, [sourceTranscripts]);
+  }, [transcriptTurns]);
   const visibleTurns = useMemo(() => {
-    if (!hasBothSources || sourceFilter === "all") return sourceTranscripts;
-    return sourceTranscripts.filter(
+    if (!hasBothSources || sourceFilter === "all") return transcriptTurns;
+    return transcriptTurns.filter(
       (turn) => sourceKey(turn.source) === sourceFilter,
     );
-  }, [sourceTranscripts, hasBothSources, sourceFilter]);
+  }, [transcriptTurns, hasBothSources, sourceFilter]);
   const systemOn = sourceMode === "microphonePlusSystem";
   const systemSource = sourceReadiness?.sources.find(
     (source) => source.source === "system",
@@ -235,9 +255,11 @@ export function NoteEditor({
   // stays disabled via processingLock so nothing can re-trigger.
   const shellState = recordingForNote?.state ?? "idle";
   const processingText = processingMessage(note.processingStatus);
-  const transcriptText = transcriptToText(note);
+  const transcriptText = transcriptToText(note, liveTranscriptTurns);
   const showTranscriptProcessing =
     processingLock && transcriptText.trim().length > 0;
+  const showLivePreviewWaiting =
+    recordingActive && liveTranscriptTurns.length === 0;
   // Processing runs in the background and is queued per note, so a recording
   // that's still transcribing/generating no longer blocks starting another —
   // you can stack messages and they process in order. The record button only
@@ -316,7 +338,7 @@ export function NoteEditor({
                 />
               </div>
             ) : null}
-            {showTranscriptProcessing ? (
+            {showTranscriptProcessing || showLivePreviewWaiting ? (
               <div
                 className="transcript-processing"
                 role="status"
@@ -324,14 +346,20 @@ export function NoteEditor({
               >
                 <DotSpinner className="transcript-processing-spinner" />
                 <span className="transcript-processing-label">
-                  {processingText ?? "Processing audio..."}
+                  {showLivePreviewWaiting
+                    ? "Listening for transcript preview..."
+                    : (processingText ?? "Processing audio...")}
                 </span>
               </div>
             ) : null}
             {visibleTurns.length ? (
               <div className="source-transcripts">
                 {visibleTurns.map((transcript) => (
-                  <TranscriptTurn key={transcript.id} transcript={transcript} />
+                  <TranscriptTurn
+                    key={transcript.id}
+                    transcript={transcript}
+                    preview={transcript.preview}
+                  />
                 ))}
               </div>
             ) : note.transcript?.text ? (
@@ -339,10 +367,13 @@ export function NoteEditor({
             ) : (
               <div className="transcript-empty">
                 <p>
-                  {processingText ??
-                    (note.processingStatus === "failed"
-                      ? "No transcript was produced."
-                      : (note.lastError ?? "No transcript is available yet."))}
+                  {recordingActive
+                    ? "Transcript preview will appear here while you record."
+                    : (processingText ??
+                      (note.processingStatus === "failed"
+                        ? "No transcript was produced."
+                        : (note.lastError ??
+                          "No transcript is available yet.")))}
                 </p>
               </div>
             )}
@@ -566,10 +597,14 @@ export function NoteEditor({
                           type="button"
                           className="record-button"
                           aria-label={
-                            recordingDisabled ? "Recording in progress" : "Record"
+                            recordingDisabled
+                              ? "Recording in progress"
+                              : "Record"
                           }
                           title={
-                            recordingDisabled ? "Recording in progress" : "Record"
+                            recordingDisabled
+                              ? "Recording in progress"
+                              : "Record"
                           }
                           disabled={recordButtonDisabled}
                           onClick={onStartRecording}
@@ -766,7 +801,7 @@ function processingMessage(status: NoteDto["processingStatus"]): string | null {
   }
 }
 
-function turnsToText(turns: TranscriptDto[]): string {
+function turnsToText(turns: RenderedTranscriptTurn[]): string {
   return turns
     .filter((turn) => turn.text.trim())
     .map((turn) => {
@@ -778,16 +813,25 @@ function turnsToText(turns: TranscriptDto[]): string {
     .join("\n\n");
 }
 
-function transcriptToText(note: NoteDto): string {
-  if (note.sourceTranscripts?.length) {
-    return turnsToText(orderedVisibleSourceTranscripts(note));
+function transcriptToText(
+  note: NoteDto,
+  liveTurns: RenderedTranscriptTurn[] = [],
+): string {
+  const sourceTurns = orderedVisibleSourceTranscripts(note);
+  if (sourceTurns.length || liveTurns.length) {
+    return turnsToText(
+      [...sourceTurns, ...liveTurns]
+        .map((turn, index) => ({ turn, index }))
+        .sort(compareSourceTranscriptOrder)
+        .map(({ turn }) => turn),
+    );
   }
   return note.transcript?.text ?? "";
 }
 
 function orderedVisibleSourceTranscripts(
   note: NoteDto,
-): NonNullable<NoteDto["sourceTranscripts"]> {
+): RenderedTranscriptTurn[] {
   return (note.sourceTranscripts ?? [])
     .filter((turn) => {
       if (turn.text.trim()) return true;
@@ -798,9 +842,27 @@ function orderedVisibleSourceTranscripts(
     .map(({ turn }) => turn);
 }
 
+function liveTranscriptEventToTurn(
+  event: LiveTranscriptEventDto,
+): RenderedTranscriptTurn {
+  return {
+    id: `live-${event.sessionId}-${event.source}-${event.segmentId}`,
+    text: event.text,
+    sourceMode: event.sourceMode,
+    source: event.source,
+    startMs: event.startMs,
+    endMs: event.endMs,
+    turnIndex: undefined,
+    language: event.language,
+    status: "running",
+    preview: true,
+    stability: event.stability,
+  };
+}
+
 function compareSourceTranscriptOrder(
-  left: { turn: TranscriptDto; index: number },
-  right: { turn: TranscriptDto; index: number },
+  left: { turn: RenderedTranscriptTurn; index: number },
+  right: { turn: RenderedTranscriptTurn; index: number },
 ) {
   const turnIndexOrder = compareOptionalNumber(
     left.turn.turnIndex,
@@ -830,7 +892,13 @@ function compareOptionalNumber(left?: number, right?: number) {
 /** A single conversation turn in the Transcription tab. Mirrors the dictation
  * history row language: a source glyph, a light meta line, and the transcript
  * text — copy reveals on hover, long turns clamp to a "Show more" toggle. */
-function TranscriptTurn({ transcript }: { transcript: TranscriptDto }) {
+function TranscriptTurn({
+  transcript,
+  preview = false,
+}: {
+  transcript: RenderedTranscriptTurn;
+  preview?: boolean;
+}) {
   const textRef = useRef<HTMLParagraphElement>(null);
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -896,6 +964,9 @@ function TranscriptTurn({ transcript }: { transcript: TranscriptDto }) {
             {sourceLabel(transcript.source)}
           </span>
           {turnTime ? <time>{turnTime}</time> : null}
+          {preview ? (
+            <span className="transcript-turn-preview">Live preview</span>
+          ) : null}
         </div>
         {hasText ? (
           <p

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -56,6 +56,21 @@ export type TranscriptDto = {
   lastError?: string;
 };
 
+export const LIVE_TRANSCRIPT_EVENT = "live-transcript-event";
+
+export type LiveTranscriptEventDto = {
+  noteId: string;
+  sessionId: string;
+  sourceMode: RecordingSourceMode;
+  source: RecordingSource;
+  segmentId: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+  language?: string;
+  stability: "partial" | "final";
+};
+
 export type AudioLevelDto = {
   peak: number;
   rms: number;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6102,6 +6102,11 @@ input:focus-visible,
   font-variant-numeric: tabular-nums;
 }
 
+.transcript-turn-preview {
+  font-size: var(--fs-xs);
+  color: var(--muted-foreground);
+}
+
 .transcript-turn-text {
   margin: 0;
   color: var(--foreground);

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -65,6 +65,7 @@ vi.mock("../lib/recording-sounds", () => ({
 }));
 
 vi.mock("../lib/tauri", () => ({
+  LIVE_TRANSCRIPT_EVENT: "live-transcript-event",
   bootstrapApp: mocks.bootstrapApp,
   createNote: mocks.createNote,
   createFolder: mocks.createFolder,

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -71,6 +71,7 @@ vi.mock("../lib/recording-sounds", () => ({
 }));
 
 vi.mock("../lib/tauri", () => ({
+  LIVE_TRANSCRIPT_EVENT: "live-transcript-event",
   bootstrapApp: mocks.bootstrapApp,
   createNote: mocks.createNote,
   createFolder: mocks.createFolder,
@@ -669,7 +670,9 @@ describe("notes recording reliability", () => {
     );
     expect(container.querySelector(".note-failure-banner")).toBeNull();
 
-    await userEvent.click(screen.getByRole("button", { name: "Transcription" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Transcription" }),
+    );
     await waitFor(() =>
       expect(mocks.updateNote).toHaveBeenCalledWith({
         noteId: "note-1",

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -99,6 +99,7 @@ vi.mock("../app/update-decision", async () => {
 });
 
 vi.mock("../lib/tauri", () => ({
+  LIVE_TRANSCRIPT_EVENT: "live-transcript-event",
   bootstrapApp: mocks.bootstrapApp,
   createNote: mocks.createNote,
   createFolder: mocks.createFolder,

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -162,6 +162,42 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Microphone response")).toBeInTheDocument();
   });
 
+  it("shows live transcript preview turns while recording", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({ activeTab: "transcription" })}
+        recordingStatus={{
+          sessionId: "session-1",
+          state: "recording",
+          elapsedMs: 8000,
+          level: { peak: 0.5, rms: 0.2, recentPeaks: [0.1, 0.3] },
+          silenceWarning: false,
+          bytesWritten: 4096,
+        }}
+        liveTranscript={[
+          {
+            noteId: "note-1",
+            sessionId: "session-1",
+            sourceMode: "microphoneOnly",
+            source: "microphone",
+            segmentId: "microphone-0",
+            startMs: 0,
+            endMs: 8000,
+            text: "Preview words from the live recording",
+            language: "en",
+            stability: "final",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Preview words from the live recording"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Live preview")).toBeInTheDocument();
+  });
+
   it("shows transcript progress while retrying over existing turns", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary
- Implements Phase 1 microphone live transcript preview for recordings using bounded PCM capture, 8 second chunk transcription, and ephemeral Tauri events.
- Adds `preview=true` support to Scribe API transcription so preview chunks are authenticated, duration-capped server-side, authorized with a wallet hold, settled with a zero-credit charge, and returned with a zero-credit receipt.
- Renders live preview turns in the note Transcription tab and clears them when recording stops, while final saved-audio processing remains the source of truth.
- Updates the live transcript ADR, README ADR index, and tests for preview reconciliation, preview authorization, duration caps, zero-credit hold release, and billing behavior.

## Notes
- Live system-audio preview is documented but not implemented in this phase because the macOS helper needs a separate preview PCM path. Final microphone-plus-system recording and transcription still use the saved source files.
- Preview is best-effort: failures do not block recording, finalization, or final transcript generation.

## Validation
- `pnpm run lint`
- `pnpm exec vitest run src/test/note-editor.test.tsx src/test/app-notes-reliability.test.tsx src/test/app-meeting-start.test.tsx src/test/app-shortcut.test.tsx`
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml live_preview --locked`
- `cargo +1.95.0-aarch64-apple-darwin clippy --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml note_transcribe_preview --all-targets --all-features --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml validate_rejects_zero_preview_audio_cap --all-targets --all-features --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`
- `git diff --check`
