### PR TITLE
Filter diagnostic artifact mentions

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7642,6 +7642,23 @@ function filesystemEntriesToArtifacts(
   });
 }
 
+const ASSISTANT_ARTIFACT_SURFACE_RE =
+  /\b(?:available|attached|created|download|downloadable|exported|saved?|stored|uploaded|written|wrote)\b/;
+
+function assistantTextSurfacesArtifactName(text: string, name: string) {
+  let searchFrom = 0;
+  while (searchFrom < text.length) {
+    const index = text.indexOf(name, searchFrom);
+    if (index === -1) return false;
+    const contextStart = Math.max(0, index - 80);
+    const contextEnd = Math.min(text.length, index + name.length + 30);
+    const context = text.slice(contextStart, contextEnd);
+    if (ASSISTANT_ARTIFACT_SURFACE_RE.test(context)) return true;
+    searchFrom = index + name.length;
+  }
+  return false;
+}
+
 // Assigns each workspace file to the first turn that mentions it, so its
 // download card renders once instead of at the end of every later response
 // that happens to repeat the file name. User turns can claim a file too, but
@@ -7673,6 +7690,7 @@ function assignArtifactsToTurns(
       const nameMentioned =
         turn.role === "assistant" &&
         !claimedNames.has(name) &&
+        assistantTextSurfacesArtifactName(text, name) &&
         text.includes(name);
       if (!pathMentioned && !nameMentioned) continue;
       claimedPaths.add(artifact.path);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7650,22 +7650,17 @@ function assistantArtifactContext(
   nameIndex: number,
   nameLength: number,
 ) {
-  const priorSentence = Math.max(
-    text.lastIndexOf(".", nameIndex),
-    text.lastIndexOf("!", nameIndex),
-    text.lastIndexOf("?", nameIndex),
-  );
-  const nextSentenceCandidates = [".", "!", "?"]
-    .map((marker) => text.indexOf(marker, nameIndex + nameLength))
-    .filter((index) => index !== -1);
+  let priorSentence = -1;
+  for (let index = nameIndex - 1; index >= 0; index -= 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if ((char === "." || char === "!" || char === "?") && /\s/.test(next)) {
+      priorSentence = index;
+      break;
+    }
+  }
   const sentenceStart = Math.max(0, priorSentence + 1, nameIndex - 600);
-  const sentenceEnd = Math.min(
-    text.length,
-    nextSentenceCandidates.length
-      ? Math.min(...nextSentenceCandidates) + 1
-      : nameIndex + nameLength + 120,
-  );
-  return text.slice(sentenceStart, sentenceEnd);
+  return text.slice(sentenceStart, nameIndex + nameLength);
 }
 
 function assistantTextSurfacesArtifactName(text: string, name: string) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7708,9 +7708,13 @@ function assignArtifactsToTurns(
     for (const artifact of artifacts) {
       const name = artifact.name.toLowerCase();
       if (!name || claimedPaths.has(artifact.path)) continue;
+      const fullPath = artifact.path.toLowerCase();
+      const promptPath = attachmentPromptPath(artifact.path).toLowerCase();
       const pathMentioned =
-        text.includes(artifact.path.toLowerCase()) ||
-        text.includes(attachmentPromptPath(artifact.path).toLowerCase());
+        turn.role === "assistant"
+          ? assistantTextSurfacesArtifactName(text, fullPath) ||
+            assistantTextSurfacesArtifactName(text, promptPath)
+          : text.includes(fullPath) || text.includes(promptPath);
       const nameMentioned =
         turn.role === "assistant" &&
         !claimedNames.has(name) &&

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7643,16 +7643,37 @@ function filesystemEntriesToArtifacts(
 }
 
 const ASSISTANT_ARTIFACT_SURFACE_RE =
-  /\b(?:available|attached|created|download|downloadable|exported|saved?|stored|uploaded|written|wrote)\b/;
+  /\b(?:available|attached|created|download|downloadable|exported|generated(?!\s+attachment\s+variants)|saved?|stored|uploaded|written|wrote)\b/;
+
+function assistantArtifactContext(
+  text: string,
+  nameIndex: number,
+  nameLength: number,
+) {
+  const priorSentence = Math.max(
+    text.lastIndexOf(".", nameIndex),
+    text.lastIndexOf("!", nameIndex),
+    text.lastIndexOf("?", nameIndex),
+  );
+  const nextSentenceCandidates = [".", "!", "?"]
+    .map((marker) => text.indexOf(marker, nameIndex + nameLength))
+    .filter((index) => index !== -1);
+  const sentenceStart = Math.max(0, priorSentence + 1, nameIndex - 600);
+  const sentenceEnd = Math.min(
+    text.length,
+    nextSentenceCandidates.length
+      ? Math.min(...nextSentenceCandidates) + 1
+      : nameIndex + nameLength + 120,
+  );
+  return text.slice(sentenceStart, sentenceEnd);
+}
 
 function assistantTextSurfacesArtifactName(text: string, name: string) {
   let searchFrom = 0;
   while (searchFrom < text.length) {
     const index = text.indexOf(name, searchFrom);
     if (index === -1) return false;
-    const contextStart = Math.max(0, index - 80);
-    const contextEnd = Math.min(text.length, index + name.length + 30);
-    const context = text.slice(contextStart, contextEnd);
+    const context = assistantArtifactContext(text, index, name.length);
     if (ASSISTANT_ARTIFACT_SURFACE_RE.test(context)) return true;
     searchFrom = index + name.length;
   }

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2170,6 +2170,152 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByLabelText("Generated files")).not.toBeInTheDocument();
   });
 
+  it("does not surface diagnostic file mentions as generated artifacts", async () => {
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: workspaceRoot,
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "june-context.md",
+              path: `${workspaceRoot}/june-context.md`,
+              kind: "file",
+              size: 14336,
+              modifiedAt: "2026-06-23T12:39:00Z",
+            },
+            {
+              name: "compressed_screenshot.jpg",
+              path: `${workspaceRoot}/compressed_screenshot.jpg`,
+              kind: "file",
+              size: 95232,
+              modifiedAt: "2026-06-23T12:39:10Z",
+            },
+            {
+              name: "small_screenshot.jpg",
+              path: `${workspaceRoot}/small_screenshot.jpg`,
+              kind: "file",
+              size: 28672,
+              modifiedAt: "2026-06-23T12:39:11Z",
+            },
+            {
+              name: "ss.png",
+              path: `${workspaceRoot}/ss.png`,
+              kind: "file",
+              size: 259072,
+              modifiedAt: "2026-06-23T12:39:12Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content:
+          "Screenshots showed generated attachment variants such as compressed_screenshot.jpg, small_screenshot.jpg, and ss.png, plus june-context.md visible in the attachment list.",
+        timestamp: "2026-06-23T12:40:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(/Screenshots showed/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Generated files")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /View files/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("surfaces genuine outputs without listing diagnostic attachment artifacts", async () => {
+    const user = userEvent.setup();
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: workspaceRoot,
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "june-context.md",
+              path: `${workspaceRoot}/june-context.md`,
+              kind: "file",
+              size: 14336,
+              modifiedAt: "2026-06-23T12:39:00Z",
+            },
+            {
+              name: "compressed_screenshot.jpg",
+              path: `${workspaceRoot}/compressed_screenshot.jpg`,
+              kind: "file",
+              size: 95232,
+              modifiedAt: "2026-06-23T12:39:10Z",
+            },
+            {
+              name: "small_screenshot.jpg",
+              path: `${workspaceRoot}/small_screenshot.jpg`,
+              kind: "file",
+              size: 28672,
+              modifiedAt: "2026-06-23T12:39:11Z",
+            },
+            {
+              name: "diagnosis.md",
+              path: `${workspaceRoot}/diagnosis.md`,
+              kind: "file",
+              size: 4096,
+              modifiedAt: "2026-06-23T12:40:10Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content:
+          "Screenshots showed variants such as compressed_screenshot.jpg and small_screenshot.jpg, plus june-context.md visible in the attachment list. I saved the triage notes as diagnosis.md.",
+        timestamp: "2026-06-23T12:40:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(/saved the triage notes/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download diagnosis.md" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download june-context.md" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Download compressed_screenshot.jpg",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download small_screenshot.jpg" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "View files (1)" }));
+    const panel = await screen.findByRole("complementary", { name: "Files" });
+    expect(within(panel).getByText("diagnosis.md")).toBeInTheDocument();
+    expect(within(panel).queryByText("june-context.md")).not.toBeInTheDocument();
+    expect(
+      within(panel).queryByText("compressed_screenshot.jpg"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(panel).queryByText("small_screenshot.jpg"),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders one download card when two workspace copies share a file name", async () => {
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
       roots: [

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2120,6 +2120,108 @@ describe("AgentWorkspace", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("surfaces long generated file lists from one assistant sentence", async () => {
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: workspaceRoot,
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "summary.md",
+              path: `${workspaceRoot}/summary.md`,
+              kind: "file",
+              size: 512,
+              modifiedAt: "2026-06-04T18:39:00Z",
+            },
+            {
+              name: "build-log.txt",
+              path: `${workspaceRoot}/build-log.txt`,
+              kind: "file",
+              size: 1024,
+              modifiedAt: "2026-06-04T18:40:00Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content:
+          "I exported the deliverables as `summary.md`, with implementation notes, validation details, and the complete command transcript available in `build-log.txt`.",
+        timestamp: "2026-06-04T18:39:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByLabelText("Generated files")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download summary.md" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download build-log.txt" }),
+    ).toBeInTheDocument();
+  });
+
+  it("recognizes generated output wording without surfacing generated attachment variants", async () => {
+    const workspaceRoot =
+      "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace";
+    mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({
+      roots: [
+        {
+          id: "workspace",
+          label: "Workspace",
+          path: workspaceRoot,
+          description: "Hermes scratch files and generated outputs.",
+          entries: [
+            {
+              name: "report.md",
+              path: `${workspaceRoot}/report.md`,
+              kind: "file",
+              size: 512,
+              modifiedAt: "2026-06-23T12:40:00Z",
+            },
+            {
+              name: "compressed_screenshot.jpg",
+              path: `${workspaceRoot}/compressed_screenshot.jpg`,
+              kind: "file",
+              size: 95232,
+              modifiedAt: "2026-06-23T12:39:10Z",
+            },
+          ],
+        },
+      ],
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "assistant",
+        content:
+          "I generated report.md. Screenshots showed generated attachment variants such as compressed_screenshot.jpg.",
+        timestamp: "2026-06-23T12:40:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByLabelText("Generated files")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download report.md" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Download compressed_screenshot.jpg",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not render download cards for files the user attached", async () => {
     const attachedPath =
       "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/june-context.md";


### PR DESCRIPTION
## Summary
- Filter filename-only generated-file cards so diagnostic mentions do not surface scratch files.
- Keep genuine generated outputs visible when response text describes a file as saved, available, written, or downloadable.
- Add regression coverage for internal context files, screenshot variants, and mixed diagnostic plus real-output responses.

## Root cause
The session file UI built generated-file cards from the full workspace snapshot and treated any filename mention in a response as a surfaced output. That made diagnostic text about files like `june-context.md` or resized screenshot variants appear as downloadable generated files.

## Validation
- `pnpm run lint`
- `pnpm test`
- `pnpm run build`

Fixes JUN-77
