### PR TITLE
Agent HUD visual tweaks: drop reply chat, retint shimmer, persist Done, center pill

### DIFF
--- a/src-tauri/src/agent_hud.rs
+++ b/src-tauri/src/agent_hud.rs
@@ -202,10 +202,12 @@ fn make_agent_hud_nonactivating(window: &WebviewWindow) {
 }
 
 /// NSPanel subclass that can become the key window. A borderless panel
-/// answers NO to `canBecomeKeyWindow` by default, which silently drops
-/// the clicks aimed at the panel's own controls (e.g. the context menu).
-/// It also overrides `sendEvent:` to intercept context-click events before
-/// WKWebView ever sees them; see `send_event` below.
+/// answers NO to `canBecomeKeyWindow` by default, so it never becomes key
+/// and the webview receives no keyboard events — Escape wouldn't dismiss the
+/// context menu and Enter/Space wouldn't toggle the pill. (Mouse clicks reach
+/// a non-activating panel regardless of key status; this is purely about
+/// keyboard delivery.) It also overrides `sendEvent:` to intercept
+/// context-click events before WKWebView ever sees them; see `send_event`.
 #[cfg(target_os = "macos")]
 fn agent_hud_panel_class() -> Option<&'static objc2::runtime::AnyClass> {
     use objc2::msg_send;

--- a/src-tauri/src/agent_hud.rs
+++ b/src-tauri/src/agent_hud.rs
@@ -24,7 +24,6 @@ static AGENT_HUD_APP: std::sync::OnceLock<AppHandle> = std::sync::OnceLock::new(
 pub struct AgentHudLayoutRequest {
     expanded: bool,
     card_count: Option<u32>,
-    replying: Option<bool>,
     context_menu_open: Option<bool>,
 }
 
@@ -61,7 +60,6 @@ pub fn agent_hud_set_layout(app: AppHandle, request: AgentHudLayoutRequest) -> R
     let (width, height) = agent_hud_window_size(
         request.expanded,
         request.card_count.unwrap_or(0),
-        request.replying.unwrap_or(false),
         request.context_menu_open.unwrap_or(false),
     );
     // The HUD is top-right anchored with a fixed native width, so resizing
@@ -71,25 +69,6 @@ pub fn agent_hud_set_layout(app: AppHandle, request: AgentHudLayoutRequest) -> R
     window
         .set_size(Size::Logical(LogicalSize::new(width, height)))
         .map_err(|error| error.to_string())
-}
-
-/// Lets the HUD accept keystrokes for its inline reply field. The panel is
-/// non-activating, so becoming key does not bring the app forward or steal
-/// focus from whatever the user is working in.
-#[tauri::command]
-pub fn agent_hud_focus_reply(app: AppHandle) -> Result<(), String> {
-    let Some(window) = app.get_webview_window(AGENT_HUD_WINDOW_LABEL) else {
-        return Ok(());
-    };
-    #[cfg(target_os = "macos")]
-    {
-        let panel = window.clone();
-        window
-            .run_on_main_thread(move || make_agent_hud_key(&panel))
-            .map_err(|error| error.to_string())
-    }
-    #[cfg(not(target_os = "macos"))]
-    window.set_focus().map_err(|error| error.to_string())
 }
 
 #[tauri::command]
@@ -109,19 +88,13 @@ pub fn agent_hud_open_agent(
 /// gutter for the top-right offset and shadow. Keep the native width constant
 /// so layout changes grow downward like a notification instead of resizing and
 /// re-anchoring horizontally.
-fn agent_hud_window_size(
-    expanded: bool,
-    card_count: u32,
-    replying: bool,
-    context_menu_open: bool,
-) -> (f64, f64) {
+fn agent_hud_window_size(expanded: bool, card_count: u32, context_menu_open: bool) -> (f64, f64) {
     let height: f64 = if !expanded || card_count == 0 {
         AGENT_HUD_COLLAPSED_WINDOW_HEIGHT
     } else {
         let rows = f64::from(card_count.min(3));
         let surface_height = 36.0 + rows * 46.0 + 6.0;
-        let reply_height = if replying { 32.0 } else { 0.0 };
-        8.0 + surface_height + reply_height + 14.0
+        8.0 + surface_height + 14.0
     };
 
     if context_menu_open {
@@ -230,9 +203,9 @@ fn make_agent_hud_nonactivating(window: &WebviewWindow) {
 
 /// NSPanel subclass that can become the key window. A borderless panel
 /// answers NO to `canBecomeKeyWindow` by default, which silently drops
-/// every keystroke aimed at the reply field. It also overrides `sendEvent:`
-/// to intercept context-click events before WKWebView ever sees them; see
-/// `send_event` below.
+/// the clicks aimed at the panel's own controls (e.g. the context menu).
+/// It also overrides `sendEvent:` to intercept context-click events before
+/// WKWebView ever sees them; see `send_event` below.
 #[cfg(target_os = "macos")]
 fn agent_hud_panel_class() -> Option<&'static objc2::runtime::AnyClass> {
     use objc2::msg_send;
@@ -304,43 +277,26 @@ fn agent_hud_panel_class() -> Option<&'static objc2::runtime::AnyClass> {
     Some(builder.register())
 }
 
-#[cfg(target_os = "macos")]
-fn make_agent_hud_key(window: &WebviewWindow) {
-    use objc2::msg_send;
-    use objc2::runtime::AnyObject;
-
-    let Ok(handle) = window.ns_window() else {
-        return;
-    };
-    if handle.is_null() {
-        return;
-    }
-    unsafe {
-        let panel = handle as *mut AnyObject;
-        let _: () = msg_send![panel, makeKeyWindow];
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn agent_hud_layout_keeps_width_stable_across_states() {
-        assert_eq!(agent_hud_window_size(false, 0, false, false).0, 304.0);
-        assert_eq!(agent_hud_window_size(true, 1, false, false).0, 304.0);
-        assert_eq!(agent_hud_window_size(true, 3, true, false).0, 304.0);
-        assert_eq!(agent_hud_window_size(false, 0, false, true).0, 304.0);
+        assert_eq!(agent_hud_window_size(false, 0, false).0, 304.0);
+        assert_eq!(agent_hud_window_size(true, 1, false).0, 304.0);
+        assert_eq!(agent_hud_window_size(true, 3, false).0, 304.0);
+        assert_eq!(agent_hud_window_size(false, 0, true).0, 304.0);
     }
 
     #[test]
     fn agent_hud_layout_grows_downward_for_expanded_content() {
-        let collapsed = agent_hud_window_size(false, 0, false, false);
-        let expanded = agent_hud_window_size(true, 1, false, false);
-        let replying = agent_hud_window_size(true, 1, true, false);
+        let collapsed = agent_hud_window_size(false, 0, false);
+        let expanded = agent_hud_window_size(true, 1, false);
+        let expanded_more = agent_hud_window_size(true, 3, false);
 
         assert_eq!(collapsed.1, AGENT_HUD_COLLAPSED_WINDOW_HEIGHT);
         assert!(expanded.1 > collapsed.1);
-        assert!(replying.1 > expanded.1);
+        assert!(expanded_more.1 > expanded.1);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,7 +215,6 @@ pub fn run() {
             agent_hud::agent_hud_show,
             agent_hud::agent_hud_hide,
             agent_hud::agent_hud_set_layout,
-            agent_hud::agent_hud_focus_reply,
             agent_hud::agent_hud_open_agent,
             meeting_hud::meeting_hud_latest_status,
             meeting_hud::meeting_hud_reopen,

--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -1,6 +1,4 @@
-import { emit, listen } from "@tauri-apps/api/event";
-import { IconArrowUp } from "central-icons/IconArrowUp";
-import { IconBubbleWide } from "central-icons/IconBubbleWide";
+import { listen } from "@tauri-apps/api/event";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconCircleQuestionmark } from "central-icons/IconCircleQuestionmark";
@@ -10,10 +8,8 @@ import { createElement, type ComponentType, type SVGProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   AGENT_OPEN_EVENT,
-  AGENT_REPLY_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   AGENT_SESSION_STATUS_EVENT,
-  type AgentReplyDetail,
   type AgentSessionStatusDetail,
   type AgentSessionStatusKind,
   type AgentSessionsChangedDetail,
@@ -26,7 +22,6 @@ import {
   type AgentHudVisibilityChangedDetail,
 } from "./lib/agent-hud-settings";
 import {
-  agentHudFocusReply,
   agentHudHide,
   agentHudOpenAgent,
   agentHudSetLayout,
@@ -57,7 +52,9 @@ const EXPANDED_KEY = "scribe:agent-hud:expanded";
 // sync with AGENT_HUD_CONTEXT_MENU_EVENT in agent_hud.rs.
 const AGENT_HUD_CONTEXT_MENU_EVENT = "scribe:agent-hud:context-menu";
 const MAX_VISIBLE_ROWS = 3;
-const COMPLETED_STATUS_TTL_MS = 2200;
+// Keep a finished session on screen long enough to actually read the "Done"
+// row before it fades out, rather than blinking away the instant it lands.
+const COMPLETED_STATUS_TTL_MS = 6500;
 const FAILED_STATUS_TTL_MS = 8 * 1000;
 // Covers the surface's fade-out transition (--t-slow) before the native
 // window hides, plus a little slack for the compositor.
@@ -90,7 +87,6 @@ const state = {
   waitingSessionIds: new Set<string>(),
   statusBySessionId: new Map<string, StatusRecord>(),
   pendingStatuses: [] as StatusRecord[],
-  replyingEntryId: undefined as string | undefined,
   // Transient auto-expand triggered when an entry newly needs input. Unlike
   // `expanded` it is not persisted to EXPANDED_KEY: it grabs attention once,
   // then an explicit collapse (setExpanded(false)) must stick.
@@ -111,17 +107,6 @@ let hideTimer: number | undefined;
 let resizeTimer: number | undefined;
 let widthFlipTimer: number | undefined;
 let windowShown = false;
-// The reply form lives outside the rebuild cycle: status events arrive in
-// bursts while sessions work, and recreating the input on each one would
-// wipe whatever the user is typing.
-let replyForm:
-  | {
-      entryId: string;
-      entry: HudEntry;
-      form: HTMLFormElement;
-      input: HTMLInputElement;
-    }
-  | undefined;
 
 function applySessionsChanged(detail?: AgentSessionsChangedDetail) {
   if (!detail) return;
@@ -172,9 +157,6 @@ function applyStatus(detail?: AgentSessionStatusDetail) {
           ...state.pendingStatuses,
         ].slice(0, MAX_VISIBLE_ROWS);
       }
-      if (state.replyingEntryId === detail.sessionId) {
-        state.replyingEntryId = undefined;
-      }
       render();
       return;
     }
@@ -208,7 +190,6 @@ function applyVisibility(enabled: boolean) {
   if (!enabled) {
     state.focused = false;
     state.menuOpen = false;
-    state.replyingEntryId = undefined;
   }
   render();
 }
@@ -239,20 +220,12 @@ function render() {
   if (waitingEntryIds.size === 0) state.attentionExpanded = false;
   lastWaitingEntryIds = waitingEntryIds;
 
-  if (
-    state.replyingEntryId &&
-    !entries.some((entry) => entry.id === state.replyingEntryId)
-  ) {
-    state.replyingEntryId = undefined;
-  }
-  if (!state.replyingEntryId) replyForm = undefined;
   const expanded =
     state.enabled &&
     hasEntries &&
     (state.attentionExpanded ||
       state.expanded ||
       state.focused ||
-      Boolean(state.replyingEntryId) ||
       // Hovering holds the panel open: it must not collapse or fade out
       // under the pointer, even when the reason it expanded goes away.
       (state.hovered && lastRenderedExpanded));
@@ -295,25 +268,15 @@ function render() {
   // collapse reveal always has content to animate.
   const stackKey = entries
     .map((entry) =>
-      [
-        entry.id,
-        entry.title,
-        entry.summary,
-        entry.status,
-        state.replyingEntryId === entry.id ? "replying" : "",
-      ].join("\u0001"),
+      [entry.id, entry.title, entry.summary, entry.status].join("\u0001"),
     )
     .join("\u0002");
   if (stackKey !== lastStackKey) {
     lastStackKey = stackKey;
-    const inputHadFocus =
-      replyForm !== undefined && document.activeElement === replyForm.input;
     stack.replaceChildren();
     entries.forEach((entry, index) => {
       stack.appendChild(renderRow(entry, index));
     });
-    // replaceChildren re-homes the cached form node, which drops focus.
-    if (inputHadFocus && replyForm?.input.isConnected) replyForm.input.focus();
   }
   stack.setAttribute("aria-hidden", expanded ? "false" : "true");
   if (menu) {
@@ -460,83 +423,7 @@ function renderRow(entry: HudEntry, index: number) {
   body.appendChild(text);
   row.appendChild(body);
 
-  const reply = document.createElement("button");
-  reply.type = "button";
-  reply.className = "agent-hud-reply";
-  reply.setAttribute("aria-label", `Reply to ${entry.title}`);
-  reply.title = "Reply";
-  appendIcon(reply, IconBubbleWide, 14);
-  reply.addEventListener("click", (event) => {
-    event.stopPropagation();
-    state.replyingEntryId = entry.id;
-    render();
-    // The HUD is a non-activating panel; ask the native side to make it the
-    // key window so the input actually receives keystrokes.
-    void agentHudFocusReply().catch(() => {});
-    window.setTimeout(() => replyForm?.input.focus(), 0);
-  });
-  row.appendChild(reply);
-
-  if (state.replyingEntryId === entry.id) {
-    row.appendChild(ensureReplyForm(entry));
-  }
-
   return row;
-}
-
-function ensureReplyForm(entry: HudEntry) {
-  if (replyForm && replyForm.entryId === entry.id) {
-    replyForm.entry = entry;
-    return replyForm.form;
-  }
-
-  const form = document.createElement("form");
-  form.className = "agent-hud-reply-form";
-  // The entrance keyframes must run only on the first mount; the cached
-  // form node gets re-appended on every stack rebuild while a draft is
-  // open, and each re-append would restart them.
-  form.addEventListener(
-    "animationend",
-    () => form.setAttribute("data-settled", ""),
-    { once: true },
-  );
-
-  const input = document.createElement("input");
-  input.className = "agent-hud-reply-input";
-  input.type = "text";
-  input.placeholder = "Reply to June";
-  input.autocomplete = "off";
-  input.spellcheck = true;
-  input.addEventListener("click", (event) => event.stopPropagation());
-  input.addEventListener("keydown", (event) => {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      state.replyingEntryId = undefined;
-      render();
-    }
-  });
-
-  const submit = document.createElement("button");
-  submit.type = "submit";
-  submit.className = "agent-hud-reply-send";
-  submit.setAttribute("aria-label", "Send reply");
-  submit.title = "Send reply";
-  appendIcon(submit, IconArrowUp, 14);
-
-  form.append(input, submit);
-  form.addEventListener("click", (event) => event.stopPropagation());
-  form.addEventListener("submit", (event) => {
-    event.preventDefault();
-    const text = input.value.trim();
-    if (!text) return;
-    const target = replyForm?.entry ?? entry;
-    state.replyingEntryId = undefined;
-    render();
-    void sendReply(target, text);
-  });
-
-  replyForm = { entryId: entry.id, entry, form, input };
-  return form;
 }
 
 function buildEntries() {
@@ -850,10 +737,9 @@ async function syncWindowLayout(
   rowCount: number,
   hasEntries: boolean,
 ) {
-  const replying = Boolean(state.replyingEntryId);
   const menuOpen = state.menuOpen;
   const visible = state.enabled && hasEntries;
-  const key = `${visible}:${expanded}:${rowCount}:${replying}:${menuOpen}`;
+  const key = `${visible}:${expanded}:${rowCount}:${menuOpen}`;
   if (key === lastLayoutKey) return;
   lastLayoutKey = key;
   if (!visible) {
@@ -863,12 +749,11 @@ async function syncWindowLayout(
   }
   cancelWindowHide();
   cancelPendingResize();
-  const height = nativeWindowHeight(expanded, rowCount, replying, menuOpen);
+  const height = nativeWindowHeight(expanded, rowCount, menuOpen);
   const apply = async () => {
     await agentHudSetLayout({
       expanded,
       cardCount: rowCount,
-      replying,
       ...(menuOpen ? { contextMenuOpen: menuOpen } : {}),
     }).catch(() => {});
     if (!windowShown) {
@@ -896,13 +781,12 @@ async function syncWindowLayout(
 function nativeWindowHeight(
   expanded: boolean,
   rowCount: number,
-  replying: boolean,
   menuOpen: boolean,
 ) {
   const height =
     !expanded || rowCount === 0
       ? 58
-      : 8 + 36 + Math.min(rowCount, 3) * 46 + 6 + (replying ? 32 : 0) + 14;
+      : 8 + 36 + Math.min(rowCount, 3) * 46 + 6 + 14;
   return menuOpen ? Math.max(height, 104) : height;
 }
 
@@ -939,7 +823,6 @@ function setExpanded(expanded: boolean) {
   if (!expanded) {
     state.focused = false;
     state.menuOpen = false;
-    state.replyingEntryId = undefined;
     // An explicit collapse clears the attention auto-expand; otherwise the
     // next render would immediately re-expand while a session still waits.
     state.attentionExpanded = false;
@@ -1021,20 +904,6 @@ async function openAgent(session?: HermesSessionInfo) {
       new CustomEvent(AGENT_OPEN_EVENT, {
         detail: { session },
       }),
-    );
-  });
-}
-
-async function sendReply(entry: HudEntry, text: string) {
-  await openAgent(entry.session);
-  const detail: AgentReplyDetail = {
-    requestId: `agent-hud:${Date.now()}:${Math.random().toString(36).slice(2)}`,
-    session: entry.session,
-    text,
-  };
-  await emit(AGENT_REPLY_EVENT, detail).catch(() => {
-    window.dispatchEvent(
-      new CustomEvent<AgentReplyDetail>(AGENT_REPLY_EVENT, { detail }),
     );
   });
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -108,11 +108,9 @@ import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_GALLERY_EVENT,
   AGENT_OPEN_EVENT,
-  AGENT_REPLY_EVENT,
   AGENT_SESSION_STATUS_EVENT,
   dispatchAgentSessionStatus,
   type AgentGalleryDetail,
-  type AgentReplyDetail,
   type AgentSessionStatusDetail,
 } from "../lib/agent-events";
 import { notifyAgentSessionStatus } from "../lib/agent-notifications";
@@ -325,8 +323,6 @@ export function App() {
   const restoreTargetRef = useRef<TabNav | null>(null);
   const [activeAgentSession, setActiveAgentSession] =
     useState<HermesSessionInfo>();
-  const [pendingAgentReply, setPendingAgentReply] =
-    useState<AgentReplyDetail>();
   // Reactive copy of the known agent sessions for the "view all" list and
   // project (folder) surfaces; the menu-bar refs below stay the source for
   // native menu state.
@@ -1112,36 +1108,6 @@ export function App() {
       aborted = true;
       unlisten?.();
       window.removeEventListener(AGENT_OPEN_EVENT, handleOpenEvent);
-    };
-  }, []);
-
-  useEffect(() => {
-    function handleReply(detail?: AgentReplyDetail) {
-      if (!detail?.text.trim()) return;
-      setAgentOrigin(undefined);
-      setActiveAgentSession(detail.session);
-      setPendingAgentReply(detail);
-      setActiveView("agent");
-    }
-
-    function handleReplyEvent(event: Event) {
-      handleReply((event as CustomEvent<AgentReplyDetail>).detail);
-    }
-
-    let aborted = false;
-    let unlisten: (() => void) | undefined;
-    window.addEventListener(AGENT_REPLY_EVENT, handleReplyEvent);
-    void listen<AgentReplyDetail>(AGENT_REPLY_EVENT, (event) => {
-      handleReply(event.payload);
-    }).then((cleanup) => {
-      if (aborted) cleanup();
-      else unlisten = cleanup;
-    });
-
-    return () => {
-      aborted = true;
-      unlisten?.();
-      window.removeEventListener(AGENT_REPLY_EVENT, handleReplyEvent);
     };
   }, []);
 
@@ -2817,7 +2783,6 @@ export function App() {
                 // session bar, so they persist while the chat scrolls beneath.
                 <AgentWorkspace
                   initialSession={activeAgentSession}
-                  pendingReply={pendingAgentReply}
                   origin={
                     agentOriginFolder
                       ? {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -133,7 +133,6 @@ import {
   dispatchAgentSessionsChanged,
   dispatchAgentSessionStatus,
   type AgentGalleryDetail,
-  type AgentReplyDetail,
   type AgentSessionsChangedDetail,
   type AgentSessionStatusKind,
 } from "../../lib/agent-events";
@@ -706,14 +705,8 @@ export type AgentWorkspaceOrigin = {
 
 type AgentWorkspaceProps = {
   initialSession?: HermesSessionInfo;
-  pendingReply?: AgentReplyDetail;
   origin?: AgentWorkspaceOrigin;
 };
-
-// Module-scoped so a remount of AgentWorkspace (e.g. navigating away from the
-// agent view and back) does not re-submit an agent HUD reply that App still holds
-// in its pendingReply state.
-const handledHudReplyIds = new Set<string>();
 
 // Mid-run continuity across remounts. While June is working, a session has
 // state that exists nowhere outside this component: the optimistic list entry
@@ -781,7 +774,6 @@ export function resetAgentSessionContinuity() {
 
 export function AgentWorkspace({
   initialSession,
-  pendingReply,
   origin,
 }: AgentWorkspaceProps = {}) {
   const initialSessionId = initialSession?.id;
@@ -1622,13 +1614,6 @@ export function AgentWorkspace({
   }, [selectedHermesSessionId]);
 
   useEffect(() => {
-    if (!pendingReply?.text.trim()) return;
-    if (handledHudReplyIds.has(pendingReply.requestId)) return;
-    handledHudReplyIds.add(pendingReply.requestId);
-    void submitHudReply(pendingReply);
-  }, [pendingReply]);
-
-  useEffect(() => {
     // The sidebar and App replace their session lists wholesale with this
     // payload, so an unhydrated broadcast (mount seed only) would collapse
     // the list they already fetched themselves and flicker it back once the
@@ -1984,55 +1969,6 @@ export function AgentWorkspace({
       // On success the hero is gone; on failure this fades the greeting and
       // suggestions back in behind the restored draft.
       setHeroLeaving(false);
-    }
-  }
-
-  async function submitHudReply(reply: AgentReplyDetail) {
-    const message = reply.text.trim();
-    if (!message) return;
-    if (submitting || importingFiles) {
-      // Another submission is in flight; keep the reply in the composer
-      // instead of dropping it silently.
-      composerEditorRef.current?.setContent(message);
-      return;
-    }
-    const targetSession = reply.session;
-    setActivePanel("chat");
-    setSelectedTaskId(undefined);
-    composerEditorRef.current?.clear();
-    setAttachments([]);
-    if (targetSession?.id) {
-      newSessionModeRef.current = false;
-      setNewSessionMode(false);
-      selectedHermesSessionIdRef.current = targetSession.id;
-      setSelectedHermesSessionId(targetSession.id);
-      setHermesSessionItems((current) =>
-        current.some((session) => session.id === targetSession.id)
-          ? current
-          : [targetSession, ...current],
-      );
-    }
-    setSubmitting(true);
-    try {
-      await submitHermesSession(message, targetSession);
-      setError(null);
-      setBusyNotice(null);
-    } catch (err) {
-      // Same merge-restore as submit(): don't clobber a draft the user
-      // started typing while the reply was in flight.
-      if (composerEditorRef.current?.isEmpty() ?? true) {
-        composerEditorRef.current?.setContent(message);
-      }
-      if (isSessionBusyError(err)) {
-        // Same as submit(): a 4009 proves the gateway is healthy, so a stale
-        // connection banner must not outlive it.
-        setError(null);
-        setBusyNotice(SESSION_BUSY_NOTICE);
-      } else {
-        setError(messageFromError(err));
-      }
-    } finally {
-      setSubmitting(false);
     }
   }
 

--- a/src/lib/agent-events.ts
+++ b/src/lib/agent-events.ts
@@ -6,7 +6,6 @@ export const AGENT_SESSIONS_CHANGED_EVENT = "scribe:agent:sessions-changed";
 export const AGENT_NEW_SESSION_PENDING_KEY = "scribe:agent:new-session-pending";
 export const AGENT_SESSION_STATUS_EVENT = "scribe:agent:session-status";
 export const AGENT_OPEN_EVENT = "scribe:agent:open";
-export const AGENT_REPLY_EVENT = "scribe:agent:reply";
 // Dev-only: toggles the agent response gallery (window.__agentGallery) or its
 // error-focused variant (window.__agentErrors).
 export const AGENT_GALLERY_EVENT = "scribe:agent:gallery";
@@ -37,12 +36,6 @@ export type AgentSessionsChangedDetail = {
   selectedSessionId?: string;
   workingSessionIds: string[];
   waitingSessionIds?: string[];
-};
-
-export type AgentReplyDetail = {
-  requestId: string;
-  session?: HermesSessionInfo;
-  text: string;
 };
 
 export function dispatchAgentSessionStatus(detail: AgentSessionStatusDetail) {

--- a/src/lib/agent-hud-demo.ts
+++ b/src/lib/agent-hud-demo.ts
@@ -40,9 +40,9 @@ type DemoState =
 const HELP = [
   "Agent HUD demo states:",
   '  __agentHud("running", n?)  n sessions working (default 1)',
-  '  __agentHud("waiting")      one session needs input (expands, reply testable)',
+  '  __agentHud("waiting")      one session needs input (expands)',
   '  __agentHud("mixed")        two running + one needing input',
-  '  __agentHud("done")         a session just finished (fades out after ~2s)',
+  '  __agentHud("done")         a session just finished (fades out after ~6s)',
   '  __agentHud("failed")       a session hit a problem (lingers ~8s)',
   '  __agentHud("stopped")      a session was cancelled',
   '  __agentHud("demo")         scripted lifecycle: start, run, need input, finish',
@@ -227,7 +227,7 @@ export function registerAgentHudDemo({ local }: AgentHudDemoOptions) {
         return `${count} running. __agentHud("clear") to reset.`;
       case "waiting":
         park(0, 1);
-        return 'Needs input: the HUD expands itself; try the reply. __agentHud("clear") to reset.';
+        return 'Needs input: the HUD expands itself. __agentHud("clear") to reset.';
       case "mixed":
         park(2, 1);
         return 'Two running, one needs input. __agentHud("clear") to reset.';

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -754,14 +754,9 @@ export async function agentHudHide() {
 export async function agentHudSetLayout(input: {
   expanded: boolean;
   cardCount?: number;
-  replying?: boolean;
   contextMenuOpen?: boolean;
 }) {
   return invoke<void>("agent_hud_set_layout", { request: input });
-}
-
-export async function agentHudFocusReply() {
-  return invoke<void>("agent_hud_focus_reply");
 }
 
 export async function agentHudOpenAgent(session?: HermesSessionInfo) {

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -10,7 +10,7 @@
  * layout the controller requests). Collapsed it is a single quiet pill:
  * the June mark, tinted by the aggregate state, plus "2 running". Click,
  * keyboard focus, or a session needing input expands it into a compact
- * list with open/reply actions.
+ * list of sessions, each opening its context in June when clicked.
  *
  * Forced dark regardless of system theme, like the dictation HUD: a
  * transient overlay has to read consistently against any wallpaper or
@@ -32,11 +32,12 @@
   /* The brand terracotta (--brand: #c25a33 ~ oklch(0.58 0.14 40) in
    * tokens.css), lifted for legibility on the dark glass. */
   --attention: oklch(0.74 0.13 42);
-  /* Shimmer highlight for the attention (needs-input) mark — warmer, brighter,
-   * and high-chroma so the tiny masked glyph has enough contrast to read.
-   * Keep in sync with meeting-hud.css. The neutral "running" shimmer uses
-   * --foreground (white) and is unaffected by this. */
-  --attention-bright: oklch(0.91 0.2 72);
+  /* Shimmer highlight for the attention (needs-input) mark — a lifted, dull
+   * terracotta rather than a bright yellow, so the sweep stays in the brand
+   * family instead of reading as gold. Still light enough that the tiny masked
+   * glyph keeps contrast. Keep in sync with meeting-hud.css. The neutral
+   * "running" shimmer uses --foreground (white) and is unaffected by this. */
+  --attention-bright: oklch(0.82 0.12 48);
 
   color: var(--foreground);
   background: transparent;
@@ -143,7 +144,10 @@ body {
   grid-template-columns: var(--hud-icon-col) 1fr auto;
   column-gap: var(--hud-col-gap);
   align-items: center;
-  height: 28px;
+  /* A touch taller than the content needs: the extra height gives the
+   * collapsed pill more presence. border-radius: 16px above is half of this,
+   * so the collapsed surface reads as a true pill. */
+  height: 32px;
   min-width: 88px;
   padding: 0 9px;
   border: 0;
@@ -204,6 +208,10 @@ body {
 
 .agent-hud-pill-label {
   overflow: hidden;
+  /* The label keeps a 1px optical nudge so the text ink sits on the pill's
+   * center line. The icons (mark, chevron) are symmetric glyphs and center
+   * geometrically, so they carry no nudge: matching them to the text would
+   * push them 1px low. Don't add translateY to the icons to "match" this. */
   padding-bottom: 1px;
   line-height: 1.18;
   transform: translateY(1px);
@@ -216,12 +224,11 @@ body {
   width: 14px;
   height: 14px;
   color: var(--muted-foreground);
-  transform: translateY(1px);
   transition: transform var(--t-med) var(--ease-out);
 }
 
 .agent-hud[data-expanded="true"] .agent-hud-chevron {
-  transform: translateY(1px) rotate(180deg);
+  transform: rotate(180deg);
 }
 
 /* June mark ------------------------------------------------------------- */
@@ -242,7 +249,6 @@ body {
   mask: var(--mark) center / 10px 12px no-repeat;
   -webkit-mask: var(--mark) center / 10px 12px no-repeat;
   background-color: var(--mark-base);
-  transform: translateY(1px);
   transition: background-color var(--t-med) var(--ease-out);
 }
 
@@ -346,7 +352,12 @@ body {
   display: block;
   min-height: 0;
   margin: 0;
-  padding: 0 0 var(--sp-1);
+  /* No bottom padding here: the stack's own padding sits outside the
+   * overflow-clipped region, so the reveal's 0fr collapse can't fold it
+   * away, and a collapsed pill would carry ~4px of dead surface below the
+   * content (pushing it visually high). The bottom breathing room lives on
+   * the last row instead, where it collapses with the rows it spaces. */
+  padding: 0;
   overflow: hidden;
   list-style: none;
   /* Hidden rows must not be clickable or tabbable; the delay keeps them
@@ -369,6 +380,13 @@ body {
   transition:
     opacity var(--t-med) var(--ease-out),
     transform var(--t-med) var(--ease-out);
+}
+
+/* Bottom breathing room before the surface's rounded corner. Lives on the
+ * last row (inside the clipped, collapsing region) rather than the stack's
+ * padding, so it folds to nothing when the panel collapses. */
+.agent-hud-row:last-child {
+  margin-bottom: var(--sp-1);
 }
 
 .agent-hud[data-expanded="true"] .agent-hud-row {
@@ -435,97 +453,6 @@ body {
   white-space: nowrap;
 }
 
-/* Reply ------------------------------------------------------------------ */
-
-.agent-hud-reply {
-  position: absolute;
-  top: 11px;
-  right: var(--sp-3);
-  display: grid;
-  place-items: center;
-  width: var(--control-xs);
-  height: var(--control-xs);
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--r-pill);
-  background: color-mix(in oklch, var(--foreground) 10%, transparent);
-  color: var(--foreground);
-  font: inherit;
-  font-size: var(--fs-xs);
-  font-weight: var(--fw-medium);
-  letter-spacing: 0;
-  cursor: pointer;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--t-fast) var(--ease-out);
-}
-
-.agent-hud-row:hover .agent-hud-reply,
-.agent-hud-row:focus-within .agent-hud-reply {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.agent-hud-row:has(.agent-hud-reply-form) .agent-hud-reply {
-  display: none;
-}
-
-.agent-hud-reply-form {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: var(--sp-2);
-  padding: 0 var(--sp-3) var(--sp-2);
-  animation: agent-hud-reply-in var(--t-med) var(--ease-out);
-}
-
-/* One-shot entrance: the cached form node re-appends on every stack
- * rebuild while a draft is open, and must not replay it (agent-hud.ts
- * sets data-settled after the first run). */
-.agent-hud-reply-form[data-settled] {
-  animation: none;
-}
-
-.agent-hud-reply-input {
-  /* The body disables selection for the overlay; the input needs it back. */
-  user-select: text;
-  min-width: 0;
-  height: var(--control-sm);
-  padding: 0 var(--sp-4);
-  border: 1px solid var(--border);
-  border-radius: var(--r-pill);
-  background: color-mix(in oklch, var(--background) 65%, transparent);
-  color: var(--foreground);
-  font: inherit;
-  font-size: var(--fs-sm);
-  letter-spacing: 0;
-  outline: none;
-}
-
-.agent-hud-reply-input::placeholder {
-  color: var(--muted-foreground);
-}
-
-.agent-hud-reply-input:focus-visible {
-  border-color: var(--ring-focus);
-}
-
-.agent-hud-reply-send {
-  display: grid;
-  place-items: center;
-  width: var(--control-sm);
-  height: var(--control-sm);
-  padding: 0;
-  border: 0;
-  border-radius: var(--r-pill);
-  background: var(--foreground);
-  color: var(--background);
-  font: inherit;
-  font-size: var(--fs-sm);
-  font-weight: var(--fw-medium);
-  letter-spacing: 0;
-  cursor: pointer;
-}
-
 /* Context menu ------------------------------------------------------------ */
 
 .agent-hud-menu {
@@ -567,9 +494,7 @@ body {
 }
 
 .agent-hud-pill:focus-visible,
-.agent-hud-row-body:focus-visible,
-.agent-hud-reply:focus-visible,
-.agent-hud-reply-send:focus-visible {
+.agent-hud-row-body:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: -2px;
 }
@@ -591,13 +516,6 @@ body {
   }
 }
 
-@keyframes agent-hud-reply-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .agent-hud-surface,
   .agent-hud-reveal,
@@ -607,8 +525,7 @@ body {
   }
 
   .agent-hud-mark,
-  .agent-hud-status,
-  .agent-hud-reply-form {
+  .agent-hud-status {
     animation: none;
   }
 }

--- a/src/styles/meeting-hud.css
+++ b/src/styles/meeting-hud.css
@@ -36,9 +36,10 @@
    * separate window and locally redefines the tokens it needs. The brand
    * terracotta (--brand in tokens.css), lifted for legibility on dark glass. */
   --attention: oklch(0.74 0.13 42);
-  /* The shimmer highlight. Warmer, brighter, and high-chroma so the tiny
-   * masked glyph has enough contrast to read without washing out to white. */
-  --attention-bright: oklch(0.91 0.2 72);
+  /* The shimmer highlight. A lifted, dull terracotta rather than a bright
+   * yellow, so the sweep stays in the brand family instead of reading as gold,
+   * while staying light enough for the tiny masked glyph to keep contrast. */
+  --attention-bright: oklch(0.82 0.12 48);
 
   color: var(--foreground);
   background: transparent;

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  AGENT_REPLY_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
   AGENT_SESSION_STATUS_EVENT,
 } from "../lib/agent-events";
@@ -60,7 +59,7 @@ describe("agent HUD", () => {
     expect(stackElement().querySelector(".dot-spinner > span")).toBeTruthy();
     expect(stackElement()).toHaveAttribute("aria-hidden", "true");
     expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
-      request: { expanded: false, cardCount: 0, replying: false },
+      request: { expanded: false, cardCount: 0 },
     });
     expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_show");
   });
@@ -166,7 +165,7 @@ describe("agent HUD", () => {
     await flushPromises();
 
     expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
-      request: { expanded: true, cardCount: 1, replying: false },
+      request: { expanded: true, cardCount: 1 },
     });
     expect(mocks.invoke).not.toHaveBeenCalledWith("agent_hud_show");
   });
@@ -187,7 +186,6 @@ describe("agent HUD", () => {
     expect(stackElement()).toHaveTextContent("Need approval");
     expect(document.querySelector(".agent-hud-status svg")).toBeTruthy();
     expect(document.querySelector(".agent-hud-chevron svg")).toBeTruthy();
-    expect(document.querySelector(".agent-hud-reply svg")).toBeTruthy();
   });
 
   it("stays collapsed after an explicit collapse while a session still needs input", async () => {
@@ -376,75 +374,6 @@ describe("agent HUD", () => {
     expect(stackElement()).not.toHaveTextContent("June is working.");
   });
 
-  it("opens a reply form and requests the taller reply layout", async () => {
-    await loadAgentHud();
-
-    emitStatus({
-      status: "waitingForUser",
-      title: "Need approval",
-      summary: "Review this step.",
-    });
-    await flushPromises();
-
-    replyButton().click();
-    await flushPromises();
-
-    expect(document.querySelector(".agent-hud-reply-input")).toBeTruthy();
-    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_set_layout", {
-      request: { expanded: true, cardCount: 1, replying: true },
-    });
-  });
-
-  it("asks the native panel for key focus when a reply opens", async () => {
-    await loadAgentHud();
-
-    emitStatus({
-      status: "waitingForUser",
-      title: "Need approval",
-      summary: "Review this step.",
-    });
-    await flushPromises();
-
-    replyButton().click();
-    await flushPromises();
-
-    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_focus_reply");
-  });
-
-  it("keeps the reply draft when a status burst re-renders the rows", async () => {
-    await loadAgentHud();
-
-    emitStatus({
-      status: "waitingForUser",
-      title: "Need approval",
-      summary: "Review this step.",
-    });
-    await flushPromises();
-
-    replyButton().click();
-    await flushPromises();
-
-    const input = document.querySelector<HTMLInputElement>(
-      ".agent-hud-reply-input",
-    );
-    expect(input).toBeTruthy();
-    input!.value = "Working on it";
-
-    emitStatus({
-      status: "waitingForUser",
-      title: "Need approval",
-      summary: "Still waiting on you.",
-    });
-    await flushPromises();
-
-    const inputs = document.querySelectorAll<HTMLInputElement>(
-      ".agent-hud-reply-input",
-    );
-    expect(inputs).toHaveLength(1);
-    expect(inputs[0]).toBe(input);
-    expect(inputs[0].value).toBe("Working on it");
-  });
-
   it("keeps the panel open under the pointer after the work resolves", async () => {
     await loadAgentHud();
 
@@ -493,53 +422,9 @@ describe("agent HUD", () => {
     expect(pillLabelElement()).toHaveTextContent("Done");
 
     hudElement().dispatchEvent(new Event("pointerleave"));
-    await vi.advanceTimersByTimeAsync(2_450);
+    await vi.advanceTimersByTimeAsync(6_550);
 
     expect(hudElement().dataset.hasEntries).toBe("false");
-  });
-
-  it("sends the HUD reply to the row session", async () => {
-    await loadAgentHud();
-
-    const session = {
-      id: "session-1",
-      title: "Need approval",
-      preview: "Review this step.",
-      started_at: new Date().toISOString(),
-      last_active: new Date().toISOString(),
-      message_count: 2,
-    };
-
-    emitSessionsChanged({
-      sessions: [session],
-      workingSessionIds: [],
-      waitingSessionIds: ["session-1"],
-    });
-    await flushPromises();
-
-    replyButton().click();
-    await flushPromises();
-
-    const input = document.querySelector<HTMLInputElement>(
-      ".agent-hud-reply-input",
-    );
-    expect(input).toBeTruthy();
-    input!.value = "Approved.";
-    document
-      .querySelector<HTMLFormElement>(".agent-hud-reply-form")
-      ?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-    await flushPromises();
-
-    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_open_agent", {
-      session,
-    });
-    expect(mocks.emit).toHaveBeenCalledWith(
-      AGENT_REPLY_EVENT,
-      expect.objectContaining({
-        session,
-        text: "Approved.",
-      }),
-    );
   });
 
   it("briefly shows Done before hiding when the agent completes", async () => {
@@ -567,7 +452,7 @@ describe("agent HUD", () => {
     expect(markElement().dataset.status).toBe("completed");
 
     mocks.invoke.mockClear();
-    await vi.advanceTimersByTimeAsync(2250);
+    await vi.advanceTimersByTimeAsync(6550);
 
     expect(hudElement().dataset.hasEntries).toBe("false");
     expect(hudElement().dataset.visible).toBe("false");
@@ -605,7 +490,7 @@ describe("agent HUD", () => {
 
     expect(pillLabelElement()).toHaveTextContent("Done");
 
-    await vi.advanceTimersByTimeAsync(2450);
+    await vi.advanceTimersByTimeAsync(6550);
 
     expect(hudElement().dataset.hasEntries).toBe("false");
   });
@@ -805,12 +690,6 @@ function stackElement() {
   const stack = document.querySelector<HTMLElement>("#agent-hud-stack");
   expect(stack).toBeTruthy();
   return stack as HTMLElement;
-}
-
-function replyButton() {
-  const reply = document.querySelector<HTMLButtonElement>(".agent-hud-reply");
-  expect(reply).toBeTruthy();
-  return reply as HTMLButtonElement;
 }
 
 function menuElement() {


### PR DESCRIPTION
Visual/UX cleanup of the agent HUD overlay.

## What
- **Remove the inline reply/chat feature.** Clicking a session row now simply opens that session's context in June. The reply bubble, inline input, and all its plumbing are removed end-to-end (reply form in `agent-hud.ts`, `AGENT_REPLY_EVENT`/`AgentReplyDetail`, App.tsx listener + `submitHudReply` in `AgentWorkspace.tsx`, `agentHudFocusReply`/`agent_hud_focus_reply`, and the `replying` window-layout param on both the TS and Rust sides).
- **Retint the needs-input shimmer.** The sweep over the June mark went from a bright yellow-gold (`oklch(0.91 0.2 72)`) to a duller terracotta (`oklch(0.82 0.12 48)`), keeping it in the brand family. Updated in both `agent-hud.css` and `meeting-hud.css` per their documented "keep in sync" invariant.
- **Persist "Done" longer.** A completed session's row now lingers ~6.5s (was 2.2s) before fading, so completions are actually readable. Failures still linger 8s; hover still pauses the countdown.
- **Center the collapsed pill.** Icons drop a stray 1px optical nudge and center geometrically; the stack's bottom padding (which leaked through the reveal's `0fr` collapse and left dead surface below the content) moves to the last row; the collapsed pill is a deliberate 32px with content centered in the full height.

## Why
Smaller, calmer HUD: one clear action per row (open in June), brand-correct color, completions you can read, and a collapsed pill whose content sits on the true center line.

## Verification
- 573 frontend tests pass (21 agent-HUD), `tsc --noEmit` clean.
- Rust compiles; both `agent_hud` window-size tests pass.
- Collapsed/expanded geometry verified live in a headless browser (content on the surface center line in both states).