### PR TITLE
Fix note retry processing state

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,7 +15,6 @@ use crate::{
     domain::{
         processing::{
             manual_notes_for_generation, process_saved_audio, process_saved_source_audio,
-            retry_from_saved_audio,
         },
         processing_queue,
         types::{
@@ -28,8 +27,8 @@ use crate::{
             DeleteNotesRequest, DictionaryEntryDto, ExplainAgentApprovalRequest,
             ExplainAgentApprovalResponse, FinishRecordingResponse, GetAgentTaskRequest,
             GetNoteRequest, ListNotesRequest, ListNotesResponse, MicrophonePermissionResponse,
-            NoteDto, OpenPrivacySettingsRequest, RecordingSessionDto, RecordingSource,
-            RecordingSourceMode, RecordingSourceReadinessDto, RecordingStatusDto,
+            NoteDto, OpenPrivacySettingsRequest, ProcessingStatus, RecordingSessionDto,
+            RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto, RecordingStatusDto,
             RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest, RenameFolderRequest,
             RetryProcessingRequest, SaveAgentAssistantMessageRequest,
             SaveAgentHermesSessionRequest, SendAgentMessageRequest, SessionFolderDto,
@@ -919,7 +918,7 @@ async fn finish_recording_session(
     let mut note = repos.get_note(&finished.note_id).await?;
     note.queued_recordings = processing_queue::queued_behind(&finished.note_id);
 
-    let task_repos = (*repos).clone();
+    let task_repos = repos.clone();
     let task_note_id = finished.note_id.clone();
     let task_session_id = finished.session_id.clone();
     let task_source_mode = finished.source_mode;
@@ -1039,7 +1038,101 @@ pub async fn retry_processing(
 ) -> Result<NoteDto, AppError> {
     let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
-    retry_from_saved_audio(&repos, &paths, &request.note_id).await
+    let sources = retry_audio_sources(&repos, &paths, &request.note_id).await?;
+    let (ticket, depth) = processing_queue::enqueue(&request.note_id);
+    if depth <= 1 {
+        repos
+            .set_note_status(&request.note_id, ProcessingStatus::Transcribing, None)
+            .await?;
+    }
+
+    let mut note = repos.get_note(&request.note_id).await?;
+    note.queued_recordings = processing_queue::queued_behind(&request.note_id);
+
+    let task_repos = repos.clone();
+    let task_note_id = request.note_id.clone();
+    tokio::spawn(async move {
+        let queue_lock = ticket.lock();
+        let _guard = queue_lock.lock().await;
+        let note = match task_repos.get_note(&task_note_id).await {
+            Ok(note) => note,
+            Err(_) => {
+                ticket.finish();
+                return;
+            }
+        };
+        let title = note.title.clone();
+        let existing_generated_note = note.generated_content.clone();
+        let manual_notes = manual_notes_for_generation(&note);
+        let result = if sources.len() == 1 {
+            let (audio_artifact_id, _source, audio_path, session_id) = sources
+                .into_iter()
+                .next()
+                .expect("retry sources were checked before starting processing");
+            process_saved_audio(
+                &task_repos,
+                &task_note_id,
+                &session_id,
+                &audio_artifact_id,
+                audio_path,
+                title,
+                existing_generated_note,
+                manual_notes,
+            )
+            .await
+        } else {
+            let session_id = sources
+                .first()
+                .map(|(_id, _source, _path, session_id)| session_id.clone())
+                .unwrap_or_default();
+            process_saved_source_audio(
+                &task_repos,
+                &task_note_id,
+                &session_id,
+                RecordingSourceMode::MicrophonePlusSystem,
+                sources
+                    .into_iter()
+                    .map(|(id, source, path, _session_id)| (id, source, path))
+                    .collect(),
+                title,
+                existing_generated_note,
+                manual_notes,
+            )
+            .await
+        };
+        if let Err(error) = result {
+            let _ = task_repos
+                .set_note_status(&task_note_id, ProcessingStatus::Failed, Some(error.message))
+                .await;
+        }
+        ticket.finish();
+    });
+    Ok(note)
+}
+
+async fn retry_audio_sources(
+    repos: &Repositories,
+    paths: &AppPaths,
+    note_id: &str,
+) -> Result<Vec<(String, String, PathBuf, String)>, AppError> {
+    let sources = repos
+        .latest_valid_audio_artifact_paths(note_id)
+        .await?
+        .into_iter()
+        .filter_map(|(id, source, path, session_id)| {
+            paths
+                .contained_recording_file(path)
+                .ok()
+                .map(|path| (id, source, path, session_id))
+        })
+        .collect::<Vec<_>>();
+    if sources.is_empty() {
+        return Err(AppError::new(
+            "audio_artifact_missing",
+            "No saved audio is available for retry.",
+        ));
+    }
+    Ok(sources)
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1,5 +1,4 @@
 use crate::{
-    app_paths::AppPaths,
     audio::turns::{
         coalesce_turns_for_transcription, detect_turns, normalize_wav_for_transcription,
         split_wav_for_transcription, write_turn_wav, DetectionSource,
@@ -727,64 +726,6 @@ pub async fn process_saved_source_audio(
         )
         .await?;
     Ok(note)
-}
-
-pub async fn retry_from_saved_audio(
-    repos: &Repositories,
-    paths: &AppPaths,
-    note_id: &str,
-) -> Result<NoteDto, AppError> {
-    let sources = repos
-        .latest_valid_audio_artifact_paths(note_id)
-        .await?
-        .into_iter()
-        .filter_map(|(id, source, path, session_id)| {
-            paths
-                .contained_recording_file(path)
-                .ok()
-                .map(|path| (id, source, path, session_id))
-        })
-        .collect::<Vec<_>>();
-    if sources.is_empty() {
-        return Err(AppError::new(
-            "audio_artifact_missing",
-            "No saved audio is available for retry.",
-        ));
-    }
-    let note = repos.get_note(note_id).await?;
-    let manual_notes = manual_notes_for_generation(&note);
-    if sources.len() == 1 {
-        let (audio_artifact_id, _source, audio_path, session_id) = sources[0].clone();
-        return process_saved_audio(
-            repos,
-            note_id,
-            &session_id,
-            &audio_artifact_id,
-            audio_path,
-            note.title,
-            note.generated_content,
-            manual_notes,
-        )
-        .await;
-    }
-    let session_id = sources
-        .first()
-        .map(|(_id, _source, _path, session_id)| session_id.clone())
-        .unwrap_or_default();
-    process_saved_source_audio(
-        repos,
-        note_id,
-        &session_id,
-        RecordingSourceMode::MicrophonePlusSystem,
-        sources
-            .into_iter()
-            .map(|(id, source, path, _session_id)| (id, source, path))
-            .collect(),
-        note.title,
-        note.generated_content,
-        manual_notes,
-    )
-    .await
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/domain/processing_queue.rs
+++ b/src-tauri/src/domain/processing_queue.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        atomic::{AtomicI64, Ordering},
+        atomic::{AtomicBool, AtomicI64, Ordering},
         Arc, LazyLock, Mutex,
     },
 };
@@ -37,6 +37,7 @@ pub struct ProcessingTicket {
     note_id: String,
     lock: Arc<AsyncMutex<()>>,
     pending: Arc<AtomicI64>,
+    finished: AtomicBool,
 }
 
 impl ProcessingTicket {
@@ -49,6 +50,9 @@ impl ProcessingTicket {
     /// Mark this job done: drop it from the pending count and prune the note's
     /// queue entry once nothing else is waiting.
     pub fn finish(&self) {
+        if self.finished.swap(true, Ordering::SeqCst) {
+            return;
+        }
         let mut map = QUEUES.lock().expect("processing queue mutex poisoned");
         let remaining = self.pending.fetch_sub(1, Ordering::SeqCst) - 1;
         if remaining <= 0 {
@@ -65,6 +69,12 @@ impl ProcessingTicket {
     }
 }
 
+impl Drop for ProcessingTicket {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
 /// Register a processing job for `note_id`. Returns the ticket and the queue
 /// depth *including* this job (1 = runs immediately, 2 = one job ahead, …).
 pub fn enqueue(note_id: &str) -> (ProcessingTicket, i64) {
@@ -78,6 +88,7 @@ pub fn enqueue(note_id: &str) -> (ProcessingTicket, i64) {
         note_id: note_id.to_string(),
         lock: queue.lock.clone(),
         pending: queue.pending.clone(),
+        finished: AtomicBool::new(false),
     };
     (ticket, depth)
 }
@@ -131,6 +142,32 @@ mod tests {
         a.finish();
         b1.finish();
         b2.finish();
+    }
+
+    #[test]
+    fn dropped_ticket_releases_pending_job() {
+        {
+            let (_ticket, depth) = enqueue("note-drop");
+            assert_eq!(depth, 1);
+        }
+
+        let (next, depth) = enqueue("note-drop");
+        assert_eq!(depth, 1);
+        next.finish();
+    }
+
+    #[test]
+    fn finish_is_idempotent() {
+        let (first, _) = enqueue("note-idempotent");
+        let (second, _) = enqueue("note-idempotent");
+
+        first.finish();
+        first.finish();
+
+        let (third, depth) = enqueue("note-idempotent");
+        assert_eq!(depth, 2);
+        second.finish();
+        third.finish();
     }
 
     #[tokio::test]

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -231,6 +231,9 @@ export function NoteEditor({
   // stays disabled via processingLock so nothing can re-trigger.
   const shellState = recordingForNote?.state ?? "idle";
   const processingText = processingMessage(note.processingStatus);
+  const transcriptText = transcriptToText(note);
+  const showTranscriptProcessing =
+    processingLock && transcriptText.trim().length > 0;
   // Processing runs in the background and is queued per note, so a recording
   // that's still transcribing/generating no longer blocks starting another —
   // you can stack messages and they process in order. The record button only
@@ -289,7 +292,7 @@ export function NoteEditor({
         ) : null}
         {activeTab === "transcription" ? (
           <div className="transcript-view">
-            {transcriptToText(note) ? (
+            {transcriptText ? (
               <div className="transcript-toolbar">
                 {hasBothSources ? (
                   <SegmentedControl
@@ -307,6 +310,18 @@ export function NoteEditor({
                       : transcriptToText(note)
                   }
                 />
+              </div>
+            ) : null}
+            {showTranscriptProcessing ? (
+              <div
+                className="transcript-processing"
+                role="status"
+                aria-live="polite"
+              >
+                <DotSpinner className="transcript-processing-spinner" />
+                <span className="transcript-processing-label">
+                  {processingText ?? "Processing audio..."}
+                </span>
               </div>
             ) : null}
             {visibleTurns.length ? (

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -307,7 +307,7 @@ export function NoteEditor({
                   text={
                     visibleTurns.length
                       ? turnsToText(visibleTurns)
-                      : transcriptToText(note)
+                      : transcriptText
                   }
                 />
               </div>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5908,6 +5908,45 @@ input:focus-visible,
   color: var(--warm-strong);
 }
 
+.transcript-processing {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  max-width: var(--content-max);
+  margin: 0 0 var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--muted) 68%, var(--card));
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.transcript-processing-spinner {
+  flex: none;
+  color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
+}
+
+.transcript-processing-label {
+  background: linear-gradient(
+    90deg,
+    var(--muted-foreground) 0%,
+    var(--muted-foreground) 35%,
+    var(--foreground) 50%,
+    var(--muted-foreground) 65%,
+    var(--muted-foreground) 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: note-text-shimmer 2s linear infinite;
+}
+
 .transcript-view p {
   max-width: var(--content-max);
   margin: 0;

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -390,4 +390,58 @@ describe("notes recording reliability", () => {
     expect(container.querySelector(".note-failure-banner")).toBeNull();
     expect(container.querySelector(".error-banner")).toBeNull();
   });
+
+  it("shows processing immediately after retry starts", async () => {
+    const failedNote = {
+      ...first,
+      activeTab: "notes" as const,
+      processingStatus: "failed" as const,
+      lastError: "The processing service returned an invalid response.",
+      audio: {
+        id: "audio-1",
+        format: "wav",
+        durationMs: 1000,
+        sizeBytes: 2048,
+        checksum: "abc",
+        createdAt: now,
+      },
+    };
+    const retryingNote = {
+      ...failedNote,
+      processingStatus: "transcribing" as const,
+      lastError: undefined,
+    };
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2" ? second : failedNote,
+    );
+    mocks.retryProcessing.mockResolvedValue(retryingNote);
+    mocks.updateNote.mockImplementation(async (input) => ({
+      ...retryingNote,
+      ...input,
+    }));
+
+    const { container } = render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Meeting notes" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /First note Preview/ }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Retry/ }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Transcribing audio/)).toBeInTheDocument(),
+    );
+    expect(container.querySelector(".note-failure-banner")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Transcription" }));
+    await waitFor(() =>
+      expect(mocks.updateNote).toHaveBeenCalledWith({
+        noteId: "note-1",
+        activeTab: "transcription",
+      }),
+    );
+  });
 });

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -162,6 +162,34 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Microphone response")).toBeInTheDocument();
   });
 
+  it("shows transcript progress while retrying over existing turns", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          activeTab: "transcription",
+          processingStatus: "transcribing",
+          sourceTranscripts: [
+            {
+              id: "turn-1",
+              text: "Previous system transcript",
+              source: "system",
+              startMs: 1000,
+              endMs: 2500,
+              turnIndex: 0,
+              status: "succeeded",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Transcribing audio...",
+    );
+    expect(screen.getByText("Previous system transcript")).toBeInTheDocument();
+  });
+
   it("orders source transcript turns by persisted turn metadata", () => {
     const { container } = render(
       <NoteEditor


### PR DESCRIPTION
## Summary
- Move note retry processing onto the same background per-note queue used after recording finishes.
- Return an active processing note immediately so the failed banner clears and the UI shows progress instead of waiting on the full retry command.
- Show a transcript-tab processing indicator when retrying over existing transcript rows.
- Remove the old synchronous retry helper and cover the retry/progress UI with tests.

## Root cause
`retry_processing` called the saved-audio retry helper directly, so the Tauri command stayed pending through transcription and note generation. When the notes generation endpoint was slow or initially returned an invalid response, retry made the detail pane look stuck and kept stale failure/transcript UI visible. The transcription tab also only surfaced processing copy in the empty state, so an existing transcript row hid the fact that retry was still running.

## Validation
- `pnpm exec vitest run src/test/note-editor.test.tsx src/test/app-notes-reliability.test.tsx`
- `pnpm exec tsc --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml processing -- --nocapture`
- `git diff --check`
