### PR TITLE
Fix Cmd-W tab closing

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,9 @@ use tauri::{Emitter, Manager};
 
 const CHECK_FOR_UPDATES_MENU_ID: &str = "check_for_updates";
 const CHECK_FOR_UPDATES_EVENT: &str = "scribe://check-for-updates";
+const CLOSE_TAB_MENU_ID: &str = "close_tab";
+const CLOSE_TAB_EVENT: &str = "scribe://close-tab";
+const CLOSE_WINDOW_MENU_ID: &str = "close_window_main";
 const OPEN_SETTINGS_MENU_ID: &str = "open_settings";
 const OPEN_SETTINGS_EVENT: &str = "scribe://open-settings";
 
@@ -111,6 +114,14 @@ pub fn run() {
         .on_menu_event(|app, event| {
             if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
                 let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());
+                return;
+            }
+            if event.id().as_ref() == CLOSE_TAB_MENU_ID {
+                let _ = app.emit(CLOSE_TAB_EVENT, ());
+                return;
+            }
+            if event.id().as_ref() == CLOSE_WINDOW_MENU_ID {
+                close_main_window(app);
                 return;
             }
             if event.id().as_ref() == OPEN_SETTINGS_MENU_ID {
@@ -353,7 +364,22 @@ fn setup_app_menu(app: &tauri::App) -> tauri::Result<()> {
         handle,
         "File",
         true,
-        &[&PredefinedMenuItem::close_window(handle, None)?],
+        &[
+            &MenuItem::with_id(
+                handle,
+                CLOSE_TAB_MENU_ID,
+                "Close tab",
+                true,
+                Some("CmdOrCtrl+W"),
+            )?,
+            &MenuItem::with_id(
+                handle,
+                CLOSE_WINDOW_MENU_ID,
+                "Close window",
+                true,
+                Some("CmdOrCtrl+Shift+W"),
+            )?,
+        ],
     )?;
     let edit_menu = Submenu::with_items(
         handle,
@@ -383,8 +409,6 @@ fn setup_app_menu(app: &tauri::App) -> tauri::Result<()> {
         &[
             &PredefinedMenuItem::minimize(handle, None)?,
             &PredefinedMenuItem::maximize(handle, None)?,
-            &PredefinedMenuItem::separator(handle)?,
-            &PredefinedMenuItem::close_window(handle, None)?,
         ],
     )?;
     let help_menu = Submenu::with_id_and_items(handle, HELP_SUBMENU_ID, "Help", true, &[])?;
@@ -434,6 +458,15 @@ fn focus_main_window(app: tauri::AppHandle) {
         let _ = window.show();
         let _ = window.unminimize();
         let _ = window.set_focus();
+    }
+}
+
+fn close_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        #[cfg(target_os = "macos")]
+        let _ = window.hide();
+        #[cfg(not(target_os = "macos"))]
+        let _ = window.close();
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,7 +117,7 @@ pub fn run() {
                 return;
             }
             if event.id().as_ref() == CLOSE_TAB_MENU_ID {
-                let _ = app.emit(CLOSE_TAB_EVENT, ());
+                emit_close_tab_if_main_window_focused(app);
                 return;
             }
             if event.id().as_ref() == CLOSE_WINDOW_MENU_ID {
@@ -289,7 +289,7 @@ fn single_instance_enabled_for_build(debug_assertions: bool, force_dev: bool) ->
 
 #[cfg(all(test, desktop))]
 mod tests {
-    use super::single_instance_enabled_for_build;
+    use super::{should_emit_close_tab_event, single_instance_enabled_for_build};
 
     #[test]
     fn single_instance_is_disabled_for_dev_builds_by_default() {
@@ -304,6 +304,13 @@ mod tests {
     #[test]
     fn single_instance_remains_enabled_for_release_builds() {
         assert!(single_instance_enabled_for_build(false, false));
+    }
+
+    #[test]
+    fn close_tab_menu_emits_only_when_main_window_focus_is_known_true() {
+        assert!(should_emit_close_tab_event(Some(true)));
+        assert!(!should_emit_close_tab_event(Some(false)));
+        assert!(!should_emit_close_tab_event(None));
     }
 }
 
@@ -468,6 +475,21 @@ fn close_main_window(app: &tauri::AppHandle) {
         #[cfg(not(target_os = "macos"))]
         let _ = window.close();
     }
+}
+
+fn emit_close_tab_if_main_window_focused(app: &tauri::AppHandle) {
+    if should_emit_close_tab_event(main_window_focus_state(app)) {
+        let _ = app.emit_to("main", CLOSE_TAB_EVENT, ());
+    }
+}
+
+fn main_window_focus_state(app: &tauri::AppHandle) -> Option<bool> {
+    app.get_webview_window("main")
+        .and_then(|window| window.is_focused().ok())
+}
+
+fn should_emit_close_tab_event(main_window_focused: Option<bool>) -> bool {
+    main_window_focused == Some(true)
 }
 
 #[tauri::command]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -133,6 +133,7 @@ import {
   AGENT_MENU_BAR_NEW_SESSION_EVENT,
   AGENT_MENU_BAR_OPEN_SESSION_EVENT,
   AGENT_MENU_BAR_SET_AGENT_HUD_EVENT,
+  CLOSE_TAB_EVENT,
   OPEN_SETTINGS_EVENT,
   buildAgentMenuBarState,
   emitAgentMenuBarState,
@@ -691,7 +692,7 @@ export function App() {
   // agent workspace opens on the hero instead of restoring the last
   // conversation. Mirrors handleNewAgentSession (applyNav alone would only swap
   // state, leaving the previous chat on screen under a "New chat" label).
-  function armNewChatLive() {
+  const armNewChatLive = useCallback(() => {
     restoreTargetRef.current = { view: "agent" };
     pendingSessionProjectRef.current = null;
     setAgentOrigin(undefined);
@@ -703,7 +704,7 @@ export function App() {
         new CustomEvent<AgentNewSessionDetail>(AGENT_NEW_SESSION_EVENT),
       );
     }, 0);
-  }
+  }, []);
 
   // The "+" / ⌘T affordance: a new tab is always a fresh chat.
   function openNewChatTab() {
@@ -719,28 +720,31 @@ export function App() {
     armNewChatLive();
   }
 
-  function closeTab(id: string) {
-    if (tabs.length <= 1) {
-      // Never leave the strip empty — reset the sole tab to a fresh chat.
-      const fresh = { id: makeTabId(), nav: defaultNav() };
-      setTabs([fresh]);
-      setActiveTabId(fresh.id);
-      armNewChatLive();
-      return;
-    }
-    const index = tabs.findIndex((tab) => tab.id === id);
-    if (index < 0) return;
-    const next = tabs.filter((tab) => tab.id !== id);
-    setTabs(next);
-    if (id === activeTabId) {
-      // Focus the right neighbor, falling back to the left — browser behavior.
-      const neighbor = next[index] ?? next[index - 1];
-      if (neighbor) {
-        setActiveTabId(neighbor.id);
-        applyNav(neighbor.nav);
+  const closeTab = useCallback(
+    (id: string) => {
+      if (tabs.length <= 1) {
+        // Never leave the strip empty — reset the sole tab to a fresh chat.
+        const fresh = { id: makeTabId(), nav: defaultNav() };
+        setTabs([fresh]);
+        setActiveTabId(fresh.id);
+        armNewChatLive();
+        return;
       }
-    }
-  }
+      const index = tabs.findIndex((tab) => tab.id === id);
+      if (index < 0) return;
+      const next = tabs.filter((tab) => tab.id !== id);
+      setTabs(next);
+      if (id === activeTabId) {
+        // Focus the right neighbor, falling back to the left — browser behavior.
+        const neighbor = next[index] ?? next[index - 1];
+        if (neighbor) {
+          setActiveTabId(neighbor.id);
+          applyNav(neighbor.nav);
+        }
+      }
+    },
+    [activeTabId, applyNav, armNewChatLive, tabs],
+  );
 
   // Keep only the given tab, focusing it. From the tab right-click menu.
   function closeOtherTabs(id: string) {
@@ -778,7 +782,23 @@ export function App() {
     );
   }
 
-  // Tab keyboard shortcuts: ⌘T new, ⌘[ / ⌘] cycle, ⌘1-9 jump (9 = last).
+  useEffect(() => {
+    let aborted = false;
+    let unlisten: (() => void) | undefined;
+    void listen(CLOSE_TAB_EVENT, () => closeTab(activeTabId)).then(
+      (cleanup) => {
+        if (aborted) cleanup();
+        else unlisten = cleanup;
+      },
+    );
+    return () => {
+      aborted = true;
+      unlisten?.();
+    };
+  }, [activeTabId, closeTab]);
+
+  // Tab keyboard shortcuts: ⌘T new, ⌘W close, ⌘[ / ⌘] cycle, ⌘1-9 jump
+  // (9 = last).
   // isPrimaryShortcut handles the cross-platform modifier (⌘ on mac, Ctrl on
   // Windows) and rejects Alt/Shift. No dependency array — re-bound each render
   // so it closes over current tabs, matching the search/new-note effects below.
@@ -790,6 +810,11 @@ export function App() {
       if (key.toLowerCase() === "t") {
         event.preventDefault();
         openNewChatTab();
+        return;
+      }
+      if (key.toLowerCase() === "w") {
+        event.preventDefault();
+        closeTab(activeTabId);
         return;
       }
       if (key === "]" || key === "}") {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -806,12 +806,13 @@ export function App() {
   useEffect(() => {
     let aborted = false;
     let unlisten: (() => void) | undefined;
-    void listen(CLOSE_TAB_EVENT, () => closeTab(activeTabIdRef.current)).then(
-      (cleanup) => {
-        if (aborted) cleanup();
-        else unlisten = cleanup;
-      },
-    );
+    void listen(CLOSE_TAB_EVENT, () => {
+      if (document.querySelector('[role="dialog"]')) return;
+      closeTab(activeTabIdRef.current);
+    }).then((cleanup) => {
+      if (aborted) cleanup();
+      else unlisten = cleanup;
+    });
     return () => {
       aborted = true;
       unlisten?.();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -318,6 +318,8 @@ export function App() {
     { id: makeTabId(), nav: { view: isMacLikePlatform() ? "agent" : "notes" } },
   ]);
   const [activeTabId, setActiveTabId] = useState<string>(() => tabs[0]!.id);
+  const tabsRef = useRef(tabs);
+  const activeTabIdRef = useRef(activeTabId);
   // Set while restoring a tab's snapshot into live state: the capture effect
   // skips writes until live navigation settles onto the target (note loads are
   // async), so a half-applied snapshot never overwrites the tab it came from.
@@ -600,6 +602,14 @@ export function App() {
     );
   }, [liveNav, activeTabId]);
 
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  useEffect(() => {
+    activeTabIdRef.current = activeTabId;
+  }, [activeTabId]);
+
   // Keep the latest selected note id reachable from applyNav without making it
   // a dependency (which would rebuild the callback on every note change).
   const selectedNoteIdRef = useRef(selectedNoteId);
@@ -666,6 +676,10 @@ export function App() {
     },
     [agentSessions],
   );
+  const applyNavRef = useRef(applyNav);
+  useEffect(() => {
+    applyNavRef.current = applyNav;
+  }, [applyNav]);
 
   function activateTab(id: string) {
     if (id === activeTabId) return;
@@ -722,28 +736,35 @@ export function App() {
 
   const closeTab = useCallback(
     (id: string) => {
-      if (tabs.length <= 1) {
+      const currentTabs = tabsRef.current;
+      const currentActiveTabId = activeTabIdRef.current;
+
+      if (currentTabs.length <= 1) {
         // Never leave the strip empty — reset the sole tab to a fresh chat.
         const fresh = { id: makeTabId(), nav: defaultNav() };
+        tabsRef.current = [fresh];
+        activeTabIdRef.current = fresh.id;
         setTabs([fresh]);
         setActiveTabId(fresh.id);
         armNewChatLive();
         return;
       }
-      const index = tabs.findIndex((tab) => tab.id === id);
+      const index = currentTabs.findIndex((tab) => tab.id === id);
       if (index < 0) return;
-      const next = tabs.filter((tab) => tab.id !== id);
+      const next = currentTabs.filter((tab) => tab.id !== id);
+      tabsRef.current = next;
       setTabs(next);
-      if (id === activeTabId) {
+      if (id === currentActiveTabId) {
         // Focus the right neighbor, falling back to the left — browser behavior.
         const neighbor = next[index] ?? next[index - 1];
         if (neighbor) {
+          activeTabIdRef.current = neighbor.id;
           setActiveTabId(neighbor.id);
-          applyNav(neighbor.nav);
+          applyNavRef.current(neighbor.nav);
         }
       }
     },
-    [activeTabId, applyNav, armNewChatLive, tabs],
+    [armNewChatLive],
   );
 
   // Keep only the given tab, focusing it. From the tab right-click menu.
@@ -785,7 +806,7 @@ export function App() {
   useEffect(() => {
     let aborted = false;
     let unlisten: (() => void) | undefined;
-    void listen(CLOSE_TAB_EVENT, () => closeTab(activeTabId)).then(
+    void listen(CLOSE_TAB_EVENT, () => closeTab(activeTabIdRef.current)).then(
       (cleanup) => {
         if (aborted) cleanup();
         else unlisten = cleanup;
@@ -795,7 +816,7 @@ export function App() {
       aborted = true;
       unlisten?.();
     };
-  }, [activeTabId, closeTab]);
+  }, [closeTab]);
 
   // Tab keyboard shortcuts: ⌘T new, ⌘W close, ⌘[ / ⌘] cycle, ⌘1-9 jump
   // (9 = last).

--- a/src/lib/menu-bar.ts
+++ b/src/lib/menu-bar.ts
@@ -8,6 +8,7 @@ export const AGENT_MENU_BAR_OPEN_SESSION_EVENT =
   "scribe:menu-bar:open-agent-session";
 export const AGENT_MENU_BAR_SET_AGENT_HUD_EVENT =
   "scribe:menu-bar:set-agent-hud";
+export const CLOSE_TAB_EVENT = "scribe://close-tab";
 export const OPEN_SETTINGS_EVENT = "scribe://open-settings";
 
 export type AgentMenuBarSessionStatus = "idle" | "running" | "waitingForUser";

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
 import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
-import { OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
+import { CLOSE_TAB_EVENT, OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
 import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
@@ -291,6 +291,59 @@ describe("App shortcuts", () => {
         "data-active",
         "true",
       ),
+    );
+  });
+
+  it("closes the active tab with Command-W", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    fireEvent.keyDown(window, { key: "n", metaKey: true, shiftKey: true });
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "New note" })).toHaveAttribute(
+        "data-active",
+        "true",
+      ),
+    );
+
+    fireEvent.keyDown(window, { key: "w", metaKey: true });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("tab", { name: "New note" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("tab", { name: "New session" })).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+  });
+
+  it("closes the active tab from the native close-tab menu event", async () => {
+    render(<App />);
+
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await waitFor(() =>
+      expect(mocks.listeners.has(CLOSE_TAB_EVENT)).toBe(true),
+    );
+    fireEvent.keyDown(window, { key: "n", metaKey: true, shiftKey: true });
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "New note" })).toHaveAttribute(
+        "data-active",
+        "true",
+      ),
+    );
+
+    mocks.listeners.get(CLOSE_TAB_EVENT)?.({});
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("tab", { name: "New note" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("tab", { name: "New session" })).toHaveAttribute(
+      "data-active",
+      "true",
     );
   });
 

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -339,6 +339,16 @@ describe("App shortcuts", () => {
     );
     expect(closeTabListenerCount()).toBe(1);
 
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+    mocks.listeners.get(CLOSE_TAB_EVENT)?.({});
+    expect(screen.getByRole("tab", { name: "New note" })).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+    dialog.remove();
+
     mocks.listeners.get(CLOSE_TAB_EVENT)?.({});
 
     await waitFor(() =>

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -321,11 +321,15 @@ describe("App shortcuts", () => {
 
   it("closes the active tab from the native close-tab menu event", async () => {
     render(<App />);
+    const closeTabListenerCount = () =>
+      mocks.listen.mock.calls.filter(([event]) => event === CLOSE_TAB_EVENT)
+        .length;
 
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
     await waitFor(() =>
       expect(mocks.listeners.has(CLOSE_TAB_EVENT)).toBe(true),
     );
+    expect(closeTabListenerCount()).toBe(1);
     fireEvent.keyDown(window, { key: "n", metaKey: true, shiftKey: true });
     await waitFor(() =>
       expect(screen.getByRole("tab", { name: "New note" })).toHaveAttribute(
@@ -333,6 +337,7 @@ describe("App shortcuts", () => {
         "true",
       ),
     );
+    expect(closeTabListenerCount()).toBe(1);
 
     mocks.listeners.get(CLOSE_TAB_EVENT)?.({});
 
@@ -345,6 +350,7 @@ describe("App shortcuts", () => {
       "data-active",
       "true",
     );
+    expect(closeTabListenerCount()).toBe(1);
   });
 
   it("opens settings from the native app menu event", async () => {


### PR DESCRIPTION
## What changed

- Replaced the native `CmdOrCtrl+W` close-window menu action with a close-tab menu event.
- Routed the native close-tab event and `Cmd/Ctrl+W` keydown through the existing active tab close logic.
- Kept window closing available separately as `CmdOrCtrl+Shift+W`.
- Added shortcut coverage for both the browser keydown path and the native menu event path.

## Why

This PR implements JUN-85.

JUN-85 reports that `Cmd+W` closes the whole June window instead of the active app tab.

## Validation

- `pnpm exec vitest run src/test/app-shortcut.test.tsx`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Known gaps

- None.
