### PR TITLE
Fix Scribe charge replay handling

### DIFF
--- a/scribe-api/crates/providers/src/os_accounts.rs
+++ b/scribe-api/crates/providers/src/os_accounts.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
-// OS Accounts returns this when a charge is replayed with the same
-// idempotency key. It means the note was already settled, so it is a
-// success signal — not a failure. Surface it as an idempotent replay so a
-// retry of an already-charged note returns its transcript instead of 502ing.
+// OS Accounts returns this when an idempotency key was already settled under
+// another action token. Scribe API is stateless, so a client retry reacquires
+// a fresh token for the same logical operation. Treat that as an idempotent
+// replay so an already-charged operation returns its result instead of 502ing.
 const ERR_IDEMPOTENCY_KEY_COLLISION: i64 = 4001;
 const CHARGE_RETRY_ATTEMPTS: u32 = 2;
 const CHARGE_RETRY_BACKOFF: Duration = Duration::from_millis(250);
@@ -142,8 +142,8 @@ impl OsAccountsHttpClient {
             return Err(ChargeError::Retryable);
         }
         let raw = response.text().await.map_err(|error| {
-            tracing::error!(%error, %url, "os_accounts: charge body read failed");
-            ChargeError::Domain(DomainError::UpstreamProvider)
+            tracing::error!(%error, %url, "os_accounts: charge body read failed (retryable)");
+            ChargeError::Retryable
         })?;
         let envelope: Envelope<ReceiptWire> = serde_json::from_str(&raw).map_err(|error| {
             tracing::error!(%error, %url, body_bytes = raw.len(), "os_accounts: charge JSON parse failed");
@@ -163,10 +163,10 @@ impl OsAccountsHttpClient {
             return Err(ChargeError::Domain(DomainError::InsufficientCredits));
         }
         if envelope.error_code == Some(ERR_IDEMPOTENCY_KEY_COLLISION) {
-            // The note was already charged under this key (e.g. an earlier
-            // attempt settled before a transient failure). Treat it as an
-            // idempotent replay: the user already paid, so return success and
-            // let the transcript through rather than failing the whole call.
+            // The operation was already charged under this key (e.g. an
+            // earlier request settled before a transient failure, then the
+            // client retried and received a new action token). Treat it as an
+            // idempotent replay: the user already paid, so return success.
             //
             // The 4001 reply carries `data: null`, so we cannot recover the
             // amount actually settled — we report this request's `credits` as
@@ -176,7 +176,7 @@ impl OsAccountsHttpClient {
                 %url,
                 body_bytes = raw.len(),
                 reported_credits = body.credits,
-                "os_accounts: charge replayed — idempotency key already settled; \
+                "os_accounts: charge replayed - idempotency key already settled; \
                  credits_charged reflects the requested estimate, not the settled amount"
             );
             return Ok(Receipt {
@@ -297,6 +297,10 @@ mod tests {
         ActionSlug, AuthorizeRequest, ChargeRequest, Credits, DomainError, OsAccountsClient, UserId,
     };
     use serde_json::json;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{body_json, header, method, path},
@@ -523,5 +527,63 @@ mod tests {
             .await;
 
         assert_eq!(receipt.map(|value| value.credits_charged.0), Ok(12));
+    }
+
+    #[tokio::test]
+    async fn charge_retries_on_body_read_failure() {
+        let api_url = start_charge_server_with_responses([
+            concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Content-Type: application/json\r\n",
+                "Content-Length: 128\r\n",
+                "Connection: close\r\n",
+                "\r\n",
+                r#"{"success":true,"data":{"credits_settled""#,
+            )
+            .as_bytes()
+            .to_vec(),
+            concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "Content-Type: application/json\r\n",
+                "Content-Length: 71\r\n",
+                "Connection: close\r\n",
+                "\r\n",
+                r#"{"success":true,"data":{"credits_settled":12,"idempotent_replay":true}}"#,
+            )
+            .as_bytes()
+            .to_vec(),
+        ])
+        .await;
+        let client = OsAccountsHttpClient::new(http::default_client(), &api_url, "osk_test");
+
+        let receipt = client
+            .charge(ChargeRequest {
+                action_token: "agts_test".to_string(),
+                credits: Credits(12),
+                idempotency_key: "note_generate:usr_123:note_1:v7".to_string(),
+            })
+            .await;
+
+        assert_eq!(
+            receipt.map(|value| (value.credits_charged.0, value.idempotent_replay)),
+            Ok((12, true))
+        );
+    }
+
+    async fn start_charge_server_with_responses<const N: usize>(responses: [Vec<u8>; N]) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("read local address");
+        tokio::spawn(async move {
+            for response in responses {
+                let (mut stream, _) = listener.accept().await.expect("accept request");
+                let mut buffer = vec![0_u8; 4096];
+                let _ = stream.read(&mut buffer).await.expect("read request");
+                stream.write_all(&response).await.expect("write response");
+                stream.shutdown().await.expect("close response");
+            }
+        });
+        format!("http://{addr}")
     }
 }

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -4,12 +4,12 @@ use crate::{
     },
     error::ServiceError,
     pricing::PricingTable,
+    util::sha256_hex,
 };
 use scribe_domain::{
     ActionSlug, AgentChatCompleter, AgentChatCompletion, AgentChatRequest, Credits, ModelId,
     ModelKind, OsAccountsClient, Receipt, UserId,
 };
-use sha2::{Digest, Sha256};
 use std::sync::Arc;
 
 pub struct AgentChatServiceDeps {
@@ -100,18 +100,7 @@ pub struct AgentChatOutput {
 }
 
 fn body_digest(body: &serde_json::Value) -> String {
-    let digest = Sha256::digest(body.to_string().as_bytes());
-    hex_lower(&digest)
-}
-
-fn hex_lower(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
+    sha256_hex(body.to_string().as_bytes())
 }
 
 #[cfg(test)]

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -457,8 +457,11 @@ mod tests {
                 RecordedCall::Charge {
                     action_token: "agt_test".to_string(),
                     credits: 4,
-                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
-                        .to_string(),
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:live-preview-session-1:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
                 },
             ]
         );
@@ -514,9 +517,74 @@ mod tests {
                 RecordedCall::Charge {
                     action_token: "agt_test".to_string(),
                     credits: 4,
-                    idempotency_key: "note_transcribe_preview:usr_123:live-preview-session-1"
-                        .to_string(),
+                    idempotency_key: concat!(
+                        "note_transcribe_preview:usr_123:live-preview-session-1:",
+                        "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                    )
+                    .to_string(),
                 },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn note_transcribe_preview_idempotency_key_distinguishes_audio_chunks() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        for audio in [vec![1, 2, 3], vec![4, 5, 6]] {
+            service
+                .transcribe(NoteTranscribeParams {
+                    user_id: UserId("usr_123".to_string()),
+                    note_id: "legacy-preview-note-id".to_string(),
+                    audio,
+                    filename: "preview.wav".to_string(),
+                    context: None,
+                    language: None,
+                    model_id: ModelId("audio-model".to_string()),
+                    preview: true,
+                })
+                .await
+                .expect("preview transcription succeeds");
+        }
+
+        let charge_keys = os_accounts
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                RecordedCall::Charge {
+                    idempotency_key, ..
+                } => Some(idempotency_key),
+                RecordedCall::Authorize { .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            charge_keys,
+            vec![
+                concat!(
+                    "note_transcribe_preview:usr_123:legacy-preview-note-id:",
+                    "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
+                )
+                .to_string(),
+                concat!(
+                    "note_transcribe_preview:usr_123:legacy-preview-note-id:",
+                    "787c798e39a5bc1910355bae6d0cd87a36b2e10fd0202a83e3bb6b005da83472",
+                )
+                .to_string(),
             ]
         );
     }

--- a/scribe-api/crates/services/src/note_transcribe.rs
+++ b/scribe-api/crates/services/src/note_transcribe.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     error::ServiceError,
     pricing::PricingTable,
-    util::ceil_seconds,
+    util::{ceil_seconds, sha256_hex},
 };
 use scribe_domain::{
     ActionSlug, AudioDurationProbe, AudioFormat, Credits, ModelId, OsAccountsClient, Receipt,
@@ -128,6 +128,7 @@ impl NoteTranscribeService {
             estimate_credits = estimate.0,
             "note_transcribe: preview request authorized"
         );
+        let audio_digest = sha256_hex(&params.audio);
         let transcript_result = self
             .transcriber
             .transcribe(TranscriptionRequest {
@@ -140,8 +141,8 @@ impl NoteTranscribeService {
             .await;
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
         let idempotency_key = format!(
-            "note_transcribe_preview:{}:{}",
-            params.user_id.0, params.note_id
+            "note_transcribe_preview:{}:{}:{}",
+            params.user_id.0, params.note_id, audio_digest
         );
         let receipt = charge(ChargeParams {
             os_accounts: self.os_accounts.as_ref(),

--- a/scribe-api/crates/services/src/util.rs
+++ b/scribe-api/crates/services/src/util.rs
@@ -1,4 +1,5 @@
 use crate::error::ServiceError;
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 
 pub(crate) fn ceil_seconds(duration: Duration) -> Result<u64, ServiceError> {
@@ -7,4 +8,19 @@ pub(crate) fn ceil_seconds(duration: Duration) -> Result<u64, ServiceError> {
         .checked_add(999)
         .map(|value| value / 1000)
         .ok_or(ServiceError::PriceOverflow)
+}
+
+pub(crate) fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    hex_lower(&digest)
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }


### PR DESCRIPTION
## Summary
- include the preview audio SHA-256 digest in Scribe preview charge idempotency keys so repeated legacy preview note IDs do not collapse different chunks into one OS Accounts charge key
- retry `/charge` response-body read failures with the same action token and idempotency key, allowing OS Accounts to return the cached settlement instead of surfacing a transient network failure
- share the existing SHA-256 hex helper between agent chat and transcription metering

## Test plan
- `cd scribe-api && cargo test -p scribe-services note_transcribe_preview -- --test-threads=1`
- `cd scribe-api && cargo test -p scribe-providers charge_ -- --test-threads=1`
- `cd scribe-api && cargo test --all-targets --all-features --locked -- --test-threads=1`
- `cd scribe-api && cargo clippy --all-targets --all-features --locked -- -D warnings`