### PR TITLE
[codex] Verify dictionary context reaches meeting transcription

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -3788,7 +3788,10 @@ mod tests {
     #[test]
     fn mid_sentence_fillers_are_removed_without_touching_articles() {
         assert_eq!(
-            clean_dictation_fillers("I, uh, need a test and an example.", DictationStyle::Standard),
+            clean_dictation_fillers(
+                "I, uh, need a test and an example.",
+                DictationStyle::Standard
+            ),
             "I need a test and an example."
         );
     }
@@ -3850,10 +3853,7 @@ mod tests {
             "First line.\nSecond line."
         );
         assert_eq!(
-            clean_dictation_fillers(
-                "Paragraph one.\n\nParagraph two.",
-                DictationStyle::Standard
-            ),
+            clean_dictation_fillers("Paragraph one.\n\nParagraph two.", DictationStyle::Standard),
             "Paragraph one.\n\nParagraph two."
         );
         // Horizontal whitespace still collapses within a line.
@@ -3882,7 +3882,10 @@ mod tests {
         // The backstop must never re-capitalize under CasualLowercase, even
         // when stripping a leading filler exposes a lowercase first word.
         assert_eq!(
-            clean_dictation_fillers("um, can you send this email?", DictationStyle::CasualLowercase),
+            clean_dictation_fillers(
+                "um, can you send this email?",
+                DictationStyle::CasualLowercase
+            ),
             "can you send this email?"
         );
         // Standard and Formal do restore the capital.

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1744,6 +1744,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn turn_transcription_requests_include_dictionary_context() {
+        let contexts = Arc::new(Mutex::new(Vec::new()));
+        let transcriber = {
+            let contexts = Arc::clone(&contexts);
+            Arc::new(move |request: TranscriptionRequest| {
+                let contexts = Arc::clone(&contexts);
+                Box::pin(async move {
+                    contexts.lock().unwrap().push((
+                        request.audio_path.to_string_lossy().to_string(),
+                        request.context,
+                    ));
+                    Ok(TranscriptionProviderResult {
+                        text: request.audio_path.to_string_lossy().to_string(),
+                        language: None,
+                        provider: "test".to_string(),
+                    })
+                }) as TranscriptionFuture
+            }) as TurnTranscriber
+        };
+
+        transcribe_turn_jobs_bounded(
+            vec![test_job("m0", "microphone", 0), test_job("s1", "system", 1)],
+            &[],
+            crate::providers::OPENAI_PROVIDER.to_string(),
+            "Meeting".to_string(),
+            Some("Custom dictionary terms:\n- DIM".to_string()),
+            transcriber,
+            None,
+            1,
+        )
+        .await
+        .expect("turn jobs should transcribe");
+
+        let contexts = contexts.lock().unwrap();
+        let context_by_path = contexts.iter().cloned().collect::<HashMap<_, _>>();
+        let first_context = context_by_path["m0"]
+            .as_ref()
+            .expect("first turn should receive dictionary context");
+        assert!(first_context.contains("Custom dictionary terms"));
+        assert!(first_context.contains("DIM"));
+        assert!(!first_context.contains("Previous transcript context"));
+
+        let second_context = context_by_path["s1"]
+            .as_ref()
+            .expect("later turn should keep dictionary context");
+        assert!(second_context.contains("Custom dictionary terms"));
+        assert!(second_context.contains("DIM"));
+        assert!(second_context.contains("Previous transcript context"));
+        assert!(second_context.contains("Microphone: m0"));
+    }
+
+    #[tokio::test]
     async fn source_lane_failures_keep_their_source_reason() {
         let transcriber = Arc::new(move |request: TranscriptionRequest| {
             Box::pin(async move {


### PR DESCRIPTION
## Summary
- Confirmed dictionary entries are already wired into meeting transcription contexts.
- Added a regression test that asserts turn transcription requests keep the custom dictionary context, including later turns that also receive previous transcript context.
- Included current rustfmt reflow for three existing dictation tests so the formatter check stays clean.

## Validation
- cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
- cargo +1.95.0-aarch64-apple-darwin test --manifest-path src-tauri/Cargo.toml turn_transcription_requests_include_dictionary_context --locked
- cargo +1.95.0-aarch64-apple-darwin test --manifest-path src-tauri/Cargo.toml --locked