### PR TITLE
Make report submissions fee-free

### DIFF
--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -17,6 +17,7 @@ pub(crate) async fn chat_completions(
     Json(mut body): Json<serde_json::Value>,
 ) -> Result<Response, ApiError> {
     let user_id = authenticated_user(&state, &headers).await?;
+    let waive_metering = take_initial_report_billing_marker(&mut body);
     let model_id = body
         .get("model")
         .and_then(serde_json::Value::as_str)
@@ -38,6 +39,7 @@ pub(crate) async fn chat_completions(
         .complete(AgentChatParams {
             user_id,
             model_id: ModelId(model_id),
+            waive_metering,
             body,
         })
         .await?;
@@ -47,6 +49,53 @@ pub(crate) async fn chat_completions(
         output.completion.body,
     )
         .into_response())
+}
+
+fn take_initial_report_billing_marker(body: &mut serde_json::Value) -> bool {
+    const INTERNAL_MARKER_KEY: &str = "__june";
+    const BILLING_INTENT_KEY: &str = "billingIntent";
+    const INITIAL_REPORT_INTENT: &str = "initial_issue_report";
+    const USER_REPORT_START: &str = "---USER REPORT---";
+    const USER_REPORT_END: &str = "---END USER REPORT---";
+
+    let is_initial_report_prompt = latest_user_message_content(body).is_some_and(|content| {
+        let content = content.trim_start();
+        let has_report_markers = content
+            .find(USER_REPORT_START)
+            .zip(content.rfind(USER_REPORT_END))
+            .is_some_and(|(start, end)| start < end);
+        has_report_markers
+            && (content.starts_with("The user is filing a bug report about the June desktop app.")
+                || content.starts_with("The user is sharing feedback about the June desktop app.")
+                || content
+                    .starts_with("The user is requesting a feature for the June desktop app."))
+    });
+    let Some(object) = body.as_object_mut() else {
+        return false;
+    };
+    let marker = object.remove(INTERNAL_MARKER_KEY);
+    is_initial_report_prompt
+        && marker
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .and_then(|object| object.get(BILLING_INTENT_KEY))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|intent| intent == INITIAL_REPORT_INTENT)
+}
+
+fn latest_user_message_content(body: &serde_json::Value) -> Option<&str> {
+    body.get("messages")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .rev()
+        .find(|message| {
+            message
+                .get("role")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|role| role == "user")
+        })?
+        .get("content")
+        .and_then(serde_json::Value::as_str)
 }
 
 #[cfg(test)]
@@ -59,12 +108,21 @@ mod tests {
         let mut body = json!({
             "model": "text-model",
             "__june": { "billingIntent": "initial_issue_report" },
-            "messages": [{ "role": "user", "content": "report" }]
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "The user is filing a bug report about the June desktop app.\n\n---USER REPORT---\nreport\n---END USER REPORT---"
+                }
+            ]
         });
 
         assert!(take_initial_report_billing_marker(&mut body));
         assert!(body.get("__june").is_none());
-        assert_eq!(body["messages"][0]["content"], "report");
+        assert!(
+            body["messages"][0]["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("---USER REPORT---"))
+        );
     }
 
     #[test]
@@ -72,7 +130,24 @@ mod tests {
         let mut body = json!({
             "model": "text-model",
             "__june": { "billingIntent": "ordinary" },
-            "messages": [{ "role": "user", "content": "hello" }]
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "The user is requesting a feature for the June desktop app.\n\n---USER REPORT---\nhello\n---END USER REPORT---"
+                }
+            ]
+        });
+
+        assert!(!take_initial_report_billing_marker(&mut body));
+        assert!(body.get("__june").is_none());
+    }
+
+    #[test]
+    fn marked_ordinary_prompt_is_consumed_without_waiver() {
+        let mut body = json!({
+            "model": "text-model",
+            "__june": { "billingIntent": "initial_issue_report" },
+            "messages": [{ "role": "user", "content": "Summarize this PDF." }]
         });
 
         assert!(!take_initial_report_billing_marker(&mut body));

--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -17,7 +17,6 @@ pub(crate) async fn chat_completions(
     Json(mut body): Json<serde_json::Value>,
 ) -> Result<Response, ApiError> {
     let user_id = authenticated_user(&state, &headers).await?;
-    let waive_metering = take_initial_report_billing_marker(&mut body);
     let model_id = body
         .get("model")
         .and_then(serde_json::Value::as_str)
@@ -39,7 +38,6 @@ pub(crate) async fn chat_completions(
         .complete(AgentChatParams {
             user_id,
             model_id: ModelId(model_id),
-            waive_metering,
             body,
         })
         .await?;
@@ -49,105 +47,4 @@ pub(crate) async fn chat_completions(
         output.completion.body,
     )
         .into_response())
-}
-
-fn take_initial_report_billing_marker(body: &mut serde_json::Value) -> bool {
-    const INTERNAL_MARKER_KEY: &str = "__june";
-    const BILLING_INTENT_KEY: &str = "billingIntent";
-    const INITIAL_REPORT_INTENT: &str = "initial_issue_report";
-    const USER_REPORT_START: &str = "---USER REPORT---";
-    const USER_REPORT_END: &str = "---END USER REPORT---";
-
-    let is_initial_report_prompt = latest_user_message_content(body).is_some_and(|content| {
-        let content = content.trim_start();
-        let has_report_markers = content
-            .find(USER_REPORT_START)
-            .zip(content.rfind(USER_REPORT_END))
-            .is_some_and(|(start, end)| start < end);
-        has_report_markers
-            && (content.starts_with("The user is filing a bug report about the June desktop app.")
-                || content.starts_with("The user is sharing feedback about the June desktop app.")
-                || content
-                    .starts_with("The user is requesting a feature for the June desktop app."))
-    });
-    let Some(object) = body.as_object_mut() else {
-        return false;
-    };
-    let marker = object.remove(INTERNAL_MARKER_KEY);
-    is_initial_report_prompt
-        && marker
-            .as_ref()
-            .and_then(serde_json::Value::as_object)
-            .and_then(|object| object.get(BILLING_INTENT_KEY))
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|intent| intent == INITIAL_REPORT_INTENT)
-}
-
-fn latest_user_message_content(body: &serde_json::Value) -> Option<&str> {
-    body.get("messages")
-        .and_then(serde_json::Value::as_array)?
-        .iter()
-        .rev()
-        .find(|message| {
-            message
-                .get("role")
-                .and_then(serde_json::Value::as_str)
-                .is_some_and(|role| role == "user")
-        })?
-        .get("content")
-        .and_then(serde_json::Value::as_str)
-}
-#[cfg(test)]
-mod tests {
-    use super::take_initial_report_billing_marker;
-    use serde_json::json;
-
-    #[test]
-    fn billing_marker_is_consumed_from_chat_body() {
-        let mut body = json!({
-            "model": "text-model",
-            "__june": { "billingIntent": "initial_issue_report" },
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "The user is filing a bug report about the June desktop app.\n\n---USER REPORT---\nreport\n---END USER REPORT---"
-                }
-            ]
-        });
-
-        assert!(take_initial_report_billing_marker(&mut body));
-        assert!(body.get("__june").is_none());
-        assert!(body["messages"][0]["content"]
-            .as_str()
-            .is_some_and(|content| content.contains("---USER REPORT---")));
-    }
-
-    #[test]
-    fn invalid_billing_marker_is_consumed_without_waiver() {
-        let mut body = json!({
-            "model": "text-model",
-            "__june": { "billingIntent": "ordinary" },
-            "messages": [
-                {
-                    "role": "user",
-                    "content": "The user is requesting a feature for the June desktop app.\n\n---USER REPORT---\nhello\n---END USER REPORT---"
-                }
-            ]
-        });
-
-        assert!(!take_initial_report_billing_marker(&mut body));
-        assert!(body.get("__june").is_none());
-    }
-
-    #[test]
-    fn marked_ordinary_prompt_is_consumed_without_waiver() {
-        let mut body = json!({
-            "model": "text-model",
-            "__june": { "billingIntent": "initial_issue_report" },
-            "messages": [{ "role": "user", "content": "Summarize this PDF." }]
-        });
-
-        assert!(!take_initial_report_billing_marker(&mut body));
-        assert!(body.get("__june").is_none());
-    }
 }

--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -55,19 +55,48 @@ fn take_initial_report_billing_marker(body: &mut serde_json::Value) -> bool {
     const INTERNAL_MARKER_KEY: &str = "__june";
     const BILLING_INTENT_KEY: &str = "billingIntent";
     const INITIAL_REPORT_INTENT: &str = "initial_issue_report";
+    const USER_REPORT_START: &str = "---USER REPORT---";
+    const USER_REPORT_END: &str = "---END USER REPORT---";
 
+    let is_initial_report_prompt = latest_user_message_content(body).is_some_and(|content| {
+        let content = content.trim_start();
+        let has_report_markers = content
+            .find(USER_REPORT_START)
+            .zip(content.rfind(USER_REPORT_END))
+            .is_some_and(|(start, end)| start < end);
+        has_report_markers
+            && (content.starts_with("The user is filing a bug report about the June desktop app.")
+                || content.starts_with("The user is sharing feedback about the June desktop app.")
+                || content
+                    .starts_with("The user is requesting a feature for the June desktop app."))
+    });
     let Some(object) = body.as_object_mut() else {
         return false;
     };
     let marker = object.remove(INTERNAL_MARKER_KEY);
-    marker
-        .as_ref()
-        .and_then(serde_json::Value::as_object)
-        .and_then(|object| object.get(BILLING_INTENT_KEY))
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|intent| intent == INITIAL_REPORT_INTENT)
+    is_initial_report_prompt
+        && marker
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .and_then(|object| object.get(BILLING_INTENT_KEY))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|intent| intent == INITIAL_REPORT_INTENT)
 }
 
+fn latest_user_message_content(body: &serde_json::Value) -> Option<&str> {
+    body.get("messages")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .rev()
+        .find(|message| {
+            message
+                .get("role")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|role| role == "user")
+        })?
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+}
 #[cfg(test)]
 mod tests {
     use super::take_initial_report_billing_marker;
@@ -78,12 +107,19 @@ mod tests {
         let mut body = json!({
             "model": "text-model",
             "__june": { "billingIntent": "initial_issue_report" },
-            "messages": [{ "role": "user", "content": "report" }]
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "The user is filing a bug report about the June desktop app.\n\n---USER REPORT---\nreport\n---END USER REPORT---"
+                }
+            ]
         });
 
         assert!(take_initial_report_billing_marker(&mut body));
         assert!(body.get("__june").is_none());
-        assert_eq!(body["messages"][0]["content"], "report");
+        assert!(body["messages"][0]["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("---USER REPORT---")));
     }
 
     #[test]
@@ -91,7 +127,24 @@ mod tests {
         let mut body = json!({
             "model": "text-model",
             "__june": { "billingIntent": "ordinary" },
-            "messages": [{ "role": "user", "content": "hello" }]
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "The user is requesting a feature for the June desktop app.\n\n---USER REPORT---\nhello\n---END USER REPORT---"
+                }
+            ]
+        });
+
+        assert!(!take_initial_report_billing_marker(&mut body));
+        assert!(body.get("__june").is_none());
+    }
+
+    #[test]
+    fn marked_ordinary_prompt_is_consumed_without_waiver() {
+        let mut body = json!({
+            "model": "text-model",
+            "__june": { "billingIntent": "initial_issue_report" },
+            "messages": [{ "role": "user", "content": "Summarize this PDF." }]
         });
 
         assert!(!take_initial_report_billing_marker(&mut body));

--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -17,6 +17,7 @@ pub(crate) async fn chat_completions(
     Json(mut body): Json<serde_json::Value>,
 ) -> Result<Response, ApiError> {
     let user_id = authenticated_user(&state, &headers).await?;
+    let waive_metering = take_initial_report_billing_marker(&mut body);
     let model_id = body
         .get("model")
         .and_then(serde_json::Value::as_str)
@@ -38,6 +39,7 @@ pub(crate) async fn chat_completions(
         .complete(AgentChatParams {
             user_id,
             model_id: ModelId(model_id),
+            waive_metering,
             body,
         })
         .await?;
@@ -47,4 +49,52 @@ pub(crate) async fn chat_completions(
         output.completion.body,
     )
         .into_response())
+}
+
+fn take_initial_report_billing_marker(body: &mut serde_json::Value) -> bool {
+    const INTERNAL_MARKER_KEY: &str = "__june";
+    const BILLING_INTENT_KEY: &str = "billingIntent";
+    const INITIAL_REPORT_INTENT: &str = "initial_issue_report";
+
+    let Some(object) = body.as_object_mut() else {
+        return false;
+    };
+    let marker = object.remove(INTERNAL_MARKER_KEY);
+    marker
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .and_then(|object| object.get(BILLING_INTENT_KEY))
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|intent| intent == INITIAL_REPORT_INTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::take_initial_report_billing_marker;
+    use serde_json::json;
+
+    #[test]
+    fn billing_marker_is_consumed_from_chat_body() {
+        let mut body = json!({
+            "model": "text-model",
+            "__june": { "billingIntent": "initial_issue_report" },
+            "messages": [{ "role": "user", "content": "report" }]
+        });
+
+        assert!(take_initial_report_billing_marker(&mut body));
+        assert!(body.get("__june").is_none());
+        assert_eq!(body["messages"][0]["content"], "report");
+    }
+
+    #[test]
+    fn invalid_billing_marker_is_consumed_without_waiver() {
+        let mut body = json!({
+            "model": "text-model",
+            "__june": { "billingIntent": "ordinary" },
+            "messages": [{ "role": "user", "content": "hello" }]
+        });
+
+        assert!(!take_initial_report_billing_marker(&mut body));
+        assert!(body.get("__june").is_none());
+    }
 }

--- a/scribe-api/crates/api/src/handlers/agent.rs
+++ b/scribe-api/crates/api/src/handlers/agent.rs
@@ -48,3 +48,34 @@ pub(crate) async fn chat_completions(
     )
         .into_response())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::take_initial_report_billing_marker;
+    use serde_json::json;
+
+    #[test]
+    fn billing_marker_is_consumed_from_chat_body() {
+        let mut body = json!({
+            "model": "text-model",
+            "__june": { "billingIntent": "initial_issue_report" },
+            "messages": [{ "role": "user", "content": "report" }]
+        });
+
+        assert!(take_initial_report_billing_marker(&mut body));
+        assert!(body.get("__june").is_none());
+        assert_eq!(body["messages"][0]["content"], "report");
+    }
+
+    #[test]
+    fn invalid_billing_marker_is_consumed_without_waiver() {
+        let mut body = json!({
+            "model": "text-model",
+            "__june": { "billingIntent": "ordinary" },
+            "messages": [{ "role": "user", "content": "hello" }]
+        });
+
+        assert!(!take_initial_report_billing_marker(&mut body));
+        assert!(body.get("__june").is_none());
+    }
+}

--- a/scribe-api/crates/api/src/handlers/issues.rs
+++ b/scribe-api/crates/api/src/handlers/issues.rs
@@ -22,6 +22,7 @@ pub struct IssueReportResponse {
 /// every attached file, including ones whose bytes were not uploaded.
 #[derive(Default)]
 struct IssueReportFields {
+    category: Option<String>,
     description: String,
     agent_diagnosis: Option<String>,
     attachment_names: Vec<String>,
@@ -63,6 +64,9 @@ impl IssueReportFields {
                 "description" => {
                     fields.description = field.text().await.map_err(multipart_invalid)?;
                 }
+                "category" => {
+                    fields.category = Some(field.text().await.map_err(multipart_invalid)?);
+                }
                 "agentDiagnosis" => {
                     fields.agent_diagnosis = Some(field.text().await.map_err(multipart_invalid)?);
                 }
@@ -86,6 +90,9 @@ impl IssueReportFields {
     fn validate(&self) -> Result<(), ApiError> {
         if self.description.trim().is_empty() {
             return Err(ApiError::bad_request("description_required"));
+        }
+        if let Some(category) = self.category.as_deref() {
+            validate_issue_category(category)?;
         }
         validation::validate_text_len(
             "description",
@@ -131,6 +138,13 @@ impl IssueReportFields {
     }
 }
 
+fn validate_issue_category(category: &str) -> Result<(), ApiError> {
+    match category {
+        "bug" | "feedback" | "feature" => Ok(()),
+        _ => Err(ApiError::bad_request("category_invalid")),
+    }
+}
+
 pub(crate) async fn submit(
     State(state): State<ApiState>,
     headers: HeaderMap,
@@ -143,6 +157,7 @@ pub(crate) async fn submit(
         .issue_reports()
         .deliver(IssueReport {
             user_id,
+            category: request.category,
             description: request.description,
             agent_diagnosis: request.agent_diagnosis,
             attachment_names: request.attachment_names,

--- a/scribe-api/crates/api/tests/http_boundary.rs
+++ b/scribe-api/crates/api/tests/http_boundary.rs
@@ -143,6 +143,7 @@ async fn integration_issue_report_delivers_attachments_to_the_sink() -> Result<(
                     "agentDiagnosis",
                     "Likely the audio capture thread is blocked",
                 ),
+                text_part("category", "feature"),
                 text_part("attachmentName", "screenshot.png"),
                 text_part("sessionId", "session-9"),
                 text_part("appVersion", "0.0.5"),
@@ -179,6 +180,7 @@ async fn integration_issue_report_delivers_attachments_to_the_sink() -> Result<(
         reports[0].agent_diagnosis.as_deref(),
         Some("Likely the audio capture thread is blocked")
     );
+    assert_eq!(reports[0].category.as_deref(), Some("feature"));
     assert_eq!(reports[0].attachment_names, vec!["screenshot.png"]);
     assert_eq!(reports[0].session_id.as_deref(), Some("session-9"));
     assert_eq!(reports[0].attachments.len(), 1);

--- a/scribe-api/crates/domain/src/lib.rs
+++ b/scribe-api/crates/domain/src/lib.rs
@@ -208,6 +208,7 @@ pub struct ChargeRequest {
 #[derive(Clone, Debug)]
 pub struct IssueReport {
     pub user_id: UserId,
+    pub category: Option<String>,
     pub description: String,
     pub agent_diagnosis: Option<String>,
     /// Names of everything the user attached, including files whose bytes

--- a/scribe-api/crates/providers/src/issue_reports.rs
+++ b/scribe-api/crates/providers/src/issue_reports.rs
@@ -7,8 +7,9 @@ use serde::Deserialize;
 /// configured label (default `bug`). Uses only os-platform's stock API:
 /// attachments are uploaded first (best-effort — a failed upload never
 /// blocks the report; the names are listed in the body either way), the
-/// Issue is created with `type: bug`, and the label is attached afterwards
-/// via the labels PUT — creating the label in the Project the first time.
+/// Issue is created with the matching report type, and bug reports get the
+/// configured label via the labels PUT — creating the label in the Project the
+/// first time.
 /// Delivery to os-platform is best-effort: the sink retries without a Project
 /// destination and finally logs the report rather than surfacing delivery
 /// failures to the user.
@@ -132,7 +133,7 @@ impl OsPlatformIssueReportSink {
             "title": issue_title(&report.description),
             "body_markdown": issue_body(report),
             "reward_amount_units": "0",
-            "type": "bug",
+            "type": issue_type(report),
             "status": "todo",
             "file_ids": file_ids,
         });
@@ -277,10 +278,14 @@ impl OsPlatformIssueReportSink {
 
     /// Best-effort tagging after the Issue exists. First report into a
     /// Project: the label won't exist yet, so the missing-label rejection
-    /// creates it and retries once. Failure here never fails the delivery —
-    /// the Issue is already filed (and carries `type: bug` regardless).
-    async fn tag_issue(&self, number_in_org: i64, destination: IssueCreateDestination) {
-        if self.label.is_empty() {
+    /// creates it and retries once. Failure here never fails the delivery.
+    async fn tag_issue(
+        &self,
+        report: &IssueReport,
+        number_in_org: i64,
+        destination: IssueCreateDestination,
+    ) {
+        if self.label.is_empty() || issue_type(report) != "bug" {
             return;
         }
         let attached = match self.put_label(number_in_org).await {
@@ -416,7 +421,8 @@ impl IssueReportSink for OsPlatformIssueReportSink {
         };
         let issue = envelope.data.as_ref();
         if let Some(issue) = issue {
-            self.tag_issue(issue.number_in_org, destination).await;
+            self.tag_issue(&report, issue.number_in_org, destination)
+                .await;
         }
         tracing::info!(
             issue = issue.map_or("", |issue| issue.external_id.as_str()),
@@ -431,6 +437,14 @@ impl IssueReportSink for OsPlatformIssueReportSink {
 
 fn is_missing_label(message: &str) -> bool {
     message.contains("label(s) not found")
+}
+
+fn issue_type(report: &IssueReport) -> &'static str {
+    match report.category.as_deref() {
+        Some("feature") => "feature",
+        Some("feedback") => "other",
+        _ => "bug",
+    }
 }
 
 const ISSUE_TITLE_MAX_CHARS: usize = 120;
@@ -492,6 +506,9 @@ fn issue_body(report: &IssueReport) -> String {
     }
     body.push_str("\n## Metadata\n\n");
     let _ = writeln!(body, "- Reporter: `{}`", report.user_id.0);
+    if let Some(category) = report.category.as_deref().filter(|v| !v.is_empty()) {
+        let _ = writeln!(body, "- Category: {category}");
+    }
     if let Some(session_id) = report.session_id.as_deref().filter(|v| !v.is_empty()) {
         let _ = writeln!(body, "- Session: `{session_id}`");
     }
@@ -598,6 +615,7 @@ mod os_platform_tests {
     fn report() -> IssueReport {
         IssueReport {
             user_id: UserId("usr_test".to_string()),
+            category: Some("bug".to_string()),
             description: "The recorder freezes\nwhen I pause it".to_string(),
             agent_diagnosis: Some("Likely the audio capture thread".to_string()),
             attachment_names: vec!["screenshot.png".to_string()],
@@ -813,6 +831,40 @@ mod os_platform_tests {
             .await;
 
         assert!(sink(&server).deliver(report()).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn os_platform_sink_preserves_feature_report_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/files"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/orgs/june/projects/bug-reports/bounties"))
+            .and(body_partial_json(serde_json::json!({
+                "title": "June report: The recorder freezes",
+                "reward_amount_units": "0",
+                "asset_symbol": "POINTS",
+                "type": "feature",
+                "status": "todo",
+                "file_ids": [],
+            })))
+            .respond_with(issue_created())
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/orgs/june/bounties/7/labels"))
+            .respond_with(labels_set())
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let mut report = report();
+        report.category = Some("feature".to_string());
+        assert!(sink(&server).deliver(report).await.is_ok());
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -42,6 +42,22 @@ impl AgentChatService {
     pub async fn complete(&self, params: AgentChatParams) -> Result<AgentChatOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        if params.waive_metering {
+            let completion = self
+                .chat_completer
+                .complete(AgentChatRequest {
+                    body: params.body,
+                    model: params.model_id,
+                })
+                .await?;
+            return Ok(AgentChatOutput {
+                completion,
+                receipt: Receipt {
+                    credits_charged: Credits(0),
+                    idempotent_replay: false,
+                },
+            });
+        }
         let estimate = Credits(self.flat_estimate_credits);
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
@@ -90,6 +106,7 @@ impl AgentChatService {
 pub struct AgentChatParams {
     pub user_id: UserId,
     pub model_id: ModelId,
+    pub waive_metering: bool,
     pub body: serde_json::Value,
 }
 

--- a/scribe-api/crates/services/src/agent_chat.rs
+++ b/scribe-api/crates/services/src/agent_chat.rs
@@ -42,22 +42,6 @@ impl AgentChatService {
     pub async fn complete(&self, params: AgentChatParams) -> Result<AgentChatOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
-        if params.waive_metering {
-            let completion = self
-                .chat_completer
-                .complete(AgentChatRequest {
-                    body: params.body,
-                    model: params.model_id,
-                })
-                .await?;
-            return Ok(AgentChatOutput {
-                completion,
-                receipt: Receipt {
-                    credits_charged: Credits(0),
-                    idempotent_replay: false,
-                },
-            });
-        }
         let estimate = Credits(self.flat_estimate_credits);
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
@@ -106,7 +90,6 @@ impl AgentChatService {
 pub struct AgentChatParams {
     pub user_id: UserId,
     pub model_id: ModelId,
-    pub waive_metering: bool,
     pub body: serde_json::Value,
 }
 

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -27,16 +27,18 @@ pub use pricing::{PricingError, PricingTable};
 #[cfg(test)]
 mod tests {
     use super::{
-        DictateCleanupParams, DictateService, DictateServiceDeps, DictateTranscribeParams,
-        NoteGenerateParams, NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams,
-        NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable, ServiceError,
+        AgentChatParams, AgentChatService, AgentChatServiceDeps, DictateCleanupParams,
+        DictateService, DictateServiceDeps, DictateTranscribeParams, NoteGenerateParams,
+        NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams, NoteTranscribeService,
+        NoteTranscribeServiceDeps, PricingTable, ServiceError,
     };
     use async_trait::async_trait;
     use pretty_assertions::assert_eq;
     use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
     use scribe_domain::{
-        AudioDurationProbe, Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner,
-        CleanupRequest, Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
+        AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe,
+        Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner, CleanupRequest,
+        Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
         OsAccountsClient, Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest,
         UserId,
     };
@@ -150,6 +152,75 @@ mod tests {
             .await
             .unwrap_or_default();
         assert_eq!(charge_call, "dictate_cleanup:usr_123:session_1:utt_2");
+    }
+
+    #[tokio::test]
+    async fn agent_chat_does_not_meter_marked_initial_issue_report_turn() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = agent_chat_service(os_accounts.clone());
+
+        let output = service
+            .complete(AgentChatParams {
+                user_id: UserId("usr_123".to_string()),
+                model_id: ModelId("text-model".to_string()),
+                waive_metering: true,
+                body: serde_json::json!({
+                    "model": "text-model",
+                    "messages": [
+                        { "role": "system", "content": "You are June." },
+                        {
+                            "role": "user",
+                            "content": "The user is filing a bug report about the June desktop app.\n\n---USER REPORT---\nBug reports are charging me.\n---END USER REPORT---"
+                        }
+                    ]
+                }),
+            })
+            .await
+            .expect("issue report chat succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn agent_chat_meters_unmarked_turns() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = agent_chat_service(os_accounts.clone());
+
+        let output = service
+            .complete(AgentChatParams {
+                user_id: UserId("usr_123".to_string()),
+                model_id: ModelId("text-model".to_string()),
+                waive_metering: false,
+                body: serde_json::json!({
+                    "model": "text-model",
+                    "messages": [{ "role": "user", "content": "Summarize this PDF." }]
+                }),
+            })
+            .await
+            .expect("agent chat succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 60);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "agent_chat".to_string(),
+                    estimate: 8200,
+                    hold_ttl: 300,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 60,
+                    idempotency_key: concat!(
+                        "agent_chat:usr_123:text-model:",
+                        "5d2fa5e23ba78fb298b4891a7d6c4c1f60caaf1b8b6461496b9aca2a945d63ed"
+                    )
+                    .to_string(),
+                },
+            ]
+        );
     }
 
     #[tokio::test]
@@ -764,6 +835,21 @@ mod tests {
         }
     }
 
+    fn agent_chat_service(os_accounts: Arc<RecordingOsAccounts>) -> AgentChatService {
+        AgentChatService::new(AgentChatServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "text-model",
+                PriceUnit::Tokens,
+                2,
+                ModelType::Text,
+            )]))),
+            os_accounts,
+            chat_completer: Arc::new(FixedAgentChatCompleter),
+            hold_ttl_seconds: 300,
+            flat_estimate_credits: 8200,
+        })
+    }
+
     fn models<const N: usize>(
         values: [(&str, PriceUnit, u64, ModelType); N],
     ) -> BTreeMap<String, ModelPriceConfig> {
@@ -872,6 +958,26 @@ mod tests {
     }
 
     struct FixedGenerator;
+
+    struct FixedAgentChatCompleter;
+
+    #[async_trait]
+    impl AgentChatCompleter for FixedAgentChatCompleter {
+        async fn complete(
+            &self,
+            _request: AgentChatRequest,
+        ) -> Result<AgentChatCompletion, DomainError> {
+            Ok(AgentChatCompletion {
+                body: br#"{"id":"chatcmpl_test"}"#.to_vec(),
+                content_type: "application/json".to_string(),
+                provider: "test".to_string(),
+                usage: TokenUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 20,
+                },
+            })
+        }
+    }
 
     #[async_trait]
     impl Generator for FixedGenerator {

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -39,7 +39,8 @@ mod tests {
         AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe,
         Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner, CleanupRequest,
         Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
-        OsAccountsClient, Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest, UserId,
+        OsAccountsClient, Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest,
+        UserId,
     };
     use std::{
         collections::BTreeMap,
@@ -179,6 +180,47 @@ mod tests {
 
         assert_eq!(output.receipt.credits_charged.0, 0);
         assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn agent_chat_meters_unmarked_turns() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = agent_chat_service(os_accounts.clone());
+
+        let output = service
+            .complete(AgentChatParams {
+                user_id: UserId("usr_123".to_string()),
+                model_id: ModelId("text-model".to_string()),
+                waive_metering: false,
+                body: serde_json::json!({
+                    "model": "text-model",
+                    "messages": [{ "role": "user", "content": "Summarize this PDF." }]
+                }),
+            })
+            .await
+            .expect("agent chat succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 60);
+        assert_eq!(
+            os_accounts.events(),
+            vec![
+                RecordedCall::Authorize {
+                    user_id: "usr_123".to_string(),
+                    action: "agent_chat".to_string(),
+                    estimate: 8200,
+                    hold_ttl: 300,
+                },
+                RecordedCall::Charge {
+                    action_token: "agt_test".to_string(),
+                    credits: 60,
+                    idempotency_key: concat!(
+                        "agent_chat:usr_123:text-model:",
+                        "5d2fa5e23ba78fb298b4891a7d6c4c1f60caaf1b8b6461496b9aca2a945d63ed"
+                    )
+                    .to_string(),
+                },
+            ]
+        );
     }
 
     #[tokio::test]

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -27,18 +27,16 @@ pub use pricing::{PricingError, PricingTable};
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentChatParams, AgentChatService, AgentChatServiceDeps, DictateCleanupParams,
-        DictateService, DictateServiceDeps, DictateTranscribeParams, NoteGenerateParams,
-        NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams, NoteTranscribeService,
-        NoteTranscribeServiceDeps, PricingTable, ServiceError,
+        DictateCleanupParams, DictateService, DictateServiceDeps, DictateTranscribeParams,
+        NoteGenerateParams, NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams,
+        NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable, ServiceError,
     };
     use async_trait::async_trait;
     use pretty_assertions::assert_eq;
     use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
     use scribe_domain::{
-        AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe,
-        Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner, CleanupRequest,
-        Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
+        AudioDurationProbe, Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner,
+        CleanupRequest, Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
         OsAccountsClient, Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest,
         UserId,
     };
@@ -152,75 +150,6 @@ mod tests {
             .await
             .unwrap_or_default();
         assert_eq!(charge_call, "dictate_cleanup:usr_123:session_1:utt_2");
-    }
-
-    #[tokio::test]
-    async fn agent_chat_does_not_meter_marked_initial_issue_report_turn() {
-        let os_accounts = Arc::new(RecordingOsAccounts::default());
-        let service = agent_chat_service(os_accounts.clone());
-
-        let output = service
-            .complete(AgentChatParams {
-                user_id: UserId("usr_123".to_string()),
-                model_id: ModelId("text-model".to_string()),
-                waive_metering: true,
-                body: serde_json::json!({
-                    "model": "text-model",
-                    "messages": [
-                        { "role": "system", "content": "You are June." },
-                        {
-                            "role": "user",
-                            "content": "The user is filing a bug report about the June desktop app.\n\n---USER REPORT---\nBug reports are charging me.\n---END USER REPORT---"
-                        }
-                    ]
-                }),
-            })
-            .await
-            .expect("issue report chat succeeds");
-
-        assert_eq!(output.receipt.credits_charged.0, 0);
-        assert_eq!(os_accounts.events(), Vec::new());
-    }
-
-    #[tokio::test]
-    async fn agent_chat_meters_unmarked_turns() {
-        let os_accounts = Arc::new(RecordingOsAccounts::default());
-        let service = agent_chat_service(os_accounts.clone());
-
-        let output = service
-            .complete(AgentChatParams {
-                user_id: UserId("usr_123".to_string()),
-                model_id: ModelId("text-model".to_string()),
-                waive_metering: false,
-                body: serde_json::json!({
-                    "model": "text-model",
-                    "messages": [{ "role": "user", "content": "Summarize this PDF." }]
-                }),
-            })
-            .await
-            .expect("agent chat succeeds");
-
-        assert_eq!(output.receipt.credits_charged.0, 60);
-        assert_eq!(
-            os_accounts.events(),
-            vec![
-                RecordedCall::Authorize {
-                    user_id: "usr_123".to_string(),
-                    action: "agent_chat".to_string(),
-                    estimate: 8200,
-                    hold_ttl: 300,
-                },
-                RecordedCall::Charge {
-                    action_token: "agt_test".to_string(),
-                    credits: 60,
-                    idempotency_key: concat!(
-                        "agent_chat:usr_123:text-model:",
-                        "5d2fa5e23ba78fb298b4891a7d6c4c1f60caaf1b8b6461496b9aca2a945d63ed"
-                    )
-                    .to_string(),
-                },
-            ]
-        );
     }
 
     #[tokio::test]
@@ -812,21 +741,6 @@ mod tests {
         assert!(matches!(result, Err(ServiceError::AuthorizationDenied)));
     }
 
-    fn agent_chat_service(os_accounts: Arc<RecordingOsAccounts>) -> AgentChatService {
-        AgentChatService::new(AgentChatServiceDeps {
-            pricing: Arc::new(PricingTable::new(models([(
-                "text-model",
-                PriceUnit::Tokens,
-                2,
-                ModelType::Text,
-            )]))),
-            os_accounts,
-            chat_completer: Arc::new(FixedAgentChatCompleter),
-            hold_ttl_seconds: 300,
-            flat_estimate_credits: 8200,
-        })
-    }
-
     async fn wait_for_charge_idempotency_key(os_accounts: &RecordingOsAccounts) -> Option<String> {
         let deadline = Instant::now() + Duration::from_secs(1);
         loop {
@@ -968,26 +882,6 @@ mod tests {
             Ok(GeneratedNote {
                 content: "Generated note".to_string(),
                 title_suggestion: Some("Title".to_string()),
-                provider: "test".to_string(),
-                usage: TokenUsage {
-                    prompt_tokens: 10,
-                    completion_tokens: 20,
-                },
-            })
-        }
-    }
-
-    struct FixedAgentChatCompleter;
-
-    #[async_trait]
-    impl AgentChatCompleter for FixedAgentChatCompleter {
-        async fn complete(
-            &self,
-            _request: AgentChatRequest,
-        ) -> Result<AgentChatCompletion, DomainError> {
-            Ok(AgentChatCompletion {
-                body: br#"{"id":"chatcmpl_test"}"#.to_vec(),
-                content_type: "application/json".to_string(),
                 provider: "test".to_string(),
                 usage: TokenUsage {
                     prompt_tokens: 10,

--- a/scribe-api/crates/services/src/lib.rs
+++ b/scribe-api/crates/services/src/lib.rs
@@ -27,18 +27,19 @@ pub use pricing::{PricingError, PricingTable};
 #[cfg(test)]
 mod tests {
     use super::{
-        DictateCleanupParams, DictateService, DictateServiceDeps, DictateTranscribeParams,
-        NoteGenerateParams, NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams,
-        NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable, ServiceError,
+        AgentChatParams, AgentChatService, AgentChatServiceDeps, DictateCleanupParams,
+        DictateService, DictateServiceDeps, DictateTranscribeParams, NoteGenerateParams,
+        NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams, NoteTranscribeService,
+        NoteTranscribeServiceDeps, PricingTable, ServiceError,
     };
     use async_trait::async_trait;
     use pretty_assertions::assert_eq;
     use scribe_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
     use scribe_domain::{
-        AudioDurationProbe, Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner,
-        CleanupRequest, Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
-        OsAccountsClient, Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest,
-        UserId,
+        AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe,
+        Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner, CleanupRequest,
+        Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
+        OsAccountsClient, Receipt, TokenUsage, Transcriber, Transcript, TranscriptionRequest, UserId,
     };
     use std::{
         collections::BTreeMap,
@@ -150,6 +151,34 @@ mod tests {
             .await
             .unwrap_or_default();
         assert_eq!(charge_call, "dictate_cleanup:usr_123:session_1:utt_2");
+    }
+
+    #[tokio::test]
+    async fn agent_chat_does_not_meter_marked_initial_issue_report_turn() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = agent_chat_service(os_accounts.clone());
+
+        let output = service
+            .complete(AgentChatParams {
+                user_id: UserId("usr_123".to_string()),
+                model_id: ModelId("text-model".to_string()),
+                waive_metering: true,
+                body: serde_json::json!({
+                    "model": "text-model",
+                    "messages": [
+                        { "role": "system", "content": "You are June." },
+                        {
+                            "role": "user",
+                            "content": "The user is filing a bug report about the June desktop app.\n\n---USER REPORT---\nBug reports are charging me.\n---END USER REPORT---"
+                        }
+                    ]
+                }),
+            })
+            .await
+            .expect("issue report chat succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
     }
 
     #[tokio::test]
@@ -741,6 +770,21 @@ mod tests {
         assert!(matches!(result, Err(ServiceError::AuthorizationDenied)));
     }
 
+    fn agent_chat_service(os_accounts: Arc<RecordingOsAccounts>) -> AgentChatService {
+        AgentChatService::new(AgentChatServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "text-model",
+                PriceUnit::Tokens,
+                2,
+                ModelType::Text,
+            )]))),
+            os_accounts,
+            chat_completer: Arc::new(FixedAgentChatCompleter),
+            hold_ttl_seconds: 300,
+            flat_estimate_credits: 8200,
+        })
+    }
+
     async fn wait_for_charge_idempotency_key(os_accounts: &RecordingOsAccounts) -> Option<String> {
         let deadline = Instant::now() + Duration::from_secs(1);
         loop {
@@ -882,6 +926,26 @@ mod tests {
             Ok(GeneratedNote {
                 content: "Generated note".to_string(),
                 title_suggestion: Some("Title".to_string()),
+                provider: "test".to_string(),
+                usage: TokenUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 20,
+                },
+            })
+        }
+    }
+
+    struct FixedAgentChatCompleter;
+
+    #[async_trait]
+    impl AgentChatCompleter for FixedAgentChatCompleter {
+        async fn complete(
+            &self,
+            _request: AgentChatRequest,
+        ) -> Result<AgentChatCompletion, DomainError> {
+            Ok(AgentChatCompletion {
+                body: br#"{"id":"chatcmpl_test"}"#.to_vec(),
+                content_type: "application/json".to_string(),
                 provider: "test".to_string(),
                 usage: TokenUsage {
                     prompt_tokens: 10,

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -26,11 +26,6 @@ const AGENT_PROXY_MAX_OUTPUT_TOKENS: u64 = 32_768;
 const AGENT_TITLE_MAX_CHARS: usize = 48;
 const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 const ERR_TOKEN_EXPIRED: i64 = 3001;
-const INTERNAL_AGENT_MARKER_KEY: &str = "__june";
-const INTERNAL_BILLING_INTENT_KEY: &str = "billingIntent";
-const INITIAL_REPORT_BILLING_INTENT: &str = "initial_issue_report";
-const USER_REPORT_START: &str = "---USER REPORT---";
-const USER_REPORT_END: &str = "---END USER REPORT---";
 const INVALID_SCRIBE_RESPONSE_MESSAGE: &str =
     "The processing service returned an invalid response.";
 
@@ -384,7 +379,6 @@ fn limit_agent_chat_messages_for_proxy(body: &mut serde_json::Value) {
 
 fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     limit_agent_chat_messages_for_proxy(body);
-    mark_initial_report_agent_chat(body);
     let Some(object) = body.as_object_mut() else {
         return;
     };
@@ -394,45 +388,6 @@ fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     );
     clamp_agent_chat_output_tokens(object, "max_tokens");
     clamp_agent_chat_output_tokens(object, "max_completion_tokens");
-}
-
-fn mark_initial_report_agent_chat(body: &mut serde_json::Value) {
-    let is_initial_report =
-        latest_user_message_content(body).is_some_and(is_initial_report_prompt_content);
-    let Some(object) = body.as_object_mut() else {
-        return;
-    };
-    object.remove(INTERNAL_AGENT_MARKER_KEY);
-    if is_initial_report {
-        object.insert(
-            INTERNAL_AGENT_MARKER_KEY.to_string(),
-            serde_json::json!({
-                INTERNAL_BILLING_INTENT_KEY: INITIAL_REPORT_BILLING_INTENT,
-            }),
-        );
-    }
-}
-
-fn latest_user_message_content(body: &serde_json::Value) -> Option<&str> {
-    body.get("messages")
-        .and_then(serde_json::Value::as_array)?
-        .iter()
-        .rev()
-        .find(|message| agent_message_role(message) == Some("user"))?
-        .get("content")
-        .and_then(serde_json::Value::as_str)
-}
-
-fn is_initial_report_prompt_content(content: &str) -> bool {
-    let content = content.trim_start();
-    let has_report_markers = content
-        .find(USER_REPORT_START)
-        .zip(content.rfind(USER_REPORT_END))
-        .is_some_and(|(start, end)| start < end);
-    has_report_markers
-        && (content.starts_with("The user is filing a bug report about the June desktop app.")
-            || content.starts_with("The user is sharing feedback about the June desktop app.")
-            || content.starts_with("The user is requesting a feature for the June desktop app."))
 }
 
 fn clamp_agent_chat_output_tokens(
@@ -1266,45 +1221,6 @@ mod tests {
         normalize_agent_chat_request_for_proxy(&mut body);
 
         assert_eq!(body["max_tokens"], serde_json::json!(-1));
-    }
-
-    #[test]
-    fn agent_proxy_marks_initial_report_prompts_for_no_charge() {
-        for opening in [
-            "The user is filing a bug report about the June desktop app.",
-            "The user is sharing feedback about the June desktop app.",
-            "The user is requesting a feature for the June desktop app.",
-        ] {
-            let mut body = serde_json::json!({
-                "model": "hermes-selected-model",
-                "messages": [
-                    { "role": "system", "content": "You are June." },
-                    {
-                        "role": "user",
-                        "content": format!("{opening}\n\n---USER REPORT---\nSomething is wrong.\n---END USER REPORT---")
-                    }
-                ],
-            });
-
-            normalize_agent_chat_request_for_proxy(&mut body);
-
-            assert_eq!(
-                body[INTERNAL_AGENT_MARKER_KEY][INTERNAL_BILLING_INTENT_KEY],
-                serde_json::json!(INITIAL_REPORT_BILLING_INTENT)
-            );
-        }
-    }
-
-    #[test]
-    fn agent_proxy_does_not_mark_ordinary_prompts_for_no_charge() {
-        let mut body = serde_json::json!({
-            "model": "hermes-selected-model",
-            "messages": [{ "role": "user", "content": "Summarize this PDF." }],
-        });
-
-        normalize_agent_chat_request_for_proxy(&mut body);
-
-        assert!(body.get(INTERNAL_AGENT_MARKER_KEY).is_none());
     }
 
     #[test]

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -26,6 +26,11 @@ const AGENT_PROXY_MAX_OUTPUT_TOKENS: u64 = 32_768;
 const AGENT_TITLE_MAX_CHARS: usize = 48;
 const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 const ERR_TOKEN_EXPIRED: i64 = 3001;
+const INTERNAL_AGENT_MARKER_KEY: &str = "__june";
+const INTERNAL_BILLING_INTENT_KEY: &str = "billingIntent";
+const INITIAL_REPORT_BILLING_INTENT: &str = "initial_issue_report";
+const USER_REPORT_START: &str = "---USER REPORT---";
+const USER_REPORT_END: &str = "---END USER REPORT---";
 const INVALID_SCRIBE_RESPONSE_MESSAGE: &str =
     "The processing service returned an invalid response.";
 
@@ -379,6 +384,7 @@ fn limit_agent_chat_messages_for_proxy(body: &mut serde_json::Value) {
 
 fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     limit_agent_chat_messages_for_proxy(body);
+    mark_initial_report_agent_chat(body);
     let Some(object) = body.as_object_mut() else {
         return;
     };
@@ -388,6 +394,45 @@ fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     );
     clamp_agent_chat_output_tokens(object, "max_tokens");
     clamp_agent_chat_output_tokens(object, "max_completion_tokens");
+}
+
+fn mark_initial_report_agent_chat(body: &mut serde_json::Value) {
+    let is_initial_report =
+        latest_user_message_content(body).is_some_and(is_initial_report_prompt_content);
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    object.remove(INTERNAL_AGENT_MARKER_KEY);
+    if is_initial_report {
+        object.insert(
+            INTERNAL_AGENT_MARKER_KEY.to_string(),
+            serde_json::json!({
+                INTERNAL_BILLING_INTENT_KEY: INITIAL_REPORT_BILLING_INTENT,
+            }),
+        );
+    }
+}
+
+fn latest_user_message_content(body: &serde_json::Value) -> Option<&str> {
+    body.get("messages")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .rev()
+        .find(|message| agent_message_role(message) == Some("user"))?
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+}
+
+fn is_initial_report_prompt_content(content: &str) -> bool {
+    let content = content.trim_start();
+    let has_report_markers = content
+        .find(USER_REPORT_START)
+        .zip(content.rfind(USER_REPORT_END))
+        .is_some_and(|(start, end)| start < end);
+    has_report_markers
+        && (content.starts_with("The user is filing a bug report about the June desktop app.")
+            || content.starts_with("The user is sharing feedback about the June desktop app.")
+            || content.starts_with("The user is requesting a feature for the June desktop app."))
 }
 
 fn clamp_agent_chat_output_tokens(

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -26,6 +26,11 @@ const AGENT_PROXY_MAX_OUTPUT_TOKENS: u64 = 32_768;
 const AGENT_TITLE_MAX_CHARS: usize = 48;
 const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 const ERR_TOKEN_EXPIRED: i64 = 3001;
+const INTERNAL_AGENT_MARKER_KEY: &str = "__june";
+const INTERNAL_BILLING_INTENT_KEY: &str = "billingIntent";
+const INITIAL_REPORT_BILLING_INTENT: &str = "initial_issue_report";
+const USER_REPORT_START: &str = "---USER REPORT---";
+const USER_REPORT_END: &str = "---END USER REPORT---";
 const INVALID_SCRIBE_RESPONSE_MESSAGE: &str =
     "The processing service returned an invalid response.";
 
@@ -379,6 +384,7 @@ fn limit_agent_chat_messages_for_proxy(body: &mut serde_json::Value) {
 
 fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     limit_agent_chat_messages_for_proxy(body);
+    mark_initial_report_agent_chat(body);
     let Some(object) = body.as_object_mut() else {
         return;
     };
@@ -388,6 +394,45 @@ fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     );
     clamp_agent_chat_output_tokens(object, "max_tokens");
     clamp_agent_chat_output_tokens(object, "max_completion_tokens");
+}
+
+fn mark_initial_report_agent_chat(body: &mut serde_json::Value) {
+    let is_initial_report =
+        latest_user_message_content(body).is_some_and(is_initial_report_prompt_content);
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+    object.remove(INTERNAL_AGENT_MARKER_KEY);
+    if is_initial_report {
+        object.insert(
+            INTERNAL_AGENT_MARKER_KEY.to_string(),
+            serde_json::json!({
+                INTERNAL_BILLING_INTENT_KEY: INITIAL_REPORT_BILLING_INTENT,
+            }),
+        );
+    }
+}
+
+fn latest_user_message_content(body: &serde_json::Value) -> Option<&str> {
+    body.get("messages")
+        .and_then(serde_json::Value::as_array)?
+        .iter()
+        .rev()
+        .find(|message| agent_message_role(message) == Some("user"))?
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+}
+
+fn is_initial_report_prompt_content(content: &str) -> bool {
+    let content = content.trim_start();
+    let has_report_markers = content
+        .find(USER_REPORT_START)
+        .zip(content.rfind(USER_REPORT_END))
+        .is_some_and(|(start, end)| start < end);
+    has_report_markers
+        && (content.starts_with("The user is filing a bug report about the June desktop app.")
+            || content.starts_with("The user is sharing feedback about the June desktop app.")
+            || content.starts_with("The user is requesting a feature for the June desktop app."))
 }
 
 fn clamp_agent_chat_output_tokens(
@@ -1221,6 +1266,45 @@ mod tests {
         normalize_agent_chat_request_for_proxy(&mut body);
 
         assert_eq!(body["max_tokens"], serde_json::json!(-1));
+    }
+
+    #[test]
+    fn agent_proxy_marks_initial_report_prompts_for_no_charge() {
+        for opening in [
+            "The user is filing a bug report about the June desktop app.",
+            "The user is sharing feedback about the June desktop app.",
+            "The user is requesting a feature for the June desktop app.",
+        ] {
+            let mut body = serde_json::json!({
+                "model": "hermes-selected-model",
+                "messages": [
+                    { "role": "system", "content": "You are June." },
+                    {
+                        "role": "user",
+                        "content": format!("{opening}\n\n---USER REPORT---\nSomething is wrong.\n---END USER REPORT---")
+                    }
+                ],
+            });
+
+            normalize_agent_chat_request_for_proxy(&mut body);
+
+            assert_eq!(
+                body[INTERNAL_AGENT_MARKER_KEY][INTERNAL_BILLING_INTENT_KEY],
+                serde_json::json!(INITIAL_REPORT_BILLING_INTENT)
+            );
+        }
+    }
+
+    #[test]
+    fn agent_proxy_does_not_mark_ordinary_prompts_for_no_charge() {
+        let mut body = serde_json::json!({
+            "model": "hermes-selected-model",
+            "messages": [{ "role": "user", "content": "Summarize this PDF." }],
+        });
+
+        normalize_agent_chat_request_for_proxy(&mut body);
+
+        assert!(body.get(INTERNAL_AGENT_MARKER_KEY).is_none());
     }
 
     #[test]

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -1224,6 +1224,45 @@ mod tests {
     }
 
     #[test]
+    fn agent_proxy_marks_initial_report_prompts_for_no_charge() {
+        for opening in [
+            "The user is filing a bug report about the June desktop app.",
+            "The user is sharing feedback about the June desktop app.",
+            "The user is requesting a feature for the June desktop app.",
+        ] {
+            let mut body = serde_json::json!({
+                "model": "hermes-selected-model",
+                "messages": [
+                    { "role": "system", "content": "You are June." },
+                    {
+                        "role": "user",
+                        "content": format!("{opening}\n\n---USER REPORT---\nSomething is wrong.\n---END USER REPORT---")
+                    }
+                ],
+            });
+
+            normalize_agent_chat_request_for_proxy(&mut body);
+
+            assert_eq!(
+                body[INTERNAL_AGENT_MARKER_KEY][INTERNAL_BILLING_INTENT_KEY],
+                serde_json::json!(INITIAL_REPORT_BILLING_INTENT)
+            );
+        }
+    }
+
+    #[test]
+    fn agent_proxy_does_not_mark_ordinary_prompts_for_no_charge() {
+        let mut body = serde_json::json!({
+            "model": "hermes-selected-model",
+            "messages": [{ "role": "user", "content": "Summarize this PDF." }],
+        });
+
+        normalize_agent_chat_request_for_proxy(&mut body);
+
+        assert!(body.get(INTERNAL_AGENT_MARKER_KEY).is_none());
+    }
+
+    #[test]
     fn agent_proxy_limits_messages_while_preserving_latest_context() {
         let mut body = serde_json::json!({
             "messages": std::iter::once(serde_json::json!({

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -165,7 +165,10 @@ import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
 } from "../../lib/hermes-messaging";
-import { displayedUserMessageText } from "../../lib/issue-report-prompt";
+import {
+  categoryPrompt,
+  displayedUserMessageText,
+} from "../../lib/issue-report-prompt";
 import {
   ComposerEditor,
   type ComposerEditorHandle,
@@ -636,7 +639,7 @@ export type AgentNewSessionDetail = {
   category?: ReportCategory;
 };
 
-/** Captured report details submitted directly to the June team. */
+/** Captured report details submitted to the June team after the LLM turn. */
 type PendingIssueReport = {
   category: ReportCategory;
   description: string;
@@ -658,7 +661,7 @@ type AgentWorkspaceErrorOptions = {
 
 type AgentWorkspaceNotice = {
   message: string;
-  sessionId: string | null;
+  sessionId: string;
 };
 
 type AgentDeleteSessionDetail = {
@@ -781,8 +784,8 @@ export function AgentWorkspace({
   const [activePanel, setActivePanel] = useState<AgentPanel>("chat");
   const [draft, setDraft] = useState("");
   // The message's single category tag, mirrored from the composer's chip. Null
-  // when the message carries no tag. Report tags submit directly to the June
-  // team instead of starting a chat turn.
+  // when the message carries no tag. Drives the report wrapper and the
+  // no-charge signal carried to the backend.
   const [category, setCategory] = useState<ReportCategory | null>(null);
   // Live mirror of `draft` for closures (the hero-chip interval) that must read
   // the current value without re-subscribing.
@@ -1025,6 +1028,11 @@ export function AgentWorkspace({
   // the fetch *started*) — the scroll-settling logic needs the landing.
   const taskHistoryLoadedIdsRef = useRef<Set<string>>(new Set());
   const newSessionModeRef = useRef(newSessionMode);
+  // sessionId -> the report captured at submit time, delivered to the June
+  // team once the agent's diagnostic turn reaches a terminal event.
+  const pendingIssueReportsRef = useRef<Map<string, PendingIssueReport>>(
+    new Map(),
+  );
   // True only while a brand-new thread is being started from the hero. The
   // hero→dock composer FLIP keys off this so it glides *only* when the empty
   // chat hands over to a fresh thread — not when the hero is dismissed by
@@ -1215,9 +1223,7 @@ export function AgentWorkspace({
     selectedHermesSessionId,
   );
   const visibleIssueReportNotice =
-    issueReportNotice &&
-    (issueReportNotice.sessionId === null ||
-      issueReportNotice.sessionId === selectedHermesSessionId)
+    issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
       ? issueReportNotice.message
       : null;
   // Holds the prior render's heroMode. Read by both the composer auto-grow
@@ -1901,7 +1907,8 @@ export function AgentWorkspace({
     const message = draft.trim();
     if ((!message && !attachments.length) || submitting || importingFiles)
       return;
-    // The composer's category chip makes this a report. Captured before the
+    // The composer's category chip makes this a report: wrap the prompt to
+    // frame it for the team and queue the delivery. Captured before the
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
     const content = promptWithAttachments(message, attachments);
@@ -1909,7 +1916,7 @@ export function AgentWorkspace({
     // up, suggestions down during the session-create latency. Without it they
     // sit frozen through the wait and then vanish in a single frame when the
     // conversation takes over.
-    if (heroMode && !reportCategory) setHeroLeaving(true);
+    if (heroMode) setHeroLeaving(true);
     setSubmitting(true);
     composerEditorRef.current?.clear();
     setDraft("");
@@ -1917,19 +1924,27 @@ export function AgentWorkspace({
     setAttachments([]);
     setIssueReportNotice(null);
     try {
-      if (reportCategory) {
-        await submitDirectIssueReport({
-          category: reportCategory,
-          // An attachments-only send has no typed text, but the server
-          // requires a description; the report must not bounce there.
-          description:
-            message || "No description was typed; see the attachments.",
-          attachmentNames: attachments.map((attachment) => attachment.name),
-          attachmentPaths: attachments.map((attachment) => attachment.path),
-        });
-      } else {
-        await submitHermesSession(content);
-      }
+      await submitHermesSession(
+        reportCategory ? categoryPrompt(reportCategory, content) : content,
+        undefined,
+        reportCategory
+          ? {
+              issueReport: {
+                category: reportCategory,
+                // An attachments-only send has no typed text, but the server
+                // requires a description; the report must not bounce there.
+                description:
+                  message || "No description was typed; see the attachments.",
+                attachmentNames: attachments.map(
+                  (attachment) => attachment.name,
+                ),
+                attachmentPaths: attachments.map(
+                  (attachment) => attachment.path,
+                ),
+              },
+            }
+          : undefined,
+      );
       setError(null);
       setBusyNotice(null);
     } catch (err) {
@@ -1950,8 +1965,8 @@ export function AgentWorkspace({
       }
     } finally {
       setSubmitting(false);
-      // On chat success the hero is gone; on direct-report success or failure
-      // this fades the greeting and suggestions back in.
+      // On success the hero is gone; on failure this fades the greeting and
+      // suggestions back in behind the restored draft.
       setHeroLeaving(false);
     }
   }
@@ -2071,29 +2086,54 @@ export function AgentWorkspace({
     setIssueReportNotice(null);
   }, [selectedHermesSessionId]);
 
-  async function submitDirectIssueReport(report: PendingIssueReport) {
+  /** Sends the captured report plus June's diagnostic reply (the last
+   * assistant message of the turn) to the June team. The diagnosis fetch is
+   * best-effort: a report without June's assessment still beats no report. */
+  async function deliverIssueReport(
+    sessionId: string,
+    report: PendingIssueReport,
+  ) {
+    let agentDiagnosis: string | undefined;
+    try {
+      const messages = await listHermesSessionMessages(sessionId);
+      agentDiagnosis = messages
+        .slice()
+        .reverse()
+        .map((message) =>
+          message.role === "assistant" ? visibleHermesMessageText(message) : "",
+        )
+        .find((text) => text.trim())
+        ?.trim();
+    } catch {
+      // Best-effort; the report ships without the diagnosis.
+    }
     try {
       await submitIssueReport({
         category: report.category,
         description: report.description,
+        agentDiagnosis,
         attachmentNames: report.attachmentNames,
         attachmentPaths: report.attachmentPaths,
+        sessionId,
       });
-      setIssueReportNotice({
-        message:
-          "Your report was sent to the June team. Thank you for helping improve June.",
-        sessionId: null,
-      });
+      if (selectedHermesSessionIdRef.current === sessionId) {
+        setIssueReportNotice({
+          message:
+            "Your report was sent to the June team. Thank you for helping improve June.",
+          sessionId,
+        });
+      }
     } catch (err) {
-      throw new Error(
-        `The issue report could not be sent. ${messageFromError(err)}`,
-      );
+      setError(`The issue report could not be sent. ${messageFromError(err)}`, {
+        sessionId,
+      });
     }
   }
 
   async function submitHermesSession(
     content: string,
     explicitSession?: HermesSessionInfo,
+    options?: { issueReport?: PendingIssueReport },
   ) {
     const targetSessionId = explicitSession?.id
       ? explicitSession.id
@@ -2102,9 +2142,10 @@ export function AgentWorkspace({
         : selectedHermesSessionId;
     // Issue reports skip title suggestion: the content is the wrapped
     // investigation prompt, which would title the session after the wrapper.
-    const titlePromise = targetSessionId
-      ? undefined
-      : agentSessionTitleForPrompt(content);
+    const titlePromise =
+      targetSessionId || options?.issueReport
+        ? undefined
+        : agentSessionTitleForPrompt(content);
     // The Unrestricted opt-in is made per session: a new session applies the
     // picker draft, and a follow-up routes to the runtime process matching
     // the mode its session was created with. Without this, one Unrestricted
@@ -2119,20 +2160,26 @@ export function AgentWorkspace({
     const created = targetSessionId
       ? undefined
       : await gateway.request<HermesRuntimeSessionResponse>("session.create", {
-          title: sessionTitle ?? titleFromPrompt(content),
+          title: options?.issueReport
+            ? "Issue report"
+            : (sessionTitle ?? titleFromPrompt(content)),
           cols: 96,
         });
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
+    if (options?.issueReport && !targetSessionId) {
+      pendingIssueReportsRef.current.set(storedSessionId, options.issueReport);
+    }
     if (!targetSessionId) {
       rememberSessionMode(storedSessionId, fullModeDraftRef.current);
     }
-    const sessionDisplayTitle =
-      explicitSession?.title?.trim() ||
-      explicitSession?.preview?.trim() ||
-      sessionTitle ||
-      titleFromPrompt(content);
+    const sessionDisplayTitle = options?.issueReport
+      ? "Issue report"
+      : explicitSession?.title?.trim() ||
+        explicitSession?.preview?.trim() ||
+        sessionTitle ||
+        titleFromPrompt(content);
     if (sessionTitle) {
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
@@ -2260,8 +2307,17 @@ export function AgentWorkspace({
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);
         }
+        // The diagnostic turn is over (even on error): file the report now so
+        // the user's description isn't lost to a failed investigation.
+        const issueReport = pendingIssueReportsRef.current.get(storedSessionId);
+        if (issueReport) {
+          pendingIssueReportsRef.current.delete(storedSessionId);
+        }
         window.setTimeout(() => {
           void refreshHermesSession(storedSessionId);
+          if (issueReport) {
+            void deliverIssueReport(storedSessionId, issueReport);
+          }
         }, 300);
       }
     });
@@ -2281,6 +2337,9 @@ export function AgentWorkspace({
         suppressStartupRequestError: !hermesSessionsHydratedRef.current,
       });
     } catch (err) {
+      // A queued report must not outlive its failed prompt; submit() re-arms
+      // issue-report mode so the retry files it again.
+      pendingIssueReportsRef.current.delete(storedSessionId);
       // The prompt never entered the session, so its optimistic bubble must
       // not linger — a retained pending message renders below every later
       // persisted message and reads as a send the agent ignored.

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -165,10 +165,7 @@ import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
 } from "../../lib/hermes-messaging";
-import {
-  categoryPrompt,
-  displayedUserMessageText,
-} from "../../lib/issue-report-prompt";
+import { displayedUserMessageText } from "../../lib/issue-report-prompt";
 import {
   ComposerEditor,
   type ComposerEditorHandle,
@@ -639,8 +636,7 @@ export type AgentNewSessionDetail = {
   category?: ReportCategory;
 };
 
-/** Frames the user's bug report for June: investigate and write a diagnosis
- * for the team instead of treating it as a normal request for help. */
+/** Captured report details submitted directly to the June team. */
 type PendingIssueReport = {
   category: ReportCategory;
   description: string;
@@ -662,7 +658,7 @@ type AgentWorkspaceErrorOptions = {
 
 type AgentWorkspaceNotice = {
   message: string;
-  sessionId: string;
+  sessionId: string | null;
 };
 
 type AgentDeleteSessionDetail = {
@@ -785,8 +781,8 @@ export function AgentWorkspace({
   const [activePanel, setActivePanel] = useState<AgentPanel>("chat");
   const [draft, setDraft] = useState("");
   // The message's single category tag, mirrored from the composer's chip. Null
-  // when the message carries no tag. Drives the report wrapper and (server
-  // side) the no-charge waiver.
+  // when the message carries no tag. Report tags submit directly to the June
+  // team instead of starting a chat turn.
   const [category, setCategory] = useState<ReportCategory | null>(null);
   // Live mirror of `draft` for closures (the hero-chip interval) that must read
   // the current value without re-subscribing.
@@ -1224,7 +1220,9 @@ export function AgentWorkspace({
     selectedHermesSessionId,
   );
   const visibleIssueReportNotice =
-    issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
+    issueReportNotice &&
+    (issueReportNotice.sessionId === null ||
+      issueReportNotice.sessionId === selectedHermesSessionId)
       ? issueReportNotice.message
       : null;
   // Holds the prior render's heroMode. Read by both the composer auto-grow
@@ -1908,8 +1906,7 @@ export function AgentWorkspace({
     const message = draft.trim();
     if ((!message && !attachments.length) || submitting || importingFiles)
       return;
-    // The composer's category chip makes this a report: wrap the prompt to
-    // frame it for the team and queue the delivery. Captured before the
+    // The composer's category chip makes this a report. Captured before the
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
     const content = promptWithAttachments(message, attachments);
@@ -1925,27 +1922,19 @@ export function AgentWorkspace({
     setAttachments([]);
     setIssueReportNotice(null);
     try {
-      await submitHermesSession(
-        reportCategory ? categoryPrompt(reportCategory, content) : content,
-        undefined,
-        reportCategory
-          ? {
-              issueReport: {
-                category: reportCategory,
-                // An attachments-only send has no typed text, but the server
-                // requires a description; the report must not bounce there.
-                description:
-                  message || "No description was typed; see the attachments.",
-                attachmentNames: attachments.map(
-                  (attachment) => attachment.name,
-                ),
-                attachmentPaths: attachments.map(
-                  (attachment) => attachment.path,
-                ),
-              },
-            }
-          : undefined,
-      );
+      if (reportCategory) {
+        await submitDirectIssueReport({
+          category: reportCategory,
+          // An attachments-only send has no typed text, but the server
+          // requires a description; the report must not bounce there.
+          description:
+            message || "No description was typed; see the attachments.",
+          attachmentNames: attachments.map((attachment) => attachment.name),
+          attachmentPaths: attachments.map((attachment) => attachment.path),
+        });
+      } else {
+        await submitHermesSession(content);
+      }
       setError(null);
       setBusyNotice(null);
     } catch (err) {
@@ -2128,6 +2117,26 @@ export function AgentWorkspace({
       setError(`The issue report could not be sent. ${messageFromError(err)}`, {
         sessionId,
       });
+    }
+  }
+
+  async function submitDirectIssueReport(report: PendingIssueReport) {
+    try {
+      await submitIssueReport({
+        category: report.category,
+        description: report.description,
+        attachmentNames: report.attachmentNames,
+        attachmentPaths: report.attachmentPaths,
+      });
+      setIssueReportNotice({
+        message:
+          "Your report was sent to the June team. Thank you for helping improve June.",
+        sessionId: null,
+      });
+    } catch (err) {
+      throw new Error(
+        `The issue report could not be sent. ${messageFromError(err)}`,
+      );
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1909,7 +1909,7 @@ export function AgentWorkspace({
     // up, suggestions down during the session-create latency. Without it they
     // sit frozen through the wait and then vanish in a single frame when the
     // conversation takes over.
-    if (heroMode) setHeroLeaving(true);
+    if (heroMode && !reportCategory) setHeroLeaving(true);
     setSubmitting(true);
     composerEditorRef.current?.clear();
     setDraft("");
@@ -1950,8 +1950,8 @@ export function AgentWorkspace({
       }
     } finally {
       setSubmitting(false);
-      // On success the hero is gone; on failure this fades the greeting and
-      // suggestions back in behind the restored draft.
+      // On chat success the hero is gone; on direct-report success or failure
+      // this fades the greeting and suggestions back in.
       setHeroLeaving(false);
     }
   }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1025,11 +1025,6 @@ export function AgentWorkspace({
   // the fetch *started*) — the scroll-settling logic needs the landing.
   const taskHistoryLoadedIdsRef = useRef<Set<string>>(new Set());
   const newSessionModeRef = useRef(newSessionMode);
-  // sessionId -> the report captured at submit time, delivered to the June
-  // team once the agent's diagnostic turn reaches a terminal event.
-  const pendingIssueReportsRef = useRef<Map<string, PendingIssueReport>>(
-    new Map(),
-  );
   // True only while a brand-new thread is being started from the hero. The
   // hero→dock composer FLIP keys off this so it glides *only* when the empty
   // chat hands over to a fresh thread — not when the hero is dismissed by
@@ -2076,50 +2071,6 @@ export function AgentWorkspace({
     setIssueReportNotice(null);
   }, [selectedHermesSessionId]);
 
-  /** Sends the captured report plus June's diagnostic reply (the last
-   * assistant message of the turn) to the June team. The diagnosis fetch is
-   * best-effort: a report without June's assessment still beats no report. */
-  async function deliverIssueReport(
-    sessionId: string,
-    report: PendingIssueReport,
-  ) {
-    let agentDiagnosis: string | undefined;
-    try {
-      const messages = await listHermesSessionMessages(sessionId);
-      agentDiagnosis = messages
-        .slice()
-        .reverse()
-        .map((message) =>
-          message.role === "assistant" ? visibleHermesMessageText(message) : "",
-        )
-        .find((text) => text.trim())
-        ?.trim();
-    } catch {
-      // Best-effort; the report ships without the diagnosis.
-    }
-    try {
-      await submitIssueReport({
-        category: report.category,
-        description: report.description,
-        agentDiagnosis,
-        attachmentNames: report.attachmentNames,
-        attachmentPaths: report.attachmentPaths,
-        sessionId,
-      });
-      if (selectedHermesSessionIdRef.current === sessionId) {
-        setIssueReportNotice({
-          message:
-            "Your report was sent to the June team. Thank you for helping improve June.",
-          sessionId,
-        });
-      }
-    } catch (err) {
-      setError(`The issue report could not be sent. ${messageFromError(err)}`, {
-        sessionId,
-      });
-    }
-  }
-
   async function submitDirectIssueReport(report: PendingIssueReport) {
     try {
       await submitIssueReport({
@@ -2143,7 +2094,6 @@ export function AgentWorkspace({
   async function submitHermesSession(
     content: string,
     explicitSession?: HermesSessionInfo,
-    options?: { issueReport?: PendingIssueReport },
   ) {
     const targetSessionId = explicitSession?.id
       ? explicitSession.id
@@ -2152,10 +2102,9 @@ export function AgentWorkspace({
         : selectedHermesSessionId;
     // Issue reports skip title suggestion: the content is the wrapped
     // investigation prompt, which would title the session after the wrapper.
-    const titlePromise =
-      targetSessionId || options?.issueReport
-        ? undefined
-        : agentSessionTitleForPrompt(content);
+    const titlePromise = targetSessionId
+      ? undefined
+      : agentSessionTitleForPrompt(content);
     // The Unrestricted opt-in is made per session: a new session applies the
     // picker draft, and a follow-up routes to the runtime process matching
     // the mode its session was created with. Without this, one Unrestricted
@@ -2170,26 +2119,20 @@ export function AgentWorkspace({
     const created = targetSessionId
       ? undefined
       : await gateway.request<HermesRuntimeSessionResponse>("session.create", {
-          title: options?.issueReport
-            ? "Issue report"
-            : (sessionTitle ?? titleFromPrompt(content)),
+          title: sessionTitle ?? titleFromPrompt(content),
           cols: 96,
         });
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
-    if (options?.issueReport && !targetSessionId) {
-      pendingIssueReportsRef.current.set(storedSessionId, options.issueReport);
-    }
     if (!targetSessionId) {
       rememberSessionMode(storedSessionId, fullModeDraftRef.current);
     }
-    const sessionDisplayTitle = options?.issueReport
-      ? "Issue report"
-      : explicitSession?.title?.trim() ||
-        explicitSession?.preview?.trim() ||
-        sessionTitle ||
-        titleFromPrompt(content);
+    const sessionDisplayTitle =
+      explicitSession?.title?.trim() ||
+      explicitSession?.preview?.trim() ||
+      sessionTitle ||
+      titleFromPrompt(content);
     if (sessionTitle) {
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
@@ -2317,17 +2260,8 @@ export function AgentWorkspace({
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);
         }
-        // The diagnostic turn is over (even on error): file the report now so
-        // the user's description isn't lost to a failed investigation.
-        const issueReport = pendingIssueReportsRef.current.get(storedSessionId);
-        if (issueReport) {
-          pendingIssueReportsRef.current.delete(storedSessionId);
-        }
         window.setTimeout(() => {
           void refreshHermesSession(storedSessionId);
-          if (issueReport) {
-            void deliverIssueReport(storedSessionId, issueReport);
-          }
         }, 300);
       }
     });
@@ -2347,9 +2281,6 @@ export function AgentWorkspace({
         suppressStartupRequestError: !hermesSessionsHydratedRef.current,
       });
     } catch (err) {
-      // A queued report must not outlive its failed prompt; submit() re-arms
-      // issue-report mode so the retry files it again.
-      pendingIssueReportsRef.current.delete(storedSessionId);
       // The prompt never entered the session, so its optimistic bubble must
       // not linger — a retained pending message renders below every later
       // persisted message and reads as a send the agent ignored.

--- a/src/components/agent/composer/reportCategory.ts
+++ b/src/components/agent/composer/reportCategory.ts
@@ -1,9 +1,8 @@
 /**
  * The three report categories a composer message can be tagged with. A tag is
  * an inline chip in the composer (see CategoryChip) — at most one per message.
- * The category drives two things: the preamble that frames the message for June
- * (see categoryPrompt in lib/issue-report-prompt.ts) and the no-charge signal carried
- * to the backend when the report is delivered.
+ * The category routes the message to the issue-report endpoint and drives
+ * triage on the backend.
  */
 
 export type ReportCategory = "bug" | "feedback" | "feature";

--- a/src/components/agent/composer/reportCategory.ts
+++ b/src/components/agent/composer/reportCategory.ts
@@ -1,8 +1,9 @@
 /**
  * The three report categories a composer message can be tagged with. A tag is
  * an inline chip in the composer (see CategoryChip) — at most one per message.
- * The category routes the message to the issue-report endpoint and drives
- * triage on the backend.
+ * The category drives two things: the preamble that frames the message for June
+ * (see categoryPrompt in lib/issue-report-prompt.ts) and triage when the
+ * report is delivered.
  */
 
 export type ReportCategory = "bug" | "feedback" | "feature";

--- a/src/lib/issue-report-prompt.ts
+++ b/src/lib/issue-report-prompt.ts
@@ -1,11 +1,66 @@
 /**
- * Legacy report prompt display helpers. Older saved sessions may contain a
- * wrapped report prompt; transcripts should still show only what the user
- * typed.
+ * The report investigation prompts. When a composer message carries a category
+ * tag (bug / feedback / feature), the user's text is wrapped in an instruction
+ * preamble for June, and the wrapped whole becomes the session's first user
+ * message. The transcript, on the other hand, must show only what the user
+ * actually typed: the preamble is plumbing, not conversation (see
+ * `displayedUserMessageText`).
  */
+
+import type { ReportCategory } from "../components/agent/composer/reportCategory";
 
 const USER_REPORT_START = "---USER REPORT---";
 const USER_REPORT_END = "---END USER REPORT---";
+
+const PREAMBLES: Record<ReportCategory, string[]> = {
+  bug: [
+    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report and sent to the June development team, so write it for them.",
+    "",
+    "Do not try to fix the issue or walk the user through troubleshooting. Instead:",
+    "1. Read the report below and inspect any attached files or screenshots closely. Describe exactly what they show, including any visible error text.",
+    "2. Give your assessment of what is going wrong and which part of the app is likely involved.",
+    "3. Note anything else the team should look at.",
+    "",
+    "Keep it concise and factual. Close by thanking the user and letting them know the report and your assessment are being sent to the June team.",
+  ],
+  feedback: [
+    "The user is sharing feedback about the June desktop app. This conversation is part of the in-app feedback flow: your reply will be attached to the feedback and sent to the June development team, so write it for them.",
+    "",
+    "Do not treat this as a task to act on. Instead:",
+    "1. Read the feedback below and inspect any attached files or screenshots closely. Describe what they show.",
+    "2. Reflect back what you heard in a sentence or two, and note which part of the app it concerns.",
+    "3. Note anything else the team should weigh.",
+    "",
+    "Keep it concise and warm. Close by thanking the user and letting them know their feedback and your summary are being sent to the June team.",
+  ],
+  feature: [
+    "The user is requesting a feature for the June desktop app. This conversation is part of the in-app request flow: your reply will be attached to the request and sent to the June development team, so write it for them.",
+    "",
+    "Do not try to build or prototype the feature. Instead:",
+    "1. Read the request below and inspect any attached files or screenshots closely. Describe what they show.",
+    "2. Summarize the request and the underlying need or problem it would solve, and note which part of the app it touches.",
+    "3. Note anything else the team should consider.",
+    "",
+    "Keep it concise and constructive. Close by thanking the user and letting them know their request and your summary are being sent to the June team.",
+  ],
+};
+
+/** Frames the user's report for June based on its category: investigate and
+ * write something for the team rather than treating it as a normal request. */
+export function categoryPrompt(category: ReportCategory, report: string) {
+  return [
+    ...PREAMBLES[category],
+    "",
+    USER_REPORT_START,
+    report,
+    USER_REPORT_END,
+  ].join("\n");
+}
+
+/** Bug-category wrapper, kept as a named export for the original report flow. */
+export function issueReportPrompt(report: string) {
+  return categoryPrompt("bug", report);
+}
 
 /** What a user message should look like in the transcript: a wrapped report
  * renders as just the report the user typed. Both markers must be present and

--- a/src/lib/issue-report-prompt.ts
+++ b/src/lib/issue-report-prompt.ts
@@ -1,70 +1,15 @@
 /**
- * The report investigation prompts. When a composer message carries a category
- * tag (bug / feedback / feature), the user's text is wrapped in an instruction
- * preamble for June, and the wrapped whole becomes the session's first user
- * message — the runtime needs it verbatim. The transcript, on the other hand,
- * must show only what the user actually typed: the preamble is plumbing, not
- * conversation (see `displayedUserMessageText`).
+ * Legacy report prompt display helpers. Older saved sessions may contain a
+ * wrapped report prompt; transcripts should still show only what the user
+ * typed.
  */
-
-import type { ReportCategory } from "../components/agent/composer/reportCategory";
 
 const USER_REPORT_START = "---USER REPORT---";
 const USER_REPORT_END = "---END USER REPORT---";
 
-const PREAMBLES: Record<ReportCategory, string[]> = {
-  bug: [
-    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report and sent to the June development team, so write it for them.",
-    "",
-    "Do not try to fix the issue or walk the user through troubleshooting. Instead:",
-    "1. Read the report below and inspect any attached files or screenshots closely. Describe exactly what they show, including any visible error text.",
-    "2. Give your assessment of what is going wrong and which part of the app is likely involved.",
-    "3. Note anything else the team should look at.",
-    "",
-    "Keep it concise and factual. Close by thanking the user and letting them know the report and your assessment are being sent to the June team.",
-  ],
-  feedback: [
-    "The user is sharing feedback about the June desktop app. This conversation is part of the in-app feedback flow: your reply will be attached to the feedback and sent to the June development team, so write it for them.",
-    "",
-    "Do not treat this as a task to act on. Instead:",
-    "1. Read the feedback below and inspect any attached files or screenshots closely. Describe what they show.",
-    "2. Reflect back what you heard in a sentence or two, and note which part of the app it concerns.",
-    "3. Note anything else the team should weigh.",
-    "",
-    "Keep it concise and warm. Close by thanking the user and letting them know their feedback and your summary are being sent to the June team.",
-  ],
-  feature: [
-    "The user is requesting a feature for the June desktop app. This conversation is part of the in-app request flow: your reply will be attached to the request and sent to the June development team, so write it for them.",
-    "",
-    "Do not try to build or prototype the feature. Instead:",
-    "1. Read the request below and inspect any attached files or screenshots closely. Describe what they show.",
-    "2. Summarize the request and the underlying need or problem it would solve, and note which part of the app it touches.",
-    "3. Note anything else the team should consider.",
-    "",
-    "Keep it concise and constructive. Close by thanking the user and letting them know their request and your summary are being sent to the June team.",
-  ],
-};
-
-/** Frames the user's report for June based on its category: investigate and
- * write something for the team rather than treating it as a normal request. */
-export function categoryPrompt(category: ReportCategory, report: string) {
-  return [
-    ...PREAMBLES[category],
-    "",
-    USER_REPORT_START,
-    report,
-    USER_REPORT_END,
-  ].join("\n");
-}
-
-/** Bug-category wrapper, kept as a named export for the original report flow. */
-export function issueReportPrompt(report: string) {
-  return categoryPrompt("bug", report);
-}
-
 /** What a user message should look like in the transcript: a wrapped report
  * renders as just the report the user typed. Both markers must be present and
- * ordered, so ordinary messages — even ones discussing the markers — pass
+ * ordered, so ordinary messages, even ones discussing the markers, pass
  * through untouched. */
 export function displayedUserMessageText(content: string): string {
   const start = content.indexOf(USER_REPORT_START);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -815,9 +815,9 @@ export type SubmitIssueReportRequest = {
   /** Which kind of report this is: "bug" | "feedback" | "feature". Drives the
    * team's triage. */
   category?: string;
-  /** The user's report as they typed it. */
+  /** The user's report as they typed it, before the investigation wrapper. */
   description: string;
-  /** June's diagnostic assessment from a report session, when available. */
+  /** June's diagnostic assessment from the report session, when available. */
   agentDiagnosis?: string;
   attachmentNames: string[];
   /** Workspace paths of the attached files; their bytes are uploaded with

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -813,11 +813,11 @@ export async function suggestAgentSessionTitle(prompt: string) {
 
 export type SubmitIssueReportRequest = {
   /** Which kind of report this is: "bug" | "feedback" | "feature". Drives the
-   * team's triage and (server side) the no-charge waiver for the turn. */
+   * team's triage. */
   category?: string;
-  /** The user's report as they typed it, before the investigation wrapper. */
+  /** The user's report as they typed it. */
   description: string;
-  /** June's diagnostic assessment from the report session, when available. */
+  /** June's diagnostic assessment from a report session, when available. */
   agentDiagnosis?: string;
   attachmentNames: string[];
   /** Workspace paths of the attached files; their bytes are uploaded with

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1388,11 +1388,13 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
         session_id: "runtime-session-1",
-        text: expect.stringContaining(
-          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
-        ),
+        text: expect.stringContaining("uploads/screenshot.png"),
       }),
     );
+    const submitted = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    )?.[1] as { text: string };
+    expect(submitted.text).not.toContain("co.opensoftware.scribe");
   });
 
   it("keeps a session draft when starting a blank new session", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -468,7 +468,7 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
-  it("wraps a submitted issue report for June and files it after the turn", async () => {
+  it("submits a bug report directly without starting a chat session", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
@@ -492,139 +492,84 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start session" }));
 
-    // June gets the investigation framing, with the user's words inside it.
-    await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
-        session_id: "runtime-session-2",
-        text: expect.stringContaining("---USER REPORT---"),
-      }),
-    );
-    const submitted = mocks.gatewayRequest.mock.calls.find(
-      ([method]) => method === "prompt.submit",
-    )?.[1] as { text: string };
-    expect(submitted.text).toContain(
-      "The recorder crashes after long meetings",
-    );
-    expect(submitted.text).toContain(
-      "Attached files copied into the June workspace:",
-    );
-    expect(submitted.text).toContain(
-      "Use these file paths when inspecting or operating on the files.",
-    );
-    expect(submitted.text).not.toContain("Scribe Hermes");
-    // The transcript shows the user's words only — the investigation
-    // framing is plumbing between June and the runtime, never UI.
-    expect(
-      await screen.findByText(/The recorder crashes after long meetings/),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/in-app reporting flow/)).toBeNull();
-    expect(screen.queryByText(/---USER REPORT---/)).toBeNull();
-    // The report waits for June's diagnosis; nothing is filed yet.
-    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
-
-    mocks.listHermesSessionMessages.mockResolvedValue([
-      {
-        id: "m1",
-        role: "user",
-        content: submitted.text,
-        timestamp: "2026-06-11T10:00:00Z",
-      },
-      {
-        id: "m2",
-        role: "assistant",
-        content: "The screenshot shows the recorder stuck on saving.",
-        timestamp: "2026-06-11T10:00:10Z",
-      },
-    ]);
-    act(() => {
-      for (const handler of mocks.gatewayEventHandlers) {
-        handler({ type: "turn.completed", session_id: "runtime-session-2" });
-      }
-    });
-
     await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
         category: "bug",
         description: "The recorder crashes after long meetings",
-        agentDiagnosis: "The screenshot shows the recorder stuck on saving.",
         attachmentNames: ["screenshot.png"],
         attachmentPaths: [
           "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
         ],
-        sessionId: "session-2",
       }),
+    );
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "session.create",
+      expect.anything(),
+    );
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "prompt.submit",
+      expect.anything(),
     );
     expect(
       await screen.findByText(/Your report was sent to the June team/),
     ).toBeInTheDocument();
-    // Drain the post-terminal refresh timer before the test ends so its
-    // session refetch cannot land inside a later test's render.
-    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
-  it("does not show a failed issue report banner after switching away", async () => {
+  it("submits feature requests directly without starting a chat session", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "feature" }),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Feature request")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "Let me pin a note to the menu bar",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "feature",
+        description: "Let me pin a note to the menu bar",
+        attachmentNames: [],
+        attachmentPaths: [],
+      }),
+    );
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "prompt.submit",
+      expect.anything(),
+    );
+  });
+
+  it("restores a failed issue report for retry", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), category: "bug" }),
     );
-    let rejectIssueReport: ((error: Error) => void) | undefined;
-    mocks.submitIssueReport.mockImplementation(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectIssueReport = reject;
-        }),
+    mocks.submitIssueReport.mockRejectedValueOnce(
+      new Error("upstream_provider_failed"),
     );
 
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("Bug report")).toBeInTheDocument();
-    await user.type(
-      await screen.findByRole("textbox"),
+    const composer = await screen.findByRole("textbox");
+    await user.type(composer, "The recorder crashes after long meetings");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    expect(
+      await screen.findByText(/The issue report could not be sent/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Bug report")).toBeInTheDocument();
+    expect(await screen.findByRole("textbox")).toHaveTextContent(
       "The recorder crashes after long meetings",
     );
-    await user.click(screen.getByRole("button", { name: "Start session" }));
-    await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
-        session_id: "runtime-session-2",
-        text: expect.stringContaining("---USER REPORT---"),
-      }),
-    );
-
-    mocks.listHermesSessionMessages.mockResolvedValue([
-      {
-        id: "m1",
-        role: "user",
-        content: "The recorder crashes after long meetings",
-        timestamp: "2026-06-11T10:00:00Z",
-      },
-      {
-        id: "m2",
-        role: "assistant",
-        content: "The recorder failed while saving.",
-        timestamp: "2026-06-11T10:00:10Z",
-      },
-    ]);
-    act(() => {
-      for (const handler of mocks.gatewayEventHandlers) {
-        handler({ type: "turn.completed", session_id: "runtime-session-2" });
-      }
-    });
-    await waitFor(() => expect(mocks.submitIssueReport).toHaveBeenCalled());
-
-    act(() => {
-      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
-    });
-    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
-
-    await act(async () => {
-      rejectIssueReport?.(new Error("upstream_provider_failed"));
-      await Promise.resolve();
-    });
-
-    expect(screen.queryByText(/The issue report could not be sent/)).toBeNull();
-    expect(screen.queryByText(/upstream_provider_failed/)).toBeNull();
-    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
   it("labels anonymous-only agent models as anonymous mode", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -468,7 +468,7 @@ describe("AgentWorkspace", () => {
     ).toBeNull();
   });
 
-  it("submits a bug report directly without starting a chat session", async () => {
+  it("wraps a submitted issue report for June and files it after the turn", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
@@ -492,61 +492,77 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start session" }));
 
+    // June gets the investigation framing, with the user's words inside it.
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+    const submitted = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    )?.[1] as { text: string };
+    expect(submitted.text).toContain(
+      "The recorder crashes after long meetings",
+    );
+    expect(submitted.text).toContain(
+      "Attached files copied into the June workspace:",
+    );
+    expect(submitted.text).toContain(
+      "Use these file paths when inspecting or operating on the files.",
+    );
+    expect(submitted.text).not.toContain("Scribe Hermes");
+    // The transcript shows the user's words only. The investigation framing is
+    // plumbing between June and the runtime, never UI.
+    expect(
+      await screen.findByText(/The recorder crashes after long meetings/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/in-app reporting flow/)).toBeNull();
+    expect(screen.queryByText(/---USER REPORT---/)).toBeNull();
+    // The report waits for June's diagnosis; nothing is filed yet.
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: submitted.text,
+        timestamp: "2026-06-11T10:00:00Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The screenshot shows the recorder stuck on saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
     await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
         category: "bug",
         description: "The recorder crashes after long meetings",
+        agentDiagnosis: "The screenshot shows the recorder stuck on saving.",
         attachmentNames: ["screenshot.png"],
         attachmentPaths: [
           "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
         ],
+        sessionId: "session-2",
       }),
     );
-    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
-      "session.create",
-      expect.anything(),
-    );
-    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
-      "prompt.submit",
-      expect.anything(),
-    );
     expect(
       await screen.findByText(/Your report was sent to the June team/),
     ).toBeInTheDocument();
+    // Drain the post-terminal refresh timer before the test ends so its
+    // session refetch cannot land inside a later test's render.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
-  it("keeps the hero steady while a direct report is in flight", async () => {
-    const user = userEvent.setup();
-    window.sessionStorage.setItem(
-      AGENT_NEW_SESSION_PENDING_KEY,
-      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
-    );
-    let resolveReport: (() => void) | undefined;
-    mocks.submitIssueReport.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveReport = () => resolve({ received: true });
-        }),
-    );
-
-    render(<AgentWorkspace />);
-
-    expect(await screen.findByText("Bug report")).toBeInTheDocument();
-    await user.type(await screen.findByRole("textbox"), "The recorder crashes");
-    await user.click(screen.getByRole("button", { name: "Start session" }));
-
-    expect(
-      screen.getByRole("region", { name: "Agent task details" }),
-    ).not.toHaveAttribute("data-hero-leaving");
-
-    await waitFor(() => expect(resolveReport).toBeDefined());
-    act(() => resolveReport?.());
-    expect(
-      await screen.findByText(/Your report was sent to the June team/),
-    ).toBeInTheDocument();
-  });
-
-  it("submits feature requests directly without starting a chat session", async () => {
+  it("wraps feature requests for June and preserves their category", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
@@ -564,43 +580,115 @@ describe("AgentWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "Start session" }));
 
     await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+    const submitted = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    )?.[1] as { text: string };
+    expect(submitted.text).toContain("requesting a feature");
+    expect(submitted.text).toContain("Let me pin a note to the menu bar");
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: submitted.text,
+        timestamp: "2026-06-11T10:00:00Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The request is for faster note access from the menu bar.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
         category: "feature",
         description: "Let me pin a note to the menu bar",
+        agentDiagnosis:
+          "The request is for faster note access from the menu bar.",
         attachmentNames: [],
         attachmentPaths: [],
+        sessionId: "session-2",
       }),
     );
-    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
-      "prompt.submit",
-      expect.anything(),
-    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
-  it("restores a failed issue report for retry", async () => {
+  it("does not show a failed issue report banner after switching away", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), category: "bug" }),
     );
-    mocks.submitIssueReport.mockRejectedValueOnce(
-      new Error("upstream_provider_failed"),
+    let rejectIssueReport: ((error: Error) => void) | undefined;
+    mocks.submitIssueReport.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectIssueReport = reject;
+        }),
     );
 
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("Bug report")).toBeInTheDocument();
-    const composer = await screen.findByRole("textbox");
-    await user.type(composer, "The recorder crashes after long meetings");
-    await user.click(screen.getByRole("button", { name: "Start session" }));
-
-    expect(
-      await screen.findByText(/The issue report could not be sent/),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Bug report")).toBeInTheDocument();
-    expect(await screen.findByRole("textbox")).toHaveTextContent(
+    await user.type(
+      await screen.findByRole("textbox"),
       "The recorder crashes after long meetings",
     );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "The recorder crashes after long meetings",
+        timestamp: "2026-06-11T10:00:00Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+    await waitFor(() => expect(mocks.submitIssueReport).toHaveBeenCalled());
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+
+    await act(async () => {
+      rejectIssueReport?.(new Error("upstream_provider_failed"));
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(/The issue report could not be sent/)).toBeNull();
+    expect(screen.queryByText(/upstream_provider_failed/)).toBeNull();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
   it("labels anonymous-only agent models as anonymous mode", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -515,6 +515,37 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the hero steady while a direct report is in flight", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let resolveReport: (() => void) | undefined;
+    mocks.submitIssueReport.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReport = () => resolve({ received: true });
+        }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(await screen.findByRole("textbox"), "The recorder crashes");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    expect(
+      screen.getByRole("region", { name: "Agent task details" }),
+    ).not.toHaveAttribute("data-hero-leaving");
+
+    await waitFor(() => expect(resolveReport).toBeDefined());
+    act(() => resolveReport?.());
+    expect(
+      await screen.findByText(/Your report was sent to the June team/),
+    ).toBeInTheDocument();
+  });
+
   it("submits feature requests directly without starting a chat session", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/issue-report-prompt.test.ts
+++ b/src/test/issue-report-prompt.test.ts
@@ -1,18 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { displayedUserMessageText } from "../lib/issue-report-prompt";
+import {
+  categoryPrompt,
+  displayedUserMessageText,
+  issueReportPrompt,
+} from "../lib/issue-report-prompt";
 
 describe("issue report prompt display", () => {
-  it("shows only the user's report for a legacy wrapped prompt", () => {
+  it("shows only the user's report for a wrapped prompt", () => {
     const report =
       "I want to report an issue with June.\n\nWhat happened: the recorder crashes";
-    const wrapped = [
-      "The user is filing a bug report about the June desktop app.",
-      "",
-      "---USER REPORT---",
-      report,
-      "---END USER REPORT---",
-    ].join("\n");
-
+    const wrapped = issueReportPrompt(report);
+    expect(wrapped).toContain("in-app reporting flow");
     expect(displayedUserMessageText(wrapped)).toBe(report);
   });
 
@@ -28,7 +26,29 @@ describe("issue report prompt display", () => {
   });
 
   it("falls back to the full content when the wrapper is empty", () => {
-    const wrapped = "---USER REPORT---\n   \n---END USER REPORT---";
+    const wrapped = issueReportPrompt("   ");
     expect(displayedUserMessageText(wrapped)).toBe(wrapped);
+  });
+
+  it("frames each category with its own preamble but the same markers", () => {
+    const report = "the sidebar feels cramped";
+    const bug = categoryPrompt("bug", report);
+    const feedback = categoryPrompt("feedback", report);
+    const feature = categoryPrompt("feature", report);
+
+    expect(bug).toContain("bug report");
+    expect(feedback).toContain("sharing feedback");
+    expect(feature).toContain("requesting a feature");
+
+    // All three wrap the user's words identically, so the transcript strips
+    // them back to exactly what was typed.
+    for (const wrapped of [bug, feedback, feature]) {
+      expect(wrapped).toContain("---USER REPORT---");
+      expect(displayedUserMessageText(wrapped)).toBe(report);
+    }
+  });
+
+  it("keeps issueReportPrompt as the bug-category wrapper", () => {
+    expect(issueReportPrompt("x")).toBe(categoryPrompt("bug", "x"));
   });
 });

--- a/src/test/issue-report-prompt.test.ts
+++ b/src/test/issue-report-prompt.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest";
-import {
-  categoryPrompt,
-  displayedUserMessageText,
-  issueReportPrompt,
-} from "../lib/issue-report-prompt";
+import { displayedUserMessageText } from "../lib/issue-report-prompt";
 
 describe("issue report prompt display", () => {
-  it("shows only the user's report for a wrapped prompt", () => {
+  it("shows only the user's report for a legacy wrapped prompt", () => {
     const report =
       "I want to report an issue with June.\n\nWhat happened: the recorder crashes";
-    const wrapped = issueReportPrompt(report);
-    expect(wrapped).toContain("in-app reporting flow");
+    const wrapped = [
+      "The user is filing a bug report about the June desktop app.",
+      "",
+      "---USER REPORT---",
+      report,
+      "---END USER REPORT---",
+    ].join("\n");
+
     expect(displayedUserMessageText(wrapped)).toBe(report);
   });
 
@@ -26,29 +28,7 @@ describe("issue report prompt display", () => {
   });
 
   it("falls back to the full content when the wrapper is empty", () => {
-    const wrapped = issueReportPrompt("   ");
+    const wrapped = "---USER REPORT---\n   \n---END USER REPORT---";
     expect(displayedUserMessageText(wrapped)).toBe(wrapped);
-  });
-
-  it("frames each category with its own preamble but the same markers", () => {
-    const report = "the sidebar feels cramped";
-    const bug = categoryPrompt("bug", report);
-    const feedback = categoryPrompt("feedback", report);
-    const feature = categoryPrompt("feature", report);
-
-    expect(bug).toContain("bug report");
-    expect(feedback).toContain("sharing feedback");
-    expect(feature).toContain("requesting a feature");
-
-    // All three wrap the user's words identically, so the transcript strips
-    // them back to exactly what was typed.
-    for (const wrapped of [bug, feedback, feature]) {
-      expect(wrapped).toContain("---USER REPORT---");
-      expect(displayedUserMessageText(wrapped)).toBe(report);
-    }
-  });
-
-  it("keeps issueReportPrompt as the bug-category wrapper", () => {
-    expect(issueReportPrompt("x")).toBe(categoryPrompt("bug", "x"));
   });
 });


### PR DESCRIPTION
## What changed
- Send bug reports, feedback, and feature requests directly through the existing issue-report endpoint instead of starting a metered chat session.
- Preserve report category, description, and attachments in the direct submission flow, with retry restoration on failure.
- Remove the obsolete report prompt wrapper and queued report-session delivery path.

## Validation
- `pnpm test src/test/agent-workspace.test.tsx src/test/issue-report-prompt.test.ts`
- `pnpm run lint`