### PR TITLE
Fix meeting live transcript preview

### DIFF
--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -47,7 +47,7 @@ pub(crate) async fn transcribe(
     )?;
     // This client field is not an authorization decision. It only requests
     // live-preview semantics; NoteTranscribeService still probes duration,
-    // enforces the preview cap, and authorizes with OS Accounts before ASR.
+    // enforces the preview cap, and returns a no-charge preview receipt.
     let preview = parse_preview_flag(form.optional_text("preview").as_deref());
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;

--- a/scribe-api/crates/api/src/handlers/notes.rs
+++ b/scribe-api/crates/api/src/handlers/notes.rs
@@ -47,7 +47,7 @@ pub(crate) async fn transcribe(
     )?;
     // This client field is not an authorization decision. It only requests
     // live-preview semantics; NoteTranscribeService still probes duration,
-    // enforces the preview cap, and returns a no-charge preview receipt.
+    // enforces the preview cap, and gates ASR through OS Accounts.
     let preview = parse_preview_flag(form.optional_text("preview").as_deref());
     let note_id = form.required_text("noteId")?;
     validation::validate_text_len("note_id", &note_id, validation::MAX_ID_CHARS)?;

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -522,6 +522,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_transcribe_preview_returns_transcript_when_zero_credit_settlement_fails() {
+        let os_accounts = Arc::new(RecordingOsAccounts {
+            fail_charge: true,
+            ..RecordingOsAccounts::default()
+        });
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "live-preview-session-1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "preview.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+            })
+            .await
+            .expect("preview transcript should not be hidden by zero-credit settlement failure");
+
+        assert_eq!(output.transcript.text, "Transcript");
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(transcriber.call_count(), 1);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 0,
+                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
+                        .to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn note_transcribe_preview_denied_authorization_does_not_dispatch_asr() {
         let os_accounts = Arc::new(RecordingOsAccounts {
             allow: false,
@@ -731,6 +789,7 @@ mod tests {
         allow: bool,
         cap: Option<u64>,
         deny_reason: Option<String>,
+        fail_charge: bool,
         events: Mutex<Vec<RecordedCall>>,
     }
 
@@ -740,6 +799,7 @@ mod tests {
                 allow: true,
                 cap: None,
                 deny_reason: None,
+                fail_charge: false,
                 events: Mutex::new(Vec::new()),
             }
         }
@@ -751,6 +811,7 @@ mod tests {
                 allow: true,
                 cap,
                 deny_reason: None,
+                fail_charge: false,
                 events: Mutex::new(Vec::new()),
             }
         }
@@ -789,6 +850,9 @@ mod tests {
                     credits: request.credits.0,
                     idempotency_key: request.idempotency_key,
                 });
+            }
+            if self.fail_charge {
+                return Err(DomainError::UpstreamProvider);
             }
             Ok(Receipt {
                 credits_charged: request.credits,

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -412,7 +412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_dispatches_asr_without_accounts_hold() {
+    async fn note_transcribe_preview_authorizes_dispatches_asr_and_charges_actual_credits() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -444,8 +444,24 @@ mod tests {
             .await
             .expect("preview transcription succeeds");
 
-        assert_eq!(output.receipt.credits_charged.0, 0);
-        assert_eq!(os_accounts.events(), Vec::new());
+        assert_eq!(output.receipt.credits_charged.0, 4);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 4,
+                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
+                        .to_string(),
+                },
+            ]
+        );
         assert_eq!(transcriber.call_count(), 1);
         assert_eq!(
             transcriber.last_context(),
@@ -455,7 +471,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_failure_does_not_create_accounts_hold() {
+    async fn note_transcribe_preview_failure_still_settles_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
             pricing: Arc::new(PricingTable::new(models([(
@@ -486,11 +502,27 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
-        assert_eq!(os_accounts.events(), Vec::new());
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "note_transcribe".to_string(),
+                    estimate: 1024,
+                    hold_ttl: 60,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 4,
+                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
+                        .to_string(),
+                },
+            ]
+        );
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_does_not_require_accounts_authorization() {
+    async fn note_transcribe_preview_denied_authorization_does_not_dispatch_asr() {
         let os_accounts = Arc::new(RecordingOsAccounts {
             allow: false,
             deny_reason: Some("insufficient_available_balance".to_string()),
@@ -512,7 +544,7 @@ mod tests {
             preview_max_audio_seconds: 30,
         });
 
-        let output = service
+        let result = service
             .transcribe(NoteTranscribeParams {
                 user_id: UserId("usr_123".to_string()),
                 note_id: "live-preview-session-1".to_string(),
@@ -523,13 +555,19 @@ mod tests {
                 model_id: ModelId("audio-model".to_string()),
                 preview: true,
             })
-            .await
-            .expect("preview transcript should not create an accounts hold");
+            .await;
 
-        assert_eq!(output.transcript.text, "Transcript");
-        assert_eq!(output.receipt.credits_charged.0, 0);
-        assert_eq!(transcriber.call_count(), 1);
-        assert_eq!(os_accounts.events(), Vec::new());
+        assert!(matches!(result, Err(ServiceError::InsufficientCredits)));
+        assert_eq!(transcriber.call_count(), 0);
+        assert_eq!(
+            os_accounts.events(),
+            vec![RecordedCall::Authorize {
+                user_id: "usr_123".to_string(),
+                action: "note_transcribe".to_string(),
+                estimate: 1024,
+                hold_ttl: 60,
+            }]
+        );
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -412,7 +412,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_authorizes_dispatches_asr_and_settles_zero_credits() {
+    async fn note_transcribe_preview_dispatches_asr_without_accounts_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let transcriber = Arc::new(RecordingTranscriber::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -445,23 +445,7 @@ mod tests {
             .expect("preview transcription succeeds");
 
         assert_eq!(output.receipt.credits_charged.0, 0);
-        assert_eq!(
-            os_accounts.events(),
-            vec![
-                RecordedCall::Authorize {
-                    user_id: "usr_123".to_string(),
-                    action: "note_transcribe".to_string(),
-                    estimate: 1024,
-                    hold_ttl: 60,
-                },
-                RecordedCall::Charge {
-                    action_token: "agt_test".to_string(),
-                    credits: 0,
-                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
-                        .to_string(),
-                },
-            ]
-        );
+        assert_eq!(os_accounts.events(), Vec::new());
         assert_eq!(transcriber.call_count(), 1);
         assert_eq!(
             transcriber.last_context(),
@@ -471,7 +455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_settles_zero_credits_when_asr_fails() {
+    async fn note_transcribe_preview_failure_does_not_create_accounts_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
             pricing: Arc::new(PricingTable::new(models([(
@@ -502,29 +486,14 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(ServiceError::UpstreamProvider)));
-        assert_eq!(
-            os_accounts.events(),
-            vec![
-                RecordedCall::Authorize {
-                    user_id: "usr_123".to_string(),
-                    action: "note_transcribe".to_string(),
-                    estimate: 1024,
-                    hold_ttl: 60,
-                },
-                RecordedCall::Charge {
-                    action_token: "agt_test".to_string(),
-                    credits: 0,
-                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
-                        .to_string(),
-                },
-            ]
-        );
+        assert_eq!(os_accounts.events(), Vec::new());
     }
 
     #[tokio::test]
-    async fn note_transcribe_preview_returns_transcript_when_zero_credit_settlement_fails() {
+    async fn note_transcribe_preview_does_not_require_accounts_authorization() {
         let os_accounts = Arc::new(RecordingOsAccounts {
-            fail_charge: true,
+            allow: false,
+            deny_reason: Some("insufficient_available_balance".to_string()),
             ..RecordingOsAccounts::default()
         });
         let transcriber = Arc::new(RecordingTranscriber::default());
@@ -555,77 +524,12 @@ mod tests {
                 preview: true,
             })
             .await
-            .expect("preview transcript should not be hidden by zero-credit settlement failure");
+            .expect("preview transcript should not create an accounts hold");
 
         assert_eq!(output.transcript.text, "Transcript");
         assert_eq!(output.receipt.credits_charged.0, 0);
         assert_eq!(transcriber.call_count(), 1);
-        assert_eq!(
-            os_accounts.events(),
-            vec![
-                RecordedCall::Authorize {
-                    user_id: "usr_123".to_string(),
-                    action: "note_transcribe".to_string(),
-                    estimate: 1024,
-                    hold_ttl: 60,
-                },
-                RecordedCall::Charge {
-                    action_token: "agt_test".to_string(),
-                    credits: 0,
-                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
-                        .to_string(),
-                },
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn note_transcribe_preview_denied_authorization_does_not_dispatch_asr() {
-        let os_accounts = Arc::new(RecordingOsAccounts {
-            allow: false,
-            deny_reason: Some("insufficient_available_balance".to_string()),
-            ..RecordingOsAccounts::default()
-        });
-        let transcriber = Arc::new(RecordingTranscriber::default());
-        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
-            pricing: Arc::new(PricingTable::new(models([(
-                "audio-model",
-                PriceUnit::Seconds,
-                2,
-                ModelType::Asr,
-            )]))),
-            os_accounts: os_accounts.clone(),
-            transcriber: transcriber.clone(),
-            duration_probe: Arc::new(FixedDurationProbe),
-            hold_ttl_seconds: 60,
-            flat_estimate_credits: 1024,
-            preview_max_audio_seconds: 30,
-        });
-
-        let result = service
-            .transcribe(NoteTranscribeParams {
-                user_id: UserId("usr_123".to_string()),
-                note_id: "live-preview-session-1".to_string(),
-                audio: vec![1, 2, 3],
-                filename: "preview.wav".to_string(),
-                context: None,
-                language: None,
-                model_id: ModelId("audio-model".to_string()),
-                preview: true,
-            })
-            .await;
-
-        assert!(matches!(result, Err(ServiceError::InsufficientCredits)));
-        assert_eq!(transcriber.call_count(), 0);
-        assert_eq!(
-            os_accounts.events(),
-            vec![RecordedCall::Authorize {
-                user_id: "usr_123".to_string(),
-                action: "note_transcribe".to_string(),
-                estimate: 1024,
-                hold_ttl: 60,
-            }]
-        );
+        assert_eq!(os_accounts.events(), Vec::new());
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -102,7 +102,8 @@ impl NoteTranscribeService {
             params,
             format,
             seconds,
-            ..
+            actual,
+            estimate,
         } = prepared;
         if seconds > self.preview_max_audio_seconds {
             return Err(ServiceError::InvalidInput {
@@ -112,13 +113,22 @@ impl NoteTranscribeService {
                 ),
             });
         }
+        let authorization = authorize_or_deny(AuthorizeParams {
+            os_accounts: self.os_accounts.as_ref(),
+            user_id: params.user_id.clone(),
+            action: ActionSlug::NoteTranscribe,
+            estimate,
+            hold_ttl_seconds: self.hold_ttl_seconds,
+        })
+        .await?;
         tracing::info!(
             note_id = %params.note_id,
             model = %params.model_id.0,
             seconds,
-            "note_transcribe: preview request accepted without metering hold"
+            estimate_credits = estimate.0,
+            "note_transcribe: preview request authorized"
         );
-        let transcript = self
+        let transcript_result = self
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
@@ -127,17 +137,28 @@ impl NoteTranscribeService {
                 language: params.language,
                 model: params.model_id.clone(),
             })
-            .await?;
+            .await;
+        let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
+        let idempotency_key = format!(
+            "note_transcribe_preview:{}:{}",
+            params.user_id.0, params.note_id
+        );
+        let receipt = charge(ChargeParams {
+            os_accounts: self.os_accounts.as_ref(),
+            action_token: authorization.action_token,
+            credits: charge_credits,
+            idempotency_key,
+        })
+        .await?;
         tracing::info!(
             note_id = %params.note_id,
-            "note_transcribe: preview transcriber returned"
+            credits_charged = receipt.credits_charged.0,
+            "note_transcribe: preview hold settled"
         );
+        let transcript = transcript_result?;
         Ok(NoteTranscribeOutput {
             transcript,
-            receipt: Receipt {
-                credits_charged: Credits(0),
-                idempotent_replay: false,
-            },
+            receipt,
         })
     }
 

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -143,13 +143,27 @@ impl NoteTranscribeService {
             })
             .await
             .map_err(ServiceError::from);
-        let receipt = charge(ChargeParams {
+        let receipt = match charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),
             action_token: authorization.action_token,
             credits: Credits(0),
             idempotency_key,
         })
-        .await?;
+        .await
+        {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                tracing::warn!(
+                    note_id = %params.note_id,
+                    error = %error,
+                    "note_transcribe: preview zero-credit settlement failed"
+                );
+                Receipt {
+                    credits_charged: Credits(0),
+                    idempotent_replay: false,
+                }
+            }
+        };
         let transcript = transcript_result?;
         tracing::info!(
             note_id = %params.note_id,

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -102,7 +102,6 @@ impl NoteTranscribeService {
             params,
             format,
             seconds,
-            estimate,
             ..
         } = prepared;
         if seconds > self.preview_max_audio_seconds {
@@ -113,26 +112,13 @@ impl NoteTranscribeService {
                 ),
             });
         }
-        let authorization = authorize_or_deny(AuthorizeParams {
-            os_accounts: self.os_accounts.as_ref(),
-            user_id: params.user_id.clone(),
-            action: ActionSlug::NoteTranscribe,
-            estimate,
-            hold_ttl_seconds: self.hold_ttl_seconds,
-        })
-        .await?;
         tracing::info!(
             note_id = %params.note_id,
             model = %params.model_id.0,
             seconds,
-            estimate_credits = estimate.0,
-            "note_transcribe: preview request authorized"
+            "note_transcribe: preview request accepted without metering hold"
         );
-        let idempotency_key = format!(
-            "note_transcribe_preview:{}:{}",
-            params.user_id.0, params.note_id
-        );
-        let transcript_result = self
+        let transcript = self
             .transcriber
             .transcribe(TranscriptionRequest {
                 audio: params.audio,
@@ -141,37 +127,17 @@ impl NoteTranscribeService {
                 language: params.language,
                 model: params.model_id.clone(),
             })
-            .await
-            .map_err(ServiceError::from);
-        let receipt = match charge(ChargeParams {
-            os_accounts: self.os_accounts.as_ref(),
-            action_token: authorization.action_token,
-            credits: Credits(0),
-            idempotency_key,
-        })
-        .await
-        {
-            Ok(receipt) => receipt,
-            Err(error) => {
-                tracing::warn!(
-                    note_id = %params.note_id,
-                    error = %error,
-                    "note_transcribe: preview zero-credit settlement failed"
-                );
-                Receipt {
-                    credits_charged: Credits(0),
-                    idempotent_replay: false,
-                }
-            }
-        };
-        let transcript = transcript_result?;
+            .await?;
         tracing::info!(
             note_id = %params.note_id,
-            "note_transcribe: preview hold settled with zero credits"
+            "note_transcribe: preview transcriber returned"
         );
         Ok(NoteTranscribeOutput {
             transcript,
-            receipt,
+            receipt: Receipt {
+                credits_charged: Credits(0),
+                idempotent_replay: false,
+            },
         })
     }
 

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,7 +1,10 @@
 use crate::{
     app_paths::AppPaths,
     audio::{
-        live_preview::{start_live_transcript_preview, LivePreviewController, LivePreviewSink},
+        live_preview::{
+            start_live_transcript_preview, start_system_live_transcript_preview,
+            LivePreviewController, LivePreviewSink, SystemLivePreviewController,
+        },
         system_macos::SystemAudioCapture,
     },
     domain::types::{
@@ -78,6 +81,8 @@ struct ActiveRecording {
     writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
     stats: Arc<Mutex<CaptureStats>>,
     live_preview: Option<LivePreviewController>,
+    system_live_preview: Option<SystemLivePreviewController>,
+    live_preview_enabled: bool,
     _stream: cpal::Stream,
 }
 
@@ -179,13 +184,15 @@ pub fn start_capture(
     let writer_for_callback = Arc::clone(&writer);
     let stats_for_callback = Arc::clone(&stats);
     let paused_for_callback = Arc::clone(&paused_flag);
-    let live_preview = if crate::scribe_api::configured() && crate::os_accounts::cached_signed_in()
-    {
+    let live_preview_available =
+        crate::scribe_api::configured() && crate::os_accounts::cached_signed_in();
+    let live_preview = if live_preview_available {
         Some(start_live_transcript_preview(
-            app,
+            app.clone(),
             note_id.clone(),
             session_id.clone(),
             source_mode,
+            RecordingSource::Microphone,
             sample_rate,
             channels,
         ))
@@ -247,6 +254,7 @@ pub fn start_capture(
         }
     }
     .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
+    let mut system_live_preview = None;
     let system_capture = if let (Some(system_partial_path), Some(system_final_path)) =
         (system_partial_path.clone(), system_final_path.clone())
     {
@@ -255,7 +263,18 @@ pub fn start_capture(
             system_final_path.clone(),
             Duration::ZERO,
         ) {
-            Ok(capture) => Some(capture),
+            Ok(capture) => {
+                if live_preview_available {
+                    system_live_preview = Some(start_system_live_transcript_preview(
+                        app.clone(),
+                        note_id.clone(),
+                        session_id.clone(),
+                        source_mode,
+                        system_partial_path,
+                    ));
+                }
+                Some(capture)
+            }
             Err(error) => {
                 if let Ok(mut writer_guard) = writer.lock() {
                     let _ = writer_guard.take();
@@ -267,6 +286,7 @@ pub fn start_capture(
     } else {
         None
     };
+    let live_preview_enabled = live_preview.is_some() || system_live_preview.is_some();
     stream
         .play()
         .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
@@ -285,6 +305,7 @@ pub fn start_capture(
         },
         silence_warning: false,
         bytes_written: 0,
+        live_preview_enabled,
         sources: source_statuses(
             source_mode,
             RecordingState::Recording,
@@ -313,6 +334,8 @@ pub fn start_capture(
         writer,
         stats,
         live_preview,
+        system_live_preview,
+        live_preview_enabled,
         _stream: stream,
     });
 
@@ -421,6 +444,7 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
         elapsed_ms: status.elapsed_ms,
         device_label: None,
         level: status.level,
+        live_preview_enabled: recording.live_preview_enabled,
         sources: status.sources,
         warnings: status.warnings,
     };
@@ -435,12 +459,16 @@ fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, A
         writer,
         paused_flag,
         live_preview,
+        system_live_preview,
         _stream,
         ..
     } = recording;
     paused_flag.store(true, Ordering::Release);
     if let Some(live_preview) = live_preview {
         live_preview.cancel();
+    }
+    if let Some(system_live_preview) = system_live_preview {
+        system_live_preview.cancel();
     }
     drop(_stream);
     let microphone_finalized = (|| -> Result<(), AppError> {
@@ -632,6 +660,7 @@ impl ActiveRecording {
             silence_warning: self.started.elapsed() >= Duration::from_secs(10)
                 && rms < DEFAULT_SILENCE_THRESHOLD,
             bytes_written,
+            live_preview_enabled: self.live_preview_enabled,
             sources: source_statuses(
                 self.source_mode,
                 state,

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -25,7 +25,7 @@ const PREVIEW_BATCH_BUFFER: usize = 512;
 const PREVIEW_STALE_BATCH_THRESHOLD: usize = PREVIEW_BATCH_BUFFER / 2;
 const PREVIEW_CHUNK_MS: i64 = 8_000;
 const PREVIEW_CONTEXT_TURNS: usize = 3;
-const PREVIEW_SILENCE_RMS_FLOOR: f32 = 0.012;
+const PREVIEW_SILENCE_RMS_FLOOR: f32 = 0.001;
 const SYSTEM_PREVIEW_POLL_MS: u64 = 500;
 
 #[derive(Debug, Clone, Serialize)]
@@ -720,8 +720,10 @@ mod tests {
     }
 
     #[test]
-    fn silence_gate_skips_quiet_preview_chunks() {
+    fn silence_gate_only_skips_near_zero_preview_chunks() {
         assert!(is_effectively_silent(&[0; 128]));
+        assert!(is_effectively_silent(&[10; 128]));
+        assert!(!is_effectively_silent(&[170; 128]));
         assert!(!is_effectively_silent(&[2_000; 128]));
     }
 

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -283,8 +283,10 @@ async fn run_system_live_preview_worker(
     let mut current_format = None;
 
     while !cancelled.load(Ordering::Acquire) {
+        let mut had_samples = false;
         match reader.read_new_samples() {
             Ok(Some(read)) if !read.samples.is_empty() => {
+                had_samples = true;
                 let format = (read.sample_rate, read.channels);
                 if current_format != Some(format) {
                     current_format = Some(format);
@@ -348,6 +350,9 @@ async fn run_system_live_preview_worker(
             }
         }
 
+        if had_samples {
+            continue;
+        }
         tokio::time::sleep(Duration::from_millis(SYSTEM_PREVIEW_POLL_MS)).await;
     }
 }

--- a/src-tauri/src/audio/live_preview.rs
+++ b/src-tauri/src/audio/live_preview.rs
@@ -6,11 +6,14 @@ use hound::{SampleFormat, WavSpec, WavWriter};
 use serde::Serialize;
 use std::{
     collections::VecDeque,
+    fs::File,
+    io::{ErrorKind, Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
     },
+    time::Duration,
 };
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
@@ -23,6 +26,7 @@ const PREVIEW_STALE_BATCH_THRESHOLD: usize = PREVIEW_BATCH_BUFFER / 2;
 const PREVIEW_CHUNK_MS: i64 = 8_000;
 const PREVIEW_CONTEXT_TURNS: usize = 3;
 const PREVIEW_SILENCE_RMS_FLOOR: f32 = 0.012;
+const SYSTEM_PREVIEW_POLL_MS: u64 = 500;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,11 +77,16 @@ pub struct LivePreviewController {
     sink: LivePreviewSink,
 }
 
+pub struct SystemLivePreviewController {
+    cancelled: Arc<AtomicBool>,
+}
+
 struct LivePreviewWorkerParams {
     app: AppHandle,
     note_id: String,
     session_id: String,
     source_mode: RecordingSourceMode,
+    source: RecordingSource,
     sample_rate: u32,
     channels: u16,
     receiver: mpsc::Receiver<LivePreviewBatch>,
@@ -88,6 +97,7 @@ struct PreviewChunkRequest<'a> {
     note_id: &'a str,
     session_id: &'a str,
     source_mode: RecordingSourceMode,
+    source: RecordingSource,
     segment_id: &'a str,
     start_ms: i64,
     end_ms: i64,
@@ -113,11 +123,24 @@ impl Drop for LivePreviewController {
     }
 }
 
+impl SystemLivePreviewController {
+    pub fn cancel(self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
+impl Drop for SystemLivePreviewController {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+}
+
 pub fn start_live_transcript_preview(
     app: AppHandle,
     note_id: String,
     session_id: String,
     source_mode: RecordingSourceMode,
+    source: RecordingSource,
     sample_rate: u32,
     channels: u16,
 ) -> LivePreviewController {
@@ -130,6 +153,7 @@ pub fn start_live_transcript_preview(
             note_id,
             session_id,
             source_mode,
+            source,
             sample_rate: sample_rate.max(1),
             channels: channels.max(1),
             receiver,
@@ -146,12 +170,36 @@ pub fn start_live_transcript_preview(
     }
 }
 
+pub fn start_system_live_transcript_preview(
+    app: AppHandle,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    partial_path: PathBuf,
+) -> SystemLivePreviewController {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = Arc::clone(&cancelled);
+    tauri::async_runtime::spawn(async move {
+        run_system_live_preview_worker(
+            app,
+            note_id,
+            session_id,
+            source_mode,
+            partial_path,
+            worker_cancelled,
+        )
+        .await;
+    });
+    SystemLivePreviewController { cancelled }
+}
+
 async fn run_live_preview_worker(params: LivePreviewWorkerParams) {
     let LivePreviewWorkerParams {
         app,
         note_id,
         session_id,
         source_mode,
+        source,
         sample_rate,
         channels,
         mut receiver,
@@ -191,12 +239,13 @@ async fn run_live_preview_worker(params: LivePreviewWorkerParams) {
                 segment_index += 1;
                 continue;
             }
-            let segment_id = format!("microphone-{segment_index}");
+            let segment_id = preview_segment_id(source, segment_index);
             let context = preview_context(&recent_preview_text);
             if let Some(event) = transcribe_preview_chunk(PreviewChunkRequest {
                 note_id: &note_id,
                 session_id: &session_id,
                 source_mode,
+                source,
                 segment_id: &segment_id,
                 start_ms,
                 end_ms,
@@ -218,6 +267,91 @@ async fn run_live_preview_worker(params: LivePreviewWorkerParams) {
     }
 }
 
+async fn run_system_live_preview_worker(
+    app: AppHandle,
+    note_id: String,
+    session_id: String,
+    source_mode: RecordingSourceMode,
+    partial_path: PathBuf,
+    cancelled: Arc<AtomicBool>,
+) {
+    let mut reader = WavTailReader::new(partial_path);
+    let mut buffer = Vec::new();
+    let mut buffer_start_sample = 0_u64;
+    let mut recent_preview_text = VecDeque::with_capacity(PREVIEW_CONTEXT_TURNS);
+    let mut segment_index = 0_i64;
+    let mut current_format = None;
+
+    while !cancelled.load(Ordering::Acquire) {
+        match reader.read_new_samples() {
+            Ok(Some(read)) if !read.samples.is_empty() => {
+                let format = (read.sample_rate, read.channels);
+                if current_format != Some(format) {
+                    current_format = Some(format);
+                    buffer.clear();
+                    buffer_start_sample = read.start_sample;
+                }
+
+                let expected_start = buffer_start_sample.saturating_add(buffer.len() as u64);
+                if buffer.is_empty() || read.start_sample != expected_start {
+                    buffer.clear();
+                    buffer_start_sample = read.start_sample;
+                }
+                buffer.extend(read.samples);
+
+                let chunk_samples =
+                    samples_for_ms(read.sample_rate, read.channels, PREVIEW_CHUNK_MS);
+                while chunk_samples > 0 && buffer.len() >= chunk_samples {
+                    let chunk_start_sample = buffer_start_sample;
+                    let samples = buffer.drain(..chunk_samples).collect::<Vec<_>>();
+                    buffer_start_sample = buffer_start_sample.saturating_add(chunk_samples as u64);
+                    let start_ms =
+                        sample_offset_ms(chunk_start_sample, read.sample_rate, read.channels);
+                    let end_ms =
+                        sample_offset_ms(buffer_start_sample, read.sample_rate, read.channels);
+                    if is_effectively_silent(&samples) {
+                        segment_index += 1;
+                        continue;
+                    }
+
+                    let segment_id = preview_segment_id(RecordingSource::System, segment_index);
+                    let context = preview_context(&recent_preview_text);
+                    if let Some(event) = transcribe_preview_chunk(PreviewChunkRequest {
+                        note_id: &note_id,
+                        session_id: &session_id,
+                        source_mode,
+                        source: RecordingSource::System,
+                        segment_id: &segment_id,
+                        start_ms,
+                        end_ms,
+                        sample_rate: read.sample_rate,
+                        channels: read.channels,
+                        samples: &samples,
+                        context,
+                    })
+                    .await
+                    {
+                        if cancelled.load(Ordering::Acquire) {
+                            return;
+                        }
+                        remember_preview_text(&mut recent_preview_text, &event.text);
+                        let _ = app.emit(LIVE_TRANSCRIPT_EVENT, event);
+                    }
+                    segment_index += 1;
+                }
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => {}
+            Err(error) => {
+                eprintln!("live transcript preview failed to read system audio: {error}");
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(SYSTEM_PREVIEW_POLL_MS)).await;
+    }
+}
+
 fn newest_preview_batch(
     mut batch: LivePreviewBatch,
     receiver: &mut mpsc::Receiver<LivePreviewBatch>,
@@ -232,6 +366,170 @@ fn should_drop_stale_batches(queued_batches: usize) -> bool {
     queued_batches >= PREVIEW_STALE_BATCH_THRESHOLD
 }
 
+struct WavTailRead {
+    start_sample: u64,
+    sample_rate: u32,
+    channels: u16,
+    samples: Vec<i16>,
+}
+
+struct WavTailReader {
+    path: PathBuf,
+    data_offset: Option<u64>,
+    sample_rate: u32,
+    channels: u16,
+    next_byte_offset: u64,
+}
+
+struct WavLayout {
+    data_offset: u64,
+    sample_rate: u32,
+    channels: u16,
+}
+
+impl WavTailReader {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            data_offset: None,
+            sample_rate: 0,
+            channels: 0,
+            next_byte_offset: 0,
+        }
+    }
+
+    fn read_new_samples(&mut self) -> std::io::Result<Option<WavTailRead>> {
+        if self.data_offset.is_none() {
+            let Some(layout) = read_wav_layout(&self.path)? else {
+                return Ok(None);
+            };
+            self.data_offset = Some(layout.data_offset);
+            self.sample_rate = layout.sample_rate;
+            self.channels = layout.channels;
+            self.next_byte_offset = layout.data_offset;
+        }
+
+        let data_offset = self.data_offset.unwrap_or(0);
+        let file_len = std::fs::metadata(&self.path)?.len();
+        if file_len < data_offset || file_len < self.next_byte_offset {
+            self.data_offset = None;
+            self.next_byte_offset = 0;
+            return Ok(None);
+        }
+
+        let available_bytes = file_len.saturating_sub(self.next_byte_offset);
+        let aligned_bytes = available_bytes - (available_bytes % 2);
+        if aligned_bytes == 0 {
+            return Ok(None);
+        }
+
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.next_byte_offset))?;
+        let mut bytes = vec![0_u8; aligned_bytes as usize];
+        match file.read_exact(&mut bytes) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => return Ok(None),
+            Err(error) => return Err(error),
+        }
+
+        let start_sample = self.next_byte_offset.saturating_sub(data_offset) / 2;
+        self.next_byte_offset = self.next_byte_offset.saturating_add(aligned_bytes);
+        let samples = bytes
+            .chunks_exact(2)
+            .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect();
+
+        Ok(Some(WavTailRead {
+            start_sample,
+            sample_rate: self.sample_rate.max(1),
+            channels: self.channels.max(1),
+            samples,
+        }))
+    }
+}
+
+fn read_wav_layout(path: &Path) -> std::io::Result<Option<WavLayout>> {
+    const HEADER_SCAN_LIMIT: u64 = 64 * 1024;
+
+    let mut file = File::open(path)?;
+    let file_len = file.metadata()?.len();
+    if file_len < 44 {
+        return Ok(None);
+    }
+
+    let scan_len = file_len.min(HEADER_SCAN_LIMIT) as usize;
+    let mut bytes = vec![0_u8; scan_len];
+    file.read_exact(&mut bytes)?;
+    if bytes.get(0..4) != Some(&b"RIFF"[..]) || bytes.get(8..12) != Some(&b"WAVE"[..]) {
+        return Ok(None);
+    }
+
+    let mut offset = 12_usize;
+    let mut sample_rate = None;
+    let mut channels = None;
+    let mut data_offset = None;
+
+    while offset + 8 <= bytes.len() {
+        let chunk_id = &bytes[offset..offset + 4];
+        let chunk_size = u32::from_le_bytes([
+            bytes[offset + 4],
+            bytes[offset + 5],
+            bytes[offset + 6],
+            bytes[offset + 7],
+        ]) as usize;
+        let chunk_data_start = offset + 8;
+
+        if chunk_id == b"fmt " {
+            if chunk_data_start + 16 > bytes.len() {
+                return Ok(None);
+            }
+            let audio_format =
+                u16::from_le_bytes([bytes[chunk_data_start], bytes[chunk_data_start + 1]]);
+            let parsed_channels =
+                u16::from_le_bytes([bytes[chunk_data_start + 2], bytes[chunk_data_start + 3]]);
+            let parsed_sample_rate = u32::from_le_bytes([
+                bytes[chunk_data_start + 4],
+                bytes[chunk_data_start + 5],
+                bytes[chunk_data_start + 6],
+                bytes[chunk_data_start + 7],
+            ]);
+            let bits_per_sample =
+                u16::from_le_bytes([bytes[chunk_data_start + 14], bytes[chunk_data_start + 15]]);
+            if !matches!(audio_format, 1 | 0xfffe)
+                || bits_per_sample != 16
+                || parsed_channels == 0
+                || parsed_sample_rate == 0
+            {
+                return Ok(None);
+            }
+            channels = Some(parsed_channels);
+            sample_rate = Some(parsed_sample_rate);
+        } else if chunk_id == b"data" {
+            data_offset = Some(chunk_data_start as u64);
+            break;
+        }
+
+        let padded_size = chunk_size.saturating_add(chunk_size % 2);
+        offset = chunk_data_start.saturating_add(padded_size);
+    }
+
+    let Some(data_offset) = data_offset else {
+        return Ok(None);
+    };
+    let Some(sample_rate) = sample_rate else {
+        return Ok(None);
+    };
+    let Some(channels) = channels else {
+        return Ok(None);
+    };
+
+    Ok(Some(WavLayout {
+        data_offset,
+        sample_rate,
+        channels,
+    }))
+}
+
 async fn transcribe_preview_chunk(
     request: PreviewChunkRequest<'_>,
 ) -> Option<LiveTranscriptEventDto> {
@@ -239,6 +537,7 @@ async fn transcribe_preview_chunk(
         note_id,
         session_id,
         source_mode,
+        source,
         segment_id,
         start_ms,
         end_ms,
@@ -275,7 +574,7 @@ async fn transcribe_preview_chunk(
                 note_id: note_id.to_string(),
                 session_id: session_id.to_string(),
                 source_mode,
-                source: RecordingSource::Microphone,
+                source,
                 segment_id: segment_id.to_string(),
                 start_ms,
                 end_ms,
@@ -301,6 +600,10 @@ fn preview_chunk_path(session_id: &str, segment_id: &str) -> PathBuf {
         segment_id,
         Uuid::new_v4()
     ))
+}
+
+fn preview_segment_id(source: RecordingSource, segment_index: i64) -> String {
+    format!("{}-{segment_index}", source.as_db())
 }
 
 fn write_preview_wav(
@@ -386,10 +689,13 @@ fn remember_preview_text(recent_preview_text: &mut VecDeque<String>, text: &str)
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::types::RecordingSource;
+
     use super::{
-        duration_ms, is_effectively_silent, newest_preview_batch, preview_context,
-        remember_preview_text, sample_offset_ms, samples_for_ms, should_drop_stale_batches,
-        LivePreviewBatch, LivePreviewSink, PREVIEW_STALE_BATCH_THRESHOLD,
+        duration_ms, is_effectively_silent, newest_preview_batch, preview_chunk_path,
+        preview_context, preview_segment_id, read_wav_layout, remember_preview_text,
+        sample_offset_ms, samples_for_ms, should_drop_stale_batches, write_preview_wav,
+        LivePreviewBatch, LivePreviewSink, WavTailReader, PREVIEW_STALE_BATCH_THRESHOLD,
     };
     use std::{
         collections::VecDeque,
@@ -499,5 +805,46 @@ mod tests {
         assert!(!context.contains("first"));
         assert!(context.contains("second\nthird\nfourth"));
         assert!(context.contains("Do not repeat it."));
+    }
+
+    #[test]
+    fn preview_segment_ids_include_audio_source() {
+        assert_eq!(
+            preview_segment_id(RecordingSource::Microphone, 7),
+            "microphone-7"
+        );
+        assert_eq!(preview_segment_id(RecordingSource::System, 3), "system-3");
+    }
+
+    #[test]
+    fn wav_tail_reader_reads_samples_once() {
+        let path = preview_chunk_path("tail-test", "reader");
+        let samples = vec![1, -2, 300, -400];
+        write_preview_wav(&path, 16_000, 2, &samples).expect("write wav");
+
+        let mut reader = WavTailReader::new(path.clone());
+        let read = reader
+            .read_new_samples()
+            .expect("read samples")
+            .expect("samples");
+
+        assert_eq!(read.start_sample, 0);
+        assert_eq!(read.sample_rate, 16_000);
+        assert_eq!(read.channels, 2);
+        assert_eq!(read.samples, samples);
+        assert!(reader.read_new_samples().expect("read none").is_none());
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn wav_layout_waits_for_complete_header() {
+        let path = preview_chunk_path("tail-test", "incomplete");
+        std::fs::write(&path, b"RIFF").expect("write incomplete wav");
+
+        let layout = read_wav_layout(&path).expect("read layout");
+
+        assert!(layout.is_none());
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -679,6 +679,7 @@ pub async fn start_recording(
         elapsed_ms: started.status.elapsed_ms,
         device_label: started.device_label,
         level: started.status.level,
+        live_preview_enabled: started.status.live_preview_enabled,
         sources: started.status.sources,
         warnings: Vec::new(),
     })

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -351,6 +351,8 @@ pub struct RecordingSessionDto {
     pub device_label: Option<String>,
     pub level: AudioLevelDto,
     #[serde(default)]
+    pub live_preview_enabled: bool,
+    #[serde(default)]
     pub sources: Vec<SourceStatusDto>,
     #[serde(default)]
     pub warnings: Vec<SourceWarningDto>,
@@ -368,6 +370,8 @@ pub struct RecordingStatusDto {
     pub level: AudioLevelDto,
     pub silence_warning: bool,
     pub bytes_written: i64,
+    #[serde(default)]
+    pub live_preview_enabled: bool,
     #[serde(default)]
     pub sources: Vec<SourceStatusDto>,
     #[serde(default)]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3371,6 +3371,7 @@ function recordingToStatus(recording: {
   state: RecordingStatusDto["state"];
   elapsedMs: number;
   level: RecordingStatusDto["level"];
+  livePreviewEnabled?: RecordingStatusDto["livePreviewEnabled"];
   sources?: RecordingStatusDto["sources"];
   warnings?: RecordingStatusDto["warnings"];
 }): RecordingStatusDto {
@@ -3383,6 +3384,7 @@ function recordingToStatus(recording: {
     level: recording.level,
     silenceWarning: false,
     bytesWritten: 0,
+    livePreviewEnabled: recording.livePreviewEnabled ?? false,
     sources: recording.sources,
     warnings: recording.warnings,
   };
@@ -3424,6 +3426,7 @@ function startingRecordingStatus(
     level: { peak: 0, rms: 0, recentPeaks: [] },
     silenceWarning: false,
     bytesWritten: 0,
+    livePreviewEnabled: false,
     sources,
     warnings: [],
   };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -119,6 +119,7 @@ import { notifyAgentSessionStatus } from "../lib/agent-notifications";
 import { messageFromError } from "../lib/errors";
 import { parseDictationHelperEvent } from "../lib/dictation-events";
 import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
+import { upsertLiveTranscriptEvent } from "../lib/live-transcript-preview";
 import {
   AGENT_MENU_BAR_NEW_SESSION_EVENT,
   AGENT_MENU_BAR_OPEN_SESSION_EVENT,
@@ -267,28 +268,6 @@ function tabMeta(
         icon: <IconNoteText size={TAB_ICON_SIZE} />,
       };
   }
-}
-
-function upsertLiveTranscriptEvent(
-  current: LiveTranscriptEventDto[],
-  next: LiveTranscriptEventDto,
-) {
-  const events = current.filter(
-    (event) =>
-      !(
-        event.sessionId === next.sessionId &&
-        event.source === next.source &&
-        event.segmentId === next.segmentId
-      ),
-  );
-  events.push(next);
-  events.sort(
-    (left, right) =>
-      left.startMs - right.startMs ||
-      left.endMs - right.endMs ||
-      left.segmentId.localeCompare(right.segmentId),
-  );
-  return events.slice(-32);
 }
 
 export function App() {

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -259,7 +259,8 @@ export function NoteEditor({
   const showTranscriptProcessing =
     processingLock && transcriptText.trim().length > 0;
   const showLivePreviewWaiting =
-    recordingActive && liveTranscriptTurns.length === 0;
+    recordingForNote?.livePreviewEnabled === true &&
+    liveTranscriptTurns.length === 0;
   // Processing runs in the background and is queued per note, so a recording
   // that's still transcribing/generating no longer blocks starting another —
   // you can stack messages and they process in order. The record button only

--- a/src/lib/live-transcript-preview.ts
+++ b/src/lib/live-transcript-preview.ts
@@ -1,0 +1,89 @@
+import type { LiveTranscriptEventDto } from "./tauri";
+
+const LIVE_TRANSCRIPT_EVENT_LIMIT = 32;
+
+export function upsertLiveTranscriptEvent(
+  current: LiveTranscriptEventDto[],
+  next: LiveTranscriptEventDto,
+) {
+  const events = current
+    .filter((event) => !isSameLiveSegment(event, next))
+    .concat(next)
+    .sort(compareLiveTranscriptEvents);
+  return coalesceAdjacentLiveTranscriptEvents(events).slice(
+    -LIVE_TRANSCRIPT_EVENT_LIMIT,
+  );
+}
+
+function coalesceAdjacentLiveTranscriptEvents(events: LiveTranscriptEventDto[]) {
+  const coalesced: LiveTranscriptEventDto[] = [];
+  for (const event of events) {
+    const previous = coalesced.at(-1);
+    if (previous && isSameLiveTurn(previous, event)) {
+      coalesced[coalesced.length - 1] = mergeLiveTranscriptEvents(
+        previous,
+        event,
+      );
+    } else {
+      coalesced.push(event);
+    }
+  }
+  return coalesced;
+}
+
+function isSameLiveSegment(
+  left: LiveTranscriptEventDto,
+  right: LiveTranscriptEventDto,
+) {
+  return (
+    left.noteId === right.noteId &&
+    left.sessionId === right.sessionId &&
+    left.source === right.source &&
+    left.segmentId === right.segmentId
+  );
+}
+
+function isSameLiveTurn(
+  left: LiveTranscriptEventDto,
+  right: LiveTranscriptEventDto,
+) {
+  return (
+    left.noteId === right.noteId &&
+    left.sessionId === right.sessionId &&
+    left.sourceMode === right.sourceMode &&
+    left.source === right.source
+  );
+}
+
+function mergeLiveTranscriptEvents(
+  left: LiveTranscriptEventDto,
+  right: LiveTranscriptEventDto,
+): LiveTranscriptEventDto {
+  return {
+    ...left,
+    startMs: Math.min(left.startMs, right.startMs),
+    endMs: Math.max(left.endMs, right.endMs),
+    text: appendLiveTranscriptText(left.text, right.text),
+    language: right.language ?? left.language,
+    stability: right.stability,
+  };
+}
+
+function appendLiveTranscriptText(left: string, right: string) {
+  const leftText = left.trim();
+  const rightText = right.trim();
+  if (!leftText) return rightText;
+  if (!rightText) return leftText;
+  return `${leftText} ${rightText}`;
+}
+
+function compareLiveTranscriptEvents(
+  left: LiveTranscriptEventDto,
+  right: LiveTranscriptEventDto,
+) {
+  return (
+    left.startMs - right.startMs ||
+    left.endMs - right.endMs ||
+    left.segmentId.localeCompare(right.segmentId)
+  );
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -243,6 +243,7 @@ export type RecordingStatusDto = {
   level: AudioLevelDto;
   silenceWarning: boolean;
   bytesWritten: number;
+  livePreviewEnabled?: boolean;
   sources?: SourceStatusDto[];
   warnings?: SourceWarningDto[];
 };
@@ -263,6 +264,7 @@ export type RecordingSessionDto = {
   elapsedMs: number;
   deviceLabel?: string;
   level: AudioLevelDto;
+  livePreviewEnabled?: boolean;
   sources?: SourceStatusDto[];
   warnings?: SourceWarningDto[];
 };

--- a/src/test/live-transcript-preview.test.ts
+++ b/src/test/live-transcript-preview.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { upsertLiveTranscriptEvent } from "../lib/live-transcript-preview";
+import type { LiveTranscriptEventDto } from "../lib/tauri";
+
+function liveEvent(
+  overrides: Partial<LiveTranscriptEventDto> = {},
+): LiveTranscriptEventDto {
+  return {
+    noteId: "note-1",
+    sessionId: "session-1",
+    sourceMode: "microphonePlusSystem",
+    source: "microphone",
+    segmentId: "microphone-0",
+    startMs: 0,
+    endMs: 8000,
+    text: "First chunk",
+    language: "en",
+    stability: "final",
+    ...overrides,
+  };
+}
+
+describe("upsertLiveTranscriptEvent", () => {
+  it("appends adjacent same-source preview chunks into one running turn", () => {
+    const events = [
+      liveEvent(),
+      liveEvent({
+        segmentId: "microphone-1",
+        startMs: 8000,
+        endMs: 16_000,
+        text: "Second chunk",
+      }),
+    ].reduce(upsertLiveTranscriptEvent, [] as LiveTranscriptEventDto[]);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        source: "microphone",
+        segmentId: "microphone-0",
+        startMs: 0,
+        endMs: 16_000,
+        text: "First chunk Second chunk",
+      }),
+    ]);
+  });
+
+  it("starts a new live turn when the source changes", () => {
+    const events = [
+      liveEvent({ segmentId: "microphone-0", text: "Mic one" }),
+      liveEvent({
+        source: "system",
+        segmentId: "system-0",
+        startMs: 8000,
+        endMs: 16_000,
+        text: "System one",
+      }),
+      liveEvent({
+        source: "system",
+        segmentId: "system-1",
+        startMs: 16_000,
+        endMs: 24_000,
+        text: "System two",
+      }),
+      liveEvent({
+        segmentId: "microphone-1",
+        startMs: 24_000,
+        endMs: 32_000,
+        text: "Mic two",
+      }),
+    ].reduce(upsertLiveTranscriptEvent, [] as LiveTranscriptEventDto[]);
+
+    expect(events.map((event) => event.text)).toEqual([
+      "Mic one",
+      "System one System two",
+      "Mic two",
+    ]);
+    expect(events.map((event) => event.source)).toEqual([
+      "microphone",
+      "system",
+      "microphone",
+    ]);
+    expect(events.map((event) => [event.startMs, event.endMs])).toEqual([
+      [0, 8000],
+      [8000, 24_000],
+      [24_000, 32_000],
+    ]);
+  });
+
+  it("orders same-source chunks before appending them", () => {
+    const events = [
+      liveEvent({
+        segmentId: "microphone-1",
+        startMs: 8000,
+        endMs: 16_000,
+        text: "Second chunk",
+      }),
+      liveEvent({
+        segmentId: "microphone-0",
+        startMs: 0,
+        endMs: 8000,
+        text: "First chunk",
+      }),
+    ].reduce(upsertLiveTranscriptEvent, [] as LiveTranscriptEventDto[]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.text).toBe("First chunk Second chunk");
+    expect(events[0]?.startMs).toBe(0);
+    expect(events[0]?.endMs).toBe(16_000);
+  });
+});

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -198,6 +198,43 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Live preview")).toBeInTheDocument();
   });
 
+  it("only shows the live preview waiting state when preview is enabled", () => {
+    const recordingStatus = {
+      sessionId: "session-1",
+      state: "recording" as const,
+      elapsedMs: 8000,
+      level: { peak: 0.5, rms: 0.2, recentPeaks: [0.1, 0.3] },
+      silenceWarning: false,
+      bytesWritten: 4096,
+    };
+    const { rerender } = render(
+      <NoteEditor
+        {...props}
+        note={note({ activeTab: "transcription" })}
+        recordingStatus={recordingStatus}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Listening for transcript preview..."),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <NoteEditor
+        {...props}
+        note={note({ activeTab: "transcription" })}
+        recordingStatus={{
+          ...recordingStatus,
+          livePreviewEnabled: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Listening for transcript preview...",
+    );
+  });
+
   it("shows transcript progress while retrying over existing turns", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary
- feed live transcript preview from system audio during dual-source meeting recordings by tailing the partial system WAV
- emit live preview events with the correct audio source and source-specific segment ids
- expose `livePreviewEnabled` in recording status so the UI only shows the preview waiting state when the backend actually started preview

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm format`
- `pnpm test:rust`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Known gaps
- I did not run a manual live meeting capture in the desktop app from this environment.