### PR TITLE
[fix] limit agent file surfacing

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7658,12 +7658,7 @@ function assignArtifactsToTurns(
   const claimedPaths = new Set<string>();
   const claimedNames = new Set<string>();
   for (const turn of turns) {
-    const text = turn.parts
-      .map((part) =>
-        part.type !== "context" && "text" in part ? part.text : "",
-      )
-      .join("\n")
-      .toLowerCase();
+    const text = artifactMatchText(turn);
     if (!text.trim()) continue;
     const mentioned: AgentArtifact[] = [];
     for (const artifact of artifacts) {
@@ -7673,7 +7668,7 @@ function assignArtifactsToTurns(
       const nameMentioned =
         turn.role === "assistant" &&
         !claimedNames.has(name) &&
-        text.includes(name);
+        deliverableNameMentioned(text, name);
       if (!pathMentioned && !nameMentioned) continue;
       claimedPaths.add(artifact.path);
       claimedNames.add(name);
@@ -7682,6 +7677,66 @@ function assignArtifactsToTurns(
     if (mentioned.length) byTurn.set(turn.id, mentioned);
   }
   return byTurn;
+}
+
+function artifactMatchText(turn: AgentChatTurn): string {
+  return turn.parts
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("\n")
+    .toLowerCase();
+}
+
+function deliverableNameMentioned(text: string, name: string): boolean {
+  let index = text.indexOf(name);
+  while (index !== -1) {
+    if (isDeliverableMentionContext(text, index, name.length)) return true;
+    index = text.indexOf(name, index + name.length);
+  }
+  return false;
+}
+
+function isDeliverableMentionContext(
+  text: string,
+  index: number,
+  length: number,
+): boolean {
+  const beforeBoundary = previousSentenceBoundary(text, index);
+  const afterBoundary = nextSentenceBoundary(text, index + length);
+  const context = text.slice(beforeBoundary + 1, afterBoundary);
+  return /\b(available|created|download|exported|generated|made|produced|rendered|saved|wrote)\b/.test(
+    context,
+  );
+}
+
+function previousSentenceBoundary(text: string, index: number): number {
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    if (isSentenceBoundaryAt(text, cursor)) return cursor;
+  }
+  return -1;
+}
+
+function nextSentenceBoundary(text: string, index: number): number {
+  for (let cursor = index; cursor < text.length; cursor += 1) {
+    if (isSentenceBoundaryAt(text, cursor)) return cursor;
+  }
+  return text.length;
+}
+
+function isSentenceBoundaryAt(text: string, index: number): boolean {
+  const char = text[index];
+  if (char === "\n" || char === "!" || char === "?") return true;
+  if (char !== ".") return false;
+  return !isFileExtensionDot(text, index);
+}
+
+function isFileExtensionDot(text: string, index: number): boolean {
+  return (
+    isAsciiAlphanumeric(text[index - 1]) && isAsciiAlphanumeric(text[index + 1])
+  );
+}
+
+function isAsciiAlphanumeric(char: string | undefined): boolean {
+  return char != null && /^[a-z0-9]$/.test(char);
 }
 
 function includesQuery(value: unknown, query: string) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7664,11 +7664,14 @@ function assignArtifactsToTurns(
     for (const artifact of artifacts) {
       const name = artifact.name.toLowerCase();
       if (!name || claimedPaths.has(artifact.path)) continue;
-      const pathMentioned = text.includes(artifact.path.toLowerCase());
+      const path = artifact.path.toLowerCase();
+      const pathMentioned =
+        text.includes(path) &&
+        (turn.role !== "assistant" || deliverableMentioned(text, path));
       const nameMentioned =
         turn.role === "assistant" &&
         !claimedNames.has(name) &&
-        deliverableNameMentioned(text, name);
+        deliverableMentioned(text, name);
       if (!pathMentioned && !nameMentioned) continue;
       claimedPaths.add(artifact.path);
       claimedNames.add(name);
@@ -7686,11 +7689,11 @@ function artifactMatchText(turn: AgentChatTurn): string {
     .toLowerCase();
 }
 
-function deliverableNameMentioned(text: string, name: string): boolean {
-  let index = text.indexOf(name);
+function deliverableMentioned(text: string, match: string): boolean {
+  let index = text.indexOf(match);
   while (index !== -1) {
-    if (isDeliverableMentionContext(text, index, name.length)) return true;
-    index = text.indexOf(name, index + name.length);
+    if (isDeliverableMentionContext(text, index, match.length)) return true;
+    index = text.indexOf(match, index + match.length);
   }
   return false;
 }
@@ -7703,8 +7706,29 @@ function isDeliverableMentionContext(
   const beforeBoundary = previousSentenceBoundary(text, index);
   const afterBoundary = nextSentenceBoundary(text, index + length);
   const context = text.slice(beforeBoundary + 1, afterBoundary);
+  return (
+    hasDeliveryKeyword(context) || hasDeliveryListHeadingContext(text, index)
+  );
+}
+
+function hasDeliveryListHeadingContext(text: string, index: number): boolean {
+  const lineStart = text.lastIndexOf("\n", index) + 1;
+  const linePrefix = text.slice(lineStart, index).trimStart();
+  if (!/^(?:[-*]|\d+[.)])\s+/.test(linePrefix)) return false;
+
+  let previousLineEnd = lineStart - 1;
+  while (previousLineEnd > 0) {
+    const previousLineStart = text.lastIndexOf("\n", previousLineEnd - 1) + 1;
+    const previousLine = text.slice(previousLineStart, previousLineEnd).trim();
+    if (previousLine) return hasDeliveryKeyword(previousLine);
+    previousLineEnd = previousLineStart - 1;
+  }
+  return false;
+}
+
+function hasDeliveryKeyword(text: string): boolean {
   return /\b(available|created|download|exported|generated|made|produced|rendered|saved|wrote)\b/.test(
-    context,
+    text,
   );
 }
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1914,6 +1914,73 @@ describe("AgentWorkspace", () => {
     expect(mocks.downloadHermesBridgeFile).toHaveBeenCalledWith(samplePath);
   });
 
+  it("does not surface files mentioned only in thought text or directory listings", async () => {
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
+    const pdfPath = `${workspaceRoot}/June Creator Get Started Guide.pdf`;
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: workspaceRoot,
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "June Creator Get Started Guide.pdf",
+              path: pdfPath,
+              kind: "file",
+              size: 128000,
+              modifiedAt: "2026-06-23T12:30:00Z",
+            },
+            {
+              name: "generate_pdf.py",
+              path: `${workspaceRoot}/generate_pdf.py`,
+              kind: "file",
+              size: 4096,
+              modifiedAt: "2026-06-23T12:28:00Z",
+            },
+            {
+              name: "screenshot.png",
+              path: `${workspaceRoot}/screenshot.png`,
+              kind: "file",
+              size: 633000,
+              modifiedAt: "2026-06-23T12:26:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content:
+          "The workspace contains generate_pdf.py and screenshot.png. The styled PDF is available as `June Creator Get Started Guide.pdf`.",
+        reasoning:
+          "I inspected generate_pdf.py and screenshot.png before writing the PDF.",
+        timestamp: "2026-06-23T12:30:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Download June Creator Get Started Guide.pdf",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "View files (1)" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download generate_pdf.py" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download screenshot.png" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders a workspace file's download card only on the first response that mentions it", async () => {
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
       roots: [

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1918,6 +1918,7 @@ describe("AgentWorkspace", () => {
     const workspaceRoot =
       "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
     const pdfPath = `${workspaceRoot}/June Creator Get Started Guide.pdf`;
+    const scriptPath = `${workspaceRoot}/generate_pdf.py`;
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
       roots: [
         {
@@ -1935,7 +1936,7 @@ describe("AgentWorkspace", () => {
             },
             {
               name: "generate_pdf.py",
-              path: `${workspaceRoot}/generate_pdf.py`,
+              path: scriptPath,
               kind: "file",
               size: 4096,
               modifiedAt: "2026-06-23T12:28:00Z",
@@ -1955,10 +1956,9 @@ describe("AgentWorkspace", () => {
       {
         id: "message-1",
         role: "assistant",
-        content:
-          "The workspace contains generate_pdf.py and screenshot.png. The styled PDF is available as `June Creator Get Started Guide.pdf`.",
+        content: `The workspace contains ${scriptPath} and screenshot.png. The styled PDF is available as \`June Creator Get Started Guide.pdf\`.`,
         reasoning:
-          "I inspected generate_pdf.py and screenshot.png before writing the PDF.",
+          "I saved generate_pdf.py while preparing the PDF and generated screenshot.png for reference.",
         timestamp: "2026-06-23T12:30:00Z",
       },
     ]);
@@ -1979,6 +1979,47 @@ describe("AgentWorkspace", () => {
     expect(
       screen.queryByRole("button", { name: "Download screenshot.png" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps generated-file list headings attached to artifact rows", async () => {
+    const reportPath =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/report.pdf";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace",
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "report.pdf",
+              path: reportPath,
+              kind: "file",
+              size: 8192,
+              modifiedAt: "2026-06-23T12:30:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: "Generated files:\n- report.pdf",
+        timestamp: "2026-06-23T12:30:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByRole("button", { name: "Download report.pdf" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "View files (1)" }),
+    ).toBeInTheDocument();
   });
 
   it("renders a workspace file's download card only on the first response that mentions it", async () => {


### PR DESCRIPTION
## Summary
- limit generated file cards to assistant answer text instead of thought/tool/internal output
- require filename-only matches to appear in delivery context like saved, generated, available, or exported
- add a regression test for JUN-81 so a PDF is surfaced without showing internal scripts or screenshots

## Root cause
The file card matcher treated every file in the workspace snapshot as eligible and matched by filename across non-user-facing turn parts. When an agent listed files it inspected, incidental workspace filenames were surfaced as downloadable files.

## Validation
- pnpm exec vitest run src/test/agent-workspace.test.tsx
- pnpm run lint