### PR TITLE
Polish tab chrome clipping

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1730,7 +1730,7 @@ function ReferralDialog({
                   ) : (
                     <IconClipboard size={14} />
                   )}
-                  {copied ? "Copied" : "Copy invite link"}
+                  {copied ? "Copied" : "Copy"}
                 </button>
               </div>
               {copyError ? (

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2645,6 +2645,7 @@ input:focus-visible,
    * taller and it pre-washes the backdrop the frosted box samples, and the
    * conversation stops showing through the glass. */
   height: 48px;
+  border-bottom-left-radius: var(--r-window);
   background: linear-gradient(to bottom, transparent, var(--card) 72%);
 }
 
@@ -5211,11 +5212,11 @@ input:focus-visible,
   gap: var(--sp-2);
   flex: 1;
   min-width: 0;
+  margin-left: calc(-1 * var(--tab-strip-shadow-pad));
   padding: var(--tab-strip-shadow-pad);
-  padding-left: 0;
   /* No scroll: tabs that don't fit fold into the overflow popover instead.
-   * Clip transient resize spillover, but leave a tiny clip margin so the flush
-   * first pill can render its normal rounded corner and soft shadow. */
+   * Clip transient resize spillover. The negative margin keeps the first tab
+   * aligned with the card while preserving paint room inside the clip edge. */
   overflow: clip;
   overflow-clip-margin: var(--tab-strip-shadow-pad);
 }
@@ -5233,7 +5234,7 @@ input:focus-visible,
   display: flex;
   align-items: center;
   gap: var(--sp-2);
-  height: calc(var(--titlebar-h) - 4px);
+  height: calc(var(--titlebar-h) - var(--sp-2));
   padding: 0 var(--sp-1) 0 var(--sp-2);
   flex: 1 1 0;
   min-width: 40px;
@@ -5335,8 +5336,8 @@ input:focus-visible,
   display: inline-grid;
   place-items: center;
   flex: 0 0 auto;
-  width: calc(var(--titlebar-h) - 4px);
-  height: calc(var(--titlebar-h) - 4px);
+  width: calc(var(--titlebar-h) - var(--sp-2));
+  height: calc(var(--titlebar-h) - var(--sp-2));
   padding: 0;
   border: 0;
   border-radius: var(--r-md);
@@ -5393,7 +5394,7 @@ input:focus-visible,
   align-items: center;
   gap: 1px;
   flex: 0 0 auto;
-  height: calc(var(--titlebar-h) - 4px);
+  height: calc(var(--titlebar-h) - var(--sp-2));
   padding: 0 var(--sp-1);
   border: 0;
   border-radius: var(--r-md);

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -25,10 +25,39 @@ function renderTabBar(overrides = {}) {
 }
 
 function cssRuleFor(selector: string) {
-  const escaped = selector.replace(/\./g, "\\.");
-  const match = appCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`));
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{`).exec(appCss);
   if (!match) throw new Error(`Missing CSS rule for ${selector}`);
-  return match[1];
+  const openIndex = match.index + match[0].length - 1;
+  let depth = 0;
+  let quote: string | null = null;
+  let escapedChar = false;
+  for (let index = openIndex; index < appCss.length; index += 1) {
+    const char = appCss[index];
+    if (quote) {
+      if (escapedChar) {
+        escapedChar = false;
+      } else if (char === "\\") {
+        escapedChar = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return appCss.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
 }
 
 describe("TabBar", () => {

--- a/src/test/tab-bar.test.tsx
+++ b/src/test/tab-bar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { TabBar } from "../components/tabs/TabBar";
+import appCss from "../styles/app.css?raw";
 
 const tabs = [
   { id: "tab-1", title: "New session", icon: <span aria-hidden /> },
@@ -23,7 +24,34 @@ function renderTabBar(overrides = {}) {
   return { ...view, props };
 }
 
+function cssRuleFor(selector: string) {
+  const escaped = selector.replace(/\./g, "\\.");
+  const match = appCss.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`));
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  return match[1];
+}
+
 describe("TabBar", () => {
+  it("centers tabs in the titlebar band while matching the card gap", () => {
+    const barRule = cssRuleFor(".tab-bar");
+    const stripRule = cssRuleFor(".tab-strip");
+    const tabRule = cssRuleFor(".tab");
+
+    expect(barRule).toContain("align-items: center;");
+    expect(stripRule).toContain("gap: var(--sp-2);");
+    expect(tabRule).toContain("height: calc(var(--titlebar-h) - var(--sp-2));");
+  });
+
+  it("keeps the first tab aligned while preserving paint room", () => {
+    const rule = cssRuleFor(".tab-strip");
+
+    expect(rule).toContain(
+      "margin-left: calc(-1 * var(--tab-strip-shadow-pad));",
+    );
+    expect(rule).toContain("padding: var(--tab-strip-shadow-pad);");
+    expect(rule).not.toContain("padding-left: 0;");
+  });
+
   it("starts a window drag from empty tab-strip space", () => {
     const { container, props } = renderTabBar();
     const strip = container.querySelector(".tab-strip");

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Lessons
 
+- When a user asks about modal/backdrop ordering, treat it as a stacking
+  contract first. Do not hide chrome unless they explicitly ask for visibility
+  changes; verify the intended z-index relationship instead.
+- When fixing clipped chrome, preserve the requested alignment. Move the clip
+  boundary or paint gutter instead of shifting the visible control.
 - When a custom chrome layer sits above the base titlebar drag layer, empty
   space in that layer must forward pointerdown to the explicit native
   `startDragging()` path while child controls guard themselves by target.


### PR DESCRIPTION
## Summary
- Round the docked agent composer dissolve so it no longer paints over the main panel's bottom-left corner.
- Keep the first titlebar tab aligned with the white panel while preserving paint room at the clipped edge.
- Tune titlebar tab sizing so centered tabs keep the same visual rhythm against the card, and add focused CSS regression coverage.

## Verification
- pnpm test src/test/tab-bar.test.tsx src/test/dialog-layering.test.ts
- pnpm run lint
- pnpm exec prettier --check src/styles/app.css src/test/tab-bar.test.tsx tasks/lessons.md