### PR TITLE
JUN-66: Add note processing progress indicator

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -801,6 +801,7 @@ function ProcessingProgressIndicator({
     (stage) => stage.status === status,
   );
   const label = processingMessage(status) ?? "Processing audio...";
+  const progressValueText = `${processingStageLabel(status)} stage in progress`;
   const classes = ["note-processing-progress", className]
     .filter(Boolean)
     .join(" ");
@@ -837,6 +838,7 @@ function ProcessingProgressIndicator({
         className="note-processing-progress-track"
         role="progressbar"
         aria-label="Note processing progress"
+        aria-valuetext={progressValueText}
       />
       <ol className="note-processing-progress-steps" aria-hidden="true">
         {PROCESSING_STAGES.map((stage, index) => {
@@ -874,6 +876,17 @@ function processingStageStatus(
       return status;
     default:
       return null;
+  }
+}
+
+function processingStageLabel(status: ProcessingStageStatus): string {
+  switch (status) {
+    case "validating":
+      return "Audio";
+    case "transcribing":
+      return "Transcript";
+    case "generating":
+      return "Summary";
   }
 }
 

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -256,10 +256,8 @@ export function NoteEditor({
     );
     return () => window.clearTimeout(timer);
   }, [consentReminderVisible]);
-  const processingLock =
-    note.processingStatus === "transcribing" ||
-    note.processingStatus === "generating" ||
-    note.processingStatus === "validating";
+  const processingStatus = processingStageStatus(note.processingStatus);
+  const processingLock = processingStatus !== null;
   const recordButtonDisabled = recordingDisabled;
   const recordOptionsDisabled = processingLock || recordingDisabled;
   const showProcessingSkeleton =
@@ -271,8 +269,7 @@ export function NoteEditor({
   const shellState = recordingForNote?.state ?? "idle";
   const processingText = processingMessage(note.processingStatus);
   const transcriptText = transcriptToText(note, liveTranscriptTurns);
-  const showTranscriptProcessing =
-    processingLock && transcriptText.trim().length > 0;
+  const showTranscriptProcessing = processingStatus !== null;
   const showLivePreviewWaiting =
     recordingForNote?.livePreviewEnabled === true &&
     liveTranscriptTurns.length === 0;
@@ -362,15 +359,13 @@ export function NoteEditor({
               >
                 <DotSpinner className="transcript-processing-spinner" />
                 <span className="transcript-processing-label">
-                  {showLivePreviewWaiting
-                    ? "Listening for transcript preview..."
-                    : (processingText ?? "Processing audio...")}
+                  Listening for transcript preview...
                 </span>
               </div>
-            ) : showTranscriptProcessing ? (
+            ) : showTranscriptProcessing && processingStatus ? (
               <ProcessingProgressIndicator
                 className="transcript-processing-progress"
-                status={note.processingStatus}
+                status={processingStatus}
               />
             ) : null}
             {visibleTurns.length ? (
@@ -385,7 +380,7 @@ export function NoteEditor({
               </div>
             ) : note.transcript?.text ? (
               <p>{note.transcript.text}</p>
-            ) : (
+            ) : showTranscriptProcessing ? null : (
               <div className="transcript-empty">
                 <p>
                   {recordingActive
@@ -411,9 +406,9 @@ export function NoteEditor({
                   : "Hit record to capture a conversation, or just start typing your thoughts here"
               }
             />
-            {processingLock ? (
+            {processingStatus ? (
               <ProcessingProgressIndicator
-                status={note.processingStatus}
+                status={processingStatus}
                 queuedRecordings={queuedRecordings}
                 queuedTooltipId={queuedTooltipId}
               />
@@ -797,7 +792,7 @@ function ProcessingProgressIndicator({
   queuedTooltipId,
   className,
 }: {
-  status: NoteDto["processingStatus"];
+  status: ProcessingStageStatus;
   queuedRecordings?: number;
   queuedTooltipId?: string;
   className?: string;
@@ -867,6 +862,19 @@ function ProcessingProgressIndicator({
       </ol>
     </div>
   );
+}
+
+function processingStageStatus(
+  status: NoteDto["processingStatus"],
+): ProcessingStageStatus | null {
+  switch (status) {
+    case "validating":
+    case "transcribing":
+    case "generating":
+      return status;
+    default:
+      return null;
+  }
 }
 
 function processingMessage(status: NoteDto["processingStatus"]): string | null {

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -87,11 +87,25 @@ type RenderedTranscriptTurn = TranscriptDto & {
   stability?: LiveTranscriptEventDto["stability"];
 };
 
+type ProcessingStageStatus = Extract<
+  NoteDto["processingStatus"],
+  "validating" | "transcribing" | "generating"
+>;
+
 const SOURCE_FILTERS = [
   { value: "all", label: "All" },
   { value: "microphone", label: "Microphone" },
   { value: "system", label: "System" },
 ] as const;
+
+const PROCESSING_STAGES: {
+  status: ProcessingStageStatus;
+  label: string;
+}[] = [
+  { status: "validating", label: "Audio" },
+  { status: "transcribing", label: "Transcript" },
+  { status: "generating", label: "Summary" },
+];
 
 const RECORD_CONSENT_REVEAL_DELAY_MS = 420;
 const RECORD_CONSENT_AUTO_HIDE_MS = 5000;
@@ -340,7 +354,7 @@ export function NoteEditor({
                 />
               </div>
             ) : null}
-            {showTranscriptProcessing || showLivePreviewWaiting ? (
+            {showLivePreviewWaiting ? (
               <div
                 className="transcript-processing"
                 role="status"
@@ -353,6 +367,11 @@ export function NoteEditor({
                     : (processingText ?? "Processing audio...")}
                 </span>
               </div>
+            ) : showTranscriptProcessing ? (
+              <ProcessingProgressIndicator
+                className="transcript-processing-progress"
+                status={note.processingStatus}
+              />
             ) : null}
             {visibleTurns.length ? (
               <div className="source-transcripts">
@@ -393,31 +412,11 @@ export function NoteEditor({
               }
             />
             {processingLock ? (
-              <div className="note-generating" role="status" aria-live="polite">
-                <DotSpinner className="note-generating-spinner" />
-                <span className="note-generating-label">
-                  {note.processingStatus === "generating"
-                    ? "Generating notes…"
-                    : "Transcribing audio…"}
-                </span>
-                {queuedRecordings > 0 ? (
-                  <span
-                    className="note-generating-count"
-                    tabIndex={0}
-                    aria-describedby={queuedTooltipId}
-                  >
-                    +{queuedRecordings}
-                    <span
-                      className="note-generating-tip"
-                      id={queuedTooltipId}
-                      role="tooltip"
-                    >
-                      {queuedRecordings} more recording
-                      {queuedRecordings > 1 ? "s" : ""} queued
-                    </span>
-                  </span>
-                ) : null}
-              </div>
+              <ProcessingProgressIndicator
+                status={note.processingStatus}
+                queuedRecordings={queuedRecordings}
+                queuedTooltipId={queuedTooltipId}
+              />
             ) : null}
             {showProcessingSkeleton ? (
               <div className="note-skeleton" aria-hidden="true">
@@ -792,12 +791,92 @@ function FolderChip({
   );
 }
 
+function ProcessingProgressIndicator({
+  status,
+  queuedRecordings = 0,
+  queuedTooltipId,
+  className,
+}: {
+  status: NoteDto["processingStatus"];
+  queuedRecordings?: number;
+  queuedTooltipId?: string;
+  className?: string;
+}) {
+  const activeIndex = PROCESSING_STAGES.findIndex(
+    (stage) => stage.status === status,
+  );
+  const label = processingMessage(status) ?? "Processing audio...";
+  const classes = ["note-processing-progress", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={classes}
+      data-status={status}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="note-processing-progress-head">
+        <DotSpinner className="note-processing-progress-spinner" />
+        <span className="note-processing-progress-label">{label}</span>
+        {queuedRecordings > 0 && queuedTooltipId ? (
+          <span
+            className="note-generating-count"
+            tabIndex={0}
+            aria-describedby={queuedTooltipId}
+          >
+            +{queuedRecordings}
+            <span
+              className="note-generating-tip"
+              id={queuedTooltipId}
+              role="tooltip"
+            >
+              {queuedRecordings} more recording
+              {queuedRecordings > 1 ? "s" : ""} queued
+            </span>
+          </span>
+        ) : null}
+      </div>
+      <div
+        className="note-processing-progress-track"
+        role="progressbar"
+        aria-label="Note processing progress"
+      />
+      <ol className="note-processing-progress-steps" aria-hidden="true">
+        {PROCESSING_STAGES.map((stage, index) => {
+          const state =
+            index < activeIndex
+              ? "done"
+              : index === activeIndex
+                ? "active"
+                : "pending";
+          return (
+            <li
+              key={stage.status}
+              className="note-processing-progress-step"
+              data-state={state}
+            >
+              <span className="note-processing-progress-dot" />
+              <span className="note-processing-progress-step-label">
+                {stage.label}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
 function processingMessage(status: NoteDto["processingStatus"]): string | null {
   switch (status) {
+    case "validating":
+      return "Preparing audio...";
     case "transcribing":
       return "Transcribing audio...";
     case "generating":
-      return "Generating note...";
+      return "Generating notes...";
     default:
       return null;
   }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6430,31 +6430,48 @@ input:focus-visible,
   font-weight: 400;
 }
 
-.note-generating {
-  display: inline-flex;
-  align-items: center;
+.note-processing-progress {
+  display: grid;
   gap: var(--sp-2);
+  width: min(100%, 380px);
   margin: var(--sp-4) 0 0;
-  padding: var(--sp-2) var(--sp-3);
+  padding: var(--sp-3);
   border-radius: var(--r-md);
   background: color-mix(in oklch, var(--muted) 68%, var(--card));
   font-size: var(--fs-md);
   font-weight: 500;
-  line-height: 1;
+  line-height: 1.1;
   pointer-events: none;
   user-select: none;
   -webkit-user-select: none;
 }
 
-/* The rolling dot spinner (drawn, colored via currentColor) — the same working
+.transcript-processing-progress {
+  max-width: min(100%, var(--content-max));
+  margin: 0 0 var(--sp-3);
+  font-size: var(--fs-sm);
+}
+
+.note-processing-progress-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
+/* The rolling dot spinner (drawn, colored via currentColor) is the same working
  * indicator as the agent chat, sidebar, and composer notice. */
-.note-generating-spinner {
+.note-processing-progress-spinner {
   flex: none;
   color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
 }
 
-.note-generating-label,
+.note-processing-progress-label,
 .text-shimmer {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   background: linear-gradient(
     90deg,
     var(--muted-foreground) 0%,
@@ -6477,12 +6494,107 @@ input:focus-visible,
   animation-duration: 1.2s;
 }
 
+.note-processing-progress-track {
+  position: relative;
+  height: 4px;
+  overflow: hidden;
+  border-radius: var(--r-pill);
+  background: color-mix(in oklch, var(--muted-foreground) 13%, transparent);
+}
+
+.note-processing-progress-track::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -42%;
+  width: 42%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in oklch, var(--warm-strong) 78%, transparent) 45%,
+    color-mix(in oklch, var(--warm-strong) 94%, var(--foreground)) 50%,
+    color-mix(in oklch, var(--warm-strong) 78%, transparent) 55%,
+    transparent 100%
+  );
+  animation: note-processing-track-sweep 1.6s var(--ease-in-out) infinite;
+}
+
+.note-processing-progress-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--sp-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.note-processing-progress-step {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+  color: color-mix(in oklch, var(--muted-foreground) 72%, transparent);
+  font-size: var(--fs-xs);
+  line-height: 1;
+}
+
+.note-processing-progress-step[data-state="done"],
+.note-processing-progress-step[data-state="active"] {
+  color: var(--warm-strong);
+}
+
+.note-processing-progress-dot {
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-radius: var(--r-pill);
+  background: currentColor;
+  opacity: 0.45;
+}
+
+.note-processing-progress-step[data-state="done"]
+  .note-processing-progress-dot {
+  opacity: 0.72;
+}
+
+.note-processing-progress-step[data-state="active"]
+  .note-processing-progress-dot {
+  opacity: 1;
+  box-shadow: 0 0 0 3px color-mix(in oklch, currentColor 16%, transparent);
+}
+
+.note-processing-progress-step-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @keyframes note-text-shimmer {
   0% {
     background-position: 150% 0;
   }
   100% {
     background-position: -50% 0;
+  }
+}
+
+@keyframes note-processing-track-sweep {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(340%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .note-processing-progress-track::before {
+    left: 0;
+    width: 100%;
+    animation: none;
   }
 }
 

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -262,7 +262,7 @@ describe("NoteEditor", () => {
     );
     expect(
       screen.getByRole("progressbar", { name: "Note processing progress" }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("aria-valuetext", "Transcript stage in progress");
     expect(screen.getByText("Previous system transcript")).toBeInTheDocument();
   });
 
@@ -282,7 +282,7 @@ describe("NoteEditor", () => {
     );
     expect(
       screen.getByRole("progressbar", { name: "Note processing progress" }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("aria-valuetext", "Transcript stage in progress");
     expect(screen.queryByText("No transcript is available yet.")).toBeNull();
   });
 
@@ -583,7 +583,7 @@ describe("NoteEditor", () => {
     expect(status).toHaveTextContent("+1");
     expect(
       screen.getByRole("progressbar", { name: "Note processing progress" }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("aria-valuetext", "Summary stage in progress");
   });
 
   it("starts recording immediately without a consent gate", async () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -260,6 +260,9 @@ describe("NoteEditor", () => {
     expect(screen.getByRole("status")).toHaveTextContent(
       "Transcribing audio...",
     );
+    expect(
+      screen.getByRole("progressbar", { name: "Note processing progress" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Previous system transcript")).toBeInTheDocument();
   });
 
@@ -558,6 +561,9 @@ describe("NoteEditor", () => {
     const status = screen.getByRole("status");
     expect(status).toHaveTextContent("Generating notes");
     expect(status).toHaveTextContent("+1");
+    expect(
+      screen.getByRole("progressbar", { name: "Note processing progress" }),
+    ).toBeInTheDocument();
   });
 
   it("starts recording immediately without a consent gate", async () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -266,6 +266,26 @@ describe("NoteEditor", () => {
     expect(screen.getByText("Previous system transcript")).toBeInTheDocument();
   });
 
+  it("shows transcript progress before any transcript text exists", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          activeTab: "transcription",
+          processingStatus: "transcribing",
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Transcribing audio...",
+    );
+    expect(
+      screen.getByRole("progressbar", { name: "Note processing progress" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No transcript is available yet.")).toBeNull();
+  });
+
   it("orders source transcript turns by persisted turn metadata", () => {
     const { container } = render(
       <NoteEditor

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -565,6 +565,23 @@ describe("NoteEditor", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows validating progress in the notes tab", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          processingStatus: "validating",
+          activeTab: "notes",
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Preparing audio...");
+    expect(
+      screen.getByRole("progressbar", { name: "Note processing progress" }),
+    ).toHaveAttribute("aria-valuetext", "Audio stage in progress");
+  });
+
   it("shows a queued count when a follow-up recording is stacked", () => {
     render(
       <NoteEditor


### PR DESCRIPTION
## Summary
- Replaces the note processing spinner chip with a compact indeterminate progress module.
- Shows staged progress for Audio, Transcript, and Summary while notes validate, transcribe, or generate.
- Reuses the same progress surface in the Notes and Transcription tabs and preserves the queued recording badge.
- Adds focused NoteEditor assertions for the progressbar surface.

## Why
JUN-66 reports that meeting notes can take long enough to feel broken. This PR improves visible processing feedback without pretending we have a measured percentage or ETA yet.

## Validation
- pnpm exec vitest run src/test/note-editor.test.tsx
- pnpm run lint
- pnpm exec prettier --check src/components/note-editor/NoteEditor.tsx src/styles/app.css src/test/note-editor.test.tsx

## Known gaps
- This does not reduce backend processing time.
- This does not add a real percentage or ETA because the current note DTO does not expose measured progress.