### PR TITLE
Fix per-chat agent model selection

### DIFF
--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -382,10 +382,18 @@ fn normalize_agent_chat_request_for_proxy(body: &mut serde_json::Value) {
     let Some(object) = body.as_object_mut() else {
         return;
     };
-    object.insert(
-        "model".to_string(),
-        serde_json::Value::String(crate::providers::generation_model()),
-    );
+    let has_request_model = object
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .map(|model| !model.is_empty())
+        .unwrap_or(false);
+    if !has_request_model {
+        object.insert(
+            "model".to_string(),
+            serde_json::Value::String(crate::providers::generation_model()),
+        );
+    }
     clamp_agent_chat_output_tokens(object, "max_tokens");
     clamp_agent_chat_output_tokens(object, "max_completion_tokens");
 }
@@ -1152,6 +1160,47 @@ mod tests {
                 .and_then(|details| details.get("retryAfterMs").cloned())
                 .and_then(|value| value.as_u64()),
             Some(2_000)
+        );
+    }
+
+    #[test]
+    fn agent_proxy_preserves_session_selected_model() {
+        let mut body = serde_json::json!({
+            "model": "hermes-selected-model",
+            "messages": [{ "role": "user", "content": "hello" }],
+        });
+
+        normalize_agent_chat_request_for_proxy(&mut body);
+
+        assert_eq!(body["model"], serde_json::json!("hermes-selected-model"));
+    }
+
+    #[test]
+    fn agent_proxy_fills_missing_model_from_settings() {
+        let mut body = serde_json::json!({
+            "messages": [{ "role": "user", "content": "hello" }],
+        });
+
+        normalize_agent_chat_request_for_proxy(&mut body);
+
+        assert_eq!(
+            body["model"],
+            serde_json::json!(crate::providers::generation_model())
+        );
+    }
+
+    #[test]
+    fn agent_proxy_replaces_blank_model_from_settings() {
+        let mut body = serde_json::json!({
+            "model": "  ",
+            "messages": [{ "role": "user", "content": "hello" }],
+        });
+
+        normalize_agent_chat_request_for_proxy(&mut body);
+
+        assert_eq!(
+            body["model"],
+            serde_json::json!(crate::providers::generation_model())
         );
     }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -986,6 +986,8 @@ export function AgentWorkspace({
   // each chat's stored model. A selection missing from the catalog still
   // shows as a name-only stub so the pill never goes blank while configured.
   const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
+  const defaultGenerationModelIdRef = useRef("");
+  const sessionModelOverridesRef = useRef<Record<string, string>>({});
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>(
     [],
   );
@@ -1488,6 +1490,8 @@ export function AgentWorkspace({
             workingSessionIds: workingSessions,
             waitingSessionIds: waitingSessions,
             pendingMessages,
+            defaultModelId: defaultGenerationModelIdRef.current,
+            sessionModelOverrides: sessionModelOverridesRef.current,
           }),
         );
         setSelectedHermesSessionId((current) => {
@@ -1562,24 +1566,28 @@ export function AgentWorkspace({
         settingsResponse.settings.generationModel ||
         modelsResponse.selectedModel;
       if (requestId === generationModelRequestSequence.current) {
+        defaultGenerationModelIdRef.current = selectedModelId;
         setGenerationModels(modelsResponse.models);
         setDefaultGenerationModelId(selectedModelId);
       }
     } catch {
       if (requestId === generationModelRequestSequence.current) {
+        defaultGenerationModelIdRef.current = "";
         setDefaultGenerationModelId("");
       }
     }
   }, []);
 
   useEffect(() => {
-    if (!defaultGenerationModelId) return;
+    defaultGenerationModelIdRef.current = defaultGenerationModelId;
+    const defaultModelId = defaultGenerationModelId.trim();
+    if (!defaultModelId) return;
     setHermesSessionItems((current) => {
       let changed = false;
       const next = current.map((session) => {
         if (session.model?.trim()) return session;
         changed = true;
-        return { ...session, model: defaultGenerationModelId };
+        return { ...session, model: defaultModelId };
       });
       return changed ? next : current;
     });
@@ -1625,7 +1633,14 @@ export function AgentWorkspace({
         ? undefined
         : selectedHermesSessionIdRef.current;
       if (sessionId) {
-        await ensureHermesBridgeSession({ sessionId, model: modelId });
+        const previousModel = hermesSessionItemsRef.current.find(
+          (session) => session.id === sessionId,
+        )?.model;
+        const previousOverride = sessionModelOverridesRef.current[sessionId];
+        sessionModelOverridesRef.current = {
+          ...sessionModelOverridesRef.current,
+          [sessionId]: modelId,
+        };
         setHermesSessionItems((current) =>
           current.map((session) =>
             session.id === sessionId
@@ -1633,10 +1648,33 @@ export function AgentWorkspace({
               : session,
           ),
         );
+        try {
+          await ensureHermesBridgeSession({ sessionId, model: modelId });
+        } catch (err) {
+          if (previousOverride) {
+            sessionModelOverridesRef.current = {
+              ...sessionModelOverridesRef.current,
+              [sessionId]: previousOverride,
+            };
+          } else {
+            const { [sessionId]: _removed, ...remainingOverrides } =
+              sessionModelOverridesRef.current;
+            sessionModelOverridesRef.current = remainingOverrides;
+          }
+          setHermesSessionItems((current) =>
+            current.map((session) =>
+              session.id === sessionId && session.model === modelId
+                ? { ...session, model: previousModel }
+                : session,
+            ),
+          );
+          throw err;
+        }
         return;
       }
 
       await setVeniceModel("generation", modelId);
+      defaultGenerationModelIdRef.current = modelId;
       setDefaultGenerationModelId(modelId);
       dispatchProviderModelSettingsChanged({ mode: "generation", modelId });
     } catch (err) {
@@ -7899,13 +7937,20 @@ function mergeActiveHermesSessions(
     workingSessionIds: Set<string>;
     waitingSessionIds: Set<string>;
     pendingMessages: Record<string, HermesSessionMessage[]>;
+    defaultModelId?: string;
+    sessionModelOverrides?: Record<string, string>;
   },
 ) {
   const currentById = new Map(current.map((session) => [session.id, session]));
+  const defaultModelId = options.defaultModelId?.trim();
+  const sessionModelOverrides = options.sessionModelOverrides ?? {};
   const mergedFresh = fresh.map((session) => {
+    const overrideModel = sessionModelOverrides[session.id]?.trim();
+    if (overrideModel) return { ...session, model: overrideModel };
     if (session.model?.trim()) return session;
     const currentModel = currentById.get(session.id)?.model?.trim();
-    return currentModel ? { ...session, model: currentModel } : session;
+    if (currentModel) return { ...session, model: currentModel };
+    return defaultModelId ? { ...session, model: defaultModelId } : session;
   });
   const seen = new Set(mergedFresh.map((session) => session.id));
   const retained = current.filter(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -982,11 +982,10 @@ export function AgentWorkspace({
   const [messagingPlatforms, setMessagingPlatforms] = useState<
     HermesMessagingPlatformInfo[] | null
   >(null);
-  // The active text model (global setting, not per-session) shown in the
-  // composer's model pill; the catalog backs the picker the pill opens. A
-  // selection missing from the catalog still shows as a name-only stub so
-  // the pill never goes blank while a model is configured.
-  const [generationModel, setGenerationModel] = useState<VeniceModelDto>();
+  // The text-model catalog backs both the global default for new chats and
+  // each chat's stored model. A selection missing from the catalog still
+  // shows as a name-only stub so the pill never goes blank while configured.
+  const [defaultGenerationModelId, setDefaultGenerationModelId] = useState("");
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>(
     [],
   );
@@ -997,9 +996,6 @@ export function AgentWorkspace({
   const composerModelTriggerRef = useRef<HTMLButtonElement | null>(null);
   const composerModelPopoverRef = useRef<HTMLDivElement | null>(null);
   const composerModelSearchRef = useRef<HTMLInputElement | null>(null);
-  const generationPrivacyBadge = generationModel
-    ? modelPrivacyBadge(generationModel)
-    : undefined;
   // Attestation walkthrough URL served by the backend (same page as Settings
   // → About → Verify server); the privacy badge links to it when known.
   const [capabilityQuery, setCapabilityQuery] = useState("");
@@ -1196,6 +1192,20 @@ export function AgentWorkspace({
       ),
     [hermesSessionItems, selectedHermesSessionId],
   );
+  const activeGenerationModelId =
+    selectedHermesSessionId && !newSessionMode
+      ? selectedHermesSession?.model?.trim() || defaultGenerationModelId
+      : defaultGenerationModelId;
+  const generationModel = useMemo(
+    () =>
+      activeGenerationModelId
+        ? selectedModelOption(generationModels, activeGenerationModelId)
+        : undefined,
+    [activeGenerationModelId, generationModels],
+  );
+  const generationPrivacyBadge = generationModel
+    ? modelPrivacyBadge(generationModel)
+    : undefined;
   const selectedHermesMessages = useMemo(() => {
     if (!selectedHermesSessionId) return [];
     return [
@@ -1553,18 +1563,27 @@ export function AgentWorkspace({
         modelsResponse.selectedModel;
       if (requestId === generationModelRequestSequence.current) {
         setGenerationModels(modelsResponse.models);
-        setGenerationModel(
-          selectedModelId
-            ? selectedModelOption(modelsResponse.models, selectedModelId)
-            : undefined,
-        );
+        setDefaultGenerationModelId(selectedModelId);
       }
     } catch {
       if (requestId === generationModelRequestSequence.current) {
-        setGenerationModel(undefined);
+        setDefaultGenerationModelId("");
       }
     }
   }, []);
+
+  useEffect(() => {
+    if (!defaultGenerationModelId) return;
+    setHermesSessionItems((current) => {
+      let changed = false;
+      const next = current.map((session) => {
+        if (session.model?.trim()) return session;
+        changed = true;
+        return { ...session, model: defaultGenerationModelId };
+      });
+      return changed ? next : current;
+    });
+  }, [defaultGenerationModelId]);
 
   useEffect(() => {
     function handleProviderModelSettingsChanged(event: Event) {
@@ -1599,13 +1618,26 @@ export function AgentWorkspace({
     void loadGenerationModel();
   }
 
-  // The picker writes the global text-model setting, so the change is
-  // dispatched app-wide: Settings' model rows and this pill both refresh
-  // through the same changed event.
   async function handleSelectGenerationModel(modelId: string) {
     setComposerModelOpen(false);
     try {
+      const sessionId = newSessionModeRef.current
+        ? undefined
+        : selectedHermesSessionIdRef.current;
+      if (sessionId) {
+        await ensureHermesBridgeSession({ sessionId, model: modelId });
+        setHermesSessionItems((current) =>
+          current.map((session) =>
+            session.id === sessionId
+              ? { ...session, model: modelId, has_model_config: true }
+              : session,
+          ),
+        );
+        return;
+      }
+
       await setVeniceModel("generation", modelId);
+      setDefaultGenerationModelId(modelId);
       dispatchProviderModelSettingsChanged({ mode: "generation", modelId });
     } catch (err) {
       setError(messageFromError(err));
@@ -2237,6 +2269,13 @@ export function AgentWorkspace({
       : newSessionModeRef.current
         ? undefined
         : selectedHermesSessionId;
+    const targetSessionModelId = targetSessionId
+      ? explicitSession?.model?.trim() ||
+        hermesSessionItemsRef.current
+          .find((session) => session.id === targetSessionId)
+          ?.model?.trim() ||
+        defaultGenerationModelId
+      : defaultGenerationModelId;
     // Issue reports skip title suggestion: the content is the wrapped
     // investigation prompt, which would title the session after the wrapper.
     const titlePromise =
@@ -2261,6 +2300,7 @@ export function AgentWorkspace({
             ? "Issue report"
             : (sessionTitle ?? titleFromPrompt(content)),
           cols: 96,
+          ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
         });
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
@@ -2292,6 +2332,7 @@ export function AgentWorkspace({
       ensureHermesBridgeSession({
         sessionId: storedSessionId,
         title: sessionDisplayTitle,
+        ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
       }),
       2500,
     ).catch(() => undefined);
@@ -2331,6 +2372,7 @@ export function AgentWorkspace({
           started_at: createdAt,
           last_active: createdAt,
           message_count: 1,
+          ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
         },
         ...current,
       ];
@@ -7859,12 +7901,18 @@ function mergeActiveHermesSessions(
     pendingMessages: Record<string, HermesSessionMessage[]>;
   },
 ) {
-  const seen = new Set(fresh.map((session) => session.id));
+  const currentById = new Map(current.map((session) => [session.id, session]));
+  const mergedFresh = fresh.map((session) => {
+    if (session.model?.trim()) return session;
+    const currentModel = currentById.get(session.id)?.model?.trim();
+    return currentModel ? { ...session, model: currentModel } : session;
+  });
+  const seen = new Set(mergedFresh.map((session) => session.id));
   const retained = current.filter(
     (session) =>
       !seen.has(session.id) && shouldRetainHermesSessionId(session.id, options),
   );
-  return [...fresh, ...retained].sort((a, b) =>
+  return [...mergedFresh, ...retained].sort((a, b) =>
     sessionTimestamp(b).localeCompare(sessionTimestamp(a)),
   );
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1629,7 +1629,7 @@ export function AgentWorkspace({
         setHermesSessionItems((current) =>
           current.map((session) =>
             session.id === sessionId
-              ? { ...session, model: modelId, has_model_config: true }
+              ? { ...session, model: modelId }
               : session,
           ),
         );

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -756,7 +756,7 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
   });
 
-  it("switches the text model from the composer's picker", async () => {
+  it("switches the text model only for the active chat", async () => {
     // Tool-capable catalog: the picker refuses tool-less models for the
     // agent, so the switch target must support function calling.
     const catalog = [
@@ -794,7 +794,6 @@ describe("AgentWorkspace", () => {
       selectedModel: "zai-org-glm-5-2",
       models: catalog,
     });
-    mocks.setVeniceModel.mockResolvedValue(undefined);
     const user = userEvent.setup();
 
     render(<AgentWorkspace initialSession={existingSession} />);
@@ -806,20 +805,6 @@ describe("AgentWorkspace", () => {
       name: "Choose text model",
     });
 
-    // The reload after the switch reads the updated setting.
-    mocks.providerModelSettings.mockResolvedValue({
-      settings: {
-        transcriptionProvider: "venice",
-        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
-        generationModel: "anonymous-only",
-      },
-    });
-    mocks.listVeniceModels.mockResolvedValue({
-      mode: "generation",
-      modelType: "text",
-      selectedModel: "anonymous-only",
-      models: catalog,
-    });
     // The popover opens on the suggested picks (GLM 5.2 is curated); the
     // switch target only exists in the full catalog behind All models.
     await user.click(
@@ -833,11 +818,12 @@ describe("AgentWorkspace", () => {
     );
 
     await waitFor(() =>
-      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
-        "generation",
-        "anonymous-only",
-      ),
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+        sessionId: "session-1",
+        model: "anonymous-only",
+      }),
     );
+    expect(mocks.setVeniceModel).not.toHaveBeenCalled();
     // The composer trigger reflects the new model and the session bar badge
     // its privacy mode.
     expect(
@@ -847,7 +833,91 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
   });
 
-  it("refreshes the model privacy label when generation model settings change", async () => {
+  it("keeps another active chat on its own model after switching the current chat", async () => {
+    const catalog = [
+      {
+        provider: "venice",
+        id: "zai-org-glm-5-2",
+        name: "GLM 5.2",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+      {
+        provider: "venice",
+        id: "kimi-k2-6",
+        name: "Kimi K2.6",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+      {
+        provider: "venice",
+        id: "anonymous-only",
+        name: "Anonymous Only",
+        modelType: "text",
+        privacy: "anonymous",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+    ];
+    const secondSession = {
+      ...existingSession,
+      id: "session-2",
+      title: "Second session",
+      preview: "Second preview",
+      last_active: "2026-06-04T12:05:00Z",
+      model: "kimi-k2-6",
+    };
+    mocks.listHermesSessions.mockResolvedValue([
+      existingSession,
+      secondSession,
+    ]);
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "zai-org-glm-5-2",
+      models: catalog,
+    });
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <AgentWorkspace initialSession={existingSession} />,
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "All models" }),
+    );
+    const panel = await screen.findByRole("group", {
+      name: "All text models",
+    });
+    await user.click(
+      within(panel).getByRole("option", { name: /Anonymous Only/ }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Anonymous Only" }),
+    ).toBeInTheDocument();
+
+    rerender(<AgentWorkspace initialSession={secondSession} />);
+
+    expect(
+      await screen.findByRole("button", { name: "Model: Kimi K2.6" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Model: Anonymous Only" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps an existing chat model when generation model settings change", async () => {
     render(<AgentWorkspace initialSession={existingSession} />);
 
     expect(await screen.findByText("Private mode")).toBeInTheDocument();
@@ -864,6 +934,15 @@ describe("AgentWorkspace", () => {
       modelType: "text",
       selectedModel: "anonymous-only",
       models: [
+        {
+          provider: "venice",
+          id: "zai-org-glm-5-2",
+          name: "GLM 5.2",
+          modelType: "text",
+          privacy: "private",
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
         {
           provider: "venice",
           id: "anonymous-only",
@@ -884,10 +963,69 @@ describe("AgentWorkspace", () => {
       );
     });
 
-    expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.queryByText("Private mode")).not.toBeInTheDocument(),
+    expect(await screen.findByText("Private mode")).toBeInTheDocument();
+    expect(screen.queryByText("Anonymous mode")).not.toBeInTheDocument();
+  });
+
+  it("uses the new-chat composer picker to update the default model", async () => {
+    const catalog = [
+      {
+        provider: "venice",
+        id: "zai-org-glm-5-2",
+        name: "GLM 5.2",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+      {
+        provider: "venice",
+        id: "anonymous-only",
+        name: "Anonymous Only",
+        modelType: "text",
+        privacy: "anonymous",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+    ];
+    mocks.listAgentTasks.mockResolvedValue({ items: [] });
+    mocks.listHermesSessions.mockResolvedValue([]);
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "zai-org-glm-5-2",
+      models: catalog,
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
     );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "All models" }),
+    );
+    const panel = await screen.findByRole("group", {
+      name: "All text models",
+    });
+    await user.click(
+      within(panel).getByRole("option", { name: /Anonymous Only/ }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "generation",
+        "anonymous-only",
+      ),
+    );
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: expect.any(String),
+      model: "anonymous-only",
+    });
   });
 
   it("ignores a stale pending New Session marker left over from a reload", async () => {
@@ -1324,9 +1462,7 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
         session_id: "runtime-session-1",
-        text: expect.stringContaining(
-          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
-        ),
+        text: expect.stringContaining("uploads/screenshot.png"),
       }),
     );
   });
@@ -1367,7 +1503,10 @@ describe("AgentWorkspace", () => {
       preview: "Second preview",
       last_active: "2026-06-04T12:05:00Z",
     };
-    mocks.listHermesSessions.mockResolvedValue([existingSession, secondSession]);
+    mocks.listHermesSessions.mockResolvedValue([
+      existingSession,
+      secondSession,
+    ]);
     const { rerender } = render(
       <AgentWorkspace initialSession={existingSession} />,
     );
@@ -1841,6 +1980,7 @@ describe("AgentWorkspace", () => {
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.create", {
         title: "Summarize Current Page",
         cols: 96,
+        model: "zai-org-glm-5-2",
       }),
     );
     expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -967,6 +967,169 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Anonymous mode")).not.toBeInTheDocument();
   });
 
+  it("keeps late-loaded existing chats on the default they first inherited", async () => {
+    const catalog = [
+      {
+        provider: "venice",
+        id: "zai-org-glm-5-2",
+        name: "GLM 5.2",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+      {
+        provider: "venice",
+        id: "anonymous-only",
+        name: "Anonymous Only",
+        modelType: "text",
+        privacy: "anonymous",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+    ];
+    const sessionResolvers: Array<
+      (sessions: (typeof existingSession)[]) => void
+    > = [];
+    mocks.listAgentTasks.mockResolvedValue({ items: [] });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "zai-org-glm-5-2",
+      models: catalog,
+    });
+    mocks.listHermesSessions.mockImplementation(
+      () =>
+        new Promise<(typeof existingSession)[]>((resolve) => {
+          sessionResolvers.push(resolve);
+        }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(sessionResolvers.length).toBeGreaterThan(0));
+
+    mocks.listHermesSessions.mockResolvedValue([existingSession]);
+    await act(async () => {
+      for (const resolveSessions of sessionResolvers) {
+        resolveSessions([existingSession]);
+      }
+    });
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    const settingsCalls = mocks.providerModelSettings.mock.calls.length;
+    const modelListCalls = mocks.listVeniceModels.mock.calls.length;
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "anonymous-only",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "anonymous-only",
+      models: catalog,
+    });
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(PROVIDER_MODEL_SETTINGS_CHANGED_EVENT, {
+          detail: { mode: "generation", modelId: "anonymous-only" },
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(mocks.providerModelSettings.mock.calls.length).toBeGreaterThan(
+        settingsCalls,
+      ),
+    );
+    await waitFor(() =>
+      expect(mocks.listVeniceModels.mock.calls.length).toBeGreaterThan(
+        modelListCalls,
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Model: GLM 5.2" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Anonymous mode")).not.toBeInTheDocument();
+  });
+
+  it("keeps an explicit chat model when a refresh returns a stale server model", async () => {
+    const catalog = [
+      {
+        provider: "venice",
+        id: "zai-org-glm-5-2",
+        name: "GLM 5.2",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+      {
+        provider: "venice",
+        id: "anonymous-only",
+        name: "Anonymous Only",
+        modelType: "text",
+        privacy: "anonymous",
+        traits: [],
+        capabilities: ["functionCalling"],
+      },
+    ];
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "zai-org-glm-5-2",
+      models: catalog,
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Model: GLM 5.2" }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: "Choose text model",
+    });
+    await user.click(
+      within(dialog).getByRole("button", { name: "All models" }),
+    );
+    const panel = await screen.findByRole("group", {
+      name: "All text models",
+    });
+    await user.click(
+      within(panel).getByRole("option", { name: /Anonymous Only/ }),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Model: Anonymous Only" }),
+    ).toBeInTheDocument();
+
+    const sessionListCalls = mocks.listHermesSessions.mock.calls.length;
+    mocks.listHermesSessions.mockResolvedValue([
+      { ...existingSession, model: "zai-org-glm-5-2" },
+    ]);
+
+    await user.type(screen.getByRole("textbox"), "continue");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessions.mock.calls.length).toBeGreaterThan(
+        sessionListCalls,
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Model: Anonymous Only" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
+  });
+
   it("uses the new-chat composer picker to update the default model", async () => {
     const catalog = [
       {


### PR DESCRIPTION
## Summary
- Scope composer model changes to the active Hermes chat by saving selected models on session metadata.
- Keep the generation model setting as the default for new chats only.
- Preserve locally known session models when refreshing session lists.

## Validation
- pnpm run lint
- pnpm test src/test/agent-workspace.test.tsx
- pnpm test