### PR TITLE
Update Hermes upstream to v2026.6.19

### DIFF
--- a/docs/hermes-upstream-v2026.6.19.md
+++ b/docs/hermes-upstream-v2026.6.19.md
@@ -1,0 +1,64 @@
+# Hermes upstream v2026.6.19
+
+## Pin
+
+- Previous June pin: `v2026.6.5`, commit `3c231eb3979ab9c57d5cd6d02f1d577a3b718b43`
+- New June pin: `v2026.6.19`, commit `2bd1977d8fad185c9b4be47884f7e87f1add0ce3`
+- Archive checksum: `7a9bd367066183898831c2760f269368ab54b458a1d1b51d14ef1f484dd490cc`
+- Upstream changelog: `https://github.com/NousResearch/hermes-agent/compare/v2026.6.5...v2026.6.19`
+
+## Compatibility checked
+
+June still starts Hermes through:
+
+```text
+hermes dashboard --no-open --host 127.0.0.1 --port <port>
+```
+
+The upstream dashboard still exposes the API surfaces June consumes:
+
+- `GET /api/sessions`
+- `POST /api/sessions`
+- `GET /api/sessions/{session_id}/messages`
+- `DELETE /api/sessions/{session_id}`
+- `GET /api/skills`
+- `PUT /api/skills/toggle`
+- `GET /api/messaging/platforms`
+- `PUT /api/messaging/platforms/{platform_id}`
+- `GET /api/cron/jobs`
+- `POST /api/cron/jobs`
+- `PUT /api/cron/jobs/{job_id}`
+- `POST /api/cron/jobs/{job_id}/pause`
+- `POST /api/cron/jobs/{job_id}/resume`
+- `POST /api/cron/jobs/{job_id}/trigger`
+- `DELETE /api/cron/jobs/{job_id}`
+- `GET /api/tools/toolsets`
+- `PUT /api/tools/toolsets/{name}`
+- `WS /api/ws`
+
+The upstream installer still leaves bare `$UV_CMD` invocations in a few install stages. June's post-extract patch remains required for app data paths containing spaces, such as `Application Support` on macOS.
+
+## Features included in the runtime update
+
+These capabilities are present in the bundled Hermes runtime after the pin bump. June does not necessarily expose each capability in first-party UI yet.
+
+- Background subagents: `delegate_task(background=true)` can return a handle immediately and let work re-enter the conversation later.
+- Image editing: `image_generate` supports image-to-image and editing flows in addition to text-to-image generation.
+- Memory batch writes: the memory tool supports atomic operation batches through an `operations` array.
+- Messaging expansion: upstream adds Photon Spectrum iMessage support, an official WhatsApp Business Cloud API adapter, richer Telegram Bot API 10.1 messages, and Raft agent network gateway support.
+- Automation Blueprints: upstream adds guided, parameterized routine setup so users do not need to write cron syntax directly.
+- Model and dashboard improvements: upstream adds dashboard profile builder flows, stronger dashboard auth, a composer model selector, xAI Grok Composer model support, Skills Hub browser updates, subagent watch windows, per-thread drafts, resizable terminal improvements, and desktop notification improvements.
+- Reliability and security: upstream includes dashboard auth hardening, fail-closed policy fixes, secret redaction, environment sanitization for cron subprocesses, Windows ConPTY and PowerShell installer fixes, and dependency security bumps.
+- Cost behavior: upstream changes curator defaults to reduce auxiliary model spend for routine background curation unless extra consolidation is explicitly enabled.
+
+## Additional June integration work
+
+No required app code migration was found for the existing June agent, skills, messaging settings, session list, or routines flows. The following upstream features need explicit June product integration before users can rely on them from June UI:
+
+- Expose Photon iMessage only after adding setup UI for `hermes photon login`, device-code auth, and any account state or failure recovery copy.
+- Expose Raft only after mapping `RAFT_PROFILE`, bridge lifecycle, and metadata-only wake events into June's session and notification model.
+- Expose WhatsApp Cloud only after adding app-scoped credential fields and validating webhook or send-message setup paths.
+- Expose Automation Blueprints by deciding how they fit with June's Routines editor instead of routing users to raw cron fields.
+- Expose image editing by wiring existing file/image attachments into the upstream `image_generate` edit inputs.
+- Expose background subagent watch handles by adding UI for pending work, completion events, and reopened sessions.
+- Decide whether upstream dashboard profile builder and Skills Hub browsing should remain hidden behind June-native settings or become first-class June surfaces.

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -31,12 +31,12 @@ const SCRIBE_HERMES_DISABLE_SANDBOX_ENV: &str = "SCRIBE_HERMES_DISABLE_SANDBOX";
 // Referenced by the spawn match arm on every target; only ever reached when
 // `prepare_sandbox` returns a profile, which it only does on macOS.
 const SANDBOX_EXEC_PATH: &str = "/usr/bin/sandbox-exec";
-// v2026.6.5 — see the bump PR for the audited pin→tag compatibility delta.
-const HERMES_AGENT_INSTALL_COMMIT: &str = "3c231eb3979ab9c57d5cd6d02f1d577a3b718b43";
+// v2026.6.19 - see the bump PR for the audited pin-to-tag compatibility delta.
+const HERMES_AGENT_INSTALL_COMMIT: &str = "2bd1977d8fad185c9b4be47884f7e87f1add0ce3";
 const HERMES_SOURCE_TARBALL_URL: &str =
-    "https://github.com/NousResearch/hermes-agent/archive/3c231eb3979ab9c57d5cd6d02f1d577a3b718b43.tar.gz";
+    "https://github.com/NousResearch/hermes-agent/archive/2bd1977d8fad185c9b4be47884f7e87f1add0ce3.tar.gz";
 const HERMES_SOURCE_TARBALL_SHA256: &str =
-    "c36c4b4a205b09673a6bc742c2c4361bac6e92139e795378a4335422458c3a43";
+    "7a9bd367066183898831c2760f269368ab54b458a1d1b51d14ef1f484dd490cc";
 const FILESYSTEM_MAX_DEPTH: usize = 2;
 const FILESYSTEM_MAX_ENTRIES_PER_DIR: usize = 80;
 const HERMES_IMPORT_MAX_BYTES: u64 = 50 * 1024 * 1024;
@@ -597,9 +597,9 @@ async fn start_hermes_bridge_inner(
         );
     }
     let port_string = port.to_string();
-    // No --tui: upstream removed the flag from the dashboard subcommand in
-    // v2026.6.5 (cae6b5486) — the embedded chat gateway (/api/ws) is always
-    // enabled now, and passing the flag is an argparse error.
+    // No --tui: upstream removed the flag from the dashboard subcommand before
+    // v2026.6.19, and the embedded chat gateway (/api/ws) is always enabled.
+    // Passing the flag is an argparse error.
     let hermes_args: [&str; 6] = [
         "dashboard",
         "--no-open",
@@ -2387,7 +2387,7 @@ if [ ! -f "$install_dir/pyproject.toml" ] || [ ! -f "$install_dir/scripts/instal
   mv "$unpacked_dir" "$install_dir"
 fi
 
-# Upstream's install.sh (v2026.6.5) runs $UV_CMD unquoted in the venv-create,
+# Upstream's install.sh (v2026.6.19) runs $UV_CMD unquoted in the venv-create,
 # uv-sync, and pip-install-tier calls. The managed uv it installs lives under
 # the app data dir — "Application Support" on macOS — so the space word-splits
 # the path and every one of those calls fails with "/Users/…/Library/


### PR DESCRIPTION
## Summary

- Bump the June-managed Hermes source pin from upstream `v2026.6.5` to `v2026.6.19` (`2bd1977d8fad185c9b4be47884f7e87f1add0ce3`).
- Update the source archive URL and checksum to keep the managed install and bundled runtime on the same verified source.
- Add `docs/hermes-upstream-v2026.6.19.md` with the compatibility audit, included upstream feature specs, and remaining June integration work.

## Compatibility audit

- Confirmed `v2026.6.19` is the latest stable upstream tag currently published.
- Confirmed June's dashboard launch path is still valid: `hermes dashboard --no-open --host 127.0.0.1 --port <port>`.
- Confirmed the dashboard APIs June uses are still present: sessions, skills, toolsets, messaging platforms, cron jobs, and `/api/ws`.
- Confirmed upstream still has bare `$UV_CMD` invocations in install stages, so June's post-extract quoting patch remains required for macOS paths like `Application Support`.
- Built a bundled runtime from the new pin and passed the relocated self-test from a path containing a space.

## Upstream features now included in the runtime

- Background subagents through `delegate_task(background=true)`.
- `image_generate` image-to-image and editing support.
- Atomic memory batch operations through an `operations` array.
- Photon Spectrum iMessage, Raft agent network gateway, WhatsApp Business Cloud API adapter, and richer Telegram Bot API 10.1 support.
- Automation Blueprints for guided routine setup without raw cron syntax.
- Dashboard/profile improvements, stronger dashboard auth, Skills Hub browser updates, subagent watch windows, per-thread drafts, resizable terminal improvements, and xAI Grok Composer support.
- Reliability, security, Windows ConPTY, PowerShell installer, dependency security, and curator cost-control updates.

## Additional June integration work

No required app migration was found for the existing June agent, skills, messaging settings, session list, or routines flows. These upstream capabilities need explicit June product work before users can depend on them in June UI:

- Photon iMessage setup UI for `hermes photon login`, device-code auth, and account recovery states.
- Raft configuration and lifecycle mapping for `RAFT_PROFILE`, bridge startup, and metadata-only wake events.
- WhatsApp Cloud credential and webhook/send-message setup flows.
- Automation Blueprint UX inside June's Routines editor.
- Image editing UI that maps June file/image attachments into upstream `image_generate` edit inputs.
- Background subagent pending/completion UI and session reopen handling.
- A product decision on whether upstream dashboard profile builder and Skills Hub browsing stay hidden or become June-native surfaces.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test src/test/hermes-adapter.test.ts src/test/hermes-gateway.test.ts src/test/routines-view.test.tsx src/test/agent-workspace.test.tsx src/test/app-settings.test.tsx`
- `pnpm lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `scripts/bundle-hermes-runtime.sh`
