### PR TITLE
Proxy OS-Guard Tool Guard through scribe-api

### DIFF
--- a/scribe-api/.env.example
+++ b/scribe-api/.env.example
@@ -50,5 +50,11 @@ SCRIBE__UPSTREAMS__VENICE__API_KEY=VENICE_API_KEY_REPLACE_ME
 # PII before forwarding to the provider. Audio transcription always stays on
 # Venice. Leave BASE_URL empty to keep chat on Venice (the default). The
 # gateway holds the provider key; callers authenticate with this bearer token.
+#
+# The same OS-Guard upstream also powers Tool Guard: the /v1/tool-guard/calls
+# and /v1/tool-guard/results endpoints proxy the desktop client's tool-call
+# arguments and tool results to OS-Guard for detection-only analysis, using
+# this server-side gateway token. Tool Guard has no Venice fallback — when
+# BASE_URL is empty those endpoints return tool_guard_unavailable.
 # SCRIBE__UPSTREAMS__OSGUARD__BASE_URL=https://osguard.example/v1
 SCRIBE__UPSTREAMS__OSGUARD__API_KEY=

--- a/scribe-api/config.toml
+++ b/scribe-api/config.toml
@@ -63,6 +63,10 @@ base_url = "https://api.venice.ai/api/v1"
 # redacted before reaching the provider; audio transcription always stays on
 # Venice. Leave base_url empty to keep chat on Venice. The gateway token is a
 # secret and is supplied via SCRIBE__UPSTREAMS__OSGUARD__API_KEY, not here.
+# This upstream also backs Tool Guard (/v1/tool-guard/calls and
+# /v1/tool-guard/results), which proxies tool-call arguments and tool results
+# to OS-Guard for detection-only analysis. Tool Guard has no Venice fallback:
+# with base_url empty those endpoints return tool_guard_unavailable.
 [upstreams.osguard]
 base_url = ""
 

--- a/scribe-api/crates/api/src/envelope.rs
+++ b/scribe-api/crates/api/src/envelope.rs
@@ -10,6 +10,7 @@ pub const ERR_AUTHORIZATION_DENIED: i32 = 4401;
 pub const ERR_POLICY_BLOCKED: i32 = 4031;
 pub const ERR_INTERNAL: i32 = 5000;
 pub const ERR_UPSTREAM: i32 = 5001;
+pub const ERR_TOOL_GUARD_UNAVAILABLE: i32 = 5031;
 
 #[derive(Serialize)]
 pub struct ApiResponse<T> {

--- a/scribe-api/crates/api/src/error.rs
+++ b/scribe-api/crates/api/src/error.rs
@@ -1,10 +1,10 @@
 use crate::envelope::{
     ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_PAYLOAD_TOO_LARGE, ERR_POLICY_BLOCKED, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
-    error_response,
+    ERR_PAYLOAD_TOO_LARGE, ERR_POLICY_BLOCKED, ERR_TOOL_GUARD_UNAVAILABLE, ERR_UNAUTHORIZED,
+    ERR_UNPROCESSABLE, ERR_UPSTREAM, error_response,
 };
 use axum::{http::StatusCode, response::IntoResponse};
-use scribe_domain::AuthError;
+use scribe_domain::{AuthError, DomainError};
 use scribe_services::ServiceError;
 use thiserror::Error;
 
@@ -26,6 +26,8 @@ pub enum ApiError {
     Upstream,
     #[error("policy_blocked")]
     PolicyBlocked,
+    #[error("tool_guard_unavailable")]
+    ToolGuardUnavailable,
     #[error("internal_error")]
     Internal,
 }
@@ -94,6 +96,15 @@ impl IntoResponse for ApiError {
             Self::PolicyBlocked => {
                 error_response(StatusCode::FORBIDDEN, ERR_POLICY_BLOCKED, "policy_blocked")
             }
+            // Tool Guard requires OS-Guard to be configured; there is no Venice
+            // fallback. When it is not configured, the feature is unavailable on
+            // this deployment rather than a per-request failure — 503 so the
+            // client can disable the capability instead of retrying.
+            Self::ToolGuardUnavailable => error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                ERR_TOOL_GUARD_UNAVAILABLE,
+                "tool_guard_unavailable",
+            ),
             Self::Internal => error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ERR_INTERNAL,
@@ -113,6 +124,18 @@ impl From<ServiceError> for ApiError {
             ServiceError::UpstreamProvider => Self::Upstream,
             ServiceError::PolicyBlocked => Self::PolicyBlocked,
             ServiceError::InvalidInput { reason } => Self::bad_request(reason),
+        }
+    }
+}
+
+impl From<DomainError> for ApiError {
+    fn from(error: DomainError) -> Self {
+        match error {
+            DomainError::PolicyBlocked => Self::PolicyBlocked,
+            DomainError::InvalidInput { reason } => Self::bad_request(reason),
+            DomainError::UpstreamProvider
+            | DomainError::ModelNotPriced
+            | DomainError::InsufficientCredits => Self::Upstream,
         }
     }
 }

--- a/scribe-api/crates/api/src/handlers/mod.rs
+++ b/scribe-api/crates/api/src/handlers/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod health;
 pub(crate) mod issues;
 pub(crate) mod models;
 pub(crate) mod notes;
+pub(crate) mod tool_guard;
 pub(crate) mod verify;

--- a/scribe-api/crates/api/src/handlers/tool_guard.rs
+++ b/scribe-api/crates/api/src/handlers/tool_guard.rs
@@ -1,0 +1,148 @@
+use crate::{
+    auth::authenticated_user, envelope::ApiResponse, error::ApiError, state::ApiState, validation,
+};
+use axum::{Json, extract::State, http::HeaderMap};
+use scribe_domain::{
+    ToolDestinationClass, ToolGuardAnalysis, ToolGuardCallAnalysisRequest,
+    ToolGuardResultAnalysisRequest,
+};
+use serde::Deserialize;
+
+/// Proxies a tool-call analysis to OS-Guard's Tool Guard. The desktop client
+/// sends the pending tool call (arguments plus correlation fields); scribe sets
+/// `caller_identity` from the authenticated principal, forwards the request with
+/// the server-side gateway token, and relays the detection analysis. The client
+/// applies the redaction operations and surfaces the advisories locally — scribe
+/// neither executes the tool nor applies any redaction.
+pub(crate) async fn analyze_call(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    Json(request): Json<ToolGuardCallBody>,
+) -> Result<Json<ApiResponse<ToolGuardAnalysis>>, ApiError> {
+    let user_id = authenticated_user(&state, &headers).await?;
+    let analyzer = state.tool_guard().ok_or(ApiError::ToolGuardUnavailable)?;
+    request.validate()?;
+    // caller_identity always comes from the verified token, never the body.
+    let analysis = analyzer
+        .analyze_call(ToolGuardCallAnalysisRequest {
+            caller_identity: user_id.0,
+            agent_turn_id: request.agent_turn_id,
+            tool_call_id: request.tool_call_id,
+            tool_name: request.tool_name,
+            destination_id: request.destination_id,
+            destination_class: request.destination_class,
+            tool_schema_ref: request.tool_schema_ref,
+            arguments: request.arguments,
+            deadline_ms: request.deadline_ms,
+            policy_context: request.policy_context,
+        })
+        .await?;
+    Ok(Json(ApiResponse::ok(analysis)))
+}
+
+/// Proxies a tool-result analysis to OS-Guard's Tool Guard. Same proxy
+/// semantics as `analyze_call`: scribe sets `caller_identity` from auth and
+/// relays the analysis; the client applies the operations before reinjecting
+/// the (redacted) result into the model context.
+pub(crate) async fn analyze_result(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    Json(request): Json<ToolGuardResultBody>,
+) -> Result<Json<ApiResponse<ToolGuardAnalysis>>, ApiError> {
+    let user_id = authenticated_user(&state, &headers).await?;
+    let analyzer = state.tool_guard().ok_or(ApiError::ToolGuardUnavailable)?;
+    request.validate()?;
+    let analysis = analyzer
+        .analyze_result(ToolGuardResultAnalysisRequest {
+            caller_identity: user_id.0,
+            agent_turn_id: request.agent_turn_id,
+            tool_call_id: request.tool_call_id,
+            destination_id: request.destination_id,
+            destination_class: request.destination_class,
+            result: request.result,
+            deadline_ms: request.deadline_ms,
+            policy_context: request.policy_context,
+        })
+        .await?;
+    Ok(Json(ApiResponse::ok(analysis)))
+}
+
+/// Tool-call analysis request body. Deliberately omits `caller_identity`: the
+/// client cannot supply its own identity — scribe derives it from auth.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ToolGuardCallBody {
+    pub agent_turn_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub destination_id: String,
+    pub destination_class: ToolDestinationClass,
+    #[serde(default)]
+    pub tool_schema_ref: Option<String>,
+    pub arguments: serde_json::Value,
+    pub deadline_ms: u64,
+    #[serde(default)]
+    pub policy_context: Option<serde_json::Value>,
+}
+
+impl ToolGuardCallBody {
+    fn validate(&self) -> Result<(), ApiError> {
+        validate_correlation_id("agentTurnId", &self.agent_turn_id)?;
+        validate_correlation_id("toolCallId", &self.tool_call_id)?;
+        validate_tool_name(&self.tool_name)?;
+        validate_correlation_id("destinationId", &self.destination_id)?;
+        validation::validate_optional_text_len(
+            "toolSchemaRef",
+            self.tool_schema_ref.as_deref(),
+            validation::MAX_MODEL_CHARS,
+        )?;
+        validate_deadline(self.deadline_ms)?;
+        Ok(())
+    }
+}
+
+/// Tool-result analysis request body. As with the call body, `caller_identity`
+/// is intentionally absent and set from auth.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ToolGuardResultBody {
+    pub agent_turn_id: String,
+    pub tool_call_id: String,
+    pub destination_id: String,
+    pub destination_class: ToolDestinationClass,
+    pub result: serde_json::Value,
+    pub deadline_ms: u64,
+    #[serde(default)]
+    pub policy_context: Option<serde_json::Value>,
+}
+
+impl ToolGuardResultBody {
+    fn validate(&self) -> Result<(), ApiError> {
+        validate_correlation_id("agentTurnId", &self.agent_turn_id)?;
+        validate_correlation_id("toolCallId", &self.tool_call_id)?;
+        validate_correlation_id("destinationId", &self.destination_id)?;
+        validate_deadline(self.deadline_ms)?;
+        Ok(())
+    }
+}
+
+fn validate_correlation_id(field: &str, value: &str) -> Result<(), ApiError> {
+    if value.trim().is_empty() {
+        return Err(ApiError::bad_request(format!("{field}_required")));
+    }
+    validation::validate_text_len(field, value, validation::MAX_ID_CHARS)
+}
+
+fn validate_tool_name(value: &str) -> Result<(), ApiError> {
+    if value.trim().is_empty() {
+        return Err(ApiError::bad_request("toolName_required"));
+    }
+    validation::validate_text_len("toolName", value, validation::MAX_MODEL_CHARS)
+}
+
+fn validate_deadline(deadline_ms: u64) -> Result<(), ApiError> {
+    if deadline_ms == 0 {
+        return Err(ApiError::bad_request("deadlineMs_required"));
+    }
+    Ok(())
+}

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -20,7 +20,8 @@ use tower_http::{cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer};
 
 pub use envelope::{
     ApiResponse, ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_PAYLOAD_TOO_LARGE, ERR_POLICY_BLOCKED, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
+    ERR_PAYLOAD_TOO_LARGE, ERR_POLICY_BLOCKED, ERR_TOOL_GUARD_UNAVAILABLE, ERR_UNAUTHORIZED,
+    ERR_UNPROCESSABLE, ERR_UPSTREAM,
 };
 pub use error::ApiError;
 pub use handlers::dictate::{
@@ -65,6 +66,16 @@ pub fn router(state: ApiState) -> Router {
         .route(
             "/v1/dictate/cleanup",
             post(handlers::dictate::cleanup).layer(DefaultBodyLimit::max(limits.max_json_bytes)),
+        )
+        .route(
+            "/v1/tool-guard/calls",
+            post(handlers::tool_guard::analyze_call)
+                .layer(DefaultBodyLimit::max(limits.max_json_bytes)),
+        )
+        .route(
+            "/v1/tool-guard/results",
+            post(handlers::tool_guard::analyze_result)
+                .layer(DefaultBodyLimit::max(limits.max_json_bytes)),
         )
         .route(
             "/v1/issue-reports",

--- a/scribe-api/crates/api/src/state.rs
+++ b/scribe-api/crates/api/src/state.rs
@@ -1,4 +1,4 @@
-use scribe_domain::{IssueReportSink, TokenVerifier};
+use scribe_domain::{IssueReportSink, TokenVerifier, ToolGuardAnalyzer};
 use scribe_services::{
     AgentChatService, DictateService, NoteGenerateService, NoteTranscribeService, PricingTable,
 };
@@ -17,6 +17,9 @@ struct ApiStateInner {
     agent_chat: Arc<AgentChatService>,
     dictate: Arc<DictateService>,
     issue_reports: Arc<dyn IssueReportSink>,
+    /// None when OS-Guard is not configured. Tool Guard has no Venice
+    /// equivalent, so its endpoints fail cleanly instead of falling back.
+    tool_guard: Option<Arc<dyn ToolGuardAnalyzer>>,
     limits: ApiLimits,
     attestation: AttestationInfo,
 }
@@ -47,6 +50,7 @@ pub struct ApiStateParams {
     pub agent_chat: Arc<AgentChatService>,
     pub dictate: Arc<DictateService>,
     pub issue_reports: Arc<dyn IssueReportSink>,
+    pub tool_guard: Option<Arc<dyn ToolGuardAnalyzer>>,
     pub limits: ApiLimits,
     pub attestation: AttestationInfo,
 }
@@ -62,6 +66,7 @@ impl ApiState {
                 agent_chat: params.agent_chat,
                 dictate: params.dictate,
                 issue_reports: params.issue_reports,
+                tool_guard: params.tool_guard,
                 limits: params.limits,
                 attestation: params.attestation,
             }),
@@ -94,6 +99,10 @@ impl ApiState {
 
     pub(crate) fn issue_reports(&self) -> &dyn IssueReportSink {
         self.inner.issue_reports.as_ref()
+    }
+
+    pub(crate) fn tool_guard(&self) -> Option<&dyn ToolGuardAnalyzer> {
+        self.inner.tool_guard.as_deref()
     }
 
     pub(crate) fn limits(&self) -> ApiLimits {

--- a/scribe-api/crates/api/tests/http_boundary.rs
+++ b/scribe-api/crates/api/tests/http_boundary.rs
@@ -11,7 +11,9 @@ use scribe_domain::{
     AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe, AuthError,
     Authorization, AuthorizeRequest, CleanedText, Cleaner, CleanupRequest, Credits, DomainError,
     GeneratedNote, GenerationRequest, Generator, IssueReport, IssueReportSink, OsAccountsClient,
-    Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest, UserId,
+    Receipt, TokenUsage, ToolGuardAnalysis, ToolGuardAnalyzer, ToolGuardCallAnalysisRequest,
+    ToolGuardRedactionPlan, ToolGuardResultAnalysisRequest, Transcriber, Transcript,
+    TranscriptionRequest, UserId,
 };
 use scribe_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps,
@@ -256,6 +258,144 @@ async fn integration_dictate_cleanup_returns_enveloped_response() -> Result<(), 
     Ok(())
 }
 
+fn tool_guard_call_body() -> serde_json::Value {
+    serde_json::json!({
+        "agentTurnId": "turn-1",
+        "toolCallId": "call-1",
+        "toolName": "web_lookup",
+        "destinationId": "web",
+        "destinationClass": "external_untrusted",
+        "arguments": { "query": "alice@example.com" },
+        "deadlineMs": 1000
+    })
+}
+
+fn tool_guard_result_body() -> serde_json::Value {
+    serde_json::json!({
+        "agentTurnId": "turn-1",
+        "toolCallId": "call-1",
+        "destinationId": "web",
+        "destinationClass": "external_untrusted",
+        "result": { "answer": "ok" },
+        "deadlineMs": 1000
+    })
+}
+
+#[tokio::test]
+async fn integration_tool_guard_call_requires_auth() -> Result<(), Box<dyn Error>> {
+    let tool_guard = Arc::new(RecordingToolGuard::default());
+    let router = router(test_state_with_tool_guard(tool_guard));
+
+    let response = oneshot(
+        &router,
+        json_request("/v1/tool-guard/calls", &tool_guard_call_body(), None)?,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body = response_json(response).await?;
+    assert_eq!(body["error_code"], 3001);
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_tool_guard_call_unconfigured_returns_unavailable() -> Result<(), Box<dyn Error>>
+{
+    // With no analyzer wired (OS-Guard unconfigured), the endpoint must fail
+    // cleanly as unavailable rather than falling back to anything.
+    let response = send(json_request(
+        "/v1/tool-guard/calls",
+        &tool_guard_call_body(),
+        Some(AUTHORIZATION),
+    )?)
+    .await;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], false);
+    assert_eq!(body["error_code"], 5031);
+    assert_eq!(body["message"], "tool_guard_unavailable");
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_tool_guard_call_relays_analysis_with_auth_identity()
+-> Result<(), Box<dyn Error>> {
+    let tool_guard = Arc::new(RecordingToolGuard::default());
+    let router = router(test_state_with_tool_guard(tool_guard.clone()));
+
+    // A client-supplied callerIdentity must be ignored: scribe sets it from the
+    // verified token (usr_test for the fake verifier).
+    let mut body = tool_guard_call_body();
+    body["callerIdentity"] = serde_json::json!("usr_spoofed");
+    let response = oneshot(
+        &router,
+        json_request("/v1/tool-guard/calls", &body, Some(AUTHORIZATION))?,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    assert_eq!(json["success"], true);
+    assert_eq!(json["data"]["request_id"], "req-test");
+    assert_eq!(
+        tool_guard.last_caller_identity(),
+        Some("usr_test".to_string())
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_tool_guard_result_relays_analysis_with_auth_identity()
+-> Result<(), Box<dyn Error>> {
+    let tool_guard = Arc::new(RecordingToolGuard::default());
+    let router = router(test_state_with_tool_guard(tool_guard.clone()));
+
+    let response = oneshot(
+        &router,
+        json_request(
+            "/v1/tool-guard/results",
+            &tool_guard_result_body(),
+            Some(AUTHORIZATION),
+        )?,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = response_json(response).await?;
+    assert_eq!(json["data"]["request_id"], "req-test");
+    assert_eq!(
+        tool_guard.last_caller_identity(),
+        Some("usr_test".to_string())
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_tool_guard_call_rejects_missing_fields() -> Result<(), Box<dyn Error>> {
+    let tool_guard = Arc::new(RecordingToolGuard::default());
+    let router = router(test_state_with_tool_guard(tool_guard));
+
+    let response = oneshot(
+        &router,
+        json_request(
+            "/v1/tool-guard/calls",
+            &serde_json::json!({ "toolName": "web_lookup" }),
+            Some(AUTHORIZATION),
+        )?,
+    )
+    .await;
+
+    // A malformed body is rejected before any forward to the gateway.
+    assert!(
+        response.status() == StatusCode::BAD_REQUEST
+            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+        "unexpected status: {}",
+        response.status()
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn integration_verify_page_is_public_html() -> Result<(), Box<dyn Error>> {
     let response = send(get_request("/verify")?).await;
@@ -322,18 +462,31 @@ fn test_state() -> ApiState {
 }
 
 fn test_state_with_attestation(attestation: AttestationInfo) -> ApiState {
-    test_state_with_sinks(Arc::new(RecordingIssueReportSink::default()), attestation)
+    test_state_with_sinks(
+        Arc::new(RecordingIssueReportSink::default()),
+        None,
+        attestation,
+    )
 }
 
 fn test_state_with_issue_sink(
     issue_reports: Arc<dyn IssueReportSink>,
     attestation: AttestationInfo,
 ) -> ApiState {
-    test_state_with_sinks(issue_reports, attestation)
+    test_state_with_sinks(issue_reports, None, attestation)
+}
+
+fn test_state_with_tool_guard(tool_guard: Arc<dyn ToolGuardAnalyzer>) -> ApiState {
+    test_state_with_sinks(
+        Arc::new(RecordingIssueReportSink::default()),
+        Some(tool_guard),
+        test_attestation(),
+    )
 }
 
 fn test_state_with_sinks(
     issue_reports: Arc<dyn IssueReportSink>,
+    tool_guard: Option<Arc<dyn ToolGuardAnalyzer>>,
     attestation: AttestationInfo,
 ) -> ApiState {
     let pricing = Arc::new(PricingTable::new(models()));
@@ -381,6 +534,7 @@ fn test_state_with_sinks(
             flat_estimate_credits: 1_000,
         })),
         issue_reports,
+        tool_guard,
         limits: ApiLimits {
             max_audio_bytes: 1024 * 1024,
             max_json_bytes: 1024 * 1024,
@@ -436,6 +590,13 @@ fn models() -> BTreeMap<String, ModelPriceConfig> {
 
 async fn send(request: Request<Body>) -> axum::response::Response {
     match test_router().oneshot(request).await {
+        Ok(response) => response,
+        Err(error) => match error {},
+    }
+}
+
+async fn oneshot(router: &Router, request: Request<Body>) -> axum::response::Response {
+    match router.clone().oneshot(request).await {
         Ok(response) => response,
         Err(error) => match error {},
     }
@@ -671,6 +832,57 @@ impl Cleaner for FakeCleaner {
                 completion_tokens: 100,
             },
         })
+    }
+}
+
+/// Records the `caller_identity` scribe forwarded so tests can assert it came
+/// from auth rather than the request body, and returns a fixed analysis.
+#[derive(Default)]
+struct RecordingToolGuard {
+    last_caller_identity: Mutex<Option<String>>,
+}
+
+impl RecordingToolGuard {
+    fn last_caller_identity(&self) -> Option<String> {
+        self.last_caller_identity
+            .lock()
+            .ok()
+            .and_then(|value| value.clone())
+    }
+
+    fn fixed_analysis() -> ToolGuardAnalysis {
+        ToolGuardAnalysis {
+            request_id: "req-test".to_string(),
+            canonical_request_hash: "hash".to_string(),
+            findings: Vec::new(),
+            advisories: Vec::new(),
+            redaction_plan: ToolGuardRedactionPlan {
+                operations: Vec::new(),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl ToolGuardAnalyzer for RecordingToolGuard {
+    async fn analyze_call(
+        &self,
+        request: ToolGuardCallAnalysisRequest,
+    ) -> Result<ToolGuardAnalysis, DomainError> {
+        if let Ok(mut last) = self.last_caller_identity.lock() {
+            *last = Some(request.caller_identity);
+        }
+        Ok(Self::fixed_analysis())
+    }
+
+    async fn analyze_result(
+        &self,
+        request: ToolGuardResultAnalysisRequest,
+    ) -> Result<ToolGuardAnalysis, DomainError> {
+        if let Ok(mut last) = self.last_caller_identity.lock() {
+            *last = Some(request.caller_identity);
+        }
+        Ok(Self::fixed_analysis())
     }
 }
 

--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -6,9 +6,9 @@ use scribe_config::{
 };
 use scribe_providers::{
     JwksTokenVerifier, LocalDevOsAccountsClient, LocalDevTokenVerifier, LogIssueReportSink,
-    MultiFormatDurationProbe, OsAccountsHttpClient, OsPlatformIssueReportSink, RoutingTranscriber,
-    VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog, WebhookIssueReportSink,
-    default_client, jwks_client,
+    MultiFormatDurationProbe, OsAccountsHttpClient, OsGuardToolGuard, OsPlatformIssueReportSink,
+    RoutingTranscriber, VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog,
+    WebhookIssueReportSink, default_client, jwks_client,
 };
 use scribe_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps,
@@ -111,6 +111,7 @@ fn build_router(
         Arc::new(MultiFormatDurationProbe);
     let token_verifier = build_token_verifier(config);
     let issue_reports = build_issue_report_sink(config, http);
+    let tool_guard = build_tool_guard(config, http);
 
     let flat_estimate_credits = config.os_accounts.flat_estimate_credits;
 
@@ -158,6 +159,7 @@ fn build_router(
         agent_chat,
         dictate,
         issue_reports,
+        tool_guard,
         limits: ApiLimits {
             max_audio_bytes: config.server.max_audio_bytes,
             max_json_bytes: config.server.max_json_bytes,
@@ -186,6 +188,25 @@ fn build_os_accounts_client(
             &config.os_accounts,
         ))
     }
+}
+
+/// Builds the Tool Guard analyzer, but only when OS-Guard is configured. Tool
+/// Guard has no Venice equivalent, so an unset `osguard.base_url` leaves the
+/// feature off and its endpoints return a clean "unavailable" error rather than
+/// falling back to a provider that cannot perform detection.
+fn build_tool_guard(
+    config: &AppConfig,
+    http: &reqwest::Client,
+) -> Option<Arc<dyn scribe_domain::ToolGuardAnalyzer>> {
+    if config.upstreams.osguard.base_url.trim().is_empty() {
+        tracing::info!("OS-Guard is not configured; Tool Guard endpoints are disabled");
+        return None;
+    }
+    tracing::info!("OS-Guard Tool Guard enabled");
+    Some(Arc::new(OsGuardToolGuard::from_config(
+        http.clone(),
+        &config.upstreams.osguard,
+    )))
 }
 
 fn build_token_verifier(config: &AppConfig) -> Arc<dyn scribe_domain::TokenVerifier> {

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::{fmt, time::Duration};
 use thiserror::Error;
 
@@ -240,6 +241,108 @@ impl std::fmt::Debug for IssueReportAttachment {
     }
 }
 
+/// Where a tool call ultimately routes. Mirrors the OS-Guard Tool Guard
+/// contract verbatim so the value the desktop client supplies is forwarded
+/// unchanged. Detection only — the class never grants or denies access here.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolDestinationClass {
+    InternalTdx,
+    TrustedUserConnector,
+    ExternalUntrusted,
+}
+
+/// A tool-call analysis request as forwarded to OS-Guard. `caller_identity` is
+/// populated by scribe from the authenticated principal and is never taken from
+/// the client body. `arguments` may contain PII and must never be logged.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ToolGuardCallAnalysisRequest {
+    pub caller_identity: String,
+    pub agent_turn_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub destination_id: String,
+    pub destination_class: ToolDestinationClass,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_schema_ref: Option<String>,
+    pub arguments: Value,
+    pub deadline_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_context: Option<Value>,
+}
+
+/// A tool-result analysis request as forwarded to OS-Guard. As with the call
+/// request, `caller_identity` comes from auth and `result` may contain PII.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ToolGuardResultAnalysisRequest {
+    pub caller_identity: String,
+    pub agent_turn_id: String,
+    pub tool_call_id: String,
+    pub destination_id: String,
+    pub destination_class: ToolDestinationClass,
+    pub result: Value,
+    pub deadline_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_context: Option<Value>,
+}
+
+/// Detection analysis returned by OS-Guard for both calls and results: PII
+/// findings, prompt-injection/jailbreak advisories, and the redaction
+/// operations the client applies locally. Carried as opaque JSON-faithful
+/// structures the client interprets; scribe only relays it. There is no guard
+/// token, no allow/block decision, and no approval round-trip.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ToolGuardAnalysis {
+    pub request_id: String,
+    pub canonical_request_hash: String,
+    #[serde(default)]
+    pub findings: Vec<ToolGuardPiiFinding>,
+    #[serde(default)]
+    pub advisories: Vec<ToolGuardAdvisory>,
+    pub redaction_plan: ToolGuardRedactionPlan,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ToolGuardPiiFinding {
+    pub finding_id: String,
+    pub pii_type: String,
+    pub confidence_bucket: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    #[serde(default)]
+    pub source_roles: Vec<String>,
+    pub locator: Value,
+    pub range: Value,
+    pub replacement: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ToolGuardAdvisory {
+    pub advisory_id: String,
+    pub advisory_type: String,
+    pub confidence_bucket: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    #[serde(default)]
+    pub source_roles: Vec<String>,
+    #[serde(default)]
+    pub categories: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ToolGuardRedactionPlan {
+    #[serde(default)]
+    pub operations: Vec<ToolGuardRedactionOperation>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ToolGuardRedactionOperation {
+    pub finding_id: String,
+    pub locator: Value,
+    pub range: Value,
+    pub replacement: String,
+}
+
 #[derive(Debug, Error, Eq, PartialEq)]
 pub enum DomainError {
     #[error("model is not priced")]
@@ -291,6 +394,23 @@ pub trait OsAccountsClient: Send + Sync {
     async fn authorize(&self, request: AuthorizeRequest) -> Result<Authorization, DomainError>;
 
     async fn charge(&self, request: ChargeRequest) -> Result<Receipt, DomainError>;
+}
+
+/// Proxies OS-Guard Tool Guard's detection-only analysis. scribe forwards the
+/// request with the server-side gateway token and relays the analysis back to
+/// the desktop client, which applies the redaction operations and surfaces the
+/// advisories locally. Detection only: no tool execution, no decision.
+#[async_trait]
+pub trait ToolGuardAnalyzer: Send + Sync {
+    async fn analyze_call(
+        &self,
+        request: ToolGuardCallAnalysisRequest,
+    ) -> Result<ToolGuardAnalysis, DomainError>;
+
+    async fn analyze_result(
+        &self,
+        request: ToolGuardResultAnalysisRequest,
+    ) -> Result<ToolGuardAnalysis, DomainError>;
 }
 
 #[async_trait]

--- a/scribe-api/crates/providers/src/lib.rs
+++ b/scribe-api/crates/providers/src/lib.rs
@@ -9,6 +9,7 @@ pub mod m4a_probe;
 pub mod openai;
 pub mod os_accounts;
 pub mod routing;
+pub mod tool_guard;
 pub mod venice;
 pub mod wav_probe;
 
@@ -24,6 +25,7 @@ pub use m4a_probe::{M4aDurationProbe, M4aProbeError};
 pub use openai::OpenAiTranscriber;
 pub use os_accounts::OsAccountsHttpClient;
 pub use routing::RoutingTranscriber;
+pub use tool_guard::OsGuardToolGuard;
 pub use venice::{
     VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog, VeniceTranscriber,
 };

--- a/scribe-api/crates/providers/src/tool_guard.rs
+++ b/scribe-api/crates/providers/src/tool_guard.rs
@@ -1,0 +1,337 @@
+use crate::retry::{self, UpstreamAttemptError};
+use async_trait::async_trait;
+use scribe_config::UpstreamConfig;
+use scribe_domain::{
+    DomainError, ToolGuardAnalysis, ToolGuardAnalyzer, ToolGuardCallAnalysisRequest,
+    ToolGuardResultAnalysisRequest,
+};
+use serde::Serialize;
+
+pub const PROVIDER_NAME: &str = "osguard";
+
+const CALLS_PATH: &str = "/tool-guard/calls";
+const RESULTS_PATH: &str = "/tool-guard/results";
+
+/// HTTP client for OS-Guard's detection-only Tool Guard endpoints. scribe holds
+/// the server-side gateway token; the desktop client never sees it. Requests
+/// are forwarded with `Authorization: Bearer <gateway token>` and the analysis
+/// is relayed back unchanged. scribe does not execute tools, apply redaction
+/// operations, or decide — it only proxies the analysis.
+pub struct OsGuardToolGuard {
+    http: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl OsGuardToolGuard {
+    pub fn from_config(http: reqwest::Client, config: &UpstreamConfig) -> Self {
+        Self {
+            http,
+            api_key: config.api_key.clone(),
+            base_url: config.base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    /// POSTs `body` to `path` under the gateway base URL with the bounded retry
+    /// the other upstream calls use. Audit-safe by construction: the request
+    /// body (which may carry PII in `arguments`/`result`) is serialized once and
+    /// never logged — only the path, status, and counts appear in traces.
+    async fn analyze<B: Serialize>(
+        &self,
+        path: &str,
+        operation: &str,
+        body: &B,
+    ) -> Result<ToolGuardAnalysis, DomainError> {
+        let url = format!("{}{}", self.base_url, path);
+        for attempt in 0..retry::UPSTREAM_ATTEMPTS {
+            let error = match self.analyze_once(&url, body).await {
+                Ok(analysis) => return Ok(analysis),
+                Err(error) => error,
+            };
+            if error.retryable && attempt + 1 < retry::UPSTREAM_ATTEMPTS {
+                tracing::warn!(
+                    %url,
+                    operation,
+                    attempt,
+                    "tool-guard: transient upstream failure, retrying"
+                );
+                tokio::time::sleep(retry::UPSTREAM_RETRY_BACKOFF).await;
+                continue;
+            }
+            return Err(error.error);
+        }
+        Err(DomainError::UpstreamProvider)
+    }
+
+    async fn analyze_once<B: Serialize>(
+        &self,
+        url: &str,
+        body: &B,
+    ) -> Result<ToolGuardAnalysis, UpstreamAttemptError> {
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .json(body)
+            .send()
+            .await
+            .map_err(|error| {
+                let retryable = retry::is_retryable_transport_error(&error);
+                tracing::error!(%error, %url, retryable, "tool-guard: transport error");
+                UpstreamAttemptError {
+                    error: DomainError::UpstreamProvider,
+                    retryable,
+                }
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let error = status_error(status);
+            // Only the generic upstream failure is worth replaying; a 400/403
+            // is deterministic and must not be retried.
+            let retryable =
+                error == DomainError::UpstreamProvider && retry::is_retryable_status(status);
+            // The error body may echo request fragments, so it is not logged.
+            let _ = response.bytes().await;
+            tracing::error!(%status, %url, retryable, "tool-guard: non-success response");
+            return Err(UpstreamAttemptError { error, retryable });
+        }
+        response
+            .json::<ToolGuardAnalysis>()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, %url, "tool-guard: response JSON parse failed");
+                UpstreamAttemptError::fatal(DomainError::UpstreamProvider)
+            })
+    }
+}
+
+#[async_trait]
+impl ToolGuardAnalyzer for OsGuardToolGuard {
+    async fn analyze_call(
+        &self,
+        request: ToolGuardCallAnalysisRequest,
+    ) -> Result<ToolGuardAnalysis, DomainError> {
+        self.analyze(CALLS_PATH, "calls", &request).await
+    }
+
+    async fn analyze_result(
+        &self,
+        request: ToolGuardResultAnalysisRequest,
+    ) -> Result<ToolGuardAnalysis, DomainError> {
+        self.analyze(RESULTS_PATH, "results", &request).await
+    }
+}
+
+/// Classifies a non-success status from the gateway. `403` is a policy block
+/// (deterministic, never retried, never billed); `400` is a bad/expired request
+/// surfaced to the client as invalid input; everything else maps to the generic
+/// upstream error, whose retryability the caller derives from the status.
+fn status_error(status: reqwest::StatusCode) -> DomainError {
+    match status {
+        reqwest::StatusCode::FORBIDDEN => DomainError::PolicyBlocked,
+        reqwest::StatusCode::BAD_REQUEST => DomainError::InvalidInput {
+            reason: "tool_guard_request_rejected".to_string(),
+        },
+        _ => DomainError::UpstreamProvider,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OsGuardToolGuard;
+    use crate::http;
+    use pretty_assertions::assert_eq;
+    use scribe_config::UpstreamConfig;
+    use scribe_domain::{
+        DomainError, ToolDestinationClass, ToolGuardAnalyzer, ToolGuardCallAnalysisRequest,
+        ToolGuardResultAnalysisRequest,
+    };
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_string_contains, header, method, path},
+    };
+
+    fn call_request() -> ToolGuardCallAnalysisRequest {
+        ToolGuardCallAnalysisRequest {
+            caller_identity: "usr_123".to_string(),
+            agent_turn_id: "turn-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "web_lookup".to_string(),
+            destination_id: "web".to_string(),
+            destination_class: ToolDestinationClass::ExternalUntrusted,
+            tool_schema_ref: Some("schema:web_lookup:v1".to_string()),
+            arguments: json!({ "query": "alice@example.com" }),
+            deadline_ms: 1000,
+            policy_context: None,
+        }
+    }
+
+    fn result_request() -> ToolGuardResultAnalysisRequest {
+        ToolGuardResultAnalysisRequest {
+            caller_identity: "usr_123".to_string(),
+            agent_turn_id: "turn-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            destination_id: "web".to_string(),
+            destination_class: ToolDestinationClass::ExternalUntrusted,
+            result: json!({ "answer": "ok" }),
+            deadline_ms: 1000,
+            policy_context: None,
+        }
+    }
+
+    fn analysis_body() -> serde_json::Value {
+        json!({
+            "request_id": "req-1",
+            "canonical_request_hash": "hash",
+            "findings": [
+                {
+                    "finding_id": "finding-1",
+                    "pii_type": "email",
+                    "confidence_bucket": "high",
+                    "score": 0.98,
+                    "source_roles": ["pii_primary"],
+                    "locator": { "target": "value", "path": [] },
+                    "range": { "start": 6, "end": 23, "unit": "unicode_codepoint" },
+                    "replacement": "[[OSG.EMAIL.1]]"
+                }
+            ],
+            "advisories": [
+                {
+                    "advisory_id": "advisory-1",
+                    "advisory_type": "prompt_injection",
+                    "confidence_bucket": "high",
+                    "source_roles": ["injection"],
+                    "categories": ["prompt_injection"]
+                }
+            ],
+            "redaction_plan": {
+                "operations": [
+                    {
+                        "finding_id": "finding-1",
+                        "locator": { "target": "value", "path": [] },
+                        "range": { "start": 6, "end": 23, "unit": "unicode_codepoint" },
+                        "replacement": "[[OSG.EMAIL.1]]"
+                    }
+                ]
+            }
+        })
+    }
+
+    fn client(server: &MockServer) -> OsGuardToolGuard {
+        OsGuardToolGuard::from_config(
+            http::default_client(),
+            &UpstreamConfig {
+                api_key: "gateway_token".to_string(),
+                base_url: server.uri(),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn analyze_call_forwards_token_and_relays_analysis() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool-guard/calls"))
+            .and(header("authorization", "Bearer gateway_token"))
+            .and(body_string_contains("\"caller_identity\":\"usr_123\""))
+            .respond_with(ResponseTemplate::new(200).set_body_json(analysis_body()))
+            .mount(&server)
+            .await;
+
+        let analysis = client(&server)
+            .analyze_call(call_request())
+            .await
+            .expect("call analysis succeeds");
+
+        assert_eq!(analysis.request_id, "req-1");
+        assert_eq!(analysis.findings.len(), 1);
+        assert_eq!(analysis.findings[0].replacement, "[[OSG.EMAIL.1]]");
+        assert_eq!(analysis.advisories[0].advisory_type, "prompt_injection");
+        assert_eq!(analysis.redaction_plan.operations.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn analyze_result_relays_analysis() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool-guard/results"))
+            .and(header("authorization", "Bearer gateway_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "request_id": "req-2",
+                "canonical_request_hash": "hash",
+                "redaction_plan": { "operations": [] }
+            })))
+            .mount(&server)
+            .await;
+
+        let analysis = client(&server)
+            .analyze_result(result_request())
+            .await
+            .expect("result analysis succeeds");
+
+        assert_eq!(analysis.request_id, "req-2");
+        assert!(analysis.findings.is_empty());
+        assert!(analysis.advisories.is_empty());
+        assert!(analysis.redaction_plan.operations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn policy_block_maps_to_policy_blocked_without_retry() {
+        // A 403 from the gateway is a deterministic policy block: it must surface
+        // as PolicyBlocked and must not be retried.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool-guard/calls"))
+            .respond_with(ResponseTemplate::new(403))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = client(&server).analyze_call(call_request()).await;
+
+        assert_eq!(result.map(|_| ()), Err(DomainError::PolicyBlocked));
+    }
+
+    #[tokio::test]
+    async fn bad_request_maps_to_invalid_input_without_retry() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool-guard/calls"))
+            .respond_with(ResponseTemplate::new(400))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = client(&server).analyze_call(call_request()).await;
+
+        assert!(matches!(result, Err(DomainError::InvalidInput { .. })));
+    }
+
+    #[tokio::test]
+    async fn transient_503_is_retried_then_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/tool-guard/calls"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/tool-guard/calls"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "request_id": "req-3",
+                "canonical_request_hash": "hash",
+                "redaction_plan": { "operations": [] }
+            })))
+            .mount(&server)
+            .await;
+
+        let analysis = client(&server)
+            .analyze_call(call_request())
+            .await
+            .expect("retry recovers");
+
+        assert_eq!(analysis.request_id, "req-3");
+    }
+}


### PR DESCRIPTION
## Summary

Adds OS-Guard **Tool Guard** support to scribe-api as a thin authenticated proxy.

Tools execute in the desktop client, not in scribe. The client does not hold the OS-Guard gateway token (it is server-side in scribe) and already routes through scribe for auth/billing. So scribe proxies OS-Guard's detection-only Tool Guard: the client calls scribe, scribe forwards to OS-Guard with the server-side gateway token, and relays the analysis back. The client then applies the redaction operations locally and surfaces advisories to the user.

scribe is a relay only: it does **not** execute tools, does **not** apply redaction operations, and does **not** make an allow/block decision. It forwards detection results. There are no guard tokens and no approval round-trip — this mirrors the detection-only contract.

This is stacked on `alex/osguard-integration` and reuses the `[upstreams.osguard]` upstream (base URL + gateway token) that branch already added.

## New endpoints

Both sit behind scribe's normal bearer auth and return the standard response envelope (`{ success, data, error_code, message }`). The `data` payload is the OS-Guard analysis verbatim (snake_case, matching the OS-Guard contract).

### `POST /v1/tool-guard/calls`
Analyzes pending tool-call arguments before execution.

Request body (camelCase; `callerIdentity` is intentionally NOT accepted — scribe sets it from the authenticated principal):
```
{
  "agentTurnId": "turn-1",
  "toolCallId": "call-1",
  "toolName": "web_lookup",
  "destinationId": "web",
  "destinationClass": "external_untrusted",  // internal_tdx | trusted_user_connector | external_untrusted
  "toolSchemaRef": "schema:web_lookup:v1",   // optional
  "arguments": { ... },                       // arbitrary JSON
  "deadlineMs": 1000,
  "policyContext": { ... }                    // optional
}
```

### `POST /v1/tool-guard/results`
Analyzes tool output before model-context reinjection. Same fields minus `toolName`/`toolSchemaRef`, with `result` (arbitrary JSON) in place of `arguments`.

### Response (`data`) for both
```
{
  "request_id": "...",
  "canonical_request_hash": "...",
  "findings": [ { finding_id, pii_type, confidence_bucket, score?, source_roles, locator, range, replacement } ],
  "advisories": [ { advisory_id, advisory_type, confidence_bucket, score?, source_roles, categories } ],
  "redaction_plan": { "operations": [ { finding_id, locator, range, replacement } ] }
}
```

## Behavior

- **caller_identity from auth, never the body.** The request DTOs omit it; scribe populates it from the verified token. A client-supplied `callerIdentity` is ignored (covered by a test).
- **OS-Guard required, no fallback.** Tool Guard has no Venice equivalent. When `upstreams.osguard.base_url` is empty the analyzer is not built and both endpoints return `503 tool_guard_unavailable` (error code `5031`) rather than falling back to anything.
- **Error mapping.** The provider client maps non-2xx from the gateway: `403` -> `PolicyBlocked` (403 `policy_blocked`, deterministic, not retried), `400` -> `InvalidInput` (400 bad request), transient (timeout/429/5xx) -> `UpstreamProvider` (502, retried once via the existing bounded retry/backoff helpers). A `403` is never retried.
- **Privacy / no payload logging.** Raw tool arguments and results may contain PII and are never logged. Traces carry only ids, status, counts, and the path — the same audit-safe pattern the existing providers use. The gateway error body is read and discarded without logging since it may echo request fragments.

## Billing

Tool Guard analysis returns no token usage, so there is no usage-based charge and the endpoints do not touch the metering/charge flow. Per-call (flat-fee) metering for Tool Guard is left as an open product decision: the codebase has no natural flat-fee mechanism to reuse cleanly for it, so wiring one in would be inventing a price. If a flat per-call fee is wanted later, it would slot in at the handler via the existing `OsAccountsClient` authorize/charge path, keyed by an idempotency key built from the correlation ids.

## Tests

- Provider client (wiremock): calls/results happy path relays the analysis and forwards the bearer token; `403` -> `PolicyBlocked` with no retry; `400` -> `InvalidInput` with no retry; transient `503` retried then succeeds.
- HTTP boundary: auth required; osguard-unconfigured -> `503 tool_guard_unavailable`; `caller_identity` comes from auth and a spoofed body value is ignored; success relays the analysis for both endpoints; malformed body rejected before any forward.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features --locked -- -D warnings`, and `cargo test --all-targets --all-features --locked` all pass (the three jobs scribe-api CI runs).
