### PR TITLE
chore: add engineering team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,25 @@
 # Require an owner review for default changes, then spell out the paths that
 # are security or release sensitive so branch protection can enforce them.
-* @junhohong
+* @junhohong @open-software-network/engineering
 
-.github/ @junhohong
-.github/workflows/ @junhohong
-.github/actions/ @junhohong
+.github/ @junhohong @open-software-network/engineering
+.github/workflows/ @junhohong @open-software-network/engineering
+.github/actions/ @junhohong @open-software-network/engineering
 
-scripts/ @junhohong
-package.json @junhohong
-pnpm-lock.yaml @junhohong
+scripts/ @junhohong @open-software-network/engineering
+package.json @junhohong @open-software-network/engineering
+pnpm-lock.yaml @junhohong @open-software-network/engineering
 
-src-tauri/ @junhohong
-src-tauri/Cargo.toml @junhohong
-src-tauri/Cargo.lock @junhohong
-src-tauri/tauri*.conf.json @junhohong
-src-tauri/capabilities/ @junhohong
-src-tauri/Entitlements.plist @junhohong
-src-tauri/native/ @junhohong
+src-tauri/ @junhohong @open-software-network/engineering
+src-tauri/Cargo.toml @junhohong @open-software-network/engineering
+src-tauri/Cargo.lock @junhohong @open-software-network/engineering
+src-tauri/tauri*.conf.json @junhohong @open-software-network/engineering
+src-tauri/capabilities/ @junhohong @open-software-network/engineering
+src-tauri/Entitlements.plist @junhohong @open-software-network/engineering
+src-tauri/native/ @junhohong @open-software-network/engineering
 
-scribe-api/ @junhohong
-scribe-api/Cargo.toml @junhohong
-scribe-api/Cargo.lock @junhohong
-scribe-api/Dockerfile @junhohong
-scribe-api/config.toml @junhohong
+scribe-api/ @junhohong @open-software-network/engineering
+scribe-api/Cargo.toml @junhohong @open-software-network/engineering
+scribe-api/Cargo.lock @junhohong @open-software-network/engineering
+scribe-api/Dockerfile @junhohong @open-software-network/engineering
+scribe-api/config.toml @junhohong @open-software-network/engineering


### PR DESCRIPTION
Add `@open-software-network/engineering` alongside `@junhohong` as a code owner on every path (default `*` plus the security/release-sensitive paths), so any engineering member's review can satisfy code-owner requirements.

## Follow-ups (not in this PR — branch ruleset settings)
- [ ] Enable **Require review from Code Owners** on the `main` ruleset. Without it this file is inert and PRs still merge on any single write-access approval.
- [ ] Confirm the **engineering** team has **Write** access to this repo, or GitHub silently ignores it as an owner.

Kept `@junhohong` explicit; if he's already in the engineering team it's harmless redundancy.

https://claude.ai/code/session_01G7P63adWK7Hx5wTjqvcKTX