### PR TITLE
Improve transcription retry resilience

### DIFF
--- a/scribe-api/crates/api/Cargo.toml
+++ b/scribe-api/crates/api/Cargo.toml
@@ -18,7 +18,7 @@ scribe-services.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tower.workspace = true
+tower = { workspace = true, features = ["timeout", "util"] }
 tower-http.workspace = true
 tracing.workspace = true
 

--- a/scribe-api/crates/api/src/envelope.rs
+++ b/scribe-api/crates/api/src/envelope.rs
@@ -1,4 +1,8 @@
-use axum::{Json, http::StatusCode, response::IntoResponse};
+use axum::{
+    Json,
+    http::{HeaderValue, StatusCode, header},
+    response::IntoResponse,
+};
 use serde::Serialize;
 
 pub const ERR_BAD_REQUEST: i32 = 2001;
@@ -9,6 +13,8 @@ pub const ERR_PAYLOAD_TOO_LARGE: i32 = 4131;
 pub const ERR_AUTHORIZATION_DENIED: i32 = 4401;
 pub const ERR_INTERNAL: i32 = 5000;
 pub const ERR_UPSTREAM: i32 = 5001;
+pub const ERR_TIMEOUT: i32 = 5041;
+pub(crate) const TRANSIENT_RETRY_AFTER_SECS: u64 = 2;
 
 #[derive(Serialize)]
 pub struct ApiResponse<T> {
@@ -48,4 +54,65 @@ pub(crate) fn error_response(
     message: &str,
 ) -> axum::response::Response {
     (status, Json(ApiResponse::err(code, message))).into_response()
+}
+
+pub(crate) fn error_response_with_retry_after(
+    status: StatusCode,
+    code: i32,
+    message: &str,
+    retry_after_secs: u64,
+) -> axum::response::Response {
+    let mut response = error_response(status, code, message);
+    if let Ok(value) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+        response.headers_mut().insert(header::RETRY_AFTER, value);
+    }
+    response
+}
+
+pub(crate) fn timeout_response() -> axum::response::Response {
+    error_response(StatusCode::GATEWAY_TIMEOUT, ERR_TIMEOUT, "timeout")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TRANSIENT_RETRY_AFTER_SECS, error_response_with_retry_after, timeout_response};
+    use axum::{
+        body::to_bytes,
+        http::{HeaderValue, StatusCode, header},
+    };
+    use pretty_assertions::assert_eq;
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), 4096)
+            .await
+            .expect("read body");
+        serde_json::from_slice(&bytes).expect("body is JSON")
+    }
+
+    #[tokio::test]
+    async fn timeout_response_uses_standard_error_envelope() {
+        let response = timeout_response();
+
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        let body = body_json(response).await;
+        assert_eq!(body["success"], false);
+        assert_eq!(body["error_code"], 5041);
+        assert_eq!(body["message"], "timeout");
+    }
+
+    #[test]
+    fn retry_after_response_sets_seconds_header() {
+        let response = error_response_with_retry_after(
+            StatusCode::TOO_MANY_REQUESTS,
+            4401,
+            "authorization_denied",
+            TRANSIENT_RETRY_AFTER_SECS,
+        );
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response.headers().get(header::RETRY_AFTER),
+            Some(&HeaderValue::from_static("2"))
+        );
+    }
 }

--- a/scribe-api/crates/api/src/error.rs
+++ b/scribe-api/crates/api/src/error.rs
@@ -1,6 +1,7 @@
 use crate::envelope::{
     ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_PAYLOAD_TOO_LARGE, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM, error_response,
+    ERR_PAYLOAD_TOO_LARGE, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
+    TRANSIENT_RETRY_AFTER_SECS, error_response, error_response_with_retry_after,
 };
 use axum::{http::StatusCode, response::IntoResponse};
 use scribe_domain::AuthError;
@@ -75,10 +76,11 @@ impl IntoResponse for ApiError {
             // Transient metering denial (e.g. a concurrency cap): the user is
             // funded and the upstream providers are fine — tell the client to
             // retry shortly instead of pretending the provider failed.
-            Self::AuthorizationDenied => error_response(
+            Self::AuthorizationDenied => error_response_with_retry_after(
                 StatusCode::TOO_MANY_REQUESTS,
                 ERR_AUTHORIZATION_DENIED,
                 "authorization_denied",
+                TRANSIENT_RETRY_AFTER_SECS,
             ),
             Self::Upstream => error_response(
                 StatusCode::BAD_GATEWAY,
@@ -118,7 +120,10 @@ pub(crate) fn from_auth_error(error: &AuthError) -> ApiError {
 #[cfg(test)]
 mod tests {
     use super::ApiError;
-    use axum::{http::StatusCode, response::IntoResponse};
+    use axum::{
+        http::{StatusCode, header},
+        response::IntoResponse,
+    };
     use pretty_assertions::assert_eq;
     use scribe_services::ServiceError;
 
@@ -138,6 +143,13 @@ mod tests {
         let response = ApiError::from(ServiceError::AuthorizationDenied).into_response();
 
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok()),
+            Some("2")
+        );
         let body = body_json(response).await;
         assert_eq!(body["error_code"], 4401);
         assert_eq!(body["message"], "authorization_denied");

--- a/scribe-api/crates/api/src/lib.rs
+++ b/scribe-api/crates/api/src/lib.rs
@@ -11,16 +11,18 @@ mod validation;
 
 use axum::{
     Router,
+    error_handling::HandleErrorLayer,
     extract::DefaultBodyLimit,
-    http::StatusCode,
+    response::IntoResponse,
     routing::{get, post},
 };
 use std::time::Duration;
-use tower_http::{cors::CorsLayer, timeout::TimeoutLayer, trace::TraceLayer};
+use tower::{BoxError, ServiceBuilder, timeout::TimeoutLayer};
+use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 pub use envelope::{
     ApiResponse, ERR_AUTHORIZATION_DENIED, ERR_BAD_REQUEST, ERR_INSUFFICIENT_CREDITS, ERR_INTERNAL,
-    ERR_PAYLOAD_TOO_LARGE, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
+    ERR_PAYLOAD_TOO_LARGE, ERR_TIMEOUT, ERR_UNAUTHORIZED, ERR_UNPROCESSABLE, ERR_UPSTREAM,
 };
 pub use error::ApiError;
 pub use handlers::dictate::{
@@ -34,10 +36,11 @@ pub use state::{ApiLimits, ApiState, ApiStateParams, AttestationInfo};
 
 pub fn router(state: ApiState) -> Router {
     let limits = state.limits();
-    let timeout = TimeoutLayer::with_status_code(
-        StatusCode::GATEWAY_TIMEOUT,
-        Duration::from_secs(limits.request_timeout_secs),
-    );
+    let timeout = ServiceBuilder::new()
+        .layer(HandleErrorLayer::new(handle_timeout_error))
+        .layer(TimeoutLayer::new(Duration::from_secs(
+            limits.request_timeout_secs,
+        )));
     Router::new()
         .route("/livez", get(handlers::health::livez))
         .route("/readyz", get(handlers::health::readyz))
@@ -76,4 +79,11 @@ pub fn router(state: ApiState) -> Router {
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::new())
         .with_state(state)
+}
+
+async fn handle_timeout_error(error: BoxError) -> axum::response::Response {
+    if error.is::<tower::timeout::error::Elapsed>() {
+        return envelope::timeout_response();
+    }
+    error::ApiError::Internal.into_response()
 }

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -37,7 +37,7 @@ const TRANSIENT_TRANSCRIPTION_RETRY_BASE_BACKOFF_MS: u64 = 1;
 #[cfg(not(test))]
 const TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS: u64 = 200;
 #[cfg(test)]
-const TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS: u64 = 0;
+const TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS: u64 = 5;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceTranscriptInput {
@@ -959,7 +959,9 @@ fn is_retryable_transcription_error(error: &AppError) -> bool {
 
 fn transient_retry_delay(operation_id: &str, attempt: usize, error: &AppError) -> Duration {
     if let Some(retry_after_ms) = retry_after_ms(error) {
-        return Duration::from_millis(retry_after_ms);
+        return Duration::from_millis(
+            retry_after_ms.saturating_add(retry_jitter_ms(operation_id, attempt)),
+        );
     }
     let backoff_multiplier = 1_u64 << attempt.min(8);
     let backoff_ms =
@@ -1955,6 +1957,21 @@ mod tests {
         assert_eq!(
             outcome.failures[0].input.warning.as_deref(),
             Some("The processing service returned an invalid response.")
+        );
+    }
+
+    #[test]
+    fn retry_after_delay_keeps_server_floor_and_adds_jitter() {
+        let operation_id = (0..100)
+            .map(|index| format!("retry-after-jitter-{index}"))
+            .find(|operation_id| retry_jitter_ms(operation_id, 0) > 0)
+            .expect("test jitter should produce a non-zero candidate");
+        let mut error = AppError::new("scribe_request_failed", "authorization_denied");
+        error.details = Some(serde_json::json!({ "retryAfterMs": 2_000 }));
+
+        assert_eq!(
+            transient_retry_delay(&operation_id, 0, &error),
+            Duration::from_millis(2_000 + retry_jitter_ms(&operation_id, 0))
         );
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -28,7 +28,16 @@ const TRANSCRIPT_COHERENCE_GAP_MS: i64 = 2_500;
 const TRANSCRIPTION_CONTEXT_MAX_CHARS: usize = 1_200;
 const TRANSCRIPTION_CONTEXT_MAX_TURNS: usize = 6;
 const DICTIONARY_CONTEXT_MAX_ENTRIES: usize = 80;
-const DEFAULT_TURN_TRANSCRIPTION_CONCURRENCY: usize = 4;
+const DEFAULT_TURN_TRANSCRIPTION_CONCURRENCY: usize = 2;
+const TRANSIENT_TRANSCRIPTION_ATTEMPTS: usize = 3;
+#[cfg(not(test))]
+const TRANSIENT_TRANSCRIPTION_RETRY_BASE_BACKOFF_MS: u64 = 300;
+#[cfg(test)]
+const TRANSIENT_TRANSCRIPTION_RETRY_BASE_BACKOFF_MS: u64 = 1;
+#[cfg(not(test))]
+const TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS: u64 = 200;
+#[cfg(test)]
+const TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS: u64 = 0;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceTranscriptInput {
@@ -836,15 +845,18 @@ async fn transcribe_prepared_audio(
         vec![request.audio_path.clone()]
     };
     if audio_paths.len() == 1 {
-        return transcriber(TranscriptionRequest {
-            provider: request.provider,
-            audio_path: audio_paths.into_iter().next().unwrap_or(request.audio_path),
-            title: request.title,
-            context: request.base_context,
-            language: request_language,
-            operation_id: Some(request.operation_id),
-            preview: false,
-        })
+        return transcribe_with_transient_retries(
+            &transcriber,
+            TranscriptionRequest {
+                provider: request.provider,
+                audio_path: audio_paths.into_iter().next().unwrap_or(request.audio_path),
+                title: request.title,
+                context: request.base_context,
+                language: request_language,
+                operation_id: Some(request.operation_id),
+                preview: false,
+            },
+        )
         .await;
     }
 
@@ -857,15 +869,18 @@ async fn transcribe_prepared_audio(
             request.base_context.as_deref(),
             build_transcription_context(&previous).as_deref(),
         );
-        let transcript = transcriber(TranscriptionRequest {
-            provider: request.provider.clone(),
-            audio_path,
-            title: request.title.clone(),
-            context,
-            language: request_language.clone(),
-            operation_id: Some(format!("{}-chunk-{index}", request.operation_id)),
-            preview: false,
-        })
+        let transcript = transcribe_with_transient_retries(
+            &transcriber,
+            TranscriptionRequest {
+                provider: request.provider.clone(),
+                audio_path,
+                title: request.title.clone(),
+                context,
+                language: request_language.clone(),
+                operation_id: Some(format!("{}-chunk-{index}", request.operation_id)),
+                preview: false,
+            },
+        )
         .await?;
         if language.is_none() {
             language = transcript.language.clone();
@@ -897,6 +912,79 @@ async fn transcribe_prepared_audio(
         language,
         provider: provider_name,
     })
+}
+
+async fn transcribe_with_transient_retries(
+    transcriber: &TurnTranscriber,
+    request: TranscriptionRequest,
+) -> Result<TranscriptionProviderResult, AppError> {
+    let operation_id = request.operation_id();
+    for attempt in 0..TRANSIENT_TRANSCRIPTION_ATTEMPTS {
+        match transcriber(request.clone()).await {
+            Ok(transcript) => return Ok(transcript),
+            Err(error) => {
+                if attempt + 1 < TRANSIENT_TRANSCRIPTION_ATTEMPTS
+                    && is_retryable_transcription_error(&error)
+                {
+                    let retry_delay = transient_retry_delay(&operation_id, attempt, &error);
+                    tracing::warn!(
+                        operation_id = %operation_id,
+                        code = %error.code,
+                        attempt = attempt + 1,
+                        retry_delay_ms = retry_delay.as_millis(),
+                        "transient transcription request failed; retrying"
+                    );
+                    tokio::time::sleep(retry_delay).await;
+                    continue;
+                }
+                return Err(error);
+            }
+        }
+    }
+    unreachable!("transcription retry loop always returns")
+}
+
+fn is_retryable_transcription_error(error: &AppError) -> bool {
+    let code = error.code.trim().to_ascii_lowercase();
+    let message = error.message.trim().to_ascii_lowercase();
+    code == "scribe_api_response_invalid"
+        || code == "empty_response"
+        || (code == "scribe_request_failed"
+            && (message == "authorization_denied"
+                || message.contains("timed out")
+                || message.contains("timeout")
+                || message.contains("connection")
+                || message.contains("error sending request")))
+}
+
+fn transient_retry_delay(operation_id: &str, attempt: usize, error: &AppError) -> Duration {
+    if let Some(retry_after_ms) = retry_after_ms(error) {
+        return Duration::from_millis(retry_after_ms);
+    }
+    let backoff_multiplier = 1_u64 << attempt.min(8);
+    let backoff_ms =
+        TRANSIENT_TRANSCRIPTION_RETRY_BASE_BACKOFF_MS.saturating_mul(backoff_multiplier);
+    Duration::from_millis(backoff_ms.saturating_add(retry_jitter_ms(operation_id, attempt)))
+}
+
+fn retry_after_ms(error: &AppError) -> Option<u64> {
+    error
+        .details
+        .as_ref()
+        .and_then(|details| details.get("retryAfterMs"))
+        .and_then(serde_json::Value::as_u64)
+}
+
+fn retry_jitter_ms(operation_id: &str, attempt: usize) -> u64 {
+    if TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS == 0 {
+        return 0;
+    }
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64 ^ attempt as u64;
+    for byte in operation_id.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash % (TRANSIENT_TRANSCRIPTION_RETRY_JITTER_MS + 1)
 }
 
 #[cfg(test)]
@@ -1354,7 +1442,10 @@ fn drop_silent_system_sources(
 /// transcript. Everything else — including system failures that aren't
 /// no_speech, and the all-sources-failed case — is still recorded.
 fn should_record_source_failure(source: &str, warning: &str, has_valid_transcript: bool) -> bool {
-    !(has_valid_transcript && source == "system" && is_no_speech_message(warning))
+    if !has_valid_transcript {
+        return true;
+    }
+    !(source == "system" && is_no_speech_message(warning))
 }
 
 fn is_no_speech_message(message: &str) -> bool {
@@ -1776,6 +1867,97 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn transient_invalid_turn_response_retries_before_failing() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let transcriber = {
+            let attempts = Arc::clone(&attempts);
+            Arc::new(move |request: TranscriptionRequest| {
+                let attempts = Arc::clone(&attempts);
+                Box::pin(async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        return Err(AppError::new(
+                            "scribe_api_response_invalid",
+                            "The processing service returned an invalid response.",
+                        ));
+                    }
+                    Ok(TranscriptionProviderResult {
+                        text: request.audio_path.to_string_lossy().to_string(),
+                        language: None,
+                        provider: "test".to_string(),
+                    })
+                }) as TranscriptionFuture
+            }) as TurnTranscriber
+        };
+
+        let outcome = transcribe_turn_jobs_by_source_lane(
+            vec![test_job("m0", "microphone", 0)],
+            crate::providers::OPENAI_PROVIDER.to_string(),
+            "Meeting".to_string(),
+            None,
+            transcriber,
+        )
+        .await
+        .expect("transient invalid response should be retried");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(outcome.failures.len(), 0);
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(outcome.candidates[0].input.text, "m0");
+    }
+
+    #[tokio::test]
+    async fn exhausted_invalid_tail_turn_stays_visible_as_failure() {
+        let tail_attempts = Arc::new(AtomicUsize::new(0));
+        let transcriber = {
+            let tail_attempts = Arc::clone(&tail_attempts);
+            Arc::new(move |request: TranscriptionRequest| {
+                let tail_attempts = Arc::clone(&tail_attempts);
+                Box::pin(async move {
+                    if request.audio_path == std::path::Path::new("tail") {
+                        tail_attempts.fetch_add(1, Ordering::SeqCst);
+                        return Err(AppError::new(
+                            "scribe_api_response_invalid",
+                            "The processing service returned an invalid response.",
+                        ));
+                    }
+                    Ok(TranscriptionProviderResult {
+                        text: request.audio_path.to_string_lossy().to_string(),
+                        language: None,
+                        provider: "test".to_string(),
+                    })
+                }) as TranscriptionFuture
+            }) as TurnTranscriber
+        };
+
+        let outcome = transcribe_turn_jobs_by_source_lane(
+            vec![
+                test_job("intro", "microphone", 0),
+                test_job("tail", "microphone", 1),
+            ],
+            crate::providers::OPENAI_PROVIDER.to_string(),
+            "Meeting".to_string(),
+            None,
+            transcriber,
+        )
+        .await
+        .expect("source lanes should complete despite a failed tail turn");
+
+        assert_eq!(
+            tail_attempts.load(Ordering::SeqCst),
+            TRANSIENT_TRANSCRIPTION_ATTEMPTS
+        );
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(outcome.failures.len(), 1);
+        assert_eq!(outcome.candidates[0].input.text, "intro");
+        assert_eq!(outcome.failures[0].input.source, "microphone");
+        assert_eq!(outcome.failures[0].input.turn_index, Some(1));
+        assert_eq!(
+            outcome.failures[0].input.warning.as_deref(),
+            Some("The processing service returned an invalid response.")
+        );
+    }
+
     #[test]
     fn turn_operation_id_includes_source_when_turn_indices_match() {
         let mic = test_job("m0", "microphone", 0);
@@ -1897,6 +2079,24 @@ mod tests {
             "system",
             "No speech detected. Try speaking louder or moving closer to the microphone.",
             true,
+        ));
+    }
+
+    #[test]
+    fn keeps_invalid_service_response_failure_once_a_source_succeeded() {
+        assert!(should_record_source_failure(
+            "microphone",
+            "The processing service returned an invalid response.",
+            true,
+        ));
+    }
+
+    #[test]
+    fn keeps_invalid_service_response_failure_when_nothing_succeeded() {
+        assert!(should_record_source_failure(
+            "microphone",
+            "The processing service returned an invalid response.",
+            false,
         ));
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -951,8 +951,7 @@ fn is_retryable_transcription_error(error: &AppError) -> bool {
         || code == "empty_response"
         || (code == "scribe_request_failed"
             && (message == "authorization_denied"
-                || message.contains("timed out")
-                || message.contains("timeout")
+                || message == "timeout"
                 || message.contains("connection")
                 || message.contains("error sending request")))
 }
@@ -1973,6 +1972,18 @@ mod tests {
             transient_retry_delay(&operation_id, 0, &error),
             Duration::from_millis(2_000 + retry_jitter_ms(&operation_id, 0))
         );
+    }
+
+    #[test]
+    fn server_timeout_envelope_is_retryable_but_client_timeout_is_not() {
+        assert!(is_retryable_transcription_error(&AppError::new(
+            "scribe_request_failed",
+            "timeout"
+        )));
+        assert!(!is_retryable_transcription_error(&AppError::new(
+            "scribe_request_failed",
+            "operation timed out"
+        )));
     }
 
     #[test]

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -880,13 +880,15 @@ where
     T: for<'de> Deserialize<'de>,
 {
     let status = response.status();
+    let retry_after_ms = response_retry_after_ms(&response);
     let body = response.text().await.map_err(network_error)?;
-    parse_response_body(path, status, &body)
+    parse_response_body(path, status, retry_after_ms, &body)
 }
 
 fn parse_response_body<T>(
     path: &str,
     status: reqwest::StatusCode,
+    retry_after_ms: Option<u64>,
     body: &str,
 ) -> Result<T, AppError>
 where
@@ -921,12 +923,25 @@ where
         ));
     }
     let _ = path;
-    Err(AppError::new(
+    let mut error = AppError::new(
         "scribe_request_failed",
         envelope
             .message
             .unwrap_or_else(|| "Couldn't reach Scribe.".to_string()),
-    ))
+    );
+    if let Some(retry_after_ms) = retry_after_ms {
+        error.details = Some(serde_json::json!({ "retryAfterMs": retry_after_ms }));
+    }
+    Err(error)
+}
+
+fn response_retry_after_ms(response: &reqwest::Response) -> Option<u64> {
+    response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(|seconds| seconds.saturating_mul(1_000))
 }
 
 fn http_client() -> &'static reqwest::Client {
@@ -1071,6 +1086,7 @@ mod tests {
         let result = parse_response_body::<GenerateResponse>(
             "/v1/notes/generate",
             reqwest::StatusCode::BAD_GATEWAY,
+            None,
             "",
         );
 
@@ -1079,6 +1095,28 @@ mod tests {
         assert_eq!(error.code, "scribe_api_response_invalid");
         assert_eq!(error.message, INVALID_SCRIBE_RESPONSE_MESSAGE);
         assert!(!error.message.contains("expected value"));
+    }
+
+    #[test]
+    fn retry_after_header_is_preserved_on_scribe_failures() {
+        let result = parse_response_body::<GenerateResponse>(
+            "/v1/notes/generate",
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            Some(2_000),
+            r#"{"data":null,"success":false,"error_code":4401,"message":"authorization_denied"}"#,
+        );
+
+        assert!(result.is_err());
+        let error = result.err().expect("authorization denial should fail");
+        assert_eq!(error.code, "scribe_request_failed");
+        assert_eq!(error.message, "authorization_denied");
+        assert_eq!(
+            error
+                .details
+                .and_then(|details| details.get("retryAfterMs").cloned())
+                .and_then(|value| value.as_u64()),
+            Some(2_000)
+        );
     }
 
     #[test]

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -836,7 +836,8 @@ function orderedVisibleSourceTranscripts(
   return (note.sourceTranscripts ?? [])
     .filter((turn) => {
       if (turn.text.trim()) return true;
-      return note.processingStatus !== "failed" && !!turn.lastError;
+      if (note.processingStatus === "failed" || !turn.lastError) return false;
+      return true;
     })
     .map((turn, index) => ({ turn, index }))
     .sort(compareSourceTranscriptOrder)
@@ -912,7 +913,7 @@ function TranscriptTurn({
   // its error ("No speech detected…"), which is worth being able to grab.
   // The error is run through userFacingFailureMessage so raw provider codes
   // never reach the clipboard (or the card below).
-  const errorMessage = userFacingFailureMessage(transcript.lastError) ?? "";
+  const errorMessage = sourceTurnFailureMessage(transcript.lastError);
   const copyValue = hasText ? transcript.text : errorMessage;
   const canCopy = copyValue.trim().length > 0;
 
@@ -1005,6 +1006,20 @@ function TranscriptTurn({
       ) : null}
     </article>
   );
+}
+
+function sourceTurnFailureMessage(message?: string) {
+  const friendly = userFacingFailureMessage(message) ?? "";
+  if (isInvalidProcessingServiceResponse(friendly)) {
+    return "Audio for this part could not be transcribed.";
+  }
+  return friendly;
+}
+
+function isInvalidProcessingServiceResponse(message: string) {
+  return message
+    .toLowerCase()
+    .includes("processing service returned an invalid response");
 }
 
 function CopyTranscriptButton({ text }: { text: string }) {

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -29,6 +29,7 @@ import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
 import { isMacLikePlatform } from "../../lib/platform";
 import {
+  isInvalidScribeResponseMessage,
   NoteFailureBanner,
   userFacingFailureMessage,
 } from "./NoteFailureBanner";
@@ -1009,17 +1010,10 @@ function TranscriptTurn({
 }
 
 function sourceTurnFailureMessage(message?: string) {
-  const friendly = userFacingFailureMessage(message) ?? "";
-  if (isInvalidProcessingServiceResponse(friendly)) {
+  if (message && isInvalidScribeResponseMessage(message)) {
     return "Audio for this part could not be transcribed.";
   }
-  return friendly;
-}
-
-function isInvalidProcessingServiceResponse(message: string) {
-  return message
-    .toLowerCase()
-    .includes("processing service returned an invalid response");
+  return userFacingFailureMessage(message) ?? "";
 }
 
 function CopyTranscriptButton({ text }: { text: string }) {

--- a/src/components/note-editor/NoteFailureBanner.tsx
+++ b/src/components/note-editor/NoteFailureBanner.tsx
@@ -48,7 +48,7 @@ function friendlyFailureSegment(message: string) {
   return source ? `${source}: ${friendly}` : friendly;
 }
 
-function isInvalidScribeResponseMessage(message: string) {
+export function isInvalidScribeResponseMessage(message: string) {
   const normalized = message.trim().toLowerCase();
   return (
     normalized.includes("scribe_api_response_invalid") ||

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -364,7 +364,7 @@ describe("NoteEditor", () => {
               endMs: 18_000,
               turnIndex: 1,
               status: "failed",
-              lastError: "The processing service returned an invalid response.",
+              lastError: "scribe_api_response_invalid",
             },
           ],
         })}
@@ -378,6 +378,7 @@ describe("NoteEditor", () => {
     expect(
       screen.queryByText(/processing service returned an invalid response/i),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/scribe_api_response_invalid/i)).not.toBeInTheDocument();
     expect(screen.getByText("0:15-0:18")).toBeInTheDocument();
   });
 

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -340,6 +340,47 @@ describe("NoteEditor", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders exhausted invalid service responses as transcript gaps", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          activeTab: "transcription",
+          sourceTranscripts: [
+            {
+              id: "turn-1",
+              text: "Usable transcript text",
+              source: "microphone",
+              startMs: 1000,
+              endMs: 14_000,
+              turnIndex: 0,
+              status: "succeeded",
+            },
+            {
+              id: "turn-2",
+              text: "",
+              source: "system",
+              startMs: 15_000,
+              endMs: 18_000,
+              turnIndex: 1,
+              status: "failed",
+              lastError: "The processing service returned an invalid response.",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Usable transcript text")).toBeInTheDocument();
+    expect(
+      screen.getByText("Audio for this part could not be transcribed."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/processing service returned an invalid response/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("0:15-0:18")).toBeInTheDocument();
+  });
+
   it("does not render whole-note failures as transcript turns", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary
- reduce final turn transcription concurrency and retry transient Scribe failures with exponential backoff, jitter, and Retry-After support
- keep exhausted invalid-response turn failures visible as timestamped transcript gaps instead of silently hiding missing audio
- return typed Scribe API timeout envelopes and include Retry-After on transient authorization denials

## Verification
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked
- pnpm run lint
- pnpm test