### PR TITLE
JUN-59: Add issue report follow-up review

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1394,6 +1394,9 @@ export function AgentWorkspace({
           ),
         }
       : undefined;
+  const visibleIssueReportHasUnsentContext = Boolean(
+    visibleIssueReportReview && (draft.trim() || attachments.length),
+  );
   // Holds the prior render's heroMode. Read by both the composer auto-grow
   // effect (to skip its glide across a hero transition) and the hero→dock FLIP
   // below (to detect the hero handoff); the FLIP effect, which runs last, is
@@ -2178,7 +2181,7 @@ export function AgentWorkspace({
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
     const reportFollowUpSessionId =
-      !reportCategory && selectedHermesSessionId
+      !reportCategory && !newSessionModeRef.current && selectedHermesSessionId
         ? selectedHermesSessionId
         : null;
     const reportFollowUp = reportFollowUpSessionId
@@ -3955,7 +3958,10 @@ export function AgentWorkspace({
               <button
                 type="button"
                 className="agent-composer-notice-button"
-                disabled={visibleIssueReportReview.submitting}
+                disabled={
+                  visibleIssueReportReview.submitting ||
+                  visibleIssueReportHasUnsentContext
+                }
                 onClick={() =>
                   void sendReviewableIssueReport(
                     visibleIssueReportReview.sessionId,
@@ -3967,7 +3973,9 @@ export function AgentWorkspace({
                 ) : null}
                 {visibleIssueReportReview.submitting
                   ? "Sending"
-                  : "Send report"}
+                  : visibleIssueReportHasUnsentContext
+                    ? "Send message first"
+                    : "Send report"}
               </button>
             </motion.div>
           ) : visibleIssueReportNotice ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2789,6 +2789,16 @@ export function AgentWorkspace({
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
+    const queuedIssueReport = options?.issueReport;
+    const clearQueuedIssueReport = () => {
+      if (
+        queuedIssueReport &&
+        pendingIssueReportsRef.current.get(storedSessionId) ===
+          queuedIssueReport
+      ) {
+        pendingIssueReportsRef.current.delete(storedSessionId);
+      }
+    };
     if (options?.issueReport) {
       pendingIssueReportsRef.current.set(storedSessionId, options.issueReport);
     }
@@ -2819,17 +2829,28 @@ export function AgentWorkspace({
       }),
       2500,
     ).catch(() => undefined);
-    const runtimeSessionId =
-      created?.session_id ??
-      runtimeSessionIds[storedSessionId] ??
-      (
-        await gateway.request<HermesRuntimeSessionResponse>("session.resume", {
-          session_id: storedSessionId,
-          cols: 96,
-        })
-      ).session_id;
-    if (!runtimeSessionId)
+    let runtimeSessionId: string | undefined;
+    try {
+      runtimeSessionId =
+        created?.session_id ??
+        runtimeSessionIds[storedSessionId] ??
+        (
+          await gateway.request<HermesRuntimeSessionResponse>(
+            "session.resume",
+            {
+              session_id: storedSessionId,
+              cols: 96,
+            },
+          )
+        ).session_id;
+    } catch (err) {
+      clearQueuedIssueReport();
+      throw err;
+    }
+    if (!runtimeSessionId) {
+      clearQueuedIssueReport();
       throw new Error("Hermes did not resume the session.");
+    }
     const createdAt = new Date().toISOString();
     // A new session (no target id) means the hero is handing over to a fresh
     // thread — arm the composer glide. Sending into an existing session leaves
@@ -2959,7 +2980,7 @@ export function AgentWorkspace({
     } catch (err) {
       // A queued report must not outlive its failed prompt; submit() re-arms
       // issue-report mode so the retry can queue it again.
-      pendingIssueReportsRef.current.delete(storedSessionId);
+      clearQueuedIssueReport();
       // The prompt never entered the session, so its optimistic bubble must
       // not linger — a retained pending message renders below every later
       // persisted message and reads as a send the agent ignored.

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -761,10 +761,23 @@ type AgentSessionContinuity = {
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
+  submittingIssueReportSessionIds: string[];
+};
+
+type IssueReportDeliveryResult =
+  | { sent: true }
+  | { sent: false; errorMessage: string };
+
+type IssueReportDeliverySettledDetail = {
+  sessionId: string;
+  report: PendingIssueReport;
+  result: IssueReportDeliveryResult;
 };
 
 let sessionContinuity: AgentSessionContinuity | null = null;
 const NEW_SESSION_DRAFT_KEY = "new-session";
+const ISSUE_REPORT_DELIVERY_SETTLED_EVENT =
+  "june-agent-issue-report-delivery-settled";
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
 
 function sessionComposerDraftKey(sessionId: string) {
@@ -812,9 +825,7 @@ function captureSessionContinuity(state: {
     if (pending.length > 0) activeIds.add(sessionId);
   }
   for (const sessionId of Object.keys(state.reviewableIssueReports)) {
-    if (!state.submittingIssueReportSessionIds.has(sessionId)) {
-      activeIds.add(sessionId);
-    }
+    activeIds.add(sessionId);
   }
   if (activeIds.size === 0) return null;
   const pick = <T,>(record: Record<string, T>) =>
@@ -831,14 +842,56 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
-    reviewableIssueReports: Object.fromEntries(
-      Object.entries(state.reviewableIssueReports).filter(
-        ([sessionId]) =>
-          activeIds.has(sessionId) &&
-          !state.submittingIssueReportSessionIds.has(sessionId),
+    reviewableIssueReports: pick(state.reviewableIssueReports),
+    submittingIssueReportSessionIds: [
+      ...state.submittingIssueReportSessionIds,
+    ].filter((sessionId) => activeIds.has(sessionId)),
+  };
+}
+
+function updateContinuityAfterIssueReportDelivery(
+  detail: IssueReportDeliverySettledDetail,
+) {
+  if (!sessionContinuity) return;
+  const reviewableIssueReports = {
+    ...sessionContinuity.reviewableIssueReports,
+  };
+  if (
+    detail.result.sent &&
+    reviewableIssueReports[detail.sessionId] === detail.report
+  ) {
+    delete reviewableIssueReports[detail.sessionId];
+  } else if (!detail.result.sent) {
+    reviewableIssueReports[detail.sessionId] =
+      reviewableIssueReports[detail.sessionId] ?? detail.report;
+  }
+  sessionContinuity = captureSessionContinuity({
+    sessionItems: sessionContinuity.sessionItems,
+    pendingMessages: sessionContinuity.pendingMessages,
+    workingSessionIds: new Set(sessionContinuity.workingSessionIds),
+    waitingSessionIds: new Set(sessionContinuity.waitingSessionIds),
+    runtimeSessionIds: sessionContinuity.runtimeSessionIds,
+    liveEvents: sessionContinuity.liveEvents,
+    titleOverrides: sessionContinuity.titleOverrides,
+    reviewableIssueReports,
+    submittingIssueReportSessionIds: new Set(
+      sessionContinuity.submittingIssueReportSessionIds.filter(
+        (sessionId) => sessionId !== detail.sessionId,
       ),
     ),
-  };
+  });
+}
+
+function dispatchIssueReportDeliverySettled(
+  detail: IssueReportDeliverySettledDetail,
+) {
+  updateContinuityAfterIssueReportDelivery(detail);
+  window.dispatchEvent(
+    new CustomEvent<IssueReportDeliverySettledDetail>(
+      ISSUE_REPORT_DELIVERY_SETTLED_EVENT,
+      { detail },
+    ),
+  );
 }
 
 function issueReportDescription(report: PendingIssueReport) {
@@ -1153,8 +1206,12 @@ export function AgentWorkspace({
     reviewableIssueReports,
   );
   const [submittingIssueReportSessionIds, setSubmittingIssueReportSessionIds] =
-    useState<Set<string>>(() => new Set());
-  const submittingIssueReportSessionIdsRef = useRef<Set<string>>(new Set());
+    useState<Set<string>>(
+      () => new Set(continuity?.submittingIssueReportSessionIds ?? []),
+    );
+  const submittingIssueReportSessionIdsRef = useRef<Set<string>>(
+    submittingIssueReportSessionIds,
+  );
   // True only while a brand-new thread is being started from the hero. The
   // hero→dock composer FLIP keys off this so it glides *only* when the empty
   // chat hands over to a fresh thread — not when the hero is dismissed by
@@ -1196,6 +1253,37 @@ export function AgentWorkspace({
     submittingIssueReportSessionIdsRef.current = next;
     setSubmittingIssueReportSessionIds(next);
   }
+
+  useEffect(() => {
+    function onIssueReportDeliverySettled(event: Event) {
+      const detail = (event as CustomEvent<IssueReportDeliverySettledDetail>)
+        .detail;
+      if (!detail?.sessionId) return;
+      setIssueReportSubmitting(detail.sessionId, false);
+      if (detail.result.sent) {
+        if (
+          reviewableIssueReportsRef.current[detail.sessionId] === detail.report
+        ) {
+          setReviewableIssueReport(detail.sessionId, null);
+        }
+        return;
+      }
+      if (!reviewableIssueReportsRef.current[detail.sessionId]) {
+        setReviewableIssueReport(detail.sessionId, detail.report);
+      }
+      setError(detail.result.errorMessage, { sessionId: detail.sessionId });
+    }
+
+    window.addEventListener(
+      ISSUE_REPORT_DELIVERY_SETTLED_EVENT,
+      onIssueReportDeliverySettled,
+    );
+    return () =>
+      window.removeEventListener(
+        ISSUE_REPORT_DELIVERY_SETTLED_EVENT,
+        onIssueReportDeliverySettled,
+      );
+  }, [setError]);
 
   useEffect(() => {
     runtimeSessionIdsRef.current = runtimeSessionIds;
@@ -2444,7 +2532,7 @@ export function AgentWorkspace({
   async function deliverIssueReport(
     sessionId: string,
     report: PendingIssueReport,
-  ): Promise<boolean> {
+  ): Promise<IssueReportDeliveryResult> {
     let agentDiagnosis: string | undefined;
     try {
       const messages = await listHermesSessionMessages(sessionId);
@@ -2475,12 +2563,11 @@ export function AgentWorkspace({
           sessionId,
         });
       }
-      return true;
+      return { sent: true };
     } catch (err) {
-      setError(`The issue report could not be sent. ${messageFromError(err)}`, {
-        sessionId,
-      });
-      return false;
+      const errorMessage = `The issue report could not be sent. ${messageFromError(err)}`;
+      setError(errorMessage, { sessionId });
+      return { sent: false, errorMessage };
     }
   }
 
@@ -2489,13 +2576,20 @@ export function AgentWorkspace({
     const report = reviewableIssueReportsRef.current[sessionId];
     if (!report) return;
     setIssueReportSubmitting(sessionId, true);
+    let result: IssueReportDeliveryResult | undefined;
     try {
-      const sent = await deliverIssueReport(sessionId, report);
-      if (sent && reviewableIssueReportsRef.current[sessionId] === report) {
+      result = await deliverIssueReport(sessionId, report);
+      if (
+        result.sent &&
+        reviewableIssueReportsRef.current[sessionId] === report
+      ) {
         setReviewableIssueReport(sessionId, null);
       }
     } finally {
       setIssueReportSubmitting(sessionId, false);
+      if (result) {
+        dispatchIssueReportDeliverySettled({ sessionId, report, result });
+      }
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2481,7 +2481,7 @@ export function AgentWorkspace({
     setIssueReportSubmitting(sessionId, true);
     try {
       const sent = await deliverIssueReport(sessionId, report);
-      if (sent) {
+      if (sent && reviewableIssueReportsRef.current[sessionId] === report) {
         setReviewableIssueReport(sessionId, null);
       }
     } finally {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1248,6 +1248,9 @@ export function AgentWorkspace({
   const issueReportDiagnosisRefreshesRef = useRef<Map<string, Promise<void>>>(
     new Map(),
   );
+  const deferredFailedIssueReportDeliverySessionIdsRef = useRef<Set<string>>(
+    new Set(),
+  );
   const [submittingIssueReportSessionIds, setSubmittingIssueReportSessionIds] =
     useState<Set<string>>(
       () => new Set(continuity?.submittingIssueReportSessionIds ?? []),
@@ -1334,6 +1337,7 @@ export function AgentWorkspace({
     const issueReport = pendingIssueReportsRef.current.get(sessionId);
     if (!issueReport) return false;
     pendingIssueReportsRef.current.delete(sessionId);
+    deferredFailedIssueReportDeliverySessionIdsRef.current.delete(sessionId);
     setReviewableIssueReport(sessionId, issueReport);
     if (options.queueDiagnosisRefresh) {
       queueIssueReportDiagnosisRefresh(sessionId);
@@ -1361,6 +1365,9 @@ export function AgentWorkspace({
       if (!detail?.sessionId) return;
       setIssueReportSubmitting(detail.sessionId, false);
       if (detail.result.sent) {
+        deferredFailedIssueReportDeliverySessionIdsRef.current.delete(
+          detail.sessionId,
+        );
         if (
           reviewableIssueReportsRef.current[detail.sessionId] === detail.report
         ) {
@@ -1368,10 +1375,11 @@ export function AgentWorkspace({
         }
         return;
       }
-      if (
-        !pendingIssueReportsRef.current.has(detail.sessionId) &&
-        !reviewableIssueReportsRef.current[detail.sessionId]
-      ) {
+      if (pendingIssueReportsRef.current.has(detail.sessionId)) {
+        deferredFailedIssueReportDeliverySessionIdsRef.current.add(
+          detail.sessionId,
+        );
+      } else if (!reviewableIssueReportsRef.current[detail.sessionId]) {
         setReviewableIssueReport(detail.sessionId, detail.report);
       }
       setError(detail.result.errorMessage, { sessionId: detail.sessionId });
@@ -2469,6 +2477,11 @@ export function AgentWorkspace({
           ...(nextIssueReport ? { issueReport: nextIssueReport } : {}),
         },
       );
+      if (reportFollowUpSessionId) {
+        deferredFailedIssueReportDeliverySessionIdsRef.current.delete(
+          reportFollowUpSessionId,
+        );
+      }
       setError(null);
       setBusyNotice(null);
     } catch (err) {
@@ -2494,8 +2507,14 @@ export function AgentWorkspace({
         (!clearedIssueReportReview.deliveryWasSubmitting ||
           submittingIssueReportSessionIdsRef.current.has(
             clearedIssueReportReview.sessionId,
+          ) ||
+          deferredFailedIssueReportDeliverySessionIdsRef.current.has(
+            clearedIssueReportReview.sessionId,
           ))
       ) {
+        deferredFailedIssueReportDeliverySessionIdsRef.current.delete(
+          clearedIssueReportReview.sessionId,
+        );
         setReviewableIssueReport(
           clearedIssueReportReview.sessionId,
           clearedIssueReportReview.report,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -778,10 +778,18 @@ type IssueReportDeliverySettledDetail = {
   result: IssueReportDeliveryResult;
 };
 
+type IssueReportFollowUpSubmitFailedDetail = {
+  sessionId: string;
+  queuedReport: PendingIssueReport;
+  restoreReport?: PendingIssueReport;
+};
+
 let sessionContinuity: AgentSessionContinuity | null = null;
 const NEW_SESSION_DRAFT_KEY = "new-session";
 const ISSUE_REPORT_DELIVERY_SETTLED_EVENT =
   "june-agent-issue-report-delivery-settled";
+const ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT =
+  "june-agent-issue-report-follow-up-submit-failed";
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
 
 function sessionComposerDraftKey(sessionId: string) {
@@ -908,6 +916,39 @@ function updateContinuityAfterIssueReportDelivery(
   });
 }
 
+function updateContinuityAfterIssueReportFollowUpSubmitFailed(
+  detail: IssueReportFollowUpSubmitFailedDetail,
+) {
+  if (!sessionContinuity) return;
+  const pendingIssueReports = { ...sessionContinuity.pendingIssueReports };
+  if (pendingIssueReports[detail.sessionId] === detail.queuedReport) {
+    delete pendingIssueReports[detail.sessionId];
+  }
+  const reviewableIssueReports = {
+    ...sessionContinuity.reviewableIssueReports,
+  };
+  if (detail.restoreReport && !reviewableIssueReports[detail.sessionId]) {
+    reviewableIssueReports[detail.sessionId] = detail.restoreReport;
+  }
+  sessionContinuity = captureSessionContinuity({
+    sessionItems: sessionContinuity.sessionItems,
+    pendingMessages: sessionContinuity.pendingMessages,
+    workingSessionIds: new Set(sessionContinuity.workingSessionIds),
+    waitingSessionIds: new Set(sessionContinuity.waitingSessionIds),
+    runtimeSessionIds: sessionContinuity.runtimeSessionIds,
+    liveEvents: sessionContinuity.liveEvents,
+    titleOverrides: sessionContinuity.titleOverrides,
+    pendingIssueReports,
+    reviewableIssueReports,
+    diagnosisRefreshIssueReportSessionIds: new Set(
+      sessionContinuity.diagnosisRefreshIssueReportSessionIds,
+    ),
+    submittingIssueReportSessionIds: new Set(
+      sessionContinuity.submittingIssueReportSessionIds,
+    ),
+  });
+}
+
 function dispatchIssueReportDeliverySettled(
   detail: IssueReportDeliverySettledDetail,
 ) {
@@ -915,6 +956,18 @@ function dispatchIssueReportDeliverySettled(
   window.dispatchEvent(
     new CustomEvent<IssueReportDeliverySettledDetail>(
       ISSUE_REPORT_DELIVERY_SETTLED_EVENT,
+      { detail },
+    ),
+  );
+}
+
+function dispatchIssueReportFollowUpSubmitFailed(
+  detail: IssueReportFollowUpSubmitFailedDetail,
+) {
+  updateContinuityAfterIssueReportFollowUpSubmitFailed(detail);
+  window.dispatchEvent(
+    new CustomEvent<IssueReportFollowUpSubmitFailedDetail>(
+      ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT,
       { detail },
     ),
   );
@@ -1385,15 +1438,43 @@ export function AgentWorkspace({
       setError(detail.result.errorMessage, { sessionId: detail.sessionId });
     }
 
+    function onIssueReportFollowUpSubmitFailed(event: Event) {
+      const detail = (
+        event as CustomEvent<IssueReportFollowUpSubmitFailedDetail>
+      ).detail;
+      if (!detail?.sessionId) return;
+      if (
+        pendingIssueReportsRef.current.get(detail.sessionId) ===
+        detail.queuedReport
+      ) {
+        pendingIssueReportsRef.current.delete(detail.sessionId);
+      }
+      if (
+        detail.restoreReport &&
+        !reviewableIssueReportsRef.current[detail.sessionId]
+      ) {
+        setReviewableIssueReport(detail.sessionId, detail.restoreReport);
+      }
+    }
+
     window.addEventListener(
       ISSUE_REPORT_DELIVERY_SETTLED_EVENT,
       onIssueReportDeliverySettled,
     );
-    return () =>
+    window.addEventListener(
+      ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT,
+      onIssueReportFollowUpSubmitFailed,
+    );
+    return () => {
       window.removeEventListener(
         ISSUE_REPORT_DELIVERY_SETTLED_EVENT,
         onIssueReportDeliverySettled,
       );
+      window.removeEventListener(
+        ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT,
+        onIssueReportFollowUpSubmitFailed,
+      );
+    };
   }, [setError]);
 
   useEffect(() => {
@@ -2414,6 +2495,7 @@ export function AgentWorkspace({
       | {
           sessionId: string;
           report: PendingIssueReport;
+          queuedReport?: PendingIssueReport;
           deliveryWasSubmitting: boolean;
         }
       | undefined;
@@ -2460,6 +2542,7 @@ export function AgentWorkspace({
         clearedIssueReportReview = {
           sessionId: reportFollowUpSessionId,
           report: reportFollowUp,
+          queuedReport: nextIssueReport,
           deliveryWasSubmitting: submittingIssueReportSessionIdsRef.current.has(
             reportFollowUpSessionId,
           ),
@@ -2502,23 +2585,33 @@ export function AgentWorkspace({
           current.length ? current : attachments,
         );
       }
-      if (
-        clearedIssueReportReview &&
-        (!clearedIssueReportReview.deliveryWasSubmitting ||
+      if (clearedIssueReportReview) {
+        const shouldRestoreIssueReportReview =
+          !clearedIssueReportReview.deliveryWasSubmitting ||
           submittingIssueReportSessionIdsRef.current.has(
             clearedIssueReportReview.sessionId,
           ) ||
           deferredFailedIssueReportDeliverySessionIdsRef.current.has(
             clearedIssueReportReview.sessionId,
-          ))
-      ) {
-        deferredFailedIssueReportDeliverySessionIdsRef.current.delete(
-          clearedIssueReportReview.sessionId,
-        );
-        setReviewableIssueReport(
-          clearedIssueReportReview.sessionId,
-          clearedIssueReportReview.report,
-        );
+          );
+        if (clearedIssueReportReview.queuedReport) {
+          dispatchIssueReportFollowUpSubmitFailed({
+            sessionId: clearedIssueReportReview.sessionId,
+            queuedReport: clearedIssueReportReview.queuedReport,
+            ...(shouldRestoreIssueReportReview
+              ? { restoreReport: clearedIssueReportReview.report }
+              : {}),
+          });
+        }
+        if (shouldRestoreIssueReportReview) {
+          deferredFailedIssueReportDeliverySessionIdsRef.current.delete(
+            clearedIssueReportReview.sessionId,
+          );
+          setReviewableIssueReport(
+            clearedIssueReportReview.sessionId,
+            clearedIssueReportReview.report,
+          );
+        }
       }
       if (isSessionBusyError(err)) {
         // A busy rejection is proof the gateway is healthy — retire any stale

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1012,14 +1012,10 @@ function messageAfterIssueReportDiagnosisBoundary(
   report: PendingIssueReport,
 ) {
   if (!report.diagnosisStartedAt) return true;
-  if (message.timestamp === undefined) return false;
-  const messageTime =
-    typeof message.timestamp === "number"
-      ? message.timestamp
-      : Date.parse(message.timestamp);
+  const messageTime = hermesMessageTimestampMs(message);
   const boundaryTime = Date.parse(report.diagnosisStartedAt);
   if (!Number.isFinite(boundaryTime)) return true;
-  return Number.isFinite(messageTime) && messageTime >= boundaryTime;
+  return messageTime !== undefined && messageTime >= boundaryTime;
 }
 
 /** Test hook: the snapshot is module state, so a test that unmounts with a

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -794,6 +794,7 @@ const ISSUE_REPORT_DELIVERY_SETTLED_EVENT =
 const ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT =
   "june-agent-issue-report-follow-up-submit-failed";
 const ISSUE_REPORT_DIAGNOSIS_REFRESH_TIMEOUT_MS = 1500;
+const ISSUE_REPORT_DIAGNOSIS_BOUNDARY_SKEW_MS = 1500;
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
 
 function sessionComposerDraftKey(sessionId: string) {
@@ -1015,7 +1016,10 @@ function messageAfterIssueReportDiagnosisBoundary(
   const messageTime = hermesMessageTimestampMs(message);
   const boundaryTime = Date.parse(report.diagnosisStartedAt);
   if (!Number.isFinite(boundaryTime)) return true;
-  return messageTime !== undefined && messageTime >= boundaryTime;
+  return (
+    messageTime !== undefined &&
+    messageTime >= boundaryTime - ISSUE_REPORT_DIAGNOSIS_BOUNDARY_SKEW_MS
+  );
 }
 
 /** Test hook: the snapshot is module state, so a test that unmounts with a

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -744,7 +744,8 @@ type AgentWorkspaceProps = {
 // state that exists nowhere outside this component: the optimistic list entry
 // (title + preview), the just-sent user bubble Hermes hasn't persisted yet,
 // the working/waiting flags that drive the reconcile poll, the stored→runtime
-// session mapping, the buffered live events, and the title override.
+// session mapping, the buffered live events, the title override, and any
+// review-ready issue report draft waiting for the user to send.
 // Navigating away (e.g. to Settings) unmounts the workspace; without this
 // snapshot the remount restores only the selected id from localStorage, and a
 // session whose first turn hasn't persisted renders as an empty "Untitled
@@ -759,6 +760,7 @@ type AgentSessionContinuity = {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  reviewableIssueReports: Record<string, PendingIssueReport>;
 };
 
 let sessionContinuity: AgentSessionContinuity | null = null;
@@ -799,6 +801,7 @@ function captureSessionContinuity(state: {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  reviewableIssueReports: Record<string, PendingIssueReport>;
 }): AgentSessionContinuity | null {
   const activeIds = new Set([
     ...state.workingSessionIds,
@@ -806,6 +809,9 @@ function captureSessionContinuity(state: {
   ]);
   for (const [sessionId, pending] of Object.entries(state.pendingMessages)) {
     if (pending.length > 0) activeIds.add(sessionId);
+  }
+  for (const sessionId of Object.keys(state.reviewableIssueReports)) {
+    activeIds.add(sessionId);
   }
   if (activeIds.size === 0) return null;
   const pick = <T,>(record: Record<string, T>) =>
@@ -822,6 +828,7 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
+    reviewableIssueReports: pick(state.reviewableIssueReports),
   };
 }
 
@@ -1132,9 +1139,9 @@ export function AgentWorkspace({
   );
   const [reviewableIssueReports, setReviewableIssueReports] = useState<
     Record<string, PendingIssueReport>
-  >({});
+  >(() => continuity?.reviewableIssueReports ?? {});
   const reviewableIssueReportsRef = useRef<Record<string, PendingIssueReport>>(
-    {},
+    reviewableIssueReports,
   );
   const [submittingIssueReportSessionIds, setSubmittingIssueReportSessionIds] =
     useState<Set<string>>(() => new Set());
@@ -1961,6 +1968,7 @@ export function AgentWorkspace({
         runtimeSessionIds: runtimeSessionIdsRef.current,
         liveEvents: liveEventsRef.current,
         titleOverrides: sessionTitleOverridesRef.current,
+        reviewableIssueReports: reviewableIssueReportsRef.current,
       });
       for (const gateway of gatewaysRef.current.values()) {
         gateway.close();

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -745,7 +745,9 @@ type AgentWorkspaceProps = {
 // (title + preview), the just-sent user bubble Hermes hasn't persisted yet,
 // the working/waiting flags that drive the reconcile poll, the stored→runtime
 // session mapping, the buffered live events, the title override, and any
-// review-ready issue report draft waiting for the user to send.
+// queued issue report draft, the review-ready report waiting for the user to
+// send, and the delayed diagnosis refresh that makes the final June answer
+// available to the report payload.
 // Navigating away (e.g. to Settings) unmounts the workspace; without this
 // snapshot the remount restores only the selected id from localStorage, and a
 // session whose first turn hasn't persisted renders as an empty "Untitled
@@ -760,7 +762,9 @@ type AgentSessionContinuity = {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
+  diagnosisRefreshIssueReportSessionIds: string[];
   submittingIssueReportSessionIds: string[];
 };
 
@@ -814,7 +818,9 @@ function captureSessionContinuity(state: {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
+  diagnosisRefreshIssueReportSessionIds: Set<string>;
   submittingIssueReportSessionIds: Set<string>;
 }): AgentSessionContinuity | null {
   const activeIds = new Set([
@@ -825,6 +831,15 @@ function captureSessionContinuity(state: {
     if (pending.length > 0) activeIds.add(sessionId);
   }
   for (const sessionId of Object.keys(state.reviewableIssueReports)) {
+    activeIds.add(sessionId);
+  }
+  for (const sessionId of Object.keys(state.pendingIssueReports)) {
+    activeIds.add(sessionId);
+  }
+  for (const sessionId of state.diagnosisRefreshIssueReportSessionIds) {
+    activeIds.add(sessionId);
+  }
+  for (const sessionId of state.submittingIssueReportSessionIds) {
     activeIds.add(sessionId);
   }
   if (activeIds.size === 0) return null;
@@ -842,7 +857,11 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
+    pendingIssueReports: pick(state.pendingIssueReports),
     reviewableIssueReports: pick(state.reviewableIssueReports),
+    diagnosisRefreshIssueReportSessionIds: [
+      ...state.diagnosisRefreshIssueReportSessionIds,
+    ].filter((sessionId) => activeIds.has(sessionId)),
     submittingIssueReportSessionIds: [
       ...state.submittingIssueReportSessionIds,
     ].filter((sessionId) => activeIds.has(sessionId)),
@@ -856,12 +875,17 @@ function updateContinuityAfterIssueReportDelivery(
   const reviewableIssueReports = {
     ...sessionContinuity.reviewableIssueReports,
   };
+  const pendingIssueReports = { ...sessionContinuity.pendingIssueReports };
+  const diagnosisRefreshIssueReportSessionIds = new Set(
+    sessionContinuity.diagnosisRefreshIssueReportSessionIds,
+  );
   if (
     detail.result.sent &&
     reviewableIssueReports[detail.sessionId] === detail.report
   ) {
     delete reviewableIssueReports[detail.sessionId];
-  } else if (!detail.result.sent) {
+    diagnosisRefreshIssueReportSessionIds.delete(detail.sessionId);
+  } else if (!detail.result.sent && !pendingIssueReports[detail.sessionId]) {
     reviewableIssueReports[detail.sessionId] =
       reviewableIssueReports[detail.sessionId] ?? detail.report;
   }
@@ -873,7 +897,9 @@ function updateContinuityAfterIssueReportDelivery(
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
+    pendingIssueReports,
     reviewableIssueReports,
+    diagnosisRefreshIssueReportSessionIds,
     submittingIssueReportSessionIds: new Set(
       sessionContinuity.submittingIssueReportSessionIds.filter(
         (sessionId) => sessionId !== detail.sessionId,
@@ -1197,13 +1223,25 @@ export function AgentWorkspace({
   // diagnostic turn finishes, it moves to reviewableIssueReports so the user
   // can add context or send it.
   const pendingIssueReportsRef = useRef<Map<string, PendingIssueReport>>(
-    new Map(),
+    new Map(Object.entries(continuity?.pendingIssueReports ?? {})),
   );
   const [reviewableIssueReports, setReviewableIssueReports] = useState<
     Record<string, PendingIssueReport>
   >(() => continuity?.reviewableIssueReports ?? {});
   const reviewableIssueReportsRef = useRef<Record<string, PendingIssueReport>>(
     reviewableIssueReports,
+  );
+  const [
+    diagnosisRefreshIssueReportSessionIds,
+    setDiagnosisRefreshIssueReportSessionIds,
+  ] = useState<Set<string>>(
+    () => new Set(continuity?.diagnosisRefreshIssueReportSessionIds ?? []),
+  );
+  const diagnosisRefreshIssueReportSessionIdsRef = useRef<Set<string>>(
+    diagnosisRefreshIssueReportSessionIds,
+  );
+  const issueReportDiagnosisRefreshesRef = useRef<Map<string, Promise<void>>>(
+    new Map(),
   );
   const [submittingIssueReportSessionIds, setSubmittingIssueReportSessionIds] =
     useState<Set<string>>(
@@ -1243,6 +1281,63 @@ export function AgentWorkspace({
     setReviewableIssueReports(next);
   }
 
+  function setIssueReportDiagnosisRefreshing(
+    sessionId: string,
+    refreshing: boolean,
+  ) {
+    const next = new Set(diagnosisRefreshIssueReportSessionIdsRef.current);
+    if (refreshing) {
+      next.add(sessionId);
+    } else {
+      next.delete(sessionId);
+    }
+    diagnosisRefreshIssueReportSessionIdsRef.current = next;
+    setDiagnosisRefreshIssueReportSessionIds(next);
+  }
+
+  function queueIssueReportDiagnosisRefresh(sessionId: string, delayMs = 300) {
+    setIssueReportDiagnosisRefreshing(sessionId, true);
+    let refresh: Promise<void>;
+    refresh = new Promise<void>((resolve) => {
+      window.setTimeout(() => {
+        void refreshHermesSession(sessionId).finally(resolve);
+      }, delayMs);
+    }).finally(() => {
+      if (issueReportDiagnosisRefreshesRef.current.get(sessionId) === refresh) {
+        issueReportDiagnosisRefreshesRef.current.delete(sessionId);
+        setIssueReportDiagnosisRefreshing(sessionId, false);
+      }
+    });
+    issueReportDiagnosisRefreshesRef.current.set(sessionId, refresh);
+    return refresh;
+  }
+
+  function waitForIssueReportDiagnosisRefresh(sessionId: string) {
+    if (!diagnosisRefreshIssueReportSessionIdsRef.current.has(sessionId)) {
+      return Promise.resolve();
+    }
+    return (
+      issueReportDiagnosisRefreshesRef.current.get(sessionId) ??
+      queueIssueReportDiagnosisRefresh(sessionId)
+    );
+  }
+
+  function promotePendingIssueReportToReview(
+    sessionId: string,
+    options: { queueDiagnosisRefresh: boolean },
+  ) {
+    const issueReport = pendingIssueReportsRef.current.get(sessionId);
+    if (!issueReport) return false;
+    pendingIssueReportsRef.current.delete(sessionId);
+    setReviewableIssueReport(sessionId, issueReport);
+    if (options.queueDiagnosisRefresh) {
+      queueIssueReportDiagnosisRefresh(sessionId);
+    } else {
+      setIssueReportDiagnosisRefreshing(sessionId, false);
+    }
+    return true;
+  }
+
   function setIssueReportSubmitting(sessionId: string, submitting: boolean) {
     const next = new Set(submittingIssueReportSessionIdsRef.current);
     if (submitting) {
@@ -1268,7 +1363,10 @@ export function AgentWorkspace({
         }
         return;
       }
-      if (!reviewableIssueReportsRef.current[detail.sessionId]) {
+      if (
+        !pendingIssueReportsRef.current.has(detail.sessionId) &&
+        !reviewableIssueReportsRef.current[detail.sessionId]
+      ) {
         setReviewableIssueReport(detail.sessionId, detail.report);
       }
       setError(detail.result.errorMessage, { sessionId: detail.sessionId });
@@ -1284,6 +1382,12 @@ export function AgentWorkspace({
         onIssueReportDeliverySettled,
       );
   }, [setError]);
+
+  useEffect(() => {
+    for (const sessionId of diagnosisRefreshIssueReportSessionIdsRef.current) {
+      queueIssueReportDiagnosisRefresh(sessionId);
+    }
+  }, []);
 
   useEffect(() => {
     runtimeSessionIdsRef.current = runtimeSessionIds;
@@ -1974,6 +2078,9 @@ export function AgentWorkspace({
           setSessionWorking(selectedHermesSessionId, true);
         }
         if (sessionHasAssistantAfterLatestUser(combined)) {
+          promotePendingIssueReportToReview(selectedHermesSessionId, {
+            queueDiagnosisRefresh: false,
+          });
           const wasActive = sessionHasActiveWork(
             selectedHermesSessionId,
             workingSessionIdsRef.current,
@@ -2071,7 +2178,10 @@ export function AgentWorkspace({
         runtimeSessionIds: runtimeSessionIdsRef.current,
         liveEvents: liveEventsRef.current,
         titleOverrides: sessionTitleOverridesRef.current,
+        pendingIssueReports: Object.fromEntries(pendingIssueReportsRef.current),
         reviewableIssueReports: reviewableIssueReportsRef.current,
+        diagnosisRefreshIssueReportSessionIds:
+          diagnosisRefreshIssueReportSessionIdsRef.current,
         submittingIssueReportSessionIds:
           submittingIssueReportSessionIdsRef.current,
       });
@@ -2591,6 +2701,7 @@ export function AgentWorkspace({
     setIssueReportSubmitting(sessionId, true);
     let result: IssueReportDeliveryResult | undefined;
     try {
+      await waitForIssueReportDiagnosisRefresh(sessionId);
       result = await deliverIssueReport(sessionId, report);
       if (
         result.sent &&
@@ -2791,14 +2902,15 @@ export function AgentWorkspace({
         }
         // The diagnostic turn is over (even on error): let the user append
         // anything June's summary surfaced before sending the bundled report.
-        const issueReport = pendingIssueReportsRef.current.get(storedSessionId);
-        if (issueReport) {
-          pendingIssueReportsRef.current.delete(storedSessionId);
-          setReviewableIssueReport(storedSessionId, issueReport);
+        const promotedIssueReport = promotePendingIssueReportToReview(
+          storedSessionId,
+          { queueDiagnosisRefresh: true },
+        );
+        if (!promotedIssueReport) {
+          window.setTimeout(() => {
+            void refreshHermesSession(storedSessionId);
+          }, 300);
         }
-        window.setTimeout(() => {
-          void refreshHermesSession(storedSessionId);
-        }, 300);
       }
     });
     const unlisten = () => {
@@ -3086,6 +3198,9 @@ export function AgentWorkspace({
       if (
         sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])
       ) {
+        promotePendingIssueReportToReview(sessionId, {
+          queueDiagnosisRefresh: false,
+        });
         const wasActive = sessionHasActiveWork(
           sessionId,
           workingSessionIdsRef.current,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1376,12 +1376,19 @@ export function AgentWorkspace({
     issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
       ? issueReportNotice.message
       : null;
-  const visibleIssueReportReview = selectedHermesSessionId
+  const selectedIssueReportReview = selectedHermesSessionId
     ? reviewableIssueReports[selectedHermesSessionId]
     : undefined;
-  const visibleIssueReportSubmitting = selectedHermesSessionId
-    ? submittingIssueReportSessionIds.has(selectedHermesSessionId)
-    : false;
+  const visibleIssueReportReview =
+    selectedHermesSessionId && selectedIssueReportReview
+      ? {
+          report: selectedIssueReportReview,
+          sessionId: selectedHermesSessionId,
+          submitting: submittingIssueReportSessionIds.has(
+            selectedHermesSessionId,
+          ),
+        }
+      : undefined;
   // Holds the prior render's heroMode. Read by both the composer auto-grow
   // effect (to skip its glide across a hero transition) and the hero→dock FLIP
   // below (to detect the hero handoff); the FLIP effect, which runs last, is
@@ -3936,22 +3943,27 @@ export function AgentWorkspace({
               transition={{ duration: 0.22, ease: "easeOut" }}
             >
               <span>
-                {visibleIssueReportReview.followUps.length
+                {visibleIssueReportReview.report.followUps.length
                   ? "Follow-up added. Add more context in chat, or send it to the June team."
                   : "Report ready. Add more context in chat, or send it to the June team."}
               </span>
-              {selectedHermesSessionId ? (
-                <button
-                  type="button"
-                  className="agent-composer-notice-button"
-                  disabled={visibleIssueReportSubmitting}
-                  onClick={() =>
-                    void sendReviewableIssueReport(selectedHermesSessionId)
-                  }
-                >
-                  {visibleIssueReportSubmitting ? "Sending" : "Send report"}
-                </button>
-              ) : null}
+              <button
+                type="button"
+                className="agent-composer-notice-button"
+                disabled={visibleIssueReportReview.submitting}
+                onClick={() =>
+                  void sendReviewableIssueReport(
+                    visibleIssueReportReview.sessionId,
+                  )
+                }
+              >
+                {visibleIssueReportReview.submitting ? (
+                  <DotSpinner className="agent-composer-notice-button-spinner" />
+                ) : null}
+                {visibleIssueReportReview.submitting
+                  ? "Sending"
+                  : "Send report"}
+              </button>
             </motion.div>
           ) : visibleIssueReportNotice ? (
             <motion.p

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1068,6 +1068,11 @@ export function AgentWorkspace({
     },
     [],
   );
+  const clearErrorForSession = useCallback((sessionId: string) => {
+    setErrorState((current) =>
+      current?.sessionId === sessionId ? null : current,
+    );
+  }, []);
   const [heroGreeting, setHeroGreeting] = useState(advanceHeroGreeting);
   const heroGreetingConsumedRef = useRef(false);
   const [heroDeck, setHeroDeck] = useState(shuffleAgentShortcuts);
@@ -1588,6 +1593,9 @@ export function AgentWorkspace({
       : undefined;
   const visibleIssueReportHasUnsentContext = Boolean(
     visibleIssueReportReview && (draft.trim() || attachments.length),
+  );
+  const visibleIssueReportImportingFiles = Boolean(
+    visibleIssueReportReview && importingFiles,
   );
   // Holds the prior render's heroMode. Read by both the composer auto-grow
   // effect (to skip its glide across a hero transition) and the hero→dock FLIP
@@ -2679,6 +2687,7 @@ export function AgentWorkspace({
         attachmentPaths: report.attachmentPaths,
         sessionId,
       });
+      clearErrorForSession(sessionId);
       if (selectedHermesSessionIdRef.current === sessionId) {
         setIssueReportNotice({
           message:
@@ -4182,6 +4191,7 @@ export function AgentWorkspace({
                 className="agent-composer-notice-button"
                 disabled={
                   visibleIssueReportReview.submitting ||
+                  visibleIssueReportImportingFiles ||
                   visibleIssueReportHasUnsentContext
                 }
                 onClick={() =>
@@ -4190,14 +4200,17 @@ export function AgentWorkspace({
                   )
                 }
               >
-                {visibleIssueReportReview.submitting ? (
+                {visibleIssueReportReview.submitting ||
+                visibleIssueReportImportingFiles ? (
                   <DotSpinner className="agent-composer-notice-button-spinner" />
                 ) : null}
                 {visibleIssueReportReview.submitting
                   ? "Sending"
-                  : visibleIssueReportHasUnsentContext
-                    ? "Send message first"
-                    : "Send report"}
+                  : visibleIssueReportImportingFiles
+                    ? "Attaching files"
+                    : visibleIssueReportHasUnsentContext
+                      ? "Send message first"
+                      : "Send report"}
               </button>
             </motion.div>
           ) : visibleIssueReportNotice ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -657,6 +657,7 @@ export type AgentNewSessionDetail = {
 type PendingIssueReport = {
   category: ReportCategory;
   description: string;
+  followUps: string[];
   attachmentNames: string[];
   /** Workspace paths captured at submit, so the files can be uploaded with
    * the report even after the composer clears its attachment chips. */
@@ -821,6 +822,36 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
+  };
+}
+
+function issueReportDescription(report: PendingIssueReport) {
+  const followUps = report.followUps
+    .map((followUp) => followUp.trim())
+    .filter(Boolean);
+  if (followUps.length === 0) return report.description;
+  return [
+    report.description,
+    "",
+    "Follow-up comments:",
+    ...followUps.map((followUp, index) => `${index + 1}. ${followUp}`),
+  ].join("\n");
+}
+
+function appendIssueReportFollowUp(
+  report: PendingIssueReport,
+  followUp: string,
+  attachmentNames: string[],
+  attachmentPaths: string[],
+): PendingIssueReport {
+  return {
+    ...report,
+    followUps: [
+      ...report.followUps,
+      followUp.trim() || "No follow-up text was typed; see the attachments.",
+    ],
+    attachmentNames: [...report.attachmentNames, ...attachmentNames],
+    attachmentPaths: [...report.attachmentPaths, ...attachmentPaths],
   };
 }
 
@@ -1093,11 +1124,21 @@ export function AgentWorkspace({
   // the fetch *started*) — the scroll-settling logic needs the landing.
   const taskHistoryLoadedIdsRef = useRef<Set<string>>(new Set());
   const newSessionModeRef = useRef(newSessionMode);
-  // sessionId -> the report captured at submit time, delivered to the June
-  // team once the agent's diagnostic turn reaches a terminal event.
+  // sessionId -> the report captured for the active report turn. Once June's
+  // diagnostic turn finishes, it moves to reviewableIssueReports so the user
+  // can add context or send it.
   const pendingIssueReportsRef = useRef<Map<string, PendingIssueReport>>(
     new Map(),
   );
+  const [reviewableIssueReports, setReviewableIssueReports] = useState<
+    Record<string, PendingIssueReport>
+  >({});
+  const reviewableIssueReportsRef = useRef<Record<string, PendingIssueReport>>(
+    {},
+  );
+  const [submittingIssueReportSessionIds, setSubmittingIssueReportSessionIds] =
+    useState<Set<string>>(() => new Set());
+  const submittingIssueReportSessionIdsRef = useRef<Set<string>>(new Set());
   // True only while a brand-new thread is being started from the hero. The
   // hero→dock composer FLIP keys off this so it glides *only* when the empty
   // chat hands over to a fresh thread — not when the hero is dismissed by
@@ -1114,6 +1155,35 @@ export function AgentWorkspace({
   // A category to seed into the composer chip once the editor is ready, set by
   // startNewTask for the sidebar/settings report entry points.
   const pendingSeedCategoryRef = useRef<ReportCategory | null>(null);
+
+  function setReviewableIssueReport(
+    sessionId: string,
+    report: PendingIssueReport | null,
+  ) {
+    setReviewableIssueReports((current) => {
+      const next = { ...current };
+      if (report) {
+        next[sessionId] = report;
+      } else {
+        delete next[sessionId];
+      }
+      reviewableIssueReportsRef.current = next;
+      return next;
+    });
+  }
+
+  function setIssueReportSubmitting(sessionId: string, submitting: boolean) {
+    setSubmittingIssueReportSessionIds((current) => {
+      const next = new Set(current);
+      if (submitting) {
+        next.add(sessionId);
+      } else {
+        next.delete(sessionId);
+      }
+      submittingIssueReportSessionIdsRef.current = next;
+      return next;
+    });
+  }
 
   useEffect(() => {
     runtimeSessionIdsRef.current = runtimeSessionIds;
@@ -1299,6 +1369,12 @@ export function AgentWorkspace({
     issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
       ? issueReportNotice.message
       : null;
+  const visibleIssueReportReview = selectedHermesSessionId
+    ? reviewableIssueReports[selectedHermesSessionId]
+    : undefined;
+  const visibleIssueReportSubmitting = selectedHermesSessionId
+    ? submittingIssueReportSessionIds.has(selectedHermesSessionId)
+    : false;
   // Holds the prior render's heroMode. Read by both the composer auto-grow
   // effect (to skip its glide across a hero transition) and the hero→dock FLIP
   // below (to detect the hero handoff); the FLIP effect, which runs last, is
@@ -2079,6 +2155,13 @@ export function AgentWorkspace({
     // frame it for the team and queue the delivery. Captured before the
     // composer clears so a failed send can restore the chip on retry.
     const reportCategory = category;
+    const reportFollowUpSessionId =
+      !reportCategory && selectedHermesSessionId
+        ? selectedHermesSessionId
+        : null;
+    const reportFollowUp = reportFollowUpSessionId
+      ? reviewableIssueReportsRef.current[reportFollowUpSessionId]
+      : undefined;
     const submittedDraftKey = composerDraftKeyRef.current;
     // A typed hero submit plays the same teardown as a run shortcut: greeting
     // up, suggestions down during the session-create latency. Without it they
@@ -2088,8 +2171,31 @@ export function AgentWorkspace({
     setSubmitting(true);
     let clearedDraft = false;
     let clearedAttachments = false;
+    let clearedIssueReportReview:
+      | { sessionId: string; report: PendingIssueReport }
+      | undefined;
     try {
       const prepared = await prepareComposerSubmission(message, attachments);
+      const nextIssueReport: PendingIssueReport | undefined = reportCategory
+        ? {
+            category: reportCategory,
+            // An attachments-only send has no typed text, but the server
+            // requires a description; the report must not bounce there.
+            description:
+              prepared.typedMessage ||
+              "No description was typed; see the attachments.",
+            followUps: [],
+            attachmentNames: attachments.map((attachment) => attachment.name),
+            attachmentPaths: attachments.map((attachment) => attachment.path),
+          }
+        : reportFollowUp
+          ? appendIssueReportFollowUp(
+              reportFollowUp,
+              prepared.typedMessage,
+              attachments.map((attachment) => attachment.name),
+              attachments.map((attachment) => attachment.path),
+            )
+          : undefined;
       if (
         draftRef.current.trim() === message &&
         categoryRef.current === reportCategory
@@ -2106,6 +2212,13 @@ export function AgentWorkspace({
         setComposerAttachments([]);
         clearedAttachments = true;
       }
+      if (reportFollowUpSessionId && reportFollowUp) {
+        setReviewableIssueReport(reportFollowUpSessionId, null);
+        clearedIssueReportReview = {
+          sessionId: reportFollowUpSessionId,
+          report: reportFollowUp,
+        };
+      }
       setIssueReportNotice(null);
       await submitHermesSession(
         reportCategory
@@ -2115,24 +2228,7 @@ export function AgentWorkspace({
         {
           displayContent: prepared.displayContent,
           titleContent: prepared.titleContent,
-          ...(reportCategory
-            ? {
-                issueReport: {
-                  category: reportCategory,
-                  // An attachments-only send has no typed text, but the server
-                  // requires a description; the report must not bounce there.
-                  description:
-                    prepared.typedMessage ||
-                    "No description was typed; see the attachments.",
-                  attachmentNames: attachments.map(
-                    (attachment) => attachment.name,
-                  ),
-                  attachmentPaths: attachments.map(
-                    (attachment) => attachment.path,
-                  ),
-                },
-              }
-            : {}),
+          ...(nextIssueReport ? { issueReport: nextIssueReport } : {}),
         },
       );
       setError(null);
@@ -2153,6 +2249,12 @@ export function AgentWorkspace({
       if (clearedAttachments) {
         setComposerAttachments((current) =>
           current.length ? current : attachments,
+        );
+      }
+      if (clearedIssueReportReview) {
+        setReviewableIssueReport(
+          clearedIssueReportReview.sessionId,
+          clearedIssueReportReview.report,
         );
       }
       if (isSessionBusyError(err)) {
@@ -2317,7 +2419,7 @@ export function AgentWorkspace({
   async function deliverIssueReport(
     sessionId: string,
     report: PendingIssueReport,
-  ) {
+  ): Promise<boolean> {
     let agentDiagnosis: string | undefined;
     try {
       const messages = await listHermesSessionMessages(sessionId);
@@ -2335,7 +2437,7 @@ export function AgentWorkspace({
     try {
       await submitIssueReport({
         category: report.category,
-        description: report.description,
+        description: issueReportDescription(report),
         agentDiagnosis,
         attachmentNames: report.attachmentNames,
         attachmentPaths: report.attachmentPaths,
@@ -2348,10 +2450,27 @@ export function AgentWorkspace({
           sessionId,
         });
       }
+      return true;
     } catch (err) {
       setError(`The issue report could not be sent. ${messageFromError(err)}`, {
         sessionId,
       });
+      return false;
+    }
+  }
+
+  async function sendReviewableIssueReport(sessionId: string) {
+    if (submittingIssueReportSessionIdsRef.current.has(sessionId)) return;
+    const report = reviewableIssueReportsRef.current[sessionId];
+    if (!report) return;
+    setIssueReportSubmitting(sessionId, true);
+    try {
+      const sent = await deliverIssueReport(sessionId, report);
+      if (sent) {
+        setReviewableIssueReport(sessionId, null);
+      }
+    } finally {
+      setIssueReportSubmitting(sessionId, false);
     }
   }
 
@@ -2399,7 +2518,7 @@ export function AgentWorkspace({
     const storedSessionId =
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
-    if (options?.issueReport && !targetSessionId) {
+    if (options?.issueReport) {
       pendingIssueReportsRef.current.set(storedSessionId, options.issueReport);
     }
     if (!targetSessionId) {
@@ -2538,8 +2657,8 @@ export function AgentWorkspace({
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);
         }
-        // The diagnostic turn is over (even on error): file the report now so
-        // the user's description isn't lost to a failed investigation.
+        // The diagnostic turn is over (even on error): let the user append
+        // anything June's summary surfaced before sending the bundled report.
         const issueReport = pendingIssueReportsRef.current.get(storedSessionId);
         if (issueReport) {
           pendingIssueReportsRef.current.delete(storedSessionId);
@@ -2547,7 +2666,7 @@ export function AgentWorkspace({
         window.setTimeout(() => {
           void refreshHermesSession(storedSessionId);
           if (issueReport) {
-            void deliverIssueReport(storedSessionId, issueReport);
+            setReviewableIssueReport(storedSessionId, issueReport);
           }
         }, 300);
       }
@@ -2569,7 +2688,7 @@ export function AgentWorkspace({
       });
     } catch (err) {
       // A queued report must not outlive its failed prompt; submit() re-arms
-      // issue-report mode so the retry files it again.
+      // issue-report mode so the retry can queue it again.
       pendingIssueReportsRef.current.delete(storedSessionId);
       // The prompt never entered the session, so its optimistic bubble must
       // not linger — a retained pending message renders below every later
@@ -3798,6 +3917,34 @@ export function AgentWorkspace({
               <DotSpinner />
               {busyNotice ?? SESSION_BUSY_NOTICE}
             </motion.p>
+          ) : visibleIssueReportReview ? (
+            <motion.div
+              key="issue-report-review"
+              className="agent-composer-notice agent-composer-notice-action"
+              role="status"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.22, ease: "easeOut" }}
+            >
+              <span>
+                {visibleIssueReportReview.followUps.length
+                  ? "Follow-up added. Add more context in chat, or send it to the June team."
+                  : "Report ready. Add more context in chat, or send it to the June team."}
+              </span>
+              {selectedHermesSessionId ? (
+                <button
+                  type="button"
+                  className="agent-composer-notice-button"
+                  disabled={visibleIssueReportSubmitting}
+                  onClick={() =>
+                    void sendReviewableIssueReport(selectedHermesSessionId)
+                  }
+                >
+                  {visibleIssueReportSubmitting ? "Sending" : "Send report"}
+                </button>
+              ) : null}
+            </motion.div>
           ) : visibleIssueReportNotice ? (
             <motion.p
               key="issue-report-notice"

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -802,6 +802,7 @@ function captureSessionContinuity(state: {
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
+  submittingIssueReportSessionIds: Set<string>;
 }): AgentSessionContinuity | null {
   const activeIds = new Set([
     ...state.workingSessionIds,
@@ -811,7 +812,9 @@ function captureSessionContinuity(state: {
     if (pending.length > 0) activeIds.add(sessionId);
   }
   for (const sessionId of Object.keys(state.reviewableIssueReports)) {
-    activeIds.add(sessionId);
+    if (!state.submittingIssueReportSessionIds.has(sessionId)) {
+      activeIds.add(sessionId);
+    }
   }
   if (activeIds.size === 0) return null;
   const pick = <T,>(record: Record<string, T>) =>
@@ -828,7 +831,13 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
-    reviewableIssueReports: pick(state.reviewableIssueReports),
+    reviewableIssueReports: Object.fromEntries(
+      Object.entries(state.reviewableIssueReports).filter(
+        ([sessionId]) =>
+          activeIds.has(sessionId) &&
+          !state.submittingIssueReportSessionIds.has(sessionId),
+      ),
+    ),
   };
 }
 
@@ -1167,29 +1176,25 @@ export function AgentWorkspace({
     sessionId: string,
     report: PendingIssueReport | null,
   ) {
-    setReviewableIssueReports((current) => {
-      const next = { ...current };
-      if (report) {
-        next[sessionId] = report;
-      } else {
-        delete next[sessionId];
-      }
-      reviewableIssueReportsRef.current = next;
-      return next;
-    });
+    const next = { ...reviewableIssueReportsRef.current };
+    if (report) {
+      next[sessionId] = report;
+    } else {
+      delete next[sessionId];
+    }
+    reviewableIssueReportsRef.current = next;
+    setReviewableIssueReports(next);
   }
 
   function setIssueReportSubmitting(sessionId: string, submitting: boolean) {
-    setSubmittingIssueReportSessionIds((current) => {
-      const next = new Set(current);
-      if (submitting) {
-        next.add(sessionId);
-      } else {
-        next.delete(sessionId);
-      }
-      submittingIssueReportSessionIdsRef.current = next;
-      return next;
-    });
+    const next = new Set(submittingIssueReportSessionIdsRef.current);
+    if (submitting) {
+      next.add(sessionId);
+    } else {
+      next.delete(sessionId);
+    }
+    submittingIssueReportSessionIdsRef.current = next;
+    setSubmittingIssueReportSessionIds(next);
   }
 
   useEffect(() => {
@@ -1976,6 +1981,8 @@ export function AgentWorkspace({
         liveEvents: liveEventsRef.current,
         titleOverrides: sessionTitleOverridesRef.current,
         reviewableIssueReports: reviewableIssueReportsRef.current,
+        submittingIssueReportSessionIds:
+          submittingIssueReportSessionIdsRef.current,
       });
       for (const gateway of gatewaysRef.current.values()) {
         gateway.close();
@@ -2677,12 +2684,10 @@ export function AgentWorkspace({
         const issueReport = pendingIssueReportsRef.current.get(storedSessionId);
         if (issueReport) {
           pendingIssueReportsRef.current.delete(storedSessionId);
+          setReviewableIssueReport(storedSessionId, issueReport);
         }
         window.setTimeout(() => {
           void refreshHermesSession(storedSessionId);
-          if (issueReport) {
-            setReviewableIssueReport(storedSessionId, issueReport);
-          }
         }, 300);
       }
     });

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2364,7 +2364,12 @@ export function AgentWorkspace({
           current.length ? current : attachments,
         );
       }
-      if (clearedIssueReportReview) {
+      if (
+        clearedIssueReportReview &&
+        submittingIssueReportSessionIdsRef.current.has(
+          clearedIssueReportReview.sessionId,
+        )
+      ) {
         setReviewableIssueReport(
           clearedIssueReportReview.sessionId,
           clearedIssueReportReview.report,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2285,7 +2285,11 @@ export function AgentWorkspace({
     let clearedDraft = false;
     let clearedAttachments = false;
     let clearedIssueReportReview:
-      | { sessionId: string; report: PendingIssueReport }
+      | {
+          sessionId: string;
+          report: PendingIssueReport;
+          deliveryWasSubmitting: boolean;
+        }
       | undefined;
     try {
       const prepared = await prepareComposerSubmission(message, attachments);
@@ -2330,6 +2334,9 @@ export function AgentWorkspace({
         clearedIssueReportReview = {
           sessionId: reportFollowUpSessionId,
           report: reportFollowUp,
+          deliveryWasSubmitting: submittingIssueReportSessionIdsRef.current.has(
+            reportFollowUpSessionId,
+          ),
         };
       }
       setIssueReportNotice(null);
@@ -2366,9 +2373,10 @@ export function AgentWorkspace({
       }
       if (
         clearedIssueReportReview &&
-        submittingIssueReportSessionIdsRef.current.has(
-          clearedIssueReportReview.sessionId,
-        )
+        (!clearedIssueReportReview.deliveryWasSubmitting ||
+          submittingIssueReportSessionIdsRef.current.has(
+            clearedIssueReportReview.sessionId,
+          ))
       ) {
         setReviewableIssueReport(
           clearedIssueReportReview.sessionId,

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -789,6 +789,8 @@ type IssueReportFollowUpSubmitFailedDetail = {
 
 let sessionContinuity: AgentSessionContinuity | null = null;
 const NEW_SESSION_DRAFT_KEY = "new-session";
+const REVIEWABLE_ISSUE_REPORTS_STORAGE_KEY =
+  "scribe:agent:reviewable-issue-reports";
 const ISSUE_REPORT_DELIVERY_SETTLED_EVENT =
   "june-agent-issue-report-delivery-settled";
 const ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT =
@@ -881,6 +883,82 @@ function captureSessionContinuity(state: {
   };
 }
 
+function persistedReviewableIssueReports(): Record<string, PendingIssueReport> {
+  try {
+    const raw = window.localStorage.getItem(
+      REVIEWABLE_ISSUE_REPORTS_STORAGE_KEY,
+    );
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>)
+        .map(([sessionId, value]) => [sessionId, persistedIssueReport(value)])
+        .filter(
+          (entry): entry is [string, PendingIssueReport] =>
+            typeof entry[0] === "string" && entry[1] !== undefined,
+        ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function persistReviewableIssueReports(
+  reports: Record<string, PendingIssueReport>,
+) {
+  try {
+    const entries = Object.entries(reports);
+    if (entries.length === 0) {
+      window.localStorage.removeItem(REVIEWABLE_ISSUE_REPORTS_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(
+      REVIEWABLE_ISSUE_REPORTS_STORAGE_KEY,
+      JSON.stringify(Object.fromEntries(entries)),
+    );
+  } catch {
+    // Best-effort: app reload restore can fail without blocking the report flow.
+  }
+}
+
+function persistedIssueReport(value: unknown): PendingIssueReport | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const candidate = value as Partial<PendingIssueReport>;
+  if (
+    !isReportCategory(candidate.category) ||
+    typeof candidate.description !== "string" ||
+    !Array.isArray(candidate.followUps) ||
+    !Array.isArray(candidate.attachmentNames) ||
+    !Array.isArray(candidate.attachmentPaths)
+  ) {
+    return undefined;
+  }
+  const followUps = candidate.followUps.filter(
+    (followUp): followUp is string => typeof followUp === "string",
+  );
+  const attachmentNames = candidate.attachmentNames.filter(
+    (name): name is string => typeof name === "string",
+  );
+  const attachmentPaths = candidate.attachmentPaths.filter(
+    (path): path is string => typeof path === "string",
+  );
+  return {
+    category: candidate.category,
+    description: candidate.description,
+    followUps,
+    attachmentNames,
+    attachmentPaths,
+    ...(typeof candidate.diagnosisStartedAt === "string"
+      ? { diagnosisStartedAt: candidate.diagnosisStartedAt }
+      : {}),
+  };
+}
+
 function updateContinuityAfterIssueReportDelivery(
   detail: IssueReportDeliverySettledDetail,
 ) {
@@ -902,6 +980,7 @@ function updateContinuityAfterIssueReportDelivery(
     reviewableIssueReports[detail.sessionId] =
       reviewableIssueReports[detail.sessionId] ?? detail.report;
   }
+  persistReviewableIssueReports(reviewableIssueReports);
   sessionContinuity = captureSessionContinuity({
     sessionItems: sessionContinuity.sessionItems,
     pendingMessages: sessionContinuity.pendingMessages,
@@ -935,6 +1014,7 @@ function updateContinuityAfterIssueReportFollowUpSubmitFailed(
   if (detail.restoreReport && !reviewableIssueReports[detail.sessionId]) {
     reviewableIssueReports[detail.sessionId] = detail.restoreReport;
   }
+  persistReviewableIssueReports(reviewableIssueReports);
   sessionContinuity = captureSessionContinuity({
     sessionItems: sessionContinuity.sessionItems,
     pendingMessages: sessionContinuity.pendingMessages,
@@ -1304,7 +1384,10 @@ export function AgentWorkspace({
   );
   const [reviewableIssueReports, setReviewableIssueReports] = useState<
     Record<string, PendingIssueReport>
-  >(() => continuity?.reviewableIssueReports ?? {});
+  >(() => ({
+    ...persistedReviewableIssueReports(),
+    ...(continuity?.reviewableIssueReports ?? {}),
+  }));
   const reviewableIssueReportsRef = useRef<Record<string, PendingIssueReport>>(
     reviewableIssueReports,
   );
@@ -1358,6 +1441,7 @@ export function AgentWorkspace({
       delete next[sessionId];
     }
     reviewableIssueReportsRef.current = next;
+    persistReviewableIssueReports(next);
     setReviewableIssueReports(next);
   }
 
@@ -3899,6 +3983,8 @@ export function AgentWorkspace({
       return next;
     });
     scrubHermesSessionState(sessionId);
+    pendingIssueReportsRef.current.delete(sessionId);
+    setReviewableIssueReport(sessionId, null);
     forgetComposerDraft(sessionComposerDraftKey(sessionId));
     // Every deletion funnels through here (the in-workspace delete and the
     // sidebar/sessions-list AGENT_DELETE_SESSION_EVENT), so this is the one

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -662,6 +662,9 @@ type PendingIssueReport = {
   /** Workspace paths captured at submit, so the files can be uploaded with
    * the report even after the composer clears its attachment chips. */
   attachmentPaths: string[];
+  /** Existing sessions can have old assistant replies; only use diagnoses
+   * produced after this queued report turn started. */
+  diagnosisStartedAt?: string;
 };
 
 type AgentWorkspaceError = {
@@ -790,6 +793,7 @@ const ISSUE_REPORT_DELIVERY_SETTLED_EVENT =
   "june-agent-issue-report-delivery-settled";
 const ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT =
   "june-agent-issue-report-follow-up-submit-failed";
+const ISSUE_REPORT_DIAGNOSIS_REFRESH_TIMEOUT_MS = 1500;
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
 
 function sessionComposerDraftKey(sessionId: string) {
@@ -1001,6 +1005,21 @@ function appendIssueReportFollowUp(
     attachmentNames: [...report.attachmentNames, ...attachmentNames],
     attachmentPaths: [...report.attachmentPaths, ...attachmentPaths],
   };
+}
+
+function messageAfterIssueReportDiagnosisBoundary(
+  message: HermesSessionMessage,
+  report: PendingIssueReport,
+) {
+  if (!report.diagnosisStartedAt) return true;
+  if (message.timestamp === undefined) return false;
+  const messageTime =
+    typeof message.timestamp === "number"
+      ? message.timestamp
+      : Date.parse(message.timestamp);
+  const boundaryTime = Date.parse(report.diagnosisStartedAt);
+  if (!Number.isFinite(boundaryTime)) return true;
+  return Number.isFinite(messageTime) && messageTime >= boundaryTime;
 }
 
 /** Test hook: the snapshot is module state, so a test that unmounts with a
@@ -2782,6 +2801,9 @@ export function AgentWorkspace({
       agentDiagnosis = messages
         .slice()
         .reverse()
+        .filter((message) =>
+          messageAfterIssueReportDiagnosisBoundary(message, report),
+        )
         .map((message) =>
           message.role === "assistant" ? visibleHermesMessageText(message) : "",
         )
@@ -2822,7 +2844,11 @@ export function AgentWorkspace({
     setIssueReportSubmitting(sessionId, true);
     let result: IssueReportDeliveryResult | undefined;
     try {
-      await waitForIssueReportDiagnosisRefresh(sessionId);
+      await withTimeout(
+        waitForIssueReportDiagnosisRefresh(sessionId),
+        ISSUE_REPORT_DIAGNOSIS_REFRESH_TIMEOUT_MS,
+        "Issue report diagnosis refresh timed out.",
+      ).catch(() => undefined);
       result = await deliverIssueReport(sessionId, report);
       if (
         result.sent &&
@@ -2883,6 +2909,9 @@ export function AgentWorkspace({
       targetSessionId ?? created?.stored_session_id ?? created?.session_id;
     if (!storedSessionId) throw new Error("Hermes did not create a session.");
     const queuedIssueReport = options?.issueReport;
+    if (queuedIssueReport && targetSessionId) {
+      queuedIssueReport.diagnosisStartedAt = new Date().toISOString();
+    }
     const clearQueuedIssueReport = () => {
       if (
         queuedIssueReport &&

--- a/src/lib/issue-report-prompt.ts
+++ b/src/lib/issue-report-prompt.ts
@@ -14,34 +14,34 @@ const USER_REPORT_END = "---END USER REPORT---";
 
 const PREAMBLES: Record<ReportCategory, string[]> = {
   bug: [
-    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report and sent to the June development team, so write it for them.",
+    "The user is filing a bug report about the June desktop app. This conversation is part of the in-app reporting flow: your reply will be attached to the report draft before it is sent to the June development team, so write it for them.",
     "",
     "Do not try to fix the issue or walk the user through troubleshooting. Instead:",
     "1. Read the report below and inspect any attached files or screenshots closely. Describe exactly what they show, including any visible error text.",
     "2. Give your assessment of what is going wrong and which part of the app is likely involved.",
     "3. Note anything else the team should look at.",
     "",
-    "Keep it concise and factual. Close by thanking the user and letting them know the report and your assessment are being sent to the June team.",
+    "Keep it concise and factual. Close by thanking the user and letting them know they can add more context before sending it to the June team.",
   ],
   feedback: [
-    "The user is sharing feedback about the June desktop app. This conversation is part of the in-app feedback flow: your reply will be attached to the feedback and sent to the June development team, so write it for them.",
+    "The user is sharing feedback about the June desktop app. This conversation is part of the in-app feedback flow: your reply will be attached to the feedback draft before it is sent to the June development team, so write it for them.",
     "",
     "Do not treat this as a task to act on. Instead:",
     "1. Read the feedback below and inspect any attached files or screenshots closely. Describe what they show.",
     "2. Reflect back what you heard in a sentence or two, and note which part of the app it concerns.",
     "3. Note anything else the team should weigh.",
     "",
-    "Keep it concise and warm. Close by thanking the user and letting them know their feedback and your summary are being sent to the June team.",
+    "Keep it concise and warm. Close by thanking the user and letting them know they can add more context before sending it to the June team.",
   ],
   feature: [
-    "The user is requesting a feature for the June desktop app. This conversation is part of the in-app request flow: your reply will be attached to the request and sent to the June development team, so write it for them.",
+    "The user is requesting a feature for the June desktop app. This conversation is part of the in-app request flow: your reply will be attached to the request draft before it is sent to the June development team, so write it for them.",
     "",
     "Do not try to build or prototype the feature. Instead:",
     "1. Read the request below and inspect any attached files or screenshots closely. Describe what they show.",
     "2. Summarize the request and the underlying need or problem it would solve, and note which part of the app it touches.",
     "3. Note anything else the team should consider.",
     "",
-    "Keep it concise and constructive. Close by thanking the user and letting them know their request and your summary are being sent to the June team.",
+    "Keep it concise and constructive. Close by thanking the user and letting them know they can add more context before sending it to the June team.",
   ],
 };
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2754,6 +2754,9 @@ input:focus-visible,
 
 .agent-composer-notice-button {
   appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--card);
@@ -2772,6 +2775,10 @@ input:focus-visible,
 .agent-composer-notice-button:disabled {
   cursor: default;
   opacity: 0.62;
+}
+
+.agent-composer-notice-button-spinner {
+  flex-shrink: 0;
 }
 
 /* No per-state / collapsed overrides or left transition needed: the single

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2777,6 +2777,11 @@ input:focus-visible,
   opacity: 0.62;
 }
 
+.agent-composer-notice-button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
 .agent-composer-notice-button-spinner {
   flex-shrink: 0;
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2747,6 +2747,33 @@ input:focus-visible,
   flex-shrink: 0;
 }
 
+.agent-composer-notice-action {
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.agent-composer-notice-button {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--card);
+  color: var(--foreground);
+  padding: var(--sp-1) var(--sp-2);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.agent-composer-notice-button:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--foreground) 32%, var(--border));
+  background: color-mix(in oklch, var(--card) 88%, var(--muted));
+}
+
+.agent-composer-notice-button:disabled {
+  cursor: default;
+  opacity: 0.62;
+}
+
 /* No per-state / collapsed overrides or left transition needed: the single
  * max(--sidebar-w-current, --sp-3) rule above already tracks the card edge in
  * every state, and animating that one variable tweens it in lockstep. */

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -666,6 +666,76 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("uses created_at for existing-session report diagnosis filtering", async () => {
+    const user = userEvent.setup();
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "Earlier unrelated diagnosis.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Attach files or tag this message",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Bug report" }),
+    );
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes from this existing chat",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-1" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "Earlier unrelated diagnosis.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The report turn reproduced the crash.",
+        created_at: Math.ceil((Date.now() + 5000) / 1000),
+      },
+    ]);
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: "The recorder crashes from this existing chat",
+        agentDiagnosis: "The report turn reproduced the crash.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-1",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("sends a report when the diagnosis refresh stalls", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -736,6 +736,59 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("allows second-precision diagnosis timestamps near the report boundary", async () => {
+    const user = userEvent.setup();
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The same-second diagnosis is relevant.",
+        created_at: Date.parse("2026-06-11T10:00:10Z") / 1000,
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await screen.findByRole("textbox");
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("june-agent-issue-report-delivery-settled", {
+          detail: {
+            sessionId: "session-1",
+            report: {
+              category: "bug",
+              description: "The recorder crashes from this existing chat",
+              followUps: [],
+              attachmentNames: [],
+              attachmentPaths: [],
+              diagnosisStartedAt: "2026-06-11T10:00:10.750Z",
+            },
+            result: {
+              sent: false,
+              errorMessage: "The issue report could not be sent. Network down.",
+            },
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: "The recorder crashes from this existing chat",
+        agentDiagnosis: "The same-second diagnosis is relevant.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-1",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("sends a report when the diagnosis refresh stalls", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1433,6 +1433,82 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("does not promote a queued report follow-up after resume fails", async () => {
+    const user = userEvent.setup();
+    const report = {
+      category: "bug" as const,
+      description: "The recorder crashes after long meetings",
+      followUps: [],
+      attachmentNames: [],
+      attachmentPaths: [],
+    };
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.reject(new Error("runtime mapping lost"));
+      }
+      return Promise.resolve({});
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    const { unmount } = render(
+      <AgentWorkspace initialSession={existingSession} />,
+    );
+
+    await screen.findByRole("textbox");
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("june-agent-issue-report-delivery-settled", {
+          detail: {
+            sessionId: "session-1",
+            report,
+            result: {
+              sent: false,
+              errorMessage: "The issue report could not be sent. Network down.",
+            },
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.resume", {
+        session_id: "session-1",
+        cols: 96,
+      }),
+    );
+    expect(await screen.findByText("runtime mapping lost")).toBeInTheDocument();
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(screen.queryByText(/Follow-up added/)).toBeNull();
+
+    const messageFetchesBeforeRemount =
+      mocks.listHermesSessionMessages.mock.calls.length;
+    unmount();
+    render(<AgentWorkspace initialSession={existingSession} />);
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(
+        messageFetchesBeforeRemount,
+      ),
+    );
+    await act(() => Promise.resolve());
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(screen.queryByText(/Follow-up added/)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Send message first" }),
+    ).toBeDisabled();
+  });
+
   it("does not show a failed issue report banner after switching away", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1260,6 +1260,110 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a report when delivery and a follow-up submit both fail", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let rejectFirstDelivery: ((error: Error) => void) | undefined;
+    let rejectFollowUp: ((error: Error) => void) | undefined;
+    mocks.submitIssueReport.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectFirstDelivery = reject;
+        }),
+    );
+    mocks.gatewayRequest.mockImplementation(
+      (method: string, args?: unknown) => {
+        if (method === "session.create") {
+          return Promise.resolve({
+            session_id: "runtime-session-2",
+            stored_session_id: "session-2",
+          });
+        }
+        if (method === "session.resume") {
+          return Promise.resolve({ session_id: "runtime-session-1" });
+        }
+        if (
+          method === "prompt.submit" &&
+          typeof args === "object" &&
+          args &&
+          "text" in args &&
+          args.text === "It also drops audio"
+        ) {
+          return new Promise((_resolve, reject) => {
+            rejectFollowUp = reject;
+          });
+        }
+        return Promise.resolve({});
+      },
+    );
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1),
+    );
+
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+    });
+
+    await act(async () => {
+      rejectFirstDelivery?.(new Error("network down"));
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole("button", { name: "Send report" })).toBeNull();
+
+    await act(async () => {
+      rejectFollowUp?.(new Error("gateway down"));
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Send message first" }),
+    ).toBeDisabled();
+    expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1);
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("restores a report when a follow-up submit fails before delivery starts", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -636,6 +636,10 @@ describe("AgentWorkspace", () => {
       await screen.findByRole("textbox"),
       "It also loses the transcript",
     );
+    expect(
+      screen.getByRole("button", { name: "Send message first" }),
+    ).toBeDisabled();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
     await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -742,6 +742,103 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("keeps a newer follow-up draft when an older report delivery finishes", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let resolveFirstDelivery:
+      | ((value: { received: boolean }) => void)
+      | undefined;
+    mocks.submitIssueReport
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstDelivery = resolve;
+          }),
+      )
+      .mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      const promptSubmits = mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "prompt.submit",
+      );
+      const followUpSubmit = promptSubmits[promptSubmits.length - 1]?.[1] as {
+        session_id: string;
+        text: string;
+      };
+      expect(followUpSubmit).toEqual({
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+    });
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    await act(async () => {
+      resolveFirstDelivery?.({ received: true });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenLastCalledWith({
+        category: "bug",
+        description:
+          "The recorder crashes after long meetings\n\nFollow-up comments:\n1. It also drops audio",
+        agentDiagnosis: "The recorder failed while saving.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-2",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("does not show a failed issue report banner after switching away", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -972,6 +972,107 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("does not restore a delivered report when a follow-up submit fails", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let resolveFirstDelivery:
+      | ((value: { received: boolean }) => void)
+      | undefined;
+    let rejectFollowUp: ((error: Error) => void) | undefined;
+    mocks.submitIssueReport.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirstDelivery = resolve;
+        }),
+    );
+    mocks.gatewayRequest.mockImplementation(
+      (method: string, args?: unknown) => {
+        if (method === "session.create") {
+          return Promise.resolve({
+            session_id: "runtime-session-2",
+            stored_session_id: "session-2",
+          });
+        }
+        if (method === "session.resume") {
+          return Promise.resolve({ session_id: "runtime-session-1" });
+        }
+        if (
+          method === "prompt.submit" &&
+          typeof args === "object" &&
+          args &&
+          "text" in args &&
+          args.text === "It also drops audio"
+        ) {
+          return new Promise((_resolve, reject) => {
+            rejectFollowUp = reject;
+          });
+        }
+        return Promise.resolve({});
+      },
+    );
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+    });
+
+    await act(async () => {
+      resolveFirstDelivery?.({ received: true });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      rejectFollowUp?.(new Error("gateway down"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Send report" })).toBeNull(),
+    );
+    expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1);
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("does not show a failed issue report banner after switching away", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1433,6 +1433,95 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a report after leaving during a failed follow-up submit", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let rejectFollowUp: ((error: Error) => void) | undefined;
+    mocks.gatewayRequest.mockImplementation(
+      (method: string, args?: unknown) => {
+        if (method === "session.create") {
+          return Promise.resolve({
+            session_id: "runtime-session-2",
+            stored_session_id: "session-2",
+          });
+        }
+        if (method === "session.resume") {
+          return Promise.resolve({ session_id: "runtime-session-1" });
+        }
+        if (
+          method === "prompt.submit" &&
+          typeof args === "object" &&
+          args &&
+          "text" in args &&
+          args.text === "It also drops audio"
+        ) {
+          return new Promise((_resolve, reject) => {
+            rejectFollowUp = reject;
+          });
+        }
+        return Promise.resolve({});
+      },
+    );
+
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+      expect(rejectFollowUp).toBeDefined();
+    });
+
+    first.unmount();
+    await act(async () => {
+      rejectFollowUp?.(new Error("gateway down"));
+      await Promise.resolve();
+    });
+
+    const sessionLoadsBeforeRemount =
+      mocks.listHermesSessions.mock.calls.length;
+    render(<AgentWorkspace />);
+    await waitFor(() =>
+      expect(mocks.listHermesSessions.mock.calls.length).toBeGreaterThan(
+        sessionLoadsBeforeRemount,
+      ),
+    );
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(screen.queryByText(/Follow-up added/)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Send message first" }),
+    ).toBeDisabled();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("does not promote a queued report follow-up after resume fails", async () => {
     const user = userEvent.setup();
     const report = {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -810,6 +810,71 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a report after leaving during failed delivery", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let rejectDelivery: ((error: Error) => void) | undefined;
+    mocks.submitIssueReport.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectDelivery = reject;
+        }),
+    );
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+
+    first.unmount();
+    await act(async () => {
+      rejectDelivery?.(new Error("network down"));
+      await Promise.resolve();
+    });
+    const sessionLoadsBeforeRemount =
+      mocks.listHermesSessions.mock.calls.length;
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessions.mock.calls.length).toBeGreaterThan(
+        sessionLoadsBeforeRemount,
+      ),
+    );
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send report" })).toBeEnabled();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("keeps a newer follow-up draft when an older report delivery finishes", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -502,7 +502,7 @@ describe("AgentWorkspace", () => {
     );
   });
 
-  it("wraps a submitted issue report for June and files it after the turn", async () => {
+  it("wraps a submitted issue report for June and waits for explicit send", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
@@ -576,6 +576,10 @@ describe("AgentWorkspace", () => {
       }
     });
 
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
     await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
         category: "bug",
@@ -593,6 +597,92 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
     // Drain the post-terminal refresh timer before the test ends so its
     // session refetch cannot land inside a later test's render.
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
+  it("appends report follow-ups before filing", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+
+    await user.type(
+      await screen.findByRole("textbox"),
+      "It also loses the transcript",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      const promptSubmits = mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "prompt.submit",
+      );
+      const followUpSubmit = promptSubmits[promptSubmits.length - 1]?.[1] as {
+        session_id: string;
+        text: string;
+      };
+      expect(followUpSubmit).toEqual({
+        session_id: "runtime-session-2",
+        text: "It also loses the transcript",
+      });
+    });
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The added note points to transcript persistence.",
+        timestamp: "2026-06-11T10:00:20Z",
+      },
+    ]);
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description:
+          "The recorder crashes after long meetings\n\nFollow-up comments:\n1. It also loses the transcript",
+        agentDiagnosis: "The added note points to transcript persistence.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-2",
+      }),
+    );
+    expect(
+      await screen.findByText(/Your report was sent to the June team/),
+    ).toBeInTheDocument();
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
@@ -644,6 +734,9 @@ describe("AgentWorkspace", () => {
         handler({ type: "turn.completed", session_id: "runtime-session-2" });
       }
     });
+    await user.click(
+      await screen.findByRole("button", { name: "Send report" }),
+    );
     await waitFor(() => expect(mocks.submitIssueReport).toHaveBeenCalled());
 
     act(() => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -686,6 +686,62 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a review-ready report after leaving and returning", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    first.unmount();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: "The recorder crashes after long meetings",
+        agentDiagnosis: "The recorder failed while saving.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-2",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("does not show a failed issue report banner after switching away", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1397,6 +1397,153 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("clears a failed issue report banner after a successful retry", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.submitIssueReport
+      .mockRejectedValueOnce(new Error("upstream_provider_failed"))
+      .mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/The issue report could not be sent/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/upstream_provider_failed/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    expect(
+      await screen.findByText(/Your report was sent to the June team/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/The issue report could not be sent/)).toBeNull();
+    expect(screen.queryByText(/upstream_provider_failed/)).toBeNull();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
+  it("keeps report sending disabled while attachment imports are pending", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let resolveImport:
+      | ((file: {
+          name: string;
+          path: string;
+          rootLabel: string;
+          size: number;
+          previewDataUrl: null;
+        }) => void)
+      | undefined;
+    mocks.importHermesBridgeFileBytes.mockImplementationOnce((name: string) =>
+      new Promise((resolve) => {
+        resolveImport = resolve;
+      }).then(() => ({
+        name,
+        path: `/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/${name}`,
+        rootLabel: "Workspace",
+        size: 5,
+        previewDataUrl: null,
+      })),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+
+    const form = document.querySelector(".agent-composer");
+    expect(form).not.toBeNull();
+    fireEvent.drop(form as HTMLFormElement, {
+      dataTransfer: {
+        files: [new File(["logs"], "logs.txt", { type: "text/plain" })],
+      },
+    });
+
+    await waitFor(() =>
+      expect(mocks.importHermesBridgeFileBytes).toHaveBeenCalledWith(
+        "logs.txt",
+        expect.any(Uint8Array),
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Attaching files" }),
+    ).toBeDisabled();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveImport?.({
+        name: "logs.txt",
+        path: "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/logs.txt",
+        rootLabel: "Workspace",
+        size: 5,
+        previewDataUrl: null,
+      });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("logs.txt")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Send message first" }),
+    ).toBeDisabled();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("labels anonymous-only agent models as anonymous mode", async () => {
     mocks.providerModelSettings.mockResolvedValue({
       settings: {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -714,7 +714,6 @@ describe("AgentWorkspace", () => {
       }
     });
 
-    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     first.unmount();
     render(<AgentWorkspace />);
 
@@ -739,6 +738,71 @@ describe("AgentWorkspace", () => {
         sessionId: "session-2",
       }),
     );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
+  it("does not restore a report after leaving during successful delivery", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let resolveDelivery: ((value: { received: boolean }) => void) | undefined;
+    mocks.submitIssueReport.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDelivery = resolve;
+        }),
+    );
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+
+    first.unmount();
+    await act(async () => {
+      resolveDelivery?.({ received: true });
+      await Promise.resolve();
+    });
+    const sessionLoadsBeforeRemount =
+      mocks.listHermesSessions.mock.calls.length;
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.listHermesSessions.mock.calls.length).toBeGreaterThan(
+        sessionLoadsBeforeRemount,
+      ),
+    );
+    expect(screen.queryByText(/Report ready/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Send report" })).toBeNull();
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -579,6 +579,9 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     expect(mocks.submitIssueReport).not.toHaveBeenCalled();
     await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 50)));
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
 
     await waitFor(() =>
       expect(mocks.submitIssueReport).toHaveBeenCalledWith({
@@ -745,6 +748,86 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a pending report follow-up after leaving before June answers", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+    });
+
+    const persistedAt = new Date().toISOString();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "The recorder crashes after long meetings",
+        timestamp: persistedAt,
+      },
+      {
+        id: "m2",
+        role: "user",
+        content: "It also drops audio",
+        timestamp: persistedAt,
+      },
+      {
+        id: "m3",
+        role: "assistant",
+        content: "The follow-up points to dropped audio persistence.",
+        timestamp: persistedAt,
+      },
+    ]);
+    first.unmount();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description:
+          "The recorder crashes after long meetings\n\nFollow-up comments:\n1. It also drops audio",
+        agentDiagnosis: "The follow-up points to dropped audio persistence.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-2",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("does not restore a report after leaving during successful delivery", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
@@ -790,6 +873,9 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Send report" }));
     expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1),
+    );
 
     first.unmount();
     await act(async () => {
@@ -855,6 +941,9 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Send report" }));
     expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1),
+    );
 
     first.unmount();
     await act(async () => {
@@ -925,6 +1014,9 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Send report" }));
     expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1),
+    );
 
     await user.type(await screen.findByRole("textbox"), "It also drops audio");
     await user.click(screen.getByRole("button", { name: "Send message" }));
@@ -953,6 +1045,98 @@ describe("AgentWorkspace", () => {
     await act(async () => {
       resolveFirstDelivery?.({ received: true });
       await Promise.resolve();
+    });
+
+    expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenLastCalledWith({
+        category: "bug",
+        description:
+          "The recorder crashes after long meetings\n\nFollow-up comments:\n1. It also drops audio",
+        agentDiagnosis: "The recorder failed while saving.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-2",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
+  it("does not restore a stale report when an older delivery fails during a follow-up", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    let rejectFirstDelivery: ((error: Error) => void) | undefined;
+    mocks.submitIssueReport
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirstDelivery = reject;
+          }),
+      )
+      .mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1),
+    );
+
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await waitFor(() => {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+    });
+
+    await act(async () => {
+      rejectFirstDelivery?.(new Error("network down"));
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("button", { name: "Send report" })).toBeNull();
+    expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
     });
 
     expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
@@ -1046,6 +1230,9 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Send report" }));
     expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledTimes(1),
+    );
 
     await user.type(await screen.findByRole("textbox"), "It also drops audio");
     await user.click(screen.getByRole("button", { name: "Send message" }));

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -996,6 +996,82 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a review-ready report after an app restart", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    const first = render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    const form = document.querySelector(".agent-composer");
+    expect(form).not.toBeNull();
+    fireEvent.drop(form as HTMLFormElement, {
+      dataTransfer: {
+        files: [new File(["png"], "screenshot.png", { type: "image/png" })],
+      },
+    });
+    expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    first.unmount();
+    resetAgentSessionContinuity();
+    mocks.gatewayEventHandlers.clear();
+
+    const restoredSession = {
+      id: "session-2",
+      title: "Issue report",
+      preview: "The recorder crashes after long meetings",
+      last_active: "2026-06-11T10:00:10Z",
+    };
+    mocks.listHermesSessions.mockResolvedValue([restoredSession]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+    render(<AgentWorkspace initialSession={restoredSession} />);
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: "The recorder crashes after long meetings",
+        agentDiagnosis: "The recorder failed while saving.",
+        attachmentNames: ["screenshot.png"],
+        attachmentPaths: [
+          "/Users/alex/Library/Application Support/co.opensoftware.scribe/hermes/workspace/uploads/screenshot.png",
+        ],
+        sessionId: "session-2",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("restores a pending report follow-up after leaving before June answers", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -603,6 +603,130 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("does not use an old assistant reply as an existing-session report diagnosis", async () => {
+    const user = userEvent.setup();
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "Earlier question",
+        timestamp: "2026-06-11T10:00:00Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "Earlier unrelated diagnosis.",
+        timestamp: "2026-06-11T10:00:10Z",
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Attach files or tag this message",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Bug report" }),
+    );
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes from this existing chat",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-1" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: "The recorder crashes from this existing chat",
+        agentDiagnosis: undefined,
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-1",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
+  it("sends a report when the diagnosis refresh stalls", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    let stalledRefreshStarted = false;
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: "The recorder failed while saving.",
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockImplementationOnce(() => {
+      stalledRefreshStarted = true;
+      return new Promise(() => {});
+    });
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+    expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await waitFor(() => expect(stalledRefreshStarted).toBe(true));
+
+    await waitFor(
+      () =>
+        expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+          category: "bug",
+          description: "The recorder crashes after long meetings",
+          agentDiagnosis: "The recorder failed while saving.",
+          attachmentNames: [],
+          attachmentPaths: [],
+          sessionId: "session-2",
+        }),
+      { timeout: 3000 },
+    );
+  });
+
   it("appends report follow-ups before filing", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
@@ -666,12 +790,13 @@ describe("AgentWorkspace", () => {
     });
 
     expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    const followUpDiagnosisAt = new Date(Date.now() + 1000).toISOString();
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
         id: "m1",
         role: "assistant",
         content: "The added note points to transcript persistence.",
-        timestamp: "2026-06-11T10:00:20Z",
+        timestamp: followUpDiagnosisAt,
       },
     ]);
     await user.click(screen.getByRole("button", { name: "Send report" }));
@@ -1048,6 +1173,14 @@ describe("AgentWorkspace", () => {
     });
 
     expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The follow-up points to dropped audio persistence.",
+        timestamp: new Date(Date.now() + 1000).toISOString(),
+      },
+    ]);
     await user.click(screen.getByRole("button", { name: "Send report" }));
 
     await waitFor(() =>
@@ -1055,7 +1188,7 @@ describe("AgentWorkspace", () => {
         category: "bug",
         description:
           "The recorder crashes after long meetings\n\nFollow-up comments:\n1. It also drops audio",
-        agentDiagnosis: "The recorder failed while saving.",
+        agentDiagnosis: "The follow-up points to dropped audio persistence.",
         attachmentNames: [],
         attachmentPaths: [],
         sessionId: "session-2",
@@ -1140,6 +1273,14 @@ describe("AgentWorkspace", () => {
     });
 
     expect(await screen.findByText(/Follow-up added/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m2",
+        role: "assistant",
+        content: "The follow-up points to dropped audio persistence.",
+        timestamp: new Date(Date.now() + 1000).toISOString(),
+      },
+    ]);
     await user.click(screen.getByRole("button", { name: "Send report" }));
 
     await waitFor(() =>
@@ -1147,7 +1288,7 @@ describe("AgentWorkspace", () => {
         category: "bug",
         description:
           "The recorder crashes after long meetings\n\nFollow-up comments:\n1. It also drops audio",
-        agentDiagnosis: "The recorder failed while saving.",
+        agentDiagnosis: "The follow-up points to dropped audio persistence.",
         attachmentNames: [],
         attachmentPaths: [],
         sessionId: "session-2",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -1073,6 +1073,75 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("restores a report when a follow-up submit fails before delivery starts", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now(), category: "bug" }),
+    );
+    mocks.gatewayRequest.mockImplementation(
+      (method: string, args?: unknown) => {
+        if (method === "session.create") {
+          return Promise.resolve({
+            session_id: "runtime-session-2",
+            stored_session_id: "session-2",
+          });
+        }
+        if (method === "session.resume") {
+          return Promise.resolve({ session_id: "runtime-session-1" });
+        }
+        if (
+          method === "prompt.submit" &&
+          typeof args === "object" &&
+          args &&
+          "text" in args &&
+          args.text === "It also drops audio"
+        ) {
+          return Promise.reject(new Error("gateway down"));
+        }
+        return Promise.resolve({});
+      },
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Bug report")).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole("textbox"),
+      "The recorder crashes after long meetings",
+    );
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-2" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    await user.type(await screen.findByRole("textbox"), "It also drops audio");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "It also drops audio",
+      });
+    });
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Send message first" }),
+    ).toBeDisabled();
+    expect(mocks.submitIssueReport).not.toHaveBeenCalled();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("does not show a failed issue report banner after switching away", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(


### PR DESCRIPTION
## Summary
- Implements JUN-59: ability to add follow-up comments on bug reports or feature requests.
- Keep tagged bug, feedback, and feature report sessions in a review-ready state after June summarizes them.
- Let follow-up messages in the same report session append to the final report payload before the user clicks Send report.
- Update report prompt copy and workspace tests for the explicit send flow.

## Validation
- pnpm exec vitest run src/test/agent-workspace.test.tsx src/test/issue-report-prompt.test.ts
- pnpm run lint
- pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/lib/issue-report-prompt.ts src/styles/app.css src/test/agent-workspace.test.tsx
- git diff --check

## Known gaps
- No manual desktop smoke test was run in this environment.