### PR TITLE
Surface background agent sessions

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -327,6 +327,7 @@ pub struct HermesSessionsRequest {
     pub offset: Option<u32>,
     pub archived: Option<String>,
     pub min_messages: Option<u32>,
+    pub include_children: Option<bool>,
     pub order: Option<String>,
     pub query: Option<String>,
 }
@@ -1150,6 +1151,9 @@ pub async fn hermes_bridge_sessions(
     }
     if let Some(min_messages) = request.min_messages {
         params.push(("min_messages", min_messages.to_string()));
+    }
+    if let Some(include_children) = request.include_children {
+        params.push(("include_children", include_children.to_string()));
     }
     if let Some(order) = request
         .order

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1167,7 +1167,10 @@ export function App() {
     let retryTimeout: number | undefined;
 
     function loadAgentMenuBarSessions(attempt: number) {
-      listHermesSessions({ limit: AGENT_MENU_BAR_SESSION_FETCH_LIMIT })
+      listHermesSessions({
+        limit: AGENT_MENU_BAR_SESSION_FETCH_LIMIT,
+        includeChildren: true,
+      })
         .then((sessions) => {
           if (cancelled) return;
           agentMenuBarSessionsRef.current = sessions;
@@ -1405,7 +1408,7 @@ export function App() {
           setActiveView("agent");
           return;
         }
-        void listHermesSessions({ limit: 100 })
+        void listHermesSessions({ limit: 100, includeChildren: true })
           .then((sessions) => {
             agentMenuBarSessionsRef.current = sessions;
             const session = sessions.find((item) => item.id === sessionId);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -118,6 +118,7 @@ import {
 } from "../../lib/tauri";
 import {
   deleteHermesSession,
+  isChildHermesSession,
   listHermesSessionMessages,
   listHermesSessions,
   sessionTimestamp,
@@ -1420,7 +1421,9 @@ export function AgentWorkspace({
       let keepLoading = false;
       setHermesSessionsLoading(true);
       try {
-        const sessions = applySessionTitleOverrides(await listHermesSessions());
+        const sessions = applySessionTitleOverrides(
+          await listHermesSessions({ includeChildren: true }),
+        );
         hermesSessionsHydratedRef.current = true;
         setHermesSessionsHydrated(true);
         const pendingMessages = pendingHermesMessagesRef.current;
@@ -4027,6 +4030,11 @@ export function AgentWorkspace({
           fullMode={
             !newSessionMode && sessionUnrestricted(selectedHermesSessionId)
           }
+          backgroundSession={
+            !newSessionMode &&
+            selectedHermesSession !== undefined &&
+            isChildHermesSession(selectedHermesSession)
+          }
           title={
             !newSessionMode && selectedHermesSessionId
               ? (selectedHermesSession?.title ?? "")
@@ -4790,6 +4798,7 @@ function AgentSessionBar({
   origin,
   privacyBadge,
   fullMode,
+  backgroundSession,
   title,
   artifactCount = 0,
   artifactsOpen = false,
@@ -4800,6 +4809,7 @@ function AgentSessionBar({
   origin?: AgentWorkspaceOrigin;
   privacyBadge?: ModelPrivacyBadge;
   fullMode?: boolean;
+  backgroundSession?: boolean;
   title?: string;
   artifactCount?: number;
   artifactsOpen?: boolean;
@@ -4908,6 +4918,16 @@ function AgentSessionBar({
         </ol>
       </nav>
       <div className="detail-bar-actions">
+        {backgroundSession ? (
+          <HoverTip
+            tip="This session was started from another agent session."
+            className="agent-safety-badge agent-background-session-badge"
+            tabIndex={0}
+            aria-label="Background session - This session was started from another agent session."
+          >
+            Background
+          </HoverTip>
+        ) : null}
         {fullMode ? <UnrestrictedBadge /> : null}
         {onToggleArtifacts && artifactCount > 0 ? (
           <button

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -50,6 +50,7 @@ import {
 } from "../../lib/agent-events";
 import {
   deleteHermesSession,
+  isChildHermesSession,
   listHermesSessions,
   sessionTimestamp,
 } from "../../lib/hermes-adapter";
@@ -706,7 +707,10 @@ export function Sidebar({
     let retryTimeout: number | undefined;
 
     function loadAgentSessions(attempt: number) {
-      listHermesSessions({ limit: AGENT_SIDEBAR_SESSION_FETCH_LIMIT })
+      listHermesSessions({
+        limit: AGENT_SIDEBAR_SESSION_FETCH_LIMIT,
+        includeChildren: true,
+      })
         .then((sessions) => {
           if (!cancelled) {
             setAgentSessions((current) =>
@@ -1956,6 +1960,7 @@ function AgentSessionRow({
   onOpenMenu: (anchor: HTMLElement) => void;
 }) {
   const title = session.title || session.preview || "Untitled session";
+  const background = isChildHermesSession(session);
   const status = waiting ? "waitingForUser" : working ? "running" : undefined;
   const time = formatSessionTime(sessionTimestamp(session));
   const menuRef = useRef<HTMLButtonElement>(null);
@@ -1986,6 +1991,9 @@ function AgentSessionRow({
       >
         <span className="note-row-title">
           <span className="note-row-title-text">{title}</span>
+          {background ? (
+            <span className="agent-session-kind">Background</span>
+          ) : null}
         </span>
       </div>
       {waiting ? (

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -494,6 +494,37 @@ function appendLiveHermesEvents(
       continue;
     }
 
+    if (
+      event.type === "background.complete" ||
+      event.type === "background.completed"
+    ) {
+      if (!currentAssistant) {
+        currentAssistant = createAssistantTurn(turns, event.receivedAt);
+        toolCreatedTurns.add(currentAssistant);
+      }
+      const payload = event.payload as Record<string, unknown> | undefined;
+      const taskId =
+        stringValue(payload?.task_id) ??
+        stringValue(payload?.taskId) ??
+        event.receivedAt;
+      const text =
+        stringValue(payload?.text, true) ??
+        stringValue(payload?.summary, true) ??
+        textFromHermesContent(payload);
+      const failed = /^\s*error\b/i.test(text ?? "");
+      upsertToolPart(currentAssistant.parts, {
+        id: `background:${taskId}`,
+        name: "Background task",
+        text: text ?? "",
+        status: failed ? "failed" : "complete",
+      });
+      if (toolCreatedTurns.has(currentAssistant)) {
+        currentAssistant.status = "complete";
+      }
+      currentAssistant = null;
+      continue;
+    }
+
     if (event.type === "clarify.request") {
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
       currentAssistant.status = "running";

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -11,6 +11,7 @@ export type HermesSessionListOptions = {
   offset?: number;
   archived?: "exclude" | "include" | "only";
   minMessages?: number;
+  includeChildren?: boolean;
   order?: "created" | "recent" | string;
   query?: string;
 };
@@ -57,6 +58,18 @@ export const SCHEDULED_RUN_SOURCE = "cron";
 
 export function isScheduledRunSession(session: HermesSessionInfo) {
   return session.source === SCHEDULED_RUN_SOURCE;
+}
+
+export function parentHermesSessionId(
+  session: HermesSessionInfo,
+): string | undefined {
+  const snake = session.parent_session_id?.trim();
+  if (snake) return snake;
+  return session.parentSessionId?.trim() || undefined;
+}
+
+export function isChildHermesSession(session: HermesSessionInfo) {
+  return Boolean(parentHermesSessionId(session));
 }
 
 /** The cron scheduler mints run session ids as

--- a/src/lib/hermes-gateway.ts
+++ b/src/lib/hermes-gateway.ts
@@ -19,6 +19,7 @@ export type HermesGatewayEventName =
   | "subagent.progress"
   | "subagent.thinking"
   | "subagent.complete"
+  | "background.complete"
   | "error"
   | (string & {});
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -516,6 +516,7 @@ export type HermesSessionInfo = {
   message_count?: number;
   tool_call_count?: number;
   parent_session_id?: string | null;
+  parentSessionId?: string | null;
   last_active?: string;
   lastActive?: string;
   preview?: string;
@@ -982,6 +983,7 @@ export async function hermesBridgeSessions(
     offset?: number;
     archived?: "exclude" | "include" | "only";
     minMessages?: number;
+    includeChildren?: boolean;
     order?: string;
     query?: string;
   } = {},

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5028,6 +5028,16 @@ input:focus-visible,
   white-space: nowrap;
 }
 
+.agent-session-kind {
+  flex: 0 0 auto;
+  max-width: 76px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+}
+
 .agent-session-status {
   line-height: 0;
 }

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -989,6 +989,34 @@ describe("Agent chat runtime", () => {
     );
   });
 
+  it("renders background completion events in the parent session", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "background.complete",
+          session_id: "parent-session",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            task_id: "bg_123",
+            text: "Finished the audit.",
+          },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "tool",
+        id: "background:bg_123",
+        name: "Background task",
+        text: "Finished the audit.",
+        status: "complete",
+      },
+    ]);
+  });
+
   it("keeps the goal label when a later subagent event omits it", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -705,6 +705,18 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("labels reopened child sessions as background sessions", async () => {
+    const childSession = {
+      ...existingSession,
+      parent_session_id: "parent-session",
+    };
+    mocks.listHermesSessions.mockResolvedValue([childSession]);
+
+    render(<AgentWorkspace initialSession={childSession} />);
+
+    expect(await screen.findByText("Background")).toBeInTheDocument();
+  });
+
   it("opens the model picker from the composer's model trigger", async () => {
     const user = userEvent.setup();
 

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -29,6 +29,8 @@ const hermesMocks = vi.hoisted(() => ({
 
 vi.mock("../lib/hermes-adapter", () => ({
   deleteHermesSession: hermesMocks.deleteHermesSession,
+  isChildHermesSession: (session: { parentHermesSessionId?: string }) =>
+    Boolean(session.parentHermesSessionId),
   listHermesSessions: hermesMocks.listHermesSessions,
   sessionTimestamp: (session: { last_active?: string; started_at?: string }) =>
     session.last_active ?? session.started_at ?? "",

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  isChildHermesSession,
   isRunningScheduledRunSession,
   isReplaceableScheduledRunTitle,
   isScheduledRunPreamble,
@@ -147,6 +148,25 @@ describe("Hermes adapter", () => {
     expect(mocks.hermesBridgeSessions).toHaveBeenLastCalledWith(
       expect.objectContaining({ minMessages: 0 }),
     );
+  });
+
+  it("can ask Hermes for child sessions when a list surface needs background work", async () => {
+    mocks.hermesBridgeSessions.mockResolvedValue({
+      sessions: [
+        {
+          id: "child-session",
+          title: "Subagent result",
+          parent_session_id: "parent-session",
+        },
+      ],
+    });
+
+    const sessions = await listHermesSessions({ includeChildren: true });
+
+    expect(mocks.hermesBridgeSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ includeChildren: true }),
+    );
+    expect(isChildHermesSession(sessions[0] as HermesSessionInfo)).toBe(true);
   });
 
   it("lists only cron-sourced sessions as scheduled runs", async () => {


### PR DESCRIPTION
## Summary
- Render Hermes `background.complete` events in the parent conversation as completed background task rows.
- Thread `includeChildren` through the Tauri Hermes sessions bridge and request child sessions from June agent session list surfaces.
- Label reopened child sessions as background sessions in the sidebar and session bar so users can find delegated work again.

## Notes
- June now sends `include_children=true` for agent session lists. The pinned Hermes dashboard route currently ignores unknown query params; this becomes fully active once the bundled runtime exposes `include_children` on the dashboard `/api/sessions` route, matching the newer platform API.

## Tests
- `pnpm test src/test/hermes-adapter.test.ts src/test/agent-chat-runtime.test.ts src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
