### PR TITLE
Make agent skills editable

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -41,6 +41,7 @@ const FILESYSTEM_MAX_ENTRIES_PER_DIR: usize = 80;
 const HERMES_IMPORT_MAX_BYTES: u64 = 50 * 1024 * 1024;
 const HERMES_IMAGE_PREVIEW_MAX_BYTES: u64 = 5 * 1024 * 1024;
 const HERMES_TEXT_PREVIEW_MAX_BYTES: u64 = 2 * 1024 * 1024;
+const HERMES_SKILL_MAX_BYTES: usize = 512 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_HEADER_BYTES: usize = 32 * 1024;
 const SCRIBE_PROVIDER_PROXY_MAX_BODY_BYTES: usize = 512 * 1024;
 
@@ -287,6 +288,27 @@ pub struct StartHermesBridgeRequest {
 pub struct ToggleHermesCapabilityRequest {
     pub name: String,
     pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesSkillRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateHermesSkillRequest {
+    pub name: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesSkillDocument {
+    pub name: String,
+    pub relative_path: String,
+    pub content: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -745,6 +767,145 @@ pub async fn toggle_hermes_bridge_skill(
         })),
     )
     .await
+}
+
+#[tauri::command]
+pub fn get_hermes_bridge_skill(
+    app: AppHandle,
+    request: HermesSkillRequest,
+) -> Result<HermesSkillDocument, AppError> {
+    let skills_root = resolve_scribe_hermes_home(&app)?.join("skills");
+    let path = resolve_hermes_skill_file_in_root(&skills_root, &request.name)?;
+    let metadata = fs::metadata(&path)
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    if metadata.len() > HERMES_SKILL_MAX_BYTES as u64 {
+        return Err(AppError::new(
+            "hermes_skill_too_large",
+            "This skill is too large to edit in June.",
+        ));
+    }
+    let content = fs::read_to_string(&path)
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    Ok(HermesSkillDocument {
+        name: request.name.trim().to_string(),
+        relative_path: skill_relative_path(&skills_root, &path)?,
+        content,
+    })
+}
+
+#[tauri::command]
+pub fn update_hermes_bridge_skill(
+    app: AppHandle,
+    request: UpdateHermesSkillRequest,
+) -> Result<HermesSkillDocument, AppError> {
+    if request.content.len() > HERMES_SKILL_MAX_BYTES {
+        return Err(AppError::new(
+            "hermes_skill_too_large",
+            "This skill is too large to edit in June.",
+        ));
+    }
+    let skills_root = resolve_scribe_hermes_home(&app)?.join("skills");
+    let path = resolve_hermes_skill_file_in_root(&skills_root, &request.name)?;
+    fs::write(&path, request.content)
+        .map_err(|error| AppError::new("hermes_skill_write_failed", error.to_string()))?;
+    let content = fs::read_to_string(&path)
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    Ok(HermesSkillDocument {
+        name: request.name.trim().to_string(),
+        relative_path: skill_relative_path(&skills_root, &path)?,
+        content,
+    })
+}
+
+fn resolve_hermes_skill_file_in_root(skills_root: &Path, name: &str) -> Result<PathBuf, AppError> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(AppError::new(
+            "hermes_skill_name_required",
+            "Skill name is required.",
+        ));
+    }
+    if name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+        return Err(AppError::new(
+            "hermes_skill_name_invalid",
+            "Skill name must be a single skill id.",
+        ));
+    }
+
+    let root = skills_root
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    let mut matches = Vec::new();
+    collect_skill_file_matches(&root, name, 0, &mut matches)
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+
+    match matches.len() {
+        0 => Err(AppError::new(
+            "hermes_skill_not_found",
+            format!("Could not find skill \"{name}\"."),
+        )),
+        1 => {
+            let path = matches
+                .remove(0)
+                .canonicalize()
+                .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+            if !path.starts_with(&root) {
+                return Err(AppError::new(
+                    "hermes_skill_path_invalid",
+                    "Skill file is outside the managed skills directory.",
+                ));
+            }
+            Ok(path)
+        }
+        _ => Err(AppError::new(
+            "hermes_skill_ambiguous",
+            format!("More than one skill named \"{name}\" exists."),
+        )),
+    }
+}
+
+fn collect_skill_file_matches(
+    directory: &Path,
+    name: &str,
+    depth: usize,
+    matches: &mut Vec<PathBuf>,
+) -> io::Result<()> {
+    if depth > 4 {
+        return Ok(());
+    }
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if entry.file_name().to_string_lossy() == name {
+            let skill_file = path.join("SKILL.md");
+            if skill_file.is_file() {
+                matches.push(skill_file);
+            }
+        }
+        collect_skill_file_matches(&path, name, depth + 1, matches)?;
+    }
+    Ok(())
+}
+
+fn skill_relative_path(skills_root: &Path, path: &Path) -> Result<String, AppError> {
+    let root = skills_root
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    let path = path
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    path.strip_prefix(root)
+        .map(|relative| relative.to_string_lossy().into_owned())
+        .map_err(|_| {
+            AppError::new(
+                "hermes_skill_path_invalid",
+                "Skill file is outside the managed skills directory.",
+            )
+        })
 }
 
 #[derive(Serialize, Clone, Copy)]
@@ -3579,6 +3740,61 @@ mod tests {
         assert!(soul.contains("You are June"));
         assert!(!soul.contains("Seatbelt"));
         assert!(!soul.contains("sandbox"));
+    }
+
+    #[test]
+    fn skill_resolver_finds_root_and_categorized_skills() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let root_skill = home.path().join("dogfood");
+        let categorized_skill = home.path().join("github").join("github-pr-workflow");
+        std::fs::create_dir_all(&root_skill).expect("root skill dir");
+        std::fs::create_dir_all(&categorized_skill).expect("categorized skill dir");
+        std::fs::write(root_skill.join("SKILL.md"), "# Dogfood\n").expect("root skill");
+        std::fs::write(categorized_skill.join("SKILL.md"), "# GitHub PR\n")
+            .expect("categorized skill");
+
+        assert_eq!(
+            resolve_hermes_skill_file_in_root(home.path(), "dogfood")
+                .expect("resolve root")
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("SKILL.md")
+        );
+        assert!(
+            resolve_hermes_skill_file_in_root(home.path(), "github-pr-workflow")
+                .expect("resolve categorized")
+                .ends_with(
+                    Path::new("github")
+                        .join("github-pr-workflow")
+                        .join("SKILL.md")
+                )
+        );
+    }
+
+    #[test]
+    fn skill_resolver_rejects_ambiguous_skill_names() {
+        let home = tempfile::tempdir().expect("tempdir");
+        for category in ["one", "two"] {
+            let dir = home.path().join(category).join("same-name");
+            std::fs::create_dir_all(&dir).expect("skill dir");
+            std::fs::write(dir.join("SKILL.md"), "# Same\n").expect("skill");
+        }
+
+        let err =
+            resolve_hermes_skill_file_in_root(home.path(), "same-name").expect_err("ambiguous");
+
+        assert_eq!(err.code, "hermes_skill_ambiguous");
+    }
+
+    #[test]
+    fn skill_resolver_rejects_path_like_names() {
+        let home = tempfile::tempdir().expect("tempdir");
+
+        for name in ["../secret", "github/github-pr-workflow", r"github\skill"] {
+            let err = resolve_hermes_skill_file_in_root(home.path(), name)
+                .expect_err("invalid skill name");
+            assert_eq!(err.code, "hermes_skill_name_invalid");
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -838,30 +838,38 @@ fn resolve_hermes_skill_file_in_root(skills_root: &Path, name: &str) -> Result<P
     let mut matches = Vec::new();
     collect_skill_file_matches(&root, name, 0, &mut matches)
         .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+    let mut matches = canonical_skill_matches(&root, matches)?;
 
     match matches.len() {
         0 => Err(AppError::new(
             "hermes_skill_not_found",
             format!("Could not find skill \"{name}\"."),
         )),
-        1 => {
-            let path = matches
-                .remove(0)
-                .canonicalize()
-                .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
-            if !path.starts_with(&root) {
-                return Err(AppError::new(
-                    "hermes_skill_path_invalid",
-                    "Skill file is outside the managed skills directory.",
-                ));
-            }
-            Ok(path)
-        }
+        1 => Ok(matches.remove(0)),
         _ => Err(AppError::new(
             "hermes_skill_ambiguous",
             format!("More than one skill named \"{name}\" exists."),
         )),
     }
+}
+
+fn canonical_skill_matches(root: &Path, matches: Vec<PathBuf>) -> Result<Vec<PathBuf>, AppError> {
+    let mut canonical_matches = Vec::new();
+    for path in matches {
+        let path = path
+            .canonicalize()
+            .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
+        if !path.starts_with(root) {
+            return Err(AppError::new(
+                "hermes_skill_path_invalid",
+                "Skill file is outside the managed skills directory.",
+            ));
+        }
+        if !canonical_matches.iter().any(|existing| existing == &path) {
+            canonical_matches.push(path);
+        }
+    }
+    Ok(canonical_matches)
 }
 
 fn collect_skill_file_matches(
@@ -3784,6 +3792,21 @@ mod tests {
             resolve_hermes_skill_file_in_root(home.path(), "same-name").expect_err("ambiguous");
 
         assert_eq!(err.code, "hermes_skill_ambiguous");
+    }
+
+    #[test]
+    fn skill_resolver_deduplicates_canonical_matches() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let dir = home.path().join("same-name");
+        std::fs::create_dir_all(&dir).expect("skill dir");
+        let skill_file = dir.join("SKILL.md");
+        std::fs::write(&skill_file, "# Same\n").expect("skill");
+        let root = home.path().canonicalize().expect("canonical root");
+
+        let matches = canonical_skill_matches(&root, vec![skill_file.clone(), skill_file])
+            .expect("canonical matches");
+
+        assert_eq!(matches.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -4,7 +4,8 @@ use rand::{distributions::Alphanumeric, Rng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fs, io,
+    fs,
+    io::{self, Write},
     net::TcpListener,
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
@@ -806,8 +807,7 @@ pub fn update_hermes_bridge_skill(
     }
     let skills_root = resolve_scribe_hermes_home(&app)?.join("skills");
     let path = resolve_hermes_skill_file_in_root(&skills_root, &request.name)?;
-    fs::write(&path, request.content)
-        .map_err(|error| AppError::new("hermes_skill_write_failed", error.to_string()))?;
+    write_managed_skill_file(&skills_root, &path, &request.content)?;
     let content = fs::read_to_string(&path)
         .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
     Ok(HermesSkillDocument {
@@ -851,6 +851,100 @@ fn resolve_hermes_skill_file_in_root(skills_root: &Path, name: &str) -> Result<P
             format!("More than one skill named \"{name}\" exists."),
         )),
     }
+}
+
+fn write_managed_skill_file(
+    skills_root: &Path,
+    path: &Path,
+    content: &str,
+) -> Result<(), AppError> {
+    let root = skills_root
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_skill_write_failed", error.to_string()))?;
+    if !path.starts_with(&root) {
+        return Err(AppError::new(
+            "hermes_skill_path_invalid",
+            "Skill file is outside the managed skills directory.",
+        ));
+    }
+
+    let parent = path.parent().ok_or_else(|| {
+        AppError::new(
+            "hermes_skill_path_invalid",
+            "Skill file is outside the managed skills directory.",
+        )
+    })?;
+    let parent = parent
+        .canonicalize()
+        .map_err(|error| AppError::new("hermes_skill_write_failed", error.to_string()))?;
+    if !parent.starts_with(&root) {
+        return Err(AppError::new(
+            "hermes_skill_path_invalid",
+            "Skill file is outside the managed skills directory.",
+        ));
+    }
+
+    let file_name = path.file_name().ok_or_else(|| {
+        AppError::new(
+            "hermes_skill_path_invalid",
+            "Skill file is outside the managed skills directory.",
+        )
+    })?;
+    let temp_path = parent.join(format!(
+        ".{}.{}.tmp",
+        file_name.to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+
+    let write_result = (|| -> io::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+        let temp_canonical = temp_path.canonicalize()?;
+        if !temp_canonical.starts_with(&root) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "temporary skill file escaped managed skills directory",
+            ));
+        }
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        replace_file(&temp_path, path)
+    })();
+
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(AppError::new(
+            "hermes_skill_write_failed",
+            error.to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn replace_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    match fs::rename(temp_path, path) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::AlreadyExists | io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            fs::remove_file(path)?;
+            fs::rename(temp_path, path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(temp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, path)
 }
 
 fn canonical_skill_matches(root: &Path, matches: Vec<PathBuf>) -> Result<Vec<PathBuf>, AppError> {
@@ -3807,6 +3901,38 @@ mod tests {
             .expect("canonical matches");
 
         assert_eq!(matches.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skill_writer_replaces_swapped_symlink_without_following_it() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let skills_root = home.path().join("skills");
+        let skill_dir = skills_root.join("same-name");
+        std::fs::create_dir_all(&skill_dir).expect("skill dir");
+        let skill_file = skill_dir.join("SKILL.md");
+        std::fs::write(&skill_file, "# Original\n").expect("skill");
+        let resolved_skill_file = skill_file.canonicalize().expect("canonical skill");
+        let outside_file = home.path().join("outside.md");
+        std::fs::write(&outside_file, "# Outside\n").expect("outside");
+        std::fs::remove_file(&skill_file).expect("remove skill");
+        std::os::unix::fs::symlink(&outside_file, &skill_file).expect("symlink");
+
+        write_managed_skill_file(&skills_root, &resolved_skill_file, "# Updated\n")
+            .expect("write skill");
+
+        assert_eq!(
+            std::fs::read_to_string(&outside_file).expect("read outside"),
+            "# Outside\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&skill_file).expect("read skill"),
+            "# Updated\n"
+        );
+        assert!(!std::fs::symlink_metadata(&skill_file)
+            .expect("skill metadata")
+            .file_type()
+            .is_symlink());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -172,6 +172,8 @@ pub fn run() {
             hermes_bridge::start_hermes_bridge,
             hermes_bridge::stop_hermes_bridge,
             hermes_bridge::toggle_hermes_bridge_skill,
+            hermes_bridge::get_hermes_bridge_skill,
+            hermes_bridge::update_hermes_bridge_skill,
             hermes_bridge::toggle_hermes_bridge_toolset,
             hermes_bridge::update_hermes_bridge_messaging_platform,
             hermes_bridge::hermes_agent_cli_access,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -110,6 +110,7 @@ import {
   type HermesMessagingPlatformInfo,
   type HermesSessionInfo,
   type HermesSessionMessage,
+  type HermesSkillDocument,
   type HermesSkillInfo,
   type HermesToolsetInfo,
   type VeniceModelDto,
@@ -5004,6 +5005,8 @@ export function SkillsToolsPanel({
   onRefresh,
   onToggleSkill,
   onToggleToolset,
+  onOpenSkill,
+  onSaveSkill,
 }: {
   loading: boolean;
   query: string;
@@ -5014,7 +5017,21 @@ export function SkillsToolsPanel({
   onRefresh: () => void;
   onToggleSkill: (skill: HermesSkillInfo, enabled: boolean) => void;
   onToggleToolset: (toolset: HermesToolsetInfo, enabled: boolean) => void;
+  onOpenSkill?: (skill: HermesSkillInfo) => Promise<HermesSkillDocument>;
+  onSaveSkill?: (
+    skill: HermesSkillInfo,
+    content: string,
+  ) => Promise<HermesSkillDocument>;
 }) {
+  const [selectedSkillName, setSelectedSkillName] = useState<string | null>(
+    null,
+  );
+  const [skillDocument, setSkillDocument] =
+    useState<HermesSkillDocument | null>(null);
+  const [skillDraft, setSkillDraft] = useState("");
+  const [skillLoading, setSkillLoading] = useState(false);
+  const [skillSaving, setSkillSaving] = useState(false);
+  const [skillError, setSkillError] = useState<string | null>(null);
   const q = query.trim().toLowerCase();
   const visibleSkills = (skills ?? [])
     .filter((skill) => capabilityMatches(skill, q))
@@ -5024,6 +5041,67 @@ export function SkillsToolsPanel({
     .sort((a, b) =>
       safeText(a.label ?? a.name).localeCompare(safeText(b.label ?? b.name)),
     );
+  const selectedSkill =
+    (skills ?? []).find((skill) => skill.name === selectedSkillName) ?? null;
+  const skillDirty =
+    Boolean(skillDocument) && skillDraft !== (skillDocument?.content ?? "");
+
+  async function openSkill(skill: HermesSkillInfo) {
+    if (!onOpenSkill) return;
+    setSelectedSkillName(skill.name);
+    setSkillDocument(null);
+    setSkillDraft("");
+    setSkillError(null);
+    setSkillLoading(true);
+    try {
+      const document = await onOpenSkill(skill);
+      setSkillDocument(document);
+      setSkillDraft(document.content);
+    } catch (err) {
+      setSkillError(messageFromError(err));
+    } finally {
+      setSkillLoading(false);
+    }
+  }
+
+  async function saveSkill() {
+    if (!selectedSkill || !onSaveSkill || !skillDocument) return;
+    setSkillSaving(true);
+    setSkillError(null);
+    try {
+      const document = await onSaveSkill(selectedSkill, skillDraft);
+      setSkillDocument(document);
+      setSkillDraft(document.content);
+    } catch (err) {
+      setSkillError(messageFromError(err));
+    } finally {
+      setSkillSaving(false);
+    }
+  }
+
+  if (selectedSkillName) {
+    return (
+      <SkillEditorPanel
+        document={skillDocument}
+        dirty={skillDirty}
+        error={skillError}
+        loading={skillLoading}
+        saving={skillSaving}
+        skill={selectedSkill}
+        value={skillDraft}
+        onBack={() => {
+          setSelectedSkillName(null);
+          setSkillDocument(null);
+          setSkillDraft("");
+          setSkillError(null);
+        }}
+        onCancel={() => setSkillDraft(skillDocument?.content ?? "")}
+        onChange={setSkillDraft}
+        onSave={() => void saveSkill()}
+      />
+    );
+  }
+
   return (
     <section className="agent-management-panel" aria-label="Skills and tools">
       <ManagementToolbar
@@ -5052,6 +5130,7 @@ export function SkillsToolsPanel({
                 meta={skill.category}
                 enabled={Boolean(skill.enabled)}
                 saving={saving === `skill:${skill.name}`}
+                onSelect={onOpenSkill ? () => void openSkill(skill) : undefined}
                 onToggle={(enabled) => onToggleSkill(skill, enabled)}
               />
             ))}
@@ -5077,6 +5156,99 @@ export function SkillsToolsPanel({
           </CapabilityGroup>
         </div>
       )}
+    </section>
+  );
+}
+
+function SkillEditorPanel({
+  dirty,
+  document,
+  error,
+  loading,
+  saving,
+  skill,
+  value,
+  onBack,
+  onCancel,
+  onChange,
+  onSave,
+}: {
+  dirty: boolean;
+  document: HermesSkillDocument | null;
+  error: string | null;
+  loading: boolean;
+  saving: boolean;
+  skill: HermesSkillInfo | null;
+  value: string;
+  onBack: () => void;
+  onCancel: () => void;
+  onChange: (value: string) => void;
+  onSave: () => void;
+}) {
+  const title = skill?.name ?? document?.name ?? "Skill";
+  return (
+    <section
+      className="agent-management-panel agent-skill-editor-panel"
+      aria-label={title}
+    >
+      <div className="agent-skill-editor">
+        <header className="agent-skill-editor-header">
+          <button
+            type="button"
+            className="btn btn-ghost agent-skill-editor-back"
+            onClick={onBack}
+          >
+            <IconChevronLeftSmall size={15} aria-hidden />
+            Skills
+          </button>
+          <div className="agent-skill-editor-heading">
+            <div>
+              <h3>{title}</h3>
+              {skill?.description ? <p>{skill.description}</p> : null}
+            </div>
+            <div className="agent-platform-pills">
+              {skill?.category ? <span>{skill.category}</span> : null}
+              {document?.relativePath ? (
+                <span>{document.relativePath}</span>
+              ) : null}
+              {skill ? (
+                <span>{skill.enabled ? "Enabled" : "Disabled"}</span>
+              ) : null}
+            </div>
+          </div>
+        </header>
+        {error ? <p className="settings-row-error">{error}</p> : null}
+        {loading ? (
+          <div className="agent-loading">
+            <Spinner />
+          </div>
+        ) : (
+          <textarea
+            className="agent-skill-editor-textarea"
+            value={value}
+            aria-label={`${title} skill Markdown`}
+            spellCheck={false}
+            onChange={(event) => onChange(event.currentTarget.value)}
+          />
+        )}
+      </div>
+      <footer className="agent-messaging-footer">
+        <button
+          type="button"
+          disabled={!dirty || saving || loading}
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="primary-action primary-solid"
+          disabled={!dirty || saving || loading || !document}
+          onClick={onSave}
+        >
+          {saving ? "Saving..." : "Save changes"}
+        </button>
+      </footer>
     </section>
   );
 }
@@ -5559,7 +5731,7 @@ function CapabilityRow({
 }) {
   return (
     <article className="agent-capability-row" data-selected={selected}>
-      <button type="button" onClick={onSelect}>
+      <button type="button" disabled={!onSelect} onClick={onSelect}>
         <div className="agent-capability-title">
           <span>{title}</span>
           {meta ? <em>{meta}</em> : null}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -62,6 +62,7 @@ import {
   useState,
 } from "react";
 import { BackButton } from "../ui/BackButton";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
 import { HoverTip } from "../ui/HoverTip";
@@ -5032,6 +5033,7 @@ export function SkillsToolsPanel({
   const [skillLoading, setSkillLoading] = useState(false);
   const [skillSaving, setSkillSaving] = useState(false);
   const [skillError, setSkillError] = useState<string | null>(null);
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const q = query.trim().toLowerCase();
   const visibleSkills = (skills ?? [])
     .filter((skill) => capabilityMatches(skill, q))
@@ -5079,26 +5081,48 @@ export function SkillsToolsPanel({
     }
   }
 
+  function closeSkillEditor() {
+    setSelectedSkillName(null);
+    setSkillDocument(null);
+    setSkillDraft("");
+    setSkillError(null);
+    setDiscardConfirmOpen(false);
+  }
+
+  function requestCloseSkillEditor() {
+    if (skillDirty) {
+      setDiscardConfirmOpen(true);
+      return;
+    }
+    closeSkillEditor();
+  }
+
   if (selectedSkillName) {
     return (
-      <SkillEditorPanel
-        document={skillDocument}
-        dirty={skillDirty}
-        error={skillError}
-        loading={skillLoading}
-        saving={skillSaving}
-        skill={selectedSkill}
-        value={skillDraft}
-        onBack={() => {
-          setSelectedSkillName(null);
-          setSkillDocument(null);
-          setSkillDraft("");
-          setSkillError(null);
-        }}
-        onCancel={() => setSkillDraft(skillDocument?.content ?? "")}
-        onChange={setSkillDraft}
-        onSave={() => void saveSkill()}
-      />
+      <>
+        <SkillEditorPanel
+          document={skillDocument}
+          dirty={skillDirty}
+          error={skillError}
+          loading={skillLoading}
+          saving={skillSaving}
+          skill={selectedSkill}
+          value={skillDraft}
+          onBack={requestCloseSkillEditor}
+          onCancel={() => setSkillDraft(skillDocument?.content ?? "")}
+          onChange={setSkillDraft}
+          onSave={() => void saveSkill()}
+        />
+        <ConfirmDialog
+          open={discardConfirmOpen}
+          title="Discard skill edits?"
+          description="Your unsaved changes will be lost."
+          confirmLabel="Discard"
+          destructive
+          onClose={() => setDiscardConfirmOpen(false)}
+          onConfirm={closeSkillEditor}
+        />
+      </>
     );
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5251,6 +5251,7 @@ function SkillEditorPanel({
             className="agent-skill-editor-textarea"
             value={value}
             aria-label={`${title} skill Markdown`}
+            disabled={saving}
             spellCheck={false}
             onChange={(event) => onChange(event.currentTarget.value)}
           />

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -10,13 +10,16 @@ import {
   hermesBridgeMessagingPlatforms,
   hermesBridgeSkills,
   hermesBridgeToolsets,
+  getHermesBridgeSkill,
   agentHudHide,
   agentHudShow,
   setHermesAgentCliAccess,
   toggleHermesBridgeSkill,
   toggleHermesBridgeToolset,
+  updateHermesBridgeSkill,
   updateHermesBridgeMessagingPlatform,
   type HermesMessagingPlatformInfo,
+  type HermesSkillDocument,
   type HermesSkillInfo,
   type HermesToolsetInfo,
   type HermesFilesystemSnapshot,
@@ -199,6 +202,22 @@ export function AgentSettingsSection() {
     }
   }
 
+  async function openSkillDocument(skill: HermesSkillInfo) {
+    return getHermesBridgeSkill(skill.name);
+  }
+
+  async function saveSkillDocument(
+    skill: HermesSkillInfo,
+    content: string,
+  ): Promise<HermesSkillDocument> {
+    const document = await updateHermesBridgeSkill({
+      name: skill.name,
+      content,
+    });
+    await loadCapabilities();
+    return document;
+  }
+
   async function setToolsetEnabled(
     toolset: HermesToolsetInfo,
     enabled: boolean,
@@ -370,6 +389,8 @@ export function AgentSettingsSection() {
             onToggleSkill={(skill, enabled) =>
               void setSkillEnabled(skill, enabled)
             }
+            onOpenSkill={openSkillDocument}
+            onSaveSkill={saveSkillDocument}
             onToggleToolset={(toolset, enabled) =>
               void setToolsetEnabled(toolset, enabled)
             }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -443,6 +443,12 @@ export type HermesSkillInfo = {
   enabled?: boolean;
 };
 
+export type HermesSkillDocument = {
+  name: string;
+  relativePath: string;
+  content: string;
+};
+
 export type HermesToolsetInfo = {
   name: string;
   label?: string;
@@ -863,6 +869,21 @@ export async function hermesBridgeStatus() {
 
 export async function hermesBridgeSkills() {
   return invoke<HermesSkillInfo[]>("hermes_bridge_skills");
+}
+
+export async function getHermesBridgeSkill(name: string) {
+  return invoke<HermesSkillDocument>("get_hermes_bridge_skill", {
+    request: { name },
+  });
+}
+
+export async function updateHermesBridgeSkill(input: {
+  name: string;
+  content: string;
+}) {
+  return invoke<HermesSkillDocument>("update_hermes_bridge_skill", {
+    request: input,
+  });
 }
 
 export async function toggleHermesBridgeSkill(input: {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -797,6 +797,10 @@ input:focus-visible,
   overflow: hidden;
 }
 
+.agent-skill-editor-panel {
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
 .agent-management-toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -884,6 +888,10 @@ input:focus-visible,
   cursor: pointer;
 }
 
+.agent-capability-row > button:first-child:disabled {
+  cursor: default;
+}
+
 .agent-capability-row[data-selected="true"] {
   margin: 0 calc(var(--sp-3) * -1);
   border-radius: var(--r-sm);
@@ -926,6 +934,62 @@ input:focus-visible,
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
   line-height: 1.35;
+}
+
+.agent-skill-editor {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.agent-skill-editor-header {
+  display: grid;
+  gap: var(--sp-4);
+  padding: var(--sp-5);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.agent-skill-editor-back {
+  width: fit-content;
+}
+
+.agent-skill-editor-heading {
+  display: grid;
+  gap: var(--sp-3);
+}
+
+.agent-skill-editor-heading h3 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--fs-lg);
+  font-weight: 600;
+}
+
+.agent-skill-editor-heading p {
+  margin: var(--sp-1) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.agent-skill-editor-textarea {
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: 0;
+  padding: var(--sp-5);
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.55;
+  outline: none;
+}
+
+.agent-skill-editor-textarea:focus {
+  box-shadow: inset 0 0 0 1px var(--ring-focus);
 }
 
 .agent-files-root {


### PR DESCRIPTION
## Summary

- Add Tauri commands to read and update existing Hermes `SKILL.md` files under the managed app skills directory.
- Add defensive skill file resolution and write handling so edits only target app-owned skill documents, reject missing/ambiguous/path-like names, dedupe canonical matches, and replace files through a verified temp file.
- Make Settings > Agent skills rows clickable, opening an in-place Markdown editor with save/cancel/back controls.
- Guard dirty Back navigation with a discard confirmation, disable Markdown edits while a save is in flight, and refresh the skills list after saving.

## Validation

- `pnpm run lint`
- `pnpm test`
- `pnpm build`
- `pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/components/settings/AgentSettingsSection.tsx src/lib/tauri.ts src/styles/app.css`
- `cargo test --manifest-path src-tauri/Cargo.toml skill_ --locked`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- GitHub checks passing on latest head: Frontend lint and tests, Tauri Rust tests, Changed paths, Socket Security

## Notes

This edits existing skills only. It does not add create/delete/move flows for skill packages or categories.
