### PR TITLE
Prevent recorder status poll backlog

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1669,7 +1669,10 @@ export function App() {
     // each poll coalesces the peaks since the last one (see Waveform.tsx). Audio
     // is sampled every ~5–10ms in Rust, so there's always a fresh peak waiting;
     // 100ms left the bars a beat behind the voice.
+    let inFlight = false;
     const interval = window.setInterval(() => {
+      if (inFlight) return;
+      inFlight = true;
       getRecordingStatus(sessionId)
         .then((status) => {
           if (!cancelled) dispatch({ type: "recordingStatusChanged", status });
@@ -1684,6 +1687,9 @@ export function App() {
             return;
           }
           setError(messageFromError(err));
+        })
+        .finally(() => {
+          inFlight = false;
         });
     }, 50);
     return () => {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -390,7 +390,10 @@ describe("notes recording reliability", () => {
 
   it("does not overlap active recording status polls", async () => {
     const pendingStatus = deferred<RecordingStatusDto>();
-    mocks.getRecordingStatus.mockReturnValue(pendingStatus.promise);
+    const resumedStatus = deferred<RecordingStatusDto>();
+    mocks.getRecordingStatus
+      .mockReturnValueOnce(pendingStatus.promise)
+      .mockReturnValue(resumedStatus.promise);
 
     await startRecordingOnFirstNote();
     await screen.findByRole("button", { name: "Done" });
@@ -412,6 +415,17 @@ describe("notes recording reliability", () => {
         bytesWritten: 2048,
       });
       await pendingStatus.promise;
+    });
+    await waitFor(() =>
+      expect(mocks.getRecordingStatus).toHaveBeenCalledTimes(2),
+    );
+    resumedStatus.resolve({
+      sessionId: "rec-1",
+      state: "recording",
+      elapsedMs: 550,
+      level: { peak: 0.2, rms: 0.1, recentPeaks: [0.2] },
+      silenceWarning: false,
+      bytesWritten: 2048,
     });
   });
 

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -9,6 +9,7 @@ import type {
   NoteDto,
   RecoverableRecordingDto,
   RecordingSessionDto,
+  RecordingStatusDto,
 } from "../lib/tauri";
 
 type TauriListener = (event: { payload: unknown }) => unknown;
@@ -385,6 +386,33 @@ describe("notes recording reliability", () => {
         screen.queryByRole("button", { name: "Open recording: First note" }),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("does not overlap active recording status polls", async () => {
+    const pendingStatus = deferred<RecordingStatusDto>();
+    mocks.getRecordingStatus.mockReturnValue(pendingStatus.promise);
+
+    await startRecordingOnFirstNote();
+    await screen.findByRole("button", { name: "Done" });
+    await waitFor(() =>
+      expect(mocks.getRecordingStatus).toHaveBeenCalledTimes(1),
+    );
+
+    await new Promise((resolve) => window.setTimeout(resolve, 180));
+
+    expect(mocks.getRecordingStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pendingStatus.resolve({
+        sessionId: "rec-1",
+        state: "recording",
+        elapsedMs: 500,
+        level: { peak: 0.2, rms: 0.1, recentPeaks: [0.2] },
+        silenceWarning: false,
+        bytesWritten: 2048,
+      });
+      await pendingStatus.promise;
+    });
   });
 
   it("ignores meeting-start signals while a recording is already live", async () => {


### PR DESCRIPTION
## Summary
- Make recorder status polling single-flight so slow status IPC calls cannot stack up during long recordings.
- Add a regression test that keeps one status request pending and verifies later ticks do not start overlapping polls.

## Tests
- pnpm vitest run src/test/app-notes-reliability.test.tsx
- pnpm run lint
- pnpm test