### PR TITLE
Scope transcription errors to failed notes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -829,8 +829,12 @@ export function App() {
   );
 
   function handleRecovery(sessionId: string, action: "validate" | "discard") {
-    void recoverRecording(sessionId, action)
-      .then((note) => {
+    const recoveryNoteId = state.activeRecoveries.find(
+      (recovery) => recovery.sessionId === sessionId,
+    )?.noteId;
+    void (async () => {
+      try {
+        const note = await recoverRecording(sessionId, action);
         if (recordingStatusRef.current?.sessionId === sessionId) {
           recordingStatusRef.current = undefined;
           setRecordingNote(undefined);
@@ -838,8 +842,18 @@ export function App() {
         }
         dispatch({ type: "noteProcessingUpdated", note });
         dispatch({ type: "recoveryRemoved", sessionId });
-      })
-      .catch((err: unknown) => setError(messageFromError(err)));
+      } catch (err) {
+        if (
+          action === "validate" &&
+          recoveryNoteId &&
+          (await applyNoteScopedProcessingFailure(recoveryNoteId, err))
+        ) {
+          dispatch({ type: "recoveryRemoved", sessionId });
+          return;
+        }
+        setError(messageFromError(err));
+      }
+    })();
   }
 
   const handleAccountChanged = useCallback(
@@ -2285,9 +2299,29 @@ export function App() {
       const result = await finishRecording(sessionId);
       dispatch({ type: "noteProcessingUpdated", note: result.note });
     } catch (err) {
-      setError(messageFromError(err));
+      if (
+        !owningNoteId ||
+        !(await applyNoteScopedProcessingFailure(owningNoteId, err))
+      ) {
+        setError(messageFromError(err));
+      }
     } finally {
       finishingSessionsRef.current.delete(sessionId);
+    }
+  }
+
+  async function applyNoteScopedProcessingFailure(
+    noteId: string,
+    err: unknown,
+  ) {
+    try {
+      const note = await getNote(noteId);
+      if (note.processingStatus !== "failed") return false;
+      dispatch({ type: "noteProcessingUpdated", note });
+      setError(null);
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -835,11 +835,7 @@ export function App() {
     void (async () => {
       try {
         const note = await recoverRecording(sessionId, action);
-        if (recordingStatusRef.current?.sessionId === sessionId) {
-          recordingStatusRef.current = undefined;
-          setRecordingNote(undefined);
-          dispatch({ type: "recordingStatusCleared" });
-        }
+        clearActiveRecordingSession(sessionId);
         dispatch({ type: "noteProcessingUpdated", note });
         dispatch({ type: "recoveryRemoved", sessionId });
       } catch (err) {
@@ -848,12 +844,20 @@ export function App() {
           recoveryNoteId &&
           (await applyNoteScopedProcessingFailure(recoveryNoteId, err))
         ) {
+          clearActiveRecordingSession(sessionId);
           dispatch({ type: "recoveryRemoved", sessionId });
           return;
         }
         setError(messageFromError(err));
       }
     })();
+  }
+
+  function clearActiveRecordingSession(sessionId: string) {
+    if (recordingStatusRef.current?.sessionId !== sessionId) return;
+    recordingStatusRef.current = undefined;
+    setRecordingNote(undefined);
+    dispatch({ type: "recordingStatusCleared" });
   }
 
   const handleAccountChanged = useCallback(

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -614,6 +614,61 @@ describe("notes recording reliability", () => {
     expect(container.querySelector(".error-banner")).toBeNull();
   });
 
+  it("clears the active recorder when a recovered transcription failure is scoped", async () => {
+    const failedNote = {
+      ...first,
+      processingStatus: "failed" as const,
+      lastError: "Microphone: upstream_provider_failed",
+      audioSources: [
+        {
+          id: "audio-1",
+          source: "microphone" as const,
+          format: "wav" as const,
+          durationMs: 1000,
+          sizeBytes: 2048,
+          checksum: "abc",
+          createdAt: now,
+        },
+      ],
+    };
+    let recoveryFailed = false;
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [first, second],
+      activeRecoveries: [recovery()],
+      providerConfigured: true,
+    });
+    mocks.getNote.mockImplementation(async (noteId: string) => {
+      if (noteId === "note-2") return second;
+      return recoveryFailed ? failedNote : first;
+    });
+    mocks.recoverRecording.mockImplementation(async () => {
+      recoveryFailed = true;
+      throw {
+        code: "transcription_failed",
+        message:
+          "Microphone: The transcription provider could not process this audio.",
+      };
+    });
+
+    await startRecordingOnFirstNote();
+    expect(await screen.findByRole("button", { name: "Done" })).toBeEnabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Recover" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Microphone: The transcription provider could not process this audio\./,
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: "Done" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Open recording: First note" }),
+    ).toBeNull();
+  });
+
   it("applies the finish result even when the note already sat in a terminal status", async () => {
     mocks.finishRecording.mockResolvedValue({
       note: { ...first, processingStatus: "transcribing" },

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -547,6 +547,73 @@ describe("notes recording reliability", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps recovered transcription failures scoped to the failed note", async () => {
+    const failedNote = {
+      ...first,
+      processingStatus: "failed" as const,
+      lastError: "Microphone: upstream_provider_failed",
+      audioSources: [
+        {
+          id: "audio-1",
+          source: "microphone" as const,
+          format: "wav" as const,
+          durationMs: 1000,
+          sizeBytes: 2048,
+          checksum: "abc",
+          createdAt: now,
+        },
+      ],
+    };
+    let recoveryFailed = false;
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [first, second],
+      activeRecoveries: [recovery()],
+      providerConfigured: true,
+    });
+    mocks.getNote.mockImplementation(async (noteId: string) => {
+      if (noteId === "note-2") return second;
+      return recoveryFailed ? failedNote : first;
+    });
+    mocks.recoverRecording.mockImplementation(async () => {
+      recoveryFailed = true;
+      throw {
+        code: "transcription_failed",
+        message:
+          "Microphone: The transcription provider could not process this audio.",
+      };
+    });
+
+    const { container } = render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Meeting notes" }),
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /First note Preview/ }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Recover" }));
+
+    await waitFor(() =>
+      expect(mocks.recoverRecording).toHaveBeenCalledWith("rec-1", "validate"),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          /Microphone: The transcription provider could not process this audio\./,
+        ),
+      ).toBeInTheDocument(),
+    );
+    expect(container.querySelector(".note-failure-banner")).not.toBeNull();
+    expect(container.querySelector(".error-banner")).toBeNull();
+    expect(screen.queryByLabelText("Recoverable recording")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Dictation" }));
+    expect(container.querySelector(".note-failure-banner")).toBeNull();
+    expect(container.querySelector(".error-banner")).toBeNull();
+  });
+
   it("applies the finish result even when the note already sat in a terminal status", async () => {
     mocks.finishRecording.mockResolvedValue({
       note: { ...first, processingStatus: "transcribing" },


### PR DESCRIPTION
## Summary
- keep recovered recording transcription failures on the owning meeting note instead of the global app banner
- reload the affected note after a recovery or finish command reports a processing failure, then render the existing note failure banner
- remove the stale recovery prompt once a recovered recording has been converted into a failed note
- add a regression test that navigates away after a failed recovered transcription and verifies the top banner stays clear

## Validation
- `pnpm test src/test/app-notes-reliability.test.tsx`
- `pnpm run lint`
- `pnpm test`
- `pnpm build`
- `pnpm exec prettier --check src/app/App.tsx src/test/app-notes-reliability.test.tsx`

## Notes
- `pnpm run format` currently fails on pre-existing formatting issues in `src/lib/live-transcript-preview.ts` and `src-tauri/tauri.conf.json`; the files touched by this PR pass Prettier.