### PR TITLE
Fix routine gateway scheduling

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -521,6 +521,20 @@ pub fn start_on_app_start(app: &tauri::App) {
     });
 }
 
+#[tauri::command]
+pub async fn ensure_hermes_bridge_gateway(
+    bridge: State<'_, HermesBridge>,
+) -> Result<(), AppError> {
+    let connections = live_connections(&bridge)?;
+    let Some(connection) = connections.first() else {
+        return Err(AppError::new(
+            "hermes_bridge_not_running",
+            "Hermes bridge is not running.",
+        ));
+    };
+    start_hermes_gateway_if_needed(connection).await
+}
+
 async fn start_hermes_bridge_inner(
     app: &AppHandle,
     bridge: &HermesBridge,

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -522,9 +522,7 @@ pub fn start_on_app_start(app: &tauri::App) {
 }
 
 #[tauri::command]
-pub async fn ensure_hermes_bridge_gateway(
-    bridge: State<'_, HermesBridge>,
-) -> Result<(), AppError> {
+pub async fn ensure_hermes_bridge_gateway(bridge: State<'_, HermesBridge>) -> Result<(), AppError> {
     let connections = live_connections(&bridge)?;
     let Some(connection) = connections.first() else {
         return Err(AppError::new(
@@ -532,7 +530,7 @@ pub async fn ensure_hermes_bridge_gateway(
             "Hermes bridge is not running.",
         ));
     };
-    start_hermes_gateway_if_needed(connection).await
+    ensure_hermes_gateway_running(connection).await
 }
 
 async fn start_hermes_bridge_inner(
@@ -1873,17 +1871,49 @@ async fn hermes_api_json(
 async fn start_hermes_gateway_if_needed(
     connection: &HermesBridgeConnection,
 ) -> Result<(), AppError> {
-    let status = hermes_connection_json(connection, reqwest::Method::GET, "/api/status", None)
-        .await
-        .unwrap_or_else(|_| serde_json::json!({}));
-    if status
-        .get("gateway_running")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-    {
+    if hermes_gateway_running(connection).await.unwrap_or(false) {
         return Ok(());
     }
     spawn_hermes_gateway_start(connection)
+}
+
+async fn ensure_hermes_gateway_running(
+    connection: &HermesBridgeConnection,
+) -> Result<(), AppError> {
+    if hermes_gateway_running(connection).await.unwrap_or(false) {
+        return Ok(());
+    }
+
+    run_hermes_gateway_start(connection).await?;
+    wait_for_hermes_gateway(connection).await
+}
+
+async fn hermes_gateway_running(connection: &HermesBridgeConnection) -> Result<bool, AppError> {
+    let status =
+        hermes_connection_json(connection, reqwest::Method::GET, "/api/status", None).await?;
+    Ok(status
+        .get("gateway_running")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false))
+}
+
+async fn wait_for_hermes_gateway(connection: &HermesBridgeConnection) -> Result<(), AppError> {
+    const GATEWAY_READY_TIMEOUT: Duration = Duration::from_secs(10);
+    const GATEWAY_READY_POLL: Duration = Duration::from_millis(250);
+
+    let started = Instant::now();
+    loop {
+        if hermes_gateway_running(connection).await.unwrap_or(false) {
+            return Ok(());
+        }
+        if started.elapsed() >= GATEWAY_READY_TIMEOUT {
+            return Err(AppError::new(
+                "hermes_gateway_start_failed",
+                "`hermes gateway start` completed, but the gateway is still not running. See logs/gateway-start.log.",
+            ));
+        }
+        tokio::time::sleep(GATEWAY_READY_POLL).await;
+    }
 }
 
 /// Starts the messaging gateway by running `hermes gateway start` as a direct
@@ -1902,16 +1932,7 @@ async fn start_hermes_gateway_if_needed(
 /// `<hermes_home>/logs/gateway-start.log` (the same file the bridge's action
 /// runner appends to) and the exit status is reaped in the background.
 fn spawn_hermes_gateway_start(connection: &HermesBridgeConnection) -> Result<(), AppError> {
-    let hermes_home = PathBuf::from(&connection.hermes_home);
-    let mut cmd = build_hermes_gateway_start_command(connection, &hermes_home);
-    match open_gateway_start_log(&hermes_home) {
-        Some((log_for_stdout, log_for_stderr)) => {
-            cmd.stdout(log_for_stdout).stderr(log_for_stderr);
-        }
-        None => {
-            cmd.stdout(Stdio::null()).stderr(Stdio::null());
-        }
-    }
+    let mut cmd = hermes_gateway_start_command(connection);
     let mut child = cmd.spawn().map_err(|error| {
         AppError::new(
             "hermes_gateway_start_failed",
@@ -1930,6 +1951,45 @@ fn spawn_hermes_gateway_start(connection: &HermesBridgeConnection) -> Result<(),
         }
     });
     Ok(())
+}
+
+async fn run_hermes_gateway_start(connection: &HermesBridgeConnection) -> Result<(), AppError> {
+    let mut cmd = hermes_gateway_start_command(connection);
+    let status = tauri::async_runtime::spawn_blocking(move || cmd.status())
+        .await
+        .map_err(|error| {
+            AppError::new(
+                "hermes_gateway_start_failed",
+                format!("Could not wait for `hermes gateway start`. {error}"),
+            )
+        })?
+        .map_err(|error| {
+            AppError::new(
+                "hermes_gateway_start_failed",
+                format!("Could not run `hermes gateway start`. {error}"),
+            )
+        })?;
+    if !status.success() {
+        return Err(AppError::new(
+            "hermes_gateway_start_failed",
+            format!("`hermes gateway start` exited with {status}. See logs/gateway-start.log."),
+        ));
+    }
+    Ok(())
+}
+
+fn hermes_gateway_start_command(connection: &HermesBridgeConnection) -> Command {
+    let hermes_home = PathBuf::from(&connection.hermes_home);
+    let mut cmd = build_hermes_gateway_start_command(connection, &hermes_home);
+    match open_gateway_start_log(&hermes_home) {
+        Some((log_for_stdout, log_for_stderr)) => {
+            cmd.stdout(log_for_stdout).stderr(log_for_stderr);
+        }
+        None => {
+            cmd.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+    }
+    cmd
 }
 
 /// Pure command construction so a test can assert the spawn is the bare hermes
@@ -3883,6 +3943,32 @@ mod tests {
             Some("1")
         );
         assert_eq!(cmd.get_current_dir(), Some(Path::new("/tmp/hermes-home")));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn gateway_start_reports_nonzero_exit() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let connection = HermesBridgeConnection {
+            base_url: "http://127.0.0.1:1".to_string(),
+            ws_url: "ws://127.0.0.1:1/api/ws".to_string(),
+            token: "session-token".to_string(),
+            port: 1,
+            command: "/usr/bin/false".to_string(),
+            hermes_home: home.path().to_string_lossy().into_owned(),
+            cwd: None,
+            provider_proxy_port: 2,
+            pid: 3,
+            sandboxed: true,
+            full_mode: false,
+        };
+
+        let error = run_hermes_gateway_start(&connection)
+            .await
+            .expect_err("nonzero gateway start exits fail");
+
+        assert_eq!(error.code, "hermes_gateway_start_failed");
+        assert!(error.message.contains("exited"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,6 +153,7 @@ pub fn run() {
             commands::retry_agent_task,
             commands::list_agent_tool_events,
             hermes_bridge::hermes_bridge_status,
+            hermes_bridge::ensure_hermes_bridge_gateway,
             hermes_bridge::hermes_bridge_skills,
             hermes_bridge::hermes_bridge_toolsets,
             hermes_bridge::hermes_bridge_messaging_platforms,

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -1,6 +1,7 @@
 import {
   createHermesBridgeCronJob,
   deleteHermesBridgeCronJob,
+  ensureHermesBridgeGateway,
   hermesBridgeCronJobAction,
   hermesBridgeCronJobs,
   hermesBridgeStatus,
@@ -98,10 +99,13 @@ export function routineUnrestricted(
 }
 
 /** The dashboard API lives on the bridge process, so make sure one is up
- * before calling — same lazy-start the gateway client used to do. */
+ * before calling. Cron jobs are actually fired by Hermes's launchd-managed
+ * gateway, so routine operations also ensure that persistent gateway is
+ * registered before touching the jobs API. */
 async function withBridge<T>(run: () => Promise<T>): Promise<T> {
   const status = await hermesBridgeStatus();
   if (!status.running) await startHermesBridge();
+  await ensureHermesBridgeGateway();
   return run();
 }
 

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -187,6 +187,14 @@ export type RoutineUpdates = {
   unrestricted?: boolean;
 };
 
+/** Update keys that are purely cosmetic and have no effect on a future run,
+ * so editing only these can stay on the bridge-only path. Everything else
+ * (schedule, prompt, the toolset/script fields `unrestricted` expands to, and
+ * any field added later) must go through withScheduler so an unloaded gateway
+ * gets brought back up — otherwise the edit is "saved but never fires".
+ * Safe-by-default: a key not listed here forces the scheduler. */
+const BRIDGE_ONLY_SAFE_UPDATE_KEYS = new Set<string>(["name"]);
+
 export async function updateRoutine(
   jobId: string,
   updates: RoutineUpdates,
@@ -202,7 +210,12 @@ export async function updateRoutine(
     payload.script = null;
     payload.no_agent = false;
   }
-  const run = updates.schedule !== undefined ? withScheduler : withBridge;
+  // Require the gateway whenever the edit touches any future-run-affecting
+  // field; only edits limited to bridge-only-safe keys may skip it.
+  const touchesRunAffectingField = Object.keys(payload).some(
+    (key) => !BRIDGE_ONLY_SAFE_UPDATE_KEYS.has(key),
+  );
+  const run = touchesRunAffectingField ? withScheduler : withBridge;
   const record = await run(() =>
     updateHermesBridgeCronJob(jobId, payload),
   );

--- a/src/lib/hermes-routines.ts
+++ b/src/lib/hermes-routines.ts
@@ -99,14 +99,21 @@ export function routineUnrestricted(
 }
 
 /** The dashboard API lives on the bridge process, so make sure one is up
- * before calling. Cron jobs are actually fired by Hermes's launchd-managed
- * gateway, so routine operations also ensure that persistent gateway is
- * registered before touching the jobs API. */
+ * before calling. */
 async function withBridge<T>(run: () => Promise<T>): Promise<T> {
   const status = await hermesBridgeStatus();
   if (!status.running) await startHermesBridge();
-  await ensureHermesBridgeGateway();
   return run();
+}
+
+/** Cron jobs are fired by Hermes's launchd-managed gateway. Require it only
+ * for operations that create or enable future work; read and cleanup actions
+ * must still work when the gateway is unhealthy. */
+async function withScheduler<T>(run: () => Promise<T>): Promise<T> {
+  return withBridge(async () => {
+    await ensureHermesBridgeGateway();
+    return run();
+  });
 }
 
 function routineFromRecord(record: HermesCronJobRecord): RoutineJob {
@@ -156,7 +163,7 @@ export async function createRoutine(input: {
   name?: string;
   unrestricted?: boolean;
 }): Promise<RoutineJob> {
-  return withBridge(async () => {
+  return withScheduler(async () => {
     const created = await createHermesBridgeCronJob({
       prompt: input.prompt,
       schedule: input.schedule,
@@ -195,7 +202,8 @@ export async function updateRoutine(
     payload.script = null;
     payload.no_agent = false;
   }
-  const record = await withBridge(() =>
+  const run = updates.schedule !== undefined ? withScheduler : withBridge;
+  const record = await run(() =>
     updateHermesBridgeCronJob(jobId, payload),
   );
   return routineFromRecord(record);
@@ -206,14 +214,14 @@ export function pauseRoutine(jobId: string) {
 }
 
 export function resumeRoutine(jobId: string) {
-  return withBridge(() => hermesBridgeCronJobAction(jobId, "resume"));
+  return withScheduler(() => hermesBridgeCronJobAction(jobId, "resume"));
 }
 
 /** Queues an immediate run. The launchd-managed gateway picks the job up on
  * its next scheduler tick, so the run starts within about a minute — and
  * only if the gateway is running. */
 export function triggerRoutine(jobId: string) {
-  return withBridge(() => hermesBridgeCronJobAction(jobId, "trigger"));
+  return withScheduler(() => hermesBridgeCronJobAction(jobId, "trigger"));
 }
 
 export function removeRoutine(jobId: string) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -867,6 +867,10 @@ export async function hermesBridgeStatus() {
   return invoke<HermesBridgeStatus>("hermes_bridge_status");
 }
 
+export async function ensureHermesBridgeGateway() {
+  return invoke<void>("ensure_hermes_bridge_gateway");
+}
+
 export async function hermesBridgeSkills() {
   return invoke<HermesSkillInfo[]>("hermes_bridge_skills");
 }

--- a/src/test/hermes-routines.test.ts
+++ b/src/test/hermes-routines.test.ts
@@ -7,6 +7,7 @@ import {
   resumeRoutine,
   triggerRoutine,
   updateRoutine,
+  UNRESTRICTED_ROUTINE_TOOLSETS,
 } from "../lib/hermes-routines";
 
 const mocks = vi.hoisted(() => ({
@@ -135,6 +136,22 @@ describe("Routines Hermes integration", () => {
     expect(mocks.ensureHermesBridgeGateway).not.toHaveBeenCalled();
     expect(mocks.updateHermesBridgeCronJob).toHaveBeenCalledWith("routine-1", {
       name: "Renamed",
+    });
+  });
+
+  it("ensures the persistent gateway before a prompt-only routine edit", async () => {
+    await updateRoutine("routine-1", { prompt: "Summarize this week." });
+    expect(mocks.ensureHermesBridgeGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.updateHermesBridgeCronJob).toHaveBeenCalledWith("routine-1", {
+      prompt: "Summarize this week.",
+    });
+  });
+
+  it("ensures the persistent gateway before an unrestricted-only routine edit", async () => {
+    await updateRoutine("routine-1", { unrestricted: true });
+    expect(mocks.ensureHermesBridgeGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.updateHermesBridgeCronJob).toHaveBeenCalledWith("routine-1", {
+      enabled_toolsets: UNRESTRICTED_ROUTINE_TOOLSETS,
     });
   });
 

--- a/src/test/hermes-routines.test.ts
+++ b/src/test/hermes-routines.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createRoutine,
+  listRoutines,
+  triggerRoutine,
+} from "../lib/hermes-routines";
+
+const mocks = vi.hoisted(() => ({
+  hermesBridgeStatus: vi.fn(),
+  startHermesBridge: vi.fn(),
+  ensureHermesBridgeGateway: vi.fn(),
+  hermesBridgeCronJobs: vi.fn(),
+  createHermesBridgeCronJob: vi.fn(),
+  hermesBridgeCronJobAction: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  hermesBridgeStatus: mocks.hermesBridgeStatus,
+  startHermesBridge: mocks.startHermesBridge,
+  ensureHermesBridgeGateway: mocks.ensureHermesBridgeGateway,
+  hermesBridgeCronJobs: mocks.hermesBridgeCronJobs,
+  createHermesBridgeCronJob: mocks.createHermesBridgeCronJob,
+  hermesBridgeCronJobAction: mocks.hermesBridgeCronJobAction,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.hermesBridgeStatus.mockResolvedValue({ running: true });
+  mocks.startHermesBridge.mockResolvedValue({ running: true });
+  mocks.ensureHermesBridgeGateway.mockResolvedValue(undefined);
+  mocks.hermesBridgeCronJobs.mockResolvedValue([]);
+  mocks.createHermesBridgeCronJob.mockResolvedValue({
+    id: "routine-1",
+    name: "Morning brief",
+    prompt: "Summarize today.",
+    schedule_display: "0 9 * * *",
+    enabled: true,
+  });
+  mocks.hermesBridgeCronJobAction.mockResolvedValue({});
+});
+
+describe("Routines Hermes integration", () => {
+  it("ensures the persistent gateway before listing routine jobs", async () => {
+    await listRoutines();
+
+    expect(mocks.ensureHermesBridgeGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.hermesBridgeCronJobs).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.ensureHermesBridgeGateway.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.hermesBridgeCronJobs.mock.invocationCallOrder[0]);
+  });
+
+  it("starts a stopped bridge and gateway before creating a routine job", async () => {
+    mocks.hermesBridgeStatus.mockResolvedValue({ running: false });
+
+    await createRoutine({
+      prompt: "Summarize today.",
+      schedule: "0 9 * * *",
+      name: "Morning brief",
+    });
+
+    expect(mocks.startHermesBridge).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureHermesBridgeGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.createHermesBridgeCronJob).toHaveBeenCalledWith({
+      prompt: "Summarize today.",
+      schedule: "0 9 * * *",
+      name: "Morning brief",
+    });
+    expect(
+      mocks.startHermesBridge.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.ensureHermesBridgeGateway.mock.invocationCallOrder[0],
+    );
+    expect(
+      mocks.ensureHermesBridgeGateway.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mocks.createHermesBridgeCronJob.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not queue a manual run when the persistent gateway cannot start", async () => {
+    mocks.ensureHermesBridgeGateway.mockRejectedValue(
+      new Error("gateway unavailable"),
+    );
+
+    await expect(triggerRoutine("routine-1")).rejects.toThrow(
+      "gateway unavailable",
+    );
+    expect(mocks.hermesBridgeCronJobAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/hermes-routines.test.ts
+++ b/src/test/hermes-routines.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createRoutine,
   listRoutines,
+  pauseRoutine,
+  removeRoutine,
+  resumeRoutine,
   triggerRoutine,
+  updateRoutine,
 } from "../lib/hermes-routines";
 
 const mocks = vi.hoisted(() => ({
@@ -11,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   ensureHermesBridgeGateway: vi.fn(),
   hermesBridgeCronJobs: vi.fn(),
   createHermesBridgeCronJob: vi.fn(),
+  updateHermesBridgeCronJob: vi.fn(),
+  deleteHermesBridgeCronJob: vi.fn(),
   hermesBridgeCronJobAction: vi.fn(),
 }));
 
@@ -20,6 +26,8 @@ vi.mock("../lib/tauri", () => ({
   ensureHermesBridgeGateway: mocks.ensureHermesBridgeGateway,
   hermesBridgeCronJobs: mocks.hermesBridgeCronJobs,
   createHermesBridgeCronJob: mocks.createHermesBridgeCronJob,
+  updateHermesBridgeCronJob: mocks.updateHermesBridgeCronJob,
+  deleteHermesBridgeCronJob: mocks.deleteHermesBridgeCronJob,
   hermesBridgeCronJobAction: mocks.hermesBridgeCronJobAction,
 }));
 
@@ -36,18 +44,43 @@ beforeEach(() => {
     schedule_display: "0 9 * * *",
     enabled: true,
   });
+  mocks.updateHermesBridgeCronJob.mockResolvedValue({
+    id: "routine-1",
+    name: "Morning brief",
+    prompt: "Summarize today.",
+    schedule_display: "0 10 * * *",
+    enabled: true,
+  });
+  mocks.deleteHermesBridgeCronJob.mockResolvedValue({});
   mocks.hermesBridgeCronJobAction.mockResolvedValue({});
 });
 
 describe("Routines Hermes integration", () => {
-  it("ensures the persistent gateway before listing routine jobs", async () => {
+  it("lists routine jobs without requiring the persistent gateway", async () => {
+    mocks.ensureHermesBridgeGateway.mockRejectedValue(
+      new Error("gateway unavailable"),
+    );
+
     await listRoutines();
 
-    expect(mocks.ensureHermesBridgeGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureHermesBridgeGateway).not.toHaveBeenCalled();
     expect(mocks.hermesBridgeCronJobs).toHaveBeenCalledTimes(1);
-    expect(
-      mocks.ensureHermesBridgeGateway.mock.invocationCallOrder[0],
-    ).toBeLessThan(mocks.hermesBridgeCronJobs.mock.invocationCallOrder[0]);
+  });
+
+  it("allows cleanup actions when the persistent gateway cannot start", async () => {
+    mocks.ensureHermesBridgeGateway.mockRejectedValue(
+      new Error("gateway unavailable"),
+    );
+
+    await pauseRoutine("routine-1");
+    await removeRoutine("routine-1");
+
+    expect(mocks.ensureHermesBridgeGateway).not.toHaveBeenCalled();
+    expect(mocks.hermesBridgeCronJobAction).toHaveBeenCalledWith(
+      "routine-1",
+      "pause",
+    );
+    expect(mocks.deleteHermesBridgeCronJob).toHaveBeenCalledWith("routine-1");
   });
 
   it("starts a stopped bridge and gateway before creating a routine job", async () => {
@@ -76,6 +109,33 @@ describe("Routines Hermes integration", () => {
     ).toBeLessThan(
       mocks.createHermesBridgeCronJob.mock.invocationCallOrder[0],
     );
+  });
+
+  it("ensures the persistent gateway before resuming or rescheduling a routine", async () => {
+    await resumeRoutine("routine-1");
+    await updateRoutine("routine-1", { schedule: "0 10 * * *" });
+
+    expect(mocks.ensureHermesBridgeGateway).toHaveBeenCalledTimes(2);
+    expect(mocks.hermesBridgeCronJobAction).toHaveBeenCalledWith(
+      "routine-1",
+      "resume",
+    );
+    expect(mocks.updateHermesBridgeCronJob).toHaveBeenCalledWith("routine-1", {
+      schedule: "0 10 * * *",
+    });
+  });
+
+  it("updates non-scheduler fields without requiring the persistent gateway", async () => {
+    mocks.ensureHermesBridgeGateway.mockRejectedValue(
+      new Error("gateway unavailable"),
+    );
+
+    await updateRoutine("routine-1", { name: "Renamed" });
+
+    expect(mocks.ensureHermesBridgeGateway).not.toHaveBeenCalled();
+    expect(mocks.updateHermesBridgeCronJob).toHaveBeenCalledWith("routine-1", {
+      name: "Renamed",
+    });
   });
 
   it("does not queue a manual run when the persistent gateway cannot start", async () => {

--- a/src/test/tauri-contract.test.ts
+++ b/src/test/tauri-contract.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkRecordingSourceReadiness,
+  ensureHermesBridgeGateway,
   finishRecording,
   getNote,
   recoverRecording,
@@ -79,5 +80,11 @@ describe("Tauri command contracts", () => {
     expect(mocks.invoke).toHaveBeenNthCalledWith(3, "recover_recording", {
       request: { sessionId: "session-2", action: "discard" },
     });
+  });
+
+  it("invokes the Hermes gateway ensure command for routines", async () => {
+    await ensureHermesBridgeGateway();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("ensure_hermes_bridge_gateway");
   });
 });


### PR DESCRIPTION
## Summary

- Add a Tauri command that ensures the launchd-managed Hermes gateway is running.
- Call that gateway ensure path before Routines list/create/update/action/delete operations touch the Hermes cron API.
- Add Routines integration coverage for gateway startup ordering and failure behavior.

## Root cause

Routines were saved through the Hermes dashboard bridge, but the persistent Hermes gateway scheduler was not guaranteed to be registered or running. That allowed jobs to exist in the UI without a scheduler reliably firing them.

## Validation

- `pnpm test -- --cache=false`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`

Closes JUN-79