### PR TITLE
Keep Hermes runs active through tool continuations

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7934,8 +7934,7 @@ function sessionHasFinalAssistantAfterLatestUser(
 }
 
 function isFinalAssistantMessage(message: HermesSessionMessage) {
-  if (hasHermesToolCalls(message.tool_calls)) return false;
-  return visibleHermesMessageText(message).trim().length > 0;
+  return !hasHermesToolCalls(message.tool_calls);
 }
 
 function hasHermesToolCalls(value: unknown) {
@@ -7943,7 +7942,12 @@ function hasHermesToolCalls(value: unknown) {
   if (Array.isArray(value)) return value.length > 0;
   if (typeof value === "string") {
     const trimmed = value.trim();
-    return Boolean(trimmed && trimmed !== "[]");
+    if (!trimmed) return false;
+    try {
+      return hasHermesToolCalls(JSON.parse(trimmed));
+    } catch {
+      return true;
+    }
   }
   if (typeof value === "object") return Object.keys(value).length > 0;
   return false;

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1756,13 +1756,12 @@ export function AgentWorkspace({
           shouldResumeSessionActivity(combined) &&
           !waitingSessionIdsRef.current.has(selectedHermesSessionId)
         ) {
-          // An in-flight run from before a remount or gateway drop: the
-          // latest message is the user's, so re-arm working state — the
-          // working-gated poll below picks the session back up and
+          // An in-flight run from before a remount or gateway drop: re-arm
+          // working state so the poll below picks the session back up and
           // reconciles it from persisted messages.
           setSessionWorking(selectedHermesSessionId, true);
         }
-        if (sessionHasAssistantAfterLatestUser(combined)) {
+        if (sessionHasFinalAssistantAfterLatestUser(combined)) {
           const wasActive = sessionHasActiveWork(
             selectedHermesSessionId,
             workingSessionIdsRef.current,
@@ -2672,7 +2671,10 @@ export function AgentWorkspace({
       });
       void suggestTitleForUntitledSession(sessionId, messages);
       if (
-        sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])
+        sessionHasFinalAssistantAfterLatestUser([
+          ...messages,
+          ...retainedPending,
+        ])
       ) {
         const wasActive = sessionHasActiveWork(
           sessionId,
@@ -7908,19 +7910,43 @@ function hermesMessageTimestampMs(message: HermesSessionMessage) {
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
-function sessionHasAssistantAfterLatestUser(messages: HermesSessionMessage[]) {
+function sessionHasFinalAssistantAfterLatestUser(
+  messages: HermesSessionMessage[],
+) {
   let latestUserIndex = -1;
-  let latestAssistantIndex = -1;
+  let latestToolIndex = -1;
+  let latestFinalAssistantIndex = -1;
   messages.forEach((message, index) => {
     if (message.role === "user") {
       latestUserIndex = index;
-    } else if (message.role === "assistant") {
-      latestAssistantIndex = index;
+    } else if (message.role === "tool") {
+      latestToolIndex = index;
+    } else if (
+      message.role === "assistant" &&
+      isFinalAssistantMessage(message)
+    ) {
+      latestFinalAssistantIndex = index;
     }
   });
-  if (latestAssistantIndex < 0) return false;
+  if (latestFinalAssistantIndex < 0) return false;
   if (latestUserIndex < 0) return true;
-  return latestAssistantIndex > latestUserIndex;
+  return latestFinalAssistantIndex > Math.max(latestUserIndex, latestToolIndex);
+}
+
+function isFinalAssistantMessage(message: HermesSessionMessage) {
+  if (hasHermesToolCalls(message.tool_calls)) return false;
+  return visibleHermesMessageText(message).trim().length > 0;
+}
+
+function hasHermesToolCalls(value: unknown) {
+  if (value === undefined || value === null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return Boolean(trimmed && trimmed !== "[]");
+  }
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return false;
 }
 
 // A session whose latest message is a recent user prompt with no assistant
@@ -7931,7 +7957,7 @@ function sessionHasAssistantAfterLatestUser(messages: HermesSessionMessage[]) {
 const RESUME_ACTIVITY_WINDOW_MS = 15 * 60 * 1000;
 
 function shouldResumeSessionActivity(messages: HermesSessionMessage[]) {
-  if (sessionHasAssistantAfterLatestUser(messages)) return false;
+  if (sessionHasFinalAssistantAfterLatestUser(messages)) return false;
   const latestUser = [...messages]
     .reverse()
     .find((message) => message.role === "user");
@@ -7959,8 +7985,6 @@ function isTerminalHermesEvent(type: string) {
   const normalized = type.toLowerCase();
   return (
     normalized === "error" ||
-    normalized === "message.complete" ||
-    normalized === "message.completed" ||
     normalized === "turn.complete" ||
     normalized === "turn.completed" ||
     normalized === "session.complete" ||

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -393,8 +393,11 @@ function appendLiveHermesEvents(
       // each subagent as a tool-style row keyed by its id, so N parallel
       // subagents show as N live rows that resolve as they finish.
       if (!currentAssistant) {
-        currentAssistant = createAssistantTurn(turns, event.receivedAt);
-        toolCreatedTurns.add(currentAssistant);
+        currentAssistant = lastAssistantTurnAfterLatestUser(turns) ?? null;
+        if (!currentAssistant) {
+          currentAssistant = createAssistantTurn(turns, event.receivedAt);
+          toolCreatedTurns.add(currentAssistant);
+        }
       }
       const payload = event.payload as Record<string, unknown> | undefined;
       const subagentId = stringValue(payload?.subagent_id);

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -468,8 +468,11 @@ function appendLiveHermesEvents(
         continue;
       }
       if (!currentAssistant) {
-        currentAssistant = createAssistantTurn(turns, event.receivedAt);
-        toolCreatedTurns.add(currentAssistant);
+        currentAssistant = lastAssistantTurnAfterLatestUser(turns) ?? null;
+        if (!currentAssistant) {
+          currentAssistant = createAssistantTurn(turns, event.receivedAt);
+          toolCreatedTurns.add(currentAssistant);
+        }
       }
       const status = toolEventStatus(event);
       if (status === "running") {
@@ -610,6 +613,15 @@ function createAssistantTurn(turns: AgentChatTurn[], createdAt: string) {
 function lastAssistantTurn(turns: AgentChatTurn[]) {
   for (let index = turns.length - 1; index >= 0; index -= 1) {
     if (turns[index]?.role === "assistant") return turns[index];
+  }
+  return undefined;
+}
+
+function lastAssistantTurnAfterLatestUser(turns: AgentChatTurn[]) {
+  for (let index = turns.length - 1; index >= 0; index -= 1) {
+    const turn = turns[index];
+    if (turn?.role === "user") return undefined;
+    if (turn?.role === "assistant") return turn;
   }
   return undefined;
 }

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -825,6 +825,36 @@ describe("Agent chat runtime", () => {
     expect(turns[0]?.status).toBe("running");
   });
 
+  it("keeps subagent follow-up with the assistant message that delegated it", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { text: "I'll delegate the research." },
+        },
+        {
+          type: "subagent.start",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: {
+            subagent_id: "sa-1",
+            goal: "Research the document export flow",
+          },
+        },
+      ],
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["I'll delegate the research.", "tool"]);
+    expect(turns[0]?.status).toBe("running");
+  });
+
   it("does not attach tool-only live events to an older assistant turn", () => {
     const messages: AgentMessageDto[] = [
       {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -794,6 +794,97 @@ describe("Agent chat runtime", () => {
     expect(turns[0]?.status).toBe("complete");
   });
 
+  it("keeps tool follow-up with the assistant message that requested it", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "message.complete",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: { text: "I'll inspect the document first." },
+        },
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.100Z",
+          payload: {
+            tool_id: "tool-1",
+            name: "read_file",
+            text: "Reading the attached DOCX.",
+          },
+        },
+      ],
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(
+      turns[0]?.parts.map((part) =>
+        part.type === "text" ? part.text : part.type,
+      ),
+    ).toEqual(["I'll inspect the document first.", "tool"]);
+    expect(turns[0]?.status).toBe("running");
+  });
+
+  it("does not attach tool-only live events to an older assistant turn", () => {
+    const messages: AgentMessageDto[] = [
+      {
+        id: "m1",
+        taskId: "task-1",
+        role: "user",
+        content: "Previous request",
+        createdAt: "2026-06-04T10:00:00.000Z",
+      },
+      {
+        id: "m2",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Previous answer",
+        createdAt: "2026-06-04T10:00:10.000Z",
+      },
+      {
+        id: "m3",
+        taskId: "task-1",
+        role: "user",
+        content: "turn this docx into a pdf",
+        createdAt: "2026-06-04T10:01:00.000Z",
+      },
+    ];
+
+    const turns = buildAgentChatTurns(
+      messages,
+      [],
+      [
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:01:01.000Z",
+          payload: {
+            tool_id: "tool-1",
+            name: "read_file",
+            text: "Reading the attached DOCX.",
+          },
+        },
+      ],
+    );
+
+    const previousAssistant = turns.find((turn) => turn.id === "m2");
+    expect(
+      previousAssistant?.parts.filter((part) => part.type === "tool"),
+    ).toHaveLength(0);
+
+    const liveAssistant = turns.at(-1);
+    expect(liveAssistant?.role).toBe("assistant");
+    expect(liveAssistant?.parts).toEqual([
+      {
+        type: "tool",
+        id: "tool-1",
+        name: "Read File",
+        text: "Reading the attached DOCX.",
+        status: "running",
+      },
+    ]);
+    expect(liveAssistant?.status).toBe("running");
+  });
+
   it("marks the in-flight turn errored even when the error has no text", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2156,6 +2156,64 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("does not resume working state when the latest assistant message has no tool calls", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "turn this docx into a pdf",
+        timestamp: new Date(Date.now() - 30_000).toISOString(),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "   ",
+        timestamp: new Date(Date.now() - 20_000).toISOString(),
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByText("turn this docx into a pdf"),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("Thinking…")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("does not resume working state for serialized empty tool calls", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "summarize the export result",
+        timestamp: new Date(Date.now() - 30_000).toISOString(),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The export is ready.",
+        tool_calls: " [ ] ",
+        timestamp: new Date(Date.now() - 20_000).toISOString(),
+      },
+      {
+        id: "m3",
+        role: "assistant",
+        content: "",
+        tool_calls: "null",
+        timestamp: new Date(Date.now() - 10_000).toISOString(),
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("The export is ready.")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText("Thinking…")).not.toBeInTheDocument(),
+    );
+  });
+
   it("keeps polling when a follow-up user message is still only pending locally", async () => {
     const user = userEvent.setup();
     mocks.listHermesSessionMessages.mockResolvedValue([

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1324,9 +1324,7 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
         session_id: "runtime-session-1",
-        text: expect.stringContaining(
-          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
-        ),
+        text: expect.stringContaining("uploads/screenshot.png"),
       }),
     );
   });
@@ -1367,7 +1365,10 @@ describe("AgentWorkspace", () => {
       preview: "Second preview",
       last_active: "2026-06-04T12:05:00Z",
     };
-    mocks.listHermesSessions.mockResolvedValue([existingSession, secondSession]);
+    mocks.listHermesSessions.mockResolvedValue([
+      existingSession,
+      secondSession,
+    ]);
     const { rerender } = render(
       <AgentWorkspace initialSession={existingSession} />,
     );
@@ -1635,6 +1636,15 @@ describe("AgentWorkspace", () => {
       "open",
     );
 
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "turn.completed",
+          session_id: "runtime-session-2",
+        });
+      }
+    });
+
     await user.type(screen.getByRole("textbox"), "next request");
     await user.click(screen.getByRole("button", { name: "Send message" }));
     await waitFor(() =>
@@ -1657,6 +1667,57 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("Thinking").closest("details")).not.toHaveAttribute(
       "open",
     );
+  });
+
+  it("keeps listening after an assistant message completes before tool follow-up", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "turn this docx into a pdf",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "turn this docx into a pdf",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.complete",
+          session_id: "runtime-session-2",
+          payload: { text: "I'll inspect the document first." },
+        });
+      }
+    });
+
+    expect(mocks.gatewayEventHandlers.size).toBe(1);
+    expect(
+      screen.getByRole("button", { name: "Stop June" }),
+    ).toBeInTheDocument();
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: {
+            tool_id: "tool-1",
+            name: "read_file",
+            text: "Reading the attached DOCX.",
+          },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Thinking")).toBeInTheDocument();
+    expect(screen.getByText("Reading the attached DOCX.")).toBeInTheDocument();
   });
 
   it("explains a pending approval before the user chooses", async () => {
@@ -1974,6 +2035,125 @@ describe("AgentWorkspace", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps a session working when persisted history ends with tool results", async () => {
+    const user = userEvent.setup();
+    mocks.listHermesSessionMessages
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        {
+          id: "m1",
+          role: "user",
+          content: "turn this docx into a pdf",
+          timestamp: "2026-06-04T12:00:00Z",
+        },
+        {
+          id: "m2",
+          role: "assistant",
+          content: "I'll inspect the document first.",
+          tool_calls: [{ id: "tool-1", name: "read_file" }],
+          timestamp: "2026-06-04T12:00:01Z",
+        },
+        {
+          id: "m3",
+          role: "tool",
+          content: "Document text...",
+          tool_call_id: "tool-1",
+          timestamp: "2026-06-04T12:00:02Z",
+        },
+      ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.active_list") {
+        return Promise.resolve({
+          sessions: [
+            {
+              id: "runtime-session-1",
+              session_key: "session-1",
+              status: "working",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+    let resolveEnsureSession: (value: unknown) => void = () => {};
+    mocks.ensureHermesBridgeSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveEnsureSession = resolve;
+        }),
+    );
+
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox"), "turn this docx into a pdf");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalled(),
+    );
+
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        resolveEnsureSession({});
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Stop June" }),
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(screen.getByText("Document text...")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Stop June" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes a recent session whose persisted history ends with tool results", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "turn this docx into a pdf",
+        timestamp: new Date(Date.now() - 30_000).toISOString(),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "I'll inspect the document first.",
+        tool_calls: [{ id: "tool-1", name: "read_file" }],
+        timestamp: new Date(Date.now() - 20_000).toISOString(),
+      },
+      {
+        id: "m3",
+        role: "tool",
+        content: "Document text...",
+        tool_call_id: "tool-1",
+        timestamp: new Date(Date.now() - 10_000).toISOString(),
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Document text...")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Stop June" }),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("keeps polling when a follow-up user message is still only pending locally", async () => {


### PR DESCRIPTION
## Summary

- Keep Hermes gateway streams active after `message.complete` so later tool events can still arrive.
- Treat persisted histories ending in tool results as unfinished when there is no final assistant response after the latest user prompt.
- Keep live tool events on the current turn while preventing follow-up prompts from attaching tool activity to older responses.

## Issue

JUN-78

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
