### PR TITLE
feat: load agent skills from ~/.agents/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ Saved audio is the source of truth for retry. If transcription or generation
 fails after capture, June keeps the audio and processing metadata so work can be
 retried without recording again.
 
+## Agent skills
+
+The agent loads skills from its managed `skills` folder and, when the folder
+exists, from `~/.agents/skills` in your home directory (the same location the
+`skills` CLI installs into). Drop a skill folder there and every agent session
+picks it up the next time it starts. Home-folder skills load read-only: the
+macOS write-jail grants writes only under June's own data directory, so the
+agent can use these skills but cannot modify them.
+
 ## Privacy and verification
 
 The production `scribe-api` backend runs in an Intel TDX confidential VM on

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -2891,7 +2891,38 @@ fn sync_hermes_config(
 ) -> Result<(), AppError> {
     let model = crate::providers::generation_model();
     let base_url = format!("http://127.0.0.1:{provider_proxy_port}/v1");
-    let config = format!(
+    let config = render_hermes_config(
+        &model,
+        &base_url,
+        provider_proxy_token,
+        &CRON_SANDBOXED_TOOLSETS.join(", "),
+        &external_skill_dirs(),
+    );
+    std::fs::write(hermes_home.join("config.yaml"), config)
+        .map_err(|error| AppError::new("hermes_bridge_config_failed", error.to_string()))
+}
+
+/// Renders the `config.yaml` June owns for every Hermes spawn. Pure so the
+/// rendered YAML (including the `skills.external_dirs` block) can be asserted in
+/// tests. Hermes deep-merges these keys over its own defaults, so June only
+/// writes the values it controls.
+fn render_hermes_config(
+    model: &str,
+    base_url: &str,
+    provider_proxy_token: &str,
+    cron_toolsets: &str,
+    external_skill_dirs: &[PathBuf],
+) -> String {
+    let skills_block = if external_skill_dirs.is_empty() {
+        "  external_dirs: []\n".to_string()
+    } else {
+        let mut block = String::from("  external_dirs:\n");
+        for dir in external_skill_dirs {
+            block.push_str(&format!("    - {}\n", yaml_string(&dir.to_string_lossy())));
+        }
+        block
+    };
+    format!(
         r#"model:
   default: {model}
   provider: custom
@@ -2904,14 +2935,29 @@ display:
   skin: mono
 platform_toolsets:
   cron: [{cron_toolsets}]
-"#,
-        model = yaml_string(&model),
-        base_url = yaml_string(&base_url),
+skills:
+{skills_block}"#,
+        model = yaml_string(model),
+        base_url = yaml_string(base_url),
         provider_proxy_token = yaml_string(provider_proxy_token),
-        cron_toolsets = CRON_SANDBOXED_TOOLSETS.join(", "),
-    );
-    std::fs::write(hermes_home.join("config.yaml"), config)
-        .map_err(|error| AppError::new("hermes_bridge_config_failed", error.to_string()))
+    )
+}
+
+/// User-global skill directories Hermes loads in addition to its built-in
+/// `$HERMES_HOME/skills`. June advertises the conventional `~/.agents/skills`
+/// folder (where the `skills` CLI installs) when it exists, so a user or team
+/// can drop skills there and have every agent session pick them up. The
+/// Seatbelt write-jail only grants writes under the app's own roots, so these
+/// external skills load read-only. A missing folder is a silent no-op.
+fn external_skill_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    for home in home_dir_candidates() {
+        let candidate = home.join(".agents").join("skills");
+        if candidate.is_dir() && !dirs.contains(&candidate) {
+            dirs.push(candidate);
+        }
+    }
+    dirs
 }
 
 /// Writes the June persona to `SOUL.md` in the Scribe-managed Hermes home.
@@ -3659,6 +3705,30 @@ mod tests {
         } else {
             assert_eq!(command, PathBuf::from("venv").join("bin").join("hermes"));
         }
+    }
+
+    #[test]
+    fn render_hermes_config_lists_external_skill_dirs() {
+        let dirs = vec![
+            PathBuf::from("/Users/dev/.agents/skills"),
+            PathBuf::from("/shared/team-skills"),
+        ];
+        let config =
+            render_hermes_config("glm", "http://127.0.0.1:9/v1", "tok", "web, memory", &dirs);
+
+        assert!(config.contains("model:\n  default: \"glm\""));
+        assert!(config.contains("  cron: [web, memory]"));
+        assert!(config.contains(
+            "skills:\n  external_dirs:\n    - \"/Users/dev/.agents/skills\"\n    - \"/shared/team-skills\"\n"
+        ));
+    }
+
+    #[test]
+    fn render_hermes_config_emits_empty_external_dirs_when_none() {
+        let config = render_hermes_config("glm", "http://127.0.0.1:9/v1", "tok", "web", &[]);
+
+        assert!(config.contains("skills:\n  external_dirs: []\n"));
+        assert!(!config.contains("    - "));
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -310,6 +310,10 @@ pub struct HermesSkillDocument {
     pub name: String,
     pub relative_path: String,
     pub content: String,
+    /// True when the skill was loaded from an external dir (e.g.
+    /// `~/.agents/skills`). June can read these but not write them, so the
+    /// editor presents them read-only.
+    pub read_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -775,8 +779,8 @@ pub fn get_hermes_bridge_skill(
     app: AppHandle,
     request: HermesSkillRequest,
 ) -> Result<HermesSkillDocument, AppError> {
-    let skills_root = resolve_scribe_hermes_home(&app)?.join("skills");
-    let path = resolve_hermes_skill_file_in_root(&skills_root, &request.name)?;
+    let roots = skill_search_roots(&app)?;
+    let (root, path, read_only) = resolve_skill_in_roots(&roots, &request.name)?;
     let metadata = fs::metadata(&path)
         .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
     if metadata.len() > HERMES_SKILL_MAX_BYTES as u64 {
@@ -789,8 +793,9 @@ pub fn get_hermes_bridge_skill(
         .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
     Ok(HermesSkillDocument {
         name: request.name.trim().to_string(),
-        relative_path: skill_relative_path(&skills_root, &path)?,
+        relative_path: skill_relative_path(&root, &path)?,
         content,
+        read_only,
     })
 }
 
@@ -806,7 +811,26 @@ pub fn update_hermes_bridge_skill(
         ));
     }
     let skills_root = resolve_scribe_hermes_home(&app)?.join("skills");
-    let path = resolve_hermes_skill_file_in_root(&skills_root, &request.name)?;
+    let path = match resolve_hermes_skill_file_in_root(&skills_root, &request.name) {
+        Ok(path) => path,
+        Err(error) if error.code == "hermes_skill_not_found" => {
+            // Skills loaded from `~/.agents/skills` live outside the managed
+            // root and are read-only in June: the agent loads them, but the
+            // editor never writes them. Surface that instead of "not found".
+            let externals: Vec<(PathBuf, bool)> = external_skill_dirs()
+                .into_iter()
+                .map(|dir| (dir, true))
+                .collect();
+            if resolve_skill_in_roots(&externals, &request.name).is_ok() {
+                return Err(AppError::new(
+                    "hermes_skill_read_only",
+                    "This skill loads from ~/.agents/skills and is read-only in June. Edit it on disk.",
+                ));
+            }
+            return Err(error);
+        }
+        Err(error) => return Err(error),
+    };
     write_managed_skill_file(&skills_root, &path, &request.content)?;
     let content = fs::read_to_string(&path)
         .map_err(|error| AppError::new("hermes_skill_read_failed", error.to_string()))?;
@@ -814,7 +838,50 @@ pub fn update_hermes_bridge_skill(
         name: request.name.trim().to_string(),
         relative_path: skill_relative_path(&skills_root, &path)?,
         content,
+        read_only: false,
     })
+}
+
+/// Ordered skill roots June searches when opening a skill: the managed
+/// `$HERMES_HOME/skills` first (editable), then any `external_skill_dirs()`
+/// (read-only). The bool is the read-only flag for skills found under that
+/// root. Non-existent roots are skipped so a missing managed dir still lets
+/// external skills resolve.
+fn skill_search_roots(app: &AppHandle) -> Result<Vec<(PathBuf, bool)>, AppError> {
+    let mut roots = Vec::new();
+    let managed = resolve_scribe_hermes_home(app)?.join("skills");
+    if managed.is_dir() {
+        roots.push((managed, false));
+    }
+    for dir in external_skill_dirs() {
+        roots.push((dir, true));
+    }
+    Ok(roots)
+}
+
+/// Resolves `name` against an ordered list of `(root, read_only)` pairs,
+/// returning the matched root, the resolved skill file, and whether it is
+/// read-only. Roots are tried in order and the first match wins; a
+/// `hermes_skill_not_found` falls through to the next root, while any other
+/// error (ambiguous name, invalid name) stops the search.
+fn resolve_skill_in_roots(
+    roots: &[(PathBuf, bool)],
+    name: &str,
+) -> Result<(PathBuf, PathBuf, bool), AppError> {
+    let mut not_found: Option<AppError> = None;
+    for (root, read_only) in roots {
+        match resolve_hermes_skill_file_in_root(root, name) {
+            Ok(path) => return Ok((root.clone(), path, *read_only)),
+            Err(error) if error.code == "hermes_skill_not_found" => not_found = Some(error),
+            Err(error) => return Err(error),
+        }
+    }
+    Err(not_found.unwrap_or_else(|| {
+        AppError::new(
+            "hermes_skill_not_found",
+            format!("Could not find skill \"{}\".", name.trim()),
+        )
+    }))
 }
 
 fn resolve_hermes_skill_file_in_root(skills_root: &Path, name: &str) -> Result<PathBuf, AppError> {
@@ -3985,6 +4052,36 @@ mod tests {
                         .join("SKILL.md")
                 )
         );
+    }
+
+    #[test]
+    fn skill_resolver_searches_external_roots_and_flags_read_only() {
+        let managed = tempfile::tempdir().expect("managed tempdir");
+        let external = tempfile::tempdir().expect("external tempdir");
+        let managed_skill = managed.path().join("dogfood");
+        std::fs::create_dir_all(&managed_skill).expect("managed skill dir");
+        std::fs::write(managed_skill.join("SKILL.md"), "# Dogfood\n").expect("managed skill");
+        let external_skill = external.path().join("caveman");
+        std::fs::create_dir_all(&external_skill).expect("external skill dir");
+        std::fs::write(external_skill.join("SKILL.md"), "# Caveman\n").expect("external skill");
+
+        let roots = vec![
+            (managed.path().to_path_buf(), false),
+            (external.path().to_path_buf(), true),
+        ];
+
+        let (_, _, managed_read_only) =
+            resolve_skill_in_roots(&roots, "dogfood").expect("resolve managed");
+        assert!(!managed_read_only, "managed skills are editable");
+
+        let (root, path, external_read_only) =
+            resolve_skill_in_roots(&roots, "caveman").expect("resolve external");
+        assert!(external_read_only, "external skills are read-only");
+        assert_eq!(root.as_path(), external.path());
+        assert!(path.ends_with(Path::new("caveman").join("SKILL.md")));
+
+        let err = resolve_skill_in_roots(&roots, "missing").expect_err("missing");
+        assert_eq!(err.code, "hermes_skill_not_found");
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5253,6 +5253,7 @@ function SkillEditorPanel({
   onSave: () => void;
 }) {
   const title = skill?.name ?? document?.name ?? "Skill";
+  const readOnly = Boolean(document?.readOnly);
   return (
     <section
       className="agent-management-panel agent-skill-editor-panel"
@@ -5278,6 +5279,7 @@ function SkillEditorPanel({
               {document?.relativePath ? (
                 <span>{document.relativePath}</span>
               ) : null}
+              {readOnly ? <span>Read-only</span> : null}
               {skill ? (
                 <span>{skill.enabled ? "Enabled" : "Disabled"}</span>
               ) : null}
@@ -5295,27 +5297,36 @@ function SkillEditorPanel({
             value={value}
             aria-label={`${title} skill Markdown`}
             disabled={saving}
+            readOnly={readOnly}
             spellCheck={false}
             onChange={(event) => onChange(event.currentTarget.value)}
           />
         )}
       </div>
       <footer className="agent-messaging-footer">
-        <button
-          type="button"
-          disabled={!dirty || saving || loading}
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          className="primary-action primary-solid"
-          disabled={!dirty || saving || loading || !document}
-          onClick={onSave}
-        >
-          {saving ? "Saving..." : "Save changes"}
-        </button>
+        {readOnly ? (
+          <p className="agent-skill-editor-readonly-note">
+            Read-only. This skill loads from ~/.agents/skills. Edit it on disk.
+          </p>
+        ) : (
+          <>
+            <button
+              type="button"
+              disabled={!dirty || saving || loading}
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="primary-action primary-solid"
+              disabled={!dirty || saving || loading || !document}
+              onClick={onSave}
+            >
+              {saving ? "Saving..." : "Save changes"}
+            </button>
+          </>
+        )}
       </footer>
     </section>
   );

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -449,6 +449,9 @@ export type HermesSkillDocument = {
   name: string;
   relativePath: string;
   content: string;
+  /** True for skills loaded from an external dir (e.g. ~/.agents/skills).
+   *  June can read but not write them, so the editor is read-only. */
+  readOnly?: boolean;
 };
 
 export type HermesToolsetInfo = {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1316,6 +1316,12 @@ input:focus-visible,
   margin-right: auto;
 }
 
+.agent-skill-editor-readonly-note {
+  margin: 0 auto 0 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
 /* Action cards (approval, clarify) — a clean system card: card surface, subtle
  * border, soft shadow. */
 .agent-safety-panel,


### PR DESCRIPTION
## What

June now configures Hermes to load skills from `~/.agents/skills` (the home-directory folder the `skills` CLI installs into), in addition to its built-in `$HERMES_HOME/skills`.

- `sync_hermes_config` now emits a `skills.external_dirs` block in the `config.yaml` June writes on every Hermes spawn.
- The config-string building is extracted into a pure `render_hermes_config(...)` so the rendered YAML is unit-testable.
- New `external_skill_dirs()` helper resolves `<home>/.agents/skills` and includes it **only when the folder exists** (missing folder is a silent no-op).

## Why

Hermes already supports extra skill directories via `skills.external_dirs` (read + `~`/env-expanded by `agent/skill_utils.py::get_external_skills_dirs`, additive in `get_all_skills_dirs`), and deep-merges June's config keys over its defaults. June just wasn't populating that key. This lets a user or team drop skills in the standard home folder and have every agent session pick them up, with no new loader, dependency, or Hermes fork.

## Sandbox behavior

Loads correctly under the macOS Seatbelt jail: the profile is `(allow default)` with a write-jail + a credential read-denylist, and `~/.agents` is not denied, so reads are permitted. Skills load **read-only** (the write-jail only grants writes under June's own data dir) — the agent can use these skills but can't modify them, which is the intended safety property. A skill that needs to write back into its own folder would only succeed in Unrestricted/Full mode.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --locked --lib hermes_bridge` → **33/33 pass**, including 2 new tests:
  - `render_hermes_config_lists_external_skill_dirs`
  - `render_hermes_config_emits_empty_external_dirs_when_none`
- `cargo fmt` clean (touched only the changed file).

## Known gaps / scope

- v1 is **read-only**: June's in-app skill editor still operates only on `$HERMES_HOME/skills`; external skills are user-managed on disk. (Intentional — write-jail blocks writes there anyway.)
- New skills are picked up on the **next** agent session start (config is rewritten per spawn), not hot-reloaded mid-session.