### PR TITLE
Handle native HUD hide on pointerdown

### DIFF
--- a/src/agent-hud.ts
+++ b/src/agent-hud.ts
@@ -967,7 +967,6 @@ hud?.addEventListener("pointerenter", () => {
 });
 
 hud?.addEventListener("pointerleave", () => {
-  if (state.menuOpen) closeMenu();
   setHovered(false);
 });
 
@@ -1011,6 +1010,13 @@ menu?.addEventListener("pointerdown", (event) => {
 });
 
 hideHud?.addEventListener("click", (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  hideFromMenu();
+});
+
+hideHud?.addEventListener("pointerdown", (event) => {
+  if (event.button !== 0) return;
   event.preventDefault();
   event.stopPropagation();
   hideFromMenu();

--- a/src/test/agent-hud.test.ts
+++ b/src/test/agent-hud.test.ts
@@ -321,6 +321,69 @@ describe("agent HUD", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_hide");
   });
 
+  it("keeps the native context menu clickable after leaving the HUD surface", async () => {
+    await loadAgentHud();
+
+    emitSessionsChanged({
+      sessions: [sessionFixture("session-1", "Need approval")],
+      workingSessionIds: [],
+      waitingSessionIds: ["session-1"],
+    });
+    await flushPromises();
+
+    const openMenuFromNative = mocks.listeners.get(
+      "scribe:agent-hud:context-menu",
+    );
+    expect(openMenuFromNative).toBeDefined();
+    openMenuFromNative?.({ payload: undefined });
+    await flushPromises();
+
+    expect(menuElement().hidden).toBe(false);
+
+    hudElement().dispatchEvent(new Event("pointerleave"));
+    await flushPromises();
+
+    expect(menuElement().hidden).toBe(false);
+
+    hideHudButton().click();
+    await flushPromises();
+
+    expect(localStorage.getItem("scribe:agent-hud:enabled")).toBe("false");
+    expect(hudElement().dataset.visible).toBe("false");
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_hide");
+  });
+
+  it("hides the HUD as soon as the native context menu item is pressed", async () => {
+    await loadAgentHud();
+
+    emitSessionsChanged({
+      sessions: [sessionFixture("session-1", "Need approval")],
+      workingSessionIds: [],
+      waitingSessionIds: ["session-1"],
+    });
+    await flushPromises();
+
+    const openMenuFromNative = mocks.listeners.get(
+      "scribe:agent-hud:context-menu",
+    );
+    expect(openMenuFromNative).toBeDefined();
+    openMenuFromNative?.({ payload: undefined });
+    await flushPromises();
+
+    hideHudButton().dispatchEvent(
+      new MouseEvent("pointerdown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      }),
+    );
+    await flushPromises();
+
+    expect(localStorage.getItem("scribe:agent-hud:enabled")).toBe("false");
+    expect(hudElement().dataset.visible).toBe("false");
+    expect(mocks.invoke).toHaveBeenCalledWith("agent_hud_hide");
+  });
+
   it("shows an active-count badge when sessions work behind a needs-input one", async () => {
     await loadAgentHud();
 


### PR DESCRIPTION
## Summary
- Keep the native agent HUD context menu usable after the pointer leaves the HUD surface
- Hide the HUD immediately when the native hide action is pressed via `pointerdown`
- Add coverage for both the menu-click flow and the preserved menu state

## Testing
- Added unit tests for native context menu interaction and hide behavior