### PR TITLE
[codex] Fix referral link overflow

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11567,6 +11567,7 @@ input:focus-visible,
   display: flex;
   flex-direction: column;
   gap: var(--sp-4);
+  min-width: 0;
 }
 
 .referral-dialog-status {
@@ -11639,6 +11640,7 @@ input:focus-visible,
 .referral-copy-card {
   display: grid;
   gap: var(--sp-3);
+  min-width: 0;
   padding: var(--sp-4);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
@@ -11682,6 +11684,7 @@ input:focus-visible,
   display: flex;
   align-items: center;
   width: 100%;
+  min-width: 0;
   min-height: 40px;
   padding: 0 var(--sp-3);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Fixes the referral dialog invite URL overflowing out of the modal when the generated link is wider than the dialog.

## Root Cause

The URL text had ellipsis styling, but the surrounding flex/grid items kept their default content-based minimum width, so the long unbroken URL could force overflow instead of shrinking within the dialog.

## Changes

- Allow the referral dialog body, copy card, and URL button to shrink with `min-width: 0`.
- Preserve the single-line URL display and existing ellipsis behavior.

## Validation

- `pnpm run lint`
- `pnpm run build`
- Headless Chrome layout smoke check confirmed `overflowPastCardPx: 0` and the invite URL text is ellipsized.