### PR TITLE
Show active routine runs in history

### DIFF
--- a/src/components/routines/RoutineRunList.tsx
+++ b/src/components/routines/RoutineRunList.tsx
@@ -1,5 +1,8 @@
 import { IconZap } from "central-icons/IconZap";
-import { sessionTimestamp } from "../../lib/hermes-adapter";
+import {
+  isRunningScheduledRunSession,
+  sessionTimestamp,
+} from "../../lib/hermes-adapter";
 import type { HermesSessionInfo } from "../../lib/tauri";
 
 /** Past runs of one or all routines: each row is a cron-sourced session,
@@ -36,7 +39,8 @@ function RunRow({
   label: string;
   onOpen: () => void;
 }) {
-  const preview = run.preview?.trim();
+  const running = isRunningScheduledRunSession(run);
+  const preview = run.preview?.trim() || (running ? "Running now" : "");
   return (
     <li className="routines-run">
       <button type="button" className="routines-run-button" onClick={onOpen}>
@@ -44,7 +48,12 @@ function RunRow({
           <IconZap size={14} />
         </span>
         <span className="routines-run-body">
-          <span className="routines-run-name">{label}</span>
+          <span className="routines-run-title">
+            <span className="routines-run-name">{label}</span>
+            {running ? (
+              <span className="routines-run-status">Running</span>
+            ) : null}
+          </span>
           {preview ? (
             <span className="routines-run-preview">{preview}</span>
           ) : null}

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -46,6 +46,7 @@ import { ROUTINE_TEMPLATES, type RoutineTemplate } from "./routine-templates";
 
 const NO_ROUTINES: RoutineJob[] = [];
 const NO_RUNS: HermesSessionInfo[] = [];
+const RUN_HISTORY_REFRESH_MS = 10000;
 
 type RoutinesViewProps = {
   /** The chat-first creation path: hands off a composed agent prompt and the
@@ -119,7 +120,7 @@ export function RoutinesView({
   // it — it degrades to a quiet notice inside the section instead.
   const loadRuns = useCallback(async () => {
     try {
-      setRuns(await listScheduledRunSessions());
+      setRuns(await listScheduledRunSessions({ includeActive: true }));
       setRunsUnavailable(false);
     } catch {
       setRunsUnavailable(true);
@@ -134,6 +135,15 @@ export function RoutinesView({
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    if (forcedEmpty) return;
+    const timer = window.setInterval(
+      () => void loadRuns(),
+      RUN_HISTORY_REFRESH_MS,
+    );
+    return () => window.clearInterval(timer);
+  }, [forcedEmpty, loadRuns]);
 
   const filtered = useMemo(() => {
     const normalized = query.trim().toLowerCase();

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -86,6 +86,7 @@ export function RoutinesView({
   const [describeUnrestricted, setDescribeUnrestricted] = useState(false);
   const [allRuns, setRuns] = useState<HermesSessionInfo[]>([]);
   const [runsUnavailableState, setRunsUnavailable] = useState(false);
+  const runLoadSequenceRef = useRef(0);
 
   // __emptyStates() preview (dev console): render the page as a fresh
   // install would see it, real data untouched underneath.
@@ -119,10 +120,15 @@ export function RoutinesView({
   // cron manager), so its failure must not take the routines list down with
   // it — it degrades to a quiet notice inside the section instead.
   const loadRuns = useCallback(async () => {
+    const sequence = runLoadSequenceRef.current + 1;
+    runLoadSequenceRef.current = sequence;
     try {
-      setRuns(await listScheduledRunSessions({ includeActive: true }));
+      const nextRuns = await listScheduledRunSessions({ includeActive: true });
+      if (runLoadSequenceRef.current !== sequence) return;
+      setRuns(nextRuns);
       setRunsUnavailable(false);
     } catch {
+      if (runLoadSequenceRef.current !== sequence) return;
       setRunsUnavailable(true);
     }
   }, []);

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -1,16 +1,10 @@
 import {
   deleteHermesBridgeSession,
-  hermesBridgeStatus,
   hermesBridgeSessionMessages,
   hermesBridgeSessions,
-  startHermesBridge,
-  type HermesBridgeConnection,
-  type HermesBridgeStatus,
   type HermesSessionInfo,
   type HermesSessionMessage,
 } from "./tauri";
-import { hermesConnectionForMode } from "./hermes-connection";
-import { HermesGatewayClient } from "./hermes-gateway";
 
 export type HermesSessionListOptions = {
   limit?: number;
@@ -76,6 +70,7 @@ export function scheduledRunJobId(sessionId: string) {
  * a recent window and filtering client-side. 200 covers weeks of mixed
  * activity; runs older than the window age out of the history view. */
 const SCHEDULED_RUN_FETCH_LIMIT = 200;
+const PENDING_SCHEDULED_RUN_ACTIVE_WINDOW_MS = 5 * 60 * 1000;
 
 export type ScheduledRunListOptions = {
   includeActive?: boolean;
@@ -85,182 +80,67 @@ export type ScheduledRunListOptions = {
 export async function listScheduledRunSessions(
   options: ScheduledRunListOptions = {},
 ) {
-  const sessions = await listHermesSessions({
+  const listOptions: HermesSessionListOptions = {
     limit: SCHEDULED_RUN_FETCH_LIMIT,
-  });
-  const storedRuns = sessions.filter(isScheduledRunSession);
-  if (!options.includeActive) return storedRuns;
-  try {
-    return mergeScheduledRunSessions(
-      storedRuns,
-      await listActiveScheduledRunSessions(),
-    );
-  } catch {
-    // Active runtime state is best effort. A websocket/status miss should not
-    // hide the persisted run history the session store already returned.
-    return storedRuns;
+  };
+  if (options.includeActive) {
+    // Cron runs are persisted as sessions before their first message lands.
+    // The global session list hides zero-message rows, but routine history
+    // needs them so a just-started run appears immediately.
+    listOptions.minMessages = 0;
   }
-}
-
-type ActiveSessionRow = {
-  id?: unknown;
-  session_id?: unknown;
-  sessionId?: unknown;
-  session_key?: unknown;
-  sessionKey?: unknown;
-  status?: unknown;
-  source?: unknown;
-  title?: unknown;
-  preview?: unknown;
-  started_at?: unknown;
-  startedAt?: unknown;
-  last_active?: unknown;
-  lastActive?: unknown;
-  message_count?: unknown;
-};
-
-/** Scheduled-routine sessions that are currently registered in the runtime. */
-export async function listActiveScheduledRunSessions() {
-  const connections = await activeSessionConnections();
-  const lists = await Promise.all(
-    connections.map(async (connection) => {
-      const client = new HermesGatewayClient();
-      try {
-        await client.connect(connection.wsUrl);
-        const response = await client.request("session.active_list", {}, 10000);
-        return normalizeActiveScheduledRunSessionsResponse(response);
-      } catch {
-        return [];
-      } finally {
-        client.close();
-      }
-    }),
-  );
-  return mergeScheduledRunSessions([], lists.flat());
-}
-
-async function activeSessionConnections() {
-  let status = await hermesBridgeStatus();
-  if (!status.running || connectionList(status).length === 0) {
-    status = await startHermesBridge();
-  }
-  const connections = [
-    ...connectionList(status),
-    hermesConnectionForMode(status, false),
-    hermesConnectionForMode(status, true),
-  ].filter((connection): connection is HermesBridgeConnection =>
-    Boolean(connection?.wsUrl),
-  );
-  return uniqueBy(connections, (connection) => connection.wsUrl);
-}
-
-function connectionList(status: HermesBridgeStatus) {
-  return status.connections?.length
-    ? status.connections
-    : status.connection
-      ? [status.connection]
-      : [];
-}
-
-export function normalizeActiveScheduledRunSessionsResponse(response: unknown) {
-  return extractList(response, "sessions").flatMap((value) => {
-    const row = value as ActiveSessionRow;
-    if (!row || typeof row !== "object") return [];
-    if (!isActiveSessionStatus(row.status)) return [];
-    const sessionId = activeSessionId(row);
-    if (!sessionId || !scheduledRunJobId(sessionId)) return [];
-    const timestamp = timestampString(
-      row.last_active ??
-        row.lastActive ??
-        row.started_at ??
-        row.startedAt ??
-        Date.now(),
-    );
-    return [
-      withScheduledRunDisplay({
-        id: sessionId,
-        active: true,
-        source: SCHEDULED_RUN_SOURCE,
-        status: statusString(row.status) ?? "running",
-        title: stringValue(row.title),
-        preview: stringValue(row.preview),
-        started_at: timestamp,
-        last_active: timestamp,
-        message_count: numberValue(row.message_count),
-      }),
-    ];
-  });
-}
-
-function activeSessionId(row: ActiveSessionRow) {
-  return (
-    stringValue(row.session_key) ??
-    stringValue(row.sessionKey) ??
-    stringValue(row.session_id) ??
-    stringValue(row.sessionId) ??
-    stringValue(row.id)
-  );
-}
-
-function isActiveSessionStatus(value: unknown) {
-  const status = statusString(value);
-  return status !== "idle" && status !== "completed" && status !== "complete";
-}
-
-function statusString(value: unknown) {
-  return stringValue(value)?.toLowerCase();
-}
-
-function stringValue(value: unknown) {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function numberValue(value: unknown) {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
+  const sessions = await listHermesSessions(listOptions);
+  const runs = sessions.filter(isScheduledRunSession);
+  return options.includeActive ? runs.map(withScheduledRunActivity) : runs;
 }
 
 export function isRunningScheduledRunSession(session: HermesSessionInfo) {
-  return isScheduledRunSession(session) && session.active === true;
-}
-
-export function mergeScheduledRunSessions(
-  storedRuns: HermesSessionInfo[],
-  activeRuns: HermesSessionInfo[],
-) {
-  const byId = new Map<string, HermesSessionInfo>();
-  for (const run of storedRuns) {
-    if (isScheduledRunSession(run)) byId.set(run.id, run);
-  }
-  for (const run of activeRuns) {
-    if (!isScheduledRunSession(run)) continue;
-    const stored = byId.get(run.id);
-    byId.set(run.id, stored ? mergeScheduledRunSession(stored, run) : run);
-  }
-  return Array.from(byId.values()).sort((a, b) =>
-    sessionTimestamp(b).localeCompare(sessionTimestamp(a)),
+  return (
+    isScheduledRunSession(session) &&
+    (session.active === true || session.is_active === true)
   );
 }
 
-function mergeScheduledRunSession(
-  stored: HermesSessionInfo,
-  active: HermesSessionInfo,
+function withScheduledRunActivity(
+  session: HermesSessionInfo,
 ): HermesSessionInfo {
-  const activeTimestamp = sessionTimestamp(active);
-  const storedTimestamp = sessionTimestamp(stored);
-  return withScheduledRunDisplay({
-    ...stored,
-    ...active,
-    title: active.title?.trim() || stored.title,
-    preview: active.preview?.trim() || stored.preview,
-    started_at: active.started_at ?? stored.started_at,
-    last_active:
-      activeTimestamp.localeCompare(storedTimestamp) > 0
-        ? activeTimestamp
-        : storedTimestamp,
-    message_count: active.message_count ?? stored.message_count,
-  });
+  if (!isScheduledRunSession(session)) return session;
+  if (!isRunningScheduledRunSession(session) && !isRecentPendingRun(session)) {
+    return session;
+  }
+  return {
+    ...session,
+    active: true,
+    status: session.status?.trim() || "running",
+    title: hasScheduledRunContent(session) ? session.title : undefined,
+    preview: session.preview?.trim() || undefined,
+  };
+}
+
+function isRecentPendingRun(session: HermesSessionInfo) {
+  if (session.message_count !== 0 || hasSessionEnded(session)) return false;
+  const timestamp = Date.parse(sessionTimestamp(session));
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return false;
+  const ageMs = Date.now() - timestamp;
+  return ageMs >= -60_000 && ageMs <= PENDING_SCHEDULED_RUN_ACTIVE_WINDOW_MS;
+}
+
+function hasSessionEnded(session: HermesSessionInfo) {
+  return Boolean(
+    stringPresent(session.ended_at) ||
+    stringPresent(session.endedAt) ||
+    stringPresent(session.end_reason),
+  );
+}
+
+function hasScheduledRunContent(session: HermesSessionInfo) {
+  return (
+    Boolean(session.preview?.trim()) || session.title !== "Untitled session"
+  );
+}
+
+function stringPresent(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 /** A scheduled run's first message is the routine prompt wrapped in a machine
@@ -429,18 +309,6 @@ function extractList(response: unknown, preferredKey: "sessions" | "messages") {
     if (Array.isArray(candidate)) return candidate;
   }
   return [];
-}
-
-function uniqueBy<T>(items: T[], key: (item: T) => string) {
-  const seen = new Set<string>();
-  const unique: T[] = [];
-  for (const item of items) {
-    const value = key(item);
-    if (seen.has(value)) continue;
-    seen.add(value);
-    unique.push(item);
-  }
-  return unique;
 }
 
 function isHermesSessionInfo(value: unknown): value is HermesSessionInfo {

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -1,10 +1,16 @@
 import {
   deleteHermesBridgeSession,
+  hermesBridgeStatus,
   hermesBridgeSessionMessages,
   hermesBridgeSessions,
+  startHermesBridge,
+  type HermesBridgeConnection,
+  type HermesBridgeStatus,
   type HermesSessionInfo,
   type HermesSessionMessage,
 } from "./tauri";
+import { hermesConnectionForMode } from "./hermes-connection";
+import { HermesGatewayClient } from "./hermes-gateway";
 
 export type HermesSessionListOptions = {
   limit?: number;
@@ -71,12 +77,190 @@ export function scheduledRunJobId(sessionId: string) {
  * activity; runs older than the window age out of the history view. */
 const SCHEDULED_RUN_FETCH_LIMIT = 200;
 
+export type ScheduledRunListOptions = {
+  includeActive?: boolean;
+};
+
 /** Recent scheduled-routine runs, newest first. */
-export async function listScheduledRunSessions() {
+export async function listScheduledRunSessions(
+  options: ScheduledRunListOptions = {},
+) {
   const sessions = await listHermesSessions({
     limit: SCHEDULED_RUN_FETCH_LIMIT,
   });
-  return sessions.filter(isScheduledRunSession);
+  const storedRuns = sessions.filter(isScheduledRunSession);
+  if (!options.includeActive) return storedRuns;
+  try {
+    return mergeScheduledRunSessions(
+      storedRuns,
+      await listActiveScheduledRunSessions(),
+    );
+  } catch {
+    // Active runtime state is best effort. A websocket/status miss should not
+    // hide the persisted run history the session store already returned.
+    return storedRuns;
+  }
+}
+
+type ActiveSessionRow = {
+  id?: unknown;
+  session_id?: unknown;
+  sessionId?: unknown;
+  session_key?: unknown;
+  sessionKey?: unknown;
+  status?: unknown;
+  source?: unknown;
+  title?: unknown;
+  preview?: unknown;
+  started_at?: unknown;
+  startedAt?: unknown;
+  last_active?: unknown;
+  lastActive?: unknown;
+  message_count?: unknown;
+};
+
+/** Scheduled-routine sessions that are currently registered in the runtime. */
+export async function listActiveScheduledRunSessions() {
+  const connections = await activeSessionConnections();
+  const lists = await Promise.all(
+    connections.map(async (connection) => {
+      const client = new HermesGatewayClient();
+      try {
+        await client.connect(connection.wsUrl);
+        const response = await client.request("session.active_list", {}, 10000);
+        return normalizeActiveScheduledRunSessionsResponse(response);
+      } catch {
+        return [];
+      } finally {
+        client.close();
+      }
+    }),
+  );
+  return mergeScheduledRunSessions([], lists.flat());
+}
+
+async function activeSessionConnections() {
+  let status = await hermesBridgeStatus();
+  if (!status.running || connectionList(status).length === 0) {
+    status = await startHermesBridge();
+  }
+  const connections = [
+    ...connectionList(status),
+    hermesConnectionForMode(status, false),
+    hermesConnectionForMode(status, true),
+  ].filter((connection): connection is HermesBridgeConnection =>
+    Boolean(connection?.wsUrl),
+  );
+  return uniqueBy(connections, (connection) => connection.wsUrl);
+}
+
+function connectionList(status: HermesBridgeStatus) {
+  return status.connections?.length
+    ? status.connections
+    : status.connection
+      ? [status.connection]
+      : [];
+}
+
+export function normalizeActiveScheduledRunSessionsResponse(response: unknown) {
+  return extractList(response, "sessions").flatMap((value) => {
+    const row = value as ActiveSessionRow;
+    if (!row || typeof row !== "object") return [];
+    if (!isActiveSessionStatus(row.status)) return [];
+    const sessionId = activeSessionId(row);
+    if (!sessionId || !scheduledRunJobId(sessionId)) return [];
+    const timestamp = timestampString(
+      row.last_active ??
+        row.lastActive ??
+        row.started_at ??
+        row.startedAt ??
+        Date.now(),
+    );
+    return [
+      withScheduledRunDisplay({
+        id: sessionId,
+        active: true,
+        source: SCHEDULED_RUN_SOURCE,
+        status: statusString(row.status) ?? "running",
+        title: stringValue(row.title),
+        preview: stringValue(row.preview),
+        started_at: timestamp,
+        last_active: timestamp,
+        message_count: numberValue(row.message_count),
+      }),
+    ];
+  });
+}
+
+function activeSessionId(row: ActiveSessionRow) {
+  return (
+    stringValue(row.session_key) ??
+    stringValue(row.sessionKey) ??
+    stringValue(row.session_id) ??
+    stringValue(row.sessionId) ??
+    stringValue(row.id)
+  );
+}
+
+function isActiveSessionStatus(value: unknown) {
+  const status = statusString(value);
+  return status !== "idle" && status !== "completed" && status !== "complete";
+}
+
+function statusString(value: unknown) {
+  return stringValue(value)?.toLowerCase();
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export function isRunningScheduledRunSession(session: HermesSessionInfo) {
+  return isScheduledRunSession(session) && session.active === true;
+}
+
+export function mergeScheduledRunSessions(
+  storedRuns: HermesSessionInfo[],
+  activeRuns: HermesSessionInfo[],
+) {
+  const byId = new Map<string, HermesSessionInfo>();
+  for (const run of storedRuns) {
+    if (isScheduledRunSession(run)) byId.set(run.id, run);
+  }
+  for (const run of activeRuns) {
+    if (!isScheduledRunSession(run)) continue;
+    const stored = byId.get(run.id);
+    byId.set(run.id, stored ? mergeScheduledRunSession(stored, run) : run);
+  }
+  return Array.from(byId.values()).sort((a, b) =>
+    sessionTimestamp(b).localeCompare(sessionTimestamp(a)),
+  );
+}
+
+function mergeScheduledRunSession(
+  stored: HermesSessionInfo,
+  active: HermesSessionInfo,
+): HermesSessionInfo {
+  const activeTimestamp = sessionTimestamp(active);
+  const storedTimestamp = sessionTimestamp(stored);
+  return withScheduledRunDisplay({
+    ...stored,
+    ...active,
+    title: active.title?.trim() || stored.title,
+    preview: active.preview?.trim() || stored.preview,
+    started_at: active.started_at ?? stored.started_at,
+    last_active:
+      activeTimestamp.localeCompare(storedTimestamp) > 0
+        ? activeTimestamp
+        : storedTimestamp,
+    message_count: active.message_count ?? stored.message_count,
+  });
 }
 
 /** A scheduled run's first message is the routine prompt wrapped in a machine
@@ -245,6 +429,18 @@ function extractList(response: unknown, preferredKey: "sessions" | "messages") {
     if (Array.isArray(candidate)) return candidate;
   }
   return [];
+}
+
+function uniqueBy<T>(items: T[], key: (item: T) => string) {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+  for (const item of items) {
+    const value = key(item);
+    if (seen.has(value)) continue;
+    seen.add(value);
+    unique.push(item);
+  }
+  return unique;
 }
 
 function isHermesSessionInfo(value: unknown): value is HermesSessionInfo {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -478,6 +478,8 @@ export type HermesMessagingPlatformsResponse = {
 
 export type HermesSessionInfo = {
   id: string;
+  active?: boolean;
+  status?: string;
   source?: string;
   user_id?: string;
   model?: string;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -479,6 +479,7 @@ export type HermesMessagingPlatformsResponse = {
 export type HermesSessionInfo = {
   id: string;
   active?: boolean;
+  is_active?: boolean;
   status?: string;
   source?: string;
   user_id?: string;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9718,7 +9718,15 @@ input:focus-visible,
   min-width: 0;
 }
 
+.routines-run-title {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
 .routines-run-name {
+  min-width: 0;
   color: var(--foreground);
   font-size: var(--fs-md);
   font-weight: 500;
@@ -9726,6 +9734,17 @@ input:focus-visible,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.routines-run-status {
+  flex: 0 0 auto;
+  padding: 1px var(--sp-2);
+  border-radius: var(--r-sm);
+  background: var(--warm-soft);
+  color: var(--warm-strong);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  line-height: 1.45;
 }
 
 .routines-run-preview {

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,13 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isRunningScheduledRunSession,
   isScheduledRunPreamble,
   isScheduledRunSession,
-  listActiveScheduledRunSessions,
   listHermesSessions,
   listScheduledRunSessions,
-  mergeScheduledRunSessions,
-  normalizeActiveScheduledRunSessionsResponse,
   normalizeHermesSessionMessagesResponse,
   normalizeHermesSessionsResponse,
   scheduledRunJobId,
@@ -93,59 +90,20 @@ describe("scheduled-run helpers", () => {
 
 const mocks = vi.hoisted(() => ({
   hermesBridgeSessions: vi.fn(),
-  hermesBridgeStatus: vi.fn(),
-  startHermesBridge: vi.fn(),
-  gatewayConnect: vi.fn(),
-  gatewayRequest: vi.fn(),
-  gatewayClose: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
   hermesBridgeSessions: mocks.hermesBridgeSessions,
-  hermesBridgeStatus: mocks.hermesBridgeStatus,
-  startHermesBridge: mocks.startHermesBridge,
   hermesBridgeSessionMessages: vi.fn(),
   deleteHermesBridgeSession: vi.fn(),
 }));
 
-vi.mock("../lib/hermes-gateway", () => ({
-  HermesGatewayClient: class {
-    connect = mocks.gatewayConnect;
-    request = mocks.gatewayRequest;
-    close = mocks.gatewayClose;
-  },
-}));
-
-function bridgeConnection(overrides: Record<string, unknown> = {}) {
-  return {
-    baseUrl: "http://127.0.0.1:44200",
-    wsUrl: "ws://127.0.0.1:44200/api/ws",
-    token: "token",
-    port: 44200,
-    command: "hermes",
-    hermesHome: "/tmp/hermes",
-    providerProxyPort: 44201,
-    pid: 123,
-    sandboxed: true,
-    fullMode: false,
-    ...overrides,
-  };
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.gatewayConnect.mockResolvedValue(undefined);
-  mocks.gatewayRequest.mockResolvedValue({ sessions: [] });
-  mocks.hermesBridgeStatus.mockResolvedValue({
-    running: true,
-    connection: bridgeConnection(),
-    connections: [bridgeConnection()],
-  });
-  mocks.startHermesBridge.mockResolvedValue({
-    running: true,
-    connection: bridgeConnection(),
-    connections: [bridgeConnection()],
-  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("Hermes adapter", () => {
@@ -189,32 +147,38 @@ describe("Hermes adapter", () => {
     ]);
   });
 
-  it("normalizes active cron sessions from the runtime", () => {
-    const runs = normalizeActiveScheduledRunSessionsResponse({
+  it("includes active scheduled runs from the session store", async () => {
+    mocks.hermesBridgeSessions.mockResolvedValue({
       sessions: [
         {
-          id: "runtime-session",
-          session_key: "cron_a1b2c3d4e5f6_20260611_090000",
-          status: "working",
+          id: "cron_a1b2c3d4e5f6_20260611_090000",
+          source: "cron",
+          is_active: true,
+          preview: "Working on the morning digest.",
           last_active: "2026-06-11T09:00:05Z",
         },
         {
-          session_key: "cron_idle_20260611_090000",
-          status: "idle",
-        },
-        {
-          session_key: "ordinary-session",
-          status: "working",
+          id: "ordinary-session",
+          is_active: true,
+          preview: "A normal chat is still running.",
         },
       ],
     });
 
+    const runs = await listScheduledRunSessions({ includeActive: true });
+
+    expect(mocks.hermesBridgeSessions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 200,
+        minMessages: 0,
+      }),
+    );
     expect(runs).toHaveLength(1);
     expect(runs[0]).toMatchObject({
       id: "cron_a1b2c3d4e5f6_20260611_090000",
       active: true,
       source: "cron",
-      status: "working",
+      status: "running",
       last_active: "2026-06-11T09:00:05Z",
     });
     expect(isRunningScheduledRunSession(runs[0] as HermesSessionInfo)).toBe(
@@ -222,65 +186,72 @@ describe("Hermes adapter", () => {
     );
   });
 
-  it("merges active runs into stored scheduled run history", () => {
-    const runs = mergeScheduledRunSessions(
-      [
-        {
-          id: "cron_a1b2c3d4e5f6_20260611_090000",
-          source: "cron",
-          title: "Stored title",
-          preview: "Stored preview",
-          last_active: "2026-06-11T09:00:01Z",
-        },
-      ],
-      [
-        {
-          id: "cron_a1b2c3d4e5f6_20260611_090000",
-          active: true,
-          source: "cron",
-          status: "working",
-          last_active: "2026-06-11T09:00:05Z",
-        },
-      ],
-    );
-
-    expect(runs).toHaveLength(1);
-    expect(runs[0]).toMatchObject({
-      id: "cron_a1b2c3d4e5f6_20260611_090000",
-      active: true,
-      status: "working",
-      title: "Stored title",
-      preview: "Stored preview",
-      last_active: "2026-06-11T09:00:05Z",
-    });
-  });
-
-  it("lists active scheduled runs from the gateway", async () => {
-    mocks.gatewayRequest.mockResolvedValue({
+  it("marks recent zero-message scheduled runs as pending", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-11T09:01:00Z"));
+    mocks.hermesBridgeSessions.mockResolvedValue({
       sessions: [
         {
-          id: "runtime-session",
-          session_key: "cron_a1b2c3d4e5f6_20260611_090000",
-          status: "working",
-          last_active: "2026-06-11T09:00:05Z",
+          id: "cron_a1b2c3d4e5f6_20260611_090000",
+          source: "cron",
+          title: "",
+          preview: "",
+          message_count: 0,
+          last_active: "2026-06-11T09:00:00Z",
+        },
+        {
+          id: "cron_finished_20260611_085500",
+          source: "cron",
+          message_count: 0,
+          ended_at: "2026-06-11T08:55:05Z",
+          last_active: "2026-06-11T08:55:00Z",
         },
       ],
     });
 
-    const runs = await listActiveScheduledRunSessions();
+    const runs = await listScheduledRunSessions({ includeActive: true });
+    const pending = runs.find((run) => run.id.includes("a1b2c3d4e5f6")) as
+      | HermesSessionInfo
+      | undefined;
+    const finished = runs.find((run) => run.id.includes("finished"));
 
-    expect(mocks.gatewayConnect).toHaveBeenCalledWith(
-      "ws://127.0.0.1:44200/api/ws",
+    expect(pending).toMatchObject({
+      id: "cron_a1b2c3d4e5f6_20260611_090000",
+      active: true,
+      status: "running",
+    });
+    expect(pending?.title).toBeUndefined();
+    expect(pending?.preview).toBeUndefined();
+    expect(isRunningScheduledRunSession(pending as HermesSessionInfo)).toBe(
+      true,
     );
-    expect(mocks.gatewayRequest).toHaveBeenCalledWith(
-      "session.active_list",
-      {},
-      10000,
+    expect(isRunningScheduledRunSession(finished as HermesSessionInfo)).toBe(
+      false,
     );
-    expect(mocks.gatewayClose).toHaveBeenCalled();
-    expect(runs.map((run) => run.id)).toEqual([
-      "cron_a1b2c3d4e5f6_20260611_090000",
-    ]);
+  });
+
+  it("does not mark old zero-message scheduled runs as running", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-11T09:10:00Z"));
+    mocks.hermesBridgeSessions.mockResolvedValue({
+      sessions: [
+        {
+          id: "cron_a1b2c3d4e5f6_20260611_090000",
+          source: "cron",
+          title: "",
+          preview: "",
+          message_count: 0,
+          last_active: "2026-06-11T09:00:00Z",
+        },
+      ],
+    });
+
+    const runs = await listScheduledRunSessions({ includeActive: true });
+
+    expect(runs).toHaveLength(1);
+    expect(isRunningScheduledRunSession(runs[0] as HermesSessionInfo)).toBe(
+      false,
+    );
   });
 
   it("normalizes raw gateway session lists and sorts by recent activity", () => {

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  isRunningScheduledRunSession,
   isScheduledRunPreamble,
   isScheduledRunSession,
+  listActiveScheduledRunSessions,
   listHermesSessions,
   listScheduledRunSessions,
+  mergeScheduledRunSessions,
+  normalizeActiveScheduledRunSessionsResponse,
   normalizeHermesSessionMessagesResponse,
   normalizeHermesSessionsResponse,
   scheduledRunJobId,
@@ -89,13 +93,60 @@ describe("scheduled-run helpers", () => {
 
 const mocks = vi.hoisted(() => ({
   hermesBridgeSessions: vi.fn(),
+  hermesBridgeStatus: vi.fn(),
+  startHermesBridge: vi.fn(),
+  gatewayConnect: vi.fn(),
+  gatewayRequest: vi.fn(),
+  gatewayClose: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
   hermesBridgeSessions: mocks.hermesBridgeSessions,
+  hermesBridgeStatus: mocks.hermesBridgeStatus,
+  startHermesBridge: mocks.startHermesBridge,
   hermesBridgeSessionMessages: vi.fn(),
   deleteHermesBridgeSession: vi.fn(),
 }));
+
+vi.mock("../lib/hermes-gateway", () => ({
+  HermesGatewayClient: class {
+    connect = mocks.gatewayConnect;
+    request = mocks.gatewayRequest;
+    close = mocks.gatewayClose;
+  },
+}));
+
+function bridgeConnection(overrides: Record<string, unknown> = {}) {
+  return {
+    baseUrl: "http://127.0.0.1:44200",
+    wsUrl: "ws://127.0.0.1:44200/api/ws",
+    token: "token",
+    port: 44200,
+    command: "hermes",
+    hermesHome: "/tmp/hermes",
+    providerProxyPort: 44201,
+    pid: 123,
+    sandboxed: true,
+    fullMode: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.gatewayConnect.mockResolvedValue(undefined);
+  mocks.gatewayRequest.mockResolvedValue({ sessions: [] });
+  mocks.hermesBridgeStatus.mockResolvedValue({
+    running: true,
+    connection: bridgeConnection(),
+    connections: [bridgeConnection()],
+  });
+  mocks.startHermesBridge.mockResolvedValue({
+    running: true,
+    connection: bridgeConnection(),
+    connections: [bridgeConnection()],
+  });
+});
 
 describe("Hermes adapter", () => {
   it("excludes message-less sessions from the default list query", async () => {
@@ -133,6 +184,100 @@ describe("Hermes adapter", () => {
     });
 
     const runs = await listScheduledRunSessions();
+    expect(runs.map((run) => run.id)).toEqual([
+      "cron_a1b2c3d4e5f6_20260611_090000",
+    ]);
+  });
+
+  it("normalizes active cron sessions from the runtime", () => {
+    const runs = normalizeActiveScheduledRunSessionsResponse({
+      sessions: [
+        {
+          id: "runtime-session",
+          session_key: "cron_a1b2c3d4e5f6_20260611_090000",
+          status: "working",
+          last_active: "2026-06-11T09:00:05Z",
+        },
+        {
+          session_key: "cron_idle_20260611_090000",
+          status: "idle",
+        },
+        {
+          session_key: "ordinary-session",
+          status: "working",
+        },
+      ],
+    });
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: "cron_a1b2c3d4e5f6_20260611_090000",
+      active: true,
+      source: "cron",
+      status: "working",
+      last_active: "2026-06-11T09:00:05Z",
+    });
+    expect(isRunningScheduledRunSession(runs[0] as HermesSessionInfo)).toBe(
+      true,
+    );
+  });
+
+  it("merges active runs into stored scheduled run history", () => {
+    const runs = mergeScheduledRunSessions(
+      [
+        {
+          id: "cron_a1b2c3d4e5f6_20260611_090000",
+          source: "cron",
+          title: "Stored title",
+          preview: "Stored preview",
+          last_active: "2026-06-11T09:00:01Z",
+        },
+      ],
+      [
+        {
+          id: "cron_a1b2c3d4e5f6_20260611_090000",
+          active: true,
+          source: "cron",
+          status: "working",
+          last_active: "2026-06-11T09:00:05Z",
+        },
+      ],
+    );
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      id: "cron_a1b2c3d4e5f6_20260611_090000",
+      active: true,
+      status: "working",
+      title: "Stored title",
+      preview: "Stored preview",
+      last_active: "2026-06-11T09:00:05Z",
+    });
+  });
+
+  it("lists active scheduled runs from the gateway", async () => {
+    mocks.gatewayRequest.mockResolvedValue({
+      sessions: [
+        {
+          id: "runtime-session",
+          session_key: "cron_a1b2c3d4e5f6_20260611_090000",
+          status: "working",
+          last_active: "2026-06-11T09:00:05Z",
+        },
+      ],
+    });
+
+    const runs = await listActiveScheduledRunSessions();
+
+    expect(mocks.gatewayConnect).toHaveBeenCalledWith(
+      "ws://127.0.0.1:44200/api/ws",
+    );
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+      "session.active_list",
+      {},
+      10000,
+    );
+    expect(mocks.gatewayClose).toHaveBeenCalled();
     expect(runs.map((run) => run.id)).toEqual([
       "cron_a1b2c3d4e5f6_20260611_090000",
     ]);

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -624,6 +624,36 @@ describe("RoutinesView run history", () => {
     expect(screen.getByText("Running")).toBeInTheDocument();
   });
 
+  it("ignores stale run history responses after a newer refresh", async () => {
+    vi.useFakeTimers();
+    mocks.listRoutines.mockResolvedValue([job()]);
+    let resolveFirstLoad: (runs: HermesSessionInfo[]) => void = () => {};
+    adapterMocks.listScheduledRunSessions
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirstLoad = resolve;
+        }),
+      )
+      .mockResolvedValueOnce([run({ active: true, preview: "" })]);
+    renderView();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Running")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirstLoad([]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+  });
+
   it("labels a run by its session title once the routine is deleted", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     adapterMocks.listScheduledRunSessions.mockResolvedValue([

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RoutinesView } from "../components/routines/RoutinesView";
 import type { RoutineJob } from "../lib/hermes-routines";
 import type { HermesSessionInfo } from "../lib/tauri";
@@ -21,7 +21,10 @@ vi.mock("../lib/hermes-routines", async (importOriginal) => ({
 }));
 
 const adapterMocks = vi.hoisted(() => ({
-  listScheduledRunSessions: vi.fn<() => Promise<HermesSessionInfo[]>>(),
+  listScheduledRunSessions:
+    vi.fn<
+      (options?: { includeActive?: boolean }) => Promise<HermesSessionInfo[]>
+    >(),
 }));
 
 vi.mock("../lib/hermes-adapter", async (importOriginal) => ({
@@ -88,6 +91,10 @@ beforeEach(() => {
   mocks.createRoutine.mockResolvedValue(job());
   mocks.updateRoutine.mockResolvedValue(job());
   adapterMocks.listScheduledRunSessions.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("RoutinesView list", () => {
@@ -574,6 +581,47 @@ describe("RoutinesView run history", () => {
       within(history).getByRole("button", { name: /morning summary/i }),
     );
     expect(onOpenRun).toHaveBeenCalledWith(session);
+    expect(adapterMocks.listScheduledRunSessions).toHaveBeenCalledWith({
+      includeActive: true,
+    });
+  });
+
+  it("marks active routine runs in history", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    adapterMocks.listScheduledRunSessions.mockResolvedValue([
+      run({
+        active: true,
+        preview: "",
+        last_active: "2026-06-10T09:00:05Z",
+      }),
+    ]);
+    renderView();
+
+    const history = await screen.findByRole("region", { name: "Run history" });
+    expect(within(history).getByText("Morning summary")).toBeInTheDocument();
+    expect(within(history).getByText("Running")).toBeInTheDocument();
+    expect(within(history).getByText("Running now")).toBeInTheDocument();
+  });
+
+  it("refreshes run history while the routines view stays open", async () => {
+    vi.useFakeTimers();
+    mocks.listRoutines.mockResolvedValue([job()]);
+    adapterMocks.listScheduledRunSessions
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([run({ active: true, preview: "" })]);
+    renderView();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const history = screen.getByRole("region", { name: "Run history" });
+    expect(within(history).getByText(/No runs yet/)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
   });
 
   it("labels a run by its session title once the routine is deleted", async () => {


### PR DESCRIPTION
## Summary
- Merge live `session.active_list` cron sessions into routine run history when requested
- Poll routine run history while the routines view is open so newly started runs appear without a manual refresh
- Mark active run rows with a Running badge and fallback preview

## Validation
- pnpm exec vitest run src/test/hermes-adapter.test.ts src/test/routines-view.test.tsx
- pnpm exec tsc --noEmit
- pnpm exec prettier --check src/lib/hermes-adapter.ts src/lib/tauri.ts src/components/routines/RoutinesView.tsx src/components/routines/RoutineRunList.tsx src/styles/app.css src/test/hermes-adapter.test.ts src/test/routines-view.test.tsx
- pnpm test

Note: `pnpm run format` still reports pre-existing formatting issues in unrelated files: src/app/App.tsx, src/components/agent/composer/CategorySuggestionList.tsx, src/components/agent/FileTypeIcon.tsx, src/components/note-editor/NoteEditor.tsx, src/lib/agent-chat-runtime.ts, src/test/agent-chat-runtime.test.ts, src/test/app-notes-reliability.test.tsx, src-tauri/tauri.conf.json.