### PR TITLE
Add automation blueprints to routines

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1295,6 +1295,14 @@ pub struct HermesCronJobRequest {
     pub job_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstantiateHermesCronBlueprintRequest {
+    pub blueprint: String,
+    #[serde(default)]
+    pub values: serde_json::Value,
+}
+
 #[tauri::command]
 pub async fn hermes_bridge_cron_jobs(
     bridge: State<'_, HermesBridge>,
@@ -1304,6 +1312,36 @@ pub async fn hermes_bridge_cron_jobs(
         reqwest::Method::GET,
         &format!("/api/cron/jobs?{CRON_PROFILE_QUERY}"),
         None,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn hermes_bridge_cron_blueprints(
+    bridge: State<'_, HermesBridge>,
+) -> Result<serde_json::Value, AppError> {
+    hermes_api_json(
+        &bridge,
+        reqwest::Method::GET,
+        "/api/cron/blueprints",
+        None,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn instantiate_hermes_bridge_cron_blueprint(
+    bridge: State<'_, HermesBridge>,
+    request: InstantiateHermesCronBlueprintRequest,
+) -> Result<serde_json::Value, AppError> {
+    hermes_api_json(
+        &bridge,
+        reqwest::Method::POST,
+        &format!("/api/cron/blueprints/instantiate?{CRON_PROFILE_QUERY}"),
+        Some(serde_json::json!({
+            "blueprint": request.blueprint,
+            "values": request.values,
+        })),
     )
     .await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -167,6 +167,8 @@ pub fn run() {
             hermes_bridge::hermes_bridge_session_messages,
             hermes_bridge::delete_hermes_bridge_session,
             hermes_bridge::hermes_bridge_cron_jobs,
+            hermes_bridge::hermes_bridge_cron_blueprints,
+            hermes_bridge::instantiate_hermes_bridge_cron_blueprint,
             hermes_bridge::create_hermes_bridge_cron_job,
             hermes_bridge::update_hermes_bridge_cron_job,
             hermes_bridge::hermes_bridge_cron_job_action,

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -21,6 +21,8 @@ import {
 } from "../../lib/hermes-adapter";
 import {
   createRoutine,
+  instantiateRoutineBlueprint,
+  listRoutineBlueprints,
   listRoutines,
   pauseRoutine,
   removeRoutine,
@@ -30,6 +32,7 @@ import {
   triggerRoutine,
   updateRoutine,
   type RoutineJob,
+  type RoutineBlueprint,
   type RoutineUpdates,
 } from "../../lib/hermes-routines";
 import {
@@ -46,6 +49,7 @@ import { formatRunTime, RoutineRunList } from "./RoutineRunList";
 import { ROUTINE_TEMPLATES, type RoutineTemplate } from "./routine-templates";
 
 const NO_ROUTINES: RoutineJob[] = [];
+const NO_BLUEPRINTS: RoutineBlueprint[] = [];
 const NO_RUNS: HermesSessionInfo[] = [];
 const RUN_HISTORY_REFRESH_MS = 10000;
 
@@ -86,6 +90,11 @@ export function RoutinesView({
   // deliberate per-creation opt-in, never a sticky preference.
   const [describeUnrestricted, setDescribeUnrestricted] = useState(false);
   const [allRuns, setRuns] = useState<HermesSessionInfo[]>([]);
+  const [allBlueprints, setBlueprints] = useState<RoutineBlueprint[]>([]);
+  const [blueprintsLoadingState, setBlueprintsLoading] = useState(true);
+  const [blueprintsErrorState, setBlueprintsError] = useState<string | null>(
+    null,
+  );
   const [runsUnavailableState, setRunsUnavailable] = useState(false);
   const runLoadSequenceRef = useRef(0);
 
@@ -94,7 +103,10 @@ export function RoutinesView({
   const forcedEmpty = useForcedEmptyStates();
   const routines = forcedEmpty ? NO_ROUTINES : allRoutines;
   const runs = forcedEmpty ? NO_RUNS : allRuns;
+  const blueprints = forcedEmpty ? NO_BLUEPRINTS : allBlueprints;
   const loading = !forcedEmpty && loadingState;
+  const blueprintsLoading = !forcedEmpty && blueprintsLoadingState;
+  const blueprintsError = !forcedEmpty ? blueprintsErrorState : null;
   const runsUnavailable = !forcedEmpty && runsUnavailableState;
 
   // `loading` gates the whole list and only covers the first fetch;
@@ -134,9 +146,21 @@ export function RoutinesView({
     }
   }, []);
 
+  const loadBlueprints = useCallback(async () => {
+    try {
+      const nextBlueprints = await listRoutineBlueprints();
+      setBlueprints(nextBlueprints);
+      setBlueprintsError(null);
+    } catch (err) {
+      setBlueprintsError(messageFromError(err));
+    } finally {
+      setBlueprintsLoading(false);
+    }
+  }, []);
+
   const refresh = useCallback(
-    () => Promise.all([loadRoutines(), loadRuns()]),
-    [loadRoutines, loadRuns],
+    () => Promise.all([loadRoutines(), loadRuns(), loadBlueprints()]),
+    [loadBlueprints, loadRoutines, loadRuns],
   );
 
   useEffect(() => {
@@ -258,6 +282,20 @@ export function RoutinesView({
     } finally {
       setCreating(false);
     }
+  }
+
+  async function submitBlueprint(
+    blueprint: RoutineBlueprint,
+    values: Record<string, unknown>,
+  ) {
+    const created = await instantiateRoutineBlueprint({
+      blueprint: blueprint.key,
+      values,
+    });
+    await loadRoutines();
+    setError(null);
+    setDetailError(null);
+    setPage({ kind: "detail", jobId: created.job_id });
   }
 
   async function confirmDelete() {
@@ -448,6 +486,12 @@ export function RoutinesView({
         </div>
       ) : routines.length === 0 ? (
         <div className="routines-hero">
+          <BlueprintSection
+            blueprints={blueprints}
+            error={blueprintsError}
+            loading={blueprintsLoading}
+            onCreate={(blueprint, values) => submitBlueprint(blueprint, values)}
+          />
           <TemplateGrid onPick={openCreate} />
         </div>
       ) : filtered.length === 0 ? (
@@ -510,12 +554,22 @@ export function RoutinesView({
       ) : null}
 
       {!loading && routines.length > 0 && !query.trim() ? (
-        <section className="routines-starters" aria-label="Starter routines">
-          <header className="routines-section-header">
-            <h2>Starter routines</h2>
-          </header>
-          <TemplateGrid onPick={openCreate} />
-        </section>
+        <>
+          <BlueprintSection
+            blueprints={blueprints}
+            error={blueprintsError}
+            loading={blueprintsLoading}
+            onCreate={(blueprint, values) =>
+              submitBlueprint(blueprint, values)
+            }
+          />
+          <section className="routines-starters" aria-label="Starter routines">
+            <header className="routines-section-header">
+              <h2>Starter routines</h2>
+            </header>
+            <TemplateGrid onPick={openCreate} />
+          </section>
+        </>
       ) : null}
 
       {describeBar}
@@ -567,6 +621,264 @@ function TemplateGrid({
         </li>
       ))}
     </ul>
+  );
+}
+
+function BlueprintSection({
+  blueprints,
+  error,
+  loading,
+  onCreate,
+}: {
+  blueprints: RoutineBlueprint[];
+  error: string | null;
+  loading: boolean;
+  onCreate: (
+    blueprint: RoutineBlueprint,
+    values: Record<string, unknown>,
+  ) => Promise<void>;
+}) {
+  if (loading) {
+    return (
+      <section
+        className="routines-starters"
+        aria-label="Automation blueprints"
+      >
+        <header className="routines-section-header">
+          <h2>Automation blueprints</h2>
+        </header>
+        <div className="folders-empty">
+          <p>Loading blueprints...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section
+        className="routines-starters"
+        aria-label="Automation blueprints"
+      >
+        <header className="routines-section-header">
+          <h2>Automation blueprints</h2>
+        </header>
+        <p className="error-banner">{error}</p>
+      </section>
+    );
+  }
+
+  if (!blueprints.length) return null;
+
+  return (
+    <section className="routines-starters" aria-label="Automation blueprints">
+      <header className="routines-section-header">
+        <h2>Automation blueprints</h2>
+      </header>
+      <ul className="routines-template-grid" role="list">
+        {blueprints.map((blueprint) => (
+          <BlueprintCard
+            key={blueprint.key}
+            blueprint={blueprint}
+            onCreate={onCreate}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function BlueprintCard({
+  blueprint,
+  onCreate,
+}: {
+  blueprint: RoutineBlueprint;
+  onCreate: (
+    blueprint: RoutineBlueprint,
+    values: Record<string, unknown>,
+  ) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    initialBlueprintValues(blueprint),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onCreate(blueprint, values);
+      setOpen(false);
+      setValues(initialBlueprintValues(blueprint));
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <li
+      className="routines-template-card routines-blueprint-card"
+      data-expanded={open || undefined}
+    >
+      <span className="routines-template-icon" aria-hidden>
+        <IconZap size={15} />
+      </span>
+      <div className="routines-template-body">
+        <span className="routines-template-name">{blueprint.title}</span>
+        <p className="routines-template-description">
+          {blueprint.description}
+        </p>
+        {blueprint.scheduleHuman ? (
+          <span className="routines-blueprint-schedule">
+            <IconCalendarRepeat size={12} aria-hidden />
+            {blueprint.scheduleHuman}
+          </span>
+        ) : null}
+        {blueprint.tags?.length ? (
+          <span className="routines-blueprint-tags" aria-label="Tags">
+            {blueprint.tags.slice(0, 3).map((tag) => (
+              <span key={tag}>{tag}</span>
+            ))}
+          </span>
+        ) : null}
+        {open ? (
+          <form
+            className="routines-blueprint-form"
+            aria-label={`${blueprint.title} blueprint`}
+            onSubmit={(event) => {
+              event.preventDefault();
+              void submit();
+            }}
+          >
+            {blueprint.fields.map((field) => (
+              <BlueprintField
+                key={field.name}
+                blueprintKey={blueprint.key}
+                field={field}
+                value={values[field.name] ?? ""}
+                onChange={(value) =>
+                  setValues((current) => ({
+                    ...current,
+                    [field.name]: value,
+                  }))
+                }
+              />
+            ))}
+            {error ? (
+              <p className="settings-row-error" role="alert">
+                {error}
+              </p>
+            ) : null}
+            <div className="routines-blueprint-actions">
+              <button
+                type="button"
+                className="btn btn-ghost"
+                disabled={submitting}
+                onClick={() => {
+                  setOpen(false);
+                  setError(null);
+                  setValues(initialBlueprintValues(blueprint));
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="primary-action primary-solid"
+                disabled={submitting}
+              >
+                {submitting ? "Scheduling..." : "Schedule"}
+              </button>
+            </div>
+          </form>
+        ) : null}
+      </div>
+      {!open ? (
+        <button
+          type="button"
+          className="icon-button routines-template-add"
+          aria-label={`Set up ${blueprint.title}`}
+          onClick={() => setOpen(true)}
+        >
+          <IconPlusMedium size={13} aria-hidden />
+        </button>
+      ) : null}
+    </li>
+  );
+}
+
+function BlueprintField({
+  blueprintKey,
+  field,
+  value,
+  onChange,
+}: {
+  blueprintKey: string;
+  field: RoutineBlueprint["fields"][number];
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const id = `blueprint-${blueprintKey}-${field.name}`;
+  const options = field.options ?? [];
+  const allowsCustomEnum = field.type === "enum" && field.strict === false;
+
+  return (
+    <label className="routines-blueprint-field" htmlFor={id}>
+      <span>{field.label}</span>
+      {allowsCustomEnum ? (
+        <>
+          <input
+            id={id}
+            list={`${id}-options`}
+            type="text"
+            value={value}
+            placeholder={field.help || field.label}
+            onChange={(event) => onChange(event.currentTarget.value)}
+          />
+          <datalist id={`${id}-options`}>
+            {options.map((option) => (
+              <option key={String(option)} value={String(option)} />
+            ))}
+          </datalist>
+        </>
+      ) : field.type === "enum" || field.type === "weekdays" ? (
+        <select
+          id={id}
+          value={value}
+          onChange={(event) => onChange(event.currentTarget.value)}
+        >
+          {options.map((option) => (
+            <option key={String(option)} value={String(option)}>
+              {String(option)}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          id={id}
+          type={field.type === "time" ? "time" : "text"}
+          value={value}
+          placeholder={field.help || field.label}
+          onChange={(event) => onChange(event.currentTarget.value)}
+        />
+      )}
+      {field.help ? <small>{field.help}</small> : null}
+    </label>
+  );
+}
+
+function initialBlueprintValues(blueprint: RoutineBlueprint) {
+  return Object.fromEntries(
+    blueprint.fields.map((field) => [
+      field.name,
+      field.default === undefined || field.default === null
+        ? ""
+        : String(field.default),
+    ]),
   );
 }
 

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -1,11 +1,14 @@
 import {
   createHermesBridgeCronJob,
   deleteHermesBridgeCronJob,
+  hermesBridgeCronBlueprints,
   hermesBridgeCronJobAction,
   hermesBridgeCronJobs,
   hermesBridgeStatus,
+  instantiateHermesBridgeCronBlueprint,
   startHermesBridge,
   updateHermesBridgeCronJob,
+  type HermesCronBlueprint,
   type HermesCronJobRecord,
 } from "./tauri";
 
@@ -45,6 +48,8 @@ export type RoutineJob = {
   /** True for script-only jobs (no agent run at all). Implies `script`. */
   no_agent?: boolean;
 };
+
+export type RoutineBlueprint = HermesCronBlueprint;
 
 /** The toolsets June puts on a routine the user opted into Unrestricted.
  * Hermes's full default set minus the toolsets its scheduler always strips
@@ -142,6 +147,11 @@ export async function listRoutines(): Promise<RoutineJob[]> {
   return records.map(routineFromRecord);
 }
 
+export async function listRoutineBlueprints(): Promise<RoutineBlueprint[]> {
+  const response = await withBridge(() => hermesBridgeCronBlueprints());
+  return response.blueprints;
+}
+
 /** Creates a routine directly through the dashboard API. The create endpoint
  * only takes prompt/schedule/name, so the unrestricted opt-in lands as an
  * immediate follow-up update; a failure there surfaces rather than silently
@@ -164,6 +174,16 @@ export async function createRoutine(input: {
     });
     return routineFromRecord(widened);
   });
+}
+
+export async function instantiateRoutineBlueprint(input: {
+  blueprint: string;
+  values: Record<string, unknown>;
+}): Promise<RoutineJob> {
+  const record = await withBridge(() =>
+    instantiateHermesBridgeCronBlueprint(input),
+  );
+  return routineFromRecord(record);
 }
 
 export type RoutineUpdates = {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1040,8 +1040,55 @@ export type HermesCronJobRecord = {
   no_agent?: boolean;
 };
 
+export type HermesCronBlueprintField = {
+  name: string;
+  type: "time" | "enum" | "text" | "weekdays" | string;
+  label: string;
+  default?: unknown;
+  options?: Array<string | number | boolean>;
+  optional?: boolean;
+  strict?: boolean;
+  help?: string;
+};
+
+export type HermesCronBlueprint = {
+  key: string;
+  title: string;
+  description: string;
+  category?: string;
+  fields: HermesCronBlueprintField[];
+  tags?: string[];
+  schedule?: string;
+  scheduleHuman?: string;
+  command?: string;
+  appUrl?: string;
+  app_url?: string;
+};
+
+export type HermesCronBlueprintsResponse = {
+  blueprints: HermesCronBlueprint[];
+};
+
 export async function hermesBridgeCronJobs() {
   return invoke<HermesCronJobRecord[]>("hermes_bridge_cron_jobs");
+}
+
+export async function hermesBridgeCronBlueprints() {
+  return invoke<HermesCronBlueprintsResponse>(
+    "hermes_bridge_cron_blueprints",
+  );
+}
+
+export async function instantiateHermesBridgeCronBlueprint(input: {
+  blueprint: string;
+  values?: Record<string, unknown>;
+}) {
+  return invoke<HermesCronJobRecord>(
+    "instantiate_hermes_bridge_cron_blueprint",
+    {
+      request: input,
+    },
+  );
 }
 
 export async function createHermesBridgeCronJob(input: {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9416,6 +9416,89 @@ input:focus-visible,
   align-self: center;
 }
 
+.routines-blueprint-card[data-expanded="true"] {
+  grid-column: 1 / -1;
+}
+
+.routines-blueprint-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+  margin-top: var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1.3;
+}
+
+.routines-blueprint-tags > span {
+  max-width: 100%;
+  padding: 2px var(--sp-2);
+  border-radius: var(--r-full);
+  background: color-mix(in oklch, var(--muted) 65%, transparent);
+  overflow-wrap: anywhere;
+}
+
+.routines-blueprint-schedule {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  margin-top: var(--sp-2);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1.3;
+}
+
+.routines-blueprint-schedule svg {
+  flex: 0 0 auto;
+}
+
+.routines-blueprint-form {
+  display: grid;
+  gap: var(--sp-3);
+  margin-top: var(--sp-4);
+}
+
+.routines-blueprint-field {
+  display: grid;
+  gap: var(--sp-1);
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.routines-blueprint-field input,
+.routines-blueprint-field select {
+  width: 100%;
+  min-height: var(--control-md);
+  padding: 0 var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  background: var(--input);
+  color: var(--foreground);
+  font: inherit;
+  font-weight: 400;
+  outline: none;
+}
+
+.routines-blueprint-field input:focus,
+.routines-blueprint-field select:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 1px var(--ring);
+}
+
+.routines-blueprint-field small {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.routines-blueprint-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--sp-2);
+}
+
 /* Routine detail/editor: the folder-detail shape — a sticky breadcrumb bar
  * carrying the actions (run now, pause/resume, save), with the editable name
  * and settings-style cards in a constrained column beneath it. */

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -2,11 +2,19 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RoutinesView } from "../components/routines/RoutinesView";
-import type { RoutineJob } from "../lib/hermes-routines";
+import type { RoutineBlueprint, RoutineJob } from "../lib/hermes-routines";
 import type { HermesSessionInfo } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   listRoutines: vi.fn<() => Promise<RoutineJob[]>>(),
+  listRoutineBlueprints: vi.fn<() => Promise<RoutineBlueprint[]>>(),
+  instantiateRoutineBlueprint:
+    vi.fn<
+      (input: {
+        blueprint: string;
+        values: Record<string, unknown>;
+      }) => Promise<RoutineJob>
+    >(),
   pauseRoutine: vi.fn(),
   resumeRoutine: vi.fn(),
   removeRoutine: vi.fn(),
@@ -62,6 +70,37 @@ function run(overrides: Partial<HermesSessionInfo> = {}): HermesSessionInfo {
   };
 }
 
+function blueprint(
+  overrides: Partial<RoutineBlueprint> = {},
+): RoutineBlueprint {
+  return {
+    key: "morning-brief",
+    title: "Morning briefing",
+    description: "Send a concise daily briefing.",
+    category: "daily",
+    scheduleHuman: "daily at 08:00",
+    tags: ["daily", "briefing"],
+    fields: [
+      {
+        name: "time",
+        type: "time",
+        label: "Time",
+        default: "08:00",
+        help: "Uses your local timezone.",
+      },
+      {
+        name: "deliver",
+        type: "enum",
+        label: "Delivery",
+        default: "local",
+        options: ["local", "origin"],
+        strict: false,
+      },
+    ],
+    ...overrides,
+  };
+}
+
 function renderView(
   props: Partial<{
     onCreateRoutine: (prompt: string) => void;
@@ -90,6 +129,8 @@ beforeEach(() => {
   mocks.triggerRoutine.mockResolvedValue({});
   mocks.createRoutine.mockResolvedValue(job());
   mocks.updateRoutine.mockResolvedValue(job());
+  mocks.listRoutineBlueprints.mockResolvedValue([]);
+  mocks.instantiateRoutineBlueprint.mockResolvedValue(job());
   adapterMocks.listScheduledRunSessions.mockResolvedValue([]);
 });
 
@@ -291,6 +332,76 @@ describe("RoutinesView templates and creation", () => {
     expect(
       await screen.findByRole("textbox", { name: "Routine name" }),
     ).toHaveValue("Morning summary");
+  });
+
+  it("shows automation blueprints and instantiates one", async () => {
+    mocks.listRoutines.mockResolvedValueOnce([]);
+    mocks.listRoutineBlueprints.mockResolvedValue([blueprint()]);
+    renderView();
+
+    const blueprints = await screen.findByRole("region", {
+      name: "Automation blueprints",
+    });
+    expect(within(blueprints).getByText("Morning briefing")).toBeVisible();
+    expect(within(blueprints).getByText("daily at 08:00")).toBeInTheDocument();
+    expect(within(blueprints).getByText("daily")).toBeInTheDocument();
+
+    await userEvent.click(
+      within(blueprints).getByRole("button", {
+        name: "Set up Morning briefing",
+      }),
+    );
+    expect(within(blueprints).getByLabelText(/time/i)).toHaveValue("08:00");
+    expect(within(blueprints).getByLabelText(/delivery/i)).toHaveValue(
+      "local",
+    );
+    await userEvent.clear(within(blueprints).getByLabelText(/delivery/i));
+    await userEvent.type(
+      within(blueprints).getByLabelText(/delivery/i),
+      "slack",
+    );
+
+    mocks.listRoutines.mockResolvedValue([job()]);
+    await userEvent.click(
+      within(blueprints).getByRole("button", { name: "Schedule" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.instantiateRoutineBlueprint).toHaveBeenCalledWith({
+        blueprint: "morning-brief",
+        values: {
+          time: "08:00",
+          deliver: "slack",
+        },
+      }),
+    );
+    expect(
+      await screen.findByRole("textbox", { name: "Routine name" }),
+    ).toHaveValue("Morning summary");
+  });
+
+  it("keeps blueprint instantiation failures inside the card", async () => {
+    mocks.listRoutines.mockResolvedValue([]);
+    mocks.listRoutineBlueprints.mockResolvedValue([blueprint()]);
+    mocks.instantiateRoutineBlueprint.mockRejectedValue(
+      new Error("time is invalid"),
+    );
+    renderView();
+
+    const blueprints = await screen.findByRole("region", {
+      name: "Automation blueprints",
+    });
+    await userEvent.click(
+      within(blueprints).getByRole("button", {
+        name: "Set up Morning briefing",
+      }),
+    );
+    await userEvent.click(
+      within(blueprints).getByRole("button", { name: "Schedule" }),
+    );
+
+    expect(await within(blueprints).findByText("time is invalid")).toBeVisible();
+    expect(screen.queryByRole("textbox", { name: "Routine name" })).toBeNull();
   });
 
   it("routes the describe path through the agent prompt, sandboxed by default", async () => {


### PR DESCRIPTION
## Summary
- expose Hermes cron blueprint catalog and instantiate endpoints through the Tauri bridge
- render automation blueprints in the Routines surface with typed fields, schedule metadata, and inline errors
- support non-strict enum slots as editable inputs with suggestions so custom delivery targets still work

## Validation
- pnpm test src/test/routines-view.test.tsx
- pnpm run lint
- cargo test --manifest-path src-tauri/Cargo.toml --locked

## Notes
- This PR only maps upstream Automation Blueprints into June's existing Routines surface. The other Hermes product surfaces are split into separate PRs.