### PR TITLE
Refine onboarding privacy copy

### DIFF
--- a/src/components/onboarding/StepChrome.tsx
+++ b/src/components/onboarding/StepChrome.tsx
@@ -14,6 +14,7 @@ export function StepCard({
   subtitle,
   mark,
   wide,
+  className,
   children,
 }: {
   title: string;
@@ -22,11 +23,15 @@ export function StepCard({
   mark?: boolean;
   /** Steps with a demo card or timeline get a little more room. */
   wide?: boolean;
+  /** Extra class on the card for step-specific layout (e.g. the welcome grid). */
+  className?: string;
   children?: ReactNode;
 }) {
   return (
     <section
-      className={`welcome-card onboarding-card${wide ? " trial-card" : ""}`}
+      className={`welcome-card onboarding-card${wide ? " trial-card" : ""}${
+        className ? ` ${className}` : ""
+      }`}
     >
       {mark ? (
         <span className="welcome-mark" aria-hidden>

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { IconCalendar1 } from "central-icons/IconCalendar1";
 import { IconLock } from "central-icons/IconLock";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSparkle } from "central-icons/IconSparkle";
@@ -14,19 +15,26 @@ import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 const JUNE_POINTS = [
   {
     icon: IconSparkle,
-    title: "An agent on your computer",
+    title: "Chat and work with June",
     detail: "Hand June real work. It runs the session and comes back done.",
   },
   {
     icon: IconMicrophone,
-    title: "Talk instead of type",
-    detail: "Dictate into any app. June writes your meeting notes too.",
+    title: "Speak instead of type",
+    detail:
+      "June turns your voice into polished writing into any app on your computer.",
+  },
+  {
+    icon: IconCalendar1,
+    title: "Effortlessly capture meetings",
+    detail:
+      "June takes notes without having to join the meeting. It detects your meetings and writes for you.",
   },
   {
     icon: IconLock,
     title: "Private by default",
     detail:
-      "Prompts leave your device only for inference, on zero-retention models by default.",
+      "Prompts leave your device only for inference, using zero data retention private models by default",
   },
 ];
 
@@ -41,7 +49,7 @@ const WINDOWS_JUNE_POINTS = [
     title: "Meeting notes from your mic",
     detail: "Record meetings from your microphone and turn them into notes.",
   },
-  JUNE_POINTS[2],
+  JUNE_POINTS[3],
 ];
 
 /**
@@ -99,7 +107,7 @@ export function SignInStep({
   return (
     <StepCard
       title="Welcome to June"
-      subtitle="Your private AI assistant."
+      subtitle="Private AI for every day life and work."
       mark
       wide
     >

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -22,7 +22,7 @@ const JUNE_POINTS = [
     icon: IconMicrophone,
     title: "Speak instead of type",
     detail:
-      "June turns your voice into polished writing into any app on your computer.",
+      "June turns your voice into polished writing in any app on your computer.",
   },
   {
     icon: IconCalendar1,
@@ -34,7 +34,7 @@ const JUNE_POINTS = [
     icon: IconLock,
     title: "Private by default",
     detail:
-      "Prompts leave your device only for inference, using zero data retention private models by default",
+      "Prompts leave your device only for inference, using zero data retention private models by default.",
   },
 ];
 
@@ -107,7 +107,7 @@ export function SignInStep({
   return (
     <StepCard
       title="Welcome to June"
-      subtitle="Private AI for every day life and work."
+      subtitle="Private AI for everyday life and work."
       mark
       wide
     >

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -27,14 +27,13 @@ const JUNE_POINTS = [
   {
     icon: IconCalendar1,
     title: "Effortlessly capture meetings",
-    detail:
-      "June takes notes without having to join the meeting. It detects your meetings and writes for you.",
+    detail: "June takes the notes without ever joining the meeting.",
   },
   {
     icon: IconLock,
     title: "Private by default",
     detail:
-      "Prompts leave your device only for inference, using zero data retention private models by default.",
+      "Prompts leave your device only for inference, on zero-retention private models.",
   },
 ];
 
@@ -69,7 +68,8 @@ export function SignInStep({
 }) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();
-  const points = isMacLikePlatform() ? JUNE_POINTS : WINDOWS_JUNE_POINTS;
+  const isMac = isMacLikePlatform();
+  const points = isMac ? JUNE_POINTS : WINDOWS_JUNE_POINTS;
 
   const cancelInFlight = useCallback(async () => {
     try {
@@ -110,6 +110,7 @@ export function SignInStep({
       subtitle="Private AI for everyday life and work."
       mark
       wide
+      className={isMac ? "welcome-card-intro" : undefined}
     >
       <ul className="onboarding-points">
         {points.map(({ icon: Icon, title, detail }) => (

--- a/src/components/onboarding/steps/TrialStep.tsx
+++ b/src/components/onboarding/steps/TrialStep.tsx
@@ -12,6 +12,24 @@ import {
 import { Spinner } from "../../ui/Spinner";
 import { StepActions, StepCard } from "../StepChrome";
 
+const PRIVACY_RECAP_ITEMS = [
+  {
+    label: "Local first",
+    detail:
+      "Your app state, recordings, transcripts, files, sessions, and memory stay on your device by default.",
+  },
+  {
+    label: "Private AI models",
+    detail:
+      "Prompts leave your device only for inference, using private models with zero data retention and no training by default.",
+  },
+  {
+    label: "Minimal data retention",
+    detail:
+      "June keeps only what's needed to maintain your account. Everything else is stored locally on your device.",
+  },
+];
+
 /**
  * The free-trial step, deliberately placed after permissions (the user has
  * invested) and right before the hands-on dictation practice (the practice
@@ -65,7 +83,24 @@ export function TrialStep({
       <StepCard
         title="You're good to go"
         subtitle="Your trial is live. Try talking to June."
+        wide
       >
+        <section
+          className="trial-privacy-recap"
+          aria-labelledby="trial-privacy-title"
+        >
+          <h2 id="trial-privacy-title">
+            And remember, June keeps it all private
+          </h2>
+          <ul>
+            {PRIVACY_RECAP_ITEMS.map((item) => (
+              <li key={item.label}>
+                <span className="trial-privacy-label">{item.label}</span>
+                <span className="trial-privacy-detail">{item.detail}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
         <StepActions onContinue={onContinue} />
       </StepCard>
     );

--- a/src/components/onboarding/steps/TrialStep.tsx
+++ b/src/components/onboarding/steps/TrialStep.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from "react";
+import { IconDevices } from "central-icons/IconDevices";
+import { IconLock } from "central-icons/IconLock";
+import { IconShieldCheck } from "central-icons/IconShieldCheck";
 import {
   isSubscriptionActive,
   useTrialCheckout,
@@ -14,19 +17,19 @@ import { StepActions, StepCard } from "../StepChrome";
 
 const PRIVACY_RECAP_ITEMS = [
   {
+    icon: IconDevices,
     label: "Local first",
-    detail:
-      "Your app state, recordings, transcripts, files, sessions, and memory stay on your device by default.",
+    detail: "Your data stays on your device by default.",
   },
   {
+    icon: IconLock,
     label: "Private AI models",
-    detail:
-      "Prompts leave your device only for inference, using private models with zero data retention and no training by default.",
+    detail: "Inference runs on private, zero-retention models by default.",
   },
   {
+    icon: IconShieldCheck,
     label: "Minimal data retention",
-    detail:
-      "June keeps only what's needed to maintain your account. Everything else is stored locally on your device.",
+    detail: "June keeps only what's needed for your account.",
   },
 ];
 
@@ -82,21 +85,22 @@ export function TrialStep({
     return (
       <StepCard
         title="You're good to go"
-        subtitle="Your trial is live. Try talking to June."
+        subtitle="Your trial is live, and June keeps it all private."
         wide
+        className="trial-card-done"
       >
         <section
           className="trial-privacy-recap"
-          aria-labelledby="trial-privacy-title"
+          aria-label="How June keeps your data private"
         >
-          <h2 id="trial-privacy-title">
-            And remember, June keeps it all private
-          </h2>
           <ul>
-            {PRIVACY_RECAP_ITEMS.map((item) => (
-              <li key={item.label}>
-                <span className="trial-privacy-label">{item.label}</span>
-                <span className="trial-privacy-detail">{item.detail}</span>
+            {PRIVACY_RECAP_ITEMS.map(({ icon: Icon, label, detail }) => (
+              <li key={label}>
+                <span className="trial-privacy-icon" aria-hidden>
+                  <Icon size={15} />
+                </span>
+                <span className="trial-privacy-label">{label}</span>
+                <span className="trial-privacy-detail">{detail}</span>
               </li>
             ))}
           </ul>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12941,6 +12941,45 @@ input:focus-visible,
   text-align: center;
 }
 
+.trial-privacy-recap {
+  margin: var(--sp-1) 0 0;
+  padding: var(--sp-3) 0;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  text-align: left;
+}
+
+.trial-privacy-recap h2 {
+  margin: 0 0 var(--sp-2);
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-align: center;
+}
+
+.trial-privacy-recap ul {
+  display: grid;
+  gap: var(--sp-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.trial-privacy-label {
+  display: block;
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+}
+
+.trial-privacy-detail {
+  display: block;
+  margin-top: 1px;
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+
 .trial-gate-link {
   padding: 0;
   border: 0;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12863,6 +12863,43 @@ input:focus-visible,
   width: min(100%, 360px);
 }
 
+/* Welcome step lays its four what-is-June points out as a 2x2 grid rather
+ * than a tall single column, so the card needs a touch more width. Cells
+ * top-align (align-items: start in .onboarding-points li) so uneven body
+ * lengths sit cleanly rather than centering against each other. */
+.welcome-card-intro {
+  width: min(100%, 500px);
+}
+
+.welcome-card-intro .onboarding-points {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-6) var(--sp-6);
+}
+
+/* The 2x2 grid wants the full card width, but the sign-in button and footer
+ * shouldn't stretch with it — keep them in a centered, button-width column. */
+.welcome-card-intro .welcome-providers,
+.welcome-card-intro .welcome-status,
+.welcome-card-intro .welcome-terms {
+  width: 100%;
+  max-width: 320px;
+  margin-inline: auto;
+}
+
+/* The trial success step lays its privacy recap out as a 3-up row, so it
+ * needs more width than the 360px trial card — but, like the welcome step,
+ * the continue button stays in a centered, button-width column. */
+.trial-card-done {
+  width: min(100%, 540px);
+}
+
+.trial-card-done .welcome-providers {
+  width: 100%;
+  max-width: 320px;
+  margin-inline: auto;
+}
+
 .trial-timeline {
   display: flex;
   flex-direction: column;
@@ -12941,43 +12978,88 @@ input:focus-visible,
   text-align: center;
 }
 
+/* Linear-style: three short, symmetric columns framed by faded-edge
+ * dividers. The privacy headline lives in the card subtitle instead of a
+ * third in-section heading, so the recap carries just two type styles
+ * (label + detail) rather than stacking heading/label/detail. Everything is
+ * centered, so it reads balanced under the hero. Static — no animation. */
 .trial-privacy-recap {
-  margin: var(--sp-1) 0 0;
-  padding: var(--sp-3) 0;
-  border-top: 1px solid var(--border-subtle);
-  border-bottom: 1px solid var(--border-subtle);
-  text-align: left;
+  position: relative;
+  margin: var(--sp-1) 0;
+  padding: var(--sp-5) 0;
+  text-align: center;
 }
 
-.trial-privacy-recap h2 {
-  margin: 0 0 var(--sp-2);
-  color: var(--foreground);
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  text-align: center;
+/* Hairline dividers top and bottom, brightest in the middle and dissolving
+ * at both ends — frames the row without a hard boxed-in border. */
+.trial-privacy-recap::before,
+.trial-privacy-recap::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--border) 50%,
+    transparent
+  );
+}
+
+.trial-privacy-recap::before {
+  top: 0;
+}
+
+.trial-privacy-recap::after {
+  bottom: 0;
 }
 
 .trial-privacy-recap ul {
   display: grid;
-  gap: var(--sp-2);
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--sp-5);
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
+.trial-privacy-recap li {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--sp-1);
+}
+
+/* Same 28px outlined chip as the welcome points and trial-timeline rows, so
+ * the icons read as one family across the flow. */
+.trial-privacy-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-bottom: var(--sp-1);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--card);
+  color: var(--warm-strong);
+}
+
 .trial-privacy-label {
   display: block;
   color: var(--foreground);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-md);
   font-weight: 600;
 }
 
 .trial-privacy-detail {
   display: block;
-  margin-top: 1px;
   color: var(--muted-foreground);
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   line-height: 1.4;
+  text-wrap: pretty;
 }
 
 .trial-gate-link {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -440,13 +440,16 @@ describe("OnboardingFlow", () => {
         ),
       ).toBeInTheDocument();
       expect(
-        screen.queryByText("Talk instead of type"),
+        screen.queryByText("Speak instead of type"),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByText(/Dictate into any app/),
+        screen.queryByText(/June turns your voice into polished writing/),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByText("An agent on your computer"),
+        screen.queryByText("Effortlessly capture meetings"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Chat and work with June"),
       ).not.toBeInTheDocument();
     } finally {
       restoreNavigator();
@@ -478,6 +481,29 @@ describe("OnboardingFlow", () => {
     await screen.findByRole("heading", {
       name: "You're good to go",
     });
+    expect(
+      screen.getByRole("heading", {
+        name: "And remember, June keeps it all private",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Local first")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your app state, recordings, transcripts, files, sessions, and memory stay on your device by default.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Private AI models")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Prompts leave your device only for inference, using private models with zero data retention and no training by default.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Minimal data retention")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "June keeps only what's needed to maintain your account. Everything else is stored locally on your device.",
+      ),
+    ).toBeInTheDocument();
     expect(mocks.focusMainWindow).toHaveBeenCalledOnce();
 
     await user.click(screen.getByRole("button", { name: "Continue" }));

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -481,28 +481,24 @@ describe("OnboardingFlow", () => {
     await screen.findByRole("heading", {
       name: "You're good to go",
     });
+    // The privacy reassurance moved from a section heading into the card
+    // subtitle; the recap below is now a labelled row of points.
     expect(
-      screen.getByRole("heading", {
-        name: "And remember, June keeps it all private",
-      }),
+      screen.getByText("Your trial is live, and June keeps it all private."),
     ).toBeInTheDocument();
     expect(screen.getByText("Local first")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Your app state, recordings, transcripts, files, sessions, and memory stay on your device by default.",
-      ),
+      screen.getByText("Your data stays on your device by default."),
     ).toBeInTheDocument();
     expect(screen.getByText("Private AI models")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Prompts leave your device only for inference, using private models with zero data retention and no training by default.",
+        "Inference runs on private, zero-retention models by default.",
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Minimal data retention")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "June keeps only what's needed to maintain your account. Everything else is stored locally on your device.",
-      ),
+      screen.getByText("June keeps only what's needed for your account."),
     ).toBeInTheDocument();
     expect(mocks.focusMainWindow).toHaveBeenCalledOnce();
 


### PR DESCRIPTION
## Summary
- Updates the June onboarding welcome copy and adds the meeting-capture point
- Adds a compact privacy recap to the trial success screen
- Aligns privacy claims with the repo privacy contract: local data by default, private zero-retention/no-training model inference, and account-only retention

## Verification
- pnpm exec vitest run src/test/onboarding.test.tsx
- pnpm run lint
- Browser preview verified at /onboarding-preview.html?step=trial