### PR TITLE
[fix] Submit issue reports directly

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2003,15 +2003,15 @@ export function AgentWorkspace({
       setComposerAttachments((current) =>
         current.length ? current : attachments,
       );
-      if (isSessionBusyError(err)) {
+      if (reportCategory) {
+        setError(
+          `The issue report could not be sent. ${messageFromError(err)}`,
+        );
+      } else if (isSessionBusyError(err)) {
         // A busy rejection is proof the gateway is healthy — retire any stale
         // connection banner along with showing the notice.
         setError(null);
         setBusyNotice(SESSION_BUSY_NOTICE);
-      } else if (reportCategory) {
-        setError(
-          `The issue report could not be sent. ${messageFromError(err)}`,
-        );
       } else {
         setError(messageFromError(err));
       }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1946,12 +1946,15 @@ export function AgentWorkspace({
     // The composer's category chip makes this a report. Captured before the
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
+    const reportSessionId = reportCategory
+      ? (selectedHermesSessionIdRef.current ?? null)
+      : null;
     const submittedDraftKey = composerDraftKeyRef.current;
     // A typed hero submit plays the same teardown as a run shortcut: greeting
     // up, suggestions down during the session-create latency. Without it they
     // sit frozen through the wait and then vanish in a single frame when the
     // conversation takes over.
-    if (heroMode) setHeroLeaving(true);
+    if (heroMode && !reportCategory) setHeroLeaving(true);
     setSubmitting(true);
     composerEditorRef.current?.clear();
     setDraft("");
@@ -1963,7 +1966,6 @@ export function AgentWorkspace({
     setIssueReportNotice(null);
     try {
       if (reportCategory) {
-        const reportSessionId = selectedHermesSessionIdRef.current ?? null;
         await submitIssueReport({
           category: reportCategory,
           // An attachments-only send has no typed text, but the server
@@ -2006,6 +2008,7 @@ export function AgentWorkspace({
       if (reportCategory) {
         setError(
           `The issue report could not be sent. ${messageFromError(err)}`,
+          { sessionId: reportSessionId },
         );
       } else if (isSessionBusyError(err)) {
         // A busy rejection is proof the gateway is healthy — retire any stale

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -165,10 +165,7 @@ import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
 } from "../../lib/hermes-messaging";
-import {
-  categoryPrompt,
-  displayedUserMessageText,
-} from "../../lib/issue-report-prompt";
+import { displayedUserMessageText } from "../../lib/issue-report-prompt";
 import {
   ComposerEditor,
   type ComposerEditorHandle,
@@ -639,17 +636,6 @@ export type AgentNewSessionDetail = {
   category?: ReportCategory;
 };
 
-/** Frames the user's bug report for June: investigate and write a diagnosis
- * for the team instead of treating it as a normal request for help. */
-type PendingIssueReport = {
-  category: ReportCategory;
-  description: string;
-  attachmentNames: string[];
-  /** Workspace paths captured at submit, so the files can be uploaded with
-   * the report even after the composer clears its attachment chips. */
-  attachmentPaths: string[];
-};
-
 type AgentWorkspaceError = {
   message: string;
   /** Null means the error belongs to the no-session workspace surface. */
@@ -662,7 +648,7 @@ type AgentWorkspaceErrorOptions = {
 
 type AgentWorkspaceNotice = {
   message: string;
-  sessionId: string;
+  sessionId: string | null;
 };
 
 type AgentDeleteSessionDetail = {
@@ -1068,11 +1054,6 @@ export function AgentWorkspace({
   // the fetch *started*) — the scroll-settling logic needs the landing.
   const taskHistoryLoadedIdsRef = useRef<Set<string>>(new Set());
   const newSessionModeRef = useRef(newSessionMode);
-  // sessionId -> the report captured at submit time, delivered to the June
-  // team once the agent's diagnostic turn reaches a terminal event.
-  const pendingIssueReportsRef = useRef<Map<string, PendingIssueReport>>(
-    new Map(),
-  );
   // True only while a brand-new thread is being started from the hero. The
   // hero→dock composer FLIP keys off this so it glides *only* when the empty
   // chat hands over to a fresh thread — not when the hero is dismissed by
@@ -1271,7 +1252,8 @@ export function AgentWorkspace({
     selectedHermesSessionId,
   );
   const visibleIssueReportNotice =
-    issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
+    issueReportNotice &&
+    issueReportNotice.sessionId === (selectedHermesSessionId ?? null)
       ? issueReportNotice.message
       : null;
   // Holds the prior render's heroMode. Read by both the composer auto-grow
@@ -1961,11 +1943,9 @@ export function AgentWorkspace({
     const message = draft.trim();
     if ((!message && !attachments.length) || submitting || importingFiles)
       return;
-    // The composer's category chip makes this a report: wrap the prompt to
-    // frame it for the team and queue the delivery. Captured before the
+    // The composer's category chip makes this a report. Captured before the
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
-    const content = promptWithAttachments(message, attachments);
     const submittedDraftKey = composerDraftKeyRef.current;
     // A typed hero submit plays the same teardown as a run shortcut: greeting
     // up, suggestions down during the session-create latency. Without it they
@@ -1982,27 +1962,29 @@ export function AgentWorkspace({
     setComposerAttachments([]);
     setIssueReportNotice(null);
     try {
-      await submitHermesSession(
-        reportCategory ? categoryPrompt(reportCategory, content) : content,
-        undefined,
-        reportCategory
-          ? {
-              issueReport: {
-                category: reportCategory,
-                // An attachments-only send has no typed text, but the server
-                // requires a description; the report must not bounce there.
-                description:
-                  message || "No description was typed; see the attachments.",
-                attachmentNames: attachments.map(
-                  (attachment) => attachment.name,
-                ),
-                attachmentPaths: attachments.map(
-                  (attachment) => attachment.path,
-                ),
-              },
-            }
-          : undefined,
-      );
+      if (reportCategory) {
+        const reportSessionId = selectedHermesSessionIdRef.current ?? null;
+        await submitIssueReport({
+          category: reportCategory,
+          // An attachments-only send has no typed text, but the server
+          // requires a description; the report must not bounce there.
+          description:
+            message || "No description was typed; see the attachments.",
+          attachmentNames: attachments.map((attachment) => attachment.name),
+          attachmentPaths: attachments.map((attachment) => attachment.path),
+          sessionId: reportSessionId ?? undefined,
+        });
+        setIssueReportNotice({
+          message:
+            "Your report was sent to the June team. Thank you for helping improve June.",
+          sessionId: reportSessionId,
+        });
+        setError(null);
+        setBusyNotice(null);
+        return;
+      }
+      const content = promptWithAttachments(message, attachments);
+      await submitHermesSession(content, undefined);
       setError(null);
       setBusyNotice(null);
     } catch (err) {
@@ -2026,6 +2008,10 @@ export function AgentWorkspace({
         // connection banner along with showing the notice.
         setError(null);
         setBusyNotice(SESSION_BUSY_NOTICE);
+      } else if (reportCategory) {
+        setError(
+          `The issue report could not be sent. ${messageFromError(err)}`,
+        );
       } else {
         setError(messageFromError(err));
       }
@@ -2154,66 +2140,18 @@ export function AgentWorkspace({
     setIssueReportNotice(null);
   }, [selectedHermesSessionId]);
 
-  /** Sends the captured report plus June's diagnostic reply (the last
-   * assistant message of the turn) to the June team. The diagnosis fetch is
-   * best-effort: a report without June's assessment still beats no report. */
-  async function deliverIssueReport(
-    sessionId: string,
-    report: PendingIssueReport,
-  ) {
-    let agentDiagnosis: string | undefined;
-    try {
-      const messages = await listHermesSessionMessages(sessionId);
-      agentDiagnosis = messages
-        .slice()
-        .reverse()
-        .map((message) =>
-          message.role === "assistant" ? visibleHermesMessageText(message) : "",
-        )
-        .find((text) => text.trim())
-        ?.trim();
-    } catch {
-      // Best-effort; the report ships without the diagnosis.
-    }
-    try {
-      await submitIssueReport({
-        category: report.category,
-        description: report.description,
-        agentDiagnosis,
-        attachmentNames: report.attachmentNames,
-        attachmentPaths: report.attachmentPaths,
-        sessionId,
-      });
-      if (selectedHermesSessionIdRef.current === sessionId) {
-        setIssueReportNotice({
-          message:
-            "Your report was sent to the June team. Thank you for helping improve June.",
-          sessionId,
-        });
-      }
-    } catch (err) {
-      setError(`The issue report could not be sent. ${messageFromError(err)}`, {
-        sessionId,
-      });
-    }
-  }
-
   async function submitHermesSession(
     content: string,
     explicitSession?: HermesSessionInfo,
-    options?: { issueReport?: PendingIssueReport },
   ) {
     const targetSessionId = explicitSession?.id
       ? explicitSession.id
       : newSessionModeRef.current
         ? undefined
         : selectedHermesSessionId;
-    // Issue reports skip title suggestion: the content is the wrapped
-    // investigation prompt, which would title the session after the wrapper.
-    const titlePromise =
-      targetSessionId || options?.issueReport
-        ? undefined
-        : agentSessionTitleForPrompt(content);
+    const titlePromise = targetSessionId
+      ? undefined
+      : agentSessionTitleForPrompt(content);
     // The Unrestricted opt-in is made per session: a new session applies the
     // picker draft, and a follow-up routes to the runtime process matching
     // the mode its session was created with. Without this, one Unrestricted
@@ -2228,26 +2166,20 @@ export function AgentWorkspace({
     const created = targetSessionId
       ? undefined
       : await gateway.request<HermesRuntimeSessionResponse>("session.create", {
-          title: options?.issueReport
-            ? "Issue report"
-            : (sessionTitle ?? titleFromPrompt(content)),
+          title: sessionTitle ?? titleFromPrompt(content),
           cols: 96,
         });
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
-    if (options?.issueReport && !targetSessionId) {
-      pendingIssueReportsRef.current.set(storedSessionId, options.issueReport);
-    }
     if (!targetSessionId) {
       rememberSessionMode(storedSessionId, fullModeDraftRef.current);
     }
-    const sessionDisplayTitle = options?.issueReport
-      ? "Issue report"
-      : explicitSession?.title?.trim() ||
-        explicitSession?.preview?.trim() ||
-        sessionTitle ||
-        titleFromPrompt(content);
+    const sessionDisplayTitle =
+      explicitSession?.title?.trim() ||
+      explicitSession?.preview?.trim() ||
+      sessionTitle ||
+      titleFromPrompt(content);
     if (sessionTitle) {
       sessionTitleOverridesRef.current = {
         ...sessionTitleOverridesRef.current,
@@ -2375,17 +2307,8 @@ export function AgentWorkspace({
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);
         }
-        // The diagnostic turn is over (even on error): file the report now so
-        // the user's description isn't lost to a failed investigation.
-        const issueReport = pendingIssueReportsRef.current.get(storedSessionId);
-        if (issueReport) {
-          pendingIssueReportsRef.current.delete(storedSessionId);
-        }
         window.setTimeout(() => {
           void refreshHermesSession(storedSessionId);
-          if (issueReport) {
-            void deliverIssueReport(storedSessionId, issueReport);
-          }
         }, 300);
       }
     });
@@ -2405,9 +2328,6 @@ export function AgentWorkspace({
         suppressStartupRequestError: !hermesSessionsHydratedRef.current,
       });
     } catch (err) {
-      // A queued report must not outlive its failed prompt; submit() re-arms
-      // issue-report mode so the retry files it again.
-      pendingIssueReportsRef.current.delete(storedSessionId);
       // The prompt never entered the session, so its optimistic bubble must
       // not linger — a retained pending message renders below every later
       // persisted message and reads as a send the agent ignored.

--- a/src/components/agent/composer/reportCategory.ts
+++ b/src/components/agent/composer/reportCategory.ts
@@ -1,9 +1,8 @@
 /**
  * The three report categories a composer message can be tagged with. A tag is
  * an inline chip in the composer (see CategoryChip) — at most one per message.
- * The category drives two things: the preamble that frames the message for June
- * (see categoryPrompt in lib/issue-report-prompt.ts) and the no-charge signal carried
- * to the backend when the report is delivered.
+ * The category is sent with the report so the backend can triage it and apply
+ * report-specific billing behavior.
  */
 
 export type ReportCategory = "bug" | "feedback" | "feature";

--- a/src/lib/issue-report-prompt.ts
+++ b/src/lib/issue-report-prompt.ts
@@ -1,71 +1,15 @@
 /**
- * The report investigation prompts. When a composer message carries a category
- * tag (bug / feedback / feature), the user's text is wrapped in an instruction
- * preamble for June, and the wrapped whole becomes the session's first user
- * message — the runtime needs it verbatim. The transcript, on the other hand,
- * must show only what the user actually typed: the preamble is plumbing, not
- * conversation (see `displayedUserMessageText`).
+ * Legacy report prompts used wrapper markers around the user's text before the
+ * direct report-submit path existed. Persisted sessions can still contain those
+ * wrapped messages, so the transcript strips them back to the report text.
  */
-
-import type { ReportCategory } from "../components/agent/composer/reportCategory";
 
 const USER_REPORT_START = "---USER REPORT---";
 const USER_REPORT_END = "---END USER REPORT---";
 
-const PREAMBLES: Record<ReportCategory, string[]> = {
-  bug: [
-    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report and sent to the June development team, so write it for them.",
-    "",
-    "Do not try to fix the issue or walk the user through troubleshooting. Instead:",
-    "1. Read the report below and inspect any attached files or screenshots closely. Describe exactly what they show, including any visible error text.",
-    "2. Give your assessment of what is going wrong and which part of the app is likely involved.",
-    "3. Note anything else the team should look at.",
-    "",
-    "Keep it concise and factual. Close by thanking the user and letting them know the report and your assessment are being sent to the June team.",
-  ],
-  feedback: [
-    "The user is sharing feedback about the June desktop app. This conversation is part of the in-app feedback flow: your reply will be attached to the feedback and sent to the June development team, so write it for them.",
-    "",
-    "Do not treat this as a task to act on. Instead:",
-    "1. Read the feedback below and inspect any attached files or screenshots closely. Describe what they show.",
-    "2. Reflect back what you heard in a sentence or two, and note which part of the app it concerns.",
-    "3. Note anything else the team should weigh.",
-    "",
-    "Keep it concise and warm. Close by thanking the user and letting them know their feedback and your summary are being sent to the June team.",
-  ],
-  feature: [
-    "The user is requesting a feature for the June desktop app. This conversation is part of the in-app request flow: your reply will be attached to the request and sent to the June development team, so write it for them.",
-    "",
-    "Do not try to build or prototype the feature. Instead:",
-    "1. Read the request below and inspect any attached files or screenshots closely. Describe what they show.",
-    "2. Summarize the request and the underlying need or problem it would solve, and note which part of the app it touches.",
-    "3. Note anything else the team should consider.",
-    "",
-    "Keep it concise and constructive. Close by thanking the user and letting them know their request and your summary are being sent to the June team.",
-  ],
-};
-
-/** Frames the user's report for June based on its category: investigate and
- * write something for the team rather than treating it as a normal request. */
-export function categoryPrompt(category: ReportCategory, report: string) {
-  return [
-    ...PREAMBLES[category],
-    "",
-    USER_REPORT_START,
-    report,
-    USER_REPORT_END,
-  ].join("\n");
-}
-
-/** Bug-category wrapper, kept as a named export for the original report flow. */
-export function issueReportPrompt(report: string) {
-  return categoryPrompt("bug", report);
-}
-
-/** What a user message should look like in the transcript: a wrapped report
- * renders as just the report the user typed. Both markers must be present and
- * ordered, so ordinary messages — even ones discussing the markers — pass
- * through untouched. */
+/** What a user message should look like in the transcript. Both markers must
+ * be present and ordered, so ordinary messages, even ones discussing the
+ * markers, pass through untouched. */
 export function displayedUserMessageText(content: string): string {
   const start = content.indexOf(USER_REPORT_START);
   if (start === -1) return content;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -545,7 +545,9 @@ describe("AgentWorkspace", () => {
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), category: "bug" }),
     );
-    mocks.submitIssueReport.mockRejectedValue(new Error("upstream_failed"));
+    mocks.submitIssueReport.mockRejectedValue(
+      new HermesGatewayError("session busy", 4009),
+    );
 
     render(<AgentWorkspace />);
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -500,7 +500,13 @@ describe("AgentWorkspace", () => {
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), category: "bug" }),
     );
-    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    let resolveReport: ((value: { received: boolean }) => void) | undefined;
+    mocks.submitIssueReport.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReport = resolve;
+        }),
+    );
 
     render(<AgentWorkspace />);
 
@@ -517,6 +523,9 @@ describe("AgentWorkspace", () => {
     });
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start session" }));
+    expect(document.querySelector(".agent-main")).not.toHaveAttribute(
+      "data-hero-leaving",
+    );
 
     await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
@@ -534,6 +543,11 @@ describe("AgentWorkspace", () => {
       expect.anything(),
     );
     expect(screen.queryByText(/---USER REPORT---/)).toBeNull();
+
+    await act(async () => {
+      resolveReport?.({ received: true });
+      await Promise.resolve();
+    });
     expect(
       await screen.findByText(/Your report was sent to the June team/),
     ).toBeInTheDocument();
@@ -569,6 +583,45 @@ describe("AgentWorkspace", () => {
       "prompt.submit",
       expect.anything(),
     );
+  });
+
+  it("does not show a delayed report failure after switching away", async () => {
+    const user = userEvent.setup();
+    let rejectReport: ((error: Error) => void) | undefined;
+    mocks.submitIssueReport.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectReport = reject;
+        }),
+    );
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Attach files or tag this message" }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /Bug report/ }));
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      screen.getByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => expect(mocks.submitIssueReport).toHaveBeenCalled());
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
+    });
+    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
+
+    await act(async () => {
+      rejectReport?.(new Error("upstream_failed"));
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(/The issue report could not be sent/)).toBeNull();
+    expect(screen.queryByText(/upstream_failed/)).toBeNull();
   });
 
   it("labels anonymous-only agent models as anonymous mode", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -494,7 +494,7 @@ describe("AgentWorkspace", () => {
     );
   });
 
-  it("wraps a submitted issue report for June and files it after the turn", async () => {
+  it("files a submitted issue report without starting a runtime turn", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
@@ -518,89 +518,34 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start session" }));
 
-    // June gets the investigation framing, with the user's words inside it.
-    await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
-        session_id: "runtime-session-2",
-        text: expect.stringContaining("---USER REPORT---"),
-      }),
-    );
-    const submitted = mocks.gatewayRequest.mock.calls.find(
-      ([method]) => method === "prompt.submit",
-    )?.[1] as { text: string };
-    expect(submitted.text).toContain(
-      "The recorder crashes after long meetings",
-    );
-    expect(submitted.text).toContain(
-      "Attached files copied into the June workspace:",
-    );
-    expect(submitted.text).toContain(
-      "Use these file paths when inspecting or operating on the files.",
-    );
-    expect(submitted.text).not.toContain("Scribe Hermes");
-    // The transcript shows the user's words only — the investigation
-    // framing is plumbing between June and the runtime, never UI.
-    expect(
-      await screen.findByText(/The recorder crashes after long meetings/),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/in-app reporting flow/)).toBeNull();
-    expect(screen.queryByText(/---USER REPORT---/)).toBeNull();
-    // The report waits for June's diagnosis; nothing is filed yet.
-    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
-
-    mocks.listHermesSessionMessages.mockResolvedValue([
-      {
-        id: "m1",
-        role: "user",
-        content: submitted.text,
-        timestamp: "2026-06-11T10:00:00Z",
-      },
-      {
-        id: "m2",
-        role: "assistant",
-        content: "The screenshot shows the recorder stuck on saving.",
-        timestamp: "2026-06-11T10:00:10Z",
-      },
-    ]);
-    act(() => {
-      for (const handler of mocks.gatewayEventHandlers) {
-        handler({ type: "turn.completed", session_id: "runtime-session-2" });
-      }
-    });
-
     await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
         category: "bug",
         description: "The recorder crashes after long meetings",
-        agentDiagnosis: "The screenshot shows the recorder stuck on saving.",
         attachmentNames: ["screenshot.png"],
         attachmentPaths: [
           "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
         ],
-        sessionId: "session-2",
       }),
     );
+    expect(mocks.startHermesBridge).not.toHaveBeenCalled();
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "prompt.submit",
+      expect.anything(),
+    );
+    expect(screen.queryByText(/---USER REPORT---/)).toBeNull();
     expect(
       await screen.findByText(/Your report was sent to the June team/),
     ).toBeInTheDocument();
-    // Drain the post-terminal refresh timer before the test ends so its
-    // session refetch cannot land inside a later test's render.
-    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
-  it("does not show a failed issue report banner after switching away", async () => {
+  it("restores a submitted issue report when direct filing fails", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), category: "bug" }),
     );
-    let rejectIssueReport: ((error: Error) => void) | undefined;
-    mocks.submitIssueReport.mockImplementation(
-      () =>
-        new Promise((_resolve, reject) => {
-          rejectIssueReport = reject;
-        }),
-    );
+    mocks.submitIssueReport.mockRejectedValue(new Error("upstream_failed"));
 
     render(<AgentWorkspace />);
 
@@ -610,47 +555,18 @@ describe("AgentWorkspace", () => {
       "The recorder crashes after long meetings",
     );
     await user.click(screen.getByRole("button", { name: "Start session" }));
-    await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
-        session_id: "runtime-session-2",
-        text: expect.stringContaining("---USER REPORT---"),
-      }),
+
+    expect(
+      await screen.findByText(/The issue report could not be sent/),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    expect(await screen.findByRole("textbox")).toHaveTextContent(
+      "The recorder crashes after long meetings",
     );
-
-    mocks.listHermesSessionMessages.mockResolvedValue([
-      {
-        id: "m1",
-        role: "user",
-        content: "The recorder crashes after long meetings",
-        timestamp: "2026-06-11T10:00:00Z",
-      },
-      {
-        id: "m2",
-        role: "assistant",
-        content: "The recorder failed while saving.",
-        timestamp: "2026-06-11T10:00:10Z",
-      },
-    ]);
-    act(() => {
-      for (const handler of mocks.gatewayEventHandlers) {
-        handler({ type: "turn.completed", session_id: "runtime-session-2" });
-      }
-    });
-    await waitFor(() => expect(mocks.submitIssueReport).toHaveBeenCalled());
-
-    act(() => {
-      window.dispatchEvent(new CustomEvent(AGENT_NEW_SESSION_EVENT));
-    });
-    expect(await screen.findByText(HERO_GREETING)).toBeInTheDocument();
-
-    await act(async () => {
-      rejectIssueReport?.(new Error("upstream_provider_failed"));
-      await Promise.resolve();
-    });
-
-    expect(screen.queryByText(/The issue report could not be sent/)).toBeNull();
-    expect(screen.queryByText(/upstream_provider_failed/)).toBeNull();
-    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "prompt.submit",
+      expect.anything(),
+    );
   });
 
   it("labels anonymous-only agent models as anonymous mode", async () => {
@@ -1324,9 +1240,7 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
         session_id: "runtime-session-1",
-        text: expect.stringContaining(
-          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
-        ),
+        text: expect.stringContaining("uploads/screenshot.png"),
       }),
     );
   });
@@ -1367,7 +1281,10 @@ describe("AgentWorkspace", () => {
       preview: "Second preview",
       last_active: "2026-06-04T12:05:00Z",
     };
-    mocks.listHermesSessions.mockResolvedValue([existingSession, secondSession]);
+    mocks.listHermesSessions.mockResolvedValue([
+      existingSession,
+      secondSession,
+    ]);
     const { rerender } = render(
       <AgentWorkspace initialSession={existingSession} />,
     );

--- a/src/test/issue-report-prompt.test.ts
+++ b/src/test/issue-report-prompt.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest";
-import {
-  categoryPrompt,
-  displayedUserMessageText,
-  issueReportPrompt,
-} from "../lib/issue-report-prompt";
+import { displayedUserMessageText } from "../lib/issue-report-prompt";
 
 describe("issue report prompt display", () => {
-  it("shows only the user's report for a wrapped prompt", () => {
+  it("shows only the user's report for a legacy wrapped prompt", () => {
     const report =
       "I want to report an issue with June.\n\nWhat happened: the recorder crashes";
-    const wrapped = issueReportPrompt(report);
-    expect(wrapped).toContain("in-app reporting flow");
+    const wrapped = [
+      "Legacy wrapped report",
+      "",
+      "---USER REPORT---",
+      report,
+      "---END USER REPORT---",
+    ].join("\n");
+
     expect(displayedUserMessageText(wrapped)).toBe(report);
   });
 
@@ -26,29 +28,14 @@ describe("issue report prompt display", () => {
   });
 
   it("falls back to the full content when the wrapper is empty", () => {
-    const wrapped = issueReportPrompt("   ");
+    const wrapped = [
+      "Legacy wrapped report",
+      "",
+      "---USER REPORT---",
+      "   ",
+      "---END USER REPORT---",
+    ].join("\n");
+
     expect(displayedUserMessageText(wrapped)).toBe(wrapped);
-  });
-
-  it("frames each category with its own preamble but the same markers", () => {
-    const report = "the sidebar feels cramped";
-    const bug = categoryPrompt("bug", report);
-    const feedback = categoryPrompt("feedback", report);
-    const feature = categoryPrompt("feature", report);
-
-    expect(bug).toContain("bug report");
-    expect(feedback).toContain("sharing feedback");
-    expect(feature).toContain("requesting a feature");
-
-    // All three wrap the user's words identically, so the transcript strips
-    // them back to exactly what was typed.
-    for (const wrapped of [bug, feedback, feature]) {
-      expect(wrapped).toContain("---USER REPORT---");
-      expect(displayedUserMessageText(wrapped)).toBe(report);
-    }
-  });
-
-  it("keeps issueReportPrompt as the bug-category wrapper", () => {
-    expect(issueReportPrompt("x")).toBe(categoryPrompt("bug", "x"));
   });
 });


### PR DESCRIPTION
## Summary

- Submit categorized issue reports directly through the existing report command instead of starting a runtime turn.
- Remove the obsolete report prompt builder while keeping legacy wrapped-message display cleanup.
- Update report-flow tests to cover direct filing, failure restore, and no prompt submission.

## Validation

- `pnpm run lint`
- `pnpm test`
- `pnpm run build`
- `pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/components/agent/composer/reportCategory.ts src/lib/issue-report-prompt.ts src/test/agent-workspace.test.tsx src/test/issue-report-prompt.test.ts`

## Known gaps

- `pnpm run format` still reports formatting issues in files outside this change: `src/app/App.tsx`, `src/lib/live-transcript-preview.ts`, `src/lib/recording-inactivity.ts`, `src/styles/app.css`, `src/test/recording-inactivity.test.ts`, and `src-tauri/tauri.conf.json`.

JUN-76