### PR TITLE
Add JUN-56 cancel subscription entry

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -118,6 +118,7 @@ struct SubscriptionWire {
     status: Option<String>,
     trial_end: Option<String>,
     current_period_end: Option<String>,
+    cancel_at_period_end: Option<bool>,
     /// Trial length from the Stripe price config, available pre-subscription.
     /// Absent on accounts APIs that don't expose it yet; the UI falls back to
     /// a pinned default.
@@ -179,6 +180,8 @@ pub struct AccountSubscription {
     pub trial_end: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_period_end: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_at_period_end: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_period_days: Option<u32>,
 }
@@ -375,6 +378,7 @@ fn local_dev_account_status() -> AccountStatus {
             status: Some("active".to_string()),
             trial_end: None,
             current_period_end: None,
+            cancel_at_period_end: None,
             trial_period_days: None,
         }),
         portal_url: None,
@@ -1343,6 +1347,7 @@ async fn fetch_snapshot(
             status: w.status,
             trial_end: w.trial_end,
             current_period_end: w.current_period_end,
+            cancel_at_period_end: w.cancel_at_period_end,
             trial_period_days: w.trial_period_days,
         });
     Ok((me.into(), balance.into(), subscription))

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -189,6 +189,17 @@ export function BillingSettingsSection({
     }
   }
 
+  async function handleCancelSubscription() {
+    try {
+      await osAccountsOpenPortal();
+      setBillingStatus(
+        "Opened your account portal. Choose Cancel subscription to end your plan.",
+      );
+    } catch (error) {
+      setBillingStatus(messageFromError(error));
+    }
+  }
+
   // Only the states reachable from inside the app: past_due and canceled park
   // the whole app on the trial gate, so settings never renders them.
   const subscription = account.subscription;
@@ -247,6 +258,13 @@ export function BillingSettingsSection({
                   onClick={() => void handleManageSubscription()}
                 >
                   Manage subscription
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => void handleCancelSubscription()}
+                >
+                  Cancel subscription
                 </button>
               </div>
             </div>

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -180,29 +180,27 @@ export function BillingSettingsSection({
     }
   }
 
-  async function handleManageSubscription() {
+  async function openPortalWithStatus(message: string) {
     try {
       await osAccountsOpenPortal();
-      setBillingStatus("Opened your account portal in the browser.");
+      setBillingStatus(message);
     } catch (error) {
       setBillingStatus(messageFromError(error));
     }
   }
 
-  async function handleCancelSubscription() {
-    try {
-      await osAccountsOpenPortal();
-      setBillingStatus(
-        "Opened your account portal. Choose Cancel subscription to end your plan.",
-      );
-    } catch (error) {
-      setBillingStatus(messageFromError(error));
-    }
-  }
+  const handleManageSubscription = () =>
+    openPortalWithStatus("Opened your account portal in the browser.");
+
+  const handleCancelSubscription = () =>
+    openPortalWithStatus(
+      "Opened your account portal. Choose Cancel subscription to end your plan.",
+    );
 
   // Only the states reachable from inside the app: past_due and canceled park
   // the whole app on the trial gate, so settings never renders them.
   const subscription = account.subscription;
+  const cancelAtPeriodEnd = subscription?.cancelAtPeriodEnd === true;
   const subscriptionRow =
     subscription?.status === "trialing"
       ? {
@@ -213,7 +211,10 @@ export function BillingSettingsSection({
         ? {
             title: "Subscription",
             detail:
-              describeEnd("Renews", subscription.currentPeriodEnd) ?? "Active",
+              describeEnd(
+                cancelAtPeriodEnd ? "Ends" : "Renews",
+                subscription.currentPeriodEnd,
+              ) ?? "Active",
           }
         : undefined;
 
@@ -259,13 +260,15 @@ export function BillingSettingsSection({
                 >
                   Manage subscription
                 </button>
-                <button
-                  type="button"
-                  className="btn btn-secondary"
-                  onClick={() => void handleCancelSubscription()}
-                >
-                  Cancel subscription
-                </button>
+                {!cancelAtPeriodEnd ? (
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => void handleCancelSubscription()}
+                  >
+                    Cancel subscription
+                  </button>
+                ) : null}
               </div>
             </div>
           ) : null}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1220,6 +1220,7 @@ export type AccountSubscription = {
   status?: "trialing" | "active" | "past_due" | "canceled" | (string & {});
   trialEnd?: string;
   currentPeriodEnd?: string;
+  cancelAtPeriodEnd?: boolean;
   /** Trial length from the Stripe price config, available pre-subscription.
    * Absent on accounts APIs that don't expose it yet. */
   trialPeriodDays?: number;

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -547,6 +547,37 @@ describe("AppSettings", () => {
     ).toBeInTheDocument();
   });
 
+  it("offers the cancel subscription action during a trial", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          subscription: {
+            subscribed: true,
+            status: "trialing",
+            trialEnd: "2027-02-03T00:00:00Z",
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+    expect(screen.getByText("Free trial")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Cancel subscription" }),
+    );
+    expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
+  });
+
   it("hides billing and sign-out controls in local mode", () => {
     render(
       <AppSettings

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -512,6 +512,41 @@ describe("AppSettings", () => {
     await waitFor(() => expect(onAccountRefresh).toHaveBeenCalledOnce());
   });
 
+  it("offers a direct cancel subscription action in billing settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          subscription: {
+            subscribed: true,
+            status: "active",
+            currentPeriodEnd: "2027-02-03T00:00:00Z",
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+    await user.click(
+      screen.getByRole("button", { name: "Cancel subscription" }),
+    );
+
+    expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
+    expect(
+      await screen.findByText(
+        "Opened your account portal. Choose Cancel subscription to end your plan.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("hides billing and sign-out controls in local mode", () => {
     render(
       <AppSettings

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -576,6 +576,42 @@ describe("AppSettings", () => {
       screen.getByRole("button", { name: "Cancel subscription" }),
     );
     expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
+    expect(
+      await screen.findByText(
+        "Opened your account portal. Choose Cancel subscription to end your plan.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the cancel subscription action once cancellation is scheduled", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          subscription: {
+            subscribed: true,
+            status: "active",
+            currentPeriodEnd: "2027-02-03T00:00:00Z",
+            cancelAtPeriodEnd: true,
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    expect(screen.getByText("Ends February 3, 2027")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel subscription" }),
+    ).not.toBeInTheDocument();
   });
 
   it("hides billing and sign-out controls in local mode", () => {


### PR DESCRIPTION
## Summary
- Add a visible Cancel subscription action in Billing settings for active and trialing subscriptions.
- Route the action through the existing OS Accounts portal handoff.
- Keep existing Manage subscription, Add funds, and refresh behavior intact.

## Validation
- pnpm exec vitest run src/test/app-settings.test.tsx src/test/trial-gate.test.tsx src/test/account-gate.test.ts
- pnpm test
- pnpm run lint
- pnpm build
- git diff --check origin/main..HEAD
- pnpm exec prettier --check src/components/account/AccountSettings.tsx src/test/app-settings.test.tsx

Note: pnpm run format currently reports pre-existing formatting issues outside this branch in src/app/App.tsx, src/lib/live-transcript-preview.ts, src/lib/recording-inactivity.ts, src/styles/app.css, src/test/recording-inactivity.test.ts, and src-tauri/tauri.conf.json.