### PR TITLE
Support pasted chat images

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1815,6 +1815,7 @@ fn image_mime_type(path: &Path) -> Option<&'static str> {
     match extension.as_str() {
         "png" => Some("image/png"),
         "jpg" | "jpeg" => Some("image/jpeg"),
+        "tif" | "tiff" => Some("image/tiff"),
         "gif" => Some("image/gif"),
         "webp" => Some("image/webp"),
         _ => None,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -8166,11 +8166,20 @@ function ensureClipboardImageName(file: File, index: number) {
 }
 
 function isClipboardImageType(type: string) {
-  return type.toLowerCase().startsWith("image/");
+  const mimeType = normalizedImageMimeType(type);
+  return (
+    mimeType === "image/png" ||
+    mimeType === "image/jpeg" ||
+    mimeType === "image/jpg" ||
+    mimeType === "image/tiff" ||
+    mimeType === "image/tif" ||
+    mimeType === "image/gif" ||
+    mimeType === "image/webp"
+  );
 }
 
 function clipboardImageExtension(file: File) {
-  const mimeType = file.type.toLowerCase().split(";")[0];
+  const mimeType = normalizedImageMimeType(file.type);
   if (mimeType === "image/jpeg" || mimeType === "image/jpg") return "jpg";
   if (mimeType === "image/tiff" || mimeType === "image/tif") return "tiff";
   const subtype = mimeType.startsWith("image/") ? mimeType.slice(6) : "";
@@ -8184,13 +8193,17 @@ function clipboardImageStem(name: string) {
 }
 
 function clipboardImageRank(file: File) {
-  const mimeType = file.type.toLowerCase().split(";")[0];
+  const mimeType = normalizedImageMimeType(file.type);
   if (mimeType === "image/png") return 50;
   if (mimeType === "image/tiff" || mimeType === "image/tif") return 40;
   if (mimeType === "image/webp") return 30;
   if (mimeType === "image/jpeg" || mimeType === "image/jpg") return 20;
   if (mimeType === "image/gif") return 10;
   return 1;
+}
+
+function normalizedImageMimeType(type: string) {
+  return type.toLowerCase().split(";")[0];
 }
 
 function toolNames(toolset: HermesToolsetInfo) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -48,8 +48,9 @@ import { IconStop } from "central-icons/IconStop";
 import { DotSpinner } from "../DotSpinner";
 import {
   type CSSProperties,
-  type FormEvent,
+  type ClipboardEvent,
   type DragEvent,
+  type FormEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
@@ -694,6 +695,11 @@ type AgentArtifactPanelState =
 
 type TauriFileDropPayload = {
   paths?: string[];
+};
+
+type FileBytesImportOptions = {
+  tooLargeMessage: string;
+  readErrorMessage: (file: File) => string;
 };
 
 type HermesRuntimeSessionResponse = {
@@ -2054,6 +2060,13 @@ export function AgentWorkspace({
     void importDroppedFiles(files);
   }
 
+  function handleComposerPaste(event: ClipboardEvent<HTMLFormElement>) {
+    const files = clipboardImageFiles(event.clipboardData);
+    if (!files.length) return;
+    event.preventDefault();
+    void importPastedImageFiles(files);
+  }
+
   async function importAttachments<T>(
     items: T[],
     importItem: (item: T) => Promise<ImportedHermesFile>,
@@ -2097,15 +2110,31 @@ export function AgentWorkspace({
   // folders) and WKWebView never exposes filesystem paths on dropped Files —
   // so read each blob and import its bytes.
   async function importDroppedFiles(files: File[]) {
+    await importFileBytes(files, {
+      tooLargeMessage: "Dropped files must be 50 MB or smaller.",
+      readErrorMessage: (file) =>
+        // Reading fails for directories, which Finder happily lets you drop.
+        `Could not read "${file.name}". Folders can't be attached.`,
+    });
+  }
+
+  async function importPastedImageFiles(files: File[]) {
+    await importFileBytes(files, {
+      tooLargeMessage: "Pasted images must be 50 MB or smaller.",
+      readErrorMessage: () => "Could not read the pasted image.",
+    });
+  }
+
+  async function importFileBytes(
+    files: File[],
+    options: FileBytesImportOptions,
+  ) {
     await importAttachments(files.slice(0, 8), async (file) => {
       if (file.size > 50 * 1024 * 1024) {
-        throw new Error("Dropped files must be 50 MB or smaller.");
+        throw new Error(options.tooLargeMessage);
       }
       const bytes = await readFileBytes(file).catch(() => {
-        // Reading fails for directories, which Finder happily lets you drop.
-        throw new Error(
-          `Could not read "${file.name}". Folders can't be attached.`,
-        );
+        throw new Error(options.readErrorMessage(file));
       });
       return importHermesBridgeFileBytes(file.name, bytes);
     });
@@ -3586,6 +3615,7 @@ export function AgentWorkspace({
         onDragEnter={() => setDropActive(true)}
         onDragLeave={() => setDropActive(false)}
         onDrop={handleComposerDrop}
+        onPaste={handleComposerPaste}
       >
         <AnimatePresence>
           {busyNotice || galleryErrors ? (
@@ -8081,6 +8111,86 @@ function formatBytes(value: number | null | undefined) {
 
 function safeText(value: unknown) {
   return typeof value === "string" ? value : "";
+}
+
+function clipboardImageFiles(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const itemFiles =
+    data.items && data.items.length
+      ? Array.from(data.items)
+          .filter(
+            (item) => item.kind === "file" && isClipboardImageType(item.type),
+          )
+          .map((item) => item.getAsFile())
+          .filter((file): file is File => Boolean(file))
+      : [];
+  if (itemFiles.length) return normalizeClipboardImageFiles(itemFiles);
+  return normalizeClipboardImageFiles(
+    Array.from(data.files ?? []).filter((file) =>
+      isClipboardImageType(file.type),
+    ),
+  );
+}
+
+function normalizeClipboardImageFiles(files: File[]): File[] {
+  if (files.length <= 1 || hasDistinctClipboardFileNames(files)) {
+    return files.map(ensureClipboardImageName);
+  }
+  const best = [...files].sort(
+    (left, right) => clipboardImageRank(right) - clipboardImageRank(left),
+  )[0];
+  return best ? [ensureClipboardImageName(best, 0)] : [];
+}
+
+function hasDistinctClipboardFileNames(files: File[]) {
+  const names = files.map((file) => file.name.trim()).filter(Boolean);
+  const stems = names.map(clipboardImageStem);
+  return (
+    names.length === files.length &&
+    new Set(names).size === files.length &&
+    new Set(stems).size === files.length
+  );
+}
+
+function ensureClipboardImageName(file: File, index: number) {
+  if (file.name.trim()) return file;
+  const suffix = index === 0 ? "" : `-${index + 1}`;
+  return new File(
+    [file],
+    `pasted-image${suffix}.${clipboardImageExtension(file)}`,
+    {
+      type: file.type,
+      lastModified: file.lastModified,
+    },
+  );
+}
+
+function isClipboardImageType(type: string) {
+  return type.toLowerCase().startsWith("image/");
+}
+
+function clipboardImageExtension(file: File) {
+  const mimeType = file.type.toLowerCase().split(";")[0];
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") return "jpg";
+  if (mimeType === "image/tiff" || mimeType === "image/tif") return "tiff";
+  const subtype = mimeType.startsWith("image/") ? mimeType.slice(6) : "";
+  return subtype.replace(/[^a-z0-9]/g, "") || "png";
+}
+
+function clipboardImageStem(name: string) {
+  const trimmed = name.trim().toLowerCase();
+  const dot = trimmed.lastIndexOf(".");
+  return dot > 0 ? trimmed.slice(0, dot) : trimmed;
+}
+
+function clipboardImageRank(file: File) {
+  const mimeType = file.type.toLowerCase().split(";")[0];
+  if (mimeType === "image/png") return 50;
+  if (mimeType === "image/tiff" || mimeType === "image/tif") return 40;
+  if (mimeType === "image/webp") return 30;
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") return 20;
+  if (mimeType === "image/gif") return 10;
+  return 1;
 }
 
 function toolNames(toolset: HermesToolsetInfo) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2692,6 +2692,32 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("ignores pasted image formats that cannot preview as attachments", async () => {
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    const svg = new File(["<svg />"], "diagram.svg", {
+      type: "image/svg+xml",
+    });
+    const form = document.querySelector(".agent-composer");
+    expect(form).not.toBeNull();
+    fireEvent.paste(form as HTMLFormElement, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            type: "image/svg+xml",
+            getAsFile: () => svg,
+          },
+        ],
+        files: [],
+      },
+    });
+
+    expect(mocks.importHermesBridgeFileBytes).not.toHaveBeenCalled();
+    expect(screen.queryByText("diagram.svg")).not.toBeInTheDocument();
+  });
+
   it("keeps a re-sent duplicate message and the running state against older identical history", async () => {
     const user = userEvent.setup();
     mocks.listHermesSessionMessages.mockResolvedValue([

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2613,6 +2613,85 @@ describe("AgentWorkspace", () => {
     expect(mocks.importHermesBridgeFile).not.toHaveBeenCalled();
   });
 
+  it("imports pasted images by uploading clipboard bytes", async () => {
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    mocks.importHermesBridgeFileBytes.mockResolvedValueOnce({
+      name: "pasted-image.png",
+      path: "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/pasted-image.png",
+      rootLabel: "Workspace",
+      size: 5,
+      previewDataUrl: "data:image/png;base64,preview",
+    });
+
+    const image = new File(["image"], "", { type: "image/png" });
+    const form = document.querySelector(".agent-composer");
+    expect(form).not.toBeNull();
+    fireEvent.paste(form as HTMLFormElement, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => image,
+          },
+        ],
+        files: [],
+      },
+    });
+
+    expect(await screen.findByText("pasted-image.png")).toBeInTheDocument();
+    expect(
+      document.querySelector(".agent-attachment-chip img"),
+    ).toHaveAttribute("src", "data:image/png;base64,preview");
+    expect(mocks.importHermesBridgeFileBytes).toHaveBeenCalledWith(
+      "pasted-image.png",
+      expect.any(Uint8Array),
+    );
+    expect(mocks.importHermesBridgeFile).not.toHaveBeenCalled();
+  });
+
+  it("chooses one preferred image when paste exposes multiple representations", async () => {
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    mocks.importHermesBridgeFileBytes.mockResolvedValueOnce({
+      name: "image.png",
+      path: "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/image.png",
+      rootLabel: "Workspace",
+      size: 3,
+      previewDataUrl: "data:image/png;base64,preview",
+    });
+
+    const tiff = new File(["tiff"], "image.tiff", { type: "image/tiff" });
+    const png = new File(["png"], "image.png", { type: "image/png" });
+    const form = document.querySelector(".agent-composer");
+    expect(form).not.toBeNull();
+    fireEvent.paste(form as HTMLFormElement, {
+      clipboardData: {
+        items: [
+          {
+            kind: "file",
+            type: "image/tiff",
+            getAsFile: () => tiff,
+          },
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => png,
+          },
+        ],
+        files: [],
+      },
+    });
+
+    expect(await screen.findByText("image.png")).toBeInTheDocument();
+    expect(mocks.importHermesBridgeFileBytes).toHaveBeenCalledTimes(1);
+    expect(mocks.importHermesBridgeFileBytes).toHaveBeenCalledWith(
+      "image.png",
+      expect.any(Uint8Array),
+    );
+  });
+
   it("keeps a re-sent duplicate message and the running state against older identical history", async () => {
     const user = userEvent.setup();
     mocks.listHermesSessionMessages.mockResolvedValue([


### PR DESCRIPTION
## Summary
- Adds Cmd+V image paste handling to the agent composer, importing clipboard image bytes through the existing Hermes attachment pipeline.
- Names unnamed clipboard blobs, appends pasted images to existing attachment chips, and avoids duplicate chips when one image appears as multiple clipboard formats.
- Adds TIFF to backend image preview MIME detection.

## Why
JUN-49 asks for image paste support in chat so screenshots and copied images can be attached without saving and using the + menu first.

## Validation
- pnpm test src/test/agent-workspace.test.tsx
- pnpm run lint
- cargo test --manifest-path src-tauri/Cargo.toml --locked

## Known gaps
- No live macOS clipboard smoke test was run in this session.
