### PR TITLE
[codex] Check for updates periodically

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -161,6 +161,8 @@ import { handleSidebarResizeStart } from "./sidebar-resize";
 import {
   checkForScribeUpdate,
   prepareScribeUpdate,
+  startPeriodicScribeUpdateChecks,
+  type UpdateCheckMode,
   type UpdateInstallProgress,
   type UpdatePromptPayload,
 } from "./update-decision";
@@ -832,6 +834,7 @@ export function App() {
   // Otherwise the launch effect and the manual-check listener below would tear
   // down and re-fire every time a download or relaunch toggles state.
   const preparingUpdateRef = useRef(false);
+  const checkingUpdateRef = useRef(false);
   const readyUpdateRef = useRef<UpdatePromptPayload<ScribeUpdate> | null>(null);
   const relaunchingUpdateRef = useRef(false);
   const updateProgressHiddenRef = useRef(false);
@@ -846,7 +849,7 @@ export function App() {
   }, [relaunchingUpdate]);
 
   const prepareUpdate = useCallback(
-    (payload: UpdatePromptPayload<ScribeUpdate>, mode: "launch" | "manual") => {
+    (payload: UpdatePromptPayload<ScribeUpdate>, mode: UpdateCheckMode) => {
       if (
         preparingUpdateRef.current ||
         readyUpdateRef.current ||
@@ -896,8 +899,9 @@ export function App() {
   );
 
   const runUpdateCheck = useCallback(
-    (mode: "launch" | "manual") => {
+    (mode: UpdateCheckMode) => {
       if (readyUpdateRef.current || relaunchingUpdateRef.current) return;
+      if (checkingUpdateRef.current) return;
       if (preparingUpdateRef.current) {
         if (mode === "manual") {
           updateProgressHiddenRef.current = false;
@@ -905,7 +909,9 @@ export function App() {
         }
         return;
       }
-      setUpdateStatus(mode === "manual" ? "Checking for updates..." : null);
+      checkingUpdateRef.current = true;
+      if (mode === "manual") setUpdateStatus("Checking for updates...");
+      else if (mode === "launch") setUpdateStatus(null);
       void checkForScribeUpdate(
         {
           check: checkScribeUpdate,
@@ -913,11 +919,16 @@ export function App() {
             prepareUpdate(payload, mode);
           },
           reportNoUpdate: () => setUpdateStatus("June is up to date."),
-          reportFailure: (message) =>
-            setUpdateStatus(`Update check failed: ${message}`),
+          reportFailure: (message) => {
+            if (mode !== "periodic") {
+              setUpdateStatus(`Update check failed: ${message}`);
+            }
+          },
         },
         mode,
-      );
+      ).finally(() => {
+        checkingUpdateRef.current = false;
+      });
     },
     [prepareUpdate],
   );
@@ -943,6 +954,12 @@ export function App() {
     if (appBlocked || launchCheckedRef.current) return;
     launchCheckedRef.current = true;
     runUpdateCheck("launch");
+  }, [appBlocked, runUpdateCheck]);
+
+  useEffect(() => {
+    if (import.meta.env.DEV) return;
+    if (appBlocked) return;
+    return startPeriodicScribeUpdateChecks(runUpdateCheck);
   }, [appBlocked, runUpdateCheck]);
 
   useEffect(() => {

--- a/src/app/update-decision.ts
+++ b/src/app/update-decision.ts
@@ -4,7 +4,9 @@ export type UpdatePromptPayload<TUpdate> = {
   notes?: string;
 };
 
-export type UpdateCheckMode = "launch" | "manual";
+export type UpdateCheckMode = "launch" | "manual" | "periodic";
+
+export const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 export type DownloadEvent =
   | { event: "Started"; data: { contentLength?: number } }
@@ -64,6 +66,17 @@ export async function checkForScribeUpdate<TUpdate extends UpdaterUpdate>(
   } catch (error) {
     deps.reportFailure(messageFromUnknown(error));
   }
+}
+
+export function startPeriodicScribeUpdateChecks(
+  runUpdateCheck: (mode: UpdateCheckMode) => void,
+  intervalMs = UPDATE_CHECK_INTERVAL_MS,
+) {
+  const timer = window.setInterval(
+    () => runUpdateCheck("periodic"),
+    intervalMs,
+  );
+  return () => window.clearInterval(timer);
 }
 
 export async function prepareScribeUpdate<TUpdate extends UpdaterUpdate>({

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -72,6 +72,7 @@ const mocks = vi.hoisted(() => ({
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
   preloadRecordingSounds: vi.fn(),
+  startPeriodicScribeUpdateChecks: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -86,6 +87,16 @@ vi.mock("../lib/recording-sounds", () => ({
   playRecordingSound: mocks.playRecordingSound,
   preloadRecordingSounds: mocks.preloadRecordingSounds,
 }));
+
+vi.mock("../app/update-decision", async () => {
+  const actual = await vi.importActual<typeof import("../app/update-decision")>(
+    "../app/update-decision",
+  );
+  return {
+    ...actual,
+    startPeriodicScribeUpdateChecks: mocks.startPeriodicScribeUpdateChecks,
+  };
+});
 
 vi.mock("../lib/tauri", () => ({
   bootstrapApp: mocks.bootstrapApp,
@@ -208,6 +219,7 @@ describe("App shortcuts", () => {
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
     mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.startPeriodicScribeUpdateChecks.mockReturnValue(vi.fn());
     mocks.listeners.clear();
     mocks.listen.mockImplementation(
       async (
@@ -222,6 +234,24 @@ describe("App shortcuts", () => {
       ...first,
       ...input,
     }));
+  });
+
+  it("starts background update checks after launch gates clear", async () => {
+    vi.stubEnv("DEV", false);
+
+    try {
+      render(<App />);
+
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+      await waitFor(() =>
+        expect(mocks.startPeriodicScribeUpdateChecks).toHaveBeenCalledOnce(),
+      );
+      expect(mocks.startPeriodicScribeUpdateChecks.mock.calls[0]?.[0]).toEqual(
+        expect.any(Function),
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("starts a new session with Command-N", async () => {

--- a/src/test/update-decision.test.ts
+++ b/src/test/update-decision.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  UPDATE_CHECK_INTERVAL_MS,
   checkForScribeUpdate,
   installScribeUpdate,
   prepareScribeUpdate,
+  startPeriodicScribeUpdateChecks,
   type UpdaterUpdate,
 } from "../app/update-decision";
 
@@ -58,6 +60,24 @@ describe("checkForScribeUpdate", () => {
     expect(reportNoUpdate).not.toHaveBeenCalled();
   });
 
+  it("keeps periodic no-update checks silent", async () => {
+    const prompt = vi.fn();
+    const reportNoUpdate = vi.fn();
+
+    await checkForScribeUpdate(
+      {
+        check: async () => null,
+        prompt,
+        reportNoUpdate,
+        reportFailure: vi.fn(),
+      },
+      "periodic",
+    );
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(reportNoUpdate).not.toHaveBeenCalled();
+  });
+
   it("reports no update for a manual check", async () => {
     const reportNoUpdate = vi.fn();
 
@@ -92,6 +112,30 @@ describe("checkForScribeUpdate", () => {
 
     expect(prompt).not.toHaveBeenCalled();
     expect(reportFailure).toHaveBeenCalledWith("signature mismatch");
+  });
+});
+
+describe("startPeriodicScribeUpdateChecks", () => {
+  it("runs periodic checks until stopped", () => {
+    vi.useFakeTimers();
+    const runUpdateCheck = vi.fn();
+
+    try {
+      const stop = startPeriodicScribeUpdateChecks(runUpdateCheck);
+
+      vi.advanceTimersByTime(UPDATE_CHECK_INTERVAL_MS - 1);
+      expect(runUpdateCheck).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(runUpdateCheck).toHaveBeenCalledWith("periodic");
+      expect(runUpdateCheck).toHaveBeenCalledTimes(1);
+
+      stop();
+      vi.advanceTimersByTime(UPDATE_CHECK_INTERVAL_MS);
+      expect(runUpdateCheck).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add an hourly background update checker after June's launch gates clear.
- Reuse the existing silent update preparation flow so a found update downloads and surfaces the existing relaunch card while the app remains open.
- Add an in-flight guard so launch, manual, and periodic checks cannot overlap.
- Keep periodic no-update and transient failure results quiet.

## Why
Previously the update card could appear on launch or after a manual check, but a user who kept June open would not learn about a newly published update until restarting or explicitly checking. The periodic check keeps long-running app sessions aware of updates without adding status-card noise.

## Validation
- `pnpm exec vitest run src/test/update-decision.test.ts src/test/app-shortcut.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/app/App.tsx src/app/update-decision.ts src/test/update-decision.test.ts src/test/app-shortcut.test.tsx`
- `git diff --check HEAD~1..HEAD`
