### PR TITLE
Keep bug submission accepted when platform delivery fails

### DIFF
--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -43,14 +43,14 @@ impl Debug for AppConfig {
 }
 
 /// Where user-submitted issue reports get forwarded. The destination defaults
-/// to the June project in os-platform; only the bot API key is environment
-/// specific. Without that key, reports land in structured logs only.
+/// to the June bug reports project in os-platform; only the bot API key is
+/// environment specific. Without that key, reports land in structured logs only.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct IssueReportsConfig {
     /// Base URL of the os-platform (fellow) API.
     #[serde(default = "default_issue_report_api_url")]
     pub os_platform_api_url: String,
-    /// fellow API key (`osk_…`) of the reporting bot user — that user
+    /// os-platform API key of the reporting bot user — that user
     /// must be a member of the target Org/Project. Redacted Debug.
     /// `SCRIBE__ISSUE_REPORTS__OS_PLATFORM_API_KEY`.
     #[serde(default)]
@@ -77,11 +77,11 @@ fn default_issue_report_api_url() -> String {
 }
 
 fn default_issue_report_org() -> String {
-    "open-software".to_string()
+    "june".to_string()
 }
 
 fn default_issue_report_project() -> String {
-    "june".to_string()
+    "bug-reports".to_string()
 }
 
 fn default_issue_report_label() -> String {

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -195,6 +195,30 @@ impl OsPlatformIssueReportSink {
         .await
     }
 
+    async fn create_org_issue_or_log(
+        &self,
+        report: &IssueReport,
+        file_ids: &[String],
+        project_message: &str,
+    ) -> Option<FellowEnvelope<FellowIssue>> {
+        match self.create_org_issue(report, file_ids).await {
+            Ok(envelope) if envelope.success => Some(envelope),
+            Ok(envelope) => {
+                tracing::error!(
+                    project_message,
+                    org_message = envelope.message.as_deref().unwrap_or(""),
+                    "issue_reports: os-platform rejected both project and org issue creates"
+                );
+                self.fallback_to_log(report, "project_and_org_create_rejected");
+                None
+            }
+            Err(_) => {
+                self.fallback_to_log(report, "org_create_transport_or_envelope_error");
+                None
+            }
+        }
+    }
+
     fn fallback_to_log(&self, report: &IssueReport, reason: &str) {
         log_issue_report_delivery_failed(report, reason, &self.org, &self.project);
     }
@@ -311,6 +335,17 @@ fn normalize_destination(org: &str, project: &str) -> Option<(String, String)> {
         return None;
     }
 
+    if (org == "open-software" && project == "june") || project == "open-software/june" {
+        tracing::warn!(
+            configured_org = %org,
+            configured_project = %project,
+            normalized_org = "june",
+            normalized_project = "bug-reports",
+            "issue_reports: remapped legacy June issue report destination"
+        );
+        return Some(("june".to_string(), "bug-reports".to_string()));
+    }
+
     let normalized_project = match project_parts.as_slice() {
         [project_slug] => *project_slug,
         [project_org, project_slug] if *project_org == org => *project_slug,
@@ -334,17 +369,6 @@ fn normalize_destination(org: &str, project: &str) -> Option<(String, String)> {
         );
     }
 
-    if org == "open-software" && normalized_project == "june" {
-        tracing::warn!(
-            configured_org = %org,
-            configured_project = %project,
-            normalized_org = "june",
-            normalized_project = "bug-reports",
-            "issue_reports: remapped legacy June issue report destination"
-        );
-        return Some(("june".to_string(), "bug-reports".to_string()));
-    }
-
     Some((org.to_string(), normalized_project.to_string()))
 }
 
@@ -353,35 +377,41 @@ impl IssueReportSink for OsPlatformIssueReportSink {
     async fn deliver(&self, report: IssueReport) -> Result<(), DomainError> {
         let file_ids = self.upload_attachments(&report).await;
 
-        let Ok(project_envelope) = self.create_project_issue(&report, &file_ids).await else {
-            self.fallback_to_log(&report, "project_create_transport_or_envelope_error");
-            return Ok(());
-        };
-        let (envelope, destination) = if project_envelope.success {
-            (project_envelope, IssueCreateDestination::Project)
-        } else {
-            let project_message = project_envelope.message.as_deref().unwrap_or("");
-            tracing::warn!(
-                message = project_message,
-                target_org = %self.org,
-                target_project = %self.project,
-                "issue_reports: os-platform rejected the project-scoped issue; retrying at org scope"
-            );
-            match self.create_org_issue(&report, &file_ids).await {
-                Ok(envelope) if envelope.success => (envelope, IssueCreateDestination::OrgFallback),
-                Ok(envelope) => {
-                    tracing::error!(
-                        project_message,
-                        org_message = envelope.message.as_deref().unwrap_or(""),
-                        "issue_reports: os-platform rejected both project and org issue creates"
-                    );
-                    self.fallback_to_log(&report, "project_and_org_create_rejected");
+        let (envelope, destination) = match self.create_project_issue(&report, &file_ids).await {
+            Ok(project_envelope) if project_envelope.success => {
+                (project_envelope, IssueCreateDestination::Project)
+            }
+            Ok(project_envelope) => {
+                let project_message = project_envelope.message.as_deref().unwrap_or("");
+                tracing::warn!(
+                    message = project_message,
+                    target_org = %self.org,
+                    target_project = %self.project,
+                    "issue_reports: os-platform rejected the project-scoped issue; retrying at org scope"
+                );
+                let Some(envelope) = self
+                    .create_org_issue_or_log(&report, &file_ids, project_message)
+                    .await
+                else {
                     return Ok(());
-                }
-                Err(_) => {
-                    self.fallback_to_log(&report, "org_create_transport_or_envelope_error");
+                };
+                (envelope, IssueCreateDestination::OrgFallback)
+            }
+            Err(_) => {
+                let project_message = "project_create_transport_or_envelope_error";
+                tracing::warn!(
+                    message = project_message,
+                    target_org = %self.org,
+                    target_project = %self.project,
+                    "issue_reports: project-scoped issue create failed before envelope; retrying at org scope"
+                );
+                let Some(envelope) = self
+                    .create_org_issue_or_log(&report, &file_ids, project_message)
+                    .await
+                else {
                     return Ok(());
-                }
+                };
+                (envelope, IssueCreateDestination::OrgFallback)
             }
         };
         let issue = envelope.data.as_ref();
@@ -679,10 +709,14 @@ mod os_platform_tests {
 
     #[test]
     fn os_platform_sink_remaps_legacy_open_software_june_destination() {
-        for project in ["june", "open-software/june"] {
+        for (org, project) in [
+            ("open-software", "june"),
+            ("open-software", "open-software/june"),
+            ("june", "open-software/june"),
+        ] {
             let config = IssueReportsConfig {
                 os_platform_api_key: "osk_test".to_string(),
-                os_platform_org: "open-software".to_string(),
+                os_platform_org: org.to_string(),
                 os_platform_project: project.to_string(),
                 ..Default::default()
             };
@@ -883,6 +917,41 @@ mod os_platform_tests {
                 "status": "todo",
                 "file_ids": [],
             })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
+            .respond_with(labels_set())
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(
+            missing_project_sink(&server)
+                .deliver(report())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_retries_at_org_scope_when_project_create_has_bad_envelope() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/june/projects/missing-project/bounties"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("bad gateway"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/june/bounties"))
             .respond_with(issue_created())
             .expect(1)
             .mount(&server)

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -334,6 +334,17 @@ fn normalize_destination(org: &str, project: &str) -> Option<(String, String)> {
         );
     }
 
+    if org == "open-software" && normalized_project == "june" {
+        tracing::warn!(
+            configured_org = %org,
+            configured_project = %project,
+            normalized_org = "june",
+            normalized_project = "bug-reports",
+            "issue_reports: remapped legacy June issue report destination"
+        );
+        return Some(("june".to_string(), "bug-reports".to_string()));
+    }
+
     Some((org.to_string(), normalized_project.to_string()))
 }
 
@@ -575,16 +586,31 @@ mod os_platform_tests {
         IssueReportsConfig {
             os_platform_api_url: api_url.to_string(),
             os_platform_api_key: "osk_test".to_string(),
-            os_platform_org: "open-software".to_string(),
-            os_platform_project: "june".to_string(),
+            os_platform_org: "june".to_string(),
+            os_platform_project: "bug-reports".to_string(),
             os_platform_reward_asset: "POINTS".to_string(),
             ..Default::default()
         }
     }
 
-    fn sink(server: &MockServer) -> OsPlatformIssueReportSink {
-        OsPlatformIssueReportSink::from_config(reqwest::Client::new(), &config(&server.uri()))
+    fn missing_project_config(api_url: &str) -> IssueReportsConfig {
+        IssueReportsConfig {
+            os_platform_project: "missing-project".to_string(),
+            ..config(api_url)
+        }
+    }
+
+    fn sink_with_config(config: &IssueReportsConfig) -> OsPlatformIssueReportSink {
+        OsPlatformIssueReportSink::from_config(reqwest::Client::new(), config)
             .expect("configured sink")
+    }
+
+    fn sink(server: &MockServer) -> OsPlatformIssueReportSink {
+        sink_with_config(&config(&server.uri()))
+    }
+
+    fn missing_project_sink(server: &MockServer) -> OsPlatformIssueReportSink {
+        sink_with_config(&missing_project_config(&server.uri()))
     }
 
     fn issue_created() -> ResponseTemplate {
@@ -636,7 +662,7 @@ mod os_platform_tests {
     }
 
     #[test]
-    fn os_platform_sink_uses_default_june_destination_with_api_key() {
+    fn os_platform_sink_uses_default_june_bug_reports_destination_with_api_key() {
         let config = IssueReportsConfig {
             os_platform_api_key: "osk_test".to_string(),
             ..Default::default()
@@ -645,24 +671,27 @@ mod os_platform_tests {
             .expect("default June issue report destination plus API key is configured");
 
         assert_eq!(sink.api_url, "https://app.opensoftware.co/api");
-        assert_eq!(sink.org, "open-software");
-        assert_eq!(sink.project, "june");
+        assert_eq!(sink.org, "june");
+        assert_eq!(sink.project, "bug-reports");
         assert_eq!(sink.label, "bug");
         assert_eq!(sink.reward_asset, "POINTS");
     }
 
     #[test]
-    fn os_platform_sink_accepts_legacy_org_project_destination() {
-        let config = IssueReportsConfig {
-            os_platform_api_key: "osk_test".to_string(),
-            os_platform_project: "open-software/june".to_string(),
-            ..Default::default()
-        };
-        let sink = OsPlatformIssueReportSink::from_config(reqwest::Client::new(), &config)
-            .expect("legacy org/project destination should normalize");
+    fn os_platform_sink_remaps_legacy_open_software_june_destination() {
+        for project in ["june", "open-software/june"] {
+            let config = IssueReportsConfig {
+                os_platform_api_key: "osk_test".to_string(),
+                os_platform_org: "open-software".to_string(),
+                os_platform_project: project.to_string(),
+                ..Default::default()
+            };
+            let sink = OsPlatformIssueReportSink::from_config(reqwest::Client::new(), &config)
+                .expect("legacy June issue report destination should remap");
 
-        assert_eq!(sink.org, "open-software");
-        assert_eq!(sink.project, "june");
+            assert_eq!(sink.org, "june");
+            assert_eq!(sink.project, "bug-reports");
+        }
     }
 
     #[test]
@@ -684,7 +713,7 @@ mod os_platform_tests {
     fn os_platform_sink_rejects_malformed_project_destination() {
         let config = IssueReportsConfig {
             os_platform_api_key: "osk_test".to_string(),
-            os_platform_project: "open-software/june/issues".to_string(),
+            os_platform_project: "june/bug-reports/issues".to_string(),
             ..Default::default()
         };
 
@@ -695,7 +724,7 @@ mod os_platform_tests {
     fn os_platform_sink_rejects_incomplete_legacy_project_destination() {
         let config = IssueReportsConfig {
             os_platform_api_key: "osk_test".to_string(),
-            os_platform_project: "open-software/".to_string(),
+            os_platform_project: "june/".to_string(),
             ..Default::default()
         };
 
@@ -706,7 +735,7 @@ mod os_platform_tests {
     fn os_platform_sink_rejects_other_org_project_destination() {
         let config = IssueReportsConfig {
             os_platform_api_key: "osk_test".to_string(),
-            os_platform_project: "other-org/june".to_string(),
+            os_platform_project: "other-org/bug-reports".to_string(),
             ..Default::default()
         };
 
@@ -726,7 +755,7 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(path("/v1/orgs/june/projects/bug-reports/bounties"))
             .and(body_partial_json(serde_json::json!({
                 "title": "June report: The recorder freezes",
                 "reward_amount_units": "0",
@@ -740,7 +769,7 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
-            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
             .and(body_partial_json(serde_json::json!({
                 "label_slugs": ["bug"],
             })))
@@ -763,7 +792,7 @@ mod os_platform_tests {
         // The attachment-upload failure above never blocks the report —
         // file_ids just ends up empty.
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(path("/v1/orgs/june/projects/bug-reports/bounties"))
             .and(body_partial_json(serde_json::json!({ "file_ids": [] })))
             .respond_with(issue_created())
             .expect(1)
@@ -772,13 +801,13 @@ mod os_platform_tests {
         // First labels PUT: the label doesn't exist in the Project yet.
         // After the label create, the retried PUT lands.
         Mock::given(method("PUT"))
-            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
             .respond_with(label_missing())
             .up_to_n_times(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/labels"))
+            .and(path("/v1/orgs/june/projects/bug-reports/labels"))
             .and(body_partial_json(serde_json::json!({
                 "name": "Bug",
                 "slug": "bug",
@@ -791,7 +820,7 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
-            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
             .respond_with(labels_set())
             .expect(1)
             .mount(&server)
@@ -809,18 +838,18 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .and(path("/v1/orgs/june/projects/bug-reports/bounties"))
             .respond_with(issue_created())
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
-            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
             .respond_with(label_missing())
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/labels"))
+            .and(path("/v1/orgs/june/projects/bug-reports/labels"))
             .respond_with(ResponseTemplate::new(403))
             .mount(&server)
             .await;
@@ -839,13 +868,13 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
-            .respond_with(issue_rejected("project 'open-software/june' not found"))
+            .and(path("/v1/orgs/june/projects/missing-project/bounties"))
+            .respond_with(issue_rejected("project 'june/missing-project' not found"))
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/bounties"))
+            .and(path("/v1/orgs/june/bounties"))
             .and(body_partial_json(serde_json::json!({
                 "title": "June report: The recorder freezes",
                 "reward_amount_units": "0",
@@ -859,13 +888,18 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
-            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
             .respond_with(labels_set())
             .expect(1)
             .mount(&server)
             .await;
 
-        assert!(sink(&server).deliver(report()).await.is_ok());
+        assert!(
+            missing_project_sink(&server)
+                .deliver(report())
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -877,31 +911,36 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
-            .respond_with(issue_rejected("project 'open-software/june' not found"))
+            .and(path("/v1/orgs/june/projects/missing-project/bounties"))
+            .respond_with(issue_rejected("project 'june/missing-project' not found"))
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/bounties"))
+            .and(path("/v1/orgs/june/bounties"))
             .respond_with(issue_created())
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("PUT"))
-            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
             .respond_with(label_missing())
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/labels"))
+            .and(path("/v1/orgs/june/projects/missing-project/labels"))
             .respond_with(ResponseTemplate::new(200))
             .expect(0)
             .mount(&server)
             .await;
 
-        assert!(sink(&server).deliver(report()).await.is_ok());
+        assert!(
+            missing_project_sink(&server)
+                .deliver(report())
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -913,13 +952,13 @@ mod os_platform_tests {
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/projects/june/bounties"))
-            .respond_with(issue_rejected("project 'open-software/june' not found"))
+            .and(path("/v1/orgs/june/projects/missing-project/bounties"))
+            .respond_with(issue_rejected("project 'june/missing-project' not found"))
             .expect(1)
             .mount(&server)
             .await;
         Mock::given(method("POST"))
-            .and(path("/v1/orgs/open-software/bounties"))
+            .and(path("/v1/orgs/june/bounties"))
             .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
                 "data": null,
                 "success": false,
@@ -930,7 +969,7 @@ mod os_platform_tests {
             .mount(&server)
             .await;
 
-        let result = sink(&server).deliver(report()).await;
+        let result = missing_project_sink(&server).deliver(report()).await;
         assert!(result.is_ok());
     }
 }

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -42,6 +42,21 @@ struct FellowIssue {
     number_in_org: i64,
 }
 
+#[derive(Clone, Copy)]
+enum IssueCreateDestination {
+    Project,
+    OrgFallback,
+}
+
+impl IssueCreateDestination {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::OrgFallback => "org_fallback",
+        }
+    }
+}
+
 impl OsPlatformIssueReportSink {
     /// `None` when the tracker isn't configured — the caller falls through
     /// to the structured log sink.
@@ -180,14 +195,8 @@ impl OsPlatformIssueReportSink {
         .await
     }
 
-    async fn fallback_to_log(&self, report: IssueReport, reason: &str) -> Result<(), DomainError> {
-        tracing::warn!(
-            reason,
-            target_org = %self.org,
-            target_project = %self.project,
-            "issue_reports: falling back to structured log"
-        );
-        LogIssueReportSink.deliver(report).await
+    fn fallback_to_log(&self, report: &IssueReport, reason: &str) {
+        log_issue_report_delivery_failed(report, reason, &self.org, &self.project);
     }
 
     /// Attaches the configured label via the labels PUT (set-replace; a
@@ -246,18 +255,33 @@ impl OsPlatformIssueReportSink {
     /// Project: the label won't exist yet, so the missing-label rejection
     /// creates it and retries once. Failure here never fails the delivery —
     /// the Issue is already filed (and carries `type: bug` regardless).
-    async fn tag_issue(&self, number_in_org: i64) {
+    async fn tag_issue(&self, number_in_org: i64, destination: IssueCreateDestination) {
         if self.label.is_empty() {
             return;
         }
         let attached = match self.put_label(number_in_org).await {
             Some(envelope) if envelope.success => true,
             Some(envelope) if envelope.message.as_deref().is_some_and(is_missing_label) => {
-                self.ensure_label().await
-                    && self
-                        .put_label(number_in_org)
-                        .await
-                        .is_some_and(|retry| retry.success)
+                match destination {
+                    IssueCreateDestination::Project => {
+                        self.ensure_label().await
+                            && self
+                                .put_label(number_in_org)
+                                .await
+                                .is_some_and(|retry| retry.success)
+                    }
+                    IssueCreateDestination::OrgFallback => {
+                        tracing::warn!(
+                            number_in_org,
+                            label = %self.label,
+                            target_org = %self.org,
+                            target_project = %self.project,
+                            destination = destination.as_str(),
+                            "issue_reports: org-fallback issue filed without label because the configured project label is unavailable"
+                        );
+                        return;
+                    }
+                }
             }
             _ => false,
         };
@@ -265,6 +289,7 @@ impl OsPlatformIssueReportSink {
             tracing::warn!(
                 number_in_org,
                 label = %self.label,
+                destination = destination.as_str(),
                 "issue_reports: issue filed but the label could not be attached"
             );
         }
@@ -318,12 +343,11 @@ impl IssueReportSink for OsPlatformIssueReportSink {
         let file_ids = self.upload_attachments(&report).await;
 
         let Ok(project_envelope) = self.create_project_issue(&report, &file_ids).await else {
-            return self
-                .fallback_to_log(report, "project_create_transport_or_envelope_error")
-                .await;
+            self.fallback_to_log(&report, "project_create_transport_or_envelope_error");
+            return Ok(());
         };
-        let envelope = if project_envelope.success {
-            project_envelope
+        let (envelope, destination) = if project_envelope.success {
+            (project_envelope, IssueCreateDestination::Project)
         } else {
             let project_message = project_envelope.message.as_deref().unwrap_or("");
             tracing::warn!(
@@ -333,32 +357,31 @@ impl IssueReportSink for OsPlatformIssueReportSink {
                 "issue_reports: os-platform rejected the project-scoped issue; retrying at org scope"
             );
             match self.create_org_issue(&report, &file_ids).await {
-                Ok(envelope) if envelope.success => envelope,
+                Ok(envelope) if envelope.success => (envelope, IssueCreateDestination::OrgFallback),
                 Ok(envelope) => {
                     tracing::error!(
                         project_message,
                         org_message = envelope.message.as_deref().unwrap_or(""),
                         "issue_reports: os-platform rejected both project and org issue creates"
                     );
-                    return self
-                        .fallback_to_log(report, "project_and_org_create_rejected")
-                        .await;
+                    self.fallback_to_log(&report, "project_and_org_create_rejected");
+                    return Ok(());
                 }
                 Err(_) => {
-                    return self
-                        .fallback_to_log(report, "org_create_transport_or_envelope_error")
-                        .await;
+                    self.fallback_to_log(&report, "org_create_transport_or_envelope_error");
+                    return Ok(());
                 }
             }
         };
         let issue = envelope.data.as_ref();
         if let Some(issue) = issue {
-            self.tag_issue(issue.number_in_org).await;
+            self.tag_issue(issue.number_in_org, destination).await;
         }
         tracing::info!(
             issue = issue.map_or("", |issue| issue.external_id.as_str()),
             user_id = %report.user_id.0,
             attachments = file_ids.len(),
+            destination = destination.as_str(),
             "issue_reports: report filed as an os-platform issue"
         );
         Ok(())
@@ -451,22 +474,43 @@ fn issue_body(report: &IssueReport) -> String {
 /// structured log line, so it still reaches whoever reads the service logs.
 pub struct LogIssueReportSink;
 
+fn log_issue_report_delivery_failed(report: &IssueReport, reason: &str, org: &str, project: &str) {
+    tracing::warn!(
+        reason,
+        target_org = %org,
+        target_project = %project,
+        user_id = %report.user_id.0,
+        description = %report.description,
+        agent_diagnosis = report.agent_diagnosis.as_deref().unwrap_or(""),
+        attachment_names = ?report.attachment_names,
+        attachments = ?report.attachments,
+        session_id = report.session_id.as_deref().unwrap_or(""),
+        app_version = report.app_version.as_deref().unwrap_or(""),
+        platform = report.platform.as_deref().unwrap_or(""),
+        "issue_reports: delivery failed; report logged only"
+    );
+}
+
+fn log_issue_report_without_sink(report: &IssueReport) {
+    tracing::warn!(
+        user_id = %report.user_id.0,
+        description = %report.description,
+        agent_diagnosis = report.agent_diagnosis.as_deref().unwrap_or(""),
+        attachment_names = ?report.attachment_names,
+        // The Debug impl reports name/type/length only — uploaded bytes
+        // never reach the logs.
+        attachments = ?report.attachments,
+        session_id = report.session_id.as_deref().unwrap_or(""),
+        app_version = report.app_version.as_deref().unwrap_or(""),
+        platform = report.platform.as_deref().unwrap_or(""),
+        "issue_reports: no delivery sink configured; report logged only"
+    );
+}
+
 #[async_trait]
 impl IssueReportSink for LogIssueReportSink {
     async fn deliver(&self, report: IssueReport) -> Result<(), DomainError> {
-        tracing::warn!(
-            user_id = %report.user_id.0,
-            description = %report.description,
-            agent_diagnosis = report.agent_diagnosis.as_deref().unwrap_or(""),
-            attachment_names = ?report.attachment_names,
-            // The Debug impl reports name/type/length only — uploaded bytes
-            // never reach the logs.
-            attachments = ?report.attachments,
-            session_id = report.session_id.as_deref().unwrap_or(""),
-            app_version = report.app_version.as_deref().unwrap_or(""),
-            platform = report.platform.as_deref().unwrap_or(""),
-            "issue_reports: no delivery sink configured; report logged only"
-        );
+        log_issue_report_without_sink(&report);
         Ok(())
     }
 }
@@ -818,6 +862,42 @@ mod os_platform_tests {
             .and(path("/v1/orgs/open-software/bounties/7/labels"))
             .respond_with(labels_set())
             .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(sink(&server).deliver(report()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_does_not_create_project_label_after_org_fallback() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(issue_rejected("project 'open-software/june' not found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/bounties"))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .respond_with(label_missing())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/labels"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
             .mount(&server)
             .await;
 

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -9,8 +9,9 @@ use serde::Deserialize;
 /// blocks the report; the names are listed in the body either way), the
 /// Issue is created with `type: bug`, and the label is attached afterwards
 /// via the labels PUT — creating the label in the Project the first time.
-/// Every step after the create is best-effort: an Issue without its tag
-/// beats a lost report.
+/// Delivery to os-platform is best-effort: the sink retries without a Project
+/// destination and finally logs the report rather than surfacing delivery
+/// failures to the user.
 pub struct OsPlatformIssueReportSink {
     http: reqwest::Client,
     api_url: String,
@@ -111,11 +112,7 @@ impl OsPlatformIssueReportSink {
         file_ids
     }
 
-    async fn create_issue(
-        &self,
-        report: &IssueReport,
-        file_ids: &[String],
-    ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
+    fn issue_create_body(&self, report: &IssueReport, file_ids: &[String]) -> serde_json::Value {
         let mut body = serde_json::json!({
             "title": issue_title(&report.description),
             "body_markdown": issue_body(report),
@@ -127,13 +124,19 @@ impl OsPlatformIssueReportSink {
         if !self.reward_asset.is_empty() {
             body["asset_symbol"] = serde_json::Value::String(self.reward_asset.clone());
         }
+        body
+    }
+
+    async fn create_issue_at(
+        &self,
+        url: String,
+        report: &IssueReport,
+        file_ids: &[String],
+    ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
         self.http
-            .post(format!(
-                "{}/v1/orgs/{}/projects/{}/bounties",
-                self.api_url, self.org, self.project
-            ))
+            .post(url)
             .bearer_auth(&self.api_key)
-            .json(&body)
+            .json(&self.issue_create_body(report, file_ids))
             .send()
             .await
             .map_err(|error| {
@@ -146,6 +149,45 @@ impl OsPlatformIssueReportSink {
                 tracing::error!(%error, "issue_reports: os-platform returned a malformed envelope");
                 DomainError::UpstreamProvider
             })
+    }
+
+    async fn create_project_issue(
+        &self,
+        report: &IssueReport,
+        file_ids: &[String],
+    ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
+        self.create_issue_at(
+            format!(
+                "{}/v1/orgs/{}/projects/{}/bounties",
+                self.api_url, self.org, self.project
+            ),
+            report,
+            file_ids,
+        )
+        .await
+    }
+
+    async fn create_org_issue(
+        &self,
+        report: &IssueReport,
+        file_ids: &[String],
+    ) -> Result<FellowEnvelope<FellowIssue>, DomainError> {
+        self.create_issue_at(
+            format!("{}/v1/orgs/{}/bounties", self.api_url, self.org),
+            report,
+            file_ids,
+        )
+        .await
+    }
+
+    async fn fallback_to_log(&self, report: IssueReport, reason: &str) -> Result<(), DomainError> {
+        tracing::warn!(
+            reason,
+            target_org = %self.org,
+            target_project = %self.project,
+            "issue_reports: falling back to structured log"
+        );
+        LogIssueReportSink.deliver(report).await
     }
 
     /// Attaches the configured label via the labels PUT (set-replace; a
@@ -275,14 +317,40 @@ impl IssueReportSink for OsPlatformIssueReportSink {
     async fn deliver(&self, report: IssueReport) -> Result<(), DomainError> {
         let file_ids = self.upload_attachments(&report).await;
 
-        let envelope = self.create_issue(&report, &file_ids).await?;
-        if !envelope.success {
-            tracing::error!(
-                message = envelope.message.as_deref().unwrap_or(""),
-                "issue_reports: os-platform rejected the issue"
+        let Ok(project_envelope) = self.create_project_issue(&report, &file_ids).await else {
+            return self
+                .fallback_to_log(report, "project_create_transport_or_envelope_error")
+                .await;
+        };
+        let envelope = if project_envelope.success {
+            project_envelope
+        } else {
+            let project_message = project_envelope.message.as_deref().unwrap_or("");
+            tracing::warn!(
+                message = project_message,
+                target_org = %self.org,
+                target_project = %self.project,
+                "issue_reports: os-platform rejected the project-scoped issue; retrying at org scope"
             );
-            return Err(DomainError::UpstreamProvider);
-        }
+            match self.create_org_issue(&report, &file_ids).await {
+                Ok(envelope) if envelope.success => envelope,
+                Ok(envelope) => {
+                    tracing::error!(
+                        project_message,
+                        org_message = envelope.message.as_deref().unwrap_or(""),
+                        "issue_reports: os-platform rejected both project and org issue creates"
+                    );
+                    return self
+                        .fallback_to_log(report, "project_and_org_create_rejected")
+                        .await;
+                }
+                Err(_) => {
+                    return self
+                        .fallback_to_log(report, "org_create_transport_or_envelope_error")
+                        .await;
+                }
+            }
+        };
         let issue = envelope.data.as_ref();
         if let Some(issue) = issue {
             self.tag_issue(issue.number_in_org).await;
@@ -498,6 +566,15 @@ mod os_platform_tests {
         }))
     }
 
+    fn issue_rejected(message: &str) -> ResponseTemplate {
+        ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "data": null,
+            "success": false,
+            "error_code": 3004,
+            "message": message,
+        }))
+    }
+
     #[test]
     fn os_platform_sink_requires_full_config() {
         let mut incomplete = config("https://fellow.test");
@@ -710,7 +787,7 @@ mod os_platform_tests {
     }
 
     #[tokio::test]
-    async fn os_platform_sink_surfaces_rejections_as_upstream_errors() {
+    async fn os_platform_sink_retries_at_org_scope_when_project_create_is_rejected() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/files"))
@@ -719,16 +796,61 @@ mod os_platform_tests {
             .await;
         Mock::given(method("POST"))
             .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(issue_rejected("project 'open-software/june' not found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/bounties"))
+            .and(body_partial_json(serde_json::json!({
+                "title": "June report: The recorder freezes",
+                "reward_amount_units": "0",
+                "asset_symbol": "POINTS",
+                "type": "bug",
+                "status": "todo",
+                "file_ids": [],
+            })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/open-software/bounties/7/labels"))
+            .respond_with(labels_set())
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(sink(&server).deliver(report()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_accepts_and_logs_when_platform_rejects_all_creates() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/projects/june/bounties"))
+            .respond_with(issue_rejected("project 'open-software/june' not found"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/open-software/bounties"))
             .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
                 "data": null,
                 "success": false,
                 "error_code": 3001,
                 "message": "caller is not an org member",
             })))
+            .expect(1)
             .mount(&server)
             .await;
 
         let result = sink(&server).deliver(report()).await;
-        assert!(matches!(result, Err(DomainError::UpstreamProvider)));
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Summary
- Make Scribe API issue report delivery best-effort after request validation instead of returning 502 when os-platform rejects the create.
- Point the default issue-report destination at the live `june/bug-reports` os-platform project, verified with the production API.
- Remap legacy `open-software/june` configuration to `june/bug-reports` so stale production env values do not keep hitting the missing project.
- Retry failed project-scoped issue creates through os-platform's org-scoped Issue route, then fall back to structured logs if both platform delivery attempts fail.
- Add regression tests for the missing-project fallback, legacy destination remap, org-fallback label behavior, and final log fallback path.

## Root cause
Production was still getting `issue_reports: os-platform rejected the issue` with `project 'open-software/june' not found`, which made the Scribe API map a valid bug report submission to an upstream 502.

Using the provided os-platform API key read-only against production confirmed:
- `GET /v1/users/me` authenticates as `junhohong`.
- `open-software` exists, but `GET /v1/orgs/open-software/projects` returns zero projects.
- `GET /v1/orgs/open-software/projects/june` returns `project 'open-software/june' not found`.
- The live June org is `june`, with project `bug-reports`.

## Validation
- `cargo +1.95.0-aarch64-apple-darwin fmt --manifest-path scribe-api/Cargo.toml --all --check`
- `git diff --check`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml -p scribe-providers issue_reports --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin clippy --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`
