### PR TITLE
Defer system audio permission until recording

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -549,9 +549,11 @@ pub async fn check_recording_source_readiness(
     // The system-audio permission probe can block for over a minute while the
     // helper waits on a CoreAudio permission grant; keep that work off the
     // async runtime so other commands stay responsive.
-    tokio::task::spawn_blocking(move || recording_source_readiness(request.source_mode))
-        .await
-        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
+    tokio::task::spawn_blocking(move || {
+        recording_source_readiness(request.source_mode, request.probe_system_audio)
+    })
+    .await
+    .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
 }
 
 /// Opens the scribe-api `/verify` page (enclave attestation, routing,
@@ -629,9 +631,10 @@ pub async fn start_recording(
     let source_mode = request.source_mode.unwrap_or_default();
     // Readiness probing and capture startup both wait on the system-audio
     // helper (up to tens of seconds); run them off the async runtime.
-    let readiness = tokio::task::spawn_blocking(move || recording_source_readiness(source_mode))
-        .await
-        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))?;
+    let readiness =
+        tokio::task::spawn_blocking(move || recording_source_readiness(source_mode, true))
+            .await
+            .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))?;
     if !readiness.ready {
         let message = readiness
             .sources
@@ -990,7 +993,10 @@ async fn finish_recording_session(
     })
 }
 
-fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSourceReadinessDto {
+fn recording_source_readiness(
+    source_mode: RecordingSourceMode,
+    probe_system_audio: bool,
+) -> RecordingSourceReadinessDto {
     let (microphone_state, microphone_hint) = microphone_permission_state();
     let microphone_ready = microphone_state == "granted";
     let mut sources = vec![SourceReadinessDto {
@@ -1007,7 +1013,11 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
         let mut system = crate::audio::system_macos::system_audio_readiness();
-        if should_probe_system_audio_permission(system.ready, is_capture_active()) {
+        if !probe_system_audio {
+            if system.permission_state == "unknown" {
+                system.ready = false;
+            }
+        } else if should_probe_system_audio_permission(system.ready, is_capture_active()) {
             if let Err(error) = crate::audio::system_macos::helper_permission_check() {
                 system.ready = false;
                 system.permission_state = "denied".to_string();
@@ -1652,6 +1662,7 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
 #[cfg(test)]
 mod tests {
     use super::should_probe_system_audio_permission;
+    use crate::domain::types::{CheckRecordingSourceReadinessRequest, RecordingSourceMode};
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
@@ -1662,5 +1673,36 @@ mod tests {
     fn probes_system_audio_permission_only_when_available_and_idle() {
         assert!(should_probe_system_audio_permission(true, false));
         assert!(!should_probe_system_audio_permission(false, false));
+    }
+
+    #[test]
+    fn readiness_request_defaults_to_system_audio_probe() {
+        let request: CheckRecordingSourceReadinessRequest =
+            serde_json::from_value(serde_json::json!({
+                "sourceMode": "microphonePlusSystem"
+            }))
+            .expect("request should deserialize");
+
+        assert_eq!(
+            request.source_mode,
+            RecordingSourceMode::MicrophonePlusSystem
+        );
+        assert!(request.probe_system_audio);
+    }
+
+    #[test]
+    fn readiness_request_can_skip_system_audio_probe() {
+        let request: CheckRecordingSourceReadinessRequest =
+            serde_json::from_value(serde_json::json!({
+                "sourceMode": "microphonePlusSystem",
+                "probeSystemAudio": false
+            }))
+            .expect("request should deserialize");
+
+        assert_eq!(
+            request.source_mode,
+            RecordingSourceMode::MicrophonePlusSystem
+        );
+        assert!(!request.probe_system_audio);
     }
 }

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -294,6 +294,12 @@ pub struct MicrophonePermissionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct CheckRecordingSourceReadinessRequest {
     pub source_mode: RecordingSourceMode,
+    #[serde(default = "default_probe_system_audio")]
+    pub probe_system_audio: bool,
+}
+
+fn default_probe_system_audio() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -80,32 +80,21 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": [
-          "$TEMP/os-scribe-dictation-*.m4a"
-        ]
+        "scope": ["$TEMP/os-scribe-dictation-*.m4a"]
       },
-      "capabilities": [
-        "main",
-        "hud",
-        "agent-hud",
-        "meeting-hud"
-      ]
+      "capabilities": ["main", "hud", "agent-hud", "meeting-hud"]
     }
   },
   "plugins": {
     "deep-link": {
       "mobile": [
         {
-          "scheme": [
-            "osscribe"
-          ],
+          "scheme": ["osscribe"],
           "appLink": false
         }
       ],
       "desktop": {
-        "schemes": [
-          "osscribe"
-        ]
+        "schemes": ["osscribe"]
       }
     },
     "updater": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -146,6 +146,7 @@ import type {
   NoteListItemDto,
   RecordingSourceMode,
   RecordingSourceReadinessDto,
+  SourceReadinessDto,
 } from "../lib/tauri";
 import { useAccountStatus } from "../lib/account-status";
 import {
@@ -380,6 +381,7 @@ export function App() {
   const [sourceReadiness, setSourceReadiness] =
     useState<RecordingSourceReadinessDto>();
   const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
+  const systemAudioSettingsReturnProbeRef = useRef(false);
   const [accessibilityStatus, setAccessibilityStatus] = useState<string>();
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
   const [readyUpdate, setReadyUpdate] =
@@ -389,11 +391,15 @@ export function App() {
   const [relaunchingUpdate, setRelaunchingUpdate] = useState(false);
   const [updateProgress, setUpdateProgress] =
     useState<UpdateInstallProgress | null>(null);
-  const systemGranted = !!sourceReadiness?.sources.find(
+  const systemSourceReadiness = sourceReadiness?.sources.find(
     (source) => source.source === "system",
-  )?.ready;
+  );
+  const systemAudioBlocked = isSystemAudioBlockedSource(systemSourceReadiness);
+  const systemAudioUnavailable = isSystemAudioUnavailableSource(
+    systemSourceReadiness,
+  );
   const sourceMode: RecordingSourceMode =
-    userWantsSystemAudio && systemGranted
+    userWantsSystemAudio && !systemAudioBlocked && !systemAudioUnavailable
       ? "microphonePlusSystem"
       : "microphoneOnly";
   const {
@@ -1539,17 +1545,22 @@ export function App() {
       .catch((err: unknown) => setError(messageFromError(err)));
   }, [appBlocked]);
 
-  // Probe with "microphonePlusSystem" on mount so sourceReadiness always
-  // has the system source. Onboarding's permissions screen normally fires
-  // the native TCC prompt in context; for users who skipped that step the
-  // helper preflight behind this call surfaces it here instead.
+  // Populate mic state plus system-audio capability on mount without running
+  // the helper permission probe. The native system-audio prompt belongs to the
+  // moment the user starts a recording that wants system audio.
   useEffect(() => {
     if (appBlocked) return;
     let cancelled = false;
     setCheckingSourceReadiness(true);
-    checkRecordingSourceReadiness("microphonePlusSystem")
+    checkRecordingSourceReadiness("microphonePlusSystem", {
+      probeSystemAudio: false,
+    })
       .then((readiness) => {
-        if (!cancelled) setSourceReadiness(readiness);
+        if (!cancelled) {
+          setSourceReadiness((previous) =>
+            mergeNonProbingSourceReadiness(previous, readiness),
+          );
+        }
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(messageFromError(err));
@@ -1557,10 +1568,9 @@ export function App() {
       .finally(() => {
         if (!cancelled) setCheckingSourceReadiness(false);
       });
-    // Eagerly request mic from the helper. This fires the native TCC
-    // prompt for fresh installs (matching the system-audio eager prompt),
-    // and for already-denied users it immediately emits the current
-    // status so the mic-blocked strip renders without further user
+    // Eagerly request mic from the helper. This fires the native TCC prompt
+    // for fresh installs, and for already-denied users it immediately emits
+    // the current status so the mic-blocked strip renders without further user
     // action. For granted users it's a no-op.
     void dictationHelperCommand({
       type: "request_microphone_permission",
@@ -1594,13 +1604,33 @@ export function App() {
         () => undefined,
       );
       if (captureActive) return;
-      void checkRecordingSourceReadiness("microphonePlusSystem")
-        .then(setSourceReadiness)
+      const previousSystem = sourceReadiness?.sources.find(
+        (source) => source.source === "system",
+      );
+      const shouldProbeSystemAudio =
+        systemAudioSettingsReturnProbeRef.current ||
+        isSystemAudioBlockedSource(previousSystem);
+      systemAudioSettingsReturnProbeRef.current = false;
+      const readinessPromise = shouldProbeSystemAudio
+        ? checkRecordingSourceReadiness("microphonePlusSystem")
+        : checkRecordingSourceReadiness("microphonePlusSystem", {
+            probeSystemAudio: false,
+          });
+      void readinessPromise
+        .then((readiness) => {
+          if (shouldProbeSystemAudio) {
+            setSourceReadiness(readiness);
+            return;
+          }
+          setSourceReadiness((previous) =>
+            mergeNonProbingSourceReadiness(previous, readiness),
+          );
+        })
         .catch(() => undefined);
     }
     window.addEventListener("focus", refresh);
     return () => window.removeEventListener("focus", refresh);
-  }, [appBlocked, state.recordingStatus?.state]);
+  }, [appBlocked, sourceReadiness, state.recordingStatus?.state]);
 
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");
@@ -1611,6 +1641,7 @@ export function App() {
   // the user to the System Settings pane.
   function handleEnableSystemAudio() {
     setUserWantsSystemAudio(true);
+    systemAudioSettingsReturnProbeRef.current = true;
     void openPrivacySettings("systemAudio");
   }
 
@@ -2142,7 +2173,11 @@ export function App() {
       try {
         setCheckingSourceReadiness(true);
         const readiness = await checkRecordingSourceReadiness(sourceMode);
-        setSourceReadiness(readiness);
+        setSourceReadiness((previous) =>
+          sourceMode === "microphoneOnly" && userWantsSystemAudio
+            ? mergeMicOnlyFallbackReadiness(previous, readiness)
+            : readiness,
+        );
 
         const micSource = readiness.sources.find(
           (source) => source.source === "microphone",
@@ -2155,10 +2190,10 @@ export function App() {
           return false;
         }
 
-        // System audio is optional. If the fresh probe shows it isn't
-        // available, fall back to mic-only for this take — the derived
-        // sourceMode will follow automatically next render via
-        // setSourceReadiness above.
+        // System audio is optional. If the fresh probe shows it is blocked or
+        // unavailable, fall back to mic-only for this take. Passive readiness
+        // refreshes preserve that blocked verdict until an explicit probe
+        // reports system audio ready again.
         const systemSource = readiness.sources.find(
           (source) => source.source === "system",
         );
@@ -3357,6 +3392,75 @@ function isDeniedPermission(state?: string) {
 // non-blocking so the banner doesn't flash before the helper's first report.
 export function isAccessibilityBlocked(state?: string) {
   return state !== undefined && state !== "granted";
+}
+
+function isSystemAudioBlockedSource(source?: SourceReadinessDto) {
+  return (
+    source?.permissionState === "denied" ||
+    source?.permissionState === "restricted"
+  );
+}
+
+function isSystemAudioUnavailableSource(source?: SourceReadinessDto) {
+  return (
+    source?.permissionState === "unsupported" ||
+    source?.captureAvailable === false
+  );
+}
+
+export function mergeMicOnlyFallbackReadiness(
+  previous: RecordingSourceReadinessDto | undefined,
+  next: RecordingSourceReadinessDto,
+): RecordingSourceReadinessDto {
+  if (next.sources.some((source) => source.source === "system")) return next;
+  const previousSystem = previous?.sources.find(
+    (source) => source.source === "system",
+  );
+  if (
+    !previousSystem ||
+    (!isSystemAudioBlockedSource(previousSystem) &&
+      !isSystemAudioUnavailableSource(previousSystem))
+  ) {
+    return next;
+  }
+
+  const sources = [...next.sources, previousSystem];
+  return {
+    ...next,
+    ready: sources.every((source) => !source.required || source.ready),
+    sources,
+  };
+}
+
+export function mergeNonProbingSourceReadiness(
+  previous: RecordingSourceReadinessDto | undefined,
+  next: RecordingSourceReadinessDto,
+): RecordingSourceReadinessDto {
+  const previousSystem = previous?.sources.find(
+    (source) => source.source === "system",
+  );
+  if (!previousSystem || !isSystemAudioBlockedSource(previousSystem)) {
+    return next;
+  }
+
+  const nextSystemIndex = next.sources.findIndex(
+    (source) => source.source === "system",
+  );
+  if (nextSystemIndex < 0) return next;
+
+  const nextSystem = next.sources[nextSystemIndex];
+  if (nextSystem.ready || nextSystem.permissionState !== "unknown") {
+    return next;
+  }
+
+  const sources = next.sources.map((source, index) =>
+    index === nextSystemIndex ? previousSystem : source,
+  );
+  return {
+    ...next,
+    ready: sources.every((source) => !source.required || source.ready),
+    sources,
+  };
 }
 
 function isNewSessionShortcut(event: KeyboardEvent) {

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -12,10 +12,7 @@ import { PermissionsStep } from "./steps/PermissionSteps";
 import { DictationPracticeStep } from "./steps/PracticeStep";
 import { SignInStep } from "./steps/SignInStep";
 import { TrialStep } from "./steps/TrialStep";
-import {
-  usePermissionStatuses,
-  useSystemAudioStatus,
-} from "./use-permission-status";
+import { usePermissionStatuses } from "./use-permission-status";
 
 type StepId = "sign-in" | "permissions" | "trial" | "dictation-practice";
 
@@ -111,10 +108,6 @@ export function OnboardingFlow({
 
   // Only poll the helper while the user is on the permissions screen.
   const permissionStatuses = usePermissionStatuses(stepId === "permissions");
-  // The probe behind this is also what fires the system-audio TCC prompt
-  // on a fresh install — deliberately run from the permissions screen, in
-  // context, instead of ambushing the user after onboarding.
-  const systemAudio = useSystemAudioStatus(stepId === "permissions");
 
   // Onboarding pitches the bare-fn default, but a version bump replays the
   // wizard for existing users, so it must not clobber a key they customized
@@ -204,12 +197,7 @@ export function OnboardingFlow({
             onContinue={goNext}
           />
         ) : stepId === "permissions" ? (
-          <PermissionsStep
-            statuses={permissionStatuses}
-            systemAudioStatus={systemAudio.status}
-            onAllowSystemAudio={systemAudio.probe}
-            onContinue={goNext}
-          />
+          <PermissionsStep statuses={permissionStatuses} onContinue={goNext} />
         ) : stepId === "trial" ? (
           <TrialStep
             account={account}

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconTextIndicator } from "central-icons/IconTextIndicator";
-import { IconVolumeFull } from "central-icons/IconVolumeFull";
 import {
   dictationHelperCommand,
   openPrivacySettings,
@@ -15,7 +14,6 @@ import {
   isMicrophoneDenied,
   isMicrophoneGranted,
   type PermissionStatuses,
-  type SystemAudioStatus,
 } from "../use-permission-status";
 
 function PermissionRow({
@@ -66,26 +64,15 @@ function PermissionRow({
 
 export function PermissionsStep({
   statuses,
-  systemAudioStatus,
-  onAllowSystemAudio,
   onContinue,
 }: {
   statuses: PermissionStatuses;
-  systemAudioStatus: SystemAudioStatus;
-  /** Re-runs the capture-helper probe; fires the TCC prompt while the
-   * permission is still undetermined. */
-  onAllowSystemAudio: () => void;
   onContinue: () => void;
 }) {
   const [showUnknownStatuses, setShowUnknownStatuses] = useState(false);
   const micGranted = isMicrophoneGranted(statuses);
   const micDenied = isMicrophoneDenied(statuses);
   const accessibilityGranted = isAccessibilityGranted(statuses);
-  const systemAudioGranted = systemAudioStatus === "granted";
-  const systemAudioDenied = systemAudioStatus === "denied";
-  // macOS < 14.2 (or a missing capture helper) can never grant; the row
-  // explains itself and stays out of the Continue gate.
-  const systemAudioUnsupported = systemAudioStatus === "unsupported";
   const showPermissionRows = statuses.checked || showUnknownStatuses;
   const macLikePlatform = isMacLikePlatform();
 
@@ -131,7 +118,7 @@ export function PermissionsStep({
       title="Let June listen and type"
       subtitle={
         macLikePlatform
-          ? "Dictation and meeting notes need three macOS permissions."
+          ? "Dictation and meeting notes need two macOS permissions."
           : "Dictation and meeting notes need microphone access."
       }
       wide
@@ -172,30 +159,6 @@ export function PermissionsStep({
                 showPermissionRows ? openAccessibilitySettings : undefined
               }
             />
-            <PermissionRow
-              icon={<IconVolumeFull size={15} />}
-              granted={showPermissionRows && systemAudioGranted}
-              probing={showPermissionRows && systemAudioStatus === "probing"}
-              title="System audio"
-              detail={
-                systemAudioDenied
-                  ? "Turned off in System Settings. Flip the toggle and June will notice."
-                  : systemAudioUnsupported
-                    ? "Needs macOS 14.2 or later."
-                    : systemAudioStatus === "probing"
-                      ? "Waiting for macOS. Approve the prompt when it appears."
-                      : "Hears your calls and meetings, only while you record."
-              }
-              onAllow={
-                showPermissionRows
-                  ? systemAudioDenied
-                    ? () => void openPrivacySettings("systemAudio")
-                    : systemAudioStatus === "unknown"
-                      ? onAllowSystemAudio
-                      : undefined
-                  : undefined
-              }
-            />
           </>
         ) : null}
       </ul>
@@ -204,9 +167,7 @@ export function PermissionsStep({
         continueDisabled={
           !showPermissionRows ||
           !micGranted ||
-          (macLikePlatform &&
-            (!accessibilityGranted ||
-              !(systemAudioGranted || systemAudioUnsupported)))
+          (macLikePlatform && !accessibilityGranted)
         }
         onSkip={onContinue}
       />

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -1,10 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
-import {
-  checkRecordingSourceReadiness,
-  dictationHelperCommand,
-} from "../../lib/tauri";
+import { dictationHelperCommand } from "../../lib/tauri";
 
 export type PermissionStatuses = {
   /** AVCaptureDevice vocabulary: "granted" | "denied" | "restricted" | "undetermined". */
@@ -36,86 +33,9 @@ export function isAccessibilityGranted(statuses: PermissionStatuses) {
  * readiness probe doesn't reflect TCC denial), so this listens for its
  * `permission_status` events and, while `active`, polls
  * `get_permission_status` so a toggle flipped in System Settings shows up
- * within a beat of the user returning — onboarding stays on the permissions
- * screen the whole time, so the usual focus-refresh in App.tsx isn't
- * running yet.
+ * within a beat of the user returning. Onboarding deliberately does not check
+ * system audio; that macOS prompt belongs to meeting recording start.
  */
-export type SystemAudioStatus =
-  | "unknown"
-  | "probing"
-  | "granted"
-  | "denied"
-  | "unsupported";
-
-/**
- * System-audio permission state for the onboarding wizard.
- *
- * There is no query-only macOS API for the system-audio TCC entry, so the
- * only way to learn the state is to run the capture-helper preflight
- * (checkRecordingSourceReadiness) — on a fresh install that probe is also
- * what surfaces the native "record system audio" prompt. Running it here,
- * on the permissions screen, is the point: the user just read why we're
- * asking, instead of getting hit with the dialog after onboarding ends.
- */
-export function useSystemAudioStatus(active: boolean): {
-  status: SystemAudioStatus;
-  probe: () => void;
-} {
-  const [status, setStatus] = useState<SystemAudioStatus>("unknown");
-  const statusRef = useRef(status);
-  statusRef.current = status;
-  const inflightRef = useRef(false);
-
-  const probe = useCallback(() => {
-    if (inflightRef.current) return;
-    inflightRef.current = true;
-    // Only the first probe shows the pending row; re-probes after a denial
-    // keep the settled state until the new verdict lands, so the System
-    // Settings hint doesn't flicker away on every window focus.
-    setStatus((prev) => (prev === "unknown" ? "probing" : prev));
-    checkRecordingSourceReadiness("microphonePlusSystem")
-      .then((readiness) => {
-        const system = readiness.sources.find(
-          (source) => source.source === "system",
-        );
-        if (!system || system.permissionState === "unsupported") {
-          setStatus("unsupported");
-        } else {
-          // The probe leaves permissionState "unknown" on success; ready is
-          // the granted signal.
-          setStatus(system.ready ? "granted" : "denied");
-        }
-      })
-      .catch(() => {
-        // IPC failure, not a TCC verdict; back to unknown so the row's
-        // Allow button can retry.
-        setStatus((prev) => (prev === "probing" ? "unknown" : prev));
-      })
-      .finally(() => {
-        inflightRef.current = false;
-      });
-  }, []);
-
-  useEffect(() => {
-    if (!active || statusRef.current !== "unknown") return;
-    probe();
-  }, [active, probe]);
-
-  // A denial is recoverable in System Settings; re-probe when the user
-  // comes back to the window. TCC is determined by then, so this never
-  // re-prompts — it just notices a flipped toggle.
-  useEffect(() => {
-    if (!active) return;
-    function onFocus() {
-      if (statusRef.current === "denied") probe();
-    }
-    window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
-  }, [active, probe]);
-
-  return { status, probe };
-}
-
 export function usePermissionStatuses(active: boolean): PermissionStatuses {
   const [statuses, setStatuses] = useState<PermissionStatuses>({
     checked: false,

--- a/src/lib/live-transcript-preview.ts
+++ b/src/lib/live-transcript-preview.ts
@@ -15,7 +15,9 @@ export function upsertLiveTranscriptEvent(
   );
 }
 
-function coalesceAdjacentLiveTranscriptEvents(events: LiveTranscriptEventDto[]) {
+function coalesceAdjacentLiveTranscriptEvents(
+  events: LiveTranscriptEventDto[],
+) {
   const coalesced: LiveTranscriptEventDto[] = [];
   for (const event of events) {
     const previous = coalesced.at(-1);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1130,11 +1130,15 @@ export async function updateNote(input: {
 
 export async function checkRecordingSourceReadiness(
   sourceMode: RecordingSourceMode,
+  options: { probeSystemAudio?: boolean } = {},
 ) {
   return invoke<RecordingSourceReadinessDto>(
     "check_recording_source_readiness",
     {
-      request: { sourceMode },
+      request: {
+        sourceMode,
+        probeSystemAudio: options.probeSystemAudio ?? true,
+      },
     },
   );
 }

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -235,6 +235,20 @@ describe("meeting start transcription event", () => {
     });
   }
 
+  it("checks system audio capability without probing permission on launch", async () => {
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.checkRecordingSourceReadiness.mock.calls).toContainEqual([
+        "microphonePlusSystem",
+        { probeSystemAudio: false },
+      ]),
+    );
+    expect(mocks.checkRecordingSourceReadiness.mock.calls).not.toContainEqual([
+      "microphonePlusSystem",
+    ]);
+  });
+
   it("creates a fresh note before recording from the meeting prompt", async () => {
     const fresh = note({
       id: "note-2",
@@ -253,6 +267,9 @@ describe("meeting start transcription event", () => {
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
     await fireMeetingStartUntilRecording();
+    expect(mocks.checkRecordingSourceReadiness.mock.calls).toContainEqual([
+      "microphonePlusSystem",
+    ]);
     expect(mocks.playRecordingSound).toHaveBeenCalledWith("start");
     expect(screen.getByLabelText("Note title")).toHaveValue("New meeting");
   });

--- a/src/test/app-permissions.test.ts
+++ b/src/test/app-permissions.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { isAccessibilityBlocked } from "../app/App";
+import {
+  isAccessibilityBlocked,
+  mergeMicOnlyFallbackReadiness,
+  mergeNonProbingSourceReadiness,
+} from "../app/App";
+import type {
+  RecordingSourceReadinessDto,
+  SourceReadinessDto,
+} from "../lib/tauri";
 
 // Regression: the dictation helper reports Accessibility as "granted" |
 // "missing" (AXIsProcessTrusted), not the microphone's denied/restricted
@@ -22,5 +30,165 @@ describe("isAccessibilityBlocked", () => {
   it("treats any other non-granted status as blocked", () => {
     expect(isAccessibilityBlocked("denied")).toBe(true);
     expect(isAccessibilityBlocked("restricted")).toBe(true);
+  });
+});
+
+function microphoneSource(): SourceReadinessDto {
+  return {
+    source: "microphone",
+    required: true,
+    ready: true,
+    permissionState: "granted",
+    deviceAvailable: true,
+    captureAvailable: true,
+  };
+}
+
+function readiness(system: SourceReadinessDto): RecordingSourceReadinessDto {
+  return {
+    sourceMode: "microphonePlusSystem",
+    ready: system.ready,
+    sources: [microphoneSource(), system],
+  };
+}
+
+describe("mergeNonProbingSourceReadiness", () => {
+  it("preserves a denied system audio verdict across nonprompting refreshes", () => {
+    const deniedSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: false,
+      permissionState: "denied",
+      deviceAvailable: true,
+      captureAvailable: false,
+      recoveryAction: "openSystemAudioSettings",
+      message: "System audio is denied.",
+    };
+    const unknownSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: false,
+      permissionState: "unknown",
+      deviceAvailable: true,
+      captureAvailable: true,
+      recoveryAction: "openSystemAudioSettings",
+    };
+
+    const merged = mergeNonProbingSourceReadiness(
+      readiness(deniedSystem),
+      readiness(unknownSystem),
+    );
+
+    expect(merged.ready).toBe(false);
+    expect(merged.sources.find((source) => source.source === "system")).toEqual(
+      deniedSystem,
+    );
+  });
+
+  it("keeps a fresh probing verdict when it is no longer unknown", () => {
+    const deniedSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: false,
+      permissionState: "denied",
+      deviceAvailable: true,
+      captureAvailable: false,
+      recoveryAction: "openSystemAudioSettings",
+    };
+    const grantedSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: true,
+      permissionState: "unknown",
+      deviceAvailable: true,
+      captureAvailable: true,
+      recoveryAction: "openSystemAudioSettings",
+    };
+
+    const merged = mergeNonProbingSourceReadiness(
+      readiness(deniedSystem),
+      readiness(grantedSystem),
+    );
+
+    expect(merged.ready).toBe(true);
+    expect(merged.sources.find((source) => source.source === "system")).toEqual(
+      grantedSystem,
+    );
+  });
+});
+
+describe("mergeMicOnlyFallbackReadiness", () => {
+  it("keeps a denied system audio verdict after a mic-only fallback check", () => {
+    const deniedSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: false,
+      permissionState: "denied",
+      deviceAvailable: true,
+      captureAvailable: false,
+      recoveryAction: "openSystemAudioSettings",
+    };
+    const micOnly: RecordingSourceReadinessDto = {
+      sourceMode: "microphoneOnly",
+      ready: true,
+      sources: [microphoneSource()],
+    };
+
+    const merged = mergeMicOnlyFallbackReadiness(
+      readiness(deniedSystem),
+      micOnly,
+    );
+
+    expect(merged.ready).toBe(false);
+    expect(merged.sources.find((source) => source.source === "system")).toEqual(
+      deniedSystem,
+    );
+  });
+
+  it("keeps an unsupported system audio verdict after a mic-only fallback check", () => {
+    const unsupportedSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: false,
+      permissionState: "unsupported",
+      deviceAvailable: false,
+      captureAvailable: false,
+      recoveryAction: "upgradeMacos",
+    };
+    const micOnly: RecordingSourceReadinessDto = {
+      sourceMode: "microphoneOnly",
+      ready: true,
+      sources: [microphoneSource()],
+    };
+
+    const merged = mergeMicOnlyFallbackReadiness(
+      readiness(unsupportedSystem),
+      micOnly,
+    );
+
+    expect(merged.ready).toBe(false);
+    expect(merged.sources.find((source) => source.source === "system")).toEqual(
+      unsupportedSystem,
+    );
+  });
+
+  it("does not add a system source when the prior system source was usable", () => {
+    const usableSystem: SourceReadinessDto = {
+      source: "system",
+      required: true,
+      ready: true,
+      permissionState: "unknown",
+      deviceAvailable: true,
+      captureAvailable: true,
+    };
+    const micOnly: RecordingSourceReadinessDto = {
+      sourceMode: "microphoneOnly",
+      ready: true,
+      sources: [microphoneSource()],
+    };
+
+    expect(
+      mergeMicOnlyFallbackReadiness(readiness(usableSystem), micOnly),
+    ).toBe(micOnly);
   });
 });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
@@ -306,6 +312,82 @@ describe("App shortcuts", () => {
     expect(
       await screen.findByRole("heading", { name: "Appearance" }),
     ).toBeInTheDocument();
+  });
+
+  it("probes system audio once after returning from System Settings", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)",
+    );
+    const user = userEvent.setup();
+    const deniedReadiness = {
+      sourceMode: "microphonePlusSystem",
+      ready: false,
+      sources: [
+        { source: "microphone", ready: true, permissionState: "granted" },
+        {
+          source: "system",
+          ready: false,
+          permissionState: "denied",
+          captureAvailable: false,
+          recoveryAction: "openSystemAudioSettings",
+        },
+      ],
+    };
+    const grantedReadiness = {
+      sourceMode: "microphonePlusSystem",
+      ready: true,
+      sources: [
+        { source: "microphone", ready: true, permissionState: "granted" },
+        {
+          source: "system",
+          ready: true,
+          permissionState: "unknown",
+          captureAvailable: true,
+          recoveryAction: "openSystemAudioSettings",
+        },
+      ],
+    };
+
+    try {
+      mocks.checkRecordingSourceReadiness
+        .mockResolvedValueOnce(deniedReadiness)
+        .mockResolvedValue(grantedReadiness);
+
+      render(<App />);
+
+      await waitFor(() =>
+        expect(mocks.checkRecordingSourceReadiness.mock.calls).toContainEqual([
+          "microphonePlusSystem",
+          { probeSystemAudio: false },
+        ]),
+      );
+      mocks.checkRecordingSourceReadiness.mockClear();
+
+      await act(async () => {
+        mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+      });
+      await user.click(await screen.findByRole("button", { name: "Audio" }));
+      await user.click(await screen.findByRole("button", { name: "Enable" }));
+
+      expect(mocks.openPrivacySettings).toHaveBeenCalledWith("systemAudio");
+
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+      });
+
+      await waitFor(() =>
+        expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledWith(
+          "microphonePlusSystem",
+        ),
+      );
+      expect(mocks.checkRecordingSourceReadiness).not.toHaveBeenCalledWith(
+        "microphonePlusSystem",
+        { probeSystemAudio: false },
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("starts a session with Ctrl-N and creates a note with Ctrl-Shift-N on Windows", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -13,7 +13,7 @@ import {
   setOnboardingResumeStep,
   subscribeToOnboardingComplete,
 } from "../lib/onboarding";
-import type { AccountStatus, RecordingSourceReadinessDto } from "../lib/tauri";
+import type { AccountStatus } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
@@ -74,35 +74,6 @@ const signedOutAccount: AccountStatus = {
 
 type ListenHandler = (event: { payload: string }) => void;
 
-// What check_recording_source_readiness returns after the capture-helper
-// probe: a passing probe leaves the system permissionState at "unknown" and
-// signals the grant via ready; a denial flips both.
-function systemAudioReadiness(granted: boolean): RecordingSourceReadinessDto {
-  return {
-    sourceMode: "microphonePlusSystem",
-    ready: granted,
-    sources: [
-      {
-        source: "microphone",
-        required: true,
-        ready: true,
-        permissionState: "granted",
-        deviceAvailable: true,
-        captureAvailable: true,
-      },
-      {
-        source: "system",
-        required: true,
-        ready: granted,
-        permissionState: granted ? "unknown" : "denied",
-        deviceAvailable: granted,
-        captureAvailable: granted,
-        recoveryAction: "openSystemAudioSettings",
-      },
-    ],
-  };
-}
-
 function shortcut(label: string) {
   return {
     code: "Fn",
@@ -137,9 +108,7 @@ describe("OnboardingFlow", () => {
       },
     );
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
-    mocks.checkRecordingSourceReadiness.mockResolvedValue(
-      systemAudioReadiness(true),
-    );
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(undefined);
     mocks.openPrivacySettings.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
     mocks.osAccountsPrepareTrialCheckout.mockResolvedValue({
@@ -812,73 +781,46 @@ describe("OnboardingFlow", () => {
     }
   });
 
-  it("probes system audio when the macOS permissions screen shows", async () => {
-    // The probe is what surfaces the system-audio TCC prompt on a fresh
-    // install; it must fire here, in context, not after onboarding.
+  it("does not probe system audio when the macOS permissions screen shows", async () => {
     const restoreNavigator = stubMacNavigatorPlatform();
     try {
       await renderFlow();
-      await waitFor(() =>
-        expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledWith(
-          "microphonePlusSystem",
-        ),
-      );
+      expect(screen.queryByText("System audio")).not.toBeInTheDocument();
+      expect(mocks.checkRecordingSourceReadiness).not.toHaveBeenCalled();
     } finally {
       restoreNavigator();
     }
   });
 
-  it("keeps continue locked and falls back to settings when system audio is denied", async () => {
-    const user = userEvent.setup();
+  it("continues on macOS after microphone and accessibility access", async () => {
     const restoreNavigator = stubMacNavigatorPlatform();
-    mocks.checkRecordingSourceReadiness.mockResolvedValue(
-      systemAudioReadiness(false),
-    );
     try {
       await renderFlow();
       grantPermissions();
 
-      await screen.findByText(
-        "Turned off in System Settings. Flip the toggle and June will notice.",
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
       );
+      await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+      await screen.findByRole("heading", { name: "Talk to June" });
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("keeps continue locked until accessibility is granted on macOS", async () => {
+    const restoreNavigator = stubMacNavigatorPlatform();
+    try {
+      await renderFlow();
+      emitDictationEvent?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+
       expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
-
-      await user.click(
-        screen.getByRole("button", { name: "Allow system audio access" }),
-      );
-      expect(mocks.openPrivacySettings).toHaveBeenCalledWith("systemAudio");
-
-      // The user flips the toggle and comes back; the focus re-probe picks
-      // up the grant.
-      mocks.checkRecordingSourceReadiness.mockResolvedValue(
-        systemAudioReadiness(true),
-      );
-      window.dispatchEvent(new Event("focus"));
-      await waitFor(() =>
-        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
-      );
-    } finally {
-      restoreNavigator();
-    }
-  });
-
-  it("does not block continue when system audio is unsupported", async () => {
-    const restoreNavigator = stubMacNavigatorPlatform();
-    const readiness = systemAudioReadiness(false);
-    const sysIdx = readiness.sources.findIndex((s) => s.source === "system");
-    readiness.sources[sysIdx] = {
-      ...readiness.sources[sysIdx],
-      permissionState: "unsupported",
-    };
-    mocks.checkRecordingSourceReadiness.mockResolvedValue(readiness);
-    try {
-      await renderFlow();
-      grantPermissions();
-
-      await screen.findByText("Needs macOS 14.2 or later.");
-      await waitFor(() =>
-        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
-      );
     } finally {
       restoreNavigator();
     }

--- a/src/test/tauri-contract.test.ts
+++ b/src/test/tauri-contract.test.ts
@@ -54,7 +54,10 @@ describe("Tauri command contracts", () => {
       1,
       "check_recording_source_readiness",
       {
-        request: { sourceMode: "microphonePlusSystem" },
+        request: {
+          sourceMode: "microphonePlusSystem",
+          probeSystemAudio: true,
+        },
       },
     );
     expect(mocks.invoke).toHaveBeenNthCalledWith(2, "start_recording", {
@@ -63,6 +66,22 @@ describe("Tauri command contracts", () => {
     expect(mocks.invoke).toHaveBeenNthCalledWith(3, "finish_recording", {
       request: { sessionId: "session-1" },
     });
+  });
+
+  it("can check recording source readiness without probing system audio", async () => {
+    await checkRecordingSourceReadiness("microphonePlusSystem", {
+      probeSystemAudio: false,
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledWith(
+      "check_recording_source_readiness",
+      {
+        request: {
+          sourceMode: "microphonePlusSystem",
+          probeSystemAudio: false,
+        },
+      },
+    );
   });
 
   it("keeps retry and recovery commands authoritative", async () => {


### PR DESCRIPTION
## Summary
- remove the system audio permission row and probe from onboarding
- add a nonprompting readiness mode so app launch/focus can check system audio capability without opening macOS TCC
- preserve the probing readiness path when starting a recording that wants system audio
- update tests for onboarding, app launch, recording start, and Tauri IPC request shape

## Verification
- pnpm lint
- pnpm format
- pnpm test
- pnpm test -- src/test/onboarding.test.tsx src/test/app-meeting-start.test.tsx src/test/tauri-contract.test.ts
- pnpm test:rust
- cargo test --manifest-path src-tauri/Cargo.toml commands::tests::readiness_request --lib