### PR TITLE
Add WhatsApp pairing setup UI

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1132,6 +1132,20 @@ pub async fn update_hermes_bridge_messaging_platform(
 }
 
 #[tauri::command]
+pub fn open_hermes_whatsapp_setup_terminal(
+    bridge: State<'_, HermesBridge>,
+) -> Result<(), AppError> {
+    let connections = live_connections(&bridge)?;
+    let Some(connection) = connections.first() else {
+        return Err(AppError::new(
+            "hermes_bridge_not_running",
+            "Start the agent before opening WhatsApp pairing.",
+        ));
+    };
+    open_whatsapp_setup_terminal(connection)
+}
+
+#[tauri::command]
 pub async fn hermes_bridge_sessions(
     bridge: State<'_, HermesBridge>,
     request: HermesSessionsRequest,
@@ -1888,6 +1902,93 @@ fn open_gateway_start_log(hermes_home: &Path) -> Option<(std::fs::File, std::fs:
     );
     let clone = file.try_clone().ok()?;
     Some((file, clone))
+}
+
+fn open_whatsapp_setup_terminal(connection: &HermesBridgeConnection) -> Result<(), AppError> {
+    #[cfg(target_os = "macos")]
+    {
+        let script = build_whatsapp_setup_terminal_applescript(connection);
+        Command::new("osascript")
+            .args(script_args(&script))
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|error| {
+                AppError::new(
+                    "whatsapp_setup_terminal_failed",
+                    format!("Could not open WhatsApp pairing in Terminal. {error}"),
+                )
+            })?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = connection;
+        Err(AppError::new(
+            "whatsapp_setup_terminal_unsupported",
+            "WhatsApp pairing must be run from a terminal on this platform.",
+        ))
+    }
+}
+
+fn script_args(script: &[String]) -> Vec<&str> {
+    script
+        .iter()
+        .flat_map(|line| ["-e", line.as_str()])
+        .collect()
+}
+
+fn build_whatsapp_setup_terminal_applescript(connection: &HermesBridgeConnection) -> Vec<String> {
+    let shell_command = build_whatsapp_setup_shell_command(connection);
+    vec![
+        "tell application \"Terminal\"".to_string(),
+        "activate".to_string(),
+        format!("do script {}", applescript_string_literal(&shell_command)),
+        "end tell".to_string(),
+    ]
+}
+
+fn build_whatsapp_setup_shell_command(connection: &HermesBridgeConnection) -> String {
+    let hermes_home = shell_single_quote(&connection.hermes_home);
+    let hermes_command = shell_single_quote(&connection.command);
+    format!(
+        "export HERMES_HOME={home}; cd {home}; {command} whatsapp; printf '\\nWhatsApp setup finished. You can close this window.\\n'",
+        home = hermes_home,
+        command = hermes_command,
+    )
+}
+
+fn applescript_string_literal(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' | '"' => {
+                quoted.push('\\');
+                quoted.push(ch);
+            }
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
+fn shell_single_quote(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\"'\"'");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 async fn hermes_connection_json(
@@ -3731,6 +3832,42 @@ mod tests {
             Some("1")
         );
         assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp/hermes-home")));
+    }
+
+    #[test]
+    fn whatsapp_setup_terminal_command_quotes_paths() {
+        let connection = HermesBridgeConnection {
+            base_url: "http://127.0.0.1:1".to_string(),
+            ws_url: "ws://127.0.0.1:1/api/ws".to_string(),
+            token: "session-token".to_string(),
+            port: 1,
+            command: "/Applications/June's Hermes/bin/hermes".to_string(),
+            hermes_home: "/Users/test/Application Support/June Hermes".to_string(),
+            cwd: None,
+            provider_proxy_port: 2,
+            pid: 3,
+            sandboxed: true,
+            full_mode: false,
+        };
+
+        let shell_command = build_whatsapp_setup_shell_command(&connection);
+
+        assert!(shell_command
+            .contains("export HERMES_HOME='/Users/test/Application Support/June Hermes'"));
+        assert!(shell_command.contains("'/Applications/June'\"'\"'s Hermes/bin/hermes' whatsapp"));
+        assert!(shell_command.contains("WhatsApp setup finished."));
+    }
+
+    #[test]
+    fn applescript_string_literal_escapes_terminal_command() {
+        assert_eq!(
+            applescript_string_literal("say \"hi\" \\"),
+            "\"say \\\"hi\\\" \\\\\""
+        );
+        assert_eq!(
+            applescript_string_literal("first\nsecond"),
+            "\"first\\nsecond\""
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,6 +178,7 @@ pub fn run() {
             hermes_bridge::update_hermes_bridge_skill,
             hermes_bridge::toggle_hermes_bridge_toolset,
             hermes_bridge::update_hermes_bridge_messaging_platform,
+            hermes_bridge::open_hermes_whatsapp_setup_terminal,
             hermes_bridge::hermes_agent_cli_access,
             hermes_bridge::set_hermes_agent_cli_access,
             commands::get_microphone_permission_state,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5332,6 +5332,7 @@ export function MessagingPanel({
   onQueryChange,
   onRefresh,
   onSaveEnv,
+  onOpenWhatsAppSetup,
   onSelectPlatform,
   onToggle,
 }: {
@@ -5345,6 +5346,7 @@ export function MessagingPanel({
   onQueryChange: (query: string) => void;
   onRefresh: () => void;
   onSaveEnv: (platform: HermesMessagingPlatformInfo) => void;
+  onOpenWhatsAppSetup?: () => void;
   onSelectPlatform: (platform: HermesMessagingPlatformInfo) => void;
   onToggle: (platform: HermesMessagingPlatformInfo, enabled: boolean) => void;
 }) {
@@ -5417,6 +5419,7 @@ export function MessagingPanel({
             saving={saving}
             onEditEnv={onEditEnv}
             onSaveEnv={onSaveEnv}
+            onOpenWhatsAppSetup={onOpenWhatsAppSetup}
             onToggle={onToggle}
           />
         </div>
@@ -5557,6 +5560,7 @@ function MessagingPlatformDetail({
   saving,
   onEditEnv,
   onSaveEnv,
+  onOpenWhatsAppSetup,
   onToggle,
 }: {
   envEdits: Record<string, string>;
@@ -5564,6 +5568,7 @@ function MessagingPlatformDetail({
   saving: string | null;
   onEditEnv: (key: string, value: string) => void;
   onSaveEnv: (platform: HermesMessagingPlatformInfo) => void;
+  onOpenWhatsAppSetup?: () => void;
   onToggle: (platform: HermesMessagingPlatformInfo, enabled: boolean) => void;
 }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -5624,6 +5629,12 @@ function MessagingPlatformDetail({
             Open setup guide
           </a>
         ) : null}
+        {platform.id === "whatsapp" ? (
+          <WhatsAppSetupGuide
+            disabled={saving === "messaging:whatsapp:setup"}
+            onOpenSetup={onOpenWhatsAppSetup}
+          />
+        ) : null}
         <MessagingFieldGroup
           title="Required"
           fields={required}
@@ -5677,6 +5688,43 @@ function MessagingPlatformDetail({
         </button>
       </footer>
     </div>
+  );
+}
+
+function WhatsAppSetupGuide({
+  disabled,
+  onOpenSetup,
+}: {
+  disabled: boolean;
+  onOpenSetup?: () => void;
+}) {
+  return (
+    <section className="agent-messaging-setup-guide">
+      <div>
+        <h4>Pair WhatsApp</h4>
+        <p>
+          WhatsApp pairing shows a QR code in Terminal. Choose bot mode for a
+          dedicated number or self-chat mode for testing.
+        </p>
+      </div>
+      <ol>
+        <li>Set allowed users below using phone numbers without spaces.</li>
+        <li>Open pairing and scan the QR code from Linked Devices.</li>
+        <li>Enable WhatsApp here, then keep the messaging gateway running.</li>
+      </ol>
+      <div className="agent-messaging-setup-actions">
+        <button
+          type="button"
+          disabled={disabled || !onOpenSetup}
+          onClick={onOpenSetup}
+        >
+          {disabled ? "Opening..." : "Open pairing"}
+        </button>
+        <span>
+          Use <code>whatsapp:+15551234567</code> with send message targets.
+        </span>
+      </div>
+    </section>
   );
 }
 

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -13,6 +13,7 @@ import {
   getHermesBridgeSkill,
   agentHudHide,
   agentHudShow,
+  openHermesWhatsAppSetupTerminal,
   setHermesAgentCliAccess,
   toggleHermesBridgeSkill,
   toggleHermesBridgeToolset,
@@ -295,6 +296,18 @@ export function AgentSettingsSection() {
     }
   }
 
+  async function openWhatsAppSetup() {
+    setSaving("messaging:whatsapp:setup");
+    try {
+      await openHermesWhatsAppSetupTerminal();
+      setError(null);
+    } catch (err) {
+      setError(messageFromError(err));
+    } finally {
+      setSaving(null);
+    }
+  }
+
   return (
     <section className="settings-group" aria-labelledby="agent-heading">
       <h2 id="agent-heading" className="settings-group-heading">
@@ -423,6 +436,7 @@ export function AgentSettingsSection() {
               setEnvEdits((current) => ({ ...current, [key]: value }))
             }
             onSaveEnv={(platform) => void saveMessagingPlatformEnv(platform)}
+            onOpenWhatsAppSetup={() => void openWhatsAppSetup()}
             onToggle={(platform, enabled) =>
               void setMessagingPlatformEnabled(platform, enabled)
             }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1090,6 +1090,10 @@ export async function updateHermesBridgeMessagingPlatform(input: {
   );
 }
 
+export async function openHermesWhatsAppSetupTerminal() {
+  return invoke<void>("open_hermes_whatsapp_setup_terminal");
+}
+
 /** `fullMode` is an explicit mode choice: passing it restarts a running
  * runtime whose mode differs (the sandbox is applied at spawn). Omit it to
  * reuse whatever is running — fresh starts are always sandboxed. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1229,6 +1229,67 @@ input:focus-visible,
   text-decoration: none;
 }
 
+.agent-messaging-setup-guide {
+  display: grid;
+  gap: var(--sp-4);
+  margin-top: var(--sp-5);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: var(--sp-5) 0;
+}
+
+.agent-messaging-setup-guide h4 {
+  margin: 0;
+  font-size: var(--fs-sm);
+}
+
+.agent-messaging-setup-guide p {
+  margin: var(--sp-1) 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.agent-messaging-setup-guide ol {
+  display: grid;
+  gap: var(--sp-2);
+  margin: 0;
+  padding-left: var(--sp-5);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+}
+
+.agent-messaging-setup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+  align-items: center;
+}
+
+.agent-messaging-setup-actions button {
+  min-height: var(--control-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-sm);
+  padding: 0 var(--sp-4);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+
+.agent-messaging-setup-actions button:disabled {
+  opacity: 0.55;
+}
+
+.agent-messaging-setup-actions span {
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
+.agent-messaging-setup-actions code {
+  color: var(--foreground);
+  font-family: var(--font-mono);
+}
+
 .agent-messaging-fields {
   margin-top: var(--sp-6);
 }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
   toggleHermesBridgeSkill: vi.fn(),
   toggleHermesBridgeToolset: vi.fn(),
   updateHermesBridgeMessagingPlatform: vi.fn(),
+  openHermesWhatsAppSetupTerminal: vi.fn(),
   agentHudShow: vi.fn(),
   agentHudHide: vi.fn(),
   hermesAgentCliAccess: vi.fn(),
@@ -75,6 +76,7 @@ vi.mock("../lib/tauri", () => ({
   toggleHermesBridgeToolset: mocks.toggleHermesBridgeToolset,
   updateHermesBridgeMessagingPlatform:
     mocks.updateHermesBridgeMessagingPlatform,
+  openHermesWhatsAppSetupTerminal: mocks.openHermesWhatsAppSetupTerminal,
   agentHudShow: mocks.agentHudShow,
   agentHudHide: mocks.agentHudHide,
   hermesAgentCliAccess: mocks.hermesAgentCliAccess,
@@ -344,6 +346,7 @@ describe("AppSettings", () => {
     mocks.hermesBridgeSkills.mockResolvedValue([]);
     mocks.hermesBridgeToolsets.mockResolvedValue([]);
     mocks.hermesBridgeMessagingPlatforms.mockResolvedValue({ platforms: [] });
+    mocks.openHermesWhatsAppSetupTerminal.mockResolvedValue(undefined);
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
       roots: [
         {
@@ -1733,6 +1736,56 @@ describe("AppSettings", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("opens the WhatsApp pairing flow from messaging settings", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeMessagingPlatforms.mockResolvedValue({
+      platforms: [
+        {
+          id: "whatsapp",
+          name: "WhatsApp",
+          description: "Use June through the bundled WhatsApp bridge.",
+          enabled: false,
+          configured: false,
+          gatewayRunning: true,
+          state: "disabled",
+          envVars: [
+            {
+              key: "WHATSAPP_ALLOWED_USERS",
+              prompt: "Allowed WhatsApp users",
+              description:
+                "Comma-separated phone numbers allowed to use the bot",
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Agent" }));
+    await user.click(screen.getByRole("button", { name: "Messaging" }));
+
+    expect(await screen.findByText("Pair WhatsApp")).toBeInTheDocument();
+    expect(
+      screen.getByText("whatsapp:+15551234567"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open pairing" }));
+
+    expect(mocks.openHermesWhatsAppSetupTerminal).toHaveBeenCalledTimes(1);
   });
 
   it("toggles the agent HUD from Agent settings", async () => {


### PR DESCRIPTION
## Summary
- add a WhatsApp-specific setup block to Agent settings > Messaging
- add a Tauri command that opens the upstream `hermes whatsapp` pairing wizard in Terminal, because the QR setup requires a real TTY
- show allowed-user and send-message target guidance alongside the existing messaging env fields

## Validation
- `pnpm test src/test/app-settings.test.tsx`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Integration notes
- The pinned upstream exposes the bundled WhatsApp bridge setup, not a WhatsApp Cloud API credential surface. This PR intentionally maps June to that supported path.
- Pairing opens Terminal so users can scan the upstream QR code. June still owns saving env fields and enabling the platform from the Messaging settings panel.
