### PR TITLE
[fix] Persist new session drafts

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -738,6 +738,7 @@ type AgentSessionContinuity = {
 let sessionContinuity: AgentSessionContinuity | null = null;
 const NEW_SESSION_DRAFT_KEY = "new-session";
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
+let lastActiveComposerDraftKey: string | null | undefined;
 
 function sessionComposerDraftKey(sessionId: string) {
   return `session:${sessionId}`;
@@ -770,6 +771,13 @@ function hasSavedNewSessionDraft() {
   return Boolean(
     snapshot &&
     (snapshot.text.trim() || snapshot.category || snapshot.attachments.length),
+  );
+}
+
+function shouldRestoreNewSessionDraft() {
+  return (
+    lastActiveComposerDraftKey === NEW_SESSION_DRAFT_KEY &&
+    hasSavedNewSessionDraft()
   );
 }
 
@@ -813,6 +821,7 @@ function captureSessionContinuity(state: {
 export function resetAgentSessionContinuity() {
   sessionContinuity = null;
   agentComposerDrafts.clear();
+  lastActiveComposerDraftKey = undefined;
 }
 
 export function AgentWorkspace({
@@ -902,7 +911,7 @@ export function AgentWorkspace({
   >(
     () =>
       initialSessionId ??
-      (hasPendingNewSessionRequest() || hasSavedNewSessionDraft()
+      (hasPendingNewSessionRequest() || shouldRestoreNewSessionDraft()
         ? undefined
         : readLastOpenSessionId()),
   );
@@ -913,7 +922,7 @@ export function AgentWorkspace({
   const [newSessionMode, setNewSessionMode] = useState(
     () =>
       !initialSessionId &&
-      (hasPendingNewSessionRequest() || hasSavedNewSessionDraft()),
+      (hasPendingNewSessionRequest() || shouldRestoreNewSessionDraft()),
   );
   const setError = useCallback(
     (message: string | null, options: AgentWorkspaceErrorOptions = {}) => {
@@ -1217,6 +1226,11 @@ export function AgentWorkspace({
   const composerDraftKeyRef = useRef<string | null>(composerDraftKey);
   composerDraftKeyRef.current = composerDraftKey;
   const restoredComposerDraftKeyRef = useRef<string | null>();
+
+  useEffect(() => {
+    lastActiveComposerDraftKey = composerDraftKey;
+  }, [composerDraftKey]);
+
   const chatArtifacts = useMemo(
     () => artifactsFromFilesystemSnapshot(filesystemSnapshot),
     [filesystemSnapshot],
@@ -1862,6 +1876,7 @@ export function AgentWorkspace({
     })();
     return () => {
       cancelled = true;
+      lastActiveComposerDraftKey = composerDraftKeyRef.current;
       // Keep any mid-run session alive for the next mount before the
       // gateways (and with them the live event streams) go away.
       sessionContinuity = captureSessionContinuity({

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -855,15 +855,27 @@ export function AgentWorkspace({
   >(
     () =>
       initialSessionId ??
-      (hasPendingNewSessionRequest() ? undefined : readLastOpenSessionId()),
+      (hasPendingNewSessionRequest() || hasSavedNewSessionDraft()
+        ? undefined
+        : readLastOpenSessionId()),
   );
   const selectedHermesSessionIdRef = useRef<string | undefined>(
     selectedHermesSessionId,
   );
   const lastAutoSubmittedRef = useRef<{ prompt: string; at: number }>();
   const [newSessionMode, setNewSessionMode] = useState(
-    () => !initialSessionId && hasPendingNewSessionRequest(),
+    () =>
+      !initialSessionId &&
+      (hasPendingNewSessionRequest() || hasSavedNewSessionDraft()),
   );
+  const selectedDraftKey = useMemo(
+    () =>
+      newSessionMode
+        ? AGENT_NEW_SESSION_DRAFT_KEY
+        : draftKeyForSession(selectedHermesSessionId),
+    [newSessionMode, selectedHermesSessionId],
+  );
+  const selectedDraftKeyRef = useRef<string | undefined>(selectedDraftKey);
   const setError = useCallback(
     (message: string | null, options: AgentWorkspaceErrorOptions = {}) => {
       if (!message) {
@@ -1054,6 +1066,10 @@ export function AgentWorkspace({
   useEffect(() => {
     runtimeSessionIdsRef.current = runtimeSessionIds;
   }, [runtimeSessionIds]);
+
+  useEffect(() => {
+    selectedDraftKeyRef.current = selectedDraftKey;
+  }, [selectedDraftKey]);
 
   useEffect(() => {
     selectedHermesSessionIdRef.current = selectedHermesSessionId;
@@ -1614,6 +1630,10 @@ export function AgentWorkspace({
   }, [selectedHermesSessionId]);
 
   useEffect(() => {
+    restoreComposerDraft(selectedDraftKey);
+  }, [selectedDraftKey]);
+
+  useEffect(() => {
     // The sidebar and App replace their session lists wholesale with this
     // payload, so an unhydrated broadcast (mount seed only) would collapse
     // the list they already fetched themselves and flicker it back once the
@@ -1924,6 +1944,7 @@ export function AgentWorkspace({
     setCategory(null);
     setAttachments([]);
     setIssueReportNotice(null);
+    forgetAgentComposerDraft(selectedDraftKeyRef.current);
     try {
       await submitHermesSession(
         reportCategory ? categoryPrompt(reportCategory, content) : content,
@@ -2174,6 +2195,7 @@ export function AgentWorkspace({
     }
     if (!targetSessionId) {
       rememberSessionMode(storedSessionId, fullModeDraftRef.current);
+      forgetAgentComposerDraft(AGENT_NEW_SESSION_DRAFT_KEY);
     }
     const sessionDisplayTitle = options?.issueReport
       ? "Issue report"
@@ -2822,6 +2844,19 @@ export function AgentWorkspace({
     setDraft("");
     setCategory(null);
     composerEditorRef.current?.clear();
+    forgetAgentComposerDraft(selectedDraftKeyRef.current);
+  }
+
+  function restoreComposerDraft(draftKey: string | undefined) {
+    const saved = readAgentComposerDraft(draftKey);
+    draftRef.current = saved;
+    setDraft(saved);
+    setCategory(null);
+    if (saved) {
+      composerEditorRef.current?.setContent(saved);
+    } else {
+      composerEditorRef.current?.clear();
+    }
   }
 
   /** Applies any pending seed category to the composer chip once the editor is
@@ -3062,6 +3097,7 @@ export function AgentWorkspace({
     // would hand full write access to any future session that recycled the
     // id.
     forgetSessionMode(sessionId);
+    forgetAgentComposerDraft(draftKeyForSession(sessionId));
   }
 
   async function deleteSelectedHermesSession(sessionId: string) {
@@ -3547,9 +3583,13 @@ export function AgentWorkspace({
               draftRef.current = text;
               setDraft(text);
               setCategory(nextCategory);
+              writeAgentComposerDraft(selectedDraftKeyRef.current, text);
             }}
             onSubmit={() => void submit()}
-            onReady={seedComposerCategory}
+            onReady={() => {
+              restoreComposerDraft(selectedDraftKeyRef.current);
+              seedComposerCategory();
+            }}
           />
           <div className="agent-composer-toolbar">
             <button
@@ -8055,6 +8095,9 @@ function omitRecordKey<T>(record: Record<string, T>, key: string) {
 // existing conversation after a relaunch is always safe, unlike the pending
 // new-session marker, which must NOT outlive its navigation.
 const AGENT_LAST_OPEN_SESSION_KEY = "scribe:agent:last-open-session";
+const AGENT_COMPOSER_DRAFTS_KEY = "scribe:agent:composer-drafts";
+const AGENT_NEW_SESSION_DRAFT_KEY = "new-session";
+const AGENT_COMPOSER_DRAFT_MAX_LENGTH = 20_000;
 
 // How long a second startNewTask call with the same prompt counts as an echo
 // of the first (marker + window event double-delivery) rather than a new ask.
@@ -8094,6 +8137,73 @@ function writeLastOpenSessionId(sessionId: string) {
   } catch {
     // Storage can be unavailable in restricted webviews; restore is best-effort.
   }
+}
+
+function draftKeyForSession(sessionId: string | undefined) {
+  return sessionId ? `session:${sessionId}` : undefined;
+}
+
+function readAgentComposerDrafts(): Record<string, string> {
+  try {
+    const raw = window.localStorage.getItem(AGENT_COMPOSER_DRAFTS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" && typeof entry[1] === "string",
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeAgentComposerDrafts(drafts: Record<string, string>) {
+  try {
+    if (Object.keys(drafts).length === 0) {
+      window.localStorage.removeItem(AGENT_COMPOSER_DRAFTS_KEY);
+      return;
+    }
+    window.localStorage.setItem(
+      AGENT_COMPOSER_DRAFTS_KEY,
+      JSON.stringify(drafts),
+    );
+  } catch {
+    // Draft persistence is best-effort; the typed text still lives in memory.
+  }
+}
+
+function readAgentComposerDraft(key: string | undefined) {
+  if (!key) return "";
+  return readAgentComposerDrafts()[key] ?? "";
+}
+
+function hasSavedNewSessionDraft() {
+  return Boolean(readAgentComposerDraft(AGENT_NEW_SESSION_DRAFT_KEY).trim());
+}
+
+function writeAgentComposerDraft(key: string | undefined, draft: string) {
+  if (!key) return;
+  const drafts = readAgentComposerDrafts();
+  const normalized = draft.slice(0, AGENT_COMPOSER_DRAFT_MAX_LENGTH);
+  if (normalized.trim()) {
+    drafts[key] = normalized;
+  } else {
+    delete drafts[key];
+  }
+  writeAgentComposerDrafts(drafts);
+}
+
+function forgetAgentComposerDraft(key: string | undefined) {
+  if (!key) return;
+  const drafts = readAgentComposerDrafts();
+  if (!(key in drafts)) return;
+  delete drafts[key];
+  writeAgentComposerDrafts(drafts);
 }
 
 export function markAgentNewSessionPending(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -737,6 +737,7 @@ type AgentSessionContinuity = {
 
 let sessionContinuity: AgentSessionContinuity | null = null;
 const NEW_SESSION_DRAFT_KEY = "new-session";
+const AGENT_COMPOSER_DRAFT_MAX_ENTRIES = 50;
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
 let lastActiveComposerDraftKey: string | null | undefined;
 
@@ -755,15 +756,31 @@ function rememberComposerDraft(
     agentComposerDrafts.delete(key);
     return;
   }
+  agentComposerDrafts.delete(key);
   agentComposerDrafts.set(key, {
     text,
     category,
     attachments: [...attachments],
   });
+  pruneComposerDrafts();
 }
 
 function forgetComposerDraft(key: string | null) {
   if (key) agentComposerDrafts.delete(key);
+}
+
+function pruneComposerDrafts() {
+  while (agentComposerDrafts.size > AGENT_COMPOSER_DRAFT_MAX_ENTRIES) {
+    let oldestKey: string | undefined;
+    for (const key of agentComposerDrafts.keys()) {
+      if (key === NEW_SESSION_DRAFT_KEY) continue;
+      oldestKey = key;
+      break;
+    }
+    oldestKey ??= agentComposerDrafts.keys().next().value;
+    if (!oldestKey) return;
+    agentComposerDrafts.delete(oldestKey);
+  }
 }
 
 function hasSavedNewSessionDraft() {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1233,6 +1233,63 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("restores an unsent new session draft after remounting", async () => {
+    const user = userEvent.setup();
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "draft from a new session");
+    expect(screen.getByRole("textbox")).toHaveTextContent(
+      "draft from a new session",
+    );
+
+    first.unmount();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toHaveTextContent(
+        "draft from a new session",
+      ),
+    );
+    expect(screen.queryByText("Existing session")).toBeNull();
+  });
+
+  it("forgets the new session draft after submitting it", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "start from this draft");
+    expect(
+      window.localStorage.getItem("scribe:agent:composer-drafts") ?? "",
+    ).toContain("start from this draft");
+
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "start from this draft",
+      }),
+    );
+    expect(
+      window.localStorage.getItem("scribe:agent:composer-drafts") ?? "",
+    ).not.toContain("start from this draft");
+  });
+
   it("submits a pending New Session prompt as a fresh Hermes session", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1294,6 +1294,35 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Existing session")).toBeNull();
   });
 
+  it("restores the last open session after leaving a saved new session draft", async () => {
+    const user = userEvent.setup();
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "new session idea");
+
+    first.rerender(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox").textContent).toBe(""),
+    );
+
+    first.unmount();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox").textContent).toBe(""),
+    );
+  });
+
   it("forgets the new session draft after submitting it", async () => {
     const user = userEvent.setup();
     const first = render(<AgentWorkspace />);


### PR DESCRIPTION
## Summary
- Persists unsent Agent composer drafts for new sessions and existing sessions in local storage.
- Restores a saved new-session draft on remount instead of falling back to the last existing session.
- Clears saved drafts after submit or session deletion.

## Validation
- pnpm test src/test/agent-workspace.test.tsx
- pnpm run lint
- pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/test/agent-workspace.test.tsx
- pnpm test

Resolves JUN-80