### PR TITLE
Document Hermes dashboard surface decision

### DIFF
--- a/docs/adr/0003-hermes-dashboard-surfaces.md
+++ b/docs/adr/0003-hermes-dashboard-surfaces.md
@@ -1,0 +1,75 @@
+# Hermes dashboard profile builder and Skills Hub surfaces
+
+## Status
+
+accepted
+
+## Context
+
+June bundles Hermes and starts the upstream dashboard locally as the runtime and
+API provider:
+
+```text
+hermes dashboard --no-open --host 127.0.0.1 --port <port>
+```
+
+June does not present the raw upstream dashboard as a user destination. It calls
+selected dashboard APIs and then renders June-native surfaces for the agent,
+skills, messaging, routines, and settings flows.
+
+The Hermes v2026.6.19 update includes two larger upstream dashboard capabilities
+that are not yet mapped into June product flows:
+
+- A dashboard profile builder for composing agent profiles and runtime settings.
+- Skills Hub browsing for discovering and installing upstream skills.
+
+Both capabilities are useful upstream, but they overlap with choices June needs
+to own directly: privacy posture, sandbox mode, local model defaults, skill
+permissions, routine behavior, messaging account state, and how agent sessions
+resume across app launches.
+
+## Decision
+
+Keep the upstream dashboard profile builder and Skills Hub browsing hidden from
+June UI for now.
+
+June should continue to treat the upstream dashboard as a local runtime and API
+surface, not as a mixed product shell. When these capabilities become important
+for June users, expose them as June-native surfaces backed by the relevant Hermes
+APIs or file contracts.
+
+Profiles should not be exposed through the upstream profile builder until June
+has a clear product model for profile scope. A June profile must define how it
+interacts with session privacy, sandboxing, model selection, routine execution,
+messaging platform settings, and any `profile=default` assumptions in scheduled
+jobs.
+
+Skills Hub browsing should not be exposed until June owns a complete install and
+review flow. That flow needs skill provenance, permission and tool-surface copy,
+update and rollback behavior, conflict handling with locally edited skills, and
+clear separation between bundled skills and user-added skills.
+
+## Consequences
+
+- The Hermes runtime update can ship without adding a raw dashboard entry point
+  in June.
+- Existing June-native skill editing, toggling, messaging settings, routines, and
+  session flows remain the supported surfaces.
+- Users will not see upstream profile builder or Skills Hub browsing until June
+  has product-specific onboarding, safety, and recovery paths.
+- Future PRs can still use Hermes APIs behind the scenes, but they should not
+  route users into a generic upstream dashboard page to complete core June
+  workflows.
+
+## Revisit triggers
+
+Revisit this decision when one or more of the following are true:
+
+- Users need multiple persistent agent profiles for materially different June
+  workflows.
+- June has a settings information architecture that can explain profile scope
+  without conflicting with privacy, sandbox, model, or routine settings.
+- Skill discovery becomes a top user request and June has a curated install flow
+  with provenance, permissions, updates, rollback, and local edit handling.
+- Hermes exposes stable APIs for profile management and Skills Hub install state
+  that June can consume without depending on upstream dashboard pages.

--- a/docs/hermes-upstream-v2026.6.19.md
+++ b/docs/hermes-upstream-v2026.6.19.md
@@ -61,4 +61,4 @@ No required app code migration was found for the existing June agent, skills, me
 - Expose Automation Blueprints by deciding how they fit with June's Routines editor instead of routing users to raw cron fields.
 - Expose image editing by wiring existing file/image attachments into the upstream `image_generate` edit inputs.
 - Expose background subagent watch handles by adding UI for pending work, completion events, and reopened sessions.
-- Decide whether upstream dashboard profile builder and Skills Hub browsing should remain hidden behind June-native settings or become first-class June surfaces.
+- Keep upstream dashboard profile builder and Skills Hub browsing hidden until June has native product surfaces for profile scope, skill provenance, permissions, updates, rollback, and local edit handling. See `docs/adr/0003-hermes-dashboard-surfaces.md`.


### PR DESCRIPTION
## Summary
- Add an ADR deciding that upstream Hermes dashboard profile builder and Skills Hub browsing stay hidden from June UI for now
- Clarify that June should expose those capabilities only as June-native product surfaces when profile scope, skill provenance, permissions, updates, rollback, and local edit handling are designed
- Link the Hermes v2026.6.19 integration notes to the ADR

## Validation
- `git diff --check`

## Notes
This is intentionally docs-only so the product decision stays separate from the Photon, Raft, WhatsApp, Automation Blueprint, image attachment, and background subagent PRs.
