### PR TITLE
Fix JUN-75 attachment prompt branding

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7650,11 +7650,11 @@ function filesystemEntriesToArtifacts(
 
 // Assigns each workspace file to the first turn that mentions it, so its
 // download card renders once instead of at the end of every later response
-// that happens to repeat the file name. User turns can claim a file too, but
-// only by full path — that's how promptWithAttachments injects attachments,
-// and a file the user just handed us shouldn't bounce back as a download.
-// Name-only matches are also deduplicated by name, so two workspace copies of
-// the same file don't produce twin cards.
+// that happens to repeat the file name. User turns can claim a file too, using
+// either the full artifact path or the workspace-relative path injected for
+// attachments, so a file the user just handed us shouldn't bounce back as a
+// download. Name-only matches are also deduplicated by name, so two workspace
+// copies of the same file don't produce twin cards.
 function assignArtifactsToTurns(
   turns: AgentChatTurn[],
   artifacts: AgentArtifact[],
@@ -7675,7 +7675,9 @@ function assignArtifactsToTurns(
     for (const artifact of artifacts) {
       const name = artifact.name.toLowerCase();
       if (!name || claimedPaths.has(artifact.path)) continue;
-      const pathMentioned = text.includes(artifact.path.toLowerCase());
+      const pathMentioned =
+        text.includes(artifact.path.toLowerCase()) ||
+        text.includes(attachmentPromptPath(artifact.path).toLowerCase());
       const nameMentioned =
         turn.role === "assistant" &&
         !claimedNames.has(name) &&

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7610,14 +7610,20 @@ function promptWithAttachments(
   return [
     message || "Use the attached file(s).",
     "",
-    "Attached files copied into the Scribe Hermes workspace:",
+    "Attached files copied into the June workspace:",
     ...attachments.map(
       (attachment) =>
-        `- ${attachment.name} (${attachment.rootLabel}): ${attachment.path}`,
+        `- ${attachment.name} (${attachment.rootLabel}): ${attachmentPromptPath(attachment.path)}`,
     ),
     "",
-    "Use these workspace paths when inspecting or operating on the files.",
+    "Use these file paths when inspecting or operating on the files.",
   ].join("\n");
+}
+
+function attachmentPromptPath(path: string) {
+  const workspaceMatch = path.match(/(?:^|[/\\])workspace[/\\](.+)$/);
+  if (workspaceMatch?.[1]) return workspaceMatch[1];
+  return path;
 }
 
 function filesystemEntriesToArtifacts(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -505,6 +505,13 @@ describe("AgentWorkspace", () => {
     expect(submitted.text).toContain(
       "The recorder crashes after long meetings",
     );
+    expect(submitted.text).toContain(
+      "Attached files copied into the June workspace:",
+    );
+    expect(submitted.text).toContain(
+      "Use these file paths when inspecting or operating on the files.",
+    );
+    expect(submitted.text).not.toContain("Scribe Hermes");
     // The transcript shows the user's words only — the investigation
     // framing is plumbing between June and the runtime, never UI.
     expect(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2157,7 +2157,7 @@ describe("AgentWorkspace", () => {
           "Summarize this.",
           "",
           "Attached files copied into the June workspace:",
-          `- june-context.md (Workspace): ${attachedPath}`,
+          "- june-context.md (Workspace): june-context.md",
           "",
           "Use these file paths when inspecting or operating on the files.",
         ].join("\n"),

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2156,10 +2156,10 @@ describe("AgentWorkspace", () => {
         content: [
           "Summarize this.",
           "",
-          "Attached files copied into the Scribe Hermes workspace:",
+          "Attached files copied into the June workspace:",
           `- june-context.md (Workspace): ${attachedPath}`,
           "",
-          "Use these workspace paths when inspecting or operating on the files.",
+          "Use these file paths when inspecting or operating on the files.",
         ].join("\n"),
         timestamp: "2026-06-04T18:38:00Z",
       },
@@ -2306,11 +2306,20 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
         session_id: "runtime-session-1",
-        text: expect.stringContaining(
-          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
-        ),
+        text: expect.stringContaining("uploads/screenshot.png"),
       }),
     );
+    const submitted = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    )?.[1] as { text: string };
+    expect(submitted.text).toContain(
+      "Attached files copied into the June workspace:",
+    );
+    expect(submitted.text).toContain(
+      "Use these file paths when inspecting or operating on the files.",
+    );
+    expect(submitted.text).not.toContain("co.opensoftware.scribe");
+    expect(submitted.text).not.toContain("Scribe Hermes");
     expect(mocks.importHermesBridgeFile).toHaveBeenCalledWith(
       "/Users/alex/Library/Application Support/CleanShot/media/screenshot.png",
     );


### PR DESCRIPTION
## Summary
- Rebrand attached-file prompt copy to the June workspace.
- Use workspace-relative file references in submitted prompts while preserving internal paths for report uploads.
- Keep user-attached files from reappearing as generated download cards when later responses mention them.

## Validation
- pnpm test
- pnpm run lint
- pnpm build
