### PR TITLE
Map Raft profile lifecycle into June

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -158,6 +158,7 @@ const ISOLATED_HERMES_ENV_VARS: &[&str] = &[
     "HERMES_ENVIRONMENT_HINT",
     "HERMES_MODEL",
     "HERMES_PROVIDER",
+    "RAFT_PROFILE",
     "OPENAI_API_KEY",
     "OPENROUTER_API_KEY",
     "VENICE_API_KEY",
@@ -1116,7 +1117,8 @@ pub async fn update_hermes_bridge_messaging_platform(
     bridge: State<'_, HermesBridge>,
     request: UpdateHermesMessagingPlatformRequest,
 ) -> Result<serde_json::Value, AppError> {
-    hermes_api_json(
+    let restart_gateway = should_restart_gateway_after_messaging_update(&request);
+    let response = hermes_api_json(
         &bridge,
         reqwest::Method::PUT,
         &format!(
@@ -1128,7 +1130,14 @@ pub async fn update_hermes_bridge_messaging_platform(
             "env": request.env.unwrap_or_default(),
         })),
     )
-    .await
+    .await?;
+    if restart_gateway {
+        let connections = live_connections(&bridge)?;
+        if let Some(connection) = connections.first() {
+            spawn_hermes_gateway_restart(connection)?;
+        }
+    }
+    Ok(response)
 }
 
 #[tauri::command]
@@ -1850,21 +1859,81 @@ fn spawn_hermes_gateway_start(connection: &HermesBridgeConnection) -> Result<(),
     Ok(())
 }
 
+/// Restarts the gateway after platform settings that are read only at gateway
+/// adapter startup change. Raft needs this because its bridge is spawned when
+/// the gateway constructs the Raft adapter from RAFT_PROFILE.
+fn spawn_hermes_gateway_restart(connection: &HermesBridgeConnection) -> Result<(), AppError> {
+    let hermes_home = PathBuf::from(&connection.hermes_home);
+    let mut cmd = build_hermes_gateway_restart_command(connection, &hermes_home);
+    match open_gateway_restart_log(&hermes_home) {
+        Some((log_for_stdout, log_for_stderr)) => {
+            cmd.stdout(log_for_stdout).stderr(log_for_stderr);
+        }
+        None => {
+            cmd.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+    }
+    let mut child = cmd.spawn().map_err(|error| {
+        AppError::new(
+            "hermes_gateway_restart_failed",
+            format!("Could not run `hermes gateway restart`. {error}"),
+        )
+    })?;
+    tauri::async_runtime::spawn_blocking(move || match child.wait() {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!("hermes gateway restart exited with {status}; see logs/gateway-restart.log");
+        }
+        Err(error) => {
+            eprintln!("could not reap hermes gateway restart: {error}");
+        }
+    });
+    Ok(())
+}
+
 /// Pure command construction so a test can assert the spawn is the bare hermes
 /// executable (no `sandbox-exec` wrapper) with the isolated environment.
 fn build_hermes_gateway_start_command(
     connection: &HermesBridgeConnection,
     hermes_home: &Path,
 ) -> Command {
+    build_hermes_gateway_lifecycle_command(connection, hermes_home, "start")
+}
+
+fn build_hermes_gateway_restart_command(
+    connection: &HermesBridgeConnection,
+    hermes_home: &Path,
+) -> Command {
+    build_hermes_gateway_lifecycle_command(connection, hermes_home, "restart")
+}
+
+fn build_hermes_gateway_lifecycle_command(
+    connection: &HermesBridgeConnection,
+    hermes_home: &Path,
+    action: &str,
+) -> Command {
     let mut cmd = Command::new(&connection.command);
-    cmd.args(["gateway", "start"]);
-    // No sandbox-status hint: `gateway start` is a helper invocation, not the
-    // agent runtime, so it never builds a system prompt.
+    cmd.args(["gateway", action]);
+    // No sandbox-status hint: gateway lifecycle commands are helper
+    // invocations, not the agent runtime, so they never build a system prompt.
     apply_isolated_hermes_env(&mut cmd, hermes_home, &connection.token, None);
     cmd.env("HERMES_NONINTERACTIVE", "1");
     cmd.current_dir(hermes_home);
     cmd.stdin(Stdio::null());
     cmd
+}
+
+fn should_restart_gateway_after_messaging_update(
+    request: &UpdateHermesMessagingPlatformRequest,
+) -> bool {
+    if request.platform_id != "raft" {
+        return false;
+    }
+    request.enabled.is_some()
+        || request
+            .env
+            .as_ref()
+            .is_some_and(|env| env.contains_key("RAFT_PROFILE"))
 }
 
 /// Opens `<hermes_home>/logs/gateway-start.log` for appending and writes the
@@ -1873,18 +1942,29 @@ fn build_hermes_gateway_start_command(
 /// `None` when the log can't be opened — the spawn then proceeds silenced
 /// rather than failing gateway startup over diagnostics.
 fn open_gateway_start_log(hermes_home: &Path) -> Option<(std::fs::File, std::fs::File)> {
+    open_gateway_action_log(hermes_home, "start")
+}
+
+fn open_gateway_restart_log(hermes_home: &Path) -> Option<(std::fs::File, std::fs::File)> {
+    open_gateway_action_log(hermes_home, "restart")
+}
+
+fn open_gateway_action_log(
+    hermes_home: &Path,
+    action: &str,
+) -> Option<(std::fs::File, std::fs::File)> {
     let log_dir = hermes_home.join("logs");
     fs::create_dir_all(&log_dir).ok()?;
     let mut file = fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(log_dir.join("gateway-start.log"))
+        .open(log_dir.join(format!("gateway-{action}.log")))
         .ok()?;
     let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
     use io::Write as _;
     let _ = writeln!(
         file,
-        "\n=== gateway-start started {timestamp} (spawned by June app, outside the sandbox) ==="
+        "\n=== gateway-{action} started {timestamp} (spawned by June app, outside the sandbox) ==="
     );
     let clone = file.try_clone().ok()?;
     Some((file, clone))
@@ -2584,6 +2664,12 @@ fn apply_isolated_hermes_env(
         .env("HERMES_DASHBOARD_SESSION_TOKEN", token)
         .env("NO_PROXY", "127.0.0.1,localhost,::1")
         .env("no_proxy", "127.0.0.1,localhost,::1");
+    if let Ok(profile) = std::env::var("RAFT_PROFILE") {
+        let profile = profile.trim();
+        if !profile.is_empty() {
+            cmd.env("RAFT_PROFILE", profile);
+        }
+    }
     if let Some(hint) = environment_hint {
         cmd.env("HERMES_ENVIRONMENT_HINT", hint);
     }
@@ -3731,6 +3817,85 @@ mod tests {
             Some("1")
         );
         assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp/hermes-home")));
+    }
+
+    #[test]
+    fn gateway_restart_spawns_bare_cli_with_raft_profile() {
+        let connection = HermesBridgeConnection {
+            base_url: "http://127.0.0.1:1".to_string(),
+            ws_url: "ws://127.0.0.1:1/api/ws".to_string(),
+            token: "session-token".to_string(),
+            port: 1,
+            command: "/opt/hermes/bin/hermes".to_string(),
+            hermes_home: "/tmp/hermes-home".to_string(),
+            cwd: None,
+            provider_proxy_port: 2,
+            pid: 3,
+            sandboxed: true,
+            full_mode: false,
+        };
+
+        std::env::set_var("RAFT_PROFILE", "june-raft-agent");
+        let cmd = build_hermes_gateway_restart_command(&connection, Path::new("/tmp/hermes-home"));
+        std::env::remove_var("RAFT_PROFILE");
+
+        assert_eq!(cmd.get_program(), "/opt/hermes/bin/hermes");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, ["gateway", "restart"]);
+        let envs: std::collections::HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|value| {
+                    (
+                        key.to_string_lossy().into_owned(),
+                        value.to_string_lossy().into_owned(),
+                    )
+                })
+            })
+            .collect();
+        assert_eq!(
+            envs.get("RAFT_PROFILE").map(String::as_str),
+            Some("june-raft-agent")
+        );
+        assert_eq!(
+            envs.get("HERMES_NONINTERACTIVE").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp/hermes-home")));
+    }
+
+    #[test]
+    fn raft_messaging_updates_request_gateway_restart() {
+        assert!(should_restart_gateway_after_messaging_update(
+            &UpdateHermesMessagingPlatformRequest {
+                platform_id: "raft".to_string(),
+                enabled: None,
+                env: Some(std::collections::HashMap::from([(
+                    "RAFT_PROFILE".to_string(),
+                    "june-raft-agent".to_string(),
+                )])),
+            }
+        ));
+        assert!(should_restart_gateway_after_messaging_update(
+            &UpdateHermesMessagingPlatformRequest {
+                platform_id: "raft".to_string(),
+                enabled: Some(true),
+                env: None,
+            }
+        ));
+        assert!(!should_restart_gateway_after_messaging_update(
+            &UpdateHermesMessagingPlatformRequest {
+                platform_id: "photon".to_string(),
+                enabled: Some(true),
+                env: Some(std::collections::HashMap::from([(
+                    "RAFT_PROFILE".to_string(),
+                    "ignored".to_string(),
+                )])),
+            }
+        ));
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -118,6 +118,7 @@ import {
 } from "../../lib/tauri";
 import {
   deleteHermesSession,
+  displayTextForRaftWakePrompt,
   listHermesSessionMessages,
   listHermesSessions,
   sessionTimestamp,
@@ -7982,7 +7983,7 @@ function stripHermesVisibleContext(value: string) {
     marker >= 0 ? withoutWarnings.slice(0, marker) : withoutWarnings;
   // Drop the scheduled-run delivery preamble so a routine's title and dedup
   // key come from its actual prompt, not the cron scaffolding.
-  return stripScheduledRunPreamble(visible.trim());
+  return displayTextForRaftWakePrompt(stripScheduledRunPreamble(visible.trim()));
 }
 
 function compactPath(path: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -7,6 +7,7 @@ import type {
 import type { HermesGatewayEvent } from "./hermes-gateway";
 import { isInsufficientCreditsMessage } from "./errors";
 import {
+  displayTextForRaftWakePrompt,
   isScheduledRunPreamble,
   stripScheduledRunPreamble,
 } from "./hermes-adapter";
@@ -897,7 +898,9 @@ function displayContentForHermesMessage(message: HermesSessionMessage) {
   if (message.role !== "user") return content.trim();
   // Scheduled runs lead with the cron delivery preamble; show the routine's
   // own instructions, not the machine scaffolding.
-  return stripScheduledRunPreamble(stripHermesContextMarkers(content));
+  return displayTextForRaftWakePrompt(
+    stripScheduledRunPreamble(stripHermesContextMarkers(content)),
+  );
 }
 
 function isScheduledRunMessage(message: HermesSessionMessage) {

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -48,7 +48,7 @@ export async function deleteHermesSession(sessionId: string) {
 export function normalizeHermesSessionsResponse(response: unknown) {
   return extractList(response, "sessions")
     .filter(isHermesSessionInfo)
-    .map(withScheduledRunDisplay)
+    .map(withJuneSessionDisplay)
     .sort((a, b) => sessionTimestamp(b).localeCompare(sessionTimestamp(a)));
 }
 
@@ -72,6 +72,10 @@ export function scheduledRunJobId(sessionId: string) {
 const SCHEDULED_RUN_FETCH_LIMIT = 200;
 const PENDING_SCHEDULED_RUN_ACTIVE_WINDOW_MS = 5 * 60 * 1000;
 const UNTITLED_SESSION_TITLE = "Untitled session";
+const RAFT_WAKE_PROMPT_PREFIX =
+  "Raft wake hint received. New Raft messages may be pending.";
+export const RAFT_WAKE_DISPLAY_TITLE = "Raft channel update";
+export const RAFT_WAKE_DISPLAY_PREVIEW = "Raft messages may be pending.";
 
 export type ScheduledRunListOptions = {
   includeActive?: boolean;
@@ -145,6 +149,16 @@ function stringPresent(value: unknown) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+export function isRaftWakePrompt(content: string) {
+  return content.trim().startsWith(RAFT_WAKE_PROMPT_PREFIX);
+}
+
+export function displayTextForRaftWakePrompt(content: string) {
+  return isRaftWakePrompt(content)
+    ? RAFT_WAKE_DISPLAY_PREVIEW
+    : content.trim();
+}
+
 /** A scheduled run's first message is the routine prompt wrapped in a machine
  * delivery preamble the cron runner injects: `[IMPORTANT: You are running as a
  * scheduled cron job. … nothing more.]`. Recognized by that exact opener so a
@@ -206,6 +220,22 @@ function withScheduledRunDisplay(
   return { ...session, title, preview: cleanedPreview || session.preview };
 }
 
+function withJuneSessionDisplay(session: HermesSessionInfo): HermesSessionInfo {
+  return withRaftWakeDisplay(withScheduledRunDisplay(session));
+}
+
+function withRaftWakeDisplay(session: HermesSessionInfo): HermesSessionInfo {
+  if (session.source !== "raft") return session;
+  const title = session.title?.trim() ?? "";
+  const preview = session.preview?.trim() ?? "";
+  if (!isRaftWakePrompt(title) && !isRaftWakePrompt(preview)) return session;
+  return {
+    ...session,
+    title: RAFT_WAKE_DISPLAY_TITLE,
+    preview: RAFT_WAKE_DISPLAY_PREVIEW,
+  };
+}
+
 export function normalizeHermesSessionMessagesResponse(response: unknown) {
   return extractList(response, "messages").flatMap(
     normalizeHermesSessionMessage,
@@ -242,7 +272,11 @@ export function titleFromPrompt(prompt: string) {
 }
 
 function promptTitleSource(prompt: string) {
-  return stripScheduledRunPreamble(prompt)
+  const withoutDeliveryPreamble = stripScheduledRunPreamble(prompt);
+  const displayPrompt = isRaftWakePrompt(withoutDeliveryPreamble)
+    ? RAFT_WAKE_DISPLAY_TITLE
+    : withoutDeliveryPreamble;
+  return displayPrompt
     .replace(/\n*--- Attached Context ---[\s\S]*$/m, "")
     .replace(/\n*--- Context Warnings ---[\s\S]*$/m, "")
     .replace(/\n+Attached files copied into[\s\S]*$/i, "")

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -120,6 +120,28 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("renders content-free Raft wake hints as external activity", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "raft-wake",
+        role: "user",
+        content:
+          "Raft wake hint received. New Raft messages may be pending. " +
+          "If you have not read the Raft manual in this session, run " +
+          "`raft manual get raft-cli-overview` before using Raft commands.",
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "Raft messages may be pending.",
+        status: "complete",
+      },
+    ]);
+  });
+
   it("extracts text from Hermes structured content payloads", () => {
     const turns = buildHermesSessionChatTurns([
       {

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  displayTextForRaftWakePrompt,
+  isRaftWakePrompt,
   isRunningScheduledRunSession,
   isReplaceableScheduledRunTitle,
   isScheduledRunPreamble,
@@ -20,6 +22,10 @@ const SCHEDULED_PREAMBLE =
   "your report as your final response. SILENT: if there is nothing new, " +
   'respond with exactly "[SILENT]" (nothing else). Never combine [SILENT] ' +
   "with content — either report normally, or say [SILENT] and nothing more.]";
+const RAFT_WAKE_PROMPT =
+  "Raft wake hint received. New Raft messages may be pending. " +
+  "If you have not read the Raft manual in this session, run " +
+  "`raft manual get raft-cli-overview` before using Raft commands.";
 
 describe("scheduled-run helpers", () => {
   it("recognizes the cron delivery preamble, not arbitrary bracketed text", () => {
@@ -299,6 +305,29 @@ describe("Hermes adapter", () => {
     expect(sessions.map((session) => session.id)).toEqual(["new", "old"]);
   });
 
+  it("maps content-free Raft wake sessions to product copy", () => {
+    const sessions = normalizeHermesSessionsResponse({
+      sessions: [
+        {
+          id: "raft-session",
+          source: "raft",
+          title: RAFT_WAKE_PROMPT,
+          preview: RAFT_WAKE_PROMPT,
+          last_active: "2026-06-11T12:00:00Z",
+        },
+      ],
+    });
+
+    expect(sessions[0]).toMatchObject({
+      title: "Raft channel update",
+      preview: "Raft messages may be pending.",
+    });
+    expect(isRaftWakePrompt(RAFT_WAKE_PROMPT)).toBe(true);
+    expect(displayTextForRaftWakePrompt(RAFT_WAKE_PROMPT)).toBe(
+      "Raft messages may be pending.",
+    );
+  });
+
   it("normalizes Hermes Desktop-style session lists", () => {
     const sessions = normalizeHermesSessionsResponse({
       sessions: [{ id: "session-1", preview: "Hello" }],
@@ -371,5 +400,6 @@ describe("Hermes adapter", () => {
       ),
     ).toBe("Summarize the Key Points from Today's");
     expect(titleFromPrompt("")).toBe("Untitled session");
+    expect(titleFromPrompt(RAFT_WAKE_PROMPT)).toBe("Raft Channel Update");
   });
 });


### PR DESCRIPTION
## Summary
- pass `RAFT_PROFILE` through June's isolated Hermes environment when present
- restart the Hermes gateway outside the app sandbox when Raft messaging settings change, so upstream can spawn or reload the Raft bridge
- replace upstream content-free Raft wake prompts with June-native session and chat copy

## Validation
- `pnpm test src/test/hermes-adapter.test.ts src/test/agent-chat-runtime.test.ts`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Integration notes
- This intentionally uses the existing Agent settings messaging platform environment field for `RAFT_PROFILE`.
- This does not add a full June-native Raft profile creation or login surface. Users still need a valid local Raft CLI profile.
