### PR TITLE
Recover interrupted paused recordings

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -28,6 +28,7 @@ use std::{
 use uuid::Uuid;
 
 pub const DEFAULT_SILENCE_THRESHOLD: f32 = 0.012;
+const RECOVERY_SNAPSHOT_INTERVAL_MS: i64 = 500;
 
 static ACTIVE_RECORDING: LazyLock<Mutex<Option<ActiveRecording>>> =
     LazyLock::new(|| Mutex::new(None));
@@ -65,6 +66,11 @@ pub struct FinishedSource {
     pub elapsed_ms: i64,
 }
 
+pub struct CaptureRecoverySnapshot {
+    pub status: RecordingStatusDto,
+    pub should_persist: bool,
+}
+
 struct ActiveRecording {
     session_id: String,
     note_id: String,
@@ -80,6 +86,7 @@ struct ActiveRecording {
     paused_flag: Arc<AtomicBool>,
     writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
     stats: Arc<Mutex<CaptureStats>>,
+    last_recovery_snapshot_elapsed_ms: i64,
     live_preview: Option<LivePreviewController>,
     system_live_preview: Option<SystemLivePreviewController>,
     live_preview_enabled: bool,
@@ -333,6 +340,7 @@ pub fn start_capture(
         paused_flag,
         writer,
         stats,
+        last_recovery_snapshot_elapsed_ms: 0,
         live_preview,
         system_live_preview,
         live_preview_enabled,
@@ -351,7 +359,7 @@ pub fn start_capture(
     })
 }
 
-pub fn pause_capture(session_id: &str) -> Result<RecordingStatusDto, AppError> {
+pub fn pause_capture(session_id: &str) -> Result<CaptureRecoverySnapshot, AppError> {
     let mut active = lock_active()?;
     let recording = active_for_session(active.as_mut(), session_id)?;
     if !recording.paused {
@@ -364,10 +372,10 @@ pub fn pause_capture(session_id: &str) -> Result<RecordingStatusDto, AppError> {
             system.pause();
         }
     }
-    Ok(recording.status())
+    Ok(recording.recovery_snapshot(RecoverySnapshotMode::Force))
 }
 
-pub fn resume_capture(session_id: &str) -> Result<RecordingStatusDto, AppError> {
+pub fn resume_capture(session_id: &str) -> Result<CaptureRecoverySnapshot, AppError> {
     let mut active = lock_active()?;
     let recording = active_for_session(active.as_mut(), session_id)?;
     if recording.paused {
@@ -378,13 +386,19 @@ pub fn resume_capture(session_id: &str) -> Result<RecordingStatusDto, AppError> 
             system.resume();
         }
     }
-    Ok(recording.status())
+    Ok(recording.recovery_snapshot(RecoverySnapshotMode::Force))
 }
 
 pub fn capture_status(session_id: &str) -> Result<RecordingStatusDto, AppError> {
     let active = lock_active()?;
     let recording = active_for_session(active.as_ref(), session_id)?;
     Ok(recording.status())
+}
+
+pub fn capture_status_for_recovery(session_id: &str) -> Result<CaptureRecoverySnapshot, AppError> {
+    let mut active = lock_active()?;
+    let recording = active_for_session(active.as_mut(), session_id)?;
+    Ok(recording.recovery_snapshot(RecoverySnapshotMode::Throttled))
 }
 
 pub fn is_capture_active() -> bool {
@@ -673,6 +687,39 @@ impl ActiveRecording {
             ),
             warnings: Vec::new(),
         }
+    }
+
+    fn recovery_snapshot(&mut self, mode: RecoverySnapshotMode) -> CaptureRecoverySnapshot {
+        let status = self.status();
+        let should_persist = match mode {
+            RecoverySnapshotMode::Force => true,
+            RecoverySnapshotMode::Throttled => {
+                status.elapsed_ms - self.last_recovery_snapshot_elapsed_ms
+                    >= RECOVERY_SNAPSHOT_INTERVAL_MS
+            }
+        };
+        if should_persist {
+            self.last_recovery_snapshot_elapsed_ms = status.elapsed_ms;
+            flush_microphone_writer_for_recovery(&self.writer);
+        }
+        CaptureRecoverySnapshot {
+            status,
+            should_persist,
+        }
+    }
+}
+
+enum RecoverySnapshotMode {
+    Throttled,
+    Force,
+}
+
+fn flush_microphone_writer_for_recovery(writer: &Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>) {
+    let Ok(mut writer_guard) = writer.lock() else {
+        return;
+    };
+    if let Some(writer) = writer_guard.as_mut() {
+        let _ = writer.flush();
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,8 +2,9 @@ use crate::{
     app_paths::AppPaths,
     audio::{
         capture::{
-            capture_status, finish_active_capture, finish_capture, is_capture_active,
+            capture_status_for_recovery, finish_active_capture, finish_capture, is_capture_active,
             microphone_permission_state, pause_capture, resume_capture, start_capture,
+            CaptureRecoverySnapshot,
         },
         recovery::scan_recoverable_recordings,
         validation::{
@@ -62,6 +63,11 @@ pub async fn bootstrap_app(app: AppHandle) -> Result<BootstrapResponse, AppError
     let active_recoveries = scan_recoverable_recordings(&repos.pool)
         .await
         .map_err(|error| AppError::new("recovery_scan_failed", error.to_string()))?;
+    for recovery in &active_recoveries {
+        repos
+            .mark_recording_recoverable(&recovery.session_id, &recovery.note_id)
+            .await?;
+    }
     let folders = repos
         .list_folders()
         .await
@@ -686,18 +692,53 @@ pub async fn start_recording(
 }
 
 #[tauri::command]
-pub async fn pause_recording(request: SessionRequest) -> Result<RecordingStatusDto, AppError> {
-    pause_capture(&request.session_id)
+pub async fn pause_recording(
+    app: AppHandle,
+    request: SessionRequest,
+) -> Result<RecordingStatusDto, AppError> {
+    let snapshot = pause_capture(&request.session_id)?;
+    if snapshot.should_persist {
+        persist_recording_recovery_snapshot(&repositories(&app).await?, &snapshot).await?;
+    }
+    Ok(snapshot.status)
 }
 
 #[tauri::command]
-pub async fn resume_recording(request: SessionRequest) -> Result<RecordingStatusDto, AppError> {
-    resume_capture(&request.session_id)
+pub async fn resume_recording(
+    app: AppHandle,
+    request: SessionRequest,
+) -> Result<RecordingStatusDto, AppError> {
+    let snapshot = resume_capture(&request.session_id)?;
+    if snapshot.should_persist {
+        persist_recording_recovery_snapshot(&repositories(&app).await?, &snapshot).await?;
+    }
+    Ok(snapshot.status)
 }
 
 #[tauri::command]
-pub async fn get_recording_status(request: SessionRequest) -> Result<RecordingStatusDto, AppError> {
-    capture_status(&request.session_id)
+pub async fn get_recording_status(
+    app: AppHandle,
+    request: SessionRequest,
+) -> Result<RecordingStatusDto, AppError> {
+    let snapshot = capture_status_for_recovery(&request.session_id)?;
+    if snapshot.should_persist {
+        persist_recording_recovery_snapshot(&repositories(&app).await?, &snapshot).await?;
+    }
+    Ok(snapshot.status)
+}
+
+async fn persist_recording_recovery_snapshot(
+    repos: &Repositories,
+    snapshot: &CaptureRecoverySnapshot,
+) -> Result<(), AppError> {
+    repos
+        .update_recording_recovery_snapshot(
+            &snapshot.status.session_id,
+            snapshot.status.state,
+            snapshot.status.elapsed_ms,
+        )
+        .await?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -1184,9 +1225,11 @@ pub async fn recover_recording(
             let Some(path) = recovery_source_path(&paths, &artifact) else {
                 continue;
             };
+            let expected_duration_ms =
+                recovery_validation_expected_duration_ms(&path, artifact.expected_duration_ms);
             let validation = validate_audio_artifact(
                 &path,
-                artifact.expected_duration_ms.max(1),
+                expected_duration_ms,
                 AudioValidationConfig::default(),
             )
             .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
@@ -1203,7 +1246,7 @@ pub async fn recover_recording(
                     validation.actual_duration_ms,
                     file_size,
                     &checksum,
-                    artifact.expected_duration_ms,
+                    expected_duration_ms,
                     Some(serde_json::to_string(&validation).unwrap_or_default()),
                     if valid {
                         None
@@ -1247,12 +1290,11 @@ pub async fn recover_recording(
             "No recoverable audio bytes are available.",
         )
     })?;
-    let validation = validate_audio_artifact(
-        &path,
-        info.expected_elapsed_ms.max(1),
-        AudioValidationConfig::default(),
-    )
-    .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
+    let expected_elapsed_ms =
+        recovery_validation_expected_duration_ms(&path, info.expected_elapsed_ms);
+    let validation =
+        validate_audio_artifact(&path, expected_elapsed_ms, AudioValidationConfig::default())
+            .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
     let checksum = checksum_file(&path).unwrap_or_default();
     let file_size = std::fs::metadata(&path)
         .map(|metadata| metadata.len() as i64)
@@ -1265,7 +1307,7 @@ pub async fn recover_recording(
             } else {
                 "invalid"
             },
-            info.expected_elapsed_ms,
+            expected_elapsed_ms,
             Some(file_size),
             Some(validation.actual_duration_ms),
             Some(checksum.clone()),
@@ -1352,6 +1394,17 @@ fn recovery_source_path(
         }
     }
     None
+}
+
+fn recovery_validation_expected_duration_ms(path: &Path, stored_duration_ms: i64) -> i64 {
+    wav_duration_ms(path).unwrap_or_else(|| stored_duration_ms.max(1))
+}
+
+fn wav_duration_ms(path: &Path) -> Option<i64> {
+    let reader = hound::WavReader::open(path).ok()?;
+    let sample_rate = reader.spec().sample_rate.max(1) as i64;
+    let duration_ms = (reader.duration() as i64 * 1000) / sample_rate;
+    (duration_ms > 0).then_some(duration_ms)
 }
 
 static AGENT_PLACEHOLDER_TASKS_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -1651,7 +1704,7 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
 
 #[cfg(test)]
 mod tests {
-    use super::should_probe_system_audio_permission;
+    use super::{recovery_validation_expected_duration_ms, should_probe_system_audio_permission};
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
@@ -1662,5 +1715,37 @@ mod tests {
     fn probes_system_audio_permission_only_when_available_and_idle() {
         assert!(should_probe_system_audio_permission(true, false));
         assert!(!should_probe_system_audio_permission(false, false));
+    }
+
+    #[test]
+    fn recovered_wav_duration_overrides_stale_stored_duration() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("partial.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).expect("writer");
+        for _ in 0..16_000 {
+            writer.write_sample(0_i16).expect("sample");
+        }
+        writer.finalize().expect("finalize");
+
+        assert_eq!(recovery_validation_expected_duration_ms(&path, 1), 1_000);
+    }
+
+    #[test]
+    fn recovered_duration_falls_back_to_stored_duration_for_unreadable_audio() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("partial.wav");
+        std::fs::write(&path, b"not wav").expect("write");
+
+        assert_eq!(
+            recovery_validation_expected_duration_ms(&path, 2_500),
+            2_500
+        );
+        assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1);
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -697,9 +697,7 @@ pub async fn pause_recording(
     request: SessionRequest,
 ) -> Result<RecordingStatusDto, AppError> {
     let snapshot = pause_capture(&request.session_id)?;
-    if snapshot.should_persist {
-        persist_recording_recovery_snapshot(&repositories(&app).await?, &snapshot).await?;
-    }
+    checkpoint_recording_recovery_snapshot(&app, &snapshot).await;
     Ok(snapshot.status)
 }
 
@@ -709,9 +707,7 @@ pub async fn resume_recording(
     request: SessionRequest,
 ) -> Result<RecordingStatusDto, AppError> {
     let snapshot = resume_capture(&request.session_id)?;
-    if snapshot.should_persist {
-        persist_recording_recovery_snapshot(&repositories(&app).await?, &snapshot).await?;
-    }
+    checkpoint_recording_recovery_snapshot(&app, &snapshot).await;
     Ok(snapshot.status)
 }
 
@@ -721,10 +717,33 @@ pub async fn get_recording_status(
     request: SessionRequest,
 ) -> Result<RecordingStatusDto, AppError> {
     let snapshot = capture_status_for_recovery(&request.session_id)?;
-    if snapshot.should_persist {
-        persist_recording_recovery_snapshot(&repositories(&app).await?, &snapshot).await?;
-    }
+    checkpoint_recording_recovery_snapshot(&app, &snapshot).await;
     Ok(snapshot.status)
+}
+
+async fn checkpoint_recording_recovery_snapshot(
+    app: &AppHandle,
+    snapshot: &CaptureRecoverySnapshot,
+) {
+    if !snapshot.should_persist {
+        return;
+    }
+    let repos = match repositories(app).await {
+        Ok(repos) => repos,
+        Err(error) => {
+            eprintln!(
+                "recording recovery checkpoint unavailable for session {}: {}: {}",
+                snapshot.status.session_id, error.code, error.message
+            );
+            return;
+        }
+    };
+    if let Err(error) = persist_recording_recovery_snapshot(&repos, snapshot).await {
+        eprintln!(
+            "recording recovery checkpoint failed for session {}: {}: {}",
+            snapshot.status.session_id, error.code, error.message
+        );
+    }
 }
 
 async fn persist_recording_recovery_snapshot(
@@ -1397,6 +1416,9 @@ fn recovery_source_path(
 }
 
 fn recovery_validation_expected_duration_ms(path: &Path, stored_duration_ms: i64) -> i64 {
+    if stored_duration_ms > 1 {
+        return stored_duration_ms;
+    }
     wav_duration_ms(path).unwrap_or_else(|| stored_duration_ms.max(1))
 }
 
@@ -1719,21 +1741,20 @@ mod tests {
 
     #[test]
     fn recovered_wav_duration_overrides_stale_stored_duration() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("partial.wav");
-        let spec = hound::WavSpec {
-            channels: 1,
-            sample_rate: 16_000,
-            bits_per_sample: 16,
-            sample_format: hound::SampleFormat::Int,
-        };
-        let mut writer = hound::WavWriter::create(&path, spec).expect("writer");
-        for _ in 0..16_000 {
-            writer.write_sample(0_i16).expect("sample");
-        }
-        writer.finalize().expect("finalize");
+        let (_dir, path) = write_one_second_wav();
 
+        assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1_000);
         assert_eq!(recovery_validation_expected_duration_ms(&path, 1), 1_000);
+    }
+
+    #[test]
+    fn recovered_wav_duration_preserves_persisted_expected_duration() {
+        let (_dir, path) = write_one_second_wav();
+
+        assert_eq!(
+            recovery_validation_expected_duration_ms(&path, 10_000),
+            10_000
+        );
     }
 
     #[test]
@@ -1747,5 +1768,22 @@ mod tests {
             2_500
         );
         assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1);
+    }
+
+    fn write_one_second_wav() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("partial.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).expect("writer");
+        for _ in 0..16_000 {
+            writer.write_sample(0_i16).expect("sample");
+        }
+        writer.finalize().expect("finalize");
+        (dir, path)
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1291,6 +1291,9 @@ pub async fn recover_recording(
         let note = repos.get_note(&info.note_id).await?;
         let existing_generated_note = note.generated_content.clone();
         let manual_notes = manual_notes_for_generation(&note);
+        repos
+            .mark_recording_recovery_valid(&info.session_id)
+            .await?;
         return process_saved_source_audio(
             &repos,
             &info.note_id,
@@ -1748,6 +1751,13 @@ mod tests {
     }
 
     #[test]
+    fn recovered_wav_duration_reads_flush_only_wav() {
+        let (_dir, path) = write_one_second_flushed_wav();
+
+        assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1_000);
+    }
+
+    #[test]
     fn recovered_wav_duration_preserves_persisted_expected_duration() {
         let (_dir, path) = write_one_second_wav();
 
@@ -1784,6 +1794,24 @@ mod tests {
             writer.write_sample(0_i16).expect("sample");
         }
         writer.finalize().expect("finalize");
+        (dir, path)
+    }
+
+    fn write_one_second_flushed_wav() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("partial.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).expect("writer");
+        for _ in 0..16_000 {
+            writer.write_sample(0_i16).expect("sample");
+        }
+        writer.flush().expect("flush");
+        std::mem::forget(writer);
         (dir, path)
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -835,9 +835,11 @@ async fn finish_recording_session(
             .iter()
             .find(|artifact| artifact.source == source.source.as_db())
         {
+            let final_path = source.final_path.to_string_lossy().into_owned();
             repos
                 .finalize_source_artifact(
                     &artifact.id,
+                    &final_path,
                     if valid { "valid" } else { "invalid" },
                     validation.actual_duration_ms,
                     file_size,
@@ -1256,11 +1258,13 @@ pub async fn recover_recording(
             let file_size = std::fs::metadata(&path)
                 .map(|metadata| metadata.len() as i64)
                 .unwrap_or_default();
+            let recovered_path = path.to_string_lossy().into_owned();
             let source = RecordingSource::from(artifact.source.as_str());
             let valid = source_audio_passes_validation(source, &validation);
             repos
                 .finalize_source_artifact(
                     &artifact.id,
+                    &recovered_path,
                     if valid { "valid" } else { "invalid" },
                     validation.actual_duration_ms,
                     file_size,

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1442,6 +1442,22 @@ impl Repositories {
         tx.commit().await
     }
 
+    pub async fn mark_recording_recovery_valid(&self, session_id: &str) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE recording_sessions
+             SET status = 'valid',
+                 last_error = NULL,
+                 ended_at = COALESCE(ended_at, ?)
+             WHERE id = ?
+               AND status = 'recoverable'",
+        )
+        .bind(timestamp())
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     pub async fn add_checkpoint(
         &self,
         session_id: &str,

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1592,6 +1592,7 @@ impl Repositories {
     pub async fn finalize_source_artifact(
         &self,
         artifact_id: &str,
+        path: &str,
         status: &str,
         duration_ms: i64,
         size_bytes: i64,
@@ -1602,10 +1603,11 @@ impl Repositories {
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             "UPDATE audio_artifacts
-             SET status = ?, duration_ms = ?, size_bytes = ?, checksum = ?, expected_duration_ms = ?,
+             SET path = ?, status = ?, duration_ms = ?, size_bytes = ?, checksum = ?, expected_duration_ms = ?,
                  validation_summary = ?, last_error = ?
              WHERE id = ?",
         )
+        .bind(path)
         .bind(status)
         .bind(duration_ms)
         .bind(size_bytes)

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1350,6 +1350,7 @@ impl Repositories {
         elapsed_ms: i64,
     ) -> Result<(), sqlx::Error> {
         let status = state.as_db();
+        let mut tx = self.pool.begin().await?;
         sqlx::query(
             "UPDATE recording_sessions
              SET status = ?, expected_elapsed_ms = max(expected_elapsed_ms, ?)
@@ -1359,7 +1360,7 @@ impl Repositories {
         .bind(status)
         .bind(elapsed_ms)
         .bind(session_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
         sqlx::query(
             "UPDATE audio_artifacts
@@ -1370,9 +1371,9 @@ impl Repositories {
         .bind(status)
         .bind(elapsed_ms)
         .bind(session_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
-        Ok(())
+        tx.commit().await
     }
 
     pub async fn mark_recording_recoverable(
@@ -1382,6 +1383,7 @@ impl Repositories {
     ) -> Result<(), sqlx::Error> {
         let now = timestamp();
         let message = "Recording interrupted before it could be finished.";
+        let mut tx = self.pool.begin().await?;
         sqlx::query(
             "UPDATE recording_sessions
              SET status = 'recoverable',
@@ -1402,7 +1404,7 @@ impl Repositories {
         .bind(message)
         .bind(&now)
         .bind(session_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
         sqlx::query(
             "UPDATE audio_artifacts
@@ -1422,14 +1424,22 @@ impl Repositories {
         )
         .bind(message)
         .bind(session_id)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
-        self.set_note_status(
-            note_id,
-            ProcessingStatus::Recoverable,
-            Some("Recording interrupted. Review recovery options.".to_string()),
+        sqlx::query(
+            "UPDATE notes
+             SET processing_status = ?,
+                 last_error = ?,
+                 updated_at = ?
+             WHERE id = ?",
         )
-        .await
+        .bind(ProcessingStatus::Recoverable.as_db())
+        .bind("Recording interrupted. Review recovery options.")
+        .bind(&now)
+        .bind(note_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await
     }
 
     pub async fn add_checkpoint(

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -3,7 +3,7 @@ use crate::domain::types::{
     AgentTaskStatus, AgentToolEventDto, AgentToolEventStatus, AppError, AudioArtifactDto,
     DictationHistoryItemDto, DictionaryEntryDto, FolderDto, ListDictationHistoryResponse,
     ListNotesResponse, NoteDto, NoteListItemDto, ProcessingStatus, RecordingSourceMode,
-    SessionFolderDto, TranscriptDto,
+    RecordingState, SessionFolderDto, TranscriptDto,
 };
 use chrono::{Duration, SecondsFormat, Utc};
 use sqlx::{Row, SqlitePool};
@@ -1341,6 +1341,95 @@ impl Repositories {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    pub async fn update_recording_recovery_snapshot(
+        &self,
+        session_id: &str,
+        state: RecordingState,
+        elapsed_ms: i64,
+    ) -> Result<(), sqlx::Error> {
+        let status = state.as_db();
+        sqlx::query(
+            "UPDATE recording_sessions
+             SET status = ?, expected_elapsed_ms = max(expected_elapsed_ms, ?)
+             WHERE id = ?
+               AND status IN ('recording', 'paused')",
+        )
+        .bind(status)
+        .bind(elapsed_ms)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "UPDATE audio_artifacts
+             SET status = ?, expected_duration_ms = max(expected_duration_ms, ?)
+             WHERE recording_session_id = ?
+               AND status IN ('recording', 'paused')",
+        )
+        .bind(status)
+        .bind(elapsed_ms)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_recording_recoverable(
+        &self,
+        session_id: &str,
+        note_id: &str,
+    ) -> Result<(), sqlx::Error> {
+        let now = timestamp();
+        let message = "Recording interrupted before it could be finished.";
+        sqlx::query(
+            "UPDATE recording_sessions
+             SET status = 'recoverable',
+                 last_error = COALESCE(last_error, ?),
+                 ended_at = COALESCE(ended_at, ?)
+             WHERE id = ?
+               AND status IN (
+                 'recording',
+                 'paused',
+                 'finalizing',
+                 'validating',
+                 'transcribing',
+                 'generating',
+                 'failed',
+                 'recoverable'
+               )",
+        )
+        .bind(message)
+        .bind(&now)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        sqlx::query(
+            "UPDATE audio_artifacts
+             SET status = 'recoverable',
+                 last_error = COALESCE(last_error, ?)
+             WHERE recording_session_id = ?
+               AND status IN (
+                 'recording',
+                 'paused',
+                 'finalizing',
+                 'validating',
+                 'transcribing',
+                 'generating',
+                 'failed',
+                 'recoverable'
+               )",
+        )
+        .bind(message)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+        self.set_note_status(
+            note_id,
+            ProcessingStatus::Recoverable,
+            Some("Recording interrupted. Review recovery options.".to_string()),
+        )
+        .await
     }
 
     pub async fn add_checkpoint(

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -887,6 +887,25 @@ pub enum RecordingState {
     Recoverable,
 }
 
+impl RecordingState {
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::PermissionDenied => "permission_denied",
+            Self::Starting => "starting",
+            Self::Recording => "recording",
+            Self::Paused => "paused",
+            Self::Finalizing => "finalizing",
+            Self::Validating => "validating",
+            Self::PartiallyValid => "partially_valid",
+            Self::Invalid => "invalid",
+            Self::Ready => "valid",
+            Self::Failed => "failed",
+            Self::Recoverable => "recoverable",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum SourceState {

--- a/src-tauri/tests/recovery.rs
+++ b/src-tauri/tests/recovery.rs
@@ -1,7 +1,7 @@
 use os_scribe_lib::{
     audio::recovery::scan_recoverable_recordings,
     db::{migrations::run_migrations, repositories::Repositories},
-    domain::types::RecordingSourceMode,
+    domain::types::{ProcessingStatus, RecordingSourceMode, RecordingState},
 };
 use sqlx::sqlite::SqlitePoolOptions;
 use tempfile::tempdir;
@@ -44,6 +44,103 @@ async fn scan_surfaces_interrupted_recording_with_audio_bytes() {
     assert_eq!(recoveries[0].note_id, note.id);
     assert!(recoveries[0].partial_path_present);
     assert_eq!(recoveries[0].bytes_found, 13);
+}
+
+#[tokio::test]
+async fn recovery_snapshot_persists_elapsed_time_for_session_and_sources() {
+    let repos = repos().await;
+    let dir = tempdir().expect("tempdir");
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            &dir.path().join("microphone.partial.wav").to_string_lossy(),
+            &dir.path().join("microphone.wav").to_string_lossy(),
+            None,
+        )
+        .await
+        .expect("session");
+    repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            &dir.path().join("microphone.partial.wav").to_string_lossy(),
+            &dir.path().join("microphone.wav").to_string_lossy(),
+        )
+        .await
+        .expect("artifact");
+
+    repos
+        .update_recording_recovery_snapshot("session-1", RecordingState::Paused, 2_500)
+        .await
+        .expect("snapshot");
+
+    let info = repos
+        .recording_recovery_info("session-1")
+        .await
+        .expect("recovery info")
+        .expect("session");
+    let artifacts = repos
+        .source_artifact_paths_for_session("session-1")
+        .await
+        .expect("artifacts");
+    let artifact_status: String =
+        sqlx::query_scalar("SELECT status FROM audio_artifacts WHERE recording_session_id = ?")
+            .bind("session-1")
+            .fetch_one(&repos.pool)
+            .await
+            .expect("artifact status");
+
+    assert_eq!(info.expected_elapsed_ms, 2_500);
+    assert_eq!(artifacts[0].expected_duration_ms, 2_500);
+    assert_eq!(artifact_status, "paused");
+}
+
+#[tokio::test]
+async fn boot_recovery_marks_note_recoverable_when_audio_survived() {
+    let repos = repos().await;
+    let dir = tempdir().expect("tempdir");
+    let partial = dir.path().join("session.partial.wav");
+    std::fs::write(&partial, b"partial audio").expect("partial bytes");
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophoneOnly,
+            &partial.to_string_lossy(),
+            &dir.path().join("session.wav").to_string_lossy(),
+            None,
+        )
+        .await
+        .expect("session");
+
+    let recoveries = scan_recoverable_recordings(&repos.pool)
+        .await
+        .expect("recovery scan");
+    for recovery in &recoveries {
+        repos
+            .mark_recording_recoverable(&recovery.session_id, &recovery.note_id)
+            .await
+            .expect("mark recoverable");
+    }
+    let recovered_note = repos.get_note(&note.id).await.expect("note");
+    let recording_status: String =
+        sqlx::query_scalar("SELECT status FROM recording_sessions WHERE id = ?")
+            .bind("session-1")
+            .fetch_one(&repos.pool)
+            .await
+            .expect("recording status");
+
+    assert_eq!(recoveries.len(), 1);
+    assert_eq!(recording_status, "recoverable");
+    assert_eq!(
+        recovered_note.processing_status,
+        ProcessingStatus::Recoverable
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/source_recovery.rs
+++ b/src-tauri/tests/source_recovery.rs
@@ -68,3 +68,47 @@ async fn scan_surfaces_recoverable_sources() {
         .iter()
         .any(|source| source.source.as_db() == "system"));
 }
+
+#[tokio::test]
+async fn scan_ignores_recovery_after_session_is_marked_valid() {
+    let repos = repos().await;
+    let dir = tempdir().expect("tempdir");
+    let note = repos.create_note(None).await.expect("note");
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            &dir.path().join("microphone.partial.wav").to_string_lossy(),
+            &dir.path().join("microphone.wav").to_string_lossy(),
+            None,
+        )
+        .await
+        .expect("session");
+    let mic_partial = dir.path().join("microphone.partial.wav");
+    std::fs::write(&mic_partial, b"mic bytes").expect("mic bytes");
+    repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            &mic_partial.to_string_lossy(),
+            &dir.path().join("microphone.wav").to_string_lossy(),
+        )
+        .await
+        .expect("mic artifact");
+    repos
+        .mark_recording_recoverable("session-1", &note.id)
+        .await
+        .expect("mark recoverable");
+
+    repos
+        .mark_recording_recovery_valid("session-1")
+        .await
+        .expect("mark valid");
+    let recoveries = scan_recoverable_recordings(&repos.pool)
+        .await
+        .expect("recoveries");
+
+    assert!(recoveries.is_empty());
+}

--- a/src-tauri/tests/source_recovery.rs
+++ b/src-tauri/tests/source_recovery.rs
@@ -112,3 +112,72 @@ async fn scan_ignores_recovery_after_session_is_marked_valid() {
 
     assert!(recoveries.is_empty());
 }
+
+#[tokio::test]
+async fn recovered_partial_source_path_remains_retryable_after_session_is_marked_valid() {
+    let repos = repos().await;
+    let dir = tempdir().expect("tempdir");
+    let note = repos.create_note(None).await.expect("note");
+    let mic_partial = dir.path().join("microphone.partial.wav");
+    let mic_final = dir.path().join("microphone.wav");
+    let mic_partial_str = mic_partial.to_string_lossy().into_owned();
+    let mic_final_str = mic_final.to_string_lossy().into_owned();
+    std::fs::write(&mic_partial, b"mic bytes").expect("mic bytes");
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophonePlusSystem,
+            &mic_partial_str,
+            &mic_final_str,
+            None,
+        )
+        .await
+        .expect("session");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            &mic_partial_str,
+            &mic_final_str,
+        )
+        .await
+        .expect("mic artifact");
+    repos
+        .mark_recording_recoverable("session-1", &note.id)
+        .await
+        .expect("mark recoverable");
+
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            &mic_partial_str,
+            "valid",
+            1_000,
+            9,
+            "checksum",
+            1_000,
+            None,
+            None,
+        )
+        .await
+        .expect("finalize source");
+    repos
+        .mark_recording_recovery_valid("session-1")
+        .await
+        .expect("mark valid");
+
+    let sources = repos
+        .latest_valid_audio_artifact_paths(&note.id)
+        .await
+        .expect("retry sources");
+    let recoveries = scan_recoverable_recordings(&repos.pool)
+        .await
+        .expect("recoveries");
+
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].1, "microphone");
+    assert_eq!(sources[0].2, mic_partial_str);
+    assert!(recoveries.is_empty());
+}


### PR DESCRIPTION
## Summary
- checkpoint active recording recovery state from pause/resume/status calls, including flushing microphone WAV headers so partial recordings stay readable after an update or crash
- mark surviving interrupted recordings as recoverable during bootstrap before notes are listed, so the existing recovery prompt is scoped to the affected note after relaunch
- recover stale-duration partial WAVs by validating against the readable WAV duration when the database duration was never updated

## Why
A paused recording could be lost from the UI after an app update because the live recording state only existed in memory. The database still had a stale recording row, often with `expected_elapsed_ms = 0`, and the partial WAV might not have had a flushed header. On relaunch, recovery could be hidden or fail validation against the stale duration.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml --test recovery`
- `cargo test --manifest-path src-tauri/Cargo.toml --test source_recovery`
- `cargo test --manifest-path src-tauri/Cargo.toml commands::tests --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `pnpm run lint`
