### PR TITLE
Add manual update check to About settings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2604,6 +2604,7 @@ export function App() {
                   onEnableSystemAudio={handleEnableSystemAudio}
                   activeTab={settingsTab}
                   onTabChange={setSettingsTab}
+                  onCheckForUpdates={() => runUpdateCheck("manual")}
                   onReportIssue={handleReportIssue}
                 />
               ) : activeView === "dictation" ? (

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -209,6 +209,8 @@ type AppSettingsProps = {
   // own nav — the standalone path exercised by app-settings tests.
   activeTab?: SettingsTab;
   onTabChange?: (tab: SettingsTab) => void;
+  // Runs the app updater's manual check flow.
+  onCheckForUpdates?: () => void;
   // Opens a new agent session seeded with a report category chip.
   onReportIssue?: (category: ReportCategory) => void;
 };
@@ -229,6 +231,7 @@ export function AppSettings({
   onEnableSystemAudio,
   activeTab: controlledTab,
   onTabChange,
+  onCheckForUpdates,
   onReportIssue,
 }: AppSettingsProps) {
   const [settings, setSettings] =
@@ -1223,6 +1226,26 @@ export function AppSettings({
                     </span>
                   </div>
                 </div>
+
+                {onCheckForUpdates ? (
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Updates</h3>
+                      <p className="settings-row-description">
+                        Check whether a newer version of June is available.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={onCheckForUpdates}
+                      >
+                        Check for updates
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
 
                 <div className="settings-row">
                   <div className="settings-row-info">

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1471,6 +1471,32 @@ describe("AppSettings", () => {
     expect(screen.getByText(APP_COMMIT_HASH)).toBeInTheDocument();
   });
 
+  it("checks for updates from About", async () => {
+    const onCheckForUpdates = vi.fn();
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+        onCheckForUpdates={onCheckForUpdates}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("tab", { name: "About" }));
+    expect(await screen.findByText("Updates")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Check for updates" }));
+
+    expect(onCheckForUpdates).toHaveBeenCalledOnce();
+  });
+
   it("opens the server attestation page from About through Rust", async () => {
     // Not an anchor: the webview drops target="_blank" navigations, so the
     // button must invoke the scribe_open_verify_page command instead.


### PR DESCRIPTION
## Summary\n- Adds an Updates row to the About settings panel with a Check for updates button.\n- Wires the button to the existing manual updater flow used by the native app menu.\n- Covers the About button with an AppSettings regression test.\n\n## Validation\n- pnpm test -- --run src/test/app-settings.test.tsx\n- pnpm run lint\n- pnpm exec prettier --check src/app/App.tsx src/components/settings/AppSettings.tsx src/test/app-settings.test.tsx\n- git diff --check\n- pnpm run build\n\n## Notes\n- Build passed with the existing Vite large-chunk warning.