### PR TITLE
Mute report icons in the account menu

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4450,25 +4450,14 @@ input:focus-visible,
   color: var(--muted-foreground);
 }
 
-/* Report shortcuts carry their category color (same oklch tints as the chip
- * and the composer "+" popover); the icon is nested in this span so the
- * muted-svg rule above doesn't override the tint. */
+/* Report shortcuts stay muted in this menu (the category tints live on the
+ * chips and the composer "+" popover); the icon is nested in this span so the
+ * muted-svg rule above still applies to it. */
 .sidebar-report-icon {
   display: inline-grid;
   place-items: center;
   flex: 0 0 auto;
-}
-
-.sidebar-report-icon[data-category="bug"] {
-  color: var(--destructive);
-}
-
-.sidebar-report-icon[data-category="feedback"] {
-  color: var(--warm-strong);
-}
-
-.sidebar-report-icon[data-category="feature"] {
-  color: var(--success);
+  color: var(--muted-foreground);
 }
 
 /* Settings nav — replaces the main sidebar list while the settings page is


### PR DESCRIPTION
## What

The bug / feedback / feature category icons in the sidebar account menu now use the muted foreground color, matching the Settings and Sign out icons, instead of carrying their category tints (red / warm / green).

## Why

The colored tints read as noisy in the account menu. They still belong in the chat composer (category chips and the "+" popover), so this change is scoped to the menu only.

## How

Dropped the three `.sidebar-report-icon[data-category=...]` color rules and set the wrapper to `var(--muted-foreground)`. The existing `.sidebar-identity-menu button > svg` muted rule now applies uniformly to the nested icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)