### PR TITLE
Persist agent composer drafts

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1204,6 +1204,7 @@ export function AgentWorkspace({
       : NEW_SESSION_DRAFT_KEY;
   const composerDraftKeyRef = useRef<string | null>(composerDraftKey);
   composerDraftKeyRef.current = composerDraftKey;
+  const restoredComposerDraftKeyRef = useRef<string | null>();
   const chatArtifacts = useMemo(
     () => artifactsFromFilesystemSnapshot(filesystemSnapshot),
     [filesystemSnapshot],
@@ -1938,6 +1939,7 @@ export function AgentWorkspace({
 
   useEffect(() => {
     if (activePanel !== "chat") return;
+    if (restoredComposerDraftKeyRef.current === composerDraftKey) return;
     restoreComposerDraft(composerDraftKey);
   }, [activePanel, composerDraftKey]);
 
@@ -2851,6 +2853,7 @@ export function AgentWorkspace({
     // for ComposerEditor's onReady to pick up and also try to apply now.
     pendingSeedCategoryRef.current = seedCategory;
     if (seedCategory) {
+      clearComposerDraft(NEW_SESSION_DRAFT_KEY);
       seedComposerCategory();
     } else if (initialPrompt) {
       rememberComposerDraft(NEW_SESSION_DRAFT_KEY, initialPrompt, null);
@@ -2900,6 +2903,7 @@ export function AgentWorkspace({
   function restoreComposerDraft(key: string | null) {
     const editor = composerEditorRef.current;
     if (!editor) return;
+    restoredComposerDraftKeyRef.current = key;
     const snapshot = key ? agentComposerDrafts.get(key) : undefined;
     draftRef.current = snapshot?.text ?? "";
     categoryRef.current = snapshot?.category ?? null;

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -665,11 +665,6 @@ type AgentWorkspaceNotice = {
   sessionId: string;
 };
 
-type ComposerDraftSnapshot = {
-  text: string;
-  category: ReportCategory | null;
-};
-
 type AgentDeleteSessionDetail = {
   sessionId: string;
 };
@@ -683,6 +678,12 @@ type AgentArtifact = {
 
 type AgentAttachment = ImportedHermesFile & {
   id: string;
+};
+
+type ComposerDraftSnapshot = {
+  text: string;
+  category: ReportCategory | null;
+  attachments: AgentAttachment[];
 };
 
 /** The right-hand file viewer: a list of every file surfaced in the
@@ -746,13 +747,18 @@ function rememberComposerDraft(
   key: string | null,
   text: string,
   category: ReportCategory | null,
+  attachments: AgentAttachment[] = [],
 ) {
   if (!key) return;
-  if (!text.trim() && !category) {
+  if (!text.trim() && !category && attachments.length === 0) {
     agentComposerDrafts.delete(key);
     return;
   }
-  agentComposerDrafts.set(key, { text, category });
+  agentComposerDrafts.set(key, {
+    text,
+    category,
+    attachments: [...attachments],
+  });
 }
 
 function forgetComposerDraft(key: string | null) {
@@ -820,7 +826,11 @@ export function AgentWorkspace({
   // Live mirror of `draft` for closures (the hero-chip interval) that must read
   // the current value without re-subscribing.
   const draftRef = useRef("");
+  const categoryRef = useRef<ReportCategory | null>(null);
   const [attachments, setAttachments] = useState<AgentAttachment[]>([]);
+  const attachmentsRef = useRef<AgentAttachment[]>([]);
+  categoryRef.current = category;
+  attachmentsRef.current = attachments;
   const [dropActive, setDropActive] = useState(false);
   const [importingFiles, setImportingFiles] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -1963,9 +1973,11 @@ export function AgentWorkspace({
     setSubmitting(true);
     composerEditorRef.current?.clear();
     setDraft("");
+    draftRef.current = "";
     setCategory(null);
+    categoryRef.current = null;
     forgetComposerDraft(submittedDraftKey);
-    setAttachments([]);
+    setComposerAttachments([]);
     setIssueReportNotice(null);
     try {
       await submitHermesSession(
@@ -1997,9 +2009,16 @@ export function AgentWorkspace({
       // typed or attached something new during the in-flight send.
       if (composerEditorRef.current?.isEmpty() ?? true) {
         composerEditorRef.current?.setContent(message, reportCategory);
-        rememberComposerDraft(submittedDraftKey, message, reportCategory);
+        rememberComposerDraft(
+          submittedDraftKey,
+          message,
+          reportCategory,
+          attachments,
+        );
       }
-      setAttachments((current) => (current.length ? current : attachments));
+      setComposerAttachments((current) =>
+        current.length ? current : attachments,
+      );
       if (isSessionBusyError(err)) {
         // A busy rejection is proof the gateway is healthy — retire any stale
         // connection banner along with showing the notice.
@@ -2047,7 +2066,7 @@ export function AgentWorkspace({
       for (const item of items) {
         imported.push(await importItem(item));
       }
-      setAttachments((current) => [
+      setComposerAttachments((current) => [
         ...current,
         ...imported.map((file) => ({
           ...file,
@@ -2091,7 +2110,9 @@ export function AgentWorkspace({
   }
 
   function removeAttachment(id: string) {
-    setAttachments((current) => current.filter((item) => item.id !== id));
+    setComposerAttachments((current) =>
+      current.filter((item) => item.id !== id),
+    );
   }
 
   // Focus the composer, then toggle the dictation helper's listening state —
@@ -2867,8 +2888,11 @@ export function AgentWorkspace({
 
   function clearComposerDraft(key = composerDraftKeyRef.current) {
     draftRef.current = "";
+    categoryRef.current = null;
+    attachmentsRef.current = [];
     setDraft("");
     setCategory(null);
+    setAttachments([]);
     forgetComposerDraft(key);
     composerEditorRef.current?.clear();
   }
@@ -2878,10 +2902,32 @@ export function AgentWorkspace({
     if (!editor) return;
     const snapshot = key ? agentComposerDrafts.get(key) : undefined;
     draftRef.current = snapshot?.text ?? "";
+    categoryRef.current = snapshot?.category ?? null;
+    attachmentsRef.current = snapshot?.attachments ?? [];
     setDraft(snapshot?.text ?? "");
     setCategory(snapshot?.category ?? null);
+    setAttachments(snapshot?.attachments ?? []);
     editor.setContent(snapshot?.text ?? "", snapshot?.category ?? null, {
       focus: false,
+    });
+  }
+
+  function setComposerAttachments(
+    nextValue:
+      | AgentAttachment[]
+      | ((current: AgentAttachment[]) => AgentAttachment[]),
+  ) {
+    setAttachments((current) => {
+      const next =
+        typeof nextValue === "function" ? nextValue(current) : nextValue;
+      attachmentsRef.current = next;
+      rememberComposerDraft(
+        composerDraftKeyRef.current,
+        draftRef.current,
+        categoryRef.current,
+        next,
+      );
+      return next;
     });
   }
 
@@ -3610,12 +3656,14 @@ export function AgentWorkspace({
             }
             onChange={(text, nextCategory) => {
               draftRef.current = text;
+              categoryRef.current = nextCategory;
               setDraft(text);
               setCategory(nextCategory);
               rememberComposerDraft(
                 composerDraftKeyRef.current,
                 text,
                 nextCategory,
+                attachmentsRef.current,
               );
             }}
             onSubmit={() => void submit()}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -665,6 +665,11 @@ type AgentWorkspaceNotice = {
   sessionId: string;
 };
 
+type ComposerDraftSnapshot = {
+  text: string;
+  category: ReportCategory | null;
+};
+
 type AgentDeleteSessionDetail = {
   sessionId: string;
 };
@@ -730,6 +735,29 @@ type AgentSessionContinuity = {
 };
 
 let sessionContinuity: AgentSessionContinuity | null = null;
+const NEW_SESSION_DRAFT_KEY = "new-session";
+const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
+
+function sessionComposerDraftKey(sessionId: string) {
+  return `session:${sessionId}`;
+}
+
+function rememberComposerDraft(
+  key: string | null,
+  text: string,
+  category: ReportCategory | null,
+) {
+  if (!key) return;
+  if (!text.trim() && !category) {
+    agentComposerDrafts.delete(key);
+    return;
+  }
+  agentComposerDrafts.set(key, { text, category });
+}
+
+function forgetComposerDraft(key: string | null) {
+  if (key) agentComposerDrafts.delete(key);
+}
 
 function captureSessionContinuity(state: {
   sessionItems: HermesSessionInfo[];
@@ -770,6 +798,7 @@ function captureSessionContinuity(state: {
  * the next test's mount. */
 export function resetAgentSessionContinuity() {
   sessionContinuity = null;
+  agentComposerDrafts.clear();
 }
 
 export function AgentWorkspace({
@@ -1158,6 +1187,13 @@ export function AgentWorkspace({
       ...(pendingHermesMessages[selectedHermesSessionId] ?? []),
     ];
   }, [hermesSessionMessages, pendingHermesMessages, selectedHermesSessionId]);
+  const composerDraftKey = selectedHermesSessionId
+    ? sessionComposerDraftKey(selectedHermesSessionId)
+    : selectedTask
+      ? null
+      : NEW_SESSION_DRAFT_KEY;
+  const composerDraftKeyRef = useRef<string | null>(composerDraftKey);
+  composerDraftKeyRef.current = composerDraftKey;
   const chatArtifacts = useMemo(
     () => artifactsFromFilesystemSnapshot(filesystemSnapshot),
     [filesystemSnapshot],
@@ -1890,6 +1926,11 @@ export function AgentWorkspace({
     }
   }, [newSessionMode, activePanel]);
 
+  useEffect(() => {
+    if (activePanel !== "chat") return;
+    restoreComposerDraft(composerDraftKey);
+  }, [activePanel, composerDraftKey]);
+
   // The busy notice's advice ("wait for the reply") expires the moment the
   // selected session stops working — including when the user switches to a
   // session that isn't running.
@@ -1913,6 +1954,7 @@ export function AgentWorkspace({
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
     const content = promptWithAttachments(message, attachments);
+    const submittedDraftKey = composerDraftKeyRef.current;
     // A typed hero submit plays the same teardown as a run shortcut: greeting
     // up, suggestions down during the session-create latency. Without it they
     // sit frozen through the wait and then vanish in a single frame when the
@@ -1922,6 +1964,7 @@ export function AgentWorkspace({
     composerEditorRef.current?.clear();
     setDraft("");
     setCategory(null);
+    forgetComposerDraft(submittedDraftKey);
     setAttachments([]);
     setIssueReportNotice(null);
     try {
@@ -1954,6 +1997,7 @@ export function AgentWorkspace({
       // typed or attached something new during the in-flight send.
       if (composerEditorRef.current?.isEmpty() ?? true) {
         composerEditorRef.current?.setContent(message, reportCategory);
+        rememberComposerDraft(submittedDraftKey, message, reportCategory);
       }
       setAttachments((current) => (current.length ? current : attachments));
       if (isSessionBusyError(err)) {
@@ -2779,6 +2823,7 @@ export function AgentWorkspace({
     setActivePanel("chat");
     setSelectedTaskId(undefined);
     selectedHermesSessionIdRef.current = undefined;
+    composerDraftKeyRef.current = NEW_SESSION_DRAFT_KEY;
     setSelectedHermesSessionId(undefined);
     // Seed the composer: a category chip for a report, the prompt otherwise.
     // The editor may not be mounted yet on a cold open, so stash the category
@@ -2787,9 +2832,10 @@ export function AgentWorkspace({
     if (seedCategory) {
       seedComposerCategory();
     } else if (initialPrompt) {
+      rememberComposerDraft(NEW_SESSION_DRAFT_KEY, initialPrompt, null);
       composerEditorRef.current?.setContent(initialPrompt);
     } else {
-      clearComposerDraft();
+      clearComposerDraft(NEW_SESSION_DRAFT_KEY);
     }
     if (!initialPrompt) return;
     dispatchAgentSessionStatus({
@@ -2802,9 +2848,11 @@ export function AgentWorkspace({
     try {
       await submitHermesSession(initialPrompt);
       composerEditorRef.current?.clear();
+      forgetComposerDraft(NEW_SESSION_DRAFT_KEY);
       setError(null);
     } catch (err) {
       composerEditorRef.current?.setContent(initialPrompt);
+      rememberComposerDraft(NEW_SESSION_DRAFT_KEY, initialPrompt, null);
       setError(messageFromError(err));
       dispatchAgentSessionStatus({
         prompt: initialPrompt,
@@ -2817,11 +2865,24 @@ export function AgentWorkspace({
     }
   }
 
-  function clearComposerDraft() {
+  function clearComposerDraft(key = composerDraftKeyRef.current) {
     draftRef.current = "";
     setDraft("");
     setCategory(null);
+    forgetComposerDraft(key);
     composerEditorRef.current?.clear();
+  }
+
+  function restoreComposerDraft(key: string | null) {
+    const editor = composerEditorRef.current;
+    if (!editor) return;
+    const snapshot = key ? agentComposerDrafts.get(key) : undefined;
+    draftRef.current = snapshot?.text ?? "";
+    setDraft(snapshot?.text ?? "");
+    setCategory(snapshot?.category ?? null);
+    editor.setContent(snapshot?.text ?? "", snapshot?.category ?? null, {
+      focus: false,
+    });
   }
 
   /** Applies any pending seed category to the composer chip once the editor is
@@ -2837,6 +2898,7 @@ export function AgentWorkspace({
     window.setTimeout(() => {
       if (pendingSeedCategoryRef.current) return;
       editor.setContent("", seed);
+      rememberComposerDraft(NEW_SESSION_DRAFT_KEY, "", seed);
     }, 0);
   }
 
@@ -2881,6 +2943,7 @@ export function AgentWorkspace({
       return;
     }
     if (shortcut.action === "attach") {
+      rememberComposerDraft(composerDraftKeyRef.current, shortcut.prompt, null);
       composerEditorRef.current?.setContent(shortcut.prompt);
       void pickAttachments();
       return;
@@ -2890,6 +2953,7 @@ export function AgentWorkspace({
     composerEditorRef.current?.setContent(shortcut.prompt, null, {
       selectPlaceholder: true,
     });
+    rememberComposerDraft(composerDraftKeyRef.current, shortcut.prompt, null);
   }
 
   async function cancelTask(taskId: string) {
@@ -3056,6 +3120,7 @@ export function AgentWorkspace({
       return next;
     });
     scrubHermesSessionState(sessionId);
+    forgetComposerDraft(sessionComposerDraftKey(sessionId));
     // Every deletion funnels through here (the in-workspace delete and the
     // sidebar/sessions-list AGENT_DELETE_SESSION_EVENT), so this is the one
     // place that drops the session's Unrestricted record — a stale entry
@@ -3547,9 +3612,17 @@ export function AgentWorkspace({
               draftRef.current = text;
               setDraft(text);
               setCategory(nextCategory);
+              rememberComposerDraft(
+                composerDraftKeyRef.current,
+                text,
+                nextCategory,
+              );
             }}
             onSubmit={() => void submit()}
-            onReady={seedComposerCategory}
+            onReady={() => {
+              restoreComposerDraft(composerDraftKeyRef.current);
+              seedComposerCategory();
+            }}
           />
           <div className="agent-composer-toolbar">
             <button

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -22,7 +22,7 @@ export type ComposerEditorHandle = {
   setContent: (
     text: string,
     category?: ReportCategory | null,
-    options?: { selectPlaceholder?: boolean },
+    options?: { selectPlaceholder?: boolean; focus?: boolean },
   ) => void;
   /** Inserts or swaps the message's single category tag at the caret. */
   insertCategory: (category: ReportCategory) => void;
@@ -225,10 +225,11 @@ export const ComposerEditor = forwardRef<
           options?.selectPlaceholder && !category
             ? placeholderSelection(text)
             : null;
+        const shouldFocus = options?.focus !== false;
         if (range) {
           editor.commands.setTextSelection(range);
-          editor.view.focus();
-        } else {
+          if (shouldFocus) editor.view.focus();
+        } else if (shouldFocus) {
           focusEnd(editor);
         }
       },

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1252,6 +1252,52 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("restores a session draft with attachments after returning to agent chat", async () => {
+    const user = userEvent.setup();
+    const first = render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listen).toHaveBeenCalledWith(
+        "tauri://drag-drop",
+        expect.any(Function),
+      ),
+    );
+
+    mocks.eventHandlers.get("tauri://drag-drop")?.({
+      payload: {
+        paths: [
+          "/Users/alex/Library/Application Support/CleanShot/media/screenshot.png",
+        ],
+      },
+    });
+
+    expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "what is in this image?");
+
+    first.unmount();
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toHaveTextContent(
+        "what is in this image?",
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: expect.stringContaining(
+          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
+        ),
+      }),
+    );
+  });
+
   it("keeps a session draft when starting a blank new session", async () => {
     const user = userEvent.setup();
     const first = render(<AgentWorkspace initialSession={existingSession} />);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -468,6 +468,32 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
+  it("clears a stale new-session draft before seeding a report chip", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "stale hero draft");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+          detail: { category: "bug" },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).not.toHaveTextContent(
+      "stale hero draft",
+    );
+  });
+
   it("wraps a submitted issue report for June and files it after the turn", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
@@ -1321,6 +1347,41 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(screen.getByRole("textbox")).toHaveTextContent(
         "come back to this",
+      ),
+    );
+  });
+
+  it("restores drafts when switching sessions without remounting", async () => {
+    const user = userEvent.setup();
+    const secondSession = {
+      ...existingSession,
+      id: "session-2",
+      title: "Second session",
+      preview: "Second preview",
+      last_active: "2026-06-04T12:05:00Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([existingSession, secondSession]);
+    const { rerender } = render(
+      <AgentWorkspace initialSession={existingSession} />,
+    );
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "first session draft");
+
+    rerender(<AgentWorkspace initialSession={secondSession} />);
+
+    expect(await screen.findByText("Second session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox").textContent).toBe(""),
+    );
+    await user.type(screen.getByRole("textbox"), "second session draft");
+
+    rerender(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toHaveTextContent(
+        "first session draft",
       ),
     );
   });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1233,6 +1233,76 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("restores a session draft after leaving and returning to agent chat", async () => {
+    const user = userEvent.setup();
+    const first = render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "carry this thought");
+    expect(screen.getByRole("textbox")).toHaveTextContent("carry this thought");
+
+    first.unmount();
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toHaveTextContent(
+        "carry this thought",
+      ),
+    );
+  });
+
+  it("keeps a session draft when starting a blank new session", async () => {
+    const user = userEvent.setup();
+    const first = render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "come back to this");
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox").textContent).toBe(""),
+    );
+
+    first.unmount();
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toHaveTextContent(
+        "come back to this",
+      ),
+    );
+  });
+
+  it("clears a cached session draft after sending it", async () => {
+    const user = userEvent.setup();
+    const first = render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "ship this");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "ship this",
+      }),
+    );
+
+    first.unmount();
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox").textContent).toBe(""),
+    );
+  });
+
   it("submits a pending New Session prompt as a fresh Hermes session", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,


### PR DESCRIPTION
## What changed

- Added an in-memory composer draft cache keyed by Hermes session, plus a new-session draft slot.
- Restored drafts when returning to a session or remounting AgentWorkspace after navigating away.
- Cleared cached drafts after successful sends and when sessions are deleted, while preserving old session drafts when starting a blank new session.
- Let draft restoration update the TipTap editor without stealing focus.

## Why

JUN-48 reports that typed agent messages disappear after navigating away and back. The minimum useful behavior is per-conversation restoration during the current app session, without writing arbitrary unsent prompts to disk.

## Validation

- pnpm run lint
- pnpm test -- src/test/agent-workspace.test.tsx
- git diff --check

## Known gaps

- Full pnpm test was not run; this touched the agent composer path and was covered by the focused AgentWorkspace suite.