### PR TITLE
[codex] Default scheduled run titles to routine names

### DIFF
--- a/src/components/routines/RoutineDetail.tsx
+++ b/src/components/routines/RoutineDetail.tsx
@@ -16,7 +16,6 @@ import {
   type RoutineJob,
   type RoutineUpdates,
 } from "../../lib/hermes-routines";
-import { isReplaceableScheduledRunTitle } from "../../lib/hermes-adapter";
 import {
   compactScheduleLabel,
   draftFromSchedule,
@@ -395,11 +394,7 @@ export function RoutineDetail({
               <div className="settings-card routines-runs-card">
                 <RoutineRunList
                   runs={runs}
-                  label={(run) =>
-                    isReplaceableScheduledRunTitle(run.title)
-                      ? routine.name
-                      : (run.title?.trim() ?? routine.name)
-                  }
+                  label={() => routine.name}
                   onOpen={onOpenRun}
                 />
               </div>

--- a/src/components/routines/RoutineDetail.tsx
+++ b/src/components/routines/RoutineDetail.tsx
@@ -16,6 +16,7 @@ import {
   type RoutineJob,
   type RoutineUpdates,
 } from "../../lib/hermes-routines";
+import { isReplaceableScheduledRunTitle } from "../../lib/hermes-adapter";
 import {
   compactScheduleLabel,
   draftFromSchedule,
@@ -394,7 +395,11 @@ export function RoutineDetail({
               <div className="settings-card routines-runs-card">
                 <RoutineRunList
                   runs={runs}
-                  label={(run) => run.title?.trim() || routine.name}
+                  label={(run) =>
+                    isReplaceableScheduledRunTitle(run.title)
+                      ? routine.name
+                      : (run.title?.trim() ?? routine.name)
+                  }
                   onOpen={onOpenRun}
                 />
               </div>

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -15,6 +15,7 @@ import { IconZap } from "central-icons/IconZap";
 import { IconPause } from "central-icons/IconPause";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  isReplaceableScheduledRunTitle,
   listScheduledRunSessions,
   scheduledRunJobId,
 } from "../../lib/hermes-adapter";
@@ -174,7 +175,10 @@ export function RoutinesView({
     (run: HermesSessionInfo) => {
       const jobId = scheduledRunJobId(run.id);
       const routine = jobId ? routinesById.get(jobId) : undefined;
-      return routine?.name || run.title?.trim() || "Routine run";
+      const sessionTitle = isReplaceableScheduledRunTitle(run.title)
+        ? ""
+        : run.title?.trim();
+      return routine?.name || sessionTitle || "Routine run";
     },
     [routinesById],
   );

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -71,6 +71,7 @@ export function scheduledRunJobId(sessionId: string) {
  * activity; runs older than the window age out of the history view. */
 const SCHEDULED_RUN_FETCH_LIMIT = 200;
 const PENDING_SCHEDULED_RUN_ACTIVE_WINDOW_MS = 5 * 60 * 1000;
+const UNTITLED_SESSION_TITLE = "Untitled session";
 
 export type ScheduledRunListOptions = {
   includeActive?: boolean;
@@ -135,7 +136,8 @@ function hasSessionEnded(session: HermesSessionInfo) {
 
 function hasScheduledRunContent(session: HermesSessionInfo) {
   return (
-    Boolean(session.preview?.trim()) || session.title !== "Untitled session"
+    Boolean(session.preview?.trim()) ||
+    !isReplaceableScheduledRunTitle(session.title)
   );
 }
 
@@ -176,6 +178,15 @@ export function stripScheduledRunPreamble(content: string) {
     .trim();
 }
 
+export function isReplaceableScheduledRunTitle(title: unknown) {
+  const value = typeof title === "string" ? title.trim() : "";
+  return (
+    !value ||
+    value.toLowerCase() === UNTITLED_SESSION_TITLE.toLowerCase() ||
+    /^\[IMPORTANT\b/i.test(value)
+  );
+}
+
 /** Gives a scheduled-run session a readable title and a clean preview when the
  * stored ones are empty or still the raw delivery preamble, so every list
  * surface stops showing "[IMPORTANT…". Non-cron sessions pass through. */
@@ -189,8 +200,9 @@ function withScheduledRunDisplay(
   // stored title is often truncated ("[IMPORTANT: You are running as"), so a
   // leading "[IMPORTANT" is enough to treat it as raw here, where we already
   // know this is a cron session.
-  const looksRaw = !storedTitle || /^\[IMPORTANT\b/i.test(storedTitle);
-  const title = looksRaw ? titleFromPrompt(cleanedPreview) : storedTitle;
+  const title = isReplaceableScheduledRunTitle(storedTitle)
+    ? titleFromPrompt(cleanedPreview)
+    : storedTitle;
   return { ...session, title, preview: cleanedPreview || session.preview };
 }
 
@@ -213,7 +225,7 @@ export function sessionTimestamp(session: HermesSessionInfo) {
 
 export function titleFromPrompt(prompt: string) {
   const source = promptTitleSource(prompt);
-  if (!source) return "Untitled session";
+  if (!source) return UNTITLED_SESSION_TITLE;
   const stripped = stripRequestPrefix(source) || source;
   const firstClause = stripped
     .split(/(?:[.!?;:]|\s+-\s+|\s+--\s+)/)
@@ -225,7 +237,7 @@ export function titleFromPrompt(prompt: string) {
     .filter(Boolean)
     .slice(0, 6);
   const title = titleCaseSessionTitle(words.join(" "));
-  if (title.length <= 72) return title || "Untitled session";
+  if (title.length <= 72) return title || UNTITLED_SESSION_TITLE;
   return `${title.slice(0, 69).trim()}...`;
 }
 

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isRunningScheduledRunSession,
+  isReplaceableScheduledRunTitle,
   isScheduledRunPreamble,
   isScheduledRunSession,
   listHermesSessions,
@@ -76,6 +77,21 @@ describe("scheduled-run helpers", () => {
     expect(sessions[0]?.title).toBe("Post the Weekly Metrics Digest");
   });
 
+  it("derives the title when the cron session still has the placeholder title", () => {
+    const sessions = normalizeHermesSessionsResponse({
+      sessions: [
+        {
+          id: "cron-3",
+          source: "cron",
+          title: "Untitled session",
+          preview: `${SCHEDULED_PREAMBLE}\n\nPrepare the morning brief for today.`,
+          last_active: "2026-06-11T12:00:00Z",
+        },
+      ],
+    });
+    expect(sessions[0]?.title).toBe("Prepare the Morning Brief for Today");
+  });
+
   it("extracts the routine job id from a cron run session id", () => {
     // The scheduler mints run ids as cron_<job id>_<YYYYMMDD_HHMMSS>.
     expect(scheduledRunJobId("cron_a1b2c3d4e5f6_20260611_093045")).toBe(
@@ -85,6 +101,15 @@ describe("scheduled-run helpers", () => {
     expect(scheduledRunJobId("cron_my_job_20260611_093045")).toBe("my_job");
     expect(scheduledRunJobId("ordinary-session-id")).toBeUndefined();
     expect(scheduledRunJobId("cron_missing_timestamp")).toBeUndefined();
+  });
+
+  it("treats empty, placeholder, and cron-scaffolded titles as replaceable", () => {
+    expect(isReplaceableScheduledRunTitle("")).toBe(true);
+    expect(isReplaceableScheduledRunTitle("Untitled session")).toBe(true);
+    expect(
+      isReplaceableScheduledRunTitle("[IMPORTANT: You are running as"),
+    ).toBe(true);
+    expect(isReplaceableScheduledRunTitle("Morning brief")).toBe(false);
   });
 });
 

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -491,24 +491,21 @@ describe("RoutinesView detail", () => {
     await userEvent.click(screen.getByRole("tab", { name: "Run history" }));
 
     const history = screen.getByRole("tabpanel", { name: "Run history" });
-    expect(
-      within(history).getByText("Morning Summary Digest"),
-    ).toBeInTheDocument();
+    expect(within(history).getByText("Morning summary")).toBeInTheDocument();
     expect(within(history).queryByText("Someone else's run")).toBeNull();
 
     await userEvent.click(
-      within(history).getByRole("button", { name: /morning summary digest/i }),
+      within(history).getByRole("button", { name: /morning summary/i }),
     );
     expect(onOpenRun).toHaveBeenCalledWith(mine);
   });
 
-  it("labels untitled detail runs with the routine name", async () => {
+  it("labels normalized detail runs with the routine name", async () => {
     mocks.listRoutines.mockResolvedValue([job({ name: "Morning brief" })]);
     adapterMocks.listScheduledRunSessions.mockResolvedValue([
       run({
-        title: "Untitled session",
-        preview:
-          "[IMPORTANT: You are running as a scheduled cron job. DELIVER...]",
+        title: "Deliver the Morning Brief",
+        preview: "Send today's important updates.",
       }),
     ]);
     renderView();
@@ -517,7 +514,7 @@ describe("RoutinesView detail", () => {
 
     const history = screen.getByRole("tabpanel", { name: "Run history" });
     expect(within(history).getByText("Morning brief")).toBeInTheDocument();
-    expect(within(history).queryByText("Untitled session")).toBeNull();
+    expect(within(history).queryByText("Deliver the Morning Brief")).toBeNull();
   });
 
   it("surfaces the last run failure", async () => {

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -502,6 +502,24 @@ describe("RoutinesView detail", () => {
     expect(onOpenRun).toHaveBeenCalledWith(mine);
   });
 
+  it("labels untitled detail runs with the routine name", async () => {
+    mocks.listRoutines.mockResolvedValue([job({ name: "Morning brief" })]);
+    adapterMocks.listScheduledRunSessions.mockResolvedValue([
+      run({
+        title: "Untitled session",
+        preview:
+          "[IMPORTANT: You are running as a scheduled cron job. DELIVER...]",
+      }),
+    ]);
+    renderView();
+    await openDetail("Morning brief");
+    await userEvent.click(screen.getByRole("tab", { name: "Run history" }));
+
+    const history = screen.getByRole("tabpanel", { name: "Run history" });
+    expect(within(history).getByText("Morning brief")).toBeInTheDocument();
+    expect(within(history).queryByText("Untitled session")).toBeNull();
+  });
+
   it("surfaces the last run failure", async () => {
     mocks.listRoutines.mockResolvedValue([
       job({ last_status: "error", last_error: "Model quota exhausted" }),
@@ -669,6 +687,22 @@ describe("RoutinesView run history", () => {
     expect(
       within(history).getByText("Weekly Metrics Digest"),
     ).toBeInTheDocument();
+  });
+
+  it("labels orphaned placeholder-title runs generically", async () => {
+    mocks.listRoutines.mockResolvedValue([job()]);
+    adapterMocks.listScheduledRunSessions.mockResolvedValue([
+      run({
+        id: "cron_gone99_20260609_080000",
+        title: "Untitled session",
+        preview: "",
+      }),
+    ]);
+    renderView();
+
+    const history = await screen.findByRole("region", { name: "Run history" });
+    expect(within(history).getByText("Routine run")).toBeInTheDocument();
+    expect(within(history).queryByText("Untitled session")).toBeNull();
   });
 
   it("filters run history with the search query", async () => {


### PR DESCRIPTION
## Summary

Fixes scheduled routine run history rows that could display `Untitled session` by treating empty, placeholder, and cron-scaffolded scheduled-run titles as replaceable. Routine detail history now labels runs with the routine name, and the global run panel falls back to the routine name or `Routine run` instead of leaking placeholders.

## What changed

- Added a shared scheduled-run title placeholder check in the Hermes adapter.
- Derived scheduled-run titles when Hermes stores `Untitled session` but the prompt preview can provide a better title for orphaned/global contexts.
- Used the scoped routine name for all routine detail run-history labels.
- Added adapter and routines-view regression tests for placeholder, normalized-title, and orphaned-run cases.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test src/test/hermes-adapter.test.ts src/test/routines-view.test.tsx`
- `pnpm run lint`
- `pnpm build`
- `pnpm exec prettier --check src/lib/hermes-adapter.ts src/components/routines/RoutinesView.tsx src/components/routines/RoutineDetail.tsx src/test/hermes-adapter.test.ts src/test/routines-view.test.tsx`
- `git diff --check`

## Automated review

- Codex reviewed `ba6c246` and found no major issues.
- Greptile reviewed `ba6c246` with confidence 5/5 and no files requiring special attention.

## Known gaps

- Full `pnpm run format` still fails on pre-existing untouched files: `src/lib/live-transcript-preview.ts` and `src-tauri/tauri.conf.json`. Touched files pass Prettier.