### PR TITLE
Harden repository for open source readiness

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,25 @@
+# Require an owner review for default changes, then spell out the paths that
+# are security or release sensitive so branch protection can enforce them.
+* @junhohong
+
+.github/ @junhohong
+.github/workflows/ @junhohong
+.github/actions/ @junhohong
+
+scripts/ @junhohong
+package.json @junhohong
+pnpm-lock.yaml @junhohong
+
+src-tauri/ @junhohong
+src-tauri/Cargo.toml @junhohong
+src-tauri/Cargo.lock @junhohong
+src-tauri/tauri*.conf.json @junhohong
+src-tauri/capabilities/ @junhohong
+src-tauri/Entitlements.plist @junhohong
+src-tauri/native/ @junhohong
+
+scribe-api/ @junhohong
+scribe-api/Cargo.toml @junhohong
+scribe-api/Cargo.lock @junhohong
+scribe-api/Dockerfile @junhohong
+scribe-api/config.toml @junhohong

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,13 +17,13 @@ runs:
         echo "channel=$channel" >> "$GITHUB_OUTPUT"
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
       with:
         toolchain: ${{ steps.toolchain.outputs.channel }}
         components: rustfmt, clippy
 
     - name: Cache cargo registry
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           ~/.cargo/registry/index
@@ -34,7 +34,7 @@ runs:
           cargo-registry-${{ runner.os }}-
 
     - name: Cache cargo target
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: scribe-api/target
         key: cargo-target-${{ runner.os }}-${{ hashFiles('scribe-api/Cargo.lock') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "12:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+    groups:
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
+      frontend-tooling:
+        patterns:
+          - "@vitejs/*"
+          - "vite"
+          - "typescript"
+          - "vitest"
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+      time: "12:15"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: cargo
+    directory: /scribe-api
+    schedule:
+      interval: weekly
+      day: monday
+      time: "12:30"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "12:45"
+      timezone: America/New_York
+    open-pull-requests-limit: 10

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Security and release checklist
+
+- [ ] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
+- [ ] Security-sensitive changes were called out in the summary.
+- [ ] Workflow action references are pinned to full-length commit SHAs.
+- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
+- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
+- [ ] User-facing copy follows the repo UI conventions.

--- a/.github/workflows/build-scribe-api.yml
+++ b/.github/workflows/build-scribe-api.yml
@@ -29,7 +29,7 @@ jobs:
       sha_short: ${{ steps.meta.outputs.sha_short }}
       digest: ${{ steps.build.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Compute metadata
         id: meta
@@ -40,9 +40,9 @@ jobs:
           echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
           echo "created=$(git log -1 --pretty=%cI)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           # Normalizes layer/file timestamps to the commit time (with
           # rewrite-timestamp below) so the image digest is reproducible.
@@ -98,7 +98,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: deploy
         uses: ./.github/actions/phala-deploy
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,25 +22,25 @@ jobs:
     name: Desktop coverage artifacts
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.15.4
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@528e28158500e8adf409c61ac0eaa6bdd47f49ca # cargo-llvm-cov
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
@@ -52,14 +52,14 @@ jobs:
         run: pnpm test:rust:coverage
 
       - name: Upload frontend coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: desktop-frontend-coverage
           path: coverage/frontend
           if-no-files-found: error
 
       - name: Upload Tauri Rust coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: desktop-rust-coverage
           path: src-tauri/target/llvm-cov/html
@@ -69,19 +69,19 @@ jobs:
     name: Scribe API coverage artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-rust
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@528e28158500e8adf409c61ac0eaa6bdd47f49ca # cargo-llvm-cov
       - name: cargo llvm-cov
         working-directory: scribe-api
         env:
           RUST_BACKTRACE: 1
         run: cargo llvm-cov --workspace --all-features --html --output-dir target/llvm-cov/html
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scribe-api-rust-coverage
           path: scribe-api/target/llvm-cov/html

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -44,16 +44,16 @@ jobs:
     name: Frontend lint and tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.15.4
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -81,7 +81,7 @@ jobs:
       rust: ${{ steps.diff.outputs.rust }}
       desktop_bundle: ${{ steps.diff.outputs.desktop_bundle }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Diff rust-relevant paths
@@ -114,13 +114,13 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry/index
@@ -131,7 +131,7 @@ jobs:
             tauri-cargo-registry-${{ runner.os }}-
 
       - name: Cache cargo target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: src-tauri/target
           key: tauri-cargo-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
@@ -147,19 +147,19 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && needs.changes.outputs.desktop_bundle == 'true'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.15.4
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -174,7 +174,7 @@ jobs:
           "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry/index
@@ -185,7 +185,7 @@ jobs:
             tauri-cargo-registry-${{ runner.os }}-
 
       - name: Cache cargo target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: src-tauri/target
           key: tauri-cargo-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
@@ -234,7 +234,7 @@ jobs:
           }
 
       - name: Upload Windows installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: june-windows-debug-nsis
           path: src-tauri/target/debug/bundle/nsis/*-setup.exe

--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -35,7 +35,7 @@ jobs:
       # actor for when main is protected (docs/adr/0001 + infra runbook).
       - name: Mint release token (GitHub App)
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -45,7 +45,7 @@ jobs:
           # though the App installation follows renames.
           repositories: os-june,os-june-releases
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 0
@@ -55,24 +55,24 @@ jobs:
           persist-credentials: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.15.4
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry/index
@@ -232,7 +232,7 @@ jobs:
         run: ./scripts/bundle-hermes-runtime.sh
 
       - name: Build, sign, notarize, and publish updater release
-        uses: tauri-apps/tauri-action@v0.6.2
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -26,35 +26,35 @@ jobs:
     steps:
       - name: Mint release token (GitHub App)
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: open-software-network
           repositories: os-june,os-june-releases
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.15.4
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry/index
@@ -254,7 +254,7 @@ jobs:
           }
 
       - name: Upload Windows artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: june-windows-production-nsis-${{ github.sha }}
           path: src-tauri/target/release/bundle/nsis/*

--- a/.github/workflows/promote-scribe-api.yml
+++ b/.github/workflows/promote-scribe-api.yml
@@ -40,9 +40,9 @@ jobs:
           fi
           echo "from-tag=${FROM_TAG}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -69,11 +69,11 @@ jobs:
     env:
       FROM_TAG: ${{ needs.verify.outputs.from-tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/repository-hygiene.yml
+++ b/.github/workflows/repository-hygiene.yml
@@ -39,7 +39,7 @@ jobs:
           )"
           key_files="$(
             git ls-files |
-              grep -Ei '(^|/)(id_rsa|id_ed25519|.*\.(pem|p8|p12|key))$' || true
+              grep -Ei '(^|/)(id_rsa|id_dsa|id_ecdsa|id_ecdsa_sk|id_ed25519|id_ed25519_sk|.*\.(pem|p8|p12|key))$' || true
           )"
           private_key_matches="$(
             git grep -I -n -E -- '-----BEGIN [A-Z ]*PRIVATE KEY-----' -- . || true

--- a/.github/workflows/repository-hygiene.yml
+++ b/.github/workflows/repository-hygiene.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! find .github/actions .github/workflows \( -name '*.yml' -o -name '*.yaml' \) -print0 |
-            xargs -0 perl -ne 'if (/uses:\s+[^.\/\s][^@\s]+@(?![0-9a-f]{40}(?:\s|$))/) { print "$ARGV:$.:$_"; $bad = 1 } END { exit($bad ? 1 : 0) }'; then
+            xargs -0 perl -ne 'next if /^\s*#/; if (/uses:\s+[^.\/\s][^@\s]+@(?![0-9a-f]{40}(?:\s|$))/) { print "$ARGV:$.:$_"; $bad = 1 } END { exit($bad ? 1 : 0) }'; then
             echo "External GitHub Actions must be pinned to full-length commit SHAs." >&2
             exit 1
           fi

--- a/.github/workflows/repository-hygiene.yml
+++ b/.github/workflows/repository-hygiene.yml
@@ -3,24 +3,8 @@ name: repository hygiene
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - ".github/**"
-      - ".env*"
-      - "**/.env*"
-      - "**/*.key"
-      - "**/*.p12"
-      - "**/*.p8"
-      - "**/*.pem"
   push:
     branches: [main]
-    paths:
-      - ".github/**"
-      - ".env*"
-      - "**/.env*"
-      - "**/*.key"
-      - "**/*.p12"
-      - "**/*.p8"
-      - "**/*.pem"
 
 permissions:
   contents: read

--- a/.github/workflows/repository-hygiene.yml
+++ b/.github/workflows/repository-hygiene.yml
@@ -41,8 +41,11 @@ jobs:
             git ls-files |
               grep -Ei '(^|/)(id_rsa|id_ed25519|.*\.(pem|p8|p12|key))$' || true
           )"
-          if [[ -n "$env_files$key_files" ]]; then
-            printf '%s\n%s\n' "$env_files" "$key_files" | sed '/^$/d' >&2
+          private_key_matches="$(
+            git grep -I -n -E -- '-----BEGIN [A-Z ]*PRIVATE KEY-----' -- . || true
+          )"
+          if [[ -n "$env_files$key_files$private_key_matches" ]]; then
+            printf '%s\n%s\n%s\n' "$env_files" "$key_files" "$private_key_matches" | sed '/^$/d' >&2
             echo "Tracked env files or private key material are not allowed." >&2
             exit 1
           fi

--- a/.github/workflows/repository-hygiene.yml
+++ b/.github/workflows/repository-hygiene.yml
@@ -1,0 +1,64 @@
+name: repository hygiene
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/**"
+      - ".env*"
+      - "**/.env*"
+      - "**/*.key"
+      - "**/*.p12"
+      - "**/*.p8"
+      - "**/*.pem"
+  push:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - ".env*"
+      - "**/.env*"
+      - "**/*.key"
+      - "**/*.p12"
+      - "**/*.p8"
+      - "**/*.pem"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repository-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hygiene:
+    name: Repository hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Require pinned external actions
+        run: |
+          set -euo pipefail
+          if ! find .github/actions .github/workflows \( -name '*.yml' -o -name '*.yaml' \) -print0 |
+            xargs -0 perl -ne 'if (/uses:\s+[^.\/\s][^@\s]+@(?![0-9a-f]{40}(?:\s|$))/) { print "$ARGV:$.:$_"; $bad = 1 } END { exit($bad ? 1 : 0) }'; then
+            echo "External GitHub Actions must be pinned to full-length commit SHAs." >&2
+            exit 1
+          fi
+
+      - name: Reject committed env and key material
+        run: |
+          set -euo pipefail
+          env_files="$(
+            git ls-files |
+              grep -E '(^|/)\.env($|[.][^/]+$)' |
+              grep -Ev '(^|/)\.env\.example$' || true
+          )"
+          key_files="$(
+            git ls-files |
+              grep -Ei '(^|/)(id_rsa|id_ed25519|.*\.(pem|p8|p12|key))$' || true
+          )"
+          if [[ -n "$env_files$key_files" ]]; then
+            printf '%s\n%s\n' "$env_files" "$key_files" | sed '/^$/d' >&2
+            echo "Tracked env files or private key material are not allowed." >&2
+            exit 1
+          fi

--- a/.github/workflows/scribe-api-watchdog.yml
+++ b/.github/workflows/scribe-api-watchdog.yml
@@ -42,7 +42,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Full history is not needed, but all tags are: the staleness
           # check reads deploy/production/* and deploy/staging/* tag dates.

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -24,7 +24,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-rust
@@ -35,7 +35,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-rust
@@ -46,7 +46,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/staging-desktop-dmg.yml
+++ b/.github/workflows/staging-desktop-dmg.yml
@@ -19,27 +19,27 @@ jobs:
     name: Build staging macOS DMG
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 9.15.4
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry/index
@@ -50,7 +50,7 @@ jobs:
             cargo-registry-${{ runner.os }}-
 
       - name: Cache cargo target
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: src-tauri/target
           key: tauri-target-${{ runner.os }}-${{ hashFiles('src-tauri/Cargo.lock') }}
@@ -109,7 +109,7 @@ jobs:
         run: pnpm tauri:build:signed-dmg --target universal-apple-darwin
 
       - name: Upload DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: os-scribe-staging-dmg-${{ github.sha }}
           path: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security policy
+
+## Supported versions
+
+Security fixes target `main` and the latest shipped June desktop and Scribe API
+release. Older releases may receive fixes when the impact warrants it.
+
+## Reporting a vulnerability
+
+Please do not file public issues for suspected vulnerabilities.
+
+Use GitHub private vulnerability reporting when it is enabled for this
+repository. If it is not available, email `security@opensoftware.co` or contact
+a repository maintainer privately.
+
+Include the affected component, reproduction steps, impact, and any relevant
+logs or proof of concept. We will acknowledge the report, keep the discussion
+private while we investigate, and coordinate disclosure timing with you.
+
+## Scope
+
+In scope:
+
+- June desktop app authentication, local storage, updater, permissions, and
+  signed release flow.
+- Scribe API authentication, model proxying, billing authorization, request
+  validation, logging, and deployment configuration.
+- GitHub Actions, release automation, container publishing, and signing
+  material handling.
+
+Out of scope:
+
+- Social engineering.
+- Denial of service without a clear security impact.
+- Issues that require physical access to an already compromised device.

--- a/docs/github-security-readiness.md
+++ b/docs/github-security-readiness.md
@@ -1,0 +1,45 @@
+# GitHub security readiness
+
+This checklist captures the repository settings and hygiene items that should
+be in place before making `open-software-network/os-june` public.
+
+## Current findings
+
+- The repository is private today.
+- The `main` branch is not protected.
+- GitHub code security, Dependabot alerts, Dependabot security updates, secret
+  scanning, and secret scanning push protection are disabled.
+- GitHub Actions allows all actions and does not require full-length commit SHA
+  pinning.
+- The `production` and `staging` environments have no protection rules, and
+  admins can bypass them.
+- The repository has no GitHub security policy configured yet.
+- Wiki and projects are enabled, and branches are not deleted after merge.
+
+## Required before going public
+
+- Enable GitHub private vulnerability reporting and point it at
+  `SECURITY.md`.
+- Enable Dependabot alerts, Dependabot security updates, secret scanning, and
+  secret scanning push protection.
+- Protect `main` with pull requests, CODEOWNERS review, required status checks,
+  stale-review dismissal, and no force pushes or deletions.
+- Configure the `production` environment with required reviewers and disable
+  admin bypass. Consider doing the same for `staging`.
+- Enable Actions SHA pinning after this PR lands, then keep third-party actions
+  pinned by commit SHA.
+- Consider restricting Actions to GitHub-owned and selected third-party actions
+  already used by this repository.
+- Disable wiki if it is unused, enable delete branch on merge, and keep default
+  workflow permissions at read-only.
+
+## Audit notes
+
+- Secret-oriented scans did not find committed `.env` files, private keys,
+  signing certificates, or generated dependency directories.
+- `cargo audit --file scribe-api/Cargo.lock` is clean.
+- `cargo audit --file src-tauri/Cargo.lock` reports no vulnerabilities after
+  the desktop crate was moved off SQLx's umbrella package.
+- The desktop lockfile still includes Linux GTK warnings through Tauri's Linux
+  webview stack. If Linux releases are added, revisit those warnings before
+  shipping that target.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -272,12 +272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,12 +585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,21 +715,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -883,17 +856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,9 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1100,9 +1060,6 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "embed-resource"
@@ -1176,17 +1133,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1782,33 +1728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,15 +2228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,21 +2293,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.13.0",
  "libc",
- "plain",
- "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2474,16 +2375,6 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
 ]
 
 [[package]]
@@ -2665,22 +2556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,33 +2573,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3037,7 +2891,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sqlx",
+ "sqlx-core",
+ "sqlx-sqlite",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
@@ -3119,18 +2974,9 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3210,37 +3056,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3572,15 +3391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,26 +3565,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4212,17 +4002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4253,16 +4032,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4304,9 +4073,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"
@@ -4333,7 +4099,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4376,29 +4142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
-]
-
-[[package]]
 name = "sqlx-core"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,7 +4150,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
- "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
@@ -4422,9 +4164,6 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "serde",
- "serde_json",
- "sha2",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -4432,127 +4171,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
-dependencies = [
- "proc-macro2",
- "quote",
- "sqlx-core",
- "sqlx-macros-core",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
-dependencies = [
- "dotenvy",
- "either",
- "heck 0.5.0",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "sha2",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
- "syn 2.0.118",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags 2.13.0",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "digest",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.6",
- "rsa",
- "serde",
- "sha1",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags 2.13.0",
- "byteorder",
- "chrono",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.6",
- "serde",
- "serde_json",
- "sha2",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
- "whoami",
 ]
 
 [[package]]
@@ -4572,7 +4190,6 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "percent-encoding",
- "serde",
  "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
@@ -4609,17 +4226,6 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
 ]
 
 [[package]]
@@ -5635,31 +5241,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5814,12 +5399,6 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -6051,16 +5630,6 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
 ]
 
 [[package]]
@@ -6299,15 +5868,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6355,21 +5915,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6431,12 +5976,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6455,12 +5994,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6476,12 +6009,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6515,12 +6042,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6536,12 +6057,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6563,12 +6078,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6584,12 +6093,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,8 @@ serde_json = "1.0"
 sha2 = "0.10"
 # Avoid the SQLx umbrella crate here. Its optional macro/database dependencies
 # put unused MySQL/Postgres packages into Cargo.lock and cargo-audit.
+# sqlx-sqlite does not expose a public runtime-tokio feature in SQLx 0.8.x, so
+# the direct sqlx-core dependency intentionally enables its runtime hook.
 sqlx = { package = "sqlx-core", version = "0.8", default-features = false, features = ["_rt-tokio", "chrono", "uuid"] }
 sqlx-sqlite = { version = "0.8", default-features = false, features = ["bundled", "chrono", "uuid"] }
 tauri = { version = "2.8.0", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-png"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,13 +25,15 @@ chrono = { version = "0.4", features = ["serde"] }
 cpal = "0.15"
 dotenvy = "0.15"
 hound = "3.5"
-keyring = "3"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "chrono", "uuid", "migrate"] }
+# Avoid the SQLx umbrella crate here. Its optional macro/database dependencies
+# put unused MySQL/Postgres packages into Cargo.lock and cargo-audit.
+sqlx = { package = "sqlx-core", version = "0.8", default-features = false, features = ["_rt-tokio", "chrono", "uuid"] }
+sqlx-sqlite = { version = "0.8", default-features = false, features = ["bundled", "chrono", "uuid"] }
 tauri = { version = "2.8.0", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/audio/recovery.rs
+++ b/src-tauri/src/audio/recovery.rs
@@ -1,13 +1,14 @@
 use crate::domain::types::{
     RecordingSource, RecordingSourceMode, RecoverableRecordingDto, RecoverableSourceDto,
 };
-use sqlx::Row;
-use sqlx::SqlitePool;
+use sqlx::query::query;
+use sqlx::row::Row;
+use sqlx_sqlite::SqlitePool;
 
 pub async fn scan_recoverable_recordings(
     pool: &SqlitePool,
-) -> Result<Vec<RecoverableRecordingDto>, sqlx::Error> {
-    let rows = sqlx::query(
+) -> Result<Vec<RecoverableRecordingDto>, sqlx::error::Error> {
+    let rows = query(
         "SELECT id, note_id, source_mode, started_at, partial_path, final_path
          FROM recording_sessions
          WHERE status IN ('recording', 'paused', 'finalizing', 'validating', 'transcribing', 'generating', 'failed', 'recoverable')",
@@ -49,8 +50,8 @@ pub async fn scan_recoverable_recordings(
 async fn recoverable_sources(
     pool: &SqlitePool,
     session_id: &str,
-) -> Result<Vec<RecoverableSourceDto>, sqlx::Error> {
-    let rows = sqlx::query(
+) -> Result<Vec<RecoverableSourceDto>, sqlx::error::Error> {
+    let rows = query(
         "SELECT source, partial_path, path, last_error
          FROM audio_artifacts
          WHERE recording_session_id = ?",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -40,8 +40,10 @@ use crate::{
     },
 };
 use chrono::{TimeZone, Utc};
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::{Row, SqlitePool};
+use sqlx::query::query;
+use sqlx::row::Row;
+use sqlx_sqlite::SqlitePool;
+use sqlx_sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::{Mutex, OnceLock};
@@ -1541,7 +1543,7 @@ async fn hydrate_agent_task_from_hermes(
         return Ok(());
     };
 
-    let rows = sqlx::query(
+    let rows = query(
         "SELECT CAST(id AS TEXT) AS id, content, timestamp
          FROM messages
          WHERE session_id = ?
@@ -1631,7 +1633,7 @@ async fn match_hermes_session_for_task(
     else {
         return Ok(None);
     };
-    let rows = sqlx::query(
+    let rows = query(
         "SELECT id
          FROM sessions
          WHERE title = ?

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -1,13 +1,11 @@
-use sqlx::SqlitePool;
+use sqlx::query::query;
+use sqlx_sqlite::SqlitePool;
 
-pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::MigrateError> {
+pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::error::Error> {
     for statement in include_str!("../../migrations/001_init.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     ensure_column(
@@ -64,37 +62,25 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
     for statement in include_str!("../../migrations/002_source_modes.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     for statement in include_str!("../../migrations/003_generation_blocks.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     for statement in include_str!("../../migrations/004_dictionary.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     for statement in include_str!("../../migrations/005_dictation_history.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     // The dedupe DELETE in this migration scans `transcripts`, so only run it
@@ -106,20 +92,14 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
         {
             let statement = statement.trim();
             if !statement.is_empty() {
-                sqlx::query(statement)
-                    .execute(_pool)
-                    .await
-                    .map_err(sqlx::migrate::MigrateError::Execute)?;
+                query(statement).execute(_pool).await?;
             }
         }
     }
     for statement in include_str!("../../migrations/007_agent.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     ensure_column(_pool, "agent_tasks", "hermes_session_id", "TEXT").await?;
@@ -134,31 +114,24 @@ pub async fn run_migrations(_pool: &SqlitePool) -> Result<(), sqlx::migrate::Mig
         {
             let statement = statement.trim();
             if !statement.is_empty() {
-                sqlx::query(statement)
-                    .execute(_pool)
-                    .await
-                    .map_err(sqlx::migrate::MigrateError::Execute)?;
+                query(statement).execute(_pool).await?;
             }
         }
     }
     for statement in include_str!("../../migrations/009_session_folders.sql").split(';') {
         let statement = statement.trim();
         if !statement.is_empty() {
-            sqlx::query(statement)
-                .execute(_pool)
-                .await
-                .map_err(sqlx::migrate::MigrateError::Execute)?;
+            query(statement).execute(_pool).await?;
         }
     }
     Ok(())
 }
 
-async fn index_exists(pool: &SqlitePool, index: &str) -> Result<bool, sqlx::migrate::MigrateError> {
-    let row = sqlx::query("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?")
+async fn index_exists(pool: &SqlitePool, index: &str) -> Result<bool, sqlx::error::Error> {
+    let row = query("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?")
         .bind(index)
         .fetch_optional(pool)
-        .await
-        .map_err(sqlx::migrate::MigrateError::Execute)?;
+        .await?;
     Ok(row.is_some())
 }
 
@@ -167,41 +140,32 @@ async fn ensure_column(
     table: &str,
     column: &str,
     definition: &str,
-) -> Result<(), sqlx::migrate::MigrateError> {
+) -> Result<(), sqlx::error::Error> {
     let pragma = format!("PRAGMA table_info({table})");
-    let rows = sqlx::query(&pragma)
-        .fetch_all(pool)
-        .await
-        .map_err(sqlx::migrate::MigrateError::Execute)?;
+    let rows = query(&pragma).fetch_all(pool).await?;
     let exists = rows.iter().any(|row| {
-        use sqlx::Row;
+        use sqlx::row::Row;
         row.get::<String, _>("name") == column
     });
     if !exists {
         let alter = format!("ALTER TABLE {table} ADD COLUMN {column} {definition}");
-        match sqlx::query(&alter).execute(pool).await {
+        match query(&alter).execute(pool).await {
             Ok(_) => {}
             Err(error) if is_duplicate_column_error(&error, column) => {}
-            Err(error) => return Err(sqlx::migrate::MigrateError::Execute(error)),
+            Err(error) => return Err(error),
         }
     }
     Ok(())
 }
 
-fn is_duplicate_column_error(error: &sqlx::Error, column: &str) -> bool {
+fn is_duplicate_column_error(error: &sqlx::error::Error, column: &str) -> bool {
     let message = error.to_string().to_lowercase();
     message.contains("duplicate column name") && message.contains(&column.to_lowercase())
 }
 
-async fn drop_index_if_exists(
-    pool: &SqlitePool,
-    index: &str,
-) -> Result<(), sqlx::migrate::MigrateError> {
+async fn drop_index_if_exists(pool: &SqlitePool, index: &str) -> Result<(), sqlx::error::Error> {
     let sql = format!("DROP INDEX IF EXISTS {}", quote_sqlite_identifier(index));
-    sqlx::query(&sql)
-        .execute(pool)
-        .await
-        .map_err(sqlx::migrate::MigrateError::Execute)?;
+    query(&sql).execute(pool).await?;
     Ok(())
 }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -6,7 +6,9 @@ use crate::domain::types::{
     RecordingState, SessionFolderDto, TranscriptDto,
 };
 use chrono::{Duration, SecondsFormat, Utc};
-use sqlx::{Row, SqlitePool};
+use sqlx::query::query;
+use sqlx::row::Row;
+use sqlx_sqlite::SqlitePool;
 use uuid::Uuid;
 
 const DICTATION_HISTORY_RETENTION_DAYS: i64 = 7;
@@ -21,8 +23,8 @@ impl Repositories {
         Self { pool }
     }
 
-    pub async fn list_folders(&self) -> Result<Vec<FolderDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    pub async fn list_folders(&self) -> Result<Vec<FolderDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, name, description, created_at, updated_at FROM folders WHERE deleted_at IS NULL ORDER BY lower(name) ASC",
         )
         .fetch_all(&self.pool)
@@ -35,7 +37,7 @@ impl Repositories {
         &self,
         name: impl AsRef<str>,
         description: Option<&str>,
-    ) -> Result<FolderDto, sqlx::Error> {
+    ) -> Result<FolderDto, sqlx::error::Error> {
         let now = timestamp();
         let description = description
             .map(|value| value.trim().to_string())
@@ -48,7 +50,7 @@ impl Repositories {
             updated_at: now,
         };
 
-        sqlx::query(
+        query(
             "INSERT INTO folders (id, name, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
         )
         .bind(&folder.id)
@@ -73,7 +75,7 @@ impl Repositories {
         let description = description
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
-        let result = sqlx::query(
+        let result = query(
             "UPDATE folders SET name = ?, description = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
         )
         .bind(trimmed)
@@ -89,7 +91,7 @@ impl Repositories {
             ));
         }
 
-        let row = sqlx::query(
+        let row = query(
             "SELECT id, name, description, created_at, updated_at FROM folders WHERE id = ? AND deleted_at IS NULL",
         )
         .bind(folder_id)
@@ -99,12 +101,15 @@ impl Repositories {
         Ok(folder_from_row(row))
     }
 
-    pub async fn create_note(&self, folder_id: Option<String>) -> Result<NoteDto, sqlx::Error> {
+    pub async fn create_note(
+        &self,
+        folder_id: Option<String>,
+    ) -> Result<NoteDto, sqlx::error::Error> {
         let now = timestamp();
         let id = Uuid::new_v4().to_string();
 
         let mut tx = self.pool.begin().await?;
-        sqlx::query(
+        query(
             "INSERT INTO notes (id, title, processing_status, created_at, updated_at) VALUES (?, '', 'draft', ?, ?)",
         )
         .bind(&id)
@@ -114,7 +119,7 @@ impl Repositories {
         .await?;
 
         if let Some(folder_id) = folder_id {
-            sqlx::query("INSERT OR IGNORE INTO note_folders (note_id, folder_id, assigned_at) VALUES (?, ?, ?)")
+            query("INSERT OR IGNORE INTO note_folders (note_id, folder_id, assigned_at) VALUES (?, ?, ?)")
                 .bind(&id)
                 .bind(folder_id)
                 .bind(&now)
@@ -126,8 +131,8 @@ impl Repositories {
         self.get_note(&id).await
     }
 
-    pub async fn get_note(&self, note_id: &str) -> Result<NoteDto, sqlx::Error> {
-        let row = sqlx::query(
+    pub async fn get_note(&self, note_id: &str) -> Result<NoteDto, sqlx::error::Error> {
+        let row = query(
             "SELECT id, title, generated_content, edited_content, active_tab, processing_status, created_at, updated_at, last_error FROM notes WHERE id = ?",
         )
         .bind(note_id)
@@ -174,9 +179,9 @@ impl Repositories {
         folder_id: Option<String>,
         limit: i64,
         _cursor: Option<String>,
-    ) -> Result<ListNotesResponse, sqlx::Error> {
+    ) -> Result<ListNotesResponse, sqlx::error::Error> {
         let rows = if let Some(folder_id) = folder_id {
-            sqlx::query(
+            query(
                 "SELECT n.id, n.title, n.generated_content, n.edited_content, n.processing_status, n.created_at, n.updated_at
                  FROM notes n
                  INNER JOIN note_folders nf ON nf.note_id = n.id
@@ -189,7 +194,7 @@ impl Repositories {
             .fetch_all(&self.pool)
             .await?
         } else {
-            sqlx::query(
+            query(
                 "SELECT id, title, generated_content, edited_content, processing_status, created_at, updated_at
                  FROM notes
                  ORDER BY created_at DESC, rowid DESC
@@ -236,8 +241,8 @@ impl Repositories {
         &self,
         note_id: &str,
         folder_id: &str,
-    ) -> Result<NoteDto, sqlx::Error> {
-        sqlx::query(
+    ) -> Result<NoteDto, sqlx::error::Error> {
+        query(
             "INSERT OR IGNORE INTO note_folders (note_id, folder_id, assigned_at) VALUES (?, ?, ?)",
         )
         .bind(note_id)
@@ -252,8 +257,8 @@ impl Repositories {
         &self,
         note_id: &str,
         folder_id: &str,
-    ) -> Result<NoteDto, sqlx::Error> {
-        sqlx::query("DELETE FROM note_folders WHERE note_id = ? AND folder_id = ?")
+    ) -> Result<NoteDto, sqlx::error::Error> {
+        query("DELETE FROM note_folders WHERE note_id = ? AND folder_id = ?")
             .bind(note_id)
             .bind(folder_id)
             .execute(&self.pool)
@@ -261,8 +266,8 @@ impl Repositories {
         self.get_note(note_id).await
     }
 
-    pub async fn list_session_folders(&self) -> Result<Vec<SessionFolderDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    pub async fn list_session_folders(&self) -> Result<Vec<SessionFolderDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT sf.session_id, sf.folder_id
              FROM session_folders sf
              INNER JOIN folders f ON f.id = sf.folder_id
@@ -284,8 +289,8 @@ impl Repositories {
         &self,
         session_id: &str,
         folder_id: &str,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "INSERT OR IGNORE INTO session_folders (session_id, folder_id, assigned_at) VALUES (?, ?, ?)",
         )
         .bind(session_id)
@@ -300,8 +305,8 @@ impl Repositories {
         &self,
         session_id: &str,
         folder_id: &str,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query("DELETE FROM session_folders WHERE session_id = ? AND folder_id = ?")
+    ) -> Result<(), sqlx::error::Error> {
+        query("DELETE FROM session_folders WHERE session_id = ? AND folder_id = ?")
             .bind(session_id)
             .bind(folder_id)
             .execute(&self.pool)
@@ -309,8 +314,10 @@ impl Repositories {
         Ok(())
     }
 
-    pub async fn list_dictionary_entries(&self) -> Result<Vec<DictionaryEntryDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    pub async fn list_dictionary_entries(
+        &self,
+    ) -> Result<Vec<DictionaryEntryDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, phrase, created_at, updated_at
              FROM dictionary_entries
              WHERE deleted_at IS NULL
@@ -326,7 +333,7 @@ impl Repositories {
         text: &str,
         language: Option<String>,
         provider: &str,
-    ) -> Result<Option<DictationHistoryItemDto>, sqlx::Error> {
+    ) -> Result<Option<DictationHistoryItemDto>, sqlx::error::Error> {
         let text = text.trim();
         if text.is_empty() {
             return Ok(None);
@@ -338,7 +345,7 @@ impl Repositories {
             provider: provider.to_string(),
             created_at: timestamp(),
         };
-        sqlx::query(
+        query(
             "INSERT INTO dictation_history (id, text, language, provider, created_at)
              VALUES (?, ?, ?, ?, ?)",
         )
@@ -356,9 +363,9 @@ impl Repositories {
     pub async fn list_dictation_history(
         &self,
         limit: i64,
-    ) -> Result<ListDictationHistoryResponse, sqlx::Error> {
+    ) -> Result<ListDictationHistoryResponse, sqlx::error::Error> {
         self.prune_old_dictation_history().await?;
-        let rows = sqlx::query(
+        let rows = query(
             "SELECT id, text, language, provider, created_at
              FROM dictation_history
              WHERE created_at >= ?
@@ -379,17 +386,17 @@ impl Repositories {
         })
     }
 
-    pub async fn prune_old_dictation_history(&self) -> Result<(), sqlx::Error> {
-        sqlx::query("DELETE FROM dictation_history WHERE created_at < ?")
+    pub async fn prune_old_dictation_history(&self) -> Result<(), sqlx::error::Error> {
+        query("DELETE FROM dictation_history WHERE created_at < ?")
             .bind(dictation_history_cutoff_timestamp())
             .execute(&self.pool)
             .await?;
         Ok(())
     }
 
-    pub async fn pause_running_agent_tasks_on_launch(&self) -> Result<(), sqlx::Error> {
+    pub async fn pause_running_agent_tasks_on_launch(&self) -> Result<(), sqlx::error::Error> {
         let now = timestamp();
-        sqlx::query(
+        query(
             "UPDATE agent_tasks
              SET status = 'paused',
                  progress_summary = 'Paused when June restarted.',
@@ -406,8 +413,10 @@ impl Repositories {
     /// is already an assistant reply. `paused` and `waiting_for_user` are
     /// deliberate resting states (placeholder pauses, clarify exchanges) and
     /// must never be force-completed by this repair.
-    pub async fn complete_agent_tasks_with_assistant_messages(&self) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    pub async fn complete_agent_tasks_with_assistant_messages(
+        &self,
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "UPDATE agent_tasks
              SET status = 'completed',
                  progress_summary = 'Completed.',
@@ -436,8 +445,8 @@ impl Repositories {
         Ok(())
     }
 
-    pub async fn list_agent_tasks(&self) -> Result<AgentTaskListResponse, sqlx::Error> {
-        let rows = sqlx::query(
+    pub async fn list_agent_tasks(&self) -> Result<AgentTaskListResponse, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, title, prompt, status, safety_profile, progress_summary, last_error,
                     hermes_session_id, created_at, updated_at, completed_at
              FROM agent_tasks
@@ -456,7 +465,7 @@ impl Repositories {
         prompt: &str,
         title: Option<&str>,
         safety_profile: AgentSafetyProfile,
-    ) -> Result<AgentTaskDto, sqlx::Error> {
+    ) -> Result<AgentTaskDto, sqlx::error::Error> {
         let now = timestamp();
         let task_id = Uuid::new_v4().to_string();
         let trimmed_prompt = prompt.trim();
@@ -467,7 +476,7 @@ impl Repositories {
             .unwrap_or_else(|| title_from_prompt(trimmed_prompt));
 
         let mut tx = self.pool.begin().await?;
-        sqlx::query(
+        query(
             "INSERT INTO agent_tasks
              (id, title, prompt, status, safety_profile, progress_summary, created_at, updated_at)
              VALUES (?, ?, ?, 'queued', ?, 'Queued for the agent runtime.', ?, ?)",
@@ -480,7 +489,7 @@ impl Repositories {
         .bind(&now)
         .execute(&mut *tx)
         .await?;
-        sqlx::query(
+        query(
             "INSERT INTO agent_messages (id, task_id, role, content, created_at)
              VALUES (?, ?, 'user', ?, ?)",
         )
@@ -494,8 +503,8 @@ impl Repositories {
         self.get_agent_task(&task_id).await
     }
 
-    pub async fn get_agent_task(&self, task_id: &str) -> Result<AgentTaskDto, sqlx::Error> {
-        let row = sqlx::query(
+    pub async fn get_agent_task(&self, task_id: &str) -> Result<AgentTaskDto, sqlx::error::Error> {
+        let row = query(
             "SELECT id, title, prompt, status, safety_profile, progress_summary, last_error,
                     hermes_session_id, created_at, updated_at, completed_at
              FROM agent_tasks
@@ -514,8 +523,8 @@ impl Repositories {
         &self,
         task_id: &str,
         hermes_session_id: &str,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query("UPDATE agent_tasks SET hermes_session_id = ? WHERE id = ?")
+    ) -> Result<(), sqlx::error::Error> {
+        query("UPDATE agent_tasks SET hermes_session_id = ? WHERE id = ?")
             .bind(hermes_session_id)
             .bind(task_id)
             .execute(&self.pool)
@@ -528,10 +537,10 @@ impl Repositories {
         task_id: &str,
         role: AgentMessageRole,
         content: &str,
-    ) -> Result<AgentMessageDto, sqlx::Error> {
+    ) -> Result<AgentMessageDto, sqlx::error::Error> {
         let now = timestamp();
         let id = Uuid::new_v4().to_string();
-        sqlx::query(
+        query(
             "INSERT INTO agent_messages (id, task_id, role, content, created_at)
              VALUES (?, ?, ?, ?, ?)",
         )
@@ -542,12 +551,12 @@ impl Repositories {
         .bind(&now)
         .execute(&self.pool)
         .await?;
-        sqlx::query("UPDATE agent_tasks SET updated_at = ? WHERE id = ?")
+        query("UPDATE agent_tasks SET updated_at = ? WHERE id = ?")
             .bind(&now)
             .bind(task_id)
             .execute(&self.pool)
             .await?;
-        let row = sqlx::query(
+        let row = query(
             "SELECT id, task_id, role, content, created_at
              FROM agent_messages
              WHERE id = ?",
@@ -570,8 +579,8 @@ impl Repositories {
         content: &str,
         created_at: &str,
         external_id: &str,
-    ) -> Result<bool, sqlx::Error> {
-        let existing = sqlx::query(
+    ) -> Result<bool, sqlx::error::Error> {
+        let existing = query(
             "SELECT 1 FROM agent_messages
              WHERE task_id = ?
                AND role = ?
@@ -587,7 +596,7 @@ impl Repositories {
         if existing.is_some() {
             return Ok(false);
         }
-        let result = sqlx::query(
+        let result = query(
             "INSERT OR IGNORE INTO agent_messages
              (id, task_id, role, content, created_at, external_id)
              VALUES (?, ?, ?, ?, ?, ?)",
@@ -609,13 +618,13 @@ impl Repositories {
         status: AgentTaskStatus,
         progress_summary: Option<&str>,
         last_error: Option<&str>,
-    ) -> Result<AgentTaskDto, sqlx::Error> {
+    ) -> Result<AgentTaskDto, sqlx::error::Error> {
         let now = timestamp();
         let completed_at = match status {
             AgentTaskStatus::Completed | AgentTaskStatus::Cancelled => Some(now.clone()),
             _ => None,
         };
-        sqlx::query(
+        query(
             "UPDATE agent_tasks
              SET status = ?, progress_summary = ?, last_error = ?, updated_at = ?,
                  completed_at = COALESCE(?, completed_at)
@@ -644,7 +653,7 @@ impl Repositories {
         progress_summary: Option<&str>,
         last_error: Option<&str>,
         allowed_current: &[AgentTaskStatus],
-    ) -> Result<bool, sqlx::Error> {
+    ) -> Result<bool, sqlx::error::Error> {
         if allowed_current.is_empty() {
             return Ok(false);
         }
@@ -660,7 +669,7 @@ impl Repositories {
                  completed_at = COALESCE(?, completed_at)
              WHERE id = ? AND status IN ({placeholders})"
         );
-        let mut query = sqlx::query(&sql)
+        let mut query = query(&sql)
             .bind(status.as_db())
             .bind(progress_summary)
             .bind(last_error)
@@ -681,14 +690,13 @@ impl Repositories {
         &self,
         task_id: &str,
         hermes_session_id: &str,
-    ) -> Result<bool, sqlx::Error> {
-        let row = sqlx::query(
-            "SELECT 1 FROM agent_tasks WHERE hermes_session_id = ? AND id != ? LIMIT 1",
-        )
-        .bind(hermes_session_id)
-        .bind(task_id)
-        .fetch_optional(&self.pool)
-        .await?;
+    ) -> Result<bool, sqlx::error::Error> {
+        let row =
+            query("SELECT 1 FROM agent_tasks WHERE hermes_session_id = ? AND id != ? LIMIT 1")
+                .bind(hermes_session_id)
+                .bind(task_id)
+                .fetch_optional(&self.pool)
+                .await?;
         Ok(row.is_some())
     }
 
@@ -701,7 +709,7 @@ impl Repositories {
         arguments_json: Option<&str>,
         result_json: Option<&str>,
         redacted: bool,
-    ) -> Result<AgentToolEventDto, sqlx::Error> {
+    ) -> Result<AgentToolEventDto, sqlx::error::Error> {
         let now = timestamp();
         let completed_at = match status {
             AgentToolEventStatus::Completed
@@ -710,7 +718,7 @@ impl Repositories {
             _ => None,
         };
         let id = Uuid::new_v4().to_string();
-        sqlx::query(
+        query(
             "INSERT INTO agent_tool_events
              (id, task_id, tool_name, status, summary, arguments_json, result_json,
               redacted, created_at, completed_at)
@@ -728,12 +736,12 @@ impl Repositories {
         .bind(completed_at)
         .execute(&self.pool)
         .await?;
-        sqlx::query("UPDATE agent_tasks SET updated_at = ? WHERE id = ?")
+        query("UPDATE agent_tasks SET updated_at = ? WHERE id = ?")
             .bind(&now)
             .bind(task_id)
             .execute(&self.pool)
             .await?;
-        let row = sqlx::query(
+        let row = query(
             "SELECT id, task_id, tool_name, status, summary, arguments_json, result_json,
                     redacted, created_at, completed_at
              FROM agent_tool_events
@@ -748,8 +756,8 @@ impl Repositories {
     pub async fn agent_tool_events(
         &self,
         task_id: &str,
-    ) -> Result<Vec<AgentToolEventDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    ) -> Result<Vec<AgentToolEventDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, task_id, tool_name, status, summary, arguments_json, result_json,
                     redacted, created_at, completed_at
              FROM agent_tool_events
@@ -762,8 +770,11 @@ impl Repositories {
         Ok(rows.into_iter().map(agent_tool_event_from_row).collect())
     }
 
-    async fn agent_messages(&self, task_id: &str) -> Result<Vec<AgentMessageDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    async fn agent_messages(
+        &self,
+        task_id: &str,
+    ) -> Result<Vec<AgentMessageDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, task_id, role, content, created_at
              FROM agent_messages
              WHERE task_id = ?
@@ -775,8 +786,8 @@ impl Repositories {
         Ok(rows.into_iter().map(agent_message_from_row).collect())
     }
 
-    pub async fn delete_dictation_history_item(&self, id: &str) -> Result<(), sqlx::Error> {
-        sqlx::query("DELETE FROM dictation_history WHERE id = ?")
+    pub async fn delete_dictation_history_item(&self, id: &str) -> Result<(), sqlx::error::Error> {
+        query("DELETE FROM dictation_history WHERE id = ?")
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -786,7 +797,7 @@ impl Repositories {
     pub async fn create_dictionary_entry(
         &self,
         phrase: &str,
-    ) -> Result<DictionaryEntryDto, sqlx::Error> {
+    ) -> Result<DictionaryEntryDto, sqlx::error::Error> {
         let now = timestamp();
         let entry = DictionaryEntryDto {
             id: Uuid::new_v4().to_string(),
@@ -794,7 +805,7 @@ impl Repositories {
             created_at: now.clone(),
             updated_at: now,
         };
-        sqlx::query(
+        query(
             "INSERT INTO dictionary_entries (id, phrase, created_at, updated_at)
              VALUES (?, ?, ?, ?)",
         )
@@ -813,7 +824,7 @@ impl Repositories {
         phrase: &str,
     ) -> Result<DictionaryEntryDto, AppError> {
         let now = timestamp();
-        let result = sqlx::query(
+        let result = query(
             "UPDATE dictionary_entries
              SET phrase = ?, updated_at = ?
              WHERE id = ? AND deleted_at IS NULL",
@@ -829,7 +840,7 @@ impl Repositories {
                 "Dictionary entry was not found.",
             ));
         }
-        let row = sqlx::query(
+        let row = query(
             "SELECT id, phrase, created_at, updated_at
              FROM dictionary_entries
              WHERE id = ? AND deleted_at IS NULL",
@@ -842,7 +853,7 @@ impl Repositories {
 
     pub async fn delete_dictionary_entry(&self, entry_id: &str) -> Result<(), AppError> {
         let now = timestamp();
-        let result = sqlx::query(
+        let result = query(
             "UPDATE dictionary_entries SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
         )
         .bind(&now)
@@ -865,7 +876,7 @@ impl Repositories {
         title: Option<String>,
         edited_content: Option<String>,
         active_tab: Option<String>,
-    ) -> Result<NoteDto, sqlx::Error> {
+    ) -> Result<NoteDto, sqlx::error::Error> {
         let current = self.get_note(note_id).await?;
         let next_title = title.unwrap_or(current.title);
         let next_content = edited_content.or(current.edited_content);
@@ -873,7 +884,7 @@ impl Repositories {
             .or(current.active_tab)
             .unwrap_or_else(|| "notes".to_string());
 
-        sqlx::query(
+        query(
             "UPDATE notes SET title = ?, edited_content = ?, active_tab = ?, updated_at = ? WHERE id = ?",
         )
         .bind(next_title)
@@ -890,8 +901,8 @@ impl Repositories {
     pub async fn audio_artifact_paths_for_note(
         &self,
         note_id: &str,
-    ) -> Result<Vec<String>, sqlx::Error> {
-        let rows = sqlx::query("SELECT path FROM audio_artifacts WHERE note_id = ?")
+    ) -> Result<Vec<String>, sqlx::error::Error> {
+        let rows = query("SELECT path FROM audio_artifacts WHERE note_id = ?")
             .bind(note_id)
             .fetch_all(&self.pool)
             .await?;
@@ -901,7 +912,7 @@ impl Repositories {
     pub async fn audio_artifact_paths_for_notes(
         &self,
         note_ids: &[String],
-    ) -> Result<Vec<String>, sqlx::Error> {
+    ) -> Result<Vec<String>, sqlx::error::Error> {
         let mut paths = Vec::new();
         for note_id in note_ids {
             paths.extend(self.audio_artifact_paths_for_note(note_id).await?);
@@ -909,13 +920,13 @@ impl Repositories {
         Ok(paths)
     }
 
-    pub async fn delete_note(&self, note_id: &str) -> Result<(), sqlx::Error> {
+    pub async fn delete_note(&self, note_id: &str) -> Result<(), sqlx::error::Error> {
         let mut tx = self.pool.begin().await?;
         delete_note_records(&mut tx, note_id).await?;
         tx.commit().await
     }
 
-    pub async fn delete_notes(&self, note_ids: &[String]) -> Result<(), sqlx::Error> {
+    pub async fn delete_notes(&self, note_ids: &[String]) -> Result<(), sqlx::error::Error> {
         let mut tx = self.pool.begin().await?;
         for note_id in note_ids {
             delete_note_records(&mut tx, note_id).await?;
@@ -927,40 +938,40 @@ impl Repositories {
         &self,
         folder_id: &str,
         delete_notes: bool,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::error::Error> {
         let now = timestamp();
         let mut tx = self.pool.begin().await?;
 
         if delete_notes {
-            sqlx::query(
+            query(
                 "DELETE FROM note_generation_blocks
                  WHERE note_id IN (SELECT note_id FROM note_folders WHERE folder_id = ?)",
             )
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
+            query(
                 "DELETE FROM generation_results
                  WHERE note_id IN (SELECT note_id FROM note_folders WHERE folder_id = ?)",
             )
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
+            query(
                 "DELETE FROM transcripts
                  WHERE note_id IN (SELECT note_id FROM note_folders WHERE folder_id = ?)",
             )
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
+            query(
                 "DELETE FROM audio_artifacts
                  WHERE note_id IN (SELECT note_id FROM note_folders WHERE folder_id = ?)",
             )
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
+            query(
                 "DELETE FROM recording_checkpoints
                  WHERE recording_session_id IN (
                    SELECT rs.id
@@ -972,14 +983,14 @@ impl Repositories {
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
+            query(
                 "DELETE FROM recording_sessions
                  WHERE note_id IN (SELECT note_id FROM note_folders WHERE folder_id = ?)",
             )
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-            sqlx::query(
+            query(
                 "DELETE FROM notes
                  WHERE id IN (SELECT note_id FROM note_folders WHERE folder_id = ?)",
             )
@@ -988,15 +999,15 @@ impl Repositories {
             .await?;
         }
 
-        sqlx::query("DELETE FROM note_folders WHERE folder_id = ?")
+        query("DELETE FROM note_folders WHERE folder_id = ?")
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-        sqlx::query("DELETE FROM session_folders WHERE folder_id = ?")
+        query("DELETE FROM session_folders WHERE folder_id = ?")
             .bind(folder_id)
             .execute(&mut *tx)
             .await?;
-        sqlx::query("UPDATE folders SET deleted_at = ?, updated_at = ? WHERE id = ?")
+        query("UPDATE folders SET deleted_at = ?, updated_at = ? WHERE id = ?")
             .bind(&now)
             .bind(&now)
             .bind(folder_id)
@@ -1011,8 +1022,8 @@ impl Repositories {
         note_id: &str,
         status: ProcessingStatus,
         last_error: Option<String>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "UPDATE notes SET processing_status = ?, last_error = ?, updated_at = ? WHERE id = ?",
         )
         .bind(status.as_db())
@@ -1029,7 +1040,7 @@ impl Repositories {
         note_id: &str,
         title: Option<String>,
         content: String,
-    ) -> Result<NoteDto, sqlx::Error> {
+    ) -> Result<NoteDto, sqlx::error::Error> {
         self.set_generated_note_for_session(note_id, None, None, title, content)
             .await
     }
@@ -1041,7 +1052,7 @@ impl Repositories {
         generation_result_id: Option<&str>,
         title: Option<String>,
         content: String,
-    ) -> Result<NoteDto, sqlx::Error> {
+    ) -> Result<NoteDto, sqlx::error::Error> {
         let current = self.get_note(note_id).await?;
         let title = if is_replaceable_generated_title(&current.title) {
             usable_generated_title(title.as_deref())
@@ -1114,7 +1125,7 @@ impl Repositories {
                 append_note_content(Some(edited_content), content)
             }
         });
-        sqlx::query(
+        query(
             "UPDATE notes SET title = ?, generated_content = ?, edited_content = ?, active_tab = 'notes', processing_status = 'ready', last_error = NULL, updated_at = ? WHERE id = ?",
         )
         .bind(title)
@@ -1131,8 +1142,8 @@ impl Repositories {
         &self,
         note_id: &str,
         recording_session_id: &str,
-    ) -> Result<bool, sqlx::Error> {
-        let row = sqlx::query(
+    ) -> Result<bool, sqlx::error::Error> {
+        let row = query(
             "SELECT 1 FROM note_generation_blocks WHERE note_id = ? AND recording_session_id = ? LIMIT 1",
         )
         .bind(note_id)
@@ -1142,12 +1153,11 @@ impl Repositories {
         Ok(row.is_some())
     }
 
-    async fn generation_block_count(&self, note_id: &str) -> Result<i64, sqlx::Error> {
-        let row =
-            sqlx::query("SELECT COUNT(*) AS count FROM note_generation_blocks WHERE note_id = ?")
-                .bind(note_id)
-                .fetch_one(&self.pool)
-                .await?;
+    async fn generation_block_count(&self, note_id: &str) -> Result<i64, sqlx::error::Error> {
+        let row = query("SELECT COUNT(*) AS count FROM note_generation_blocks WHERE note_id = ?")
+            .bind(note_id)
+            .fetch_one(&self.pool)
+            .await?;
         Ok(row.get("count"))
     }
 
@@ -1156,12 +1166,12 @@ impl Repositories {
         note_id: &str,
         content: Option<&str>,
         title_suggestion: Option<&str>,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::error::Error> {
         let Some(content) = content.map(str::trim).filter(|value| !value.is_empty()) else {
             return Ok(());
         };
         let now = timestamp();
-        sqlx::query(
+        query(
             "INSERT INTO note_generation_blocks
              (id, note_id, recording_session_id, generation_result_id, content, title_suggestion, sort_order, created_at, updated_at)
              VALUES (?, ?, NULL, NULL, ?, ?, 0, ?, ?)",
@@ -1184,9 +1194,9 @@ impl Repositories {
         generation_result_id: Option<&str>,
         title_suggestion: Option<&str>,
         content: &str,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::error::Error> {
         let now = timestamp();
-        if let Some(row) = sqlx::query(
+        if let Some(row) = query(
             "SELECT id FROM note_generation_blocks WHERE note_id = ? AND recording_session_id = ? LIMIT 1",
         )
         .bind(note_id)
@@ -1195,7 +1205,7 @@ impl Repositories {
         .await?
         {
             let id: String = row.get("id");
-            sqlx::query(
+            query(
                 "UPDATE note_generation_blocks
                  SET generation_result_id = ?, content = ?, title_suggestion = ?, updated_at = ?
                  WHERE id = ?",
@@ -1211,7 +1221,7 @@ impl Repositories {
         }
 
         let sort_order = self.next_generation_block_sort_order(note_id).await?;
-        sqlx::query(
+        query(
             "INSERT INTO note_generation_blocks
              (id, note_id, recording_session_id, generation_result_id, content, title_suggestion, sort_order, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -1230,8 +1240,11 @@ impl Repositories {
         Ok(())
     }
 
-    async fn next_generation_block_sort_order(&self, note_id: &str) -> Result<i64, sqlx::Error> {
-        let row = sqlx::query(
+    async fn next_generation_block_sort_order(
+        &self,
+        note_id: &str,
+    ) -> Result<i64, sqlx::error::Error> {
+        let row = query(
             "SELECT COALESCE(MAX(sort_order), -1) + 1 AS next_order
              FROM note_generation_blocks
              WHERE note_id = ?",
@@ -1245,8 +1258,8 @@ impl Repositories {
     async fn compose_generation_blocks(
         &self,
         note_id: &str,
-    ) -> Result<Option<String>, sqlx::Error> {
-        let rows = sqlx::query(
+    ) -> Result<Option<String>, sqlx::error::Error> {
+        let rows = query(
             "SELECT content
              FROM note_generation_blocks
              WHERE note_id = ?
@@ -1275,8 +1288,8 @@ impl Repositories {
         partial_path: &str,
         final_path: &str,
         device_label: Option<String>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "INSERT INTO recording_sessions (id, note_id, source_mode, status, started_at, expected_elapsed_ms, device_label, permission_state, partial_path, final_path)
              VALUES (?, ?, ?, 'recording', ?, 0, ?, 'granted', ?, ?)",
         )
@@ -1297,8 +1310,8 @@ impl Repositories {
     pub async fn recording_session_source_mode(
         &self,
         session_id: &str,
-    ) -> Result<Option<RecordingSourceMode>, sqlx::Error> {
-        let row = sqlx::query("SELECT source_mode FROM recording_sessions WHERE id = ?")
+    ) -> Result<Option<RecordingSourceMode>, sqlx::error::Error> {
+        let row = query("SELECT source_mode FROM recording_sessions WHERE id = ?")
             .bind(session_id)
             .fetch_optional(&self.pool)
             .await?;
@@ -1318,8 +1331,8 @@ impl Repositories {
         rms_amplitude: Option<f32>,
         validation_summary: Option<String>,
         last_error: Option<String>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "UPDATE recording_sessions
              SET status = ?, expected_elapsed_ms = ?, file_size_bytes = ?, duration_ms = ?, checksum = ?,
                  peak_amplitude = ?, rms_amplitude = ?, validation_summary = ?, last_error = ?,
@@ -1348,10 +1361,10 @@ impl Repositories {
         session_id: &str,
         state: RecordingState,
         elapsed_ms: i64,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::error::Error> {
         let status = state.as_db();
         let mut tx = self.pool.begin().await?;
-        sqlx::query(
+        query(
             "UPDATE recording_sessions
              SET status = ?, expected_elapsed_ms = max(expected_elapsed_ms, ?)
              WHERE id = ?
@@ -1362,7 +1375,7 @@ impl Repositories {
         .bind(session_id)
         .execute(&mut *tx)
         .await?;
-        sqlx::query(
+        query(
             "UPDATE audio_artifacts
              SET status = ?, expected_duration_ms = max(expected_duration_ms, ?)
              WHERE recording_session_id = ?
@@ -1380,11 +1393,11 @@ impl Repositories {
         &self,
         session_id: &str,
         note_id: &str,
-    ) -> Result<(), sqlx::Error> {
+    ) -> Result<(), sqlx::error::Error> {
         let now = timestamp();
         let message = "Recording interrupted before it could be finished.";
         let mut tx = self.pool.begin().await?;
-        sqlx::query(
+        query(
             "UPDATE recording_sessions
              SET status = 'recoverable',
                  last_error = COALESCE(last_error, ?),
@@ -1406,7 +1419,7 @@ impl Repositories {
         .bind(session_id)
         .execute(&mut *tx)
         .await?;
-        sqlx::query(
+        query(
             "UPDATE audio_artifacts
              SET status = 'recoverable',
                  last_error = COALESCE(last_error, ?)
@@ -1426,7 +1439,7 @@ impl Repositories {
         .bind(session_id)
         .execute(&mut *tx)
         .await?;
-        sqlx::query(
+        query(
             "UPDATE notes
              SET processing_status = ?,
                  last_error = ?,
@@ -1442,8 +1455,11 @@ impl Repositories {
         tx.commit().await
     }
 
-    pub async fn mark_recording_recovery_valid(&self, session_id: &str) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    pub async fn mark_recording_recovery_valid(
+        &self,
+        session_id: &str,
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "UPDATE recording_sessions
              SET status = 'valid',
                  last_error = NULL,
@@ -1463,8 +1479,8 @@ impl Repositories {
         session_id: &str,
         kind: &str,
         details: Option<String>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "INSERT INTO recording_checkpoints (id, recording_session_id, kind, created_at, details) VALUES (?, ?, ?, ?, ?)",
         )
         .bind(Uuid::new_v4().to_string())
@@ -1484,8 +1500,8 @@ impl Repositories {
         source: Option<&str>,
         kind: &str,
         details: Option<String>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "INSERT INTO recording_checkpoints (id, recording_session_id, source_artifact_id, source, kind, created_at, details)
              VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
@@ -1508,7 +1524,7 @@ impl Repositories {
         source: &str,
         partial_path: &str,
         final_path: &str,
-    ) -> Result<AudioArtifactDto, sqlx::Error> {
+    ) -> Result<AudioArtifactDto, sqlx::error::Error> {
         let artifact = AudioArtifactDto {
             id: Uuid::new_v4().to_string(),
             source: source.to_string(),
@@ -1518,7 +1534,7 @@ impl Repositories {
             checksum: String::new(),
             created_at: timestamp(),
         };
-        sqlx::query(
+        query(
             "INSERT INTO audio_artifacts
              (id, note_id, recording_session_id, source, partial_path, path, format, duration_ms, size_bytes, checksum, status, expected_duration_ms, created_at)
              VALUES (?, ?, ?, ?, ?, ?, 'wav', 0, 0, '', 'recording', 0, ?)",
@@ -1538,8 +1554,8 @@ impl Repositories {
     pub async fn source_artifacts_for_session(
         &self,
         session_id: &str,
-    ) -> Result<Vec<AudioArtifactDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    ) -> Result<Vec<AudioArtifactDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
              FROM audio_artifacts
              WHERE recording_session_id = ?
@@ -1565,8 +1581,8 @@ impl Repositories {
     pub async fn source_artifact_paths_for_session(
         &self,
         session_id: &str,
-    ) -> Result<Vec<SourceArtifactPath>, sqlx::Error> {
-        let rows = sqlx::query(
+    ) -> Result<Vec<SourceArtifactPath>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, note_id, source, partial_path, path, expected_duration_ms
              FROM audio_artifacts
              WHERE recording_session_id = ?
@@ -1600,8 +1616,8 @@ impl Repositories {
         expected_duration_ms: i64,
         validation_summary: Option<String>,
         last_error: Option<String>,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
+    ) -> Result<(), sqlx::error::Error> {
+        query(
             "UPDATE audio_artifacts
              SET path = ?, status = ?, duration_ms = ?, size_bytes = ?, checksum = ?, expected_duration_ms = ?,
                  validation_summary = ?, last_error = ?
@@ -1629,7 +1645,7 @@ impl Repositories {
         duration_ms: i64,
         size_bytes: i64,
         checksum: &str,
-    ) -> Result<AudioArtifactDto, sqlx::Error> {
+    ) -> Result<AudioArtifactDto, sqlx::error::Error> {
         let artifact = AudioArtifactDto {
             id: Uuid::new_v4().to_string(),
             source: "microphone".to_string(),
@@ -1639,7 +1655,7 @@ impl Repositories {
             checksum: checksum.to_string(),
             created_at: timestamp(),
         };
-        sqlx::query(
+        query(
             "INSERT INTO audio_artifacts (id, note_id, recording_session_id, source, path, format, duration_ms, size_bytes, checksum, status, expected_duration_ms, created_at)
              VALUES (?, ?, ?, 'microphone', ?, 'wav', ?, ?, ?, 'valid', ?, ?)",
         )
@@ -1660,8 +1676,8 @@ impl Repositories {
     pub async fn latest_audio_artifact_path(
         &self,
         note_id: &str,
-    ) -> Result<Option<(String, String)>, sqlx::Error> {
-        let row = sqlx::query(
+    ) -> Result<Option<(String, String)>, sqlx::error::Error> {
+        let row = query(
             "SELECT id, path FROM audio_artifacts WHERE note_id = ? AND status = 'valid' ORDER BY created_at DESC LIMIT 1",
         )
         .bind(note_id)
@@ -1673,8 +1689,8 @@ impl Repositories {
     async fn latest_audio_artifact(
         &self,
         note_id: &str,
-    ) -> Result<Option<AudioArtifactDto>, sqlx::Error> {
-        let row = sqlx::query(
+    ) -> Result<Option<AudioArtifactDto>, sqlx::error::Error> {
+        let row = query(
             "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
              FROM audio_artifacts
              WHERE note_id = ? AND status = 'valid'
@@ -1698,8 +1714,8 @@ impl Repositories {
     pub async fn latest_valid_audio_artifact_paths(
         &self,
         note_id: &str,
-    ) -> Result<Vec<(String, String, String, String)>, sqlx::Error> {
-        let session = sqlx::query(
+    ) -> Result<Vec<(String, String, String, String)>, sqlx::error::Error> {
+        let session = query(
             "SELECT recording_session_id
              FROM audio_artifacts
              WHERE note_id = ? AND status = 'valid'
@@ -1713,7 +1729,7 @@ impl Repositories {
             return Ok(Vec::new());
         };
         let session_id: String = session.get("recording_session_id");
-        let rows = sqlx::query(
+        let rows = query(
             "SELECT id, source, path, recording_session_id
              FROM audio_artifacts
              WHERE note_id = ? AND recording_session_id = ? AND status = 'valid'
@@ -1739,8 +1755,8 @@ impl Repositories {
     async fn latest_audio_sources(
         &self,
         note_id: &str,
-    ) -> Result<Vec<AudioArtifactDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    ) -> Result<Vec<AudioArtifactDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
              FROM audio_artifacts
              WHERE note_id = ? AND status = 'valid'
@@ -1763,8 +1779,11 @@ impl Repositories {
             .collect())
     }
 
-    async fn latest_transcript(&self, note_id: &str) -> Result<Option<TranscriptDto>, sqlx::Error> {
-        let row = sqlx::query(
+    async fn latest_transcript(
+        &self,
+        note_id: &str,
+    ) -> Result<Option<TranscriptDto>, sqlx::error::Error> {
+        let row = query(
             "SELECT id, text, source_mode, source, start_ms, end_ms, turn_index, language, status, last_error
              FROM transcripts
              WHERE note_id = ?
@@ -1790,8 +1809,11 @@ impl Repositories {
         }))
     }
 
-    async fn source_transcripts(&self, note_id: &str) -> Result<Vec<TranscriptDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    async fn source_transcripts(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<TranscriptDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT t.id, t.text, t.source_mode, t.source, t.start_ms, t.end_ms, t.turn_index, t.language, t.status, t.last_error
              FROM transcripts t
              LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
@@ -1830,8 +1852,8 @@ impl Repositories {
     pub async fn successful_source_turn_transcripts_for_session(
         &self,
         session_id: &str,
-    ) -> Result<Vec<TranscriptDto>, sqlx::Error> {
-        let rows = sqlx::query(
+    ) -> Result<Vec<TranscriptDto>, sqlx::error::Error> {
+        let rows = query(
             "SELECT id, text, source_mode, source, start_ms, end_ms, turn_index, language, status, last_error
              FROM transcripts
              WHERE recording_session_id = ?
@@ -1869,7 +1891,7 @@ impl Repositories {
         text: &str,
         language: Option<String>,
         provider: &str,
-    ) -> Result<TranscriptDto, sqlx::Error> {
+    ) -> Result<TranscriptDto, sqlx::error::Error> {
         let transcript = TranscriptDto {
             id: Uuid::new_v4().to_string(),
             text: text.to_string(),
@@ -1883,7 +1905,7 @@ impl Repositories {
             last_error: None,
         };
         let now = timestamp();
-        sqlx::query(
+        query(
             "INSERT INTO transcripts (id, note_id, audio_artifact_id, source_artifact_id, source, source_mode, text, language, provider, status, retry_count, created_at, updated_at)
              VALUES (?, ?, ?, ?, 'microphone', 'microphone_only', ?, ?, ?, 'succeeded', 0, ?, ?)",
         )
@@ -1915,7 +1937,7 @@ impl Repositories {
         start_ms: Option<i64>,
         end_ms: Option<i64>,
         turn_index: Option<i64>,
-    ) -> Result<TranscriptDto, sqlx::Error> {
+    ) -> Result<TranscriptDto, sqlx::error::Error> {
         let transcript = TranscriptDto {
             id: Uuid::new_v4().to_string(),
             text: text.to_string(),
@@ -1929,7 +1951,7 @@ impl Repositories {
             last_error: None,
         };
         let now = timestamp();
-        sqlx::query(
+        query(
             "INSERT INTO transcripts
              (id, note_id, recording_session_id, audio_artifact_id, source_artifact_id, source, source_mode, text, start_ms, end_ms, turn_index, language, provider, status, retry_count, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'succeeded', 0, ?, ?)",
@@ -1968,9 +1990,9 @@ impl Repositories {
         start_ms: i64,
         end_ms: i64,
         turn_index: i64,
-    ) -> Result<TranscriptDto, sqlx::Error> {
+    ) -> Result<TranscriptDto, sqlx::error::Error> {
         let now = timestamp();
-        let row = sqlx::query(
+        let row = query(
             "INSERT INTO transcripts
              (id, note_id, recording_session_id, audio_artifact_id, source_artifact_id, source, source_mode, text, start_ms, end_ms, turn_index, language, provider, status, retry_count, last_error, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'succeeded', 0, NULL, ?, ?)
@@ -2035,7 +2057,7 @@ impl Repositories {
         start_ms: Option<i64>,
         end_ms: Option<i64>,
         turn_index: Option<i64>,
-    ) -> Result<TranscriptDto, sqlx::Error> {
+    ) -> Result<TranscriptDto, sqlx::error::Error> {
         let transcript = TranscriptDto {
             id: Uuid::new_v4().to_string(),
             text: String::new(),
@@ -2049,7 +2071,7 @@ impl Repositories {
             last_error: Some(last_error.to_string()),
         };
         let now = timestamp();
-        sqlx::query(
+        query(
             "INSERT INTO transcripts
              (id, note_id, recording_session_id, audio_artifact_id, source_artifact_id, source, source_mode, text, start_ms, end_ms, turn_index, language, provider, status, retry_count, last_error, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, NULL, ?, 'failed', 0, ?, ?, ?)",
@@ -2086,9 +2108,9 @@ impl Repositories {
         start_ms: i64,
         end_ms: i64,
         turn_index: i64,
-    ) -> Result<TranscriptDto, sqlx::Error> {
+    ) -> Result<TranscriptDto, sqlx::error::Error> {
         let now = timestamp();
-        let row = sqlx::query(
+        let row = query(
             "INSERT INTO transcripts
              (id, note_id, recording_session_id, audio_artifact_id, source_artifact_id, source, source_mode, text, start_ms, end_ms, turn_index, language, provider, status, retry_count, last_error, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, ?, ?, NULL, ?, 'failed', 0, ?, ?, ?)
@@ -2147,10 +2169,10 @@ impl Repositories {
         title_suggestion: Option<String>,
         provider: &str,
         prompt_version: &str,
-    ) -> Result<String, sqlx::Error> {
+    ) -> Result<String, sqlx::error::Error> {
         let now = timestamp();
         let id = Uuid::new_v4().to_string();
-        sqlx::query(
+        query(
             "INSERT INTO generation_results (id, note_id, transcript_id, content, title_suggestion, provider, prompt_version, status, retry_count, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, 'succeeded', 0, ?, ?)",
         )
@@ -2171,8 +2193,8 @@ impl Repositories {
     pub async fn recording_recovery_info(
         &self,
         session_id: &str,
-    ) -> Result<Option<RecordingRecoveryInfo>, sqlx::Error> {
-        let row = sqlx::query(
+    ) -> Result<Option<RecordingRecoveryInfo>, sqlx::error::Error> {
+        let row = query(
             "SELECT id, note_id, source_mode, partial_path, final_path, expected_elapsed_ms
              FROM recording_sessions
              WHERE id = ?",
@@ -2194,12 +2216,12 @@ impl Repositories {
         &self,
         session_id: &str,
         note_id: &str,
-    ) -> Result<NoteDto, sqlx::Error> {
-        sqlx::query("UPDATE recording_sessions SET status = 'failed', last_error = 'Discarded by user' WHERE id = ?")
+    ) -> Result<NoteDto, sqlx::error::Error> {
+        query("UPDATE recording_sessions SET status = 'failed', last_error = 'Discarded by user' WHERE id = ?")
             .bind(session_id)
             .execute(&self.pool)
             .await?;
-        sqlx::query(
+        query(
             "UPDATE audio_artifacts
              SET status = 'discarded', last_error = 'Discarded by user'
              WHERE recording_session_id = ?",
@@ -2216,8 +2238,8 @@ impl Repositories {
         self.get_note(note_id).await
     }
 
-    async fn folder_ids(&self, note_id: &str) -> Result<Vec<String>, sqlx::Error> {
-        let rows = sqlx::query(
+    async fn folder_ids(&self, note_id: &str) -> Result<Vec<String>, sqlx::error::Error> {
+        let rows = query(
             "SELECT nf.folder_id
              FROM note_folders nf
              INNER JOIN folders f ON f.id = nf.folder_id
@@ -2232,41 +2254,41 @@ impl Repositories {
 }
 
 async fn delete_note_records(
-    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    tx: &mut sqlx::transaction::Transaction<'_, sqlx_sqlite::Sqlite>,
     note_id: &str,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("DELETE FROM note_generation_blocks WHERE note_id = ?")
+) -> Result<(), sqlx::error::Error> {
+    query("DELETE FROM note_generation_blocks WHERE note_id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
-    sqlx::query("DELETE FROM generation_results WHERE note_id = ?")
+    query("DELETE FROM generation_results WHERE note_id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
-    sqlx::query("DELETE FROM transcripts WHERE note_id = ?")
+    query("DELETE FROM transcripts WHERE note_id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
-    sqlx::query("DELETE FROM audio_artifacts WHERE note_id = ?")
+    query("DELETE FROM audio_artifacts WHERE note_id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
-    sqlx::query(
+    query(
         "DELETE FROM recording_checkpoints
          WHERE recording_session_id IN (SELECT id FROM recording_sessions WHERE note_id = ?)",
     )
     .bind(note_id)
     .execute(&mut **tx)
     .await?;
-    sqlx::query("DELETE FROM recording_sessions WHERE note_id = ?")
+    query("DELETE FROM recording_sessions WHERE note_id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
-    sqlx::query("DELETE FROM note_folders WHERE note_id = ?")
+    query("DELETE FROM note_folders WHERE note_id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
-    sqlx::query("DELETE FROM notes WHERE id = ?")
+    query("DELETE FROM notes WHERE id = ?")
         .bind(note_id)
         .execute(&mut **tx)
         .await?;
@@ -2558,7 +2580,7 @@ pub fn timestamp() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
 }
 
-fn folder_from_row(row: sqlx::sqlite::SqliteRow) -> FolderDto {
+fn folder_from_row(row: sqlx_sqlite::SqliteRow) -> FolderDto {
     FolderDto {
         id: row.get("id"),
         name: row.get("name"),
@@ -2578,7 +2600,7 @@ fn folder_from_row(row: sqlx::sqlite::SqliteRow) -> FolderDto {
     }
 }
 
-fn dictionary_entry_from_row(row: sqlx::sqlite::SqliteRow) -> DictionaryEntryDto {
+fn dictionary_entry_from_row(row: sqlx_sqlite::SqliteRow) -> DictionaryEntryDto {
     DictionaryEntryDto {
         id: row.get("id"),
         phrase: row.get("phrase"),
@@ -2587,7 +2609,7 @@ fn dictionary_entry_from_row(row: sqlx::sqlite::SqliteRow) -> DictionaryEntryDto
     }
 }
 
-fn dictation_history_item_from_row(row: sqlx::sqlite::SqliteRow) -> DictationHistoryItemDto {
+fn dictation_history_item_from_row(row: sqlx_sqlite::SqliteRow) -> DictationHistoryItemDto {
     DictationHistoryItemDto {
         id: row.get("id"),
         text: row.get("text"),
@@ -2597,7 +2619,7 @@ fn dictation_history_item_from_row(row: sqlx::sqlite::SqliteRow) -> DictationHis
     }
 }
 
-fn agent_task_from_row(row: sqlx::sqlite::SqliteRow) -> AgentTaskDto {
+fn agent_task_from_row(row: sqlx_sqlite::SqliteRow) -> AgentTaskDto {
     AgentTaskDto {
         id: row.get("id"),
         title: row.get("title"),
@@ -2615,7 +2637,7 @@ fn agent_task_from_row(row: sqlx::sqlite::SqliteRow) -> AgentTaskDto {
     }
 }
 
-fn agent_message_from_row(row: sqlx::sqlite::SqliteRow) -> AgentMessageDto {
+fn agent_message_from_row(row: sqlx_sqlite::SqliteRow) -> AgentMessageDto {
     AgentMessageDto {
         id: row.get("id"),
         task_id: row.get("task_id"),
@@ -2625,7 +2647,7 @@ fn agent_message_from_row(row: sqlx::sqlite::SqliteRow) -> AgentMessageDto {
     }
 }
 
-fn agent_tool_event_from_row(row: sqlx::sqlite::SqliteRow) -> AgentToolEventDto {
+fn agent_tool_event_from_row(row: sqlx_sqlite::SqliteRow) -> AgentToolEventDto {
     AgentToolEventDto {
         id: row.get("id"),
         task_id: row.get("task_id"),

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -19,8 +19,8 @@ impl AppError {
     }
 }
 
-impl From<sqlx::Error> for AppError {
-    fn from(value: sqlx::Error) -> Self {
+impl From<sqlx::error::Error> for AppError {
+    fn from(value: sqlx::error::Error) -> Self {
         Self::new("storage_unavailable", value.to_string())
     }
 }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -1368,6 +1368,11 @@ async fn store_tokens(pair: &TokenPair) -> Result<(), AppError> {
     if use_dev_plaintext_token_store() {
         return store_dev_plaintext_tokens(json).await;
     }
+    store_platform_tokens(json).await
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+async fn store_platform_tokens(json: String) -> Result<(), AppError> {
     tokio::task::spawn_blocking(move || {
         keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_USER)
             .and_then(|entry| entry.set_password(&json))
@@ -1377,11 +1382,24 @@ async fn store_tokens(pair: &TokenPair) -> Result<(), AppError> {
     .map_err(|e| AppError::new("keychain_write_failed", e.to_string()))
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+async fn store_platform_tokens(_json: String) -> Result<(), AppError> {
+    Err(AppError::new(
+        "secure_token_storage_unavailable",
+        "Secure token storage is only available on macOS and Windows.",
+    ))
+}
+
 async fn load_tokens() -> Option<TokenPair> {
     #[cfg(debug_assertions)]
     if use_dev_plaintext_token_store() {
         return load_dev_plaintext_tokens().await;
     }
+    load_platform_tokens().await
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+async fn load_platform_tokens() -> Option<TokenPair> {
     let raw = tokio::task::spawn_blocking(|| {
         keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_USER)
             .ok()
@@ -1390,6 +1408,11 @@ async fn load_tokens() -> Option<TokenPair> {
     .await
     .ok()??;
     serde_json::from_str(&raw).ok()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+async fn load_platform_tokens() -> Option<TokenPair> {
+    None
 }
 
 async fn clear_tokens() {
@@ -1401,6 +1424,11 @@ async fn clear_tokens() {
         .await;
         return;
     }
+    clear_platform_tokens().await;
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+async fn clear_platform_tokens() {
     let _ = tokio::task::spawn_blocking(|| {
         if let Ok(entry) = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_USER) {
             let _ = entry.delete_credential();
@@ -1408,6 +1436,9 @@ async fn clear_tokens() {
     })
     .await;
 }
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+async fn clear_platform_tokens() {}
 
 #[cfg(debug_assertions)]
 fn use_dev_plaintext_token_store() -> bool {

--- a/src-tauri/tests/agent.rs
+++ b/src-tauri/tests/agent.rs
@@ -2,7 +2,7 @@ use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::{AgentMessageRole, AgentSafetyProfile, AgentTaskStatus, AgentToolEventStatus},
 };
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx_sqlite::SqlitePoolOptions;
 
 async fn test_repositories() -> Repositories {
     let pool = SqlitePoolOptions::new()

--- a/src-tauri/tests/dictionary.rs
+++ b/src-tauri/tests/dictionary.rs
@@ -1,6 +1,7 @@
 use chrono::{Duration, SecondsFormat, Utc};
 use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::query::query;
+use sqlx_sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {
     let pool = SqlitePoolOptions::new()
@@ -18,7 +19,7 @@ async fn dictation_history_keeps_recent_items_and_prunes_old_items() {
     let old_created_at =
         (Utc::now() - Duration::days(8)).to_rfc3339_opts(SecondsFormat::Millis, true);
 
-    sqlx::query(
+    query(
         "INSERT INTO dictation_history (id, text, language, provider, created_at)
          VALUES ('old', 'Old dictation', NULL, 'openai', ?)",
     )

--- a/src-tauri/tests/folders.rs
+++ b/src-tauri/tests/folders.rs
@@ -1,5 +1,5 @@
 use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx_sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {
     let pool = SqlitePoolOptions::new()

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -2,7 +2,7 @@ use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::{ProcessingStatus, RecordingSourceMode},
 };
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx_sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {
     let pool = SqlitePoolOptions::new()

--- a/src-tauri/tests/recovery.rs
+++ b/src-tauri/tests/recovery.rs
@@ -3,7 +3,8 @@ use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::{ProcessingStatus, RecordingSourceMode, RecordingState},
 };
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::query_scalar::query_scalar;
+use sqlx_sqlite::SqlitePoolOptions;
 use tempfile::tempdir;
 
 async fn repos() -> Repositories {
@@ -88,7 +89,7 @@ async fn recovery_snapshot_persists_elapsed_time_for_session_and_sources() {
         .await
         .expect("artifacts");
     let artifact_status: String =
-        sqlx::query_scalar("SELECT status FROM audio_artifacts WHERE recording_session_id = ?")
+        query_scalar("SELECT status FROM audio_artifacts WHERE recording_session_id = ?")
             .bind("session-1")
             .fetch_one(&repos.pool)
             .await
@@ -129,7 +130,7 @@ async fn boot_recovery_marks_note_recoverable_when_audio_survived() {
     }
     let recovered_note = repos.get_note(&note.id).await.expect("note");
     let recording_status: String =
-        sqlx::query_scalar("SELECT status FROM recording_sessions WHERE id = ?")
+        query_scalar("SELECT status FROM recording_sessions WHERE id = ?")
             .bind("session-1")
             .fetch_one(&repos.pool)
             .await

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -2,7 +2,8 @@ use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::RecordingSourceMode,
 };
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::query::query;
+use sqlx_sqlite::SqlitePoolOptions;
 
 async fn test_repositories() -> Repositories {
     let pool = SqlitePoolOptions::new()
@@ -185,13 +186,13 @@ async fn note_source_transcripts_are_ordered_by_session_then_turn() {
         )
         .await
         .expect("second session should be created");
-    sqlx::query("UPDATE recording_sessions SET started_at = ? WHERE id = ?")
+    query("UPDATE recording_sessions SET started_at = ? WHERE id = ?")
         .bind("2026-05-20T10:00:00.000Z")
         .bind("session-1")
         .execute(&repos.pool)
         .await
         .expect("first session timestamp");
-    sqlx::query("UPDATE recording_sessions SET started_at = ? WHERE id = ?")
+    query("UPDATE recording_sessions SET started_at = ? WHERE id = ?")
         .bind("2026-05-20T10:05:00.000Z")
         .bind("session-2")
         .execute(&repos.pool)

--- a/src-tauri/tests/source_recovery.rs
+++ b/src-tauri/tests/source_recovery.rs
@@ -3,7 +3,7 @@ use os_scribe_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::RecordingSourceMode,
 };
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx_sqlite::SqlitePoolOptions;
 use tempfile::tempdir;
 
 async fn repos() -> Repositories {

--- a/src-tauri/tests/storage.rs
+++ b/src-tauri/tests/storage.rs
@@ -1,5 +1,5 @@
 use os_scribe_lib::db::{migrations::run_migrations, repositories::Repositories};
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx_sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::str::FromStr;
 use tempfile::tempdir;
 


### PR DESCRIPTION
## Summary

- Add open-source hygiene files: SECURITY.md, CODEOWNERS, Dependabot config, PR template, and a GitHub security readiness checklist.
- Pin all third-party GitHub Actions to full-length commit SHAs and add a repository hygiene workflow that rejects unpinned external actions plus committed env/key material.
- Move the desktop app off SQLx's umbrella crate and onto sqlx-core plus sqlx-sqlite so unused MySQL/Postgres macro dependencies, including the RSA advisory path, are removed from src-tauri/Cargo.lock.
- Gate desktop token persistence to macOS and Windows credential stores, with unsupported targets failing closed instead of compiling unrelated secure-storage backends.

## GitHub settings found during audit

These are not fully fixable in a PR, so docs/github-security-readiness.md records them for the admin checklist:

- main is not branch protected.
- Code security, Dependabot alerts/security updates, secret scanning, and secret scanning push protection are disabled.
- Actions currently allows all actions and does not require SHA pinning.
- production and staging environments have no protection rules, and admins can bypass them.
- No GitHub security policy is configured yet.
- Wiki/projects are enabled, and delete branch on merge is disabled.

## Validation

- cargo test --manifest-path src-tauri/Cargo.toml
- cargo audit --file src-tauri/Cargo.lock
- cargo audit --file scribe-api/Cargo.lock
- pnpm audit --audit-level moderate --prod
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- pnpm exec prettier --check ".github/**/*.{yml,yaml,md}" "SECURITY.md" "docs/github-security-readiness.md"
- ruby YAML parse over .github workflow/action/dependabot YAML
- repository hygiene shell checks for pinned actions and committed env/key material
- git diff --check

Note: cargo-audit still prints warning-class advisories for Tauri's Linux GTK/WebKit transitive stack, but exits 0 and reports no vulnerabilities.
