### PR TITLE
Add explicit skill slash commands

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -175,6 +175,7 @@ import {
   explicitSkillInvocationPrompt,
   parseSkillSlashCommands,
   resolveSkillSlashCommands,
+  type SkillSlashResolution,
   skillSlashResolutionError,
 } from "../../lib/skill-slash-commands";
 import {
@@ -1953,14 +1954,9 @@ export function AgentWorkspace({
       throw new Error("Add a request after the skill command.");
     }
 
+    const resolved = resolutions.filter(isResolvedSkillSlashResolution);
     const documents = await Promise.all(
-      resolutions.map((resolution) =>
-        getHermesBridgeSkill(
-          resolution.status === "resolved"
-            ? resolution.skill.name
-            : resolution.token,
-        ),
-      ),
+      resolved.map((resolution) => getHermesBridgeSkill(resolution.skill.name)),
     );
     const displayContent = promptWithAttachments(
       typedMessage,
@@ -3059,7 +3055,6 @@ export function AgentWorkspace({
           `Skill commands are unavailable. ${messageFromError(err)}`,
         );
       }
-      setSkills([]);
       return [];
     } finally {
       setSkillCommandLoading(false);
@@ -8007,6 +8002,12 @@ function visibleHermesMessageText(message: HermesSessionMessage) {
     textFromHermesValue(message.text) ??
     "";
   return displayedComposerUserMessageText(stripHermesVisibleContext(text));
+}
+
+function isResolvedSkillSlashResolution(
+  resolution: SkillSlashResolution,
+): resolution is Extract<SkillSlashResolution, { status: "resolved" }> {
+  return resolution.status === "resolved";
 }
 
 function displayedComposerUserMessageText(content: string): string {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -75,6 +75,7 @@ import {
   dictationHelperCommand,
   explainAgentApproval,
   getAgentTask,
+  getHermesBridgeSkill,
   ensureHermesBridgeSession,
   hermesBridgeFilesystemSnapshot,
   hermesBridgeMessagingPlatforms,
@@ -169,6 +170,13 @@ import {
   categoryPrompt,
   displayedUserMessageText,
 } from "../../lib/issue-report-prompt";
+import {
+  displayedSkillInvocationText,
+  explicitSkillInvocationPrompt,
+  parseSkillSlashCommands,
+  resolveSkillSlashCommands,
+  skillSlashResolutionError,
+} from "../../lib/skill-slash-commands";
 import {
   ComposerEditor,
   type ComposerEditorHandle,
@@ -680,6 +688,13 @@ type AgentAttachment = ImportedHermesFile & {
   id: string;
 };
 
+type PreparedComposerSubmission = {
+  displayContent: string;
+  runtimeContent: string;
+  titleContent: string;
+  typedMessage: string;
+};
+
 /** The right-hand file viewer: a list of every file surfaced in the
  * conversation, or one file opened for reading. */
 type AgentArtifactPanelState =
@@ -959,6 +974,7 @@ export function AgentWorkspace({
   // → About → Verify server); the privacy badge links to it when known.
   const [capabilityQuery, setCapabilityQuery] = useState("");
   const [capabilityLoading, setCapabilityLoading] = useState(false);
+  const [skillCommandLoading, setSkillCommandLoading] = useState(false);
   const [capabilitySaving, setCapabilitySaving] = useState<string | null>(null);
   const [selectedMessagingPlatformId, setSelectedMessagingPlatformId] =
     useState<string>();
@@ -1903,6 +1919,61 @@ export function AgentWorkspace({
     setBusyNotice(null);
   }, [busyNotice, selectedHermesSessionId, workingSessionIds]);
 
+  async function prepareComposerSubmission(
+    message: string,
+    messageAttachments: AgentAttachment[],
+  ): Promise<PreparedComposerSubmission> {
+    const parsed = parseSkillSlashCommands(message);
+    if (!parsed.commandNames.length) {
+      const content = promptWithAttachments(message, messageAttachments);
+      return {
+        displayContent: content,
+        runtimeContent: content,
+        titleContent: message,
+        typedMessage: message,
+      };
+    }
+
+    const availableSkills = await loadSkillCommands();
+    const resolutions = resolveSkillSlashCommands(
+      parsed.commandNames,
+      availableSkills,
+    );
+    const problem = resolutions.find(
+      (resolution) => resolution.status !== "resolved",
+    );
+    if (problem) {
+      throw new Error(
+        skillSlashResolutionError(problem) ?? "Skill command failed.",
+      );
+    }
+
+    const typedMessage = parsed.prompt.trim();
+    if (!typedMessage && !messageAttachments.length) {
+      throw new Error("Add a request after the skill command.");
+    }
+
+    const documents = await Promise.all(
+      resolutions.map((resolution) =>
+        getHermesBridgeSkill(
+          resolution.status === "resolved"
+            ? resolution.skill.name
+            : resolution.token,
+        ),
+      ),
+    );
+    const displayContent = promptWithAttachments(
+      typedMessage,
+      messageAttachments,
+    );
+    return {
+      displayContent,
+      runtimeContent: explicitSkillInvocationPrompt(documents, displayContent),
+      titleContent: typedMessage,
+      typedMessage,
+    };
+  }
+
   async function submit(event?: FormEvent) {
     event?.preventDefault();
     const message = draft.trim();
@@ -1912,39 +1983,46 @@ export function AgentWorkspace({
     // frame it for the team and queue the delivery. Captured before the
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
-    const content = promptWithAttachments(message, attachments);
     // A typed hero submit plays the same teardown as a run shortcut: greeting
     // up, suggestions down during the session-create latency. Without it they
     // sit frozen through the wait and then vanish in a single frame when the
     // conversation takes over.
     if (heroMode) setHeroLeaving(true);
     setSubmitting(true);
-    composerEditorRef.current?.clear();
-    setDraft("");
-    setCategory(null);
-    setAttachments([]);
-    setIssueReportNotice(null);
     try {
+      const prepared = await prepareComposerSubmission(message, attachments);
+      composerEditorRef.current?.clear();
+      setDraft("");
+      setCategory(null);
+      setAttachments([]);
+      setIssueReportNotice(null);
       await submitHermesSession(
-        reportCategory ? categoryPrompt(reportCategory, content) : content,
-        undefined,
         reportCategory
-          ? {
-              issueReport: {
-                category: reportCategory,
-                // An attachments-only send has no typed text, but the server
-                // requires a description; the report must not bounce there.
-                description:
-                  message || "No description was typed; see the attachments.",
-                attachmentNames: attachments.map(
-                  (attachment) => attachment.name,
-                ),
-                attachmentPaths: attachments.map(
-                  (attachment) => attachment.path,
-                ),
-              },
-            }
-          : undefined,
+          ? categoryPrompt(reportCategory, prepared.runtimeContent)
+          : prepared.runtimeContent,
+        undefined,
+        {
+          displayContent: prepared.displayContent,
+          titleContent: prepared.titleContent,
+          ...(reportCategory
+            ? {
+                issueReport: {
+                  category: reportCategory,
+                  // An attachments-only send has no typed text, but the server
+                  // requires a description; the report must not bounce there.
+                  description:
+                    prepared.typedMessage ||
+                    "No description was typed; see the attachments.",
+                  attachmentNames: attachments.map(
+                    (attachment) => attachment.name,
+                  ),
+                  attachmentPaths: attachments.map(
+                    (attachment) => attachment.path,
+                  ),
+                },
+              }
+            : {}),
+        },
       );
       setError(null);
       setBusyNotice(null);
@@ -2134,8 +2212,14 @@ export function AgentWorkspace({
   async function submitHermesSession(
     content: string,
     explicitSession?: HermesSessionInfo,
-    options?: { issueReport?: PendingIssueReport },
+    options?: {
+      issueReport?: PendingIssueReport;
+      displayContent?: string;
+      titleContent?: string;
+    },
   ) {
+    const displayContent = options?.displayContent ?? content;
+    const titleContent = options?.titleContent ?? displayContent;
     const targetSessionId = explicitSession?.id
       ? explicitSession.id
       : newSessionModeRef.current
@@ -2146,7 +2230,7 @@ export function AgentWorkspace({
     const titlePromise =
       targetSessionId || options?.issueReport
         ? undefined
-        : agentSessionTitleForPrompt(content);
+        : agentSessionTitleForPrompt(titleContent);
     // The Unrestricted opt-in is made per session: a new session applies the
     // picker draft, and a follow-up routes to the runtime process matching
     // the mode its session was created with. Without this, one Unrestricted
@@ -2163,7 +2247,7 @@ export function AgentWorkspace({
       : await gateway.request<HermesRuntimeSessionResponse>("session.create", {
           title: options?.issueReport
             ? "Issue report"
-            : (sessionTitle ?? titleFromPrompt(content)),
+            : (sessionTitle ?? titleFromPrompt(titleContent)),
           cols: 96,
         });
     const storedSessionId =
@@ -2180,7 +2264,7 @@ export function AgentWorkspace({
       : explicitSession?.title?.trim() ||
         explicitSession?.preview?.trim() ||
         sessionTitle ||
-        titleFromPrompt(content);
+        titleFromPrompt(titleContent);
     if (sessionTitle) {
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
@@ -2231,7 +2315,7 @@ export function AgentWorkspace({
         {
           id: storedSessionId,
           title: sessionDisplayTitle,
-          preview: content,
+          preview: displayContent,
           started_at: createdAt,
           last_active: createdAt,
           message_count: 1,
@@ -2242,7 +2326,7 @@ export function AgentWorkspace({
     const pendingUserMessage: HermesSessionMessage = {
       id: `pending:user:${Date.now()}`,
       role: "user",
-      content,
+      content: displayContent,
       timestamp: createdAt,
     };
     setPendingHermesMessages((current) => {
@@ -2261,7 +2345,7 @@ export function AgentWorkspace({
     dispatchAgentSessionStatus({
       sessionId: storedSessionId,
       title: sessionDisplayTitle,
-      prompt: content,
+      prompt: displayContent,
       status: "running",
       summary: "June is working.",
     });
@@ -2961,6 +3045,27 @@ export function AgentWorkspace({
     }
   }
 
+  async function loadSkillCommands(options?: { silent?: boolean }) {
+    if (skills) return skills;
+    setSkillCommandLoading(true);
+    try {
+      await ensureHermesGateway();
+      const nextSkills = await hermesBridgeSkills();
+      setSkills(nextSkills);
+      return nextSkills;
+    } catch (err) {
+      if (!options?.silent) {
+        throw new Error(
+          `Skill commands are unavailable. ${messageFromError(err)}`,
+        );
+      }
+      setSkills([]);
+      return [];
+    } finally {
+      setSkillCommandLoading(false);
+    }
+  }
+
   async function loadCapabilities() {
     setCapabilityLoading(true);
     try {
@@ -3536,6 +3641,7 @@ export function AgentWorkspace({
           ) : null}
           <ComposerEditor
             ref={composerEditorRef}
+            skills={skills}
             placeholder={
               importingFiles
                 ? "Attaching file…"
@@ -3547,6 +3653,13 @@ export function AgentWorkspace({
               draftRef.current = text;
               setDraft(text);
               setCategory(nextCategory);
+              if (
+                !skills &&
+                !skillCommandLoading &&
+                text.trimStart().startsWith("/")
+              ) {
+                void loadSkillCommands({ silent: true });
+              }
             }}
             onSubmit={() => void submit()}
             onReady={seedComposerCategory}
@@ -6040,7 +6153,7 @@ function AgentChatTurnRow({
               key={`${turn.id}:text:${index}`}
               // Issue-report sessions open with the wrapped investigation
               // prompt; the transcript shows only what the user typed.
-              markdown={displayedUserMessageText(part.text)}
+              markdown={displayedComposerUserMessageText(part.text)}
             />
           ))}
         </div>
@@ -7893,7 +8006,17 @@ function visibleHermesMessageText(message: HermesSessionMessage) {
     textFromHermesValue(message.content) ??
     textFromHermesValue(message.text) ??
     "";
-  return stripHermesVisibleContext(text);
+  return displayedComposerUserMessageText(stripHermesVisibleContext(text));
+}
+
+function displayedComposerUserMessageText(content: string): string {
+  let text = content;
+  for (let index = 0; index < 3; index += 1) {
+    const next = displayedUserMessageText(displayedSkillInvocationText(text));
+    if (next === text) return text;
+    text = next;
+  }
+  return text;
 }
 
 function textFromHermesValue(value: unknown): string | undefined {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -949,6 +949,7 @@ export function AgentWorkspace({
     ReadonlySet<string>
   >(new Set());
   const [skills, setSkills] = useState<HermesSkillInfo[] | null>(null);
+  const skillCommandsLoadRef = useRef<Promise<HermesSkillInfo[]> | null>(null);
   const [toolsets, setToolsets] = useState<HermesToolsetInfo[] | null>(null);
   const [messagingPlatforms, setMessagingPlatforms] = useState<
     HermesMessagingPlatformInfo[] | null
@@ -3043,12 +3044,20 @@ export function AgentWorkspace({
 
   async function loadSkillCommands(options?: { silent?: boolean }) {
     if (skills) return skills;
-    setSkillCommandLoading(true);
+    let loadPromise = skillCommandsLoadRef.current;
+    if (!loadPromise) {
+      setSkillCommandLoading(true);
+      loadPromise = (async () => {
+        await ensureHermesGateway();
+        const nextSkills = await hermesBridgeSkills();
+        setSkills(nextSkills);
+        return nextSkills;
+      })();
+      skillCommandsLoadRef.current = loadPromise;
+    }
+
     try {
-      await ensureHermesGateway();
-      const nextSkills = await hermesBridgeSkills();
-      setSkills(nextSkills);
-      return nextSkills;
+      return await loadPromise;
     } catch (err) {
       if (!options?.silent) {
         throw new Error(
@@ -3057,7 +3066,10 @@ export function AgentWorkspace({
       }
       return [];
     } finally {
-      setSkillCommandLoading(false);
+      if (skillCommandsLoadRef.current === loadPromise) {
+        skillCommandsLoadRef.current = null;
+        setSkillCommandLoading(false);
+      }
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -173,8 +173,11 @@ import {
 import {
   displayedSkillInvocationText,
   explicitSkillInvocationPrompt,
+  isPathLikeSlashToken,
   parseSkillSlashCommands,
+  parseSkillSlashCommandTokens,
   resolveSkillSlashCommands,
+  skillDocumentLookupName,
   type SkillSlashResolution,
   skillSlashResolutionError,
 } from "../../lib/skill-slash-commands";
@@ -807,7 +810,9 @@ export function AgentWorkspace({
   // Live mirror of `draft` for closures (the hero-chip interval) that must read
   // the current value without re-subscribing.
   const draftRef = useRef("");
+  const categoryRef = useRef<ReportCategory | null>(null);
   const [attachments, setAttachments] = useState<AgentAttachment[]>([]);
+  const attachmentsRef = useRef<AgentAttachment[]>([]);
   const [dropActive, setDropActive] = useState(false);
   const [importingFiles, setImportingFiles] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -1865,6 +1870,14 @@ export function AgentWorkspace({
   }, [bridge.running, workingSessionIds]);
 
   useEffect(() => {
+    categoryRef.current = category;
+  }, [category]);
+
+  useEffect(() => {
+    attachmentsRef.current = attachments;
+  }, [attachments]);
+
+  useEffect(() => {
     let disposed = false;
     const unlisteners: Array<() => void> = [];
     const installListener = async (eventName: string) => {
@@ -1926,6 +1939,10 @@ export function AgentWorkspace({
     messageAttachments: AgentAttachment[],
   ): Promise<PreparedComposerSubmission> {
     const parsed = parseSkillSlashCommands(message);
+    const commandTokens = commandTokensForResolutions(
+      parsed.commandNames,
+      parseSkillSlashCommandTokens(message),
+    );
     if (!parsed.commandNames.length) {
       const content = promptWithAttachments(message, messageAttachments);
       return {
@@ -1941,7 +1958,26 @@ export function AgentWorkspace({
       parsed.commandNames,
       availableSkills,
     );
-    const problem = resolutions.find(
+    const pathLikePromptIndex = resolutions.findIndex(
+      (resolution, index) =>
+        resolution.status !== "resolved" &&
+        isPathLikeSlashToken(commandTokens[index]?.name ?? ""),
+    );
+    if (pathLikePromptIndex === 0) {
+      const content = promptWithAttachments(message, messageAttachments);
+      return {
+        displayContent: content,
+        runtimeContent: content,
+        titleContent: message,
+        typedMessage: message,
+      };
+    }
+
+    const skillResolutions =
+      pathLikePromptIndex === -1
+        ? resolutions
+        : resolutions.slice(0, pathLikePromptIndex);
+    const problem = skillResolutions.find(
       (resolution) => resolution.status !== "resolved",
     );
     if (problem) {
@@ -1950,14 +1986,22 @@ export function AgentWorkspace({
       );
     }
 
-    const typedMessage = parsed.prompt.trim();
+    const typedMessage =
+      pathLikePromptIndex === -1
+        ? parsed.prompt.trim()
+        : message.slice(commandTokens[pathLikePromptIndex].from).trimStart();
     if (!typedMessage && !messageAttachments.length) {
       throw new Error("Add a request after the skill command.");
     }
 
-    const resolved = resolutions.filter(isResolvedSkillSlashResolution);
+    const resolved = skillResolutions.filter(isResolvedSkillSlashResolution);
     const documents = await Promise.all(
-      resolved.map((resolution) => getHermesBridgeSkill(resolution.skill.name)),
+      resolved.map(async (resolution) => ({
+        ...(await getHermesBridgeSkill(
+          skillDocumentLookupName(resolution.skill.name),
+        )),
+        name: resolution.skill.name,
+      })),
     );
     const displayContent = promptWithAttachments(
       typedMessage,
@@ -1986,12 +2030,23 @@ export function AgentWorkspace({
     // conversation takes over.
     if (heroMode) setHeroLeaving(true);
     setSubmitting(true);
+    let clearedDraft = false;
+    let clearedAttachments = false;
     try {
       const prepared = await prepareComposerSubmission(message, attachments);
-      composerEditorRef.current?.clear();
-      setDraft("");
-      setCategory(null);
-      setAttachments([]);
+      if (
+        draftRef.current.trim() === message &&
+        categoryRef.current === reportCategory
+      ) {
+        composerEditorRef.current?.clear();
+        setDraft("");
+        setCategory(null);
+        clearedDraft = true;
+      }
+      if (sameAgentAttachments(attachmentsRef.current, attachments)) {
+        setAttachments([]);
+        clearedAttachments = true;
+      }
       setIssueReportNotice(null);
       await submitHermesSession(
         reportCategory
@@ -2027,10 +2082,12 @@ export function AgentWorkspace({
       // Restore the composer so a failed send doesn't eat the message, its
       // category chip, or its attachments — but only where the user hasn't
       // typed or attached something new during the in-flight send.
-      if (composerEditorRef.current?.isEmpty() ?? true) {
+      if (clearedDraft && (composerEditorRef.current?.isEmpty() ?? true)) {
         composerEditorRef.current?.setContent(message, reportCategory);
       }
-      setAttachments((current) => (current.length ? current : attachments));
+      if (clearedAttachments) {
+        setAttachments((current) => (current.length ? current : attachments));
+      }
       if (isSessionBusyError(err)) {
         // A busy rejection is proof the gateway is healthy — retire any stale
         // connection banner along with showing the notice.
@@ -3658,6 +3715,7 @@ export function AgentWorkspace({
             }
             onChange={(text, nextCategory) => {
               draftRef.current = text;
+              categoryRef.current = nextCategory;
               setDraft(text);
               setCategory(nextCategory);
               if (
@@ -8020,6 +8078,35 @@ function isResolvedSkillSlashResolution(
   resolution: SkillSlashResolution,
 ): resolution is Extract<SkillSlashResolution, { status: "resolved" }> {
   return resolution.status === "resolved";
+}
+
+function sameAgentAttachments(
+  left: AgentAttachment[],
+  right: AgentAttachment[],
+) {
+  return (
+    left.length === right.length &&
+    left.every((attachment, index) => attachment.id === right[index]?.id)
+  );
+}
+
+function commandTokensForResolutions(
+  commandNames: string[],
+  tokens: Array<{ name: string; from: number; to: number }>,
+) {
+  return commandNames
+    .map((name) =>
+      tokens.find(
+        (token) => slashCommandKey(token.name) === slashCommandKey(name),
+      ),
+    )
+    .filter((token): token is { name: string; from: number; to: number } =>
+      Boolean(token),
+    );
+}
+
+function slashCommandKey(name: string) {
+  return name.trim().toLowerCase();
 }
 
 function displayedComposerUserMessageText(content: string): string {

--- a/src/components/agent/composer/CategorySuggestionList.tsx
+++ b/src/components/agent/composer/CategorySuggestionList.tsx
@@ -5,13 +5,19 @@ import {
   useImperativeHandle,
   useState,
 } from "react";
+import { IconToolbox } from "central-icons/IconToolbox";
 
 import { CategoryIcon } from "./CategoryIcon";
 import type { ReportCategoryDef } from "./reportCategory";
+import type { HermesSkillInfo } from "../../../lib/tauri";
+
+export type ComposerSlashCommandItem =
+  | { kind: "category"; category: ReportCategoryDef }
+  | { kind: "skill"; skill: HermesSkillInfo };
 
 export type CategorySuggestionListProps = {
-  items: ReportCategoryDef[];
-  command: (item: ReportCategoryDef) => void;
+  items: ComposerSlashCommandItem[];
+  command: (item: ComposerSlashCommandItem) => void;
 };
 
 export type CategorySuggestionListHandle = {
@@ -80,7 +86,7 @@ export const CategorySuggestionList = forwardRef<
     >
       {items.map((item, index) => (
         <button
-          key={item.key}
+          key={commandItemKey(item)}
           type="button"
           role="option"
           aria-selected={index === selected}
@@ -93,13 +99,44 @@ export const CategorySuggestionList = forwardRef<
           }}
           onMouseEnter={() => setSelected(index)}
         >
-          <span className="agent-category-menu-icon" data-category={item.key}>
-            <CategoryIcon category={item.key} size={16} />
+          <span
+            className="agent-category-menu-icon"
+            data-category={
+              item.kind === "category" ? item.category.key : undefined
+            }
+          >
+            {item.kind === "category" ? (
+              <CategoryIcon category={item.category.key} size={16} />
+            ) : (
+              <IconToolbox size={16} aria-hidden />
+            )}
           </span>
-          <span className="agent-category-menu-label">{item.label}</span>
+          <span className="agent-category-menu-copy">
+            <span className="agent-category-menu-label">
+              {commandItemLabel(item)}
+            </span>
+            <span className="agent-category-menu-detail">
+              {commandItemDetail(item)}
+            </span>
+          </span>
         </button>
       ))}
     </div>
   );
 });
 CategorySuggestionList.displayName = "CategorySuggestionList";
+
+function commandItemKey(item: ComposerSlashCommandItem) {
+  return item.kind === "category"
+    ? `category:${item.category.key}`
+    : `skill:${item.skill.name}`;
+}
+
+function commandItemLabel(item: ComposerSlashCommandItem) {
+  return item.kind === "category" ? item.category.label : `/${item.skill.name}`;
+}
+
+function commandItemDetail(item: ComposerSlashCommandItem) {
+  if (item.kind === "category") return item.category.hint;
+  return item.skill.description?.trim() || "Run this skill for the turn";
+}

--- a/src/components/agent/composer/CategorySuggestionList.tsx
+++ b/src/components/agent/composer/CategorySuggestionList.tsx
@@ -3,13 +3,17 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
+  useRef,
   useState,
 } from "react";
-import { IconToolbox } from "central-icons/IconToolbox";
+import { IconBuildingBlocks } from "central-icons/IconBuildingBlocks";
 
 import { CategoryIcon } from "./CategoryIcon";
 import type { ReportCategoryDef } from "./reportCategory";
 import type { HermesSkillInfo } from "../../../lib/tauri";
+
+const SKILL_DETAIL_HOVER_INTENT_MS = 150;
 
 export type ComposerSlashCommandItem =
   | { kind: "category"; category: ReportCategoryDef }
@@ -32,12 +36,74 @@ export const CategorySuggestionList = forwardRef<
   CategorySuggestionListProps
 >(({ items, command }, ref) => {
   const [selected, setSelected] = useState(0);
+  const [activeSource, setActiveSource] = useState<
+    "keyboard" | "pointer" | null
+  >(null);
+  const [detail, setDetail] = useState<{
+    index: number;
+    key: string;
+    top: number;
+    side: "left" | "right";
+  } | null>(null);
+  const [fade, setFade] = useState({ top: false, bottom: false });
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const rowRefs = useRef(new Map<number, HTMLButtonElement>());
+  const hoverTimerRef = useRef<number | null>(null);
+  const cancelHoverIntent = useCallback(() => {
+    if (hoverTimerRef.current !== null) {
+      window.clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  }, []);
+  const hoverIntent = useCallback(
+    (action: () => void) => {
+      cancelHoverIntent();
+      hoverTimerRef.current = window.setTimeout(
+        action,
+        SKILL_DETAIL_HOVER_INTENT_MS,
+      );
+    },
+    [cancelHoverIntent],
+  );
+  const updateFade = useCallback(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const canScroll = el.scrollHeight - el.clientHeight > 1;
+    const atTop = el.scrollTop <= 1;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+    setFade((prev) => {
+      const top = canScroll && !atTop;
+      const bottom = canScroll && !atBottom;
+      return prev.top === top && prev.bottom === bottom
+        ? prev
+        : { top, bottom };
+    });
+  }, []);
 
   // Snap the highlight back to the top whenever the filtered set changes so a
   // press of Enter never targets a row that just scrolled out of the results.
   useEffect(() => {
+    cancelHoverIntent();
     setSelected(0);
-  }, [items]);
+    setActiveSource(null);
+    setDetail(null);
+  }, [items, cancelHoverIntent]);
+
+  useEffect(() => cancelHoverIntent, [cancelHoverIntent]);
+
+  useLayoutEffect(() => {
+    updateFade();
+    const frame = window.requestAnimationFrame(updateFade);
+    return () => window.cancelAnimationFrame(frame);
+  }, [items, updateFade]);
+
+  useEffect(() => {
+    const el = menuRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(updateFade);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [updateFade]);
 
   const choose = useCallback(
     (index: number) => {
@@ -47,17 +113,67 @@ export const CategorySuggestionList = forwardRef<
     [items, command],
   );
 
+  const showSkillDetail = useCallback(
+    (index: number, row = rowRefs.current.get(index) ?? null) => {
+      const item = items[index];
+      const menu = menuRef.current;
+      if (item?.kind !== "skill" || !menu || !row || !skillHasDetail(item)) {
+        setDetail(null);
+        return;
+      }
+
+      const menuRect = menu.getBoundingClientRect();
+      const rowRect = row.getBoundingClientRect();
+      const gap = 6;
+      const margin = 12;
+      const cardWidth = 300;
+      const canOpenRight =
+        menuRect.right + gap + cardWidth <= window.innerWidth - margin;
+      const canOpenLeft = menuRect.left - gap - cardWidth >= margin;
+      const side = canOpenRight ? "right" : canOpenLeft ? "left" : null;
+      if (!side) {
+        setDetail(null);
+        return;
+      }
+
+      const cardHeightGuess = 150;
+      const maxTop = Math.max(
+        0,
+        window.innerHeight - menuRect.top - margin - cardHeightGuess,
+      );
+      setDetail({
+        index,
+        key: commandItemKey(item),
+        side,
+        top: Math.min(Math.max(rowRect.top - menuRect.top, 0), maxTop),
+      });
+    },
+    [items],
+  );
+
   useImperativeHandle(
     ref,
     () => ({
       onKeyDown: (event) => {
         if (items.length === 0) return false;
         if (event.key === "ArrowDown") {
-          setSelected((index) => (index + 1) % items.length);
+          setSelected((index) => {
+            const next = (index + 1) % items.length;
+            setActiveSource("keyboard");
+            cancelHoverIntent();
+            window.requestAnimationFrame(() => showSkillDetail(next));
+            return next;
+          });
           return true;
         }
         if (event.key === "ArrowUp") {
-          setSelected((index) => (index - 1 + items.length) % items.length);
+          setSelected((index) => {
+            const next = (index - 1 + items.length) % items.length;
+            setActiveSource("keyboard");
+            cancelHoverIntent();
+            window.requestAnimationFrame(() => showSkillDetail(next));
+            return next;
+          });
           return true;
         }
         if (event.key === "Enter" || event.key === "Tab") {
@@ -67,7 +183,7 @@ export const CategorySuggestionList = forwardRef<
         return false;
       },
     }),
-    [items, selected, choose],
+    [items, selected, choose, showSkillDetail, cancelHoverIntent],
   );
 
   if (items.length === 0) {
@@ -78,51 +194,131 @@ export const CategorySuggestionList = forwardRef<
     );
   }
 
+  const detailItem = detail ? items[detail.index] : undefined;
+  const activeDetail =
+    detail &&
+    detail.index === selected &&
+    detailItem &&
+    commandItemKey(detailItem) === detail.key &&
+    detailItem.kind === "skill"
+      ? detailItem
+      : null;
+  const categories = items
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => item.kind === "category");
+  const skills = items
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => item.kind === "skill");
+
   return (
     <div
-      className="agent-category-menu"
-      role="listbox"
-      aria-label="Tag this message"
+      className="agent-category-menu-shell"
+      onMouseLeave={() => {
+        cancelHoverIntent();
+        setActiveSource(null);
+        setDetail(null);
+      }}
     >
-      {items.map((item, index) => (
-        <button
-          key={commandItemKey(item)}
-          type="button"
-          role="option"
-          aria-selected={index === selected}
-          data-active={index === selected || undefined}
-          // mousedown (not click) so the press commits before the editor's
-          // blur can tear the popover down.
-          onMouseDown={(event) => {
-            event.preventDefault();
-            choose(index);
+      <div
+        className="agent-category-menu-scroll-wrap"
+        data-fade-top={fade.top || undefined}
+        data-fade-bottom={fade.bottom || undefined}
+      >
+        <div
+          ref={menuRef}
+          className="agent-category-menu"
+          role="listbox"
+          aria-label="Tag this message"
+          onScroll={() => {
+            updateFade();
+            setDetail(null);
           }}
-          onMouseEnter={() => setSelected(index)}
         >
-          <span
-            className="agent-category-menu-icon"
-            data-category={
-              item.kind === "category" ? item.category.key : undefined
-            }
-          >
-            {item.kind === "category" ? (
-              <CategoryIcon category={item.category.key} size={16} />
-            ) : (
-              <IconToolbox size={16} aria-hidden />
-            )}
-          </span>
-          <span className="agent-category-menu-copy">
-            <span className="agent-category-menu-label">
-              {commandItemLabel(item)}
-            </span>
-            <span className="agent-category-menu-detail">
-              {commandItemDetail(item)}
-            </span>
-          </span>
-        </button>
-      ))}
+          {categories.map(({ item, index }) => renderCommandRow(item, index))}
+          {skills.length ? (
+            <div className="agent-category-menu-section" role="presentation">
+              <div className="agent-category-menu-section-label">Skills</div>
+              {skills.map(({ item, index }) => renderCommandRow(item, index))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {activeDetail?.kind === "skill" ? (
+        <div
+          className="agent-category-menu-detail-card"
+          data-side={detail?.side}
+          style={{ top: detail?.top ?? 0 }}
+        >
+          <p className="agent-category-menu-detail-title">
+            {activeDetail.skill.name}
+          </p>
+          {activeDetail.skill.category ? (
+            <p className="agent-category-menu-detail-meta">
+              {activeDetail.skill.category}
+            </p>
+          ) : null}
+          {activeDetail.skill.description?.trim() ? (
+            <p className="agent-category-menu-detail-desc">
+              {activeDetail.skill.description.trim()}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
+
+  function renderCommandRow(item: ComposerSlashCommandItem, index: number) {
+    return (
+      <button
+        key={commandItemKey(item)}
+        ref={(node) => {
+          if (node) rowRefs.current.set(index, node);
+          else rowRefs.current.delete(index);
+        }}
+        type="button"
+        role="option"
+        aria-selected={index === selected}
+        data-active={activeSource && index === selected ? true : undefined}
+        data-kind={item.kind}
+        // mousedown (not click) so the press commits before the editor's
+        // blur can tear the popover down.
+        onMouseDown={(event) => {
+          event.preventDefault();
+          choose(index);
+        }}
+        onMouseEnter={(event) => {
+          setSelected(index);
+          setActiveSource("pointer");
+          const row = event.currentTarget;
+          hoverIntent(() => showSkillDetail(index, row));
+        }}
+        onFocus={(event) => {
+          setSelected(index);
+          setActiveSource("keyboard");
+          cancelHoverIntent();
+          showSkillDetail(index, event.currentTarget);
+        }}
+      >
+        <span
+          className="agent-category-menu-icon"
+          data-category={
+            item.kind === "category" ? item.category.key : undefined
+          }
+        >
+          {item.kind === "category" ? (
+            <CategoryIcon category={item.category.key} size={16} />
+          ) : (
+            <IconBuildingBlocks size={16} aria-hidden />
+          )}
+        </span>
+        <span className="agent-category-menu-copy">
+          <span className="agent-category-menu-label">
+            {commandItemLabel(item)}
+          </span>
+        </span>
+      </button>
+    );
+  }
 });
 CategorySuggestionList.displayName = "CategorySuggestionList";
 
@@ -133,10 +329,12 @@ function commandItemKey(item: ComposerSlashCommandItem) {
 }
 
 function commandItemLabel(item: ComposerSlashCommandItem) {
-  return item.kind === "category" ? item.category.label : `/${item.skill.name}`;
+  return item.kind === "category" ? item.category.label : item.skill.name;
 }
 
-function commandItemDetail(item: ComposerSlashCommandItem) {
-  if (item.kind === "category") return item.category.hint;
-  return item.skill.description?.trim() || "Run this skill for the turn";
+function skillHasDetail(item: ComposerSlashCommandItem) {
+  return (
+    item.kind === "skill" &&
+    Boolean(item.skill.description?.trim() || item.skill.category?.trim())
+  );
 }

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -6,11 +6,12 @@ import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 
 import {
   CATEGORY_CHIP_NODE,
-  CategoryChip,
   categoryFromDoc,
+  createCategoryChip,
   insertReportCategory,
 } from "./categoryChip";
 import type { ReportCategory } from "./reportCategory";
+import type { HermesSkillInfo } from "../../../lib/tauri";
 
 export type ComposerEditorHandle = {
   focus: () => void;
@@ -31,6 +32,7 @@ export type ComposerEditorHandle = {
 
 type ComposerEditorProps = {
   placeholder: string;
+  skills?: HermesSkillInfo[] | null;
   onChange: (text: string, category: ReportCategory | null) => void;
   onSubmit: () => void;
   /** Hands the live editor up to the parent (e.g. so the composer box can read
@@ -93,8 +95,9 @@ function buildDoc(text: string, category?: ReportCategory | null) {
 export const ComposerEditor = forwardRef<
   ComposerEditorHandle,
   ComposerEditorProps
->(({ placeholder, onChange, onSubmit, onReady }, ref) => {
+>(({ placeholder, skills, onChange, onSubmit, onReady }, ref) => {
   const frameRef = useRef<HTMLDivElement | null>(null);
+  const skillsRef = useRef(skills);
   // Latest callbacks behind refs so the editor (created once) never closes
   // over a stale handler.
   const onChangeRef = useRef(onChange);
@@ -104,7 +107,8 @@ export const ComposerEditor = forwardRef<
     onChangeRef.current = onChange;
     onSubmitRef.current = onSubmit;
     onReadyRef.current = onReady;
-  }, [onChange, onSubmit, onReady]);
+    skillsRef.current = skills;
+  }, [onChange, onSubmit, onReady, skills]);
 
   function updateScrollFades(nextEditor: Editor | null) {
     const frame = frameRef.current;
@@ -149,7 +153,7 @@ export const ComposerEditor = forwardRef<
         trailingNode: false,
       }),
       Placeholder.configure({ placeholder }),
-      CategoryChip,
+      createCategoryChip({ skills: () => skillsRef.current }),
     ],
     editorProps: {
       attributes: {

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -6,6 +6,7 @@ import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 
 import {
   CATEGORY_CHIP_NODE,
+  CATEGORY_SKILLS_CHANGED_EVENT,
   categoryFromDoc,
   createCategoryChip,
   insertReportCategory,
@@ -109,6 +110,14 @@ export const ComposerEditor = forwardRef<
     onReadyRef.current = onReady;
     skillsRef.current = skills;
   }, [onChange, onSubmit, onReady, skills]);
+
+  useEffect(() => {
+    document
+      .querySelectorAll(".agent-category-menu-host")
+      .forEach((host) =>
+        host.dispatchEvent(new CustomEvent(CATEGORY_SKILLS_CHANGED_EVENT)),
+      );
+  }, [skills]);
 
   function updateScrollFades(nextEditor: Editor | null) {
     const frame = frameRef.current;

--- a/src/components/agent/composer/categoryChip.ts
+++ b/src/components/agent/composer/categoryChip.ts
@@ -8,6 +8,7 @@ import type { EditorState, Transaction } from "@tiptap/pm/state";
 import { CategoryChipView } from "./CategoryChipView";
 import {
   CategorySuggestionList,
+  type ComposerSlashCommandItem,
   type CategorySuggestionListHandle,
   type CategorySuggestionListProps,
 } from "./CategorySuggestionList";
@@ -15,8 +16,9 @@ import {
   matchReportCategories,
   reportCategoryDef,
   type ReportCategory,
-  type ReportCategoryDef,
 } from "./reportCategory";
+import type { HermesSkillInfo } from "../../../lib/tauri";
+import { matchSkillSlashSuggestions } from "../../../lib/skill-slash-commands";
 
 /** Node name for the inline category chip. Distinct from the generic
  * "mention" node so the composer's chip styling never bleeds into (or
@@ -112,7 +114,7 @@ export function insertReportCategory(editor: Editor, category: ReportCategory) {
  * on Mention so it inherits the atom-node behaviour ProseMirror gives for
  * free: one backspace removes it, the caret can't land inside it, and text
  * wraps around it. */
-export const CategoryChip = Mention.extend({
+const CategoryChipBase = Mention.extend({
   name: CATEGORY_CHIP_NODE,
 
   addAttributes() {
@@ -137,109 +139,168 @@ export const CategoryChip = Mention.extend({
   addNodeView() {
     return ReactNodeViewRenderer(CategoryChipView);
   },
-}).configure({
-  deleteTriggerWithBackspace: true,
-  renderHTML({ node }) {
-    const def = reportCategoryDef(node.attrs.category as string);
-    return [
-      "span",
-      {
-        class: "agent-category-chip",
-        "data-category": (node.attrs.category as string) ?? "",
-      },
-      def?.label ?? "",
-    ];
-  },
-  suggestion: {
-    char: TRIGGER_CHAR,
-    // A leading "/" only — typing a path like "src/foo" mid-word must not pop
-    // the palette.
-    allowSpaces: false,
-    items: ({ query }) => matchReportCategories(query),
-    command: ({ editor, range, props }) => {
-      const { key: category } = props as unknown as ReportCategoryDef;
-      editor
-        .chain()
-        .focus()
-        .command(insertCategoryCommand(category, range))
-        .run();
-    },
-    render: () => {
-      let renderer: ReactRenderer<
-        CategorySuggestionListHandle,
-        CategorySuggestionListProps
-      > | null = null;
-      let host: HTMLDivElement | null = null;
+});
 
-      function position(props: {
-        clientRect?: (() => DOMRect | null) | null;
-        editor: Editor;
-      }) {
-        if (!host || !props.clientRect) return;
-        const rect = props.clientRect();
-        if (!rect) return;
-        const gap = 6;
-        const pad = 8;
-        const hostRect = host.getBoundingClientRect();
-        const maxLeft = window.innerWidth - hostRect.width - pad;
-        const left = Math.min(Math.max(rect.left, pad), Math.max(pad, maxLeft));
-        const composerBox = props.editor.view.dom.closest<HTMLElement>(
-          ".agent-composer-box",
-        );
-        if (composerBox) {
-          const composerRect = composerBox.getBoundingClientRect();
-          host.style.top = "";
-          host.style.bottom = `${Math.max(
-            window.innerHeight - composerRect.top + gap,
-            pad,
-          )}px`;
-          host.style.left = `${left}px`;
+export type CategoryChipOptions = {
+  skills?: () => HermesSkillInfo[] | null | undefined;
+};
+
+export function createCategoryChip(options: CategoryChipOptions = {}) {
+  return CategoryChipBase.configure({
+    deleteTriggerWithBackspace: true,
+    renderHTML({ node }) {
+      const def = reportCategoryDef(node.attrs.category as string);
+      return [
+        "span",
+        {
+          class: "agent-category-chip",
+          "data-category": (node.attrs.category as string) ?? "",
+        },
+        def?.label ?? "",
+      ];
+    },
+    suggestion: {
+      char: TRIGGER_CHAR,
+      // A leading "/" only — typing a path like "src/foo" mid-word must not pop
+      // the palette.
+      allowSpaces: false,
+      items: ({ query }) =>
+        composerSlashCommandItems(query, options.skills?.()),
+      command: ({ editor, range, props }) => {
+        const item = props as unknown as ComposerSlashCommandItem;
+        if (item.kind === "category") {
+          const { key: category } = item.category;
+          editor
+            .chain()
+            .focus()
+            .command(insertCategoryCommand(category, range))
+            .run();
           return;
         }
-        // Prefer opening above the caret (the composer sits low on screen),
-        // dropping below only when there's no room up top.
-        const aboveTop = rect.top - hostRect.height - gap;
-        const belowTop = rect.bottom + gap;
-        const fitsAbove = aboveTop >= pad;
-        const top = fitsAbove ? aboveTop : belowTop;
-        host.style.bottom = "";
-        host.style.top = `${Math.max(top, pad)}px`;
-        host.style.left = `${left}px`;
-      }
+        insertSkillSlashCommand(editor, item.skill.name, range);
+      },
+      render: () => {
+        let renderer: ReactRenderer<
+          CategorySuggestionListHandle,
+          CategorySuggestionListProps
+        > | null = null;
+        let host: HTMLDivElement | null = null;
 
-      return {
-        onStart(props) {
-          renderer = new ReactRenderer(CategorySuggestionList, {
-            props: { items: props.items, command: props.command },
-            editor: props.editor,
-          });
-          host = document.createElement("div");
-          host.className = "agent-category-menu-host";
-          host.appendChild(renderer.element);
-          document.body.appendChild(host);
-          position(props);
-        },
-        onUpdate(props) {
-          renderer?.updateProps({ items: props.items, command: props.command });
-          position(props);
-        },
-        onKeyDown(props) {
-          if (props.event.key === "Escape") {
+        function position(props: {
+          clientRect?: (() => DOMRect | null) | null;
+          editor: Editor;
+        }) {
+          if (!host || !props.clientRect) return;
+          const rect = props.clientRect();
+          if (!rect) return;
+          const gap = 6;
+          const pad = 8;
+          const hostRect = host.getBoundingClientRect();
+          const maxLeft = window.innerWidth - hostRect.width - pad;
+          const left = Math.min(
+            Math.max(rect.left, pad),
+            Math.max(pad, maxLeft),
+          );
+          const composerBox = props.editor.view.dom.closest<HTMLElement>(
+            ".agent-composer-box",
+          );
+          if (composerBox) {
+            const composerRect = composerBox.getBoundingClientRect();
+            host.style.top = "";
+            host.style.bottom = `${Math.max(
+              window.innerHeight - composerRect.top + gap,
+              pad,
+            )}px`;
+            host.style.left = `${left}px`;
+            return;
+          }
+          // Prefer opening above the caret (the composer sits low on screen),
+          // dropping below only when there's no room up top.
+          const aboveTop = rect.top - hostRect.height - gap;
+          const belowTop = rect.bottom + gap;
+          const fitsAbove = aboveTop >= pad;
+          const top = fitsAbove ? aboveTop : belowTop;
+          host.style.bottom = "";
+          host.style.top = `${Math.max(top, pad)}px`;
+          host.style.left = `${left}px`;
+        }
+
+        return {
+          onStart(props) {
+            renderer = new ReactRenderer(CategorySuggestionList, {
+              props: { items: props.items, command: props.command },
+              editor: props.editor,
+            });
+            host = document.createElement("div");
+            host.className = "agent-category-menu-host";
+            host.appendChild(renderer.element);
+            document.body.appendChild(host);
+            position(props);
+          },
+          onUpdate(props) {
+            renderer?.updateProps({
+              items: props.items,
+              command: props.command,
+            });
+            position(props);
+          },
+          onKeyDown(props) {
+            if (props.event.key === "Escape") {
+              renderer?.destroy();
+              host?.remove();
+              renderer = null;
+              host = null;
+              return true;
+            }
+            return renderer?.ref?.onKeyDown(props.event) ?? false;
+          },
+          onExit() {
             renderer?.destroy();
             host?.remove();
             renderer = null;
             host = null;
-            return true;
-          }
-          return renderer?.ref?.onKeyDown(props.event) ?? false;
-        },
-        onExit() {
-          renderer?.destroy();
-          host?.remove();
-          renderer = null;
-          host = null;
-        },
-      };
+          },
+        };
+      },
     },
-  },
-});
+  });
+}
+
+export const CategoryChip = createCategoryChip();
+
+function composerSlashCommandItems(
+  query: string,
+  skills: HermesSkillInfo[] | null | undefined,
+): ComposerSlashCommandItem[] {
+  return [
+    ...matchReportCategories(query).map((category) => ({
+      kind: "category" as const,
+      category,
+    })),
+    ...matchSkillSlashSuggestions(query, skills).map((skill) => ({
+      kind: "skill" as const,
+      skill,
+    })),
+  ];
+}
+
+function insertSkillSlashCommand(
+  editor: Editor,
+  skillName: string,
+  range: { from: number; to: number },
+) {
+  const text = `/${skillName} `;
+  editor
+    .chain()
+    .focus()
+    .command(({ tr, state, dispatch }) => {
+      if (!dispatch) return true;
+      const from = tr.mapping.map(range.from);
+      const to = tr.mapping.map(range.to);
+      tr.replaceWith(from, to, state.schema.text(text));
+      tr.setSelection(TextSelection.create(tr.doc, from + text.length));
+      dispatch(tr.scrollIntoView());
+      return true;
+    })
+    .run();
+}

--- a/src/components/agent/composer/categoryChip.ts
+++ b/src/components/agent/composer/categoryChip.ts
@@ -28,6 +28,7 @@ export const CATEGORY_CHIP_NODE = "reportCategory";
 /** The single character that opens the category palette. "/" reads as a
  * command; "#" would read as a tag and is intentionally not used. */
 const TRIGGER_CHAR = "/";
+const SLASH_MENU_ITEM_LIMIT = 5;
 
 /** Reads the active category from a doc by scanning for the chip node. The
  * single-chip invariant (enforced on insert) means the first hit is the
@@ -204,22 +205,28 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           const composerBox = props.editor.view.dom.closest<HTMLElement>(
             ".agent-composer-box",
           );
-          if (composerBox) {
-            const composerRect = composerBox.getBoundingClientRect();
-            host.style.top = "";
-            host.style.bottom = `${Math.max(
-              window.innerHeight - composerRect.top + gap,
-              pad,
-            )}px`;
-            host.style.left = `${left}px`;
-            return;
-          }
-          // Prefer opening above the caret (the composer sits low on screen),
-          // dropping below only when there's no room up top.
-          const aboveTop = rect.top - hostRect.height - gap;
-          const belowTop = rect.bottom + gap;
-          const fitsAbove = aboveTop >= pad;
-          const top = fitsAbove ? aboveTop : belowTop;
+
+          const anchorRect = composerBox?.getBoundingClientRect() ?? rect;
+          const belowTop = anchorRect.bottom + gap;
+          const belowSpace = window.innerHeight - belowTop - pad;
+          const aboveSpace = anchorRect.top - gap - pad;
+          const fitsBelow = belowSpace >= hostRect.height;
+          const placeBelow = fitsBelow || belowSpace >= aboveSpace;
+          const maxHeight = Math.max(
+            88,
+            Math.min(placeBelow ? belowSpace : aboveSpace, 280),
+          );
+          const top = placeBelow
+            ? belowTop
+            : Math.max(
+                anchorRect.top - Math.min(hostRect.height, maxHeight) - gap,
+                pad,
+              );
+
+          host.style.setProperty(
+            "--agent-category-menu-max-height",
+            `${maxHeight}px`,
+          );
           host.style.bottom = "";
           host.style.top = `${Math.max(top, pad)}px`;
           host.style.left = `${left}px`;
@@ -272,16 +279,21 @@ function composerSlashCommandItems(
   query: string,
   skills: HermesSkillInfo[] | null | undefined,
 ): ComposerSlashCommandItem[] {
+  const categories = matchReportCategories(query).map((category) => ({
+    kind: "category" as const,
+    category,
+  }));
   return [
-    ...matchReportCategories(query).map((category) => ({
-      kind: "category" as const,
-      category,
-    })),
-    ...matchSkillSlashSuggestions(query, skills).map((skill) => ({
+    ...categories,
+    ...matchSkillSlashSuggestions(
+      query,
+      skills,
+      Math.max(SLASH_MENU_ITEM_LIMIT - categories.length, 0),
+    ).map((skill) => ({
       kind: "skill" as const,
       skill,
     })),
-  ];
+  ].slice(0, SLASH_MENU_ITEM_LIMIT);
 }
 
 function insertSkillSlashCommand(

--- a/src/components/agent/composer/categoryChip.ts
+++ b/src/components/agent/composer/categoryChip.ts
@@ -1,7 +1,7 @@
 import Mention from "@tiptap/extension-mention";
 import type { Editor } from "@tiptap/react";
 import { ReactNodeViewRenderer, ReactRenderer } from "@tiptap/react";
-import { TextSelection } from "@tiptap/pm/state";
+import { PluginKey, TextSelection } from "@tiptap/pm/state";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { EditorState, Transaction } from "@tiptap/pm/state";
 
@@ -28,7 +28,9 @@ export const CATEGORY_CHIP_NODE = "reportCategory";
 /** The single character that opens the category palette. "/" reads as a
  * command; "#" would read as a tag and is intentionally not used. */
 const TRIGGER_CHAR = "/";
-const SLASH_MENU_ITEM_LIMIT = 5;
+const SLASH_MENU_SKILL_LIMIT = Number.MAX_SAFE_INTEGER;
+const CATEGORY_SUGGESTION_PLUGIN_KEY = new PluginKey("agentCategorySuggestion");
+export const CATEGORY_SKILLS_CHANGED_EVENT = "agent-category-skills-changed";
 
 /** Reads the active category from a doc by scanning for the chip node. The
  * single-chip invariant (enforced on insert) means the first hit is the
@@ -162,6 +164,7 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
     },
     suggestion: {
       char: TRIGGER_CHAR,
+      pluginKey: CATEGORY_SUGGESTION_PLUGIN_KEY,
       // A leading "/" only — typing a path like "src/foo" mid-word must not pop
       // the palette.
       allowSpaces: false,
@@ -186,6 +189,13 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           CategorySuggestionListProps
         > | null = null;
         let host: HTMLDivElement | null = null;
+        let latestProps: {
+          command: CategorySuggestionListProps["command"];
+          editor: Editor;
+          query: string;
+          clientRect?: (() => DOMRect | null) | null;
+        } | null = null;
+        let ownerDocument: Document | null = null;
 
         function position(props: {
           clientRect?: (() => DOMRect | null) | null;
@@ -196,20 +206,25 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           if (!rect) return;
           const gap = 6;
           const pad = 8;
-          const hostRect = host.getBoundingClientRect();
-          const maxLeft = window.innerWidth - hostRect.width - pad;
-          const left = Math.min(
-            Math.max(rect.left, pad),
-            Math.max(pad, maxLeft),
-          );
           const composerBox = props.editor.view.dom.closest<HTMLElement>(
             ".agent-composer-box",
           );
-
-          const anchorRect = composerBox?.getBoundingClientRect() ?? rect;
+          const composerRect = composerBox?.getBoundingClientRect();
+          const width = Math.min(
+            composerRect?.width ?? host.getBoundingClientRect().width,
+            window.innerWidth - pad * 2,
+          );
+          host.style.setProperty("--agent-category-menu-width", `${width}px`);
+          const maxLeft = window.innerWidth - width - pad;
+          const left = Math.min(
+            Math.max(composerRect?.left ?? rect.left, pad),
+            Math.max(pad, maxLeft),
+          );
+          const anchorRect = composerRect ?? rect;
           const belowTop = anchorRect.bottom + gap;
           const belowSpace = window.innerHeight - belowTop - pad;
           const aboveSpace = anchorRect.top - gap - pad;
+          const hostRect = host.getBoundingClientRect();
           const fitsBelow = belowSpace >= hostRect.height;
           const placeBelow = fitsBelow || belowSpace >= aboveSpace;
           const maxHeight = Math.max(
@@ -232,19 +247,82 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           host.style.left = `${left}px`;
         }
 
+        function updateLatestProps(props: {
+          command: unknown;
+          editor: Editor;
+          query: string;
+          clientRect?: (() => DOMRect | null) | null;
+        }) {
+          latestProps = {
+            ...props,
+            command: props.command as CategorySuggestionListProps["command"],
+          };
+        }
+
+        function refreshItems() {
+          if (!renderer || !latestProps) return;
+          renderer.updateProps({
+            items: composerSlashCommandItems(
+              latestProps.query,
+              options.skills?.(),
+            ),
+            command: latestProps.command,
+          });
+          position(latestProps);
+        }
+
+        function dismissFromPointerDown(event: PointerEvent) {
+          const target = event.target;
+          if (!(target instanceof Node) || host?.contains(target)) return;
+          const view = latestProps?.editor.view;
+          if (!view) return;
+          view.dispatch(
+            view.state.tr.setMeta(CATEGORY_SUGGESTION_PLUGIN_KEY, {
+              exit: true,
+            }),
+          );
+        }
+
+        function cleanupPopover() {
+          renderer?.destroy();
+          host?.removeEventListener(
+            CATEGORY_SKILLS_CHANGED_EVENT,
+            refreshItems,
+          );
+          ownerDocument?.removeEventListener(
+            "pointerdown",
+            dismissFromPointerDown,
+            true,
+          );
+          host?.remove();
+          renderer = null;
+          host = null;
+          latestProps = null;
+          ownerDocument = null;
+        }
+
         return {
           onStart(props) {
+            updateLatestProps(props);
             renderer = new ReactRenderer(CategorySuggestionList, {
               props: { items: props.items, command: props.command },
               editor: props.editor,
             });
             host = document.createElement("div");
             host.className = "agent-category-menu-host";
+            host.addEventListener(CATEGORY_SKILLS_CHANGED_EVENT, refreshItems);
             host.appendChild(renderer.element);
             document.body.appendChild(host);
+            ownerDocument = props.editor.view.dom.ownerDocument;
+            ownerDocument.addEventListener(
+              "pointerdown",
+              dismissFromPointerDown,
+              true,
+            );
             position(props);
           },
           onUpdate(props) {
+            updateLatestProps(props);
             renderer?.updateProps({
               items: props.items,
               command: props.command,
@@ -253,19 +331,13 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
           },
           onKeyDown(props) {
             if (props.event.key === "Escape") {
-              renderer?.destroy();
-              host?.remove();
-              renderer = null;
-              host = null;
+              cleanupPopover();
               return true;
             }
             return renderer?.ref?.onKeyDown(props.event) ?? false;
           },
           onExit() {
-            renderer?.destroy();
-            host?.remove();
-            renderer = null;
-            host = null;
+            cleanupPopover();
           },
         };
       },
@@ -285,15 +357,13 @@ function composerSlashCommandItems(
   }));
   return [
     ...categories,
-    ...matchSkillSlashSuggestions(
-      query,
-      skills,
-      Math.max(SLASH_MENU_ITEM_LIMIT - categories.length, 0),
-    ).map((skill) => ({
-      kind: "skill" as const,
-      skill,
-    })),
-  ].slice(0, SLASH_MENU_ITEM_LIMIT);
+    ...matchSkillSlashSuggestions(query, skills, SLASH_MENU_SKILL_LIMIT).map(
+      (skill) => ({
+        kind: "skill" as const,
+        skill,
+      }),
+    ),
+  ];
 }
 
 function insertSkillSlashCommand(

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -899,11 +899,19 @@ function displayContentForHermesMessage(message: HermesSessionMessage) {
   if (message.role !== "user") return content.trim();
   // Scheduled runs lead with the cron delivery preamble; show the routine's
   // own instructions, not the machine scaffolding.
-  return displayedUserMessageText(
-    displayedSkillInvocationText(
-      stripScheduledRunPreamble(stripHermesContextMarkers(content)),
-    ),
+  return displayedUserPromptText(
+    stripScheduledRunPreamble(stripHermesContextMarkers(content)),
   );
+}
+
+function displayedUserPromptText(content: string) {
+  let text = content;
+  for (let index = 0; index < 3; index += 1) {
+    const next = displayedUserMessageText(displayedSkillInvocationText(text));
+    if (next === text) return text;
+    text = next;
+  }
+  return text;
 }
 
 function isScheduledRunMessage(message: HermesSessionMessage) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -10,6 +10,8 @@ import {
   isScheduledRunPreamble,
   stripScheduledRunPreamble,
 } from "./hermes-adapter";
+import { displayedUserMessageText } from "./issue-report-prompt";
+import { displayedSkillInvocationText } from "./skill-slash-commands";
 
 export type LiveHermesEvent = HermesGatewayEvent & {
   receivedAt: string;
@@ -897,7 +899,11 @@ function displayContentForHermesMessage(message: HermesSessionMessage) {
   if (message.role !== "user") return content.trim();
   // Scheduled runs lead with the cron delivery preamble; show the routine's
   // own instructions, not the machine scaffolding.
-  return stripScheduledRunPreamble(stripHermesContextMarkers(content));
+  return displayedUserMessageText(
+    displayedSkillInvocationText(
+      stripScheduledRunPreamble(stripHermesContextMarkers(content)),
+    ),
+  );
 }
 
 function isScheduledRunMessage(message: HermesSessionMessage) {

--- a/src/lib/skill-slash-commands.ts
+++ b/src/lib/skill-slash-commands.ts
@@ -139,11 +139,22 @@ export function explicitSkillInvocationPrompt(
 }
 
 export function displayedSkillInvocationText(content: string): string {
-  const start = content.indexOf(USER_REQUEST_START);
+  const text = content.trim();
+  if (!text.startsWith(EXPLICIT_SKILLS_START)) return content;
+
+  const skillsEnd = text.indexOf(EXPLICIT_SKILLS_END);
+  if (skillsEnd === -1) return content;
+
+  const start = text.indexOf(
+    USER_REQUEST_START,
+    skillsEnd + EXPLICIT_SKILLS_END.length,
+  );
   if (start === -1) return content;
-  const end = content.lastIndexOf(USER_REQUEST_END);
+  const end = text.lastIndexOf(USER_REQUEST_END);
   if (end <= start) return content;
-  const request = content.slice(start + USER_REQUEST_START.length, end).trim();
+  if (text.slice(end + USER_REQUEST_END.length).trim()) return content;
+
+  const request = text.slice(start + USER_REQUEST_START.length, end).trim();
   return request || content;
 }
 

--- a/src/lib/skill-slash-commands.ts
+++ b/src/lib/skill-slash-commands.ts
@@ -1,0 +1,187 @@
+import type { HermesSkillDocument, HermesSkillInfo } from "./tauri";
+
+const EXPLICIT_SKILLS_START = "---EXPLICIT SKILLS---";
+const EXPLICIT_SKILLS_END = "---END EXPLICIT SKILLS---";
+const USER_REQUEST_START = "---USER REQUEST---";
+const USER_REQUEST_END = "---END USER REQUEST---";
+
+export type ParsedSkillSlashCommands = {
+  commandNames: string[];
+  prompt: string;
+};
+
+export type SkillSlashResolution =
+  | { status: "resolved"; token: string; skill: HermesSkillInfo }
+  | {
+      status: "missing";
+      token: string;
+      suggestions: HermesSkillInfo[];
+    }
+  | {
+      status: "ambiguous";
+      token: string;
+      matches: HermesSkillInfo[];
+    };
+
+export function parseSkillSlashCommands(
+  input: string,
+): ParsedSkillSlashCommands {
+  let index = 0;
+  const commandNames: string[] = [];
+  const seen = new Set<string>();
+
+  while (index < input.length) {
+    while (index < input.length && /\s/.test(input[index])) index += 1;
+    if (input[index] !== "/") break;
+
+    const commandStart = index + 1;
+    index = commandStart;
+    while (index < input.length && !/\s/.test(input[index])) index += 1;
+
+    const command = input.slice(commandStart, index).trim();
+    if (!command) break;
+
+    const key = normalizeSkillName(command);
+    if (!seen.has(key)) {
+      seen.add(key);
+      commandNames.push(command);
+    }
+  }
+
+  return {
+    commandNames,
+    prompt: input.slice(index).trimStart(),
+  };
+}
+
+export function matchSkillSlashSuggestions(
+  query: string,
+  skills: HermesSkillInfo[] | null | undefined,
+  limit = 8,
+) {
+  const normalized = normalizeSkillName(query);
+  return (skills ?? [])
+    .map((skill) => ({ skill, score: skillMatchScore(skill, normalized) }))
+    .filter((item) => item.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        safeText(a.skill.name).localeCompare(safeText(b.skill.name)),
+    )
+    .slice(0, limit)
+    .map((item) => item.skill);
+}
+
+export function resolveSkillSlashCommands(
+  commandNames: string[],
+  skills: HermesSkillInfo[],
+): SkillSlashResolution[] {
+  return commandNames.map((token) => {
+    const matches = matchingSkills(token, skills);
+    if (matches.length === 1) {
+      return { status: "resolved", token, skill: matches[0] };
+    }
+    if (matches.length > 1) {
+      return { status: "ambiguous", token, matches };
+    }
+    return {
+      status: "missing",
+      token,
+      suggestions: matchSkillSlashSuggestions(token, skills, 3),
+    };
+  });
+}
+
+export function skillSlashResolutionError(resolution: SkillSlashResolution) {
+  if (resolution.status === "resolved") return null;
+  if (resolution.status === "ambiguous") {
+    const matches = resolution.matches
+      .slice(0, 4)
+      .map((skill) => `/${skill.name}`)
+      .join(", ");
+    return `/${resolution.token} matches more than one skill. Use ${matches}.`;
+  }
+  const suggestions = resolution.suggestions
+    .map((skill) => `/${skill.name}`)
+    .join(", ");
+  return suggestions
+    ? `Could not find skill /${resolution.token}. Try ${suggestions}.`
+    : `Could not find skill /${resolution.token}.`;
+}
+
+export function explicitSkillInvocationPrompt(
+  documents: HermesSkillDocument[],
+  request: string,
+) {
+  const skillBlocks = documents.map((document) =>
+    [
+      `Skill: ${document.name}`,
+      document.relativePath ? `Path: ${document.relativePath}` : null,
+      "",
+      document.content.trim(),
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n"),
+  );
+  return [
+    EXPLICIT_SKILLS_START,
+    "The user explicitly invoked these skills for this turn. Follow each selected skill's instructions before handling the user request. Use normal automatic skill matching for any additional relevant skills.",
+    "",
+    ...skillBlocks.flatMap((block, index) =>
+      index === 0 ? [block] : ["", block],
+    ),
+    EXPLICIT_SKILLS_END,
+    "",
+    USER_REQUEST_START,
+    request,
+    USER_REQUEST_END,
+  ].join("\n");
+}
+
+export function displayedSkillInvocationText(content: string): string {
+  const start = content.indexOf(USER_REQUEST_START);
+  if (start === -1) return content;
+  const end = content.lastIndexOf(USER_REQUEST_END);
+  if (end <= start) return content;
+  const request = content.slice(start + USER_REQUEST_START.length, end).trim();
+  return request || content;
+}
+
+function matchingSkills(token: string, skills: HermesSkillInfo[]) {
+  const normalized = normalizeSkillName(token);
+  const exact = skills.filter(
+    (skill) => normalizeSkillName(skill.name) === normalized,
+  );
+  if (exact.length) return exact;
+  return skills.filter((skill) =>
+    skillAliases(skill.name).some((alias) => alias === normalized),
+  );
+}
+
+function skillMatchScore(skill: HermesSkillInfo, query: string) {
+  if (!query) return 1;
+  const name = normalizeSkillName(skill.name);
+  if (name === query) return 100;
+  if (skillAliases(skill.name).some((alias) => alias === query)) return 90;
+  if (name.startsWith(query)) return 80;
+  if (skillAliases(skill.name).some((alias) => alias.startsWith(query))) {
+    return 70;
+  }
+  if (name.includes(query)) return 60;
+  const description = normalizeSkillName(skill.description ?? "");
+  const category = normalizeSkillName(skill.category ?? "");
+  if (description.includes(query) || category.includes(query)) return 40;
+  return 0;
+}
+
+function skillAliases(name: string) {
+  return name.split(/[/:]/).map(normalizeSkillName).filter(Boolean);
+}
+
+function normalizeSkillName(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function safeText(value: unknown) {
+  return typeof value === "string" ? value : "";
+}

--- a/src/lib/skill-slash-commands.ts
+++ b/src/lib/skill-slash-commands.ts
@@ -27,6 +27,11 @@ export type SkillSlashResolution =
       status: "ambiguous";
       token: string;
       matches: HermesSkillInfo[];
+    }
+  | {
+      status: "disabled";
+      token: string;
+      matches: HermesSkillInfo[];
     };
 
 export function parseSkillSlashCommands(
@@ -78,6 +83,7 @@ export function matchSkillSlashSuggestions(
 ) {
   const normalized = normalizeSkillName(query);
   return (skills ?? [])
+    .filter(isSkillEnabled)
     .map((skill) => ({ skill, score: skillMatchScore(skill, normalized) }))
     .filter((item) => item.score > 0)
     .sort(
@@ -93,18 +99,24 @@ export function resolveSkillSlashCommands(
   commandNames: string[],
   skills: HermesSkillInfo[],
 ): SkillSlashResolution[] {
+  const enabledSkills = skills.filter(isSkillEnabled);
+  const disabledSkills = skills.filter((skill) => !isSkillEnabled(skill));
   return commandNames.map((token) => {
-    const matches = matchingSkills(token, skills);
+    const matches = matchingSkills(token, enabledSkills);
     if (matches.length === 1) {
       return { status: "resolved", token, skill: matches[0] };
     }
     if (matches.length > 1) {
       return { status: "ambiguous", token, matches };
     }
+    const disabledMatches = matchingSkills(token, disabledSkills);
+    if (disabledMatches.length) {
+      return { status: "disabled", token, matches: disabledMatches };
+    }
     return {
       status: "missing",
       token,
-      suggestions: matchSkillSlashSuggestions(token, skills, 3),
+      suggestions: matchSkillSlashSuggestions(token, enabledSkills, 3),
     };
   });
 }
@@ -117,6 +129,18 @@ export function skillSlashResolutionError(resolution: SkillSlashResolution) {
       .map((skill) => `/${skill.name}`)
       .join(", ");
     return `/${resolution.token} matches more than one skill. Use ${matches}.`;
+  }
+  if (resolution.status === "disabled") {
+    const matches = resolution.matches
+      .slice(0, 4)
+      .map((skill) => `/${skill.name}`)
+      .join(", ");
+    if (!matches) {
+      return `/${resolution.token} is disabled. Enable it in Agent settings to use it.`;
+    }
+    return resolution.matches.length === 1
+      ? `${matches} is disabled. Enable it in Agent settings to use it.`
+      : `${matches} are disabled. Enable one in Agent settings to use it.`;
   }
   const suggestions = resolution.suggestions
     .map((skill) => `/${skill.name}`)
@@ -221,4 +245,8 @@ function normalizeSkillName(value: string) {
 
 function safeText(value: unknown) {
   return typeof value === "string" ? value : "";
+}
+
+function isSkillEnabled(skill: HermesSkillInfo) {
+  return skill.enabled !== false;
 }

--- a/src/lib/skill-slash-commands.ts
+++ b/src/lib/skill-slash-commands.ts
@@ -10,6 +10,12 @@ export type ParsedSkillSlashCommands = {
   prompt: string;
 };
 
+export type ParsedSkillSlashCommandToken = {
+  name: string;
+  from: number;
+  to: number;
+};
+
 export type SkillSlashResolution =
   | { status: "resolved"; token: string; skill: HermesSkillInfo }
   | {
@@ -26,14 +32,32 @@ export type SkillSlashResolution =
 export function parseSkillSlashCommands(
   input: string,
 ): ParsedSkillSlashCommands {
-  let index = 0;
+  const commands = parseSkillSlashCommandTokens(input);
   const commandNames: string[] = [];
   const seen = new Set<string>();
+  for (const command of commands) {
+    const key = normalizeSkillName(command.name);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    commandNames.push(command.name);
+  }
+  return {
+    commandNames,
+    prompt: input.slice(commands.at(-1)?.to ?? 0).trimStart(),
+  };
+}
+
+export function parseSkillSlashCommandTokens(
+  input: string,
+): ParsedSkillSlashCommandToken[] {
+  let index = 0;
+  const commands: ParsedSkillSlashCommandToken[] = [];
 
   while (index < input.length) {
     while (index < input.length && /\s/.test(input[index])) index += 1;
     if (input[index] !== "/") break;
 
+    const from = index;
     const commandStart = index + 1;
     index = commandStart;
     while (index < input.length && !/\s/.test(input[index])) index += 1;
@@ -41,17 +65,10 @@ export function parseSkillSlashCommands(
     const command = input.slice(commandStart, index).trim();
     if (!command) break;
 
-    const key = normalizeSkillName(command);
-    if (!seen.has(key)) {
-      seen.add(key);
-      commandNames.push(command);
-    }
+    commands.push({ name: command, from, to: index });
   }
 
-  return {
-    commandNames,
-    prompt: input.slice(index).trimStart(),
-  };
+  return commands;
 }
 
 export function matchSkillSlashSuggestions(
@@ -156,6 +173,15 @@ export function displayedSkillInvocationText(content: string): string {
 
   const request = text.slice(start + USER_REQUEST_START.length, end).trim();
   return request || content;
+}
+
+export function skillDocumentLookupName(name: string) {
+  const parts = name.trim().split(/[/:]/).filter(Boolean);
+  return parts.at(-1) ?? name.trim();
+}
+
+export function isPathLikeSlashToken(token: string) {
+  return token.includes("/") || token.includes("\\");
 }
 
 function matchingSkills(token: string, skills: HermesSkillInfo[]) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3467,6 +3467,21 @@ input:focus-visible,
   line-height: 1.3;
 }
 
+.agent-category-menu-copy {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.agent-category-menu-detail {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Leading glyph, tinted per category (default muted for "Attach files", which
  * carries no category). Same oklch tints as the chip. */
 .agent-category-menu-icon,
@@ -5183,8 +5198,7 @@ input:focus-visible,
    * the window edge). Derived from --sidebar-w-current so it tweens on the same
    * clock as the grid — and lives on the card, not the whole .main-column, so
    * the tab strip above isn't pushed by it. */
-  margin: 0 0 var(--sp-3)
-    max(0px, calc(var(--sp-3) - var(--sidebar-w-current)));
+  margin: 0 0 var(--sp-3) max(0px, calc(var(--sp-3) - var(--sidebar-w-current)));
   border-radius: var(--r-window);
   background: var(--card);
   color: var(--card-foreground);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3413,6 +3413,28 @@ input:focus-visible,
 .agent-category-menu-host {
   position: fixed;
   z-index: 60;
+  width: var(--agent-category-menu-width, auto);
+}
+
+.agent-category-menu-shell {
+  position: relative;
+  width: 100%;
+}
+
+.agent-category-menu-scroll-wrap,
+.agent-category-menu-empty,
+.agent-attach-menu {
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-lg);
+  background: var(--popover);
+  box-shadow: var(--shadow-lg);
+}
+
+.agent-category-menu-scroll-wrap {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  contain: paint;
 }
 
 .agent-category-menu,
@@ -3420,20 +3442,49 @@ input:focus-visible,
   display: flex;
   flex-direction: column;
   gap: 1px;
-  min-width: 232px;
-  max-width: min(420px, calc(100vw - 16px));
   padding: var(--sp-1);
-  border-radius: var(--r-lg);
-  background: var(--popover);
-  border: 1px solid var(--popover-border);
-  box-shadow: var(--shadow-lg);
 }
 
 .agent-category-menu {
-  width: min(420px, calc(100vw - 16px));
+  width: 100%;
+  min-width: 0;
+  max-width: calc(100vw - 16px);
   max-height: var(--agent-category-menu-max-height, 280px);
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.agent-category-menu-scroll-wrap::before,
+.agent-category-menu-scroll-wrap::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  left: 0;
+  z-index: 1;
+  height: 16px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) var(--ease-out);
+}
+
+.agent-category-menu-scroll-wrap::before {
+  top: 0;
+  background: linear-gradient(to bottom, var(--popover), transparent);
+}
+
+.agent-category-menu-scroll-wrap::after {
+  bottom: 0;
+  background: linear-gradient(to top, var(--popover), transparent);
+}
+
+.agent-category-menu-scroll-wrap[data-fade-top="true"]::before,
+.agent-category-menu-scroll-wrap[data-fade-bottom="true"]::after {
+  opacity: 1;
+}
+
+.agent-attach-menu {
+  min-width: 232px;
+  max-width: min(420px, calc(100vw - 16px));
 }
 
 .agent-category-menu-empty {
@@ -3444,7 +3495,8 @@ input:focus-visible,
 
 .agent-category-menu button,
 .agent-attach-menu button {
-  display: flex;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
   align-items: center;
   gap: var(--sp-2);
   width: 100%;
@@ -3457,8 +3509,15 @@ input:focus-visible,
   cursor: pointer;
 }
 
+.agent-attach-menu button {
+  display: flex;
+}
+
 .agent-category-menu button[data-active],
-.agent-category-menu button:hover,
+.agent-category-menu button:hover {
+  background: color-mix(in oklch, var(--muted) 45%, transparent);
+}
+
 .agent-attach-menu button:hover {
   background: var(--surface-subtle);
 }
@@ -3471,23 +3530,73 @@ input:focus-visible,
 
 .agent-category-menu-label,
 .agent-attach-menu-label {
+  overflow: hidden;
   font-size: var(--fs-md);
   line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agent-category-menu-copy {
-  display: grid;
+  display: flex;
+  align-items: center;
   min-width: 0;
+}
+
+.agent-category-menu-section {
+  display: grid;
   gap: 1px;
 }
 
-.agent-category-menu-detail {
-  overflow: hidden;
+.agent-category-menu-section-label {
+  padding: var(--sp-2) var(--sp-2) var(--sp-1);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.2;
+}
+
+.agent-category-menu-detail-card {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  width: min(300px, calc(100vw - 24px));
+  padding: var(--sp-3);
+  border: 1px solid var(--popover-border);
+  border-radius: var(--r-md);
+  background: var(--popover);
+  box-shadow: var(--shadow-lg);
+  color: var(--popover-foreground);
+}
+
+.agent-category-menu-detail-card[data-side="right"] {
+  left: calc(100% + 6px);
+}
+
+.agent-category-menu-detail-card[data-side="left"] {
+  right: calc(100% + 6px);
+}
+
+.agent-category-menu-detail-title {
+  margin: 0;
+  font-size: var(--fs-md);
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.agent-category-menu-detail-meta {
+  margin: var(--sp-1) 0 0;
   color: var(--muted-foreground);
   font-size: var(--fs-xs);
   line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+.agent-category-menu-detail-desc {
+  max-height: 180px;
+  margin: var(--sp-2) 0 0;
+  overflow: auto;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
 }
 
 /* Leading glyph, tinted per category (default muted for "Attach files", which

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -3421,11 +3421,19 @@ input:focus-visible,
   flex-direction: column;
   gap: 1px;
   min-width: 232px;
+  max-width: min(420px, calc(100vw - 16px));
   padding: var(--sp-1);
   border-radius: var(--r-lg);
   background: var(--popover);
   border: 1px solid var(--popover-border);
   box-shadow: var(--shadow-lg);
+}
+
+.agent-category-menu {
+  width: min(420px, calc(100vw - 16px));
+  max-height: var(--agent-category-menu-max-height, 280px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .agent-category-menu-empty {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   repairContractionSpacing,
   toolEventKey,
 } from "../lib/agent-chat-runtime";
+import { categoryPrompt } from "../lib/issue-report-prompt";
 import { explicitSkillInvocationPrompt } from "../lib/skill-slash-commands";
 import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
 
@@ -144,6 +145,37 @@ describe("Agent chat runtime", () => {
       {
         type: "text",
         text: "implement issue JUN-46",
+        status: "complete",
+      },
+    ]);
+  });
+
+  it("strips report prompts that contain explicit skill context", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "user",
+        content: categoryPrompt(
+          "feature",
+          explicitSkillInvocationPrompt(
+            [
+              {
+                name: "repo-build-pr",
+                relativePath: "repo-build-pr/SKILL.md",
+                content: "# Repo build PR\n\nOpen a draft PR.",
+              },
+            ],
+            "add slash commands",
+          ),
+        ),
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "add slash commands",
         status: "complete",
       },
     ]);

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   repairContractionSpacing,
   toolEventKey,
 } from "../lib/agent-chat-runtime";
+import { explicitSkillInvocationPrompt } from "../lib/skill-slash-commands";
 import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
 
 describe("repairContractionSpacing", () => {
@@ -117,6 +118,34 @@ describe("Agent chat runtime", () => {
         status: "complete",
       },
       { type: "text", text: "Hi! How can I help?", status: "complete" },
+    ]);
+  });
+
+  it("strips explicit skill context from persisted Hermes user messages", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "user",
+        content: explicitSkillInvocationPrompt(
+          [
+            {
+              name: "repo-build-pr",
+              relativePath: "repo-build-pr/SKILL.md",
+              content: "# Repo build PR\n\nOpen a draft PR.",
+            },
+          ],
+          "implement issue JUN-46",
+        ),
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: "implement issue JUN-46",
+        status: "complete",
+      },
     ]);
   });
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   createAgentTask: vi.fn(),
   ensureHermesBridgeSession: vi.fn(),
   getAgentTask: vi.fn(),
+  getHermesBridgeSkill: vi.fn(),
   hermesBridgeFilesystemSnapshot: vi.fn(),
   hermesBridgeFilePreview: vi.fn(),
   hermesBridgeFileText: vi.fn(),
@@ -92,6 +93,7 @@ vi.mock("../lib/tauri", () => ({
   createAgentTask: mocks.createAgentTask,
   ensureHermesBridgeSession: mocks.ensureHermesBridgeSession,
   getAgentTask: mocks.getAgentTask,
+  getHermesBridgeSkill: mocks.getHermesBridgeSkill,
   hermesBridgeFilesystemSnapshot: mocks.hermesBridgeFilesystemSnapshot,
   hermesBridgeFilePreview: mocks.hermesBridgeFilePreview,
   hermesBridgeFileText: mocks.hermesBridgeFileText,
@@ -243,6 +245,12 @@ describe("AgentWorkspace", () => {
     mocks.listHermesSessions.mockResolvedValue([existingSession]);
     mocks.listHermesSessionMessages.mockResolvedValue([]);
     mocks.hermesAgentCliAccess.mockResolvedValue({ enabled: false });
+    mocks.hermesBridgeSkills.mockResolvedValue([]);
+    mocks.getHermesBridgeSkill.mockImplementation(async (name: string) => ({
+      name,
+      relativePath: `${name}/SKILL.md`,
+      content: `# ${name}\n\nUse ${name}.`,
+    }));
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
     mocks.hermesBridgeFilePreview.mockResolvedValue(null);
     mocks.hermesBridgeFileText.mockResolvedValue(null);
@@ -1868,6 +1876,93 @@ describe("AgentWorkspace", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("submits leading skill slash commands as explicit skill context", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "repo-build-pr",
+        description: "Build a branch and open a PR",
+        enabled: true,
+      },
+      {
+        name: "os-platform",
+        description: "Read live Open Software Issues",
+        enabled: true,
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox"),
+      "/repo-build-pr /os-platform implement issue JUN-46",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.getHermesBridgeSkill).toHaveBeenCalledWith("repo-build-pr"),
+    );
+    expect(mocks.getHermesBridgeSkill).toHaveBeenCalledWith("os-platform");
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({
+          session_id: "runtime-session-1",
+          text: expect.stringContaining("---EXPLICIT SKILLS---"),
+        }),
+      ),
+    );
+    const submitCall = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    );
+    const submittedText = submitCall?.[1]?.text as string;
+    expect(submittedText).toContain("Skill: repo-build-pr");
+    expect(submittedText).toContain("Skill: os-platform");
+    expect(submittedText).toContain("implement issue JUN-46");
+    expect(submittedText).not.toContain(
+      "/repo-build-pr /os-platform implement issue JUN-46",
+    );
+    expect(screen.getByText("implement issue JUN-46")).toBeInTheDocument();
+    expect(screen.queryByText("---EXPLICIT SKILLS---")).toBeNull();
+  });
+
+  it("keeps the draft and suggests matches for an unknown skill command", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "repo-build-pr",
+        description: "Build a branch and open a PR",
+        enabled: true,
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox"),
+      "/repo-build implement issue JUN-46",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(
+      await screen.findByText(
+        "Could not find skill /repo-build. Try /repo-build-pr.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveTextContent(
+      "/repo-build implement issue JUN-46",
+    );
+    expect(mocks.getHermesBridgeSkill).not.toHaveBeenCalled();
+    expect(
+      mocks.gatewayRequest.mock.calls.some(
+        ([method]) => method === "prompt.submit",
+      ),
+    ).toBe(false);
   });
 
   it("renders generated workspace files mentioned by Hermes as downloadable artifacts", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2002,6 +2002,50 @@ describe("AgentWorkspace", () => {
     ).toBe(true);
   });
 
+  it("shares an in-flight slash-prefetch with submit", async () => {
+    const user = userEvent.setup();
+    let resolveSkills: (
+      skills: Array<{
+        name: string;
+        description: string;
+        enabled: boolean;
+      }>,
+    ) => void = () => {};
+    mocks.hermesBridgeSkills.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSkills = resolve;
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "/");
+    await waitFor(() =>
+      expect(mocks.hermesBridgeSkills).toHaveBeenCalledTimes(1),
+    );
+
+    await user.type(
+      screen.getByRole("textbox"),
+      "repo-build-pr implement issue JUN-46",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(mocks.hermesBridgeSkills).toHaveBeenCalledTimes(1);
+
+    resolveSkills([
+      {
+        name: "repo-build-pr",
+        description: "Build a branch and open a PR",
+        enabled: true,
+      },
+    ]);
+
+    await waitFor(() =>
+      expect(mocks.getHermesBridgeSkill).toHaveBeenCalledWith("repo-build-pr"),
+    );
+    expect(mocks.hermesBridgeSkills).toHaveBeenCalledTimes(1);
+  });
+
   it("renders generated workspace files mentioned by Hermes as downloadable artifacts", async () => {
     const user = userEvent.setup();
     const samplePath =

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1965,6 +1965,43 @@ describe("AgentWorkspace", () => {
     ).toBe(false);
   });
 
+  it("retries skill loading on submit after a silent slash-prefetch failure", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeSkills
+      .mockRejectedValueOnce(new Error("Hermes bridge is starting."))
+      .mockResolvedValue([
+        {
+          name: "repo-build-pr",
+          description: "Build a branch and open a PR",
+          enabled: true,
+        },
+      ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "/");
+    await waitFor(() => expect(mocks.hermesBridgeSkills).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByRole("textbox"),
+      "repo-build-pr implement issue JUN-46",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.getHermesBridgeSkill).toHaveBeenCalledWith("repo-build-pr"),
+    );
+    expect(
+      mocks.gatewayRequest.mock.calls.some(
+        ([method, params]) =>
+          method === "prompt.submit" &&
+          typeof params?.text === "string" &&
+          params.text.includes("implement issue JUN-46"),
+      ),
+    ).toBe(true);
+  });
+
   it("renders generated workspace files mentioned by Hermes as downloadable artifacts", async () => {
     const user = userEvent.setup();
     const samplePath =

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2077,6 +2077,41 @@ describe("AgentWorkspace", () => {
     ).toBe(false);
   });
 
+  it("rejects disabled skill slash commands", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "repo-build-pr",
+        description: "Build a branch and open a PR",
+        enabled: false,
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox"),
+      "/repo-build-pr implement issue JUN-46",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(
+      await screen.findByText(
+        "/repo-build-pr is disabled. Enable it in Agent settings to use it.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveTextContent(
+      "/repo-build-pr implement issue JUN-46",
+    );
+    expect(mocks.getHermesBridgeSkill).not.toHaveBeenCalled();
+    expect(
+      mocks.gatewayRequest.mock.calls.some(
+        ([method]) => method === "prompt.submit",
+      ),
+    ).toBe(false);
+  });
+
   it("retries skill loading on submit after a silent slash-prefetch failure", async () => {
     const user = userEvent.setup();
     mocks.hermesBridgeSkills

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1930,6 +1930,118 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("---EXPLICIT SKILLS---")).toBeNull();
   });
 
+  it("fetches qualified skill documents by backend skill id", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "tools/gh-address-comments",
+        description: "Address GitHub review comments",
+        enabled: true,
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox"),
+      "/tools/gh-address-comments review PR feedback",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.getHermesBridgeSkill).toHaveBeenCalledWith(
+        "gh-address-comments",
+      ),
+    );
+    const submitCall = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    );
+    const submittedText = submitCall?.[1]?.text as string;
+    expect(submittedText).toContain("Skill: tools/gh-address-comments");
+    expect(submittedText).toContain("review PR feedback");
+  });
+
+  it("sends path-prefixed prompts normally when no skill matches", async () => {
+    const user = userEvent.setup();
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "repo-build-pr",
+        description: "Build a branch and open a PR",
+        enabled: true,
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox"),
+      "/Users/alex/Desktop/report.pdf summarize this file",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith(
+        "prompt.submit",
+        expect.objectContaining({
+          text: "/Users/alex/Desktop/report.pdf summarize this file",
+        }),
+      ),
+    );
+    expect(mocks.getHermesBridgeSkill).not.toHaveBeenCalled();
+  });
+
+  it("keeps edits made while skill preparation is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveSkillDocument: (document: {
+      name: string;
+      relativePath: string;
+      content: string;
+    }) => void = () => {};
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "repo-build-pr",
+        description: "Build a branch and open a PR",
+        enabled: true,
+      },
+    ]);
+    mocks.getHermesBridgeSkill.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSkillDocument = resolve;
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    const textbox = screen.getByRole("textbox");
+    await user.type(textbox, "/repo-build-pr implement issue JUN-46");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.getHermesBridgeSkill).toHaveBeenCalledWith("repo-build-pr"),
+    );
+
+    await user.click(textbox);
+    await user.type(textbox, " and keep this draft edit");
+    resolveSkillDocument({
+      name: "repo-build-pr",
+      relativePath: "repo-build-pr/SKILL.md",
+      content: "# Repo build PR\n\nOpen a draft PR.",
+    });
+
+    await waitFor(() =>
+      expect(
+        mocks.gatewayRequest.mock.calls.some(
+          ([method]) => method === "prompt.submit",
+        ),
+      ).toBe(true),
+    );
+    expect(textbox).toHaveTextContent(
+      "/repo-build-pr implement issue JUN-46 and keep this draft edit",
+    );
+  });
+
   it("keeps the draft and suggests matches for an unknown skill command", async () => {
     const user = userEvent.setup();
     mocks.hermesBridgeSkills.mockResolvedValue([

--- a/src/test/category-suggestion-list.test.tsx
+++ b/src/test/category-suggestion-list.test.tsx
@@ -1,0 +1,131 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CategorySuggestionList } from "../components/agent/composer/CategorySuggestionList";
+import { REPORT_CATEGORIES } from "../components/agent/composer/reportCategory";
+
+describe("category suggestion list", () => {
+  it("keeps rows compact and moves skill descriptions to hover detail", () => {
+    const command = vi.fn();
+
+    render(
+      <CategorySuggestionList
+        command={command}
+        items={[
+          { kind: "category", category: REPORT_CATEGORIES[0] },
+          {
+            kind: "skill",
+            skill: {
+              name: "skill-creator",
+              description: "Create new skills and improve existing skills.",
+              category: "Personal",
+              enabled: true,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Bug report")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Something isn't working right"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Skills")).toBeInTheDocument();
+    expect(screen.getByText("skill-creator")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Create new skills and improve existing skills."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.focus(screen.getByRole("option", { name: /skill-creator/i }));
+
+    expect(
+      screen.getByText("Create new skills and improve existing skills."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the hover detail matched to the active skill row", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <CategorySuggestionList
+          command={vi.fn()}
+          items={[
+            {
+              kind: "skill",
+              skill: {
+                name: "airtable",
+                description: "Manage Airtable records.",
+                enabled: true,
+              },
+            },
+            {
+              kind: "skill",
+              skill: {
+                name: "apple-notes",
+                description: "Manage Apple Notes via memo CLI.",
+                enabled: true,
+              },
+            },
+          ]}
+        />,
+      );
+
+      fireEvent.mouseEnter(
+        screen.getByRole("option", { name: /apple-notes/i }),
+      );
+      act(() => vi.advanceTimersByTime(150));
+      expect(
+        screen.getByText("Manage Apple Notes via memo CLI."),
+      ).toBeInTheDocument();
+
+      fireEvent.mouseEnter(screen.getByRole("option", { name: /airtable/i }));
+      act(() => vi.advanceTimersByTime(150));
+      expect(screen.getByText("Manage Airtable records.")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Manage Apple Notes via memo CLI."),
+      ).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows edge fades only where the skills list has hidden scroll content", () => {
+    render(
+      <CategorySuggestionList
+        command={vi.fn()}
+        items={Array.from({ length: 12 }, (_, index) => ({
+          kind: "skill" as const,
+          skill: {
+            name: `skill-${index}`,
+            description: `Skill ${index}`,
+            enabled: true,
+          },
+        }))}
+      />,
+    );
+
+    const list = screen.getByRole("listbox", { name: "Tag this message" });
+    const wrap = list.parentElement;
+    expect(wrap).toHaveClass("agent-category-menu-scroll-wrap");
+
+    Object.defineProperties(list, {
+      clientHeight: { configurable: true, value: 120 },
+      scrollHeight: { configurable: true, value: 360 },
+      scrollTop: { configurable: true, writable: true, value: 0 },
+    });
+
+    fireEvent.scroll(list);
+    expect(wrap).not.toHaveAttribute("data-fade-top");
+    expect(wrap).toHaveAttribute("data-fade-bottom", "true");
+
+    list.scrollTop = 80;
+    fireEvent.scroll(list);
+    expect(wrap).toHaveAttribute("data-fade-top", "true");
+    expect(wrap).toHaveAttribute("data-fade-bottom", "true");
+
+    list.scrollTop = 240;
+    fireEvent.scroll(list);
+    expect(wrap).toHaveAttribute("data-fade-top", "true");
+    expect(wrap).not.toHaveAttribute("data-fade-bottom");
+  });
+});

--- a/src/test/composer-editor-slash-menu.test.tsx
+++ b/src/test/composer-editor-slash-menu.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ComposerEditor } from "../components/agent/composer/ComposerEditor";
+import type { HermesSkillInfo } from "../lib/tauri";
+
+const skills: HermesSkillInfo[] = [
+  {
+    name: "skill-creator",
+    description: "Create or update a skill.",
+    category: "productivity",
+    enabled: true,
+  },
+];
+
+describe("composer slash menu", () => {
+  it("dismisses on outside click without removing or retriggering the slash", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <ComposerEditor
+          placeholder="Message June"
+          skills={skills}
+          onChange={vi.fn()}
+          onSubmit={vi.fn()}
+        />
+        <button type="button">Outside</button>
+      </>,
+    );
+
+    const textbox = await screen.findByRole("textbox", {
+      name: "Message June",
+    });
+    await user.type(textbox, "/");
+    await waitFor(() =>
+      expect(document.querySelector(".agent-category-menu-host")).toBeTruthy(),
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() =>
+      expect(document.querySelector(".agent-category-menu-host")).toBeNull(),
+    );
+    expect(textbox).toHaveTextContent("/");
+
+    await user.click(textbox);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(document.querySelector(".agent-category-menu-host")).toBeNull();
+    expect(textbox).toHaveTextContent("/");
+  });
+});

--- a/src/test/skill-slash-commands.test.ts
+++ b/src/test/skill-slash-commands.test.ts
@@ -97,6 +97,29 @@ describe("skill slash commands", () => {
     );
   });
 
+  it("rejects disabled skills and omits them from suggestions", () => {
+    const disabledSkills: HermesSkillInfo[] = [
+      ...skills,
+      {
+        name: "disabled-review",
+        description: "Review pull requests",
+        enabled: false,
+      },
+    ];
+    const [resolution] = resolveSkillSlashCommands(
+      ["disabled-review"],
+      disabledSkills,
+    );
+
+    expect(resolution).toMatchObject({ status: "disabled" });
+    expect(skillSlashResolutionError(resolution)).toBe(
+      "/disabled-review is disabled. Enable it in Agent settings to use it.",
+    );
+    expect(
+      matchSkillSlashSuggestions("disabled", disabledSkills).map((s) => s.name),
+    ).toEqual([]);
+  });
+
   it("ranks autocomplete suggestions by name and description", () => {
     expect(
       matchSkillSlashSuggestions("platform", skills).map((s) => s.name),

--- a/src/test/skill-slash-commands.test.ts
+++ b/src/test/skill-slash-commands.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  displayedSkillInvocationText,
+  explicitSkillInvocationPrompt,
+  matchSkillSlashSuggestions,
+  parseSkillSlashCommands,
+  resolveSkillSlashCommands,
+  skillSlashResolutionError,
+} from "../lib/skill-slash-commands";
+import type { HermesSkillDocument, HermesSkillInfo } from "../lib/tauri";
+
+const skills: HermesSkillInfo[] = [
+  {
+    name: "repo-build-pr",
+    description: "Build a branch and open a PR",
+    enabled: true,
+  },
+  {
+    name: "github:gh-address-comments",
+    description: "Address GitHub review comments",
+    enabled: true,
+  },
+  {
+    name: "tools/gh-address-comments",
+    description: "Address GitHub review comments from another source",
+    enabled: true,
+  },
+  {
+    name: "os-platform",
+    description: "Query Open Software platform Issues",
+    enabled: true,
+  },
+];
+
+describe("skill slash commands", () => {
+  it("extracts leading slash commands and leaves the user request", () => {
+    expect(
+      parseSkillSlashCommands(
+        "  /repo-build-pr /os-platform implement issue JUN-46",
+      ),
+    ).toEqual({
+      commandNames: ["repo-build-pr", "os-platform"],
+      prompt: "implement issue JUN-46",
+    });
+  });
+
+  it("resolves exact and qualified short names", () => {
+    const resolutions = resolveSkillSlashCommands(
+      ["repo-build-pr", "os-platform"],
+      skills,
+    );
+
+    expect(resolutions).toMatchObject([
+      { status: "resolved", skill: { name: "repo-build-pr" } },
+      { status: "resolved", skill: { name: "os-platform" } },
+    ]);
+  });
+
+  it("reports ambiguous short names with concrete choices", () => {
+    const [resolution] = resolveSkillSlashCommands(
+      ["gh-address-comments"],
+      skills,
+    );
+
+    expect(resolution).toMatchObject({ status: "ambiguous" });
+    expect(skillSlashResolutionError(resolution)).toBe(
+      "/gh-address-comments matches more than one skill. Use /github:gh-address-comments, /tools/gh-address-comments.",
+    );
+  });
+
+  it("offers nearby suggestions for missing skills", () => {
+    const [resolution] = resolveSkillSlashCommands(["repo-build"], skills);
+
+    expect(resolution).toMatchObject({ status: "missing" });
+    expect(skillSlashResolutionError(resolution)).toBe(
+      "Could not find skill /repo-build. Try /repo-build-pr.",
+    );
+  });
+
+  it("ranks autocomplete suggestions by name and description", () => {
+    expect(
+      matchSkillSlashSuggestions("platform", skills).map((s) => s.name),
+    ).toEqual(["os-platform"]);
+    expect(
+      matchSkillSlashSuggestions("review", skills).map((s) => s.name),
+    ).toEqual(["github:gh-address-comments", "tools/gh-address-comments"]);
+  });
+
+  it("wraps skill documents and strips them back to the visible request", () => {
+    const documents: HermesSkillDocument[] = [
+      {
+        name: "repo-build-pr",
+        relativePath: "repo-build-pr/SKILL.md",
+        content: "# Repo build PR\n\nOpen a draft PR.",
+      },
+    ];
+    const wrapped = explicitSkillInvocationPrompt(
+      documents,
+      "implement issue JUN-46",
+    );
+
+    expect(wrapped).toContain("Skill: repo-build-pr");
+    expect(wrapped).toContain("Open a draft PR.");
+    expect(displayedSkillInvocationText(wrapped)).toBe(
+      "implement issue JUN-46",
+    );
+  });
+});

--- a/src/test/skill-slash-commands.test.ts
+++ b/src/test/skill-slash-commands.test.ts
@@ -106,4 +106,11 @@ describe("skill slash commands", () => {
       "implement issue JUN-46",
     );
   });
+
+  it("does not strip ordinary messages that mention the marker strings", () => {
+    const ordinary =
+      "Explain this example:\n---USER REQUEST---\nhello\n---END USER REQUEST---";
+
+    expect(displayedSkillInvocationText(ordinary)).toBe(ordinary);
+  });
 });

--- a/src/test/skill-slash-commands.test.ts
+++ b/src/test/skill-slash-commands.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   displayedSkillInvocationText,
   explicitSkillInvocationPrompt,
+  isPathLikeSlashToken,
   matchSkillSlashSuggestions,
   parseSkillSlashCommands,
+  parseSkillSlashCommandTokens,
   resolveSkillSlashCommands,
+  skillDocumentLookupName,
   skillSlashResolutionError,
 } from "../lib/skill-slash-commands";
 import type { HermesSkillDocument, HermesSkillInfo } from "../lib/tauri";
@@ -42,6 +45,22 @@ describe("skill slash commands", () => {
     ).toEqual({
       commandNames: ["repo-build-pr", "os-platform"],
       prompt: "implement issue JUN-46",
+    });
+  });
+
+  it("tracks slash command token positions", () => {
+    expect(parseSkillSlashCommandTokens("  /repo-build-pr /tmp/log")).toEqual([
+      { name: "repo-build-pr", from: 2, to: 16 },
+      { name: "tmp/log", from: 17, to: 25 },
+    ]);
+  });
+
+  it("deduplicates command names without moving the prompt before duplicates", () => {
+    expect(
+      parseSkillSlashCommands("/repo-build-pr /repo-build-pr implement"),
+    ).toEqual({
+      commandNames: ["repo-build-pr"],
+      prompt: "implement",
     });
   });
 
@@ -85,6 +104,22 @@ describe("skill slash commands", () => {
     expect(
       matchSkillSlashSuggestions("review", skills).map((s) => s.name),
     ).toEqual(["github:gh-address-comments", "tools/gh-address-comments"]);
+  });
+
+  it("maps qualified skills to the backend document lookup name", () => {
+    expect(skillDocumentLookupName("tools/gh-address-comments")).toBe(
+      "gh-address-comments",
+    );
+    expect(skillDocumentLookupName("github:gh-address-comments")).toBe(
+      "gh-address-comments",
+    );
+    expect(skillDocumentLookupName("repo-build-pr")).toBe("repo-build-pr");
+  });
+
+  it("detects path-like slash tokens", () => {
+    expect(isPathLikeSlashToken("Users/alex/Desktop/report.pdf")).toBe(true);
+    expect(isPathLikeSlashToken("tmp/log")).toBe(true);
+    expect(isPathLikeSlashToken("repo-build-pr")).toBe(false);
   });
 
   it("wraps skill documents and strips them back to the visible request", () => {


### PR DESCRIPTION
## What changed

- Added leading `/skill` parsing and resolution for the June agent composer, including exact, short-name, missing, and ambiguous skill handling.
- Extended the existing `/` composer palette to show both report tags and Hermes skills.
- Fetches selected skill documents for a single turn and wraps the runtime prompt with explicit skill context while keeping the visible chat transcript as the user's request.
- Added display stripping for persisted Hermes messages so the injected skill context does not show in reloaded conversations.

## Why

JUN-46 asks for deterministic, user-controlled skill invocation from the June chat input without relying only on automatic skill matching.

## Validation

- `pnpm test -- --run src/test/skill-slash-commands.test.ts src/test/agent-chat-runtime.test.ts src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `pnpm test`
- `pnpm exec prettier --check src/lib/skill-slash-commands.ts src/components/agent/composer/CategorySuggestionList.tsx src/components/agent/composer/categoryChip.ts src/components/agent/composer/ComposerEditor.tsx src/components/agent/AgentWorkspace.tsx src/lib/agent-chat-runtime.ts src/styles/app.css src/test/skill-slash-commands.test.ts src/test/agent-workspace.test.tsx src/test/agent-chat-runtime.test.ts`

## Known gaps

- Repo-wide `pnpm run format` still reports existing formatting issues outside this PR in `src/app/App.tsx`, `src/lib/live-transcript-preview.ts`, `src/lib/recording-inactivity.ts`, `src/test/recording-inactivity.test.ts`, and `src-tauri/tauri.conf.json`. The files touched by this PR pass the Prettier check listed above.
