### PR TITLE
Pause stale meeting recordings

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -537,7 +537,9 @@ fn write_input_data<I>(
     let mut preview_samples = preview.map(|_| Vec::new());
     {
         let mut callback_peak = 0.0_f32;
+        let mut saw_sample = false;
         for sample in data {
+            saw_sample = true;
             let clamped = sample.clamp(-1.0, 1.0);
             let pcm_sample = (clamped * i16::MAX as f32) as i16;
             let normalized = clamped.abs();
@@ -551,7 +553,7 @@ fn write_input_data<I>(
                 samples.push(pcm_sample);
             }
         }
-        if callback_peak > 0.0 {
+        if saw_sample {
             if stats.recent_peaks.len() == 24 {
                 stats.recent_peaks.pop_front();
             }

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -134,25 +134,7 @@ impl SystemAudioCapture {
     pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
         if let Ok(status) = read_status(&self.status_path) {
             if let Ok(mut stats) = self.stats.lock() {
-                if let Some(level) = status.level {
-                    stats.max_level = stats.max_level.max(status.max_level.unwrap_or(level));
-                    stats.level = AudioLevelDto {
-                        peak: level,
-                        rms: level,
-                        recent_peaks: vec![level],
-                    };
-                }
-                if status.event == "error" {
-                    stats.last_error = Some(
-                        status
-                            .message
-                            .unwrap_or_else(|| "System audio capture failed.".to_string()),
-                    );
-                } else if status.message.is_some() {
-                    stats.last_error = status.message;
-                } else if status.event == "ready" || status.event == "level" {
-                    stats.last_error = None;
-                }
+                apply_helper_status(&mut stats, &status);
                 if stats
                     .last_debug_log
                     .map(|logged| logged.elapsed() >= Duration::from_secs(2))
@@ -200,6 +182,32 @@ impl SystemAudioCapture {
             self.log_path.display()
         ));
         Ok(self.final_path)
+    }
+}
+
+fn apply_helper_status(stats: &mut SystemAudioStats, status: &HelperStatus) {
+    if let Some(level) = status.level {
+        stats.max_level = stats.max_level.max(status.max_level.unwrap_or(level));
+        stats.level = AudioLevelDto {
+            peak: level,
+            rms: level,
+            recent_peaks: vec![level],
+        };
+    } else {
+        stats.level = AudioLevelDto::default();
+    }
+
+    if status.event == "error" {
+        stats.last_error = Some(
+            status
+                .message
+                .clone()
+                .unwrap_or_else(|| "System audio capture failed.".to_string()),
+        );
+    } else if status.message.is_some() {
+        stats.last_error = status.message.clone();
+    } else if status.event == "ready" || status.event == "level" {
+        stats.last_error = None;
     }
 }
 
@@ -597,7 +605,10 @@ fn dump_helper_log(_path: &Path) {}
 
 #[cfg(test)]
 mod tests {
-    use super::{macos_version_string_supports_system_audio, system_audio_min_macos_version_label};
+    use super::{
+        apply_helper_status, macos_version_string_supports_system_audio,
+        system_audio_min_macos_version_label, HelperStatus, SystemAudioStats,
+    };
 
     #[test]
     fn system_audio_support_label_uses_shared_minimum_version() {
@@ -619,5 +630,56 @@ mod tests {
         assert!(!macos_version_string_supports_system_audio(""));
         assert!(!macos_version_string_supports_system_audio("14.beta"));
         assert!(!macos_version_string_supports_system_audio("not-a-version"));
+    }
+
+    #[test]
+    fn helper_level_status_updates_recent_activity() {
+        let mut stats = SystemAudioStats::default();
+
+        apply_helper_status(
+            &mut stats,
+            &HelperStatus {
+                event: "level".to_string(),
+                level: Some(0.42),
+                max_level: Some(0.55),
+                message: None,
+            },
+        );
+
+        assert_eq!(stats.level.peak, 0.42);
+        assert_eq!(stats.level.rms, 0.42);
+        assert_eq!(stats.level.recent_peaks, vec![0.42]);
+        assert_eq!(stats.max_level, 0.55);
+        assert_eq!(stats.last_error, None);
+    }
+
+    #[test]
+    fn helper_non_level_status_clears_stale_recent_activity() {
+        let mut stats = SystemAudioStats {
+            level: crate::domain::types::AudioLevelDto {
+                peak: 0.8,
+                rms: 0.8,
+                recent_peaks: vec![0.8],
+            },
+            max_level: 0.8,
+            last_error: None,
+            last_debug_log: None,
+        };
+
+        apply_helper_status(
+            &mut stats,
+            &HelperStatus {
+                event: "stalled".to_string(),
+                level: None,
+                max_level: None,
+                message: Some("System audio stalled.".to_string()),
+            },
+        );
+
+        assert_eq!(stats.level.peak, 0.0);
+        assert_eq!(stats.level.rms, 0.0);
+        assert!(stats.level.recent_peaks.is_empty());
+        assert_eq!(stats.max_level, 0.8);
+        assert_eq!(stats.last_error, Some("System audio stalled.".to_string()));
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -121,6 +121,17 @@ import { parseDictationHelperEvent } from "../lib/dictation-events";
 import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
 import { upsertLiveTranscriptEvent } from "../lib/live-transcript-preview";
 import {
+  RECORDING_INACTIVITY_RESPONSE_MS,
+  RECORDING_INACTIVITY_SNOOZE_MS,
+  nextRecordingInactivityDecision,
+  recordingHasActivity,
+  type RecordingInactivityTracker,
+} from "../lib/recording-inactivity";
+import {
+  notifyRecordingAutoPaused,
+  notifyRecordingStillMeetingPrompt,
+} from "../lib/recording-notifications";
+import {
   AGENT_MENU_BAR_NEW_SESSION_EVENT,
   AGENT_MENU_BAR_OPEN_SESSION_EVENT,
   AGENT_MENU_BAR_SET_AGENT_HUD_EVENT,
@@ -198,6 +209,11 @@ function sidebarMaxWidth() {
 }
 
 const TAB_ICON_SIZE = 14;
+
+type RecordingInactivityPrompt = {
+  sessionId: string;
+  expiresAt: number;
+};
 
 // The icon + label a tab shows for a snapshot. Titles for entity views (note,
 // project, agent session) are looked up live from the loaded data, so a tab's
@@ -418,6 +434,12 @@ export function App() {
     string | undefined
   >(undefined);
   const recordingStatusRef = useRef(state.recordingStatus);
+  const recordingInactivityTrackerRef = useRef<RecordingInactivityTracker>({});
+  const [recordingInactivityPrompt, setRecordingInactivityPrompt] =
+    useState<RecordingInactivityPrompt | null>(null);
+  const [recordingInactivityNow, setRecordingInactivityNow] = useState(() =>
+    Date.now(),
+  );
   const recordingStartInFlightRef = useRef(false);
   const [liveTranscriptEvents, setLiveTranscriptEvents] = useState<
     LiveTranscriptEventDto[]
@@ -2334,8 +2356,10 @@ export function App() {
       const status = await pauseRecording(sessionId);
       dispatch({ type: "recordingStatusChanged", status });
       playRecordingSound("pause");
+      return true;
     } catch (err) {
       setError(messageFromError(err));
+      return false;
     }
   }
 
@@ -2348,6 +2372,101 @@ export function App() {
       setError(messageFromError(err));
     }
   }
+
+  useEffect(() => {
+    const status = state.recordingStatus;
+    const now = Date.now();
+    const decision = nextRecordingInactivityDecision(
+      recordingInactivityTrackerRef.current,
+      status,
+      now,
+    );
+    recordingInactivityTrackerRef.current = decision.tracker;
+
+    if (
+      recordingInactivityPrompt &&
+      (!status ||
+        status.sessionId !== recordingInactivityPrompt.sessionId ||
+        status.state !== "recording" ||
+        recordingHasActivity(status))
+    ) {
+      setRecordingInactivityPrompt(null);
+      return;
+    }
+
+    if (
+      !status ||
+      !decision.shouldPrompt ||
+      recordingInactivityPrompt?.sessionId === status.sessionId
+    ) {
+      return;
+    }
+
+    const prompt = {
+      sessionId: status.sessionId,
+      expiresAt: now + RECORDING_INACTIVITY_RESPONSE_MS,
+    };
+    setRecordingInactivityNow(now);
+    setRecordingInactivityPrompt(prompt);
+    void notifyRecordingStillMeetingPrompt(status.sessionId);
+  }, [recordingInactivityPrompt, state.recordingStatus]);
+
+  useEffect(() => {
+    if (!recordingInactivityPrompt) return;
+
+    setRecordingInactivityNow(Date.now());
+    const tick = window.setInterval(() => {
+      setRecordingInactivityNow(Date.now());
+    }, 1000);
+    const timeout = window.setTimeout(() => {
+      const currentStatus = recordingStatusRef.current;
+      const sessionId = recordingInactivityPrompt.sessionId;
+      recordingInactivityTrackerRef.current = { sessionId };
+      setRecordingInactivityPrompt(null);
+      if (
+        currentStatus?.sessionId !== sessionId ||
+        currentStatus.state !== "recording"
+      ) {
+        return;
+      }
+      void handlePauseRecording(sessionId).then((paused) => {
+        if (paused) void notifyRecordingAutoPaused(sessionId);
+      });
+    }, Math.max(0, recordingInactivityPrompt.expiresAt - Date.now()));
+
+    return () => {
+      window.clearInterval(tick);
+      window.clearTimeout(timeout);
+    };
+  }, [recordingInactivityPrompt]);
+
+  function handleKeepRecordingAfterInactivityPrompt() {
+    const sessionId = recordingInactivityPrompt?.sessionId;
+    if (sessionId) {
+      recordingInactivityTrackerRef.current = {
+        sessionId,
+        snoozedUntil: Date.now() + RECORDING_INACTIVITY_SNOOZE_MS,
+      };
+    }
+    setRecordingInactivityPrompt(null);
+  }
+
+  function handlePauseRecordingAfterInactivityPrompt() {
+    const sessionId = recordingInactivityPrompt?.sessionId;
+    if (!sessionId) return;
+    recordingInactivityTrackerRef.current = { sessionId };
+    setRecordingInactivityPrompt(null);
+    void handlePauseRecording(sessionId);
+  }
+
+  const recordingInactivitySecondsRemaining = recordingInactivityPrompt
+    ? Math.max(
+        0,
+        Math.ceil(
+          (recordingInactivityPrompt.expiresAt - recordingInactivityNow) / 1000,
+        ),
+      )
+    : 0;
 
   if (accountLoading) {
     return (
@@ -3081,6 +3200,38 @@ export function App() {
           </AnimatePresence>
         </section>
       </div>
+      <Dialog
+        open={recordingInactivityPrompt !== null}
+        onClose={handleKeepRecordingAfterInactivityPrompt}
+        title="Still in a meeting?"
+        description="June has not heard meeting audio for a while."
+        width={420}
+        footer={
+          <>
+            <button
+              type="button"
+              className="primary-action"
+              onClick={handlePauseRecordingAfterInactivityPrompt}
+            >
+              Pause recording
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              onClick={handleKeepRecordingAfterInactivityPrompt}
+            >
+              Keep recording
+            </button>
+          </>
+        }
+      >
+        <div className="dialog-body">
+          <p className="recording-inactivity-copy">
+            June will pause this recording in{" "}
+            {recordingInactivitySecondsRemaining} seconds if you do not answer.
+          </p>
+        </div>
+      </Dialog>
       <MoveNoteToFolderDialog
         open={moveDialogNoteIds !== null}
         onClose={() => setMoveDialogNoteIds(null)}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2351,7 +2351,7 @@ export function App() {
     }
   }
 
-  async function handlePauseRecording(sessionId: string) {
+  const handlePauseRecording = useCallback(async (sessionId: string) => {
     try {
       const status = await pauseRecording(sessionId);
       dispatch({ type: "recordingStatusChanged", status });
@@ -2361,7 +2361,7 @@ export function App() {
       setError(messageFromError(err));
       return false;
     }
-  }
+  }, []);
 
   async function handleResumeRecording(sessionId: string) {
     playRecordingSound("start");
@@ -2438,7 +2438,7 @@ export function App() {
       window.clearInterval(tick);
       window.clearTimeout(timeout);
     };
-  }, [recordingInactivityPrompt]);
+  }, [handlePauseRecording, recordingInactivityPrompt]);
 
   function handleKeepRecordingAfterInactivityPrompt() {
     const sessionId = recordingInactivityPrompt?.sessionId;

--- a/src/lib/recording-inactivity.ts
+++ b/src/lib/recording-inactivity.ts
@@ -92,5 +92,5 @@ function activityLevel(level: AudioLevelDto | undefined) {
   if (level.recentPeaks.length > 0) {
     return Math.max(...level.recentPeaks);
   }
-  return level.rms;
+  return 0;
 }

--- a/src/lib/recording-inactivity.ts
+++ b/src/lib/recording-inactivity.ts
@@ -1,0 +1,95 @@
+import type { AudioLevelDto, RecordingStatusDto } from "./tauri";
+
+export const RECORDING_INACTIVITY_MIN_ELAPSED_MS = 10 * 60 * 1000;
+export const RECORDING_INACTIVITY_QUIET_MS = 5 * 60 * 1000;
+export const RECORDING_INACTIVITY_RESPONSE_MS = 30 * 1000;
+export const RECORDING_INACTIVITY_SNOOZE_MS = 10 * 60 * 1000;
+export const RECORDING_INACTIVITY_LEVEL_THRESHOLD = 0.015;
+
+export type RecordingInactivityTracker = {
+  sessionId?: string;
+  quietStartedAt?: number;
+  snoozedUntil?: number;
+};
+
+export type RecordingInactivityDecision = {
+  tracker: RecordingInactivityTracker;
+  shouldPrompt: boolean;
+};
+
+export function nextRecordingInactivityDecision(
+  tracker: RecordingInactivityTracker,
+  status: RecordingStatusDto | undefined,
+  now: number,
+): RecordingInactivityDecision {
+  if (!status || status.state !== "recording") {
+    return { tracker: {}, shouldPrompt: false };
+  }
+
+  const sameSession = tracker.sessionId === status.sessionId;
+  const baseTracker = sameSession
+    ? tracker
+    : { sessionId: status.sessionId };
+
+  if (status.elapsedMs < RECORDING_INACTIVITY_MIN_ELAPSED_MS) {
+    return {
+      tracker: {
+        sessionId: status.sessionId,
+        snoozedUntil: baseTracker.snoozedUntil,
+      },
+      shouldPrompt: false,
+    };
+  }
+
+  if (recordingHasActivity(status)) {
+    return {
+      tracker: {
+        sessionId: status.sessionId,
+        snoozedUntil: baseTracker.snoozedUntil,
+      },
+      shouldPrompt: false,
+    };
+  }
+
+  if (baseTracker.snoozedUntil && now < baseTracker.snoozedUntil) {
+    return {
+      tracker: {
+        ...baseTracker,
+        quietStartedAt: undefined,
+      },
+      shouldPrompt: false,
+    };
+  }
+
+  const quietStartedAt = baseTracker.quietStartedAt ?? now;
+  const nextTracker = {
+    sessionId: status.sessionId,
+    quietStartedAt,
+    snoozedUntil: baseTracker.snoozedUntil,
+  };
+
+  return {
+    tracker: nextTracker,
+    shouldPrompt: now - quietStartedAt >= RECORDING_INACTIVITY_QUIET_MS,
+  };
+}
+
+export function recordingHasActivity(status: RecordingStatusDto) {
+  return recordingActivityLevel(status) >= RECORDING_INACTIVITY_LEVEL_THRESHOLD;
+}
+
+export function recordingActivityLevel(status: RecordingStatusDto) {
+  const sourceLevels =
+    status.sources && status.sources.length > 0
+      ? status.sources.map((source) => source.level)
+      : [status.level];
+  return Math.max(0, ...sourceLevels.map(activityLevel));
+}
+
+function activityLevel(level: AudioLevelDto | undefined) {
+  if (!level) return 0;
+  if (level.recentPeaks.length > 0) {
+    return Math.max(...level.recentPeaks);
+  }
+  return level.rms;
+}

--- a/src/lib/recording-inactivity.ts
+++ b/src/lib/recording-inactivity.ts
@@ -52,10 +52,11 @@ export function nextRecordingInactivityDecision(
   }
 
   if (baseTracker.snoozedUntil && now < baseTracker.snoozedUntil) {
+    const quietStartedAt = baseTracker.quietStartedAt ?? now;
     return {
       tracker: {
         ...baseTracker,
-        quietStartedAt: undefined,
+        quietStartedAt,
       },
       shouldPrompt: false,
     };

--- a/src/lib/recording-notifications.ts
+++ b/src/lib/recording-notifications.ts
@@ -17,22 +17,30 @@ async function canNotify() {
 
 export async function notifyRecordingStillMeetingPrompt(sessionId: string) {
   if (!(await canNotify())) return false;
-  sendNotification({
-    title: "Still in a meeting?",
-    body: "June will pause the recording soon if you do not answer.",
-    group: `scribe-recording-${sessionId}`,
-    sound: NOTIFICATION_SOUND,
-  });
-  return true;
+  try {
+    await sendNotification({
+      title: "Still in a meeting?",
+      body: "June will pause the recording soon if you do not answer.",
+      group: `scribe-recording-${sessionId}`,
+      sound: NOTIFICATION_SOUND,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function notifyRecordingAutoPaused(sessionId: string) {
   if (!(await canNotify())) return false;
-  sendNotification({
-    title: "June paused recording",
-    body: "No meeting audio was detected. Open June to resume or finish.",
-    group: `scribe-recording-${sessionId}`,
-    sound: NOTIFICATION_SOUND,
-  });
-  return true;
+  try {
+    await sendNotification({
+      title: "June paused recording",
+      body: "No meeting audio was detected. Open June to resume or finish.",
+      group: `scribe-recording-${sessionId}`,
+      sound: NOTIFICATION_SOUND,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/recording-notifications.ts
+++ b/src/lib/recording-notifications.ts
@@ -1,0 +1,38 @@
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+
+const NOTIFICATION_SOUND = "Ping";
+
+async function canNotify() {
+  let granted = await isPermissionGranted().catch(() => false);
+  if (!granted) {
+    const permission = await requestPermission().catch(() => "denied" as const);
+    granted = permission === "granted";
+  }
+  return granted;
+}
+
+export async function notifyRecordingStillMeetingPrompt(sessionId: string) {
+  if (!(await canNotify())) return false;
+  sendNotification({
+    title: "Still in a meeting?",
+    body: "June will pause the recording soon if you do not answer.",
+    group: `scribe-recording-${sessionId}`,
+    sound: NOTIFICATION_SOUND,
+  });
+  return true;
+}
+
+export async function notifyRecordingAutoPaused(sessionId: string) {
+  if (!(await canNotify())) return false;
+  sendNotification({
+    title: "June paused recording",
+    body: "No meeting audio was detected. Open June to resume or finish.",
+    group: `scribe-recording-${sessionId}`,
+    sound: NOTIFICATION_SOUND,
+  });
+  return true;
+}

--- a/src/lib/recording-notifications.ts
+++ b/src/lib/recording-notifications.ts
@@ -3,8 +3,10 @@ import {
   requestPermission,
   sendNotification,
 } from "@tauri-apps/plugin-notification";
+import { RECORDING_INACTIVITY_RESPONSE_MS } from "./recording-inactivity";
 
 const NOTIFICATION_SOUND = "Ping";
+const RESPONSE_SECONDS = Math.round(RECORDING_INACTIVITY_RESPONSE_MS / 1000);
 
 async function canNotify() {
   let granted = await isPermissionGranted().catch(() => false);
@@ -20,7 +22,7 @@ export async function notifyRecordingStillMeetingPrompt(sessionId: string) {
   try {
     await sendNotification({
       title: "Still in a meeting?",
-      body: "June will pause the recording soon if you do not answer.",
+      body: `June will pause the recording in ${RESPONSE_SECONDS} seconds if you do not answer.`,
       group: `scribe-recording-${sessionId}`,
       sound: NOTIFICATION_SOUND,
     });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12197,6 +12197,13 @@ input:focus-visible,
   margin: calc(-1 * var(--sp-1));
 }
 
+.recording-inactivity-copy {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  line-height: 1.5;
+}
+
 .dialog-field {
   display: flex;
   flex-direction: column;

--- a/src/test/recording-inactivity.test.ts
+++ b/src/test/recording-inactivity.test.ts
@@ -108,7 +108,23 @@ describe("recording inactivity", () => {
     );
 
     expect(decision.shouldPrompt).toBe(false);
-    expect(decision.tracker.quietStartedAt).toBeUndefined();
+    expect(decision.tracker.quietStartedAt).toBe(1_000);
+  });
+
+  it("prompts immediately after the snooze expires when audio stayed quiet", () => {
+    const tracker: RecordingInactivityTracker = {
+      sessionId: "session-1",
+      quietStartedAt: 1_000,
+      snoozedUntil: 1_000 + RECORDING_INACTIVITY_SNOOZE_MS,
+    };
+
+    const decision = nextRecordingInactivityDecision(
+      tracker,
+      status(),
+      1_000 + RECORDING_INACTIVITY_SNOOZE_MS,
+    );
+
+    expect(decision.shouldPrompt).toBe(true);
   });
 
   it("resets when the recording is no longer active", () => {

--- a/src/test/recording-inactivity.test.ts
+++ b/src/test/recording-inactivity.test.ts
@@ -55,6 +55,15 @@ describe("recording inactivity", () => {
     expect(recordingHasActivity(quietAfterSpeech)).toBe(false);
   });
 
+  it("treats missing recent peaks as quiet instead of falling back to rms", () => {
+    const staleRms = status({
+      level: { peak: 0.8, rms: 0.05, recentPeaks: [] },
+    });
+
+    expect(recordingActivityLevel(staleRms)).toBe(0);
+    expect(recordingHasActivity(staleRms)).toBe(false);
+  });
+
   it("keeps source activity from opening the prompt", () => {
     const activeSystemAudio = status({
       level: { peak: 0.001, rms: 0.001, recentPeaks: [0.001] },

--- a/src/test/recording-inactivity.test.ts
+++ b/src/test/recording-inactivity.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  RECORDING_INACTIVITY_MIN_ELAPSED_MS,
+  RECORDING_INACTIVITY_QUIET_MS,
+  RECORDING_INACTIVITY_SNOOZE_MS,
+  nextRecordingInactivityDecision,
+  recordingActivityLevel,
+  recordingHasActivity,
+  type RecordingInactivityTracker,
+} from "../lib/recording-inactivity";
+import type { RecordingStatusDto } from "../lib/tauri";
+
+function status(overrides: Partial<RecordingStatusDto> = {}): RecordingStatusDto {
+  return {
+    sessionId: "session-1",
+    state: "recording",
+    elapsedMs: RECORDING_INACTIVITY_MIN_ELAPSED_MS,
+    level: { peak: 0, rms: 0, recentPeaks: [0] },
+    silenceWarning: false,
+    bytesWritten: 1024,
+    ...overrides,
+  };
+}
+
+describe("recording inactivity", () => {
+  it("waits until a recording is old enough before tracking quiet time", () => {
+    const decision = nextRecordingInactivityDecision(
+      {},
+      status({ elapsedMs: RECORDING_INACTIVITY_MIN_ELAPSED_MS - 1 }),
+      1_000,
+    );
+
+    expect(decision.shouldPrompt).toBe(false);
+    expect(decision.tracker.quietStartedAt).toBeUndefined();
+  });
+
+  it("opens the prompt after a continuous quiet stretch", () => {
+    const first = nextRecordingInactivityDecision({}, status(), 1_000);
+    const second = nextRecordingInactivityDecision(
+      first.tracker,
+      status(),
+      1_000 + RECORDING_INACTIVITY_QUIET_MS,
+    );
+
+    expect(first.shouldPrompt).toBe(false);
+    expect(second.shouldPrompt).toBe(true);
+  });
+
+  it("uses recent audio instead of all-time peak for quiet detection", () => {
+    const quietAfterSpeech = status({
+      level: { peak: 0.8, rms: 0.05, recentPeaks: [0, 0] },
+    });
+
+    expect(recordingActivityLevel(quietAfterSpeech)).toBe(0);
+    expect(recordingHasActivity(quietAfterSpeech)).toBe(false);
+  });
+
+  it("keeps source activity from opening the prompt", () => {
+    const activeSystemAudio = status({
+      level: { peak: 0.001, rms: 0.001, recentPeaks: [0.001] },
+      sources: [
+        {
+          source: "microphone",
+          state: "recording",
+          elapsedMs: RECORDING_INACTIVITY_MIN_ELAPSED_MS,
+          bytesWritten: 1024,
+          level: { peak: 0.001, rms: 0.001, recentPeaks: [0.001] },
+          silenceWarning: false,
+          pathFinalized: false,
+        },
+        {
+          source: "system",
+          state: "recording",
+          elapsedMs: RECORDING_INACTIVITY_MIN_ELAPSED_MS,
+          bytesWritten: 1024,
+          level: { peak: 0.7, rms: 0.1, recentPeaks: [0.05] },
+          silenceWarning: false,
+          pathFinalized: false,
+        },
+      ],
+    });
+    const tracker: RecordingInactivityTracker = {
+      sessionId: "session-1",
+      quietStartedAt: 1_000,
+    };
+
+    const decision = nextRecordingInactivityDecision(
+      tracker,
+      activeSystemAudio,
+      1_000 + RECORDING_INACTIVITY_QUIET_MS,
+    );
+
+    expect(decision.shouldPrompt).toBe(false);
+    expect(decision.tracker.quietStartedAt).toBeUndefined();
+  });
+
+  it("snoozes quiet prompts after the user keeps recording", () => {
+    const tracker: RecordingInactivityTracker = {
+      sessionId: "session-1",
+      quietStartedAt: 1_000,
+      snoozedUntil: 1_000 + RECORDING_INACTIVITY_SNOOZE_MS,
+    };
+
+    const decision = nextRecordingInactivityDecision(
+      tracker,
+      status(),
+      1_000 + RECORDING_INACTIVITY_QUIET_MS,
+    );
+
+    expect(decision.shouldPrompt).toBe(false);
+    expect(decision.tracker.quietStartedAt).toBeUndefined();
+  });
+
+  it("resets when the recording is no longer active", () => {
+    const decision = nextRecordingInactivityDecision(
+      { sessionId: "session-1", quietStartedAt: 1_000 },
+      status({ state: "paused" }),
+      1_000 + RECORDING_INACTIVITY_QUIET_MS,
+    );
+
+    expect(decision).toEqual({ tracker: {}, shouldPrompt: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add a quiet-recording guard that asks `Still in a meeting?` after a recording is at least 10 minutes old and has been quiet for 5 continuous minutes
- pause the recording automatically if the prompt is ignored for 30 seconds
- let users keep recording, which snoozes the quiet prompt for 10 minutes, or pause immediately
- send native notifications when the prompt appears and when an ignored prompt successfully pauses the recording
- record zero-valued recent peaks in the capture layer so true silence clears stale waveform/activity peaks

## Why
Meeting recordings can be left running behind another VM or window after the call ends. Pausing instead of finishing preserves the session and lets the user resume, finish, trim mentally, or discard later without continuing to capture dead air.

## Validation
- `pnpm exec vitest run src/test/recording-inactivity.test.ts src/test/recorder.test.tsx src/test/app-meeting-start.test.tsx src/test/app-notes-reliability.test.tsx`
- `pnpm exec vitest run src/test/recording-inactivity.test.ts src/test/app-notes-reliability.test.tsx`
- `pnpm run lint`
- `pnpm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Notes
- The guard uses recent source peaks, not all-time recording peak or cumulative RMS, so earlier speech does not keep a stale recording marked active.
- Ignoring the prompt pauses rather than stops, matching the Slack decision in the prompt.