### PR TITLE
[codex] default to GLM 5.2 text model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ OPENAI_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
 
 # Initial chat model used to turn transcripts and manual notes into generated note content.
 # The Settings tab can override this with any text model returned by Scribe API.
-VENICE_GENERATION_MODEL=zai-org-glm-5
+VENICE_GENERATION_MODEL=zai-org-glm-5-2
 
 # --- OS Accounts (Login with Open Software) ---------------------------------
 # Identity only in the desktop app. The App API key (osk_) is server-side only

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -89,9 +89,26 @@ model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
 privacy = "private"
 
-# Fallback pricing for the default text model (kimi-k2-6); the live
-# Venice catalog overrides this on boot. Keep in sync with
+# Fallback pricing for the default and suggested text models; the live Venice
+# catalog overrides this on boot. Keep the GLM 5.2 entry in sync with
 # DEFAULT_GENERATION_MODEL in the Tauri providers module.
+[pricing."zai-org-glm-5-2"]
+unit = "tokens"
+input_credits_per_million_tokens = 1750
+output_credits_per_million_tokens = 5500
+provider = "venice"
+model_type = "text"
+display_name = "GLM 5.2"
+privacy = "private"
+context_tokens = 200000
+capabilities = [
+  "supportsFunctionCalling",
+  "supportsReasoning",
+  "supportsReasoningEffort",
+  "supportsResponseSchema",
+  "supportsWebSearch",
+]
+
 [pricing."kimi-k2-6"]
 unit = "tokens"
 input_credits_per_million_tokens = 850
@@ -100,6 +117,25 @@ provider = "venice"
 model_type = "text"
 display_name = "Kimi K2.6"
 privacy = "private"
+context_tokens = 256000
+capabilities = ["supportsFunctionCalling"]
+
+[pricing."zai-org-glm-5-1"]
+unit = "tokens"
+input_credits_per_million_tokens = 1750
+output_credits_per_million_tokens = 5500
+provider = "venice"
+model_type = "text"
+display_name = "GLM 5.1"
+privacy = "private"
+context_tokens = 200000
+capabilities = [
+  "supportsFunctionCalling",
+  "supportsReasoning",
+  "supportsReasoningEffort",
+  "supportsResponseSchema",
+  "supportsWebSearch",
+]
 
 [pricing."zai-org-glm-5"]
 unit = "tokens"
@@ -109,6 +145,8 @@ provider = "venice"
 model_type = "text"
 display_name = "GLM 5"
 privacy = "private"
+context_tokens = 198000
+capabilities = ["supportsFunctionCalling"]
 
 [pricing."nvidia-nemotron-3-nano-30b-a3b"]
 unit = "tokens"

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -303,6 +303,16 @@ pub struct ModelPriceConfig {
     pub capabilities: Vec<String>,
 }
 
+#[derive(Clone, Copy)]
+struct TextModelFallback {
+    id: &'static str,
+    display_name: &'static str,
+    input_credits_per_million_tokens: u64,
+    output_credits_per_million_tokens: u64,
+    context_tokens: i64,
+    capabilities: &'static [&'static str],
+}
+
 /// Built-in pricing fallback, used only when the live Venice catalog can't be
 /// reached at startup so metered charges still settle. The catalog carries the
 /// authoritative numbers and extends over this on every boot. Split out of
@@ -350,91 +360,77 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     // charges still settle. The live catalog (which carries the authoritative
     // numbers) extends over this on every boot. Keep the GLM 5.2 entry in sync
     // with DEFAULT_GENERATION_MODEL in the Tauri providers module.
-    pricing.insert(
-        "zai-org-glm-5-2".to_string(),
-        ModelPriceConfig {
-            unit: PriceUnit::Tokens,
-            credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(1_750),
-            output_credits_per_million_tokens: Some(5_500),
-            provider: ModelProvider::Venice,
-            model_type: ModelType::Text,
-            display_name: "GLM 5.2".to_string(),
-            description: None,
-            privacy: Some("private".to_string()),
-            pricing: None,
-            context_tokens: Some(200_000),
-            traits: Vec::new(),
-            capabilities: vec![
-                "supportsFunctionCalling".to_string(),
-                "supportsReasoning".to_string(),
-                "supportsReasoningEffort".to_string(),
-                "supportsResponseSchema".to_string(),
-                "supportsWebSearch".to_string(),
+    for model in [
+        TextModelFallback {
+            id: "zai-org-glm-5-2",
+            display_name: "GLM 5.2",
+            input_credits_per_million_tokens: 1_750,
+            output_credits_per_million_tokens: 5_500,
+            context_tokens: 200_000,
+            capabilities: &[
+                "supportsFunctionCalling",
+                "supportsReasoning",
+                "supportsReasoningEffort",
+                "supportsResponseSchema",
+                "supportsWebSearch",
             ],
         },
-    );
-    pricing.insert(
-        "kimi-k2-6".to_string(),
-        ModelPriceConfig {
-            unit: PriceUnit::Tokens,
-            credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(850),
-            output_credits_per_million_tokens: Some(4_660),
-            provider: ModelProvider::Venice,
-            model_type: ModelType::Text,
-            display_name: "Kimi K2.6".to_string(),
-            description: None,
-            privacy: Some("private".to_string()),
-            pricing: None,
-            context_tokens: Some(256_000),
-            traits: Vec::new(),
-            capabilities: vec!["supportsFunctionCalling".to_string()],
+        TextModelFallback {
+            id: "kimi-k2-6",
+            display_name: "Kimi K2.6",
+            input_credits_per_million_tokens: 850,
+            output_credits_per_million_tokens: 4_660,
+            context_tokens: 256_000,
+            capabilities: &["supportsFunctionCalling"],
         },
-    );
-    pricing.insert(
-        "zai-org-glm-5-1".to_string(),
-        ModelPriceConfig {
-            unit: PriceUnit::Tokens,
-            credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(1_750),
-            output_credits_per_million_tokens: Some(5_500),
-            provider: ModelProvider::Venice,
-            model_type: ModelType::Text,
-            display_name: "GLM 5.1".to_string(),
-            description: None,
-            privacy: Some("private".to_string()),
-            pricing: None,
-            context_tokens: Some(200_000),
-            traits: Vec::new(),
-            capabilities: vec![
-                "supportsFunctionCalling".to_string(),
-                "supportsReasoning".to_string(),
-                "supportsReasoningEffort".to_string(),
-                "supportsResponseSchema".to_string(),
-                "supportsWebSearch".to_string(),
+        TextModelFallback {
+            id: "zai-org-glm-5-1",
+            display_name: "GLM 5.1",
+            input_credits_per_million_tokens: 1_750,
+            output_credits_per_million_tokens: 5_500,
+            context_tokens: 200_000,
+            capabilities: &[
+                "supportsFunctionCalling",
+                "supportsReasoning",
+                "supportsReasoningEffort",
+                "supportsResponseSchema",
+                "supportsWebSearch",
             ],
         },
-    );
-    pricing.insert(
-        "zai-org-glm-5".to_string(),
-        ModelPriceConfig {
-            unit: PriceUnit::Tokens,
-            credits_per_million_seconds: None,
-            input_credits_per_million_tokens: Some(1_000),
-            output_credits_per_million_tokens: Some(3_200),
-            provider: ModelProvider::Venice,
-            model_type: ModelType::Text,
-            display_name: "GLM 5".to_string(),
-            description: None,
-            privacy: Some("private".to_string()),
-            pricing: None,
-            context_tokens: Some(198_000),
-            traits: Vec::new(),
-            capabilities: vec!["supportsFunctionCalling".to_string()],
+        TextModelFallback {
+            id: "zai-org-glm-5",
+            display_name: "GLM 5",
+            input_credits_per_million_tokens: 1_000,
+            output_credits_per_million_tokens: 3_200,
+            context_tokens: 198_000,
+            capabilities: &["supportsFunctionCalling"],
         },
-    );
+    ] {
+        pricing.insert(model.id.to_string(), text_model_config(model));
+    }
     pricing
+}
+
+fn text_model_config(model: TextModelFallback) -> ModelPriceConfig {
+    ModelPriceConfig {
+        unit: PriceUnit::Tokens,
+        credits_per_million_seconds: None,
+        input_credits_per_million_tokens: Some(model.input_credits_per_million_tokens),
+        output_credits_per_million_tokens: Some(model.output_credits_per_million_tokens),
+        provider: ModelProvider::Venice,
+        model_type: ModelType::Text,
+        display_name: model.display_name.to_string(),
+        description: None,
+        privacy: Some("private".to_string()),
+        pricing: None,
+        context_tokens: Some(model.context_tokens),
+        traits: Vec::new(),
+        capabilities: model
+            .capabilities
+            .iter()
+            .map(|capability| (*capability).to_string())
+            .collect(),
+    }
 }
 
 impl Default for AppConfig {

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -345,11 +345,35 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             capabilities: Vec::new(),
         },
     );
-    // Fallback pricing for the default text model, used only when the live
-    // Venice catalog can't be reached at startup so metered charges still
-    // settle. The live catalog (which carries the authoritative numbers)
-    // extends over this on every boot. Keep the first entry in sync with
-    // DEFAULT_GENERATION_MODEL in the Tauri providers module.
+    // Fallback pricing for the default and suggested text models, used only
+    // when the live Venice catalog can't be reached at startup so metered
+    // charges still settle. The live catalog (which carries the authoritative
+    // numbers) extends over this on every boot. Keep the GLM 5.2 entry in sync
+    // with DEFAULT_GENERATION_MODEL in the Tauri providers module.
+    pricing.insert(
+        "zai-org-glm-5-2".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Tokens,
+            credits_per_million_seconds: None,
+            input_credits_per_million_tokens: Some(1_750),
+            output_credits_per_million_tokens: Some(5_500),
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Text,
+            display_name: "GLM 5.2".to_string(),
+            description: None,
+            privacy: Some("private".to_string()),
+            pricing: None,
+            context_tokens: Some(200_000),
+            traits: Vec::new(),
+            capabilities: vec![
+                "supportsFunctionCalling".to_string(),
+                "supportsReasoning".to_string(),
+                "supportsReasoningEffort".to_string(),
+                "supportsResponseSchema".to_string(),
+                "supportsWebSearch".to_string(),
+            ],
+        },
+    );
     pricing.insert(
         "kimi-k2-6".to_string(),
         ModelPriceConfig {
@@ -365,7 +389,31 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             pricing: None,
             context_tokens: Some(256_000),
             traits: Vec::new(),
-            capabilities: Vec::new(),
+            capabilities: vec!["supportsFunctionCalling".to_string()],
+        },
+    );
+    pricing.insert(
+        "zai-org-glm-5-1".to_string(),
+        ModelPriceConfig {
+            unit: PriceUnit::Tokens,
+            credits_per_million_seconds: None,
+            input_credits_per_million_tokens: Some(1_750),
+            output_credits_per_million_tokens: Some(5_500),
+            provider: ModelProvider::Venice,
+            model_type: ModelType::Text,
+            display_name: "GLM 5.1".to_string(),
+            description: None,
+            privacy: Some("private".to_string()),
+            pricing: None,
+            context_tokens: Some(200_000),
+            traits: Vec::new(),
+            capabilities: vec![
+                "supportsFunctionCalling".to_string(),
+                "supportsReasoning".to_string(),
+                "supportsReasoningEffort".to_string(),
+                "supportsResponseSchema".to_string(),
+                "supportsWebSearch".to_string(),
+            ],
         },
     );
     pricing.insert(
@@ -381,9 +429,9 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             description: None,
             privacy: Some("private".to_string()),
             pricing: None,
-            context_tokens: None,
+            context_tokens: Some(198_000),
             traits: Vec::new(),
-            capabilities: Vec::new(),
+            capabilities: vec!["supportsFunctionCalling".to_string()],
         },
     );
     pricing

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -14,7 +14,7 @@ use tauri::{AppHandle, Manager, State};
 pub const PROVIDER_OPENAI: &str = "openai";
 pub const PROVIDER_VENICE: &str = "venice";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
-pub const DEFAULT_GENERATION_MODEL: &str = "kimi-k2-6";
+pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-2";
 
 // Kept exported under the legacy names so existing callers compile until they
 // migrate to the names above.

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -163,7 +163,7 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
   transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
   // Mirrors DEFAULT_GENERATION_MODEL in the Rust providers module and the
   // leading Suggested pick in lib/suggested-models.ts.
-  generationModel: "kimi-k2-6",
+  generationModel: "zai-org-glm-5-2",
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -16,12 +16,13 @@ export type SuggestedModel = {
  * Curation snapshot (June 2026), from the live Venice catalog plus public
  * benchmarks (SWE-bench agentic coding, Artificial Analysis intelligence
  * index):
+ * - GLM 5.2: latest GLM flagship and June's default text model, with
+ *   reasoning effort controls, tool use, 200K context, $1.75/$5.50 per 1M
+ *   tokens.
  * - Kimi K2.6: leads the open-weights intelligence rankings, built for long
- *   agentic tool runs, 256K context, $0.85/$4.66 — June's default.
- * - GLM 5.1: latest GLM flagship, top-tier agentic coding and tool use among
- *   open models, 200K context, $1.75/$5.50 per 1M tokens.
- * - GLM 4.7: Venice's own catalog default and "function calling default" —
- *   near-flagship quality at a fraction of the price, $0.55/$2.65.
+ *   agentic tool runs, 256K context, $0.85/$4.66.
+ * - GLM 5.1: previous GLM flagship, top-tier agentic coding and tool use
+ *   among open models, 200K context, $1.75/$5.50 per 1M tokens.
  * - Parakeet: fast, accurate everyday dictation at the lowest price tier.
  * - Whisper Large v3: best multilingual accuracy at the same low price.
  *
@@ -35,19 +36,19 @@ export type SuggestedModel = {
 export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
   generation: [
     {
+      id: "zai-org-glm-5-2",
+      reason:
+        "Default pick: latest GLM flagship with strong reasoning, tool use, structured output, and zero data retention.",
+    },
+    {
       id: "kimi-k2-6",
       reason:
-        "Best overall: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
+        "Best alternate: leads independent intelligence rankings and excels at long tool-driven tasks, with zero data retention.",
     },
     {
       id: "zai-org-glm-5-1",
       reason:
-        "Best GLM pick: latest GLM flagship, with top-tier agentic coding and tool use among open models and zero data retention.",
-    },
-    {
-      id: "zai-org-glm-4.7",
-      reason:
-        "Best value: near-flagship quality at a fraction of the price, and Venice's own default for tool calling, with zero data retention.",
+        "Stable GLM alternate: previous GLM flagship with top-tier agentic coding, tool use, and zero data retention.",
     },
   ],
   transcription: [

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11567,6 +11567,7 @@ input:focus-visible,
   display: flex;
   flex-direction: column;
   gap: var(--sp-4);
+  min-width: 0;
 }
 
 .referral-dialog-status {
@@ -11639,6 +11640,7 @@ input:focus-visible,
 .referral-copy-card {
   display: grid;
   gap: var(--sp-3);
+  min-width: 0;
   padding: var(--sp-4);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
@@ -11682,6 +11684,7 @@ input:focus-visible,
   display: flex;
   align-items: center;
   width: 100%;
+  min-width: 0;
   min-height: 40px;
   padding: 0 var(--sp-3);
   border: 1px solid var(--border);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11567,7 +11567,6 @@ input:focus-visible,
   display: flex;
   flex-direction: column;
   gap: var(--sp-4);
-  min-width: 0;
 }
 
 .referral-dialog-status {
@@ -11640,7 +11639,6 @@ input:focus-visible,
 .referral-copy-card {
   display: grid;
   gap: var(--sp-3);
-  min-width: 0;
   padding: var(--sp-4);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
@@ -11684,7 +11682,6 @@ input:focus-visible,
   display: flex;
   align-items: center;
   width: 100%;
-  min-width: 0;
   min-height: 40px;
   padding: 0 var(--sp-3);
   border: 1px solid var(--border);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -195,14 +195,23 @@ describe("AgentWorkspace", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "kimi-k2-6",
+        generationModel: "zai-org-glm-5-2",
       },
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "kimi-k2-6",
+      selectedModel: "zai-org-glm-5-2",
       models: [
+        {
+          provider: "venice",
+          id: "zai-org-glm-5-2",
+          name: "GLM 5.2",
+          modelType: "text",
+          privacy: "private",
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
         {
           provider: "venice",
           id: "kimi-k2-6",
@@ -638,14 +647,14 @@ describe("AgentWorkspace", () => {
 
     // The session composer carries the same model trigger as the hero.
     await user.click(
-      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
     );
 
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
     });
     expect(
-      within(dialog).getByRole("option", { name: /Kimi K2.6/ }),
+      within(dialog).getByRole("option", { name: /GLM 5\.2/ }),
     ).toBeInTheDocument();
   });
 
@@ -653,6 +662,15 @@ describe("AgentWorkspace", () => {
     // Tool-capable catalog: the picker refuses tool-less models for the
     // agent, so the switch target must support function calling.
     const catalog = [
+      {
+        provider: "venice",
+        id: "zai-org-glm-5-2",
+        name: "GLM 5.2",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
       {
         provider: "venice",
         id: "kimi-k2-6",
@@ -675,7 +693,7 @@ describe("AgentWorkspace", () => {
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "kimi-k2-6",
+      selectedModel: "zai-org-glm-5-2",
       models: catalog,
     });
     mocks.setVeniceModel.mockResolvedValue(undefined);
@@ -684,7 +702,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
     );
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",
@@ -704,7 +722,7 @@ describe("AgentWorkspace", () => {
       selectedModel: "anonymous-only",
       models: catalog,
     });
-    // The popover opens on the suggested picks (Kimi K2.6 is curated); the
+    // The popover opens on the suggested picks (GLM 5.2 is curated); the
     // switch target only exists in the full catalog behind All models.
     await user.click(
       within(dialog).getByRole("button", { name: "All models" }),
@@ -2570,8 +2588,17 @@ describe("AgentWorkspace", () => {
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
       modelType: "text",
-      selectedModel: "kimi-k2-6",
+      selectedModel: "zai-org-glm-5-2",
       models: [
+        {
+          provider: "venice",
+          id: "zai-org-glm-5-2",
+          name: "GLM 5.2",
+          modelType: "text",
+          privacy: "private",
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
         {
           provider: "venice",
           id: "kimi-k2-6",
@@ -2605,7 +2632,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     await user.click(
-      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
     );
     const dialog = await screen.findByRole("dialog", {
       name: "Choose text model",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -172,14 +172,16 @@ describe("AppSettings", () => {
       settings: {
         transcriptionProvider: "venice",
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "kimi-k2-6",
+        generationModel: "zai-org-glm-5-2",
       },
     });
     mocks.listVeniceModels.mockImplementation(async (mode) => ({
       mode,
       modelType: mode === "transcription" ? "asr" : "text",
       selectedModel:
-        mode === "transcription" ? "nvidia/parakeet-tdt-0.6b-v3" : "kimi-k2-6",
+        mode === "transcription"
+          ? "nvidia/parakeet-tdt-0.6b-v3"
+          : "zai-org-glm-5-2",
       models:
         mode === "transcription"
           ? [
@@ -222,6 +224,20 @@ describe("AppSettings", () => {
               },
             ]
           : [
+              {
+                provider: "venice",
+                id: "zai-org-glm-5-2",
+                name: "GLM 5.2",
+                modelType: "text",
+                description: "Latest GLM text model for writing notes.",
+                privacy: "private",
+                priceUnit: "tokens",
+                inputCreditsPerMillionTokens: 1750,
+                outputCreditsPerMillionTokens: 5500,
+                contextTokens: 200000,
+                traits: [],
+                capabilities: ["supportsFunctionCalling"],
+              },
               {
                 provider: "venice",
                 id: "kimi-k2-6",
@@ -296,7 +312,7 @@ describe("AppSettings", () => {
           : "venice",
       transcriptionModel:
         mode === "transcription" ? modelId : "nvidia/parakeet-tdt-0.6b-v3",
-      generationModel: mode === "generation" ? modelId : "kimi-k2-6",
+      generationModel: mode === "generation" ? modelId : "zai-org-glm-5-2",
     }));
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
@@ -1326,19 +1342,25 @@ describe("AppSettings", () => {
     // Suggested is the default view: only the curated picks present in the
     // catalog show, each with its recommendation reason.
     expect(
+      await screen.findByRole("option", { name: /GLM 5\.2/ }),
+    ).toBeInTheDocument();
+    expect(
       await screen.findByRole("option", { name: /GLM 5\.1/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /Kimi K2\.6/ }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: /Venice Uncensored/ }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/Best overall/)).toBeInTheDocument();
+    expect(screen.getByText(/Default pick/)).toBeInTheDocument();
 
     // All shows the full catalog, without recommendation copy.
     await user.click(screen.getByRole("tab", { name: "All" }));
     expect(
       screen.getByRole("option", { name: /Venice Uncensored/ }),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/Best overall/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Default pick/)).not.toBeInTheDocument();
 
     // Searching looks across the whole catalog even from Suggested, and a
     // suggested pick stays selectable.


### PR DESCRIPTION
## Summary

- Make Venice GLM 5.2 (`zai-org-glm-5-2`) the default generation/text model across Tauri, frontend defaults, and `.env.example`.
- Update suggested text models to GLM 5.2, Kimi K2.6, and GLM 5.1.
- Add Scribe API fallback pricing and capability metadata for GLM 5.2 and GLM 5.1 while preserving GLM 5 for older saved settings.
- Update model-picker tests and fixtures for the new default.

## Validation

- `pnpm exec vitest run src/test/app-settings.test.tsx src/test/agent-workspace.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml providers::tests --locked`
- `cargo +1.95.0 test --manifest-path scribe-api/Cargo.toml -p scribe-config --locked`
- `pnpm run lint`
- `pnpm exec prettier --check src/lib/suggested-models.ts src/components/settings/AppSettings.tsx src/test/agent-workspace.test.tsx src/test/app-settings.test.tsx`

Note: `pnpm run format` still reports pre-existing formatting warnings in `src/components/agent/composer/CategorySuggestionList.tsx`, `src/components/agent/FileTypeIcon.tsx`, `src/lib/agent-chat-runtime.ts`, `src/test/agent-chat-runtime.test.ts`, and `src-tauri/tauri.conf.json`; those files are outside this PR.