### PR TITLE
Map image attachments into image edit workflow

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7660,6 +7660,7 @@ function promptWithAttachments(
   attachments: AgentAttachment[],
 ): string {
   if (!attachments.length) return message;
+  const imageAttachments = attachments.filter(isImageAttachment);
   return [
     message || "Use the attached file(s).",
     "",
@@ -7668,9 +7669,28 @@ function promptWithAttachments(
       (attachment) =>
         `- ${attachment.name} (${attachment.rootLabel}): ${attachment.path}`,
     ),
+    ...(imageAttachments.length
+      ? [
+          "",
+          "Image edit workflow:",
+          ...imageAttachments.map(
+            (attachment) => `- Image source: ${attachment.path}`,
+          ),
+          "For image edit, transform, restyle, or generate-from-image requests, " +
+            "run vision_analyze on each image source first.",
+          "Then call image_generate with a text prompt that combines the " +
+            "visual analysis and the requested edits. image_generate does not " +
+            "accept image files directly in this Hermes version.",
+        ]
+      : []),
     "",
     "Use these workspace paths when inspecting or operating on the files.",
   ].join("\n");
+}
+
+function isImageAttachment(attachment: AgentAttachment) {
+  if (attachment.previewDataUrl?.startsWith("data:image/")) return true;
+  return /\.(?:avif|gif|heic|heif|jpe?g|png|webp)$/i.test(attachment.name);
 }
 
 function filesystemEntriesToArtifacts(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2304,6 +2304,12 @@ describe("AgentWorkspace", () => {
         ),
       }),
     );
+    const submitted = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    )?.[1] as { text: string };
+    expect(submitted.text).toContain("Image edit workflow:");
+    expect(submitted.text).toContain("vision_analyze");
+    expect(submitted.text).toContain("image_generate");
     expect(mocks.importHermesBridgeFile).toHaveBeenCalledWith(
       "/Users/alex/Library/Application Support/CleanShot/media/screenshot.png",
     );


### PR DESCRIPTION
## Summary
- detect image attachments in the agent composer by preview data or file extension
- add an image edit workflow block to the submitted prompt with exact workspace image paths
- instruct the agent to analyze attached images with `vision_analyze` before building an `image_generate` prompt for edit, transform, restyle, or generate-from-image requests

## Validation
- `pnpm test src/test/agent-workspace.test.tsx`
- `pnpm run lint`

## Integration notes
- The pinned Hermes upstream `image_generate` schema is prompt-only and does not accept image files directly. This PR maps June image attachments into the supported upstream flow: image path to `vision_analyze`, then text prompt to `image_generate`.
- No Rust files changed.
