### PR TITLE
Add Photon iMessage setup to messaging settings

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -202,12 +202,22 @@ pub struct HermesBridge {
     /// per-process proxy would rewrite the file under the other process.
     /// Started lazily on the first spawn, lives until app shutdown.
     provider_proxy: Mutex<Option<SharedProviderProxy>>,
+    /// One foreground-managed Photon setup action. The setup command performs
+    /// device-code login, project provisioning, env/auth writes, and sidecar
+    /// dependency install, so June starts it outside the agent sandbox and
+    /// exposes its log for the settings UI.
+    photon_setup: Mutex<Option<HermesActionProcess>>,
 }
 
 struct HermesProcess {
     generation: u64,
     child: Child,
     connection: HermesBridgeConnection,
+}
+
+struct HermesActionProcess {
+    child: Child,
+    log_path: PathBuf,
 }
 
 struct SharedProviderProxy {
@@ -318,6 +328,21 @@ pub struct UpdateHermesMessagingPlatformRequest {
     pub platform_id: String,
     pub enabled: Option<bool>,
     pub env: Option<std::collections::HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartHermesPhotonSetupRequest {
+    pub phone: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesPhotonSetupStatus {
+    pub running: bool,
+    pub exit_code: Option<i32>,
+    pub pid: Option<u32>,
+    pub lines: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1132,6 +1157,77 @@ pub async fn update_hermes_bridge_messaging_platform(
 }
 
 #[tauri::command]
+pub async fn start_hermes_photon_setup(
+    bridge: State<'_, HermesBridge>,
+    request: StartHermesPhotonSetupRequest,
+) -> Result<HermesPhotonSetupStatus, AppError> {
+    let phone = validate_e164_phone(&request.phone)?;
+    let connections = live_connections(&bridge)?;
+    let Some(connection) = connections.first() else {
+        return Err(AppError::new(
+            "hermes_bridge_not_running",
+            "Hermes bridge is not running.",
+        ));
+    };
+    {
+        let mut guard = bridge.photon_setup.lock().map_err(|_| {
+            AppError::new("hermes_photon_setup_failed", "Photon setup lock failed.")
+        })?;
+        if let Some(action) = guard.as_mut() {
+            if action
+                .child
+                .try_wait()
+                .map_err(|error| AppError::new("hermes_photon_setup_failed", error.to_string()))?
+                .is_none()
+            {
+                return photon_setup_status_from_action(action);
+            }
+        }
+    }
+
+    let hermes_home = PathBuf::from(&connection.hermes_home);
+    let (log_path, stdout, stderr) = open_photon_setup_log(&hermes_home)?;
+    let mut cmd = Command::new(&connection.command);
+    cmd.args(["photon", "setup", "--phone", phone.as_str()]);
+    apply_isolated_hermes_env(&mut cmd, &hermes_home, &connection.token, None);
+    cmd.env("HERMES_NONINTERACTIVE", "1");
+    cmd.current_dir(&hermes_home)
+        .stdin(Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr);
+    let child = cmd.spawn().map_err(|error| {
+        AppError::new(
+            "hermes_photon_setup_failed",
+            format!("Could not start Photon setup. {error}"),
+        )
+    })?;
+    {
+        let mut guard = bridge.photon_setup.lock().map_err(|_| {
+            AppError::new("hermes_photon_setup_failed", "Photon setup lock failed.")
+        })?;
+        *guard = Some(HermesActionProcess { child, log_path });
+        if let Some(action) = guard.as_mut() {
+            return photon_setup_status_from_action(action);
+        }
+    }
+    Err(AppError::new(
+        "hermes_photon_setup_failed",
+        "Photon setup could not be tracked.",
+    ))
+}
+
+#[tauri::command]
+pub async fn hermes_photon_setup_status(
+    bridge: State<'_, HermesBridge>,
+) -> Result<HermesPhotonSetupStatus, AppError> {
+    let fallback_log_path = live_connections(&bridge)
+        .ok()
+        .and_then(|connections| connections.first().cloned())
+        .map(|connection| PathBuf::from(connection.hermes_home).join("logs/photon-setup.log"));
+    photon_setup_status_inner(&bridge, fallback_log_path)
+}
+
+#[tauri::command]
 pub async fn hermes_bridge_sessions(
     bridge: State<'_, HermesBridge>,
     request: HermesSessionsRequest,
@@ -1888,6 +1984,103 @@ fn open_gateway_start_log(hermes_home: &Path) -> Option<(std::fs::File, std::fs:
     );
     let clone = file.try_clone().ok()?;
     Some((file, clone))
+}
+
+fn validate_e164_phone(raw: &str) -> Result<String, AppError> {
+    let phone = raw.trim();
+    let digits = phone.strip_prefix('+').ok_or_else(|| {
+        AppError::new(
+            "hermes_photon_phone_invalid",
+            "Enter a phone number in E.164 format, like +15551234567.",
+        )
+    })?;
+    if !(7..=15).contains(&digits.len())
+        || digits.starts_with('0')
+        || !digits.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return Err(AppError::new(
+            "hermes_photon_phone_invalid",
+            "Enter a phone number in E.164 format, like +15551234567.",
+        ));
+    }
+    Ok(phone.to_string())
+}
+
+fn open_photon_setup_log(
+    hermes_home: &Path,
+) -> Result<(PathBuf, std::fs::File, std::fs::File), AppError> {
+    let log_dir = hermes_home.join("logs");
+    fs::create_dir_all(&log_dir)
+        .map_err(|error| AppError::new("hermes_photon_setup_failed", error.to_string()))?;
+    let log_path = log_dir.join("photon-setup.log");
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|error| AppError::new("hermes_photon_setup_failed", error.to_string()))?;
+    let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+    let _ = writeln!(
+        file,
+        "\n=== photon-setup started {timestamp} (spawned by June app, outside the sandbox) ==="
+    );
+    let clone = file
+        .try_clone()
+        .map_err(|error| AppError::new("hermes_photon_setup_failed", error.to_string()))?;
+    Ok((log_path, file, clone))
+}
+
+fn photon_setup_status_inner(
+    bridge: &HermesBridge,
+    fallback_log_path: Option<PathBuf>,
+) -> Result<HermesPhotonSetupStatus, AppError> {
+    let mut guard = bridge.photon_setup.lock().map_err(|_| {
+        AppError::new("hermes_photon_setup_failed", "Photon setup lock failed.")
+    })?;
+    if let Some(action) = guard.as_mut() {
+        return photon_setup_status_from_action(action);
+    }
+    let lines = fallback_log_path
+        .as_deref()
+        .map(|path| tail_file_lines(path, 80))
+        .unwrap_or_default();
+    Ok(HermesPhotonSetupStatus {
+        running: false,
+        exit_code: None,
+        pid: None,
+        lines,
+    })
+}
+
+fn photon_setup_status_from_action(
+    action: &mut HermesActionProcess,
+) -> Result<HermesPhotonSetupStatus, AppError> {
+    let status = action
+        .child
+        .try_wait()
+        .map_err(|error| AppError::new("hermes_photon_setup_failed", error.to_string()))?;
+    Ok(HermesPhotonSetupStatus {
+        running: status.is_none(),
+        exit_code: status.and_then(|status| status.code()),
+        pid: Some(action.child.id()),
+        lines: tail_file_lines(&action.log_path, 80),
+    })
+}
+
+fn tail_file_lines(path: &Path, count: usize) -> Vec<String> {
+    if count == 0 {
+        return Vec::new();
+    }
+    let Ok(text) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut lines = text
+        .lines()
+        .rev()
+        .take(count)
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    lines.reverse();
+    lines
 }
 
 async fn hermes_connection_json(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -156,6 +156,8 @@ pub fn run() {
             hermes_bridge::hermes_bridge_skills,
             hermes_bridge::hermes_bridge_toolsets,
             hermes_bridge::hermes_bridge_messaging_platforms,
+            hermes_bridge::start_hermes_photon_setup,
+            hermes_bridge::hermes_photon_setup_status,
             hermes_bridge::hermes_bridge_filesystem_snapshot,
             hermes_bridge::download_hermes_bridge_file,
             hermes_bridge::hermes_bridge_file_preview,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -80,6 +80,7 @@ import {
   hermesBridgeMessagingPlatforms,
   hermesBridgeFilePreview,
   hermesBridgeFileText,
+  hermesPhotonSetupStatus,
   hermesAgentCliAccess,
   hermesBridgeSkills,
   hermesBridgeStatus,
@@ -95,6 +96,7 @@ import {
   sendAgentMessage,
   setHermesAgentCliAccess,
   setVeniceModel,
+  startHermesPhotonSetup,
   startHermesBridge,
   submitIssueReport,
   suggestAgentSessionTitle,
@@ -106,6 +108,7 @@ import {
   type HermesBridgeStatus,
   type HermesFilesystemEntry,
   type HermesFilesystemSnapshot,
+  type HermesPhotonSetupStatus,
   type ImportedHermesFile,
   type HermesMessagingEnvVarInfo,
   type HermesMessagingPlatformInfo,
@@ -5416,6 +5419,7 @@ export function MessagingPanel({
             platform={selected}
             saving={saving}
             onEditEnv={onEditEnv}
+            onRefresh={onRefresh}
             onSaveEnv={onSaveEnv}
             onToggle={onToggle}
           />
@@ -5556,6 +5560,7 @@ function MessagingPlatformDetail({
   platform,
   saving,
   onEditEnv,
+  onRefresh,
   onSaveEnv,
   onToggle,
 }: {
@@ -5563,10 +5568,88 @@ function MessagingPlatformDetail({
   platform: HermesMessagingPlatformInfo | null;
   saving: string | null;
   onEditEnv: (key: string, value: string) => void;
+  onRefresh: () => void;
   onSaveEnv: (platform: HermesMessagingPlatformInfo) => void;
   onToggle: (platform: HermesMessagingPlatformInfo, enabled: boolean) => void;
 }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [photonPhone, setPhotonPhone] = useState("");
+  const [photonStatus, setPhotonStatus] =
+    useState<HermesPhotonSetupStatus | null>(null);
+  const [photonLoading, setPhotonLoading] = useState(false);
+  const [photonError, setPhotonError] = useState<string | null>(null);
+  const refreshAfterPhotonSetupRef = useRef(false);
+  const isPhoton = platform?.id === "photon";
+
+  useEffect(() => {
+    if (!isPhoton) {
+      setPhotonStatus(null);
+      setPhotonError(null);
+      refreshAfterPhotonSetupRef.current = false;
+      return;
+    }
+    let cancelled = false;
+    setPhotonLoading(true);
+    hermesPhotonSetupStatus()
+      .then((status) => {
+        if (!cancelled) {
+          setPhotonStatus(status);
+          setPhotonError(null);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setPhotonError(messageFromError(err));
+      })
+      .finally(() => {
+        if (!cancelled) setPhotonLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isPhoton]);
+
+  useEffect(() => {
+    if (!isPhoton || !photonStatus?.running) return;
+    const timer = window.setInterval(() => {
+      void refreshPhotonSetupStatus();
+    }, 3000);
+    return () => window.clearInterval(timer);
+  }, [isPhoton, photonStatus?.running]);
+
+  useEffect(() => {
+    if (!isPhoton || !refreshAfterPhotonSetupRef.current) return;
+    if (photonSetupExitCode(photonStatus) !== 0) return;
+    refreshAfterPhotonSetupRef.current = false;
+    onRefresh();
+  }, [isPhoton, onRefresh, photonStatus]);
+
+  async function refreshPhotonSetupStatus() {
+    setPhotonLoading(true);
+    try {
+      const status = await hermesPhotonSetupStatus();
+      setPhotonStatus(status);
+      setPhotonError(null);
+    } catch (err) {
+      setPhotonError(messageFromError(err));
+    } finally {
+      setPhotonLoading(false);
+    }
+  }
+
+  async function startPhotonSetup() {
+    setPhotonLoading(true);
+    try {
+      const status = await startHermesPhotonSetup({ phone: photonPhone });
+      refreshAfterPhotonSetupRef.current = true;
+      setPhotonStatus(status);
+      setPhotonError(null);
+    } catch (err) {
+      setPhotonError(messageFromError(err));
+    } finally {
+      setPhotonLoading(false);
+    }
+  }
+
   if (!platform) {
     return (
       <div className="agent-messaging-detail">
@@ -5624,6 +5707,17 @@ function MessagingPlatformDetail({
             Open setup guide
           </a>
         ) : null}
+        {isPhoton ? (
+          <PhotonSetupPanel
+            error={photonError}
+            loading={photonLoading}
+            phone={photonPhone}
+            status={photonStatus}
+            onPhoneChange={setPhotonPhone}
+            onRefresh={() => void refreshPhotonSetupStatus()}
+            onStart={() => void startPhotonSetup()}
+          />
+        ) : null}
         <MessagingFieldGroup
           title="Required"
           fields={required}
@@ -5678,6 +5772,138 @@ function MessagingPlatformDetail({
       </footer>
     </div>
   );
+}
+
+function PhotonSetupPanel({
+  error,
+  loading,
+  phone,
+  status,
+  onPhoneChange,
+  onRefresh,
+  onStart,
+}: {
+  error: string | null;
+  loading: boolean;
+  phone: string;
+  status: HermesPhotonSetupStatus | null;
+  onPhoneChange: (phone: string) => void;
+  onRefresh: () => void;
+  onStart: () => void;
+}) {
+  const exitCode = photonSetupExitCode(status);
+  const running = Boolean(status?.running);
+  const deviceAuth = photonDeviceAuth(status?.lines ?? []);
+  const canStart = isE164Phone(phone) && !running && !loading;
+  const statusLabel = running
+    ? "Running"
+    : exitCode === 0
+      ? "Complete"
+      : exitCode != null
+        ? "Needs retry"
+        : "Not started";
+
+  return (
+    <section className="agent-photon-setup" aria-label="Photon setup">
+      <div className="agent-photon-setup-header">
+        <div>
+          <h4>Photon setup</h4>
+          <p>
+            Connect iMessage through Photon with a one-time device-code login.
+            June opens Photon in your browser, provisions a project, registers
+            your phone, and installs the local sidecar.
+          </p>
+        </div>
+        <span data-state={statusLabel.toLowerCase().replaceAll(" ", "-")}>
+          {statusLabel}
+        </span>
+      </div>
+      <label className="agent-messaging-field">
+        <span>Your iMessage phone number</span>
+        <input
+          type="tel"
+          value={phone}
+          placeholder="+15551234567"
+          disabled={running}
+          onChange={(event) => onPhoneChange(event.currentTarget.value)}
+        />
+        <small>
+          Use E.164 format. Re-running setup is safe after a partial login or
+          interrupted project setup.
+        </small>
+      </label>
+      <div className="agent-photon-setup-actions">
+        <button type="button" disabled={loading} onClick={onRefresh}>
+          {loading ? "Checking..." : "Refresh status"}
+        </button>
+        <button
+          type="button"
+          className="primary-action primary-solid"
+          disabled={!canStart}
+          onClick={onStart}
+        >
+          {running ? "Running setup..." : "Start setup"}
+        </button>
+      </div>
+      {deviceAuth ? (
+        <div className="agent-photon-device-code">
+          <div>
+            <span>Device code</span>
+            <code>{deviceAuth.code}</code>
+          </div>
+          <a href={deviceAuth.url} target="_blank" rel="noreferrer">
+            Open Photon
+          </a>
+        </div>
+      ) : null}
+      {running ? (
+        <p className="agent-photon-setup-note">
+          Approve the device-code page in your browser. June will keep checking
+          while setup finishes.
+        </p>
+      ) : exitCode === 0 ? (
+        <p className="agent-photon-setup-note">
+          Photon setup completed. The messaging catalog will refresh with the
+          saved credentials.
+        </p>
+      ) : exitCode != null ? (
+        <p className="agent-photon-setup-note">
+          Photon setup stopped before finishing. Run setup again to reuse
+          completed steps and continue recovery.
+        </p>
+      ) : null}
+      {error ? (
+        <p className="settings-row-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {status?.lines.length ? (
+        <pre className="agent-photon-log" aria-label="Photon setup log">
+          {status.lines.join("\n")}
+        </pre>
+      ) : null}
+    </section>
+  );
+}
+
+function photonSetupExitCode(status: HermesPhotonSetupStatus | null) {
+  return status?.exitCode ?? status?.exit_code ?? null;
+}
+
+function photonDeviceAuth(lines: string[]) {
+  let url: string | null = null;
+  let code: string | null = null;
+  for (const line of lines) {
+    const urlMatch = line.match(/Open this URL:\s+(https?:\/\/\S+)/);
+    if (urlMatch) url = urlMatch[1];
+    const codeMatch = line.match(/Enter the code:\s+([A-Za-z0-9-]+)/);
+    if (codeMatch) code = codeMatch[1];
+  }
+  return url && code ? { url, code } : null;
+}
+
+function isE164Phone(value: string) {
+  return /^\+[1-9]\d{6,14}$/.test(value.trim());
 }
 
 function MessagingFieldGroup({

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -499,6 +499,14 @@ export type HermesMessagingPlatformsResponse = {
   platforms: HermesMessagingPlatformInfo[];
 };
 
+export type HermesPhotonSetupStatus = {
+  running: boolean;
+  exitCode?: number | null;
+  exit_code?: number | null;
+  pid?: number | null;
+  lines: string[];
+};
+
 export type HermesSessionInfo = {
   id: string;
   active?: boolean;
@@ -934,6 +942,16 @@ export async function hermesBridgeMessagingPlatforms() {
   return invoke<HermesMessagingPlatformsResponse>(
     "hermes_bridge_messaging_platforms",
   );
+}
+
+export async function startHermesPhotonSetup(input: { phone: string }) {
+  return invoke<HermesPhotonSetupStatus>("start_hermes_photon_setup", {
+    request: input,
+  });
+}
+
+export async function hermesPhotonSetupStatus() {
+  return invoke<HermesPhotonSetupStatus>("hermes_photon_setup_status");
 }
 
 export async function hermesBridgeFilesystemSnapshot() {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1229,6 +1229,121 @@ input:focus-visible,
   text-decoration: none;
 }
 
+.agent-photon-setup {
+  display: grid;
+  gap: var(--sp-4);
+  margin-top: var(--sp-5);
+  padding: var(--sp-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+  background: var(--surface-subtle);
+}
+
+.agent-photon-setup-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--sp-3);
+  align-items: start;
+}
+
+.agent-photon-setup-header h4 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 700;
+}
+
+.agent-photon-setup-header p,
+.agent-photon-setup-note {
+  margin: var(--sp-1) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.agent-photon-setup-header > span {
+  border-radius: var(--r-pill);
+  padding: 2px var(--sp-2);
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+}
+
+.agent-photon-setup-header > span[data-state="complete"] {
+  color: var(--success);
+}
+
+.agent-photon-setup-header > span[data-state="needs-retry"] {
+  color: var(--destructive);
+}
+
+.agent-photon-setup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--sp-2);
+}
+
+.agent-photon-setup-actions button,
+.agent-photon-device-code a {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--control-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  padding: 0 var(--sp-4);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  font: inherit;
+  text-decoration: none;
+}
+
+.agent-photon-setup-actions button:disabled {
+  opacity: 0.55;
+}
+
+.agent-photon-device-code {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-3);
+  border-radius: var(--r-sm);
+  background: var(--background);
+}
+
+.agent-photon-device-code div {
+  display: grid;
+  gap: 2px;
+}
+
+.agent-photon-device-code span {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.agent-photon-device-code code {
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-lg);
+}
+
+.agent-photon-log {
+  max-height: 220px;
+  margin: 0;
+  padding: var(--sp-3);
+  overflow: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
 .agent-messaging-fields {
   margin-top: var(--sp-6);
 }

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeFilePreview: vi.fn(),
   hermesBridgeFileText: vi.fn(),
   hermesBridgeMessagingPlatforms: vi.fn(),
+  hermesPhotonSetupStatus: vi.fn(),
   hermesBridgeSkills: vi.fn(),
   hermesBridgeStatus: vi.fn(),
   hermesBridgeToolsets: vi.fn(),
@@ -55,6 +56,7 @@ const mocks = vi.hoisted(() => ({
   saveAgentHermesSession: vi.fn(),
   sendAgentMessage: vi.fn(),
   startHermesBridge: vi.fn(),
+  startHermesPhotonSetup: vi.fn(),
   submitIssueReport: vi.fn(),
   suggestAgentSessionTitle: vi.fn(),
   explainAgentApproval: vi.fn(),
@@ -96,6 +98,7 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeFilePreview: mocks.hermesBridgeFilePreview,
   hermesBridgeFileText: mocks.hermesBridgeFileText,
   hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
+  hermesPhotonSetupStatus: mocks.hermesPhotonSetupStatus,
   hermesAgentCliAccess: mocks.hermesAgentCliAccess,
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
@@ -114,6 +117,7 @@ vi.mock("../lib/tauri", () => ({
   saveAgentHermesSession: mocks.saveAgentHermesSession,
   sendAgentMessage: mocks.sendAgentMessage,
   startHermesBridge: mocks.startHermesBridge,
+  startHermesPhotonSetup: mocks.startHermesPhotonSetup,
   submitIssueReport: mocks.submitIssueReport,
   suggestAgentSessionTitle: mocks.suggestAgentSessionTitle,
   explainAgentApproval: mocks.explainAgentApproval,
@@ -246,6 +250,17 @@ describe("AgentWorkspace", () => {
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
     mocks.hermesBridgeFilePreview.mockResolvedValue(null);
     mocks.hermesBridgeFileText.mockResolvedValue(null);
+    mocks.hermesPhotonSetupStatus.mockResolvedValue({
+      running: false,
+      exitCode: null,
+      lines: [],
+    });
+    mocks.startHermesPhotonSetup.mockResolvedValue({
+      running: true,
+      exitCode: null,
+      pid: 1234,
+      lines: [],
+    });
     mocks.importHermesBridgeFile.mockImplementation(async (path: string) => ({
       name: path.split("/").pop() ?? "attachment",
       path: `/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/${path.split("/").pop() ?? "attachment"}`,

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -34,7 +34,9 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeSkills: vi.fn(),
   hermesBridgeToolsets: vi.fn(),
   hermesBridgeMessagingPlatforms: vi.fn(),
+  hermesPhotonSetupStatus: vi.fn(),
   hermesBridgeFilesystemSnapshot: vi.fn(),
+  startHermesPhotonSetup: vi.fn(),
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
   updateHermesBridgeMessagingPlatform: vi.fn(),
@@ -70,7 +72,9 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
   hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
+  hermesPhotonSetupStatus: mocks.hermesPhotonSetupStatus,
   hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
+  startHermesPhotonSetup: mocks.startHermesPhotonSetup,
   toggleHermesBridgeSkill: mocks.toggleHermesBridgeSkill,
   toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform:
@@ -344,6 +348,20 @@ describe("AppSettings", () => {
     mocks.hermesBridgeSkills.mockResolvedValue([]);
     mocks.hermesBridgeToolsets.mockResolvedValue([]);
     mocks.hermesBridgeMessagingPlatforms.mockResolvedValue({ platforms: [] });
+    mocks.hermesPhotonSetupStatus.mockResolvedValue({
+      running: false,
+      exitCode: null,
+      lines: [],
+    });
+    mocks.startHermesPhotonSetup.mockResolvedValue({
+      running: true,
+      exitCode: null,
+      pid: 1234,
+      lines: [
+        "Open this URL: https://app.photon.example/device",
+        "Enter the code: JUNE-1234",
+      ],
+    });
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
       roots: [
         {
@@ -1733,6 +1751,73 @@ describe("AppSettings", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("starts Photon setup from messaging settings", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeMessagingPlatforms.mockResolvedValue({
+      platforms: [
+        {
+          id: "photon",
+          name: "iMessage via Photon",
+          description: "Send and receive iMessage through Photon.",
+          docsUrl: "https://docs.example.com/photon",
+          enabled: false,
+          configured: false,
+          gatewayRunning: true,
+          state: "not_configured",
+          envVars: [
+            {
+              key: "PHOTON_PROJECT_ID",
+              prompt: "Project ID",
+              required: true,
+            },
+            {
+              key: "PHOTON_PROJECT_SECRET",
+              prompt: "Project secret",
+              required: true,
+              isPassword: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Agent" }));
+    await user.click(screen.getByRole("button", { name: "Messaging" }));
+
+    expect(await screen.findByText("Photon setup")).toBeInTheDocument();
+    const startButton = screen.getByRole("button", { name: "Start setup" });
+    expect(startButton).toBeDisabled();
+
+    await user.type(
+      screen.getByLabelText(/Your iMessage phone number/i),
+      "+15551234567",
+    );
+    await user.click(startButton);
+
+    await waitFor(() =>
+      expect(mocks.startHermesPhotonSetup).toHaveBeenCalledWith({
+        phone: "+15551234567",
+      }),
+    );
+    expect(await screen.findByText("JUNE-1234")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open Photon" }),
+    ).toHaveAttribute("href", "https://app.photon.example/device");
   });
 
   it("toggles the agent HUD from Agent settings", async () => {


### PR DESCRIPTION
## Summary
- add Tauri bridge commands to start and poll `hermes photon setup --phone` from the existing Hermes command
- add a Photon-only setup card in Agent settings > Messaging with phone validation, device-code status, log tailing, retry states, and catalog refresh after success
- add frontend coverage for the Photon setup flow plus bridge mock coverage for AgentWorkspace

## Why
Hermes Photon setup is currently CLI-only. June needs a native surface for iMessage setup, device-code authentication, and recovery from interrupted setup runs before users can depend on Photon from the app.

## Validation
- `pnpm test src/test/app-settings.test.tsx src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Notes
- The setup action runs outside the agent Seatbelt sandbox because upstream setup writes Hermes auth/env files and installs the Photon sidecar.
- Rust tests still emit the existing unused `Manager` warning in `src/commands.rs`.