### PR TITLE
Match account sign-in button to onboarding

### DIFF
--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { BorderBeam } from "border-beam";
 import { isMacLikePlatform } from "../../lib/platform";
 import { osAccountsCancelLogin, osAccountsLogin } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
+import { BrandPrimaryButton } from "../ui/BrandPrimaryButton";
 
 type Props = {
   account: AccountStatus;
@@ -78,27 +78,13 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
                 </button>
               </div>
             ) : (
-              <BorderBeam
-                active={!loading}
-                borderRadius={10}
-                className="onboarding-primary-beam"
-                colorVariant="sunset"
-                duration={4.8}
-                size="sm"
-                staticColors
-                strength={0.22}
-                theme="light"
+              <BrandPrimaryButton
+                disabled={loading}
+                onClick={() => void handleSignIn()}
               >
-                <button
-                  type="button"
-                  className="primary-action onboarding-continue"
-                  disabled={loading}
-                  onClick={() => void handleSignIn()}
-                >
-                  <OsMark />
-                  <span>Continue with OpenSoftware</span>
-                </button>
-              </BorderBeam>
+                <OsMark />
+                <span>Continue with OpenSoftware</span>
+              </BrandPrimaryButton>
             )}
           </div>
         ) : (

--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
+import { BorderBeam } from "border-beam";
 import { isMacLikePlatform } from "../../lib/platform";
 import { osAccountsCancelLogin, osAccountsLogin } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
-import { Spinner } from "../ui/Spinner";
 
 type Props = {
   account: AccountStatus;
@@ -62,12 +62,11 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
           <div className="welcome-providers">
             {busy ? (
               <div
-                className="welcome-auth-progress"
+                className="welcome-auth-progress onboarding-waiting"
                 role="status"
                 aria-live="polite"
               >
                 <span className="welcome-progress-label">
-                  <Spinner className="welcome-spinner" aria-hidden />
                   <span>Complete sign-in in browser</span>
                 </span>
                 <button
@@ -79,15 +78,27 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
                 </button>
               </div>
             ) : (
-              <button
-                type="button"
-                className="primary-action"
-                disabled={loading}
-                onClick={() => void handleSignIn()}
+              <BorderBeam
+                active={!loading}
+                borderRadius={10}
+                className="onboarding-primary-beam"
+                colorVariant="sunset"
+                duration={4.8}
+                size="sm"
+                staticColors
+                strength={0.22}
+                theme="light"
               >
-                <OsMark />
-                <span>Continue with OpenSoftware</span>
-              </button>
+                <button
+                  type="button"
+                  className="primary-action onboarding-continue"
+                  disabled={loading}
+                  onClick={() => void handleSignIn()}
+                >
+                  <OsMark />
+                  <span>Continue with OpenSoftware</span>
+                </button>
+              </BorderBeam>
             )}
           </div>
         ) : (

--- a/src/components/onboarding/StepChrome.tsx
+++ b/src/components/onboarding/StepChrome.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
-import { BorderBeam } from "border-beam";
 import { JuneMark } from "../account/AccountGate";
+import { BrandPrimaryButton } from "../ui/BrandPrimaryButton";
 
 /**
  * One onboarding screen = one welcome-card: a serif title, at most one muted
@@ -59,9 +59,9 @@ export function StepActions({
 }) {
   return (
     <div className="welcome-providers">
-      <OnboardingPrimaryButton disabled={continueDisabled} onClick={onContinue}>
+      <BrandPrimaryButton disabled={continueDisabled} onClick={onContinue}>
         {continueLabel}
-      </OnboardingPrimaryButton>
+      </BrandPrimaryButton>
       {onSkip ? (
         <button type="button" className="onboarding-skip" onClick={onSkip}>
           {skipLabel}
@@ -71,35 +71,4 @@ export function StepActions({
   );
 }
 
-export function OnboardingPrimaryButton({
-  children,
-  disabled,
-  onClick,
-}: {
-  children: ReactNode;
-  disabled?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <BorderBeam
-      active={!disabled}
-      borderRadius={10}
-      className="onboarding-primary-beam"
-      colorVariant="sunset"
-      duration={4.8}
-      size="sm"
-      staticColors
-      strength={0.22}
-      theme="light"
-    >
-      <button
-        type="button"
-        className="primary-action onboarding-continue"
-        disabled={disabled}
-        onClick={onClick}
-      >
-        {children}
-      </button>
-    </BorderBeam>
-  );
-}
+export { BrandPrimaryButton as OnboardingPrimaryButton };

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -6,7 +6,6 @@ import { isMacLikePlatform } from "../../../lib/platform";
 import { osAccountsCancelLogin, osAccountsLogin } from "../../../lib/tauri";
 import type { AccountStatus } from "../../../lib/tauri";
 import { OsMark } from "../../account/AccountGate";
-import { Spinner } from "../../ui/Spinner";
 import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 
 // macOS can introduce the full agent, dictation, and notes surface because the
@@ -126,7 +125,6 @@ export function SignInStep({
               aria-live="polite"
             >
               <span className="welcome-progress-label">
-                <Spinner className="welcome-spinner" aria-hidden />
                 <span>Complete sign-in in browser</span>
               </span>
               <button

--- a/src/components/ui/BrandPrimaryButton.tsx
+++ b/src/components/ui/BrandPrimaryButton.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { BorderBeam } from "border-beam";
+
+type Props = {
+  children: ReactNode;
+  disabled?: boolean;
+  onClick: () => void;
+};
+
+export function BrandPrimaryButton({ children, disabled, onClick }: Props) {
+  return (
+    <BorderBeam
+      active={!disabled}
+      borderRadius={10}
+      className="onboarding-primary-beam"
+      colorVariant="sunset"
+      duration={4.8}
+      size="sm"
+      staticColors
+      strength={0.22}
+      theme="light"
+    >
+      <button
+        type="button"
+        className="primary-action onboarding-continue"
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    </BorderBeam>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12236,8 +12236,8 @@ input:focus-visible,
 
 /* The wizard's in-flight rows (sign-in handoff, trial checkout) keep the
    terracotta primary's exact footprint but fade it flat: a disabled-feeling
-   tint of the button it replaces, not a raised control. Only the spinner
-   keeps full terracotta — it's the live part. */
+   tint of the button it replaces, not a raised control. Flows that still have
+   active backend work can keep a terracotta spinner as the live part. */
 .welcome-auth-progress.onboarding-waiting {
   border-color: color-mix(in oklch, var(--brand) 16%, transparent);
   border-radius: var(--r-lg);


### PR DESCRIPTION
## Summary
- Restyle the signed-out account gate primary action to use the onboarding terracotta button and border beam treatment.
- Match the sign-in browser handoff row to the onboarding warm waiting state.
- Remove the spinner from sign-in handoff rows so they read as user handoff states, while leaving active processing spinners elsewhere intact.

## Verification
- pnpm test -- src/test/onboarding.test.tsx src/test/app-shortcut.test.tsx src/test/account-gate.test.ts
- pnpm run lint