### PR TITLE
[codex] Align note tab title and chrome

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -206,7 +206,7 @@ function tabMeta(
         ? notes.find((n) => n.id === nav.noteId)
         : undefined;
       return {
-        title: note?.title?.trim() || "Untitled note",
+        title: note?.title?.trim() || "New note",
         icon: <IconNoteText size={TAB_ICON_SIZE} />,
       };
     }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5126,16 +5126,19 @@ input:focus-visible,
  * cut the active tab's shadow and right edge. Scrolls only in the extreme case
  * where even icon-width tabs overflow. */
 .tab-strip {
+  --tab-strip-shadow-pad: 4px;
+
   display: flex;
   align-items: center;
   gap: var(--sp-2);
   flex: 1;
   min-width: 0;
-  padding: 4px;
+  padding: var(--tab-strip-shadow-pad);
+  padding-left: 0;
   /* No scroll: tabs that don't fit fold into the overflow popover instead.
-   * hidden (not auto) clips any transient overflow during a resize gracefully;
-   * the 4px padding keeps it from clipping the tab shadows. */
-  overflow: hidden;
+   * Keep overflow visible so a flush first pill can render its normal rounded
+   * corner and soft shadow instead of clipping against the strip edge. */
+  overflow: visible;
 }
 
 /* Each tab takes up to a quarter of the bar by default (capped so it never gets

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5136,9 +5136,10 @@ input:focus-visible,
   padding: var(--tab-strip-shadow-pad);
   padding-left: 0;
   /* No scroll: tabs that don't fit fold into the overflow popover instead.
-   * Keep overflow visible so a flush first pill can render its normal rounded
-   * corner and soft shadow instead of clipping against the strip edge. */
-  overflow: visible;
+   * Clip transient resize spillover, but leave a tiny clip margin so the flush
+   * first pill can render its normal rounded corner and soft shadow. */
+  overflow: clip;
+  overflow-clip-margin: var(--tab-strip-shadow-pad);
 }
 
 /* Each tab takes up to a quarter of the bar by default (capped so it never gets

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -243,7 +243,7 @@ describe("App shortcuts", () => {
   });
 
   it("creates a loose note with Command-Shift-N but ignores bare n", async () => {
-    const { container } = render(<App />);
+    render(<App />);
 
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
@@ -256,8 +256,10 @@ describe("App shortcuts", () => {
       expect(mocks.createNote).toHaveBeenCalledWith(undefined),
     );
     await waitFor(() =>
-      expect(container.querySelector(".tab[data-active] .tab-label"))
-        .toHaveTextContent("New note"),
+      expect(screen.getByRole("tab", { name: "New note" })).toHaveAttribute(
+        "data-active",
+        "true",
+      ),
     );
   });
 

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -243,7 +243,7 @@ describe("App shortcuts", () => {
   });
 
   it("creates a loose note with Command-Shift-N but ignores bare n", async () => {
-    render(<App />);
+    const { container } = render(<App />);
 
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
@@ -254,6 +254,10 @@ describe("App shortcuts", () => {
 
     await waitFor(() =>
       expect(mocks.createNote).toHaveBeenCalledWith(undefined),
+    );
+    await waitFor(() =>
+      expect(container.querySelector(".tab[data-active] .tab-label"))
+        .toHaveTextContent("New note"),
     );
   });
 


### PR DESCRIPTION
## Summary
- Make empty note tabs use the same `New note` label as the editor and note lists.
- Align the first window chrome tab with the main panel edge without clipping its rounded corner or shadow.
- Add regression coverage for the blank-note tab label.

## Validation
- `pnpm test -- src/test/app-shortcut.test.tsx`
- `pnpm run lint`
- `pnpm run build`

## Notes
- Screenshot QA could not be automated in this environment because Browser control and Playwright/Chrome were unavailable.
