### PR TITLE
Rework referral entry point and dialog

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -53,7 +53,7 @@ import {
   listHermesSessions,
   sessionTimestamp,
 } from "../../lib/hermes-adapter";
-import { messageFromError } from "../../lib/errors";
+import { errorCode, messageFromError } from "../../lib/errors";
 import { NOTE_DND_MIME } from "../../lib/dnd";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
 import { isPrimaryShortcut, primaryShortcutLabel } from "../../lib/platform";
@@ -64,6 +64,7 @@ import type {
   ReferralSummary,
 } from "../../lib/tauri";
 import { osAccountsReferralSummary } from "../../lib/tauri";
+import { JuneMark } from "../account/AccountGate";
 import { type SettingsTab } from "../settings/AppSettings";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
@@ -255,6 +256,9 @@ export function Sidebar({
     useState<ReferralSummary | null>(null);
   const [referralLoading, setReferralLoading] = useState(false);
   const [referralError, setReferralError] = useState<string | null>(null);
+  // The deployment can simply not offer referrals (a 404 from /referrals/me).
+  // That's not a transient failure, so it gets a calm message with no retry.
+  const [referralUnavailable, setReferralUnavailable] = useState(false);
   const [referralCopyError, setReferralCopyError] = useState<string | null>(
     null,
   );
@@ -375,9 +379,11 @@ export function Sidebar({
     if (!account.signedIn) return;
     setReferralLoading(true);
     setReferralError(null);
+    setReferralUnavailable(false);
     try {
       setReferralSummary(await osAccountsReferralSummary());
     } catch (error) {
+      setReferralUnavailable(errorCode(error) === "referrals_unavailable");
       setReferralError(messageFromError(error));
     } finally {
       setReferralLoading(false);
@@ -399,13 +405,21 @@ export function Sidebar({
       await navigator.clipboard.writeText(referralSummary.url);
       setReferralCopyError(null);
       setReferralCopied(true);
-      window.setTimeout(() => setReferralCopied(false), 1600);
     } catch {
       setReferralCopyError(
         "Could not copy the link. Select it and copy manually.",
       );
     }
   }
+
+  // Reset the "Copied" affordance the way every other copy button does
+  // (NoteEditor, dictation rows): a single effect with cleanup, so closing
+  // the dialog mid-flight can't fire a stray setState.
+  useEffect(() => {
+    if (!referralCopied) return;
+    const timer = window.setTimeout(() => setReferralCopied(false), 1600);
+    return () => window.clearTimeout(timer);
+  }, [referralCopied]);
 
   const commandPaletteGroups = useMemo<CommandPaletteGroup[]>(() => {
     const normalized = normalizeCommandQuery(commandQuery);
@@ -1101,22 +1115,19 @@ export function Sidebar({
 
       <footer className="sidebar-footer">
         {footerAccessory}
-        <button
-          type="button"
-          className="sidebar-nav-item sidebar-referral"
-          disabled={!account.signedIn}
-          onClick={openReferralDialog}
-        >
-          <span className="sidebar-nav-icon">
-            <IconGift1 size={18} />
-          </span>
-          <span className="sidebar-nav-label">Invite friends</span>
-        </button>
         <SidebarIdentity
           account={account}
           menuOpen={identityMenuOpen}
           onToggleMenu={() => setIdentityMenuOpen((open) => !open)}
           onCloseMenu={() => setIdentityMenuOpen(false)}
+          onInviteFriends={
+            account.signedIn
+              ? () => {
+                  setIdentityMenuOpen(false);
+                  openReferralDialog();
+                }
+              : undefined
+          }
           onOpenSettings={() => {
             setIdentityMenuOpen(false);
             onChangeView("settings");
@@ -1145,6 +1156,7 @@ export function Sidebar({
         summary={referralSummary}
         loading={referralLoading}
         error={referralError}
+        unavailable={referralUnavailable}
         copyError={referralCopyError}
         copied={referralCopied}
         onClose={() => setReferralDialogOpen(false)}
@@ -1579,6 +1591,7 @@ function ReferralDialog({
   summary,
   loading,
   error,
+  unavailable,
   copyError,
   copied,
   onClose,
@@ -1589,69 +1602,79 @@ function ReferralDialog({
   summary: ReferralSummary | null;
   loading: boolean;
   error: string | null;
+  unavailable: boolean;
   copyError: string | null;
   copied: boolean;
   onClose: () => void;
   onRetry: () => void;
   onCopy: () => void;
 }) {
-  const availableMonths = summary?.availableMonths ?? 0;
   const pendingFriends = summary?.pendingCount ?? 0;
   return (
     <Dialog
       open={open}
       onClose={onClose}
-      title="Give 1 month, get 1 month"
-      description="Share June with a friend. When they become a paying subscriber, you earn a free month too."
-      leading={<IconPeople size={16} />}
-      width={460}
-      footer={
-        <button type="button" className="btn btn-secondary" onClick={onClose}>
-          Done
-        </button>
-      }
+      title="Give a month, get a month"
+      className="referral-dialog"
+      width={640}
+      initialFocusSelector=".referral-copy-inset"
     >
-      <div className="referral-dialog-body">
-        {loading ? (
-          <div className="referral-dialog-status" role="status">
-            <DotSpinner /> Loading referral link
-          </div>
-        ) : error ? (
-          <div className="referral-error-card">
-            <span className="referral-error-title">
-              Invite link unavailable
-            </span>
-            <p>{error}</p>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={onRetry}
-            >
-              Try again
-            </button>
-          </div>
-        ) : summary ? (
-          <>
-            <div className="referral-offer-row" aria-label="Referral reward">
-              <div>
-                <span className="referral-offer-value">1 month</span>
-                <span className="referral-offer-label">For your friend</span>
-              </div>
-              <div>
-                <span className="referral-offer-value">1 month</span>
-                <span className="referral-offer-label">For you</span>
-              </div>
+      <div className="referral-split">
+        <div className="referral-hero">
+          <span className="referral-hero-logo" aria-hidden>
+            <JuneMark />
+          </span>
+          <span className="referral-hero-eyebrow">
+            <IconGift1 size={13} />
+            Refer a friend
+          </span>
+          <p className="referral-hero-title">Give a month, get a month</p>
+          <p className="referral-hero-copy">
+            Share June with a friend. They get a free month, and when they
+            subscribe, so do you.
+          </p>
+        </div>
+        <div className="referral-panel">
+          {loading ? (
+            <div className="referral-dialog-status" role="status">
+              <DotSpinner /> Loading referral link
             </div>
-            <div className="referral-copy-card">
-              <div className="referral-copy-heading">
-                <span>Your invite link</span>
+          ) : unavailable ? (
+            // Deployment doesn't offer referrals — retrying can't fix that, so
+            // there's no "Try again", just a calm note.
+            <div className="referral-dialog-status">
+              <p>Invite links aren't available yet. Check back soon.</p>
+            </div>
+          ) : error ? (
+            <div className="referral-error-card">
+              <span className="referral-error-title">
+                Invite link unavailable
+              </span>
+              <p>{error}</p>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={onRetry}
+              >
+                Try again
+              </button>
+            </div>
+          ) : summary ? (
+            <>
+              <span className="referral-panel-title">
+                Share your invite link
+              </span>
+              <div className="referral-link-field">
+                <input
+                  className="referral-link-url"
+                  value={summary.url}
+                  readOnly
+                  aria-label="Invite link"
+                  onFocus={(event) => event.currentTarget.select()}
+                />
                 <button
                   type="button"
-                  className="referral-copy-icon"
-                  aria-label={
-                    copied ? "Invite link copied" : "Copy invite link"
-                  }
-                  title={copied ? "Copied" : "Copy invite link"}
+                  className="referral-copy-inset"
                   onClick={onCopy}
                 >
                   {copied ? (
@@ -1659,66 +1682,33 @@ function ReferralDialog({
                   ) : (
                     <IconClipboard size={14} />
                   )}
+                  {copied ? "Copied" : "Copy invite link"}
                 </button>
               </div>
-              <button
-                type="button"
-                className="referral-link-box"
-                onClick={onCopy}
-                title="Copy invite link"
-              >
-                <span>{summary.url}</span>
-              </button>
-              <button
-                type="button"
-                className="primary-action primary-solid referral-copy-primary"
-                onClick={onCopy}
-              >
-                {copied ? (
-                  <IconCheckmark1Small size={14} />
-                ) : (
-                  <IconClipboard size={14} />
-                )}
-                {copied ? "Copied" : "Copy invite link"}
-              </button>
               {copyError ? (
                 <p className="referral-copy-error">{copyError}</p>
               ) : null}
-            </div>
-            <div className="referral-stats">
-              <div>
-                <span className="referral-stat-value">
-                  {summary.qualifiedCount}
-                </span>
-                <span className="referral-stat-label">Rewarded friends</span>
+              <div className="referral-stats">
+                <div>
+                  <span className="referral-stat-value">
+                    {summary.qualifiedCount}
+                  </span>
+                  <span className="referral-stat-label">Friends referred</span>
+                </div>
               </div>
-              <div>
-                <span className="referral-stat-value">{availableMonths}</span>
-                <span className="referral-stat-label">
-                  {monthLabel(availableMonths)} earned
-                </span>
-              </div>
-            </div>
-            {pendingFriends > 0 ? (
-              <p className="referral-progress-note">
-                {pendingFriends} invited{" "}
-                {pendingFriends === 1 ? "friend is" : "friends are"} waiting to
-                subscribe.
-              </p>
-            ) : null}
-          </>
-        ) : (
-          <div className="referral-dialog-status">
-            <p>Sign in to get your referral link.</p>
-          </div>
-        )}
+              {pendingFriends > 0 ? (
+                <p className="referral-progress-note">
+                  {pendingFriends} invited{" "}
+                  {pendingFriends === 1 ? "friend is" : "friends are"} waiting
+                  to subscribe.
+                </p>
+              ) : null}
+            </>
+          ) : null}
+        </div>
       </div>
     </Dialog>
   );
-}
-
-function monthLabel(months: number) {
-  return months === 1 ? "Month" : "Months";
 }
 
 // The user's name is the settings entry point: clicking it opens a small
@@ -1736,6 +1726,7 @@ function SidebarIdentity({
   menuOpen,
   onToggleMenu,
   onCloseMenu,
+  onInviteFriends,
   onOpenSettings,
   onReportIssue,
   onSignOut,
@@ -1744,6 +1735,7 @@ function SidebarIdentity({
   menuOpen: boolean;
   onToggleMenu: () => void;
   onCloseMenu: () => void;
+  onInviteFriends?: () => void;
   onOpenSettings: () => void;
   onReportIssue?: (category: ReportCategory) => void;
   onSignOut?: () => void;
@@ -1784,6 +1776,17 @@ function SidebarIdentity({
       </button>
       {menuOpen ? (
         <div className="sidebar-identity-menu" role="menu">
+          {onInviteFriends ? (
+            <button
+              type="button"
+              role="menuitem"
+              className="sidebar-invite-item"
+              onClick={onInviteFriends}
+            >
+              <IconGift1 size={14} />
+              Invite friends
+            </button>
+          ) : null}
           <button type="button" role="menuitem" onClick={onOpenSettings}>
             <IconSettingsGear4 size={14} />
             Settings

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1666,7 +1666,6 @@ function ReferralDialog({
       title="Give a month, get a month"
       className="referral-dialog"
       width={640}
-      initialFocusSelector=".referral-copy-inset"
     >
       <div className="referral-split">
         <div className="referral-hero">

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -7,6 +7,17 @@ export function messageFromError(err: unknown) {
   return String(err);
 }
 
+/** Stable error code from a thrown Tauri `AppError` (`{ code, message }`),
+ * or undefined for anything without one. Lets callers branch on a specific
+ * failure (e.g. "referrals_unavailable") instead of matching message text. */
+export function errorCode(err: unknown): string | undefined {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
 export function isHermesSessionsStartupRequestError(err: unknown) {
   return /error sending request for url \(http:\/\/127\.0\.0\.1:\d+\/api\/sessions(?:\?|[)/])/i.test(
     messageFromError(err),

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4395,15 +4395,6 @@ input:focus-visible,
   border-top: 0;
 }
 
-.sidebar-referral:disabled {
-  cursor: default;
-  opacity: 0.48;
-}
-
-.sidebar-referral:disabled:hover {
-  background: transparent;
-}
-
 .sidebar[data-collapsed="true"] .update-popover {
   display: none;
 }
@@ -4457,6 +4448,12 @@ input:focus-visible,
 
 .sidebar-identity-menu button > svg {
   color: var(--muted-foreground);
+}
+
+/* The invite action carries the brand terracotta so it pops against the
+ * otherwise-muted menu icons. */
+.sidebar-identity-menu button.sidebar-invite-item > svg {
+  color: var(--brand);
 }
 
 /* Report shortcuts stay muted in this menu (the category tints live on the
@@ -11563,18 +11560,226 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
-.referral-dialog-body {
-  display: flex;
-  flex-direction: column;
-  gap: var(--sp-4);
+/* Referral dialog — a 50/50 split. The left is a terracotta hero (brand
+ * gradient + the app's fractal-noise grain, the same recipe as
+ * .dictation-hint) that carries the offer; the right is the borderless
+ * action panel with the invite link and stats. The shared Dialog chrome is
+ * suppressed via this class hook so the headline can live in the hero. */
+.referral-dialog {
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
 }
 
+/* Float just the close button into the top-right corner. The accessible
+ * title stays in the DOM (for aria-labelledby) but is visually hidden. */
+.referral-dialog .dialog-header {
+  position: absolute;
+  top: var(--sp-3);
+  right: var(--sp-3);
+  z-index: 3;
+  gap: 0;
+}
+
+.referral-dialog .dialog-leading {
+  display: none;
+}
+
+.referral-dialog .dialog-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.referral-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  min-height: 340px;
+}
+
+.referral-hero {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--sp-4);
+  padding: var(--sp-7);
+  color: oklch(100% 0 0);
+  /* Derived entirely from the fixed --brand terracotta (not --warm-* which
+   * flip lightness in dark mode) so the hero stays a rich, white-text-safe
+   * terracotta in both themes: a soft highlight top-left, brand mid, deep
+   * terracotta bottom-right. */
+  background:
+    radial-gradient(
+      120% 120% at 12% 8%,
+      color-mix(in oklch, var(--brand) 82%, white),
+      transparent 55%
+    ),
+    linear-gradient(
+      152deg,
+      var(--brand) 0%,
+      color-mix(in oklch, var(--brand) 68%, black) 100%
+    );
+}
+
+/* The app's signature grain (lifted from .dictation-hint) over the warm
+ * gradient so the panel never reads as a flat fill. */
+.referral-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  mix-blend-mode: soft-light;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+.referral-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* June brandmark, pinned to the top-left corner of the hero. Absolute so it
+ * floats above the centered offer copy; white via currentColor against the
+ * terracotta. Placed after the `> *` rule so this position wins. */
+.referral-hero-logo {
+  position: absolute;
+  top: var(--sp-6);
+  left: var(--sp-7);
+  display: inline-flex;
+  color: oklch(100% 0 0);
+  opacity: 0.92;
+}
+
+.referral-hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  width: max-content;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, oklch(100% 0 0) 20%, transparent);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.referral-hero-title {
+  margin: 0;
+  font-size: var(--fs-2xl);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.referral-hero-copy {
+  margin: 0;
+  font-size: var(--fs-md);
+  line-height: 1.5;
+  color: color-mix(in oklch, oklch(100% 0 0) 86%, transparent);
+}
+
+.referral-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--sp-4);
+  padding: var(--sp-7);
+}
+
+.referral-panel-title {
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  font-weight: 500;
+}
+
+/* Borderless filled field with the Copy button inset on the right. */
+.referral-link-field {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-1) var(--sp-1) var(--sp-3);
+  border-radius: var(--r-md);
+  background: var(--surface-subtle);
+}
+
+.referral-link-url {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  text-overflow: ellipsis;
+}
+
+.referral-link-url:focus,
+.referral-link-url:focus-visible {
+  outline: none;
+}
+
+.referral-copy-inset {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-height: var(--control-md);
+  padding: 0 var(--sp-3);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.referral-copy-inset:hover {
+  opacity: 0.9;
+}
+
+.referral-copy-error,
+.referral-progress-note {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+/* Borderless stat — a plain figure, no card chrome. */
+.referral-stats > div {
+  min-width: 0;
+}
+
+.referral-stat-value,
+.referral-stat-label {
+  display: block;
+}
+
+.referral-stat-value {
+  color: var(--foreground);
+  font-size: var(--fs-2xl);
+  font-weight: 600;
+}
+
+.referral-stat-label {
+  margin-top: var(--sp-1);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+/* Right-panel states (loading / unavailable / error) stay borderless. */
 .referral-dialog-status {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--sp-3);
-  min-height: 44px;
   color: var(--muted-foreground);
   font-size: var(--fs-md);
 }
@@ -11587,10 +11792,6 @@ input:focus-visible,
   display: grid;
   justify-items: start;
   gap: var(--sp-3);
-  padding: var(--sp-4);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface-subtle);
 }
 
 .referral-error-title {
@@ -11603,152 +11804,6 @@ input:focus-visible,
   margin: 0;
   color: var(--muted-foreground);
   font-size: var(--fs-md);
-}
-
-.referral-offer-row {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--sp-3);
-}
-
-.referral-offer-row > div {
-  min-width: 0;
-  padding: var(--sp-4);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--card);
-}
-
-.referral-offer-value,
-.referral-offer-label {
-  display: block;
-}
-
-.referral-offer-value {
-  color: var(--foreground);
-  font-size: var(--fs-xl);
-  font-weight: 600;
-}
-
-.referral-offer-label {
-  margin-top: var(--sp-1);
-  color: var(--muted-foreground);
-  font-size: var(--fs-sm);
-}
-
-.referral-copy-card {
-  display: grid;
-  gap: var(--sp-3);
-  padding: var(--sp-4);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--surface-subtle);
-}
-
-.referral-copy-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp-3);
-  color: var(--foreground);
-  font-size: var(--fs-sm);
-  font-weight: 500;
-}
-
-.referral-copy-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--card);
-  color: var(--muted-foreground);
-  cursor: pointer;
-  transition:
-    background-color var(--t-fast) var(--ease-out),
-    color var(--t-fast) var(--ease-out),
-    border-color var(--t-fast) var(--ease-out);
-}
-
-.referral-copy-icon:hover {
-  background: var(--muted);
-  color: var(--foreground);
-  border-color: var(--ring);
-}
-
-.referral-link-box {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  min-height: 40px;
-  padding: 0 var(--sp-3);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--card);
-  color: var(--foreground);
-  font-family: var(--font-mono);
-  font-size: var(--fs-sm);
-  text-align: left;
-  cursor: pointer;
-  transition:
-    background-color var(--t-fast) var(--ease-out),
-    border-color var(--t-fast) var(--ease-out);
-}
-
-.referral-link-box:hover {
-  background: var(--muted);
-  border-color: var(--ring);
-}
-
-.referral-link-box span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.referral-copy-primary {
-  width: 100%;
-}
-
-.referral-copy-error,
-.referral-progress-note {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: var(--fs-sm);
-}
-
-.referral-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--sp-3);
-}
-
-.referral-stats > div {
-  min-width: 0;
-  padding: var(--sp-4);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: color-mix(in oklch, var(--card) 72%, var(--muted));
-}
-
-.referral-stat-value,
-.referral-stat-label {
-  display: block;
-}
-
-.referral-stat-value {
-  color: var(--foreground);
-  font-size: var(--fs-xl);
-  font-weight: 500;
-}
-
-.referral-stat-label {
-  margin-top: var(--sp-1);
-  color: var(--muted-foreground);
-  font-size: var(--fs-sm);
 }
 
 /* Generous padding (+ negative outer margin) so the inputs' focus

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -11983,9 +11983,16 @@ input:focus-visible,
   text-overflow: ellipsis;
 }
 
-.referral-link-url:focus,
-.referral-link-url:focus-visible {
+.referral-link-url:focus {
   outline: none;
+}
+
+/* Keep a visible ring for keyboard focus (clipped inside the field's
+ * rounding) — only the mouse-focus outline is suppressed above. */
+.referral-link-url:focus-visible {
+  outline: 2px solid var(--ring-focus);
+  outline-offset: -2px;
+  border-radius: var(--r-sm);
 }
 
 .referral-copy-inset {


### PR DESCRIPTION
## What

Cleanup pass over the in-app referral work (#310), driven by Mobbin references.

### Entry point
Moves **Invite friends** out of the sidebar footer (it sat as a standalone nav item with a permanently greyed icon when signed out) into the **account menu** as the top row, with a terracotta gift icon so it pops. This matches how invite/referral entry points consistently live inside the account/profile menu across the apps surveyed (Gopuff, PayPal, Vivid, Cash App).

### Dialog redesign
Rebuilds the referral dialog as a **50/50 split** (Heidi / Base44 / Lovable style):
- **Left:** a terracotta hero carrying the offer, built from our own kit — the fixed `--brand` gradient (theme-stable; `--warm-*` flip lightness in dark mode and would wash it out) plus the app's existing `feTurbulence` grain, with the June mark pinned to the top-left corner.
- **Right:** a borderless action panel with the invite link in a filled field + **inset Copy button** (full label), and a single **"Friends referred"** stat (months and friends are 1:1, so the separate months figure was redundant).

### Robustness / cleanup
- New `errorCode()` helper distinguishes the deployment-level `referrals_unavailable` 404 from transient errors, so that case shows a calm note instead of a retry that can never succeed.
- Drops the redundant copy affordances (three triggers → one), the duplicate offer row, and the dead sign-in branch from the original implementation.
- Copy reset now uses the app's standard `useEffect` + `clearTimeout` pattern.

## Verification
- `tsc --noEmit` clean
- `prettier --check` clean
- UI to be eyeballed in-browser (light + dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)