### PR TITLE
Expand agent skill editor area

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7705,7 +7705,7 @@ input:focus-visible,
 .settings-agent-card {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr);
-  min-height: 640px;
+  min-height: clamp(640px, calc(100dvh - 96px), 900px);
   padding: 0;
   overflow: hidden;
 }
@@ -7715,7 +7715,17 @@ input:focus-visible,
 }
 
 .settings-agent-card .agent-management-panel {
+  height: 100%;
   min-height: 0;
+}
+
+.settings-agent-card .agent-skill-editor-panel,
+.settings-agent-card .agent-skill-editor {
+  height: 100%;
+}
+
+.settings-agent-card .agent-skill-editor-textarea {
+  min-height: clamp(360px, 52dvh, 620px);
 }
 
 .settings-agent-card .agent-messaging-layout {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7705,7 +7705,11 @@ input:focus-visible,
 .settings-agent-card {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr);
-  min-height: clamp(640px, calc(100dvh - 96px), 900px);
+  min-height: clamp(
+    var(--settings-agent-card-min-h),
+    calc(100dvh - var(--settings-agent-card-viewport-offset)),
+    var(--settings-agent-card-max-h)
+  );
   padding: 0;
   overflow: hidden;
 }
@@ -7715,6 +7719,7 @@ input:focus-visible,
 }
 
 .settings-agent-card .agent-management-panel {
+  grid-row: 3;
   height: 100%;
   min-height: 0;
 }
@@ -7725,7 +7730,11 @@ input:focus-visible,
 }
 
 .settings-agent-card .agent-skill-editor-textarea {
-  min-height: clamp(360px, 52dvh, 620px);
+  min-height: clamp(
+    var(--settings-skill-editor-min-h),
+    var(--settings-skill-editor-ideal-h),
+    var(--settings-skill-editor-max-h)
+  );
 }
 
 .settings-agent-card .agent-messaging-layout {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -104,6 +104,17 @@
    * so the column doesn't feel marooned in whitespace on big monitors. */
   --content-max: 760px;
 
+  /* Agent settings editor sizing. Keeps the skill Markdown editor large
+   * enough for real editing while preserving bounded settings cards. */
+  --settings-agent-card-min-h: 640px;
+  --settings-agent-card-max-h: 900px;
+  --settings-agent-card-viewport-offset: calc(
+    var(--titlebar-h) + var(--sp-12) + var(--sp-7) + var(--sp-3)
+  );
+  --settings-skill-editor-min-h: 360px;
+  --settings-skill-editor-ideal-h: 52dvh;
+  --settings-skill-editor-max-h: 620px;
+
   /* Agent chat column: the thread rail and the docked composer share this
    * width so they stay concentric. Narrower than --content-max (chat reads
    * as a conversation, not a document) but steps up with it below. */


### PR DESCRIPTION
## Summary
- Make the Agent settings card use more of the viewport instead of stopping at a fixed 640px minimum
- Ensure the nested skill editor grids fill the card row
- Give the skill Markdown textarea a responsive minimum height so editing long SKILL.md files is not cramped

## Validation
- pnpm run lint
- pnpm exec vitest run src/test/app-settings.test.tsx
- git diff --check

## Notes
- CSS-only layout change scoped to the Agent settings card.