### PR TITLE
Fix dialogs rendering behind tabs

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8282,7 +8282,7 @@ input:focus-visible,
 
 /* Hover callout card (HoverTip) — the Venice-style explainer behind privacy
  * pills. Body-portaled at a fixed position, so it must sit above dialogs
- * (backdrop is z-index 110). data-side="top" anchors the card's bottom edge
+ * (backdrop is z-index 112). data-side="top" anchors the card's bottom edge
  * to the coordinate instead of its top. */
 .hover-tip {
   position: fixed;
@@ -11735,7 +11735,7 @@ input:focus-visible,
 .dialog-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 110;
+  z-index: 112;
   display: grid;
   place-items: center;
   padding: var(--sp-8);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8282,7 +8282,7 @@ input:focus-visible,
 
 /* Hover callout card (HoverTip) — the Venice-style explainer behind privacy
  * pills. Body-portaled at a fixed position, so it must sit above dialogs
- * (backdrop is z-index 80). data-side="top" anchors the card's bottom edge
+ * (backdrop is z-index 110). data-side="top" anchors the card's bottom edge
  * to the coordinate instead of its top. */
 .hover-tip {
   position: fixed;
@@ -11735,7 +11735,7 @@ input:focus-visible,
 .dialog-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 80;
+  z-index: 110;
   display: grid;
   place-items: center;
   padding: var(--sp-8);

--- a/src/test/dialog-layering.test.ts
+++ b/src/test/dialog-layering.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import appCss from "../styles/app.css?raw";
+
+function zIndexFor(selector: string) {
+  const escaped = selector.replace(/\./g, "\\.");
+  const match = appCss.match(
+    new RegExp(`${escaped}\\s*\\{[\\s\\S]*?z-index:\\s*(\\d+)`),
+  );
+  if (!match) throw new Error(`Missing z-index for ${selector}`);
+  return Number(match[1]);
+}
+
+describe("dialog layering", () => {
+  it("keeps modal dialogs above the titlebar tab strip", () => {
+    expect(zIndexFor(".dialog-backdrop")).toBeGreaterThan(
+      zIndexFor(".tab-bar"),
+    );
+  });
+
+  it("keeps hover tips above dialogs", () => {
+    expect(zIndexFor(".hover-tip")).toBeGreaterThan(
+      zIndexFor(".dialog-backdrop"),
+    );
+  });
+});

--- a/src/test/dialog-layering.test.ts
+++ b/src/test/dialog-layering.test.ts
@@ -17,6 +17,12 @@ describe("dialog layering", () => {
     );
   });
 
+  it("keeps modal dialogs above the sidebar toggle", () => {
+    expect(zIndexFor(".dialog-backdrop")).toBeGreaterThan(
+      zIndexFor(".chrome-sidebar-toggle"),
+    );
+  });
+
   it("keeps hover tips above dialogs", () => {
     expect(zIndexFor(".hover-tip")).toBeGreaterThan(
       zIndexFor(".dialog-backdrop"),

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,28 @@
+# Tabs Behind Dialog
+
+- [x] Inspect the screenshot and current tab/dialog layering.
+- [x] Locate the shared CSS stacking context for titlebar tabs and dialogs.
+- [x] Patch layering so modal dialogs render above the tab strip.
+- [x] Add focused regression coverage.
+- [x] Run targeted tests and practical build checks.
+
+## Notes
+
+The screenshot shows the titlebar tab strip painted above an open dialog
+backdrop. The fix should preserve the custom titlebar drag behavior while
+making modal dialog layers clear the titlebar surface.
+
+## Verification
+
+- `pnpm test -- src/test/dialog-layering.test.ts src/test/tab-bar.test.tsx`
+- `pnpm run lint`
+- `pnpm run build`
+- `pnpm test`
+- `curl -I http://127.0.0.1:1422/` against a temporary Vite server returned
+  `200 OK`
+
+## Previous Work
+
 # Microphone Source Label Note Leak
 
 - [x] Inspect the screenshot and identify whether the leak is generated note text or transcript display.


### PR DESCRIPTION
## Summary
- Raise the shared dialog backdrop above the custom titlebar tab layer so open dialogs cover tabs.
- Keep hover tips above dialogs and update the nearby layering comment.
- Add a CSS contract test for dialog, tab, and hover-tip z-index ordering.

## Verification
- pnpm test -- src/test/dialog-layering.test.ts src/test/tab-bar.test.tsx
- pnpm run lint
- pnpm run build
- pnpm test