### PR TITLE
Stream agent chat responses end-to-end (fix reasoning-model 502s)

### DIFF
--- a/scribe-api/Cargo.lock
+++ b/scribe-api/Cargo.lock
@@ -78,6 +78,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1470,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
+ "bytes",
  "pretty_assertions",
  "scribe-config",
  "scribe-domain",
@@ -1477,6 +1500,8 @@ name = "scribe-domain"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "bytes",
+ "futures-util",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1486,8 +1511,11 @@ dependencies = [
 name = "scribe-providers"
 version = "0.2.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "base64",
+ "bytes",
+ "futures-util",
  "hound",
  "jsonwebtoken",
  "mp4",
@@ -1507,7 +1535,10 @@ dependencies = [
 name = "scribe-services"
 version = "0.2.0"
 dependencies = [
+ "async-stream",
  "async-trait",
+ "bytes",
+ "futures-util",
  "pretty_assertions",
  "scribe-config",
  "scribe-domain",

--- a/scribe-api/Cargo.toml
+++ b/scribe-api/Cargo.toml
@@ -17,10 +17,12 @@ scribe-domain = { path = "crates/domain" }
 scribe-providers = { path = "crates/providers" }
 scribe-services = { path = "crates/services" }
 
+async-stream = "0.3"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["multipart"] }
 base64 = "0.22"
 bytes = "1"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive"] }
 dotenvy = "0.15"
 figment = { version = "0.10", features = ["env", "toml"] }

--- a/scribe-api/crates/api/Cargo.toml
+++ b/scribe-api/crates/api/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 axum.workspace = true
+bytes.workspace = true
 scribe-config.workspace = true
 scribe-domain.workspace = true
 scribe-services.workspace = true

--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use axum::{
     Json,
+    body::Body,
     extract::State,
     http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
     response::{IntoResponse, Response},
@@ -50,15 +51,31 @@ async fn chat_completions_with_route(
             serde_json::Value::String(model_id.clone()),
         );
     }
-    let output = state
-        .agent_chat()
-        .complete(AgentChatParams {
-            user_id,
-            model_id: ModelId(model_id),
-            body: body.clone(),
-            route,
-        })
-        .await?;
+    let streaming = body
+        .get("stream")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let params = AgentChatParams {
+        user_id,
+        model_id: ModelId(model_id),
+        body: body.clone(),
+        route,
+    };
+
+    // A streaming caller gets the provider response forwarded as it arrives, so
+    // a slow reasoning model does not stall behind a fully buffered response (a
+    // non-streaming caller still gets a single buffered JSON body).
+    if streaming {
+        let output = state.agent_chat().complete_streaming(params).await?;
+        return Ok((
+            StatusCode::OK,
+            [(CONTENT_TYPE, output.content_type)],
+            Body::from_stream(output.body),
+        )
+            .into_response());
+    }
+
+    let output = state.agent_chat().complete(params).await?;
     Ok((
         StatusCode::OK,
         [(CONTENT_TYPE, output.completion.content_type)],

--- a/scribe-api/crates/domain/Cargo.toml
+++ b/scribe-api/crates/domain/Cargo.toml
@@ -12,6 +12,8 @@ workspace = true
 
 [dependencies]
 async-trait.workspace = true
+bytes.workspace = true
+futures-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -82,6 +82,19 @@ pub struct AgentChatCompletion {
     pub usage: TokenUsage,
 }
 
+/// A streamed agent-chat completion: the provider response body forwarded to the
+/// caller as it arrives, instead of buffered. `usage` is filled in once the
+/// terminal usage frame is seen (end of stream), so billing can settle after the
+/// body has been forwarded rather than before the response starts.
+pub struct AgentChatStream {
+    pub content_type: String,
+    pub provider: String,
+    pub usage: std::sync::Arc<std::sync::Mutex<Option<TokenUsage>>>,
+    pub body: std::pin::Pin<
+        Box<dyn futures_util::Stream<Item = Result<bytes::Bytes, DomainError>> + Send>,
+    >,
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenUsage {
@@ -387,6 +400,26 @@ pub trait Cleaner: Send + Sync {
 pub trait AgentChatCompleter: Send + Sync {
     async fn complete(&self, request: AgentChatRequest)
     -> Result<AgentChatCompletion, DomainError>;
+
+    /// Stream the completion body as it arrives. The default buffers via
+    /// `complete` and emits the whole body as a single chunk, so existing
+    /// (non-streaming) implementations keep working unchanged; streaming
+    /// providers override this to forward the upstream response incrementally.
+    async fn complete_streaming(
+        &self,
+        request: AgentChatRequest,
+    ) -> Result<AgentChatStream, DomainError> {
+        let completion = self.complete(request).await?;
+        let usage = std::sync::Arc::new(std::sync::Mutex::new(Some(completion.usage)));
+        let chunk = bytes::Bytes::from(completion.body);
+        let body = Box::pin(futures_util::stream::once(async move { Ok(chunk) }));
+        Ok(AgentChatStream {
+            content_type: completion.content_type,
+            provider: completion.provider,
+            usage,
+            body,
+        })
+    }
 }
 
 #[async_trait]

--- a/scribe-api/crates/providers/Cargo.toml
+++ b/scribe-api/crates/providers/Cargo.toml
@@ -11,8 +11,11 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+async-stream.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+bytes.workspace = true
+futures-util.workspace = true
 hound.workspace = true
 mp4.workspace = true
 jsonwebtoken.workspace = true

--- a/scribe-api/crates/providers/src/http.rs
+++ b/scribe-api/crates/providers/src/http.rs
@@ -1,7 +1,12 @@
 use reqwest::Client;
 use std::time::Duration;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_mins(1);
+// Reasoning models on a large agent prompt (system + many tool definitions)
+// can take well over a minute to produce a buffered completion; a 1-minute
+// client timeout cuts those off and surfaces as upstream 502s with retries.
+// Match the OS-Guard request deadline (180s) so a slow-but-valid reasoning
+// turn completes instead of being killed mid-generation.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub fn default_client() -> Client {

--- a/scribe-api/crates/providers/src/http.rs
+++ b/scribe-api/crates/providers/src/http.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 // client timeout cuts those off and surfaces as upstream 502s with retries.
 // Match the OS-Guard request deadline (180s) so a slow-but-valid reasoning
 // turn completes instead of being killed mid-generation.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
+const DEFAULT_TIMEOUT: Duration = Duration::from_mins(3);
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub fn default_client() -> Client {

--- a/scribe-api/crates/providers/src/venice.rs
+++ b/scribe-api/crates/providers/src/venice.rs
@@ -481,19 +481,7 @@ impl VeniceChat {
         model: scribe_domain::ModelId,
     ) -> Result<AgentChatCompletion, DomainError> {
         prepare_agent_chat_body(&mut body, &model)?;
-        let url = format!("{}/chat/completions", self.base_url);
-        let response = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.api_key)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| {
-                tracing::error!(%error, %url, model = %model.0, "chat: agent transport error");
-                DomainError::UpstreamProvider
-            })?;
-        let status = response.status();
+        let response = self.send_agent_request_with_retry(&body, &model).await?;
         let content_type = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
@@ -501,19 +489,9 @@ impl VeniceChat {
             .unwrap_or("application/json")
             .to_string();
         let body = response.bytes().await.map_err(|error| {
-            tracing::error!(%error, %url, model = %model.0, "chat: agent body read failed");
+            tracing::error!(%error, model = %model.0, "chat: agent body read failed");
             DomainError::UpstreamProvider
         })?;
-        if !status.is_success() {
-            tracing::error!(
-                %status,
-                %url,
-                model = %model.0,
-                body_bytes = body.len(),
-                "chat: agent non-success response"
-            );
-            return Err(self.status_error(status));
-        }
         let usage = usage_from_chat_body(&body, &content_type)?;
         Ok(AgentChatCompletion {
             body: body.to_vec(),
@@ -521,6 +499,79 @@ impl VeniceChat {
             provider: PROVIDER_NAME.to_string(),
             usage,
         })
+    }
+
+    /// Send the agent chat request with a bounded retry on transient failures
+    /// (connection reset, 429, 5xx) — the same policy the note/dictation paths
+    /// use. The agent chat path previously had none, so a single transient 5xx
+    /// from the gateway (e.g. a flaky reasoning model upstream) surfaced as a
+    /// hard 502. Metering settles only after success, so a replayed attempt can
+    /// never double-charge. Returns a response whose status is already success.
+    async fn send_agent_request_with_retry(
+        &self,
+        body: &serde_json::Value,
+        model: &scribe_domain::ModelId,
+    ) -> Result<reqwest::Response, DomainError> {
+        let url = format!("{}/chat/completions", self.base_url);
+        for attempt in 0..retry::UPSTREAM_ATTEMPTS {
+            let attempt_error = match self.send_agent_once(&url, body, model).await {
+                Ok(response) => return Ok(response),
+                Err(error) => error,
+            };
+            if attempt_error.retryable && attempt + 1 < retry::UPSTREAM_ATTEMPTS {
+                tracing::warn!(
+                    %url,
+                    model = %model.0,
+                    attempt,
+                    "chat: agent transient failure, retrying"
+                );
+                tokio::time::sleep(retry::UPSTREAM_RETRY_BACKOFF).await;
+                continue;
+            }
+            return Err(attempt_error.error);
+        }
+        Err(DomainError::UpstreamProvider)
+    }
+
+    /// One agent chat upstream attempt: send and validate the status, classifying
+    /// the failure as retryable or not. The body is left unread so the caller can
+    /// buffer or stream it.
+    async fn send_agent_once(
+        &self,
+        url: &str,
+        body: &serde_json::Value,
+        model: &scribe_domain::ModelId,
+    ) -> Result<reqwest::Response, UpstreamAttemptError> {
+        let response = self
+            .http
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .json(body)
+            .send()
+            .await
+            .map_err(|error| {
+                let retryable = retry::is_retryable_transport_error(&error);
+                tracing::error!(%error, %url, model = %model.0, retryable, "chat: agent transport error");
+                UpstreamAttemptError {
+                    error: DomainError::UpstreamProvider,
+                    retryable,
+                }
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let error = self.status_error(status);
+            let retryable =
+                error == DomainError::UpstreamProvider && retry::is_retryable_status(status);
+            tracing::error!(
+                %status,
+                %url,
+                model = %model.0,
+                retryable,
+                "chat: agent non-success response"
+            );
+            return Err(UpstreamAttemptError { error, retryable });
+        }
+        Ok(response)
     }
 
     /// Streaming counterpart of `complete_raw`: forwards the upstream response
@@ -535,36 +586,15 @@ impl VeniceChat {
         model: scribe_domain::ModelId,
     ) -> Result<scribe_domain::AgentChatStream, DomainError> {
         prepare_agent_chat_body(&mut body, &model)?;
-        let url = format!("{}/chat/completions", self.base_url);
-        let response = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.api_key)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|error| {
-                tracing::error!(%error, %url, model = %model.0, "chat: agent transport error");
-                DomainError::UpstreamProvider
-            })?;
-        let status = response.status();
+        // Retry the establish phase (send + status) on transient failures before
+        // any byte is streamed; once streaming starts a retry is impossible.
+        let response = self.send_agent_request_with_retry(&body, &model).await?;
         let content_type = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
             .and_then(|value| value.to_str().ok())
             .unwrap_or("application/json")
             .to_string();
-        if !status.is_success() {
-            let body = response.bytes().await.unwrap_or_default();
-            tracing::error!(
-                %status,
-                %url,
-                model = %model.0,
-                body_bytes = body.len(),
-                "chat: agent non-success response"
-            );
-            return Err(self.status_error(status));
-        }
 
         let usage = std::sync::Arc::new(std::sync::Mutex::new(None));
         let usage_for_stream = usage.clone();
@@ -641,6 +671,12 @@ fn prepare_agent_chat_body(
         if let Some(options) = stream_options.as_object_mut() {
             options.insert("include_usage".to_string(), serde_json::Value::Bool(true));
         }
+    } else {
+        // `stream_options` is only valid alongside `stream: true`; Venice rejects
+        // the request with a 400 otherwise (which surfaces here as a 502). Some
+        // clients (e.g. the Hermes agent runtime) send it even on a buffered
+        // request, so strip it for non-streaming calls.
+        object.remove("stream_options");
     }
     Ok(())
 }

--- a/scribe-api/crates/providers/src/venice.rs
+++ b/scribe-api/crates/providers/src/venice.rs
@@ -14,6 +14,15 @@ use std::collections::BTreeMap;
 pub const PROVIDER_NAME: &str = "venice";
 
 const CREDITS_PER_USD: f64 = 1_000.0;
+
+/// Trailing SSE bytes retained from a streamed response — enough to contain the
+/// final usage frame without buffering the whole (possibly multi-MB) body.
+const MAX_USAGE_TAIL_BYTES: usize = 64 * 1024;
+
+/// Whether `haystack` contains the byte sequence `needle`.
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    needle.len() <= haystack.len() && haystack.windows(needle.len()).any(|w| w == needle)
+}
 const RATE_SCALE: f64 = 1_000_000.0;
 
 /// Standing safety policy injected as the leading system message on every
@@ -577,9 +586,11 @@ impl VeniceChat {
     /// Streaming counterpart of `complete_raw`: forwards the upstream response
     /// body to the caller as it arrives instead of buffering it. The status is
     /// validated before any byte is streamed (so a policy block / error still
-    /// surfaces as an error response). The terminal usage frame is parsed at end
-    /// of stream into the returned `usage` handle so the caller can settle
-    /// billing once forwarding completes.
+    /// surfaces as an error response). Only a bounded trailing window of the SSE
+    /// is retained (enough to hold the terminal usage frame), and the usage is
+    /// captured into the returned handle as soon as that frame streams — before
+    /// `[DONE]` — so a caller can settle billing even if the client disconnects
+    /// immediately after the terminal frame.
     async fn complete_raw_streaming(
         &self,
         mut body: serde_json::Value,
@@ -603,12 +614,31 @@ impl VeniceChat {
         let upstream = response.bytes_stream();
         let stream = async_stream::stream! {
             use futures_util::StreamExt;
-            let mut accumulated: Vec<u8> = Vec::new();
+            // Retain only a bounded trailing window — large enough to hold the
+            // final usage frame, not the whole (potentially multi-MB) response.
+            let mut tail: Vec<u8> = Vec::new();
+            let mut usage_captured = false;
             futures_util::pin_mut!(upstream);
             while let Some(item) = upstream.next().await {
                 match item {
                     Ok(chunk) => {
-                        accumulated.extend_from_slice(&chunk);
+                        tail.extend_from_slice(&chunk);
+                        if tail.len() > MAX_USAGE_TAIL_BYTES {
+                            let trim = tail.len() - MAX_USAGE_TAIL_BYTES;
+                            tail.drain(..trim);
+                        }
+                        // Capture usage the moment its frame (or the terminal
+                        // [DONE]) appears, before forwarding it onward, so the
+                        // handle is populated even if the client drops the
+                        // connection right after the last frame.
+                        if !usage_captured
+                            && (contains(&chunk, b"\"usage\"") || contains(&chunk, b"[DONE]"))
+                            && let Ok(parsed) = usage_from_chat_body(&tail, &content_type_for_usage)
+                            && let Ok(mut guard) = usage_for_stream.lock()
+                        {
+                            *guard = Some(parsed);
+                            usage_captured = true;
+                        }
                         yield Ok(chunk);
                     }
                     Err(error) => {
@@ -618,12 +648,7 @@ impl VeniceChat {
                     }
                 }
             }
-            // Stream complete: extract the usage frame so the caller can settle.
-            if let Ok(parsed) = usage_from_chat_body(&accumulated, &content_type_for_usage) {
-                if let Ok(mut guard) = usage_for_stream.lock() {
-                    *guard = Some(parsed);
-                }
-            } else {
+            if !usage_captured {
                 tracing::warn!(
                     model = %model_id,
                     "chat: no usage frame in streamed agent response; billing skipped"

--- a/scribe-api/crates/providers/src/venice.rs
+++ b/scribe-api/crates/providers/src/venice.rs
@@ -318,6 +318,15 @@ impl AgentChatCompleter for VeniceAgentChat {
     ) -> Result<AgentChatCompletion, DomainError> {
         self.chat.complete_raw(request.body, request.model).await
     }
+
+    async fn complete_streaming(
+        &self,
+        request: AgentChatRequest,
+    ) -> Result<scribe_domain::AgentChatStream, DomainError> {
+        self.chat
+            .complete_raw_streaming(request.body, request.model)
+            .await
+    }
 }
 
 impl VeniceCleaner {
@@ -471,30 +480,7 @@ impl VeniceChat {
         mut body: serde_json::Value,
         model: scribe_domain::ModelId,
     ) -> Result<AgentChatCompletion, DomainError> {
-        let Some(object) = body.as_object_mut() else {
-            return Err(DomainError::InvalidInput {
-                reason: "invalid_chat_completion_body".to_string(),
-            });
-        };
-        object.insert(
-            "model".to_string(),
-            serde_json::Value::String(model.0.clone()),
-        );
-        inject_safety_context(object);
-        if object.get("stream").and_then(serde_json::Value::as_bool) == Some(true) {
-            let stream_options = object
-                .entry("stream_options")
-                .or_insert_with(|| serde_json::json!({}));
-            // Replace a non-object `stream_options` instead of leaving it:
-            // without `include_usage` the stream carries no usage frame, so
-            // metering fails after the upstream call has already been made.
-            if !stream_options.is_object() {
-                *stream_options = serde_json::json!({});
-            }
-            if let Some(options) = stream_options.as_object_mut() {
-                options.insert("include_usage".to_string(), serde_json::Value::Bool(true));
-            }
-        }
+        prepare_agent_chat_body(&mut body, &model)?;
         let url = format!("{}/chat/completions", self.base_url);
         let response = self
             .http
@@ -536,6 +522,127 @@ impl VeniceChat {
             usage,
         })
     }
+
+    /// Streaming counterpart of `complete_raw`: forwards the upstream response
+    /// body to the caller as it arrives instead of buffering it. The status is
+    /// validated before any byte is streamed (so a policy block / error still
+    /// surfaces as an error response). The terminal usage frame is parsed at end
+    /// of stream into the returned `usage` handle so the caller can settle
+    /// billing once forwarding completes.
+    async fn complete_raw_streaming(
+        &self,
+        mut body: serde_json::Value,
+        model: scribe_domain::ModelId,
+    ) -> Result<scribe_domain::AgentChatStream, DomainError> {
+        prepare_agent_chat_body(&mut body, &model)?;
+        let url = format!("{}/chat/completions", self.base_url);
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, %url, model = %model.0, "chat: agent transport error");
+                DomainError::UpstreamProvider
+            })?;
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("application/json")
+            .to_string();
+        if !status.is_success() {
+            let body = response.bytes().await.unwrap_or_default();
+            tracing::error!(
+                %status,
+                %url,
+                model = %model.0,
+                body_bytes = body.len(),
+                "chat: agent non-success response"
+            );
+            return Err(self.status_error(status));
+        }
+
+        let usage = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let usage_for_stream = usage.clone();
+        let content_type_for_usage = content_type.clone();
+        let model_id = model.0.clone();
+        let upstream = response.bytes_stream();
+        let stream = async_stream::stream! {
+            use futures_util::StreamExt;
+            let mut accumulated: Vec<u8> = Vec::new();
+            futures_util::pin_mut!(upstream);
+            while let Some(item) = upstream.next().await {
+                match item {
+                    Ok(chunk) => {
+                        accumulated.extend_from_slice(&chunk);
+                        yield Ok(chunk);
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, model = %model_id, "chat: agent stream read failed");
+                        yield Err(DomainError::UpstreamProvider);
+                        return;
+                    }
+                }
+            }
+            // Stream complete: extract the usage frame so the caller can settle.
+            if let Ok(parsed) = usage_from_chat_body(&accumulated, &content_type_for_usage) {
+                if let Ok(mut guard) = usage_for_stream.lock() {
+                    *guard = Some(parsed);
+                }
+            } else {
+                tracing::warn!(
+                    model = %model_id,
+                    "chat: no usage frame in streamed agent response; billing skipped"
+                );
+            }
+        };
+
+        Ok(scribe_domain::AgentChatStream {
+            content_type,
+            provider: PROVIDER_NAME.to_string(),
+            usage,
+            body: Box::pin(stream),
+        })
+    }
+}
+
+/// Apply the gateway-bound mutations every agent chat body needs: pin the model,
+/// prepend the standing safety policy, and (when streaming) force
+/// `stream_options.include_usage` so the response carries a usage frame for
+/// metering. Shared by the buffered and streaming provider paths.
+fn prepare_agent_chat_body(
+    body: &mut serde_json::Value,
+    model: &scribe_domain::ModelId,
+) -> Result<(), DomainError> {
+    let Some(object) = body.as_object_mut() else {
+        return Err(DomainError::InvalidInput {
+            reason: "invalid_chat_completion_body".to_string(),
+        });
+    };
+    object.insert(
+        "model".to_string(),
+        serde_json::Value::String(model.0.clone()),
+    );
+    inject_safety_context(object);
+    if object.get("stream").and_then(serde_json::Value::as_bool) == Some(true) {
+        let stream_options = object
+            .entry("stream_options")
+            .or_insert_with(|| serde_json::json!({}));
+        // Replace a non-object `stream_options` instead of leaving it: without
+        // `include_usage` the stream carries no usage frame, so metering fails
+        // after the upstream call has already been made.
+        if !stream_options.is_object() {
+            *stream_options = serde_json::json!({});
+        }
+        if let Some(options) = stream_options.as_object_mut() {
+            options.insert("include_usage".to_string(), serde_json::Value::Bool(true));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize)]

--- a/scribe-api/crates/services/Cargo.toml
+++ b/scribe-api/crates/services/Cargo.toml
@@ -11,6 +11,9 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+async-stream.workspace = true
+bytes.workspace = true
+futures-util.workspace = true
 scribe-config.workspace = true
 scribe-domain.workspace = true
 serde.workspace = true

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -1,16 +1,17 @@
 use crate::{
     charge_flow::{
-        AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        AsyncChargeParams, AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap,
+        log_settled, spawn_charge,
     },
     error::ServiceError,
     pricing::PricingTable,
 };
 use scribe_domain::{
     ActionSlug, AgentChatCompleter, AgentChatCompletion, AgentChatRequest, Credits, ModelId,
-    ModelKind, OsAccountsClient, Receipt, UserId,
+    ModelKind, OsAccountsClient, Receipt, TokenUsage, UserId,
 };
 use sha2::{Digest, Sha256};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 pub struct AgentChatServiceDeps {
     pub pricing: Arc<PricingTable>,
@@ -117,57 +118,34 @@ impl AgentChatService {
             })
             .await?;
 
-        // Billing context moved into the forwarding stream; settled at its end.
-        let os_accounts = self.os_accounts.clone();
-        let pricing = self.pricing.clone();
-        let user_id = params.user_id.clone();
-        let model_id = params.model_id.clone();
-        let action_token = authorization.action_token;
-        let cap_credits = authorization.cap_credits;
-        let usage_handle = stream.usage.clone();
+        // Settlement is owned by a guard that fires when the response body is
+        // dropped — whether it streamed to completion or the client disconnected
+        // after the final frame. The charge is spawned detached so it cannot be
+        // cancelled by the connection closing (the provider captures usage when
+        // its frame streams, before [DONE], so it is available at drop time).
+        let billing = StreamBilling {
+            os_accounts: self.os_accounts.clone(),
+            pricing: self.pricing.clone(),
+            user_id: params.user_id.clone(),
+            model_id: params.model_id.clone(),
+            cap_credits: authorization.cap_credits,
+            idempotency_key: format!(
+                "agent_chat:{}:{}:{}",
+                params.user_id.0, params.model_id.0, body_digest
+            ),
+            usage: stream.usage.clone(),
+            action_token: Some(authorization.action_token),
+        };
         let content_type = stream.content_type.clone();
         let upstream = stream.body;
 
         let billed = async_stream::stream! {
             use futures_util::StreamExt;
+            // Held for the lifetime of the body; its Drop settles billing.
+            let _billing = billing;
             futures_util::pin_mut!(upstream);
             while let Some(item) = upstream.next().await {
                 yield item;
-            }
-            // Stream fully forwarded: settle from the captured usage frame.
-            let usage = usage_handle.lock().ok().and_then(|mut guard| guard.take());
-            let Some(usage) = usage else {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    model = %model_id.0,
-                    "agent chat: no usage captured from stream; not charging (hold expires)"
-                );
-                return;
-            };
-            let actual = match pricing.price_token_usage(&model_id.0, usage) {
-                Ok(actual) => actual,
-                Err(error) => {
-                    tracing::error!(%error, model = %model_id.0, "agent chat: post-stream pricing failed; not charging");
-                    return;
-                }
-            };
-            let charge_credits = clamp_to_cap(actual, cap_credits);
-            let idempotency_key =
-                format!("agent_chat:{}:{}:{}", user_id.0, model_id.0, body_digest);
-            match charge(ChargeParams {
-                os_accounts: os_accounts.as_ref(),
-                action_token,
-                credits: charge_credits,
-                idempotency_key,
-            })
-            .await
-            {
-                Ok(receipt) => log_settled(ActionSlug::AgentChat, &user_id, &model_id.0, &receipt),
-                Err(error) => tracing::error!(
-                    %error,
-                    user_id = %user_id.0,
-                    "agent chat: post-stream charge failed; hold will expire"
-                ),
             }
         };
 
@@ -182,6 +160,63 @@ impl AgentChatService {
             AgentChatRoute::Guarded => self.guarded_chat_completer.as_ref(),
             AgentChatRoute::Direct => self.direct_chat_completer.as_ref(),
         }
+    }
+}
+
+/// Settles billing for a streamed agent chat when the response body is dropped.
+/// Dropping happens whether the stream completed or the client disconnected, so
+/// settlement is never lost to a connection close after the final frame. The
+/// charge is spawned detached so the connection lifetime cannot cancel it.
+struct StreamBilling {
+    os_accounts: Arc<dyn OsAccountsClient>,
+    pricing: Arc<PricingTable>,
+    user_id: UserId,
+    model_id: ModelId,
+    cap_credits: Option<Credits>,
+    idempotency_key: String,
+    usage: Arc<Mutex<Option<TokenUsage>>>,
+    action_token: Option<String>,
+}
+
+impl Drop for StreamBilling {
+    fn drop(&mut self) {
+        let Some(action_token) = self.action_token.take() else {
+            return;
+        };
+        // Outside a Tokio runtime (e.g. dropped in a sync test) there is nothing
+        // to spawn onto; skip rather than panic.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let usage = self.usage.lock().ok().and_then(|mut guard| guard.take());
+        let Some(usage) = usage else {
+            tracing::warn!(
+                user_id = %self.user_id.0,
+                model = %self.model_id.0,
+                "agent chat: stream ended without usage; not charging (hold expires)"
+            );
+            return;
+        };
+        let actual = match self.pricing.price_token_usage(&self.model_id.0, usage) {
+            Ok(actual) => actual,
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    model = %self.model_id.0,
+                    "agent chat: post-stream pricing failed; not charging"
+                );
+                return;
+            }
+        };
+        spawn_charge(AsyncChargeParams {
+            os_accounts: self.os_accounts.clone(),
+            user_id: self.user_id.clone(),
+            action: ActionSlug::AgentChat,
+            model_id: Some(self.model_id.0.clone()),
+            action_token,
+            credits: clamp_to_cap(actual, self.cap_credits),
+            idempotency_key: self.idempotency_key.clone(),
+        });
     }
 }
 

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -88,12 +88,113 @@ impl AgentChatService {
         })
     }
 
+    /// Streaming counterpart of `complete`: holds credits up front, forwards the
+    /// provider response body to the caller as it arrives, and settles billing
+    /// once the stream completes (from the usage frame captured at end of
+    /// stream). A post-stream charge failure is logged and the hold expires by
+    /// TTL — it can never double-charge because the idempotency key is stable.
+    pub async fn complete_streaming(
+        &self,
+        params: AgentChatParams,
+    ) -> Result<AgentChatStreamOutput, ServiceError> {
+        self.pricing
+            .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        let estimate = Credits(self.flat_estimate_credits);
+        let authorization = authorize_or_deny(AuthorizeParams {
+            os_accounts: self.os_accounts.as_ref(),
+            user_id: params.user_id.clone(),
+            action: ActionSlug::AgentChat,
+            estimate,
+            hold_ttl_seconds: self.hold_ttl_seconds,
+        })
+        .await?;
+        let body_digest = body_digest(&params.body);
+        let stream = self
+            .chat_completer(params.route)
+            .complete_streaming(AgentChatRequest {
+                body: params.body,
+                model: params.model_id.clone(),
+            })
+            .await?;
+
+        // Billing context moved into the forwarding stream; settled at its end.
+        let os_accounts = self.os_accounts.clone();
+        let pricing = self.pricing.clone();
+        let user_id = params.user_id.clone();
+        let model_id = params.model_id.clone();
+        let action_token = authorization.action_token;
+        let cap_credits = authorization.cap_credits;
+        let usage_handle = stream.usage.clone();
+        let content_type = stream.content_type.clone();
+        let upstream = stream.body;
+
+        let billed = async_stream::stream! {
+            use futures_util::StreamExt;
+            futures_util::pin_mut!(upstream);
+            while let Some(item) = upstream.next().await {
+                yield item;
+            }
+            // Stream fully forwarded: settle from the captured usage frame.
+            let usage = usage_handle.lock().ok().and_then(|mut guard| guard.take());
+            let Some(usage) = usage else {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    model = %model_id.0,
+                    "agent chat: no usage captured from stream; not charging (hold expires)"
+                );
+                return;
+            };
+            let actual = match pricing.price_token_usage(&model_id.0, usage) {
+                Ok(actual) => actual,
+                Err(error) => {
+                    tracing::error!(%error, model = %model_id.0, "agent chat: post-stream pricing failed; not charging");
+                    return;
+                }
+            };
+            let charge_credits = clamp_to_cap(actual, cap_credits);
+            let idempotency_key =
+                format!("agent_chat:{}:{}:{}", user_id.0, model_id.0, body_digest);
+            match charge(ChargeParams {
+                os_accounts: os_accounts.as_ref(),
+                action_token,
+                credits: charge_credits,
+                idempotency_key,
+            })
+            .await
+            {
+                Ok(receipt) => log_settled(ActionSlug::AgentChat, &user_id, &model_id.0, &receipt),
+                Err(error) => tracing::error!(
+                    %error,
+                    user_id = %user_id.0,
+                    "agent chat: post-stream charge failed; hold will expire"
+                ),
+            }
+        };
+
+        Ok(AgentChatStreamOutput {
+            content_type,
+            body: Box::pin(billed),
+        })
+    }
+
     fn chat_completer(&self, route: AgentChatRoute) -> &dyn AgentChatCompleter {
         match route {
             AgentChatRoute::Guarded => self.guarded_chat_completer.as_ref(),
             AgentChatRoute::Direct => self.direct_chat_completer.as_ref(),
         }
     }
+}
+
+/// A streamed agent-chat response: the content type plus the body stream that
+/// forwards the provider response and settles billing when it ends.
+pub struct AgentChatStreamOutput {
+    pub content_type: String,
+    pub body: std::pin::Pin<
+        Box<
+            dyn futures_util::Stream<Item = Result<bytes::Bytes, scribe_domain::DomainError>>
+                + Send,
+        >,
+    >,
 }
 
 #[derive(Clone, Debug)]

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -12,6 +12,7 @@ mod util;
 
 pub use agent_chat::{
     AgentChatOutput, AgentChatParams, AgentChatRoute, AgentChatService, AgentChatServiceDeps,
+    AgentChatStreamOutput,
 };
 pub use dictate::{
     DictateCleanupOutput, DictateCleanupParams, DictateService, DictateServiceDeps,


### PR DESCRIPTION
## Problem

Agent chat buffered the **entire** OS-Guard response before replying to the client: `complete_raw` did `response.bytes().await` and the handler returned the whole body at once. So a streaming caller (June) received **nothing until the upstream finished**. With a slow reasoning model (kimi-k2-6, zai-…) the desktop client timed out and surfaced `502 upstream_provider_failed` — even though OS-Guard itself now streams token-by-token, scribe re-buffered it.

Verified empirically: through scribe, TTFB **= total** (e.g. 4.70s/4.70s); direct to the gateway, TTFB 0.93s vs total 4.91s (progressive). The streaming benefit was lost at the scribe layer.

## Change

Streaming agent chat now forwards the provider SSE to the caller as it arrives:

- **domain**: `AgentChatCompleter` gains `complete_streaming` (default buffers via `complete`; `VeniceAgentChat` overrides) returning `AgentChatStream { content_type, provider, usage, body }` — `usage` is an `Arc<Mutex<Option<TokenUsage>>>` filled from the terminal usage frame at end of stream.
- **providers/venice**: `complete_raw_streaming` validates status **before** streaming (a policy block / upstream error still surfaces as an error, not a half-stream), forwards `bytes_stream()`, and parses the usage frame at end. Body-prep (model pin, safety context, `stream_options.include_usage`) extracted and shared with the buffered path.
- **services/agent_chat**: `complete_streaming` holds credits up front, forwards the body, and **settles billing at end of stream** from the captured usage (stable idempotency key — a post-stream charge failure logs and the hold expires by TTL, never double-charges).
- **api/handler**: `stream:true` returns an axum streaming body; `stream:false` keeps the buffered JSON path unchanged.

Stacked on #352 (uses its `Guarded`/`Direct` route split).

## Verification (scribe → OS-Guard → Venice, kimi-k2-6)

- Streaming: **TTFB 1.68s vs total 5.02s** (was 4.70s = total) — progressive ✅
- Streaming PII: email rehydrated, **zero placeholder leak**, `[DONE]` ✅
- Non-streaming: buffered JSON unchanged ✅
- Billing settle fires at stream end (`"settled metered request"` after the response completes) ✅
- e2e matrix 20/21 (the one miss is the flaky reasoning model on the *non-streaming* buffered path — passes on re-run, not affected by this change). Workspace tests + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)