### PR TITLE
Fix JUN-81 agent file surfacing

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7659,9 +7659,7 @@ function assignArtifactsToTurns(
   const claimedNames = new Set<string>();
   for (const turn of turns) {
     const text = turn.parts
-      .map((part) =>
-        part.type !== "context" && "text" in part ? part.text : "",
-      )
+      .map((part) => (part.type === "text" ? part.text : ""))
       .join("\n")
       .toLowerCase();
     if (!text.trim()) continue;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2120,6 +2120,94 @@ describe("AgentWorkspace", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not surface files only mentioned inside tool output", async () => {
+    const user = userEvent.setup();
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: workspaceRoot,
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "sample.pdf",
+              path: `${workspaceRoot}/sample.pdf`,
+              kind: "file",
+              size: 1768,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+            {
+              name: "screenshot.png",
+              path: `${workspaceRoot}/screenshot.png`,
+              kind: "file",
+              size: 2048,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+            {
+              name: "generate_pdf.py",
+              path: `${workspaceRoot}/generate_pdf.py`,
+              kind: "file",
+              size: 512,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content: "Done. The PDF is available as `sample.pdf`.",
+        timestamp: "2026-06-04T18:39:00Z",
+        tool_calls: JSON.stringify([
+          {
+            id: "call-1",
+            function: {
+              name: "list_files",
+              arguments: "{}",
+            },
+          },
+        ]),
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        content: "sample.pdf\nscreenshot.png\ngenerate_pdf.py",
+        timestamp: "2026-06-04T18:39:01Z",
+        tool_call_id: "call-1",
+        tool_name: "list_files",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByLabelText("Generated files")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download sample.pdf" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download screenshot.png" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download generate_pdf.py" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole("button", { name: "View files (1)" }),
+    );
+
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    expect(within(panel).getByText("sample.pdf")).toBeInTheDocument();
+    expect(within(panel).queryByText("screenshot.png")).not.toBeInTheDocument();
+    expect(
+      within(panel).queryByText("generate_pdf.py"),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not render download cards for files the user attached", async () => {
     const attachedPath =
       "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/june-context.md";


### PR DESCRIPTION
## Summary
- Fixes JUN-81 by limiting generated-file surfacing to user-facing text parts instead of tool output or reasoning internals.
- Prevents workspace directory listings inside Thought/tool logs from filling the chat Files panel with unrelated scratch files.
- Adds a regression test for a PDF response where a tool output lists extra workspace files.

## Validation
- pnpm exec vitest run src/test/agent-workspace.test.tsx
- pnpm run lint

## Notes
- Live os-platform Issue JUN-81 is in the june org and describes the full workspace file list leaking into a user-facing conversion response.