### PR TITLE
Fix messaging platform loading hang

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -161,6 +161,7 @@ import {
   isHermesSessionsStartupRequestError,
   messageFromError,
 } from "../../lib/errors";
+import { withTimeout } from "../../lib/async-timeout";
 import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
@@ -4935,28 +4936,6 @@ async function agentSessionTitleForPrompt(prompt: string) {
   } catch {
     return titleFromPrompt(prompt);
   }
-}
-
-function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  message = "Agent title generation timed out.",
-) {
-  return new Promise<T>((resolve, reject) => {
-    const timeout = window.setTimeout(() => {
-      reject(new Error(message));
-    }, timeoutMs);
-    promise.then(
-      (value) => {
-        window.clearTimeout(timeout);
-        resolve(value);
-      },
-      (error: unknown) => {
-        window.clearTimeout(timeout);
-        reject(error);
-      },
-    );
-  });
 }
 
 function isReplaceableAgentSessionTitle(title: unknown) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -162,6 +162,10 @@ import {
   messageFromError,
 } from "../../lib/errors";
 import {
+  MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
+  MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
+} from "../../lib/hermes-messaging";
+import {
   categoryPrompt,
   displayedUserMessageText,
 } from "../../lib/issue-report-prompt";
@@ -2992,7 +2996,11 @@ export function AgentWorkspace({
     setCapabilityLoading(true);
     try {
       await ensureHermesGateway();
-      const response = await hermesBridgeMessagingPlatforms();
+      const response = await withTimeout(
+        hermesBridgeMessagingPlatforms(),
+        MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
+        MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
+      );
       setMessagingPlatforms(response.platforms);
       setSelectedMessagingPlatformId((current) => {
         if (current && response.platforms.some((item) => item.id === current)) {
@@ -3002,6 +3010,7 @@ export function AgentWorkspace({
       });
       setError(null);
     } catch (err) {
+      setMessagingPlatforms((current) => current ?? []);
       setError(messageFromError(err));
     } finally {
       setCapabilityLoading(false);
@@ -4928,10 +4937,14 @@ async function agentSessionTitleForPrompt(prompt: string) {
   }
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message = "Agent title generation timed out.",
+) {
   return new Promise<T>((resolve, reject) => {
     const timeout = window.setTimeout(() => {
-      reject(new Error("Agent title generation timed out."));
+      reject(new Error(message));
     }, timeoutMs);
     promise.then(
       (value) => {

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -30,6 +30,11 @@ import {
   setAgentHudEnabled,
   type AgentHudVisibilityChangedDetail,
 } from "../../lib/agent-hud-settings";
+import { withTimeout } from "../../lib/async-timeout";
+import {
+  MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
+  MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
+} from "../../lib/hermes-messaging";
 import { Switch } from "../ui/Switch";
 
 type AgentSettingsPanel = "skills" | "messaging" | "files";
@@ -152,7 +157,11 @@ export function AgentSettingsSection() {
   async function loadMessagingPlatforms() {
     setLoading(true);
     try {
-      const response = await hermesBridgeMessagingPlatforms();
+      const response = await withTimeout(
+        hermesBridgeMessagingPlatforms(),
+        MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
+        MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
+      );
       setPlatforms(response.platforms);
       setSelectedPlatformId((current) => {
         if (current && response.platforms.some((item) => item.id === current)) {
@@ -162,6 +171,7 @@ export function AgentSettingsSection() {
       });
       setError(null);
     } catch (err) {
+      setPlatforms((current) => current ?? []);
       setError(messageFromError(err));
     } finally {
       setLoading(false);

--- a/src/lib/async-timeout.ts
+++ b/src/lib/async-timeout.ts
@@ -1,0 +1,19 @@
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/src/lib/async-timeout.ts
+++ b/src/lib/async-timeout.ts
@@ -1,7 +1,7 @@
 export function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
-  message: string,
+  message = "Operation timed out.",
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(message)), timeoutMs);

--- a/src/lib/hermes-messaging.ts
+++ b/src/lib/hermes-messaging.ts
@@ -1,0 +1,3 @@
+export const MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS = 15_000;
+export const MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE =
+  "Messaging platforms took too long to load. Try refresh.";

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -11,6 +12,7 @@ import { AppSettings } from "../components/settings/AppSettings";
 import type { DictationSettingsDto } from "../lib/tauri";
 import { APP_COMMIT_HASH, APP_VERSION } from "../app/build-info";
 import { AGENT_HUD_ENABLED_KEY } from "../lib/agent-hud-settings";
+import { MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS } from "../lib/hermes-messaging";
 import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 
 const mocks = vi.hoisted(() => ({
@@ -1560,6 +1562,43 @@ describe("AppSettings", () => {
     expect(screen.getByText("sample.pdf")).toBeInTheDocument();
     expect(screen.getByText("USER.md")).toBeInTheDocument();
     expect(screen.queryByText("Logs")).toBeNull();
+  });
+
+  it("shows a refreshable messaging state when platform loading hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.hermesBridgeMessagingPlatforms.mockReturnValue(
+        new Promise(() => {}),
+      );
+      render(
+        <AppSettings
+          account={signedInAccount}
+          accountLoading={false}
+          sourceMode="microphoneOnly"
+          checkingSourceReadiness={false}
+          onAccountChanged={vi.fn()}
+          onAccountRefresh={vi.fn()}
+          onSourceModeChange={vi.fn()}
+          onEnableSystemAudio={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("tab", { name: "Agent" }));
+      fireEvent.click(screen.getByRole("button", { name: "Messaging" }));
+
+      await act(async () => {
+        vi.advanceTimersByTime(MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS);
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByRole("status", { name: "Loading" })).toBeNull();
+      expect(screen.getByText("No matching platforms")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Refresh" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("toggles the agent HUD from Agent settings", async () => {


### PR DESCRIPTION
## Summary\n- Add a bounded timeout for Hermes messaging platform loads so the Agent settings Messaging tab cannot stay on the initial spinner forever.\n- Collapse failed initial messaging loads to an empty platform list while keeping Refresh available.\n- Add a regression test for a never-settling messaging platform request.\n\n## Validation\n- pnpm test\n- pnpm test -- --run src/test/app-settings.test.tsx\n- pnpm run lint\n- pnpm run build\n- pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/components/settings/AgentSettingsSection.tsx src/test/app-settings.test.tsx src/lib/async-timeout.ts src/lib/hermes-messaging.ts\n- git diff --check\n\n## Notes\n- pnpm run format still reports existing formatting issues in src/lib/live-transcript-preview.ts and src-tauri/tauri.conf.json; those files are outside this PR.