### PR TITLE
chore: symlink missing .agents skills into .claude/skills

### DIFF
--- a/.claude/skills/os-platform
+++ b/.claude/skills/os-platform
@@ -1,0 +1,1 @@
+../../.agents/skills/os-platform

--- a/.claude/skills/speckit-git-commit
+++ b/.claude/skills/speckit-git-commit
@@ -1,0 +1,1 @@
+../../.agents/skills/speckit-git-commit

--- a/.claude/skills/speckit-git-feature
+++ b/.claude/skills/speckit-git-feature
@@ -1,0 +1,1 @@
+../../.agents/skills/speckit-git-feature

--- a/.claude/skills/speckit-git-initialize
+++ b/.claude/skills/speckit-git-initialize
@@ -1,0 +1,1 @@
+../../.agents/skills/speckit-git-initialize

--- a/.claude/skills/speckit-git-remote
+++ b/.claude/skills/speckit-git-remote
@@ -1,0 +1,1 @@
+../../.agents/skills/speckit-git-remote

--- a/.claude/skills/speckit-git-validate
+++ b/.claude/skills/speckit-git-validate
@@ -1,0 +1,1 @@
+../../.agents/skills/speckit-git-validate


### PR DESCRIPTION
## What

Adds 6 relative symlinks under `.claude/skills/` pointing at skills that already live in `.agents/skills/` but were not yet exposed under `.claude/skills/`:

- `os-platform` -> `../../.agents/skills/os-platform`
- `speckit-git-commit` -> `../../.agents/skills/speckit-git-commit`
- `speckit-git-feature` -> `../../.agents/skills/speckit-git-feature`
- `speckit-git-initialize` -> `../../.agents/skills/speckit-git-initialize`
- `speckit-git-remote` -> `../../.agents/skills/speckit-git-remote`
- `speckit-git-validate` -> `../../.agents/skills/speckit-git-validate`

## Why

`.claude/skills/` already mirrors `.agents/skills/` via relative symlinks (4 existing: `os-accounts-integration`, `os-rust-backend`, `os-rust-backend-ci`, `repo-build-pr`). This fills the gap for the remaining skills so they're discoverable from `.claude/skills/` too. All 6 are committed as git symlinks (mode `120000`).

## Follow-up (not in this PR)

The 9 `speckit-*` entries (`analyze`, `checklist`, `clarify`, `constitution`, `implement`, `plan`, `specify`, `tasks`, `taskstoissues`) are currently committed as real directory copies rather than symlinks. Converting them to symlinks for consistency / dedup could be a separate change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes more agent skills through the Claude skills directory. The main changes are:

- Added a symlink for the `os-platform` skill.
- Added symlinks for five `speckit-git-*` skills.
- Pointed each new Claude skill entry at its existing `.agents/skills` directory.

<h3>Confidence Score: 5/5</h3>

The change is limited to adding relative symlinks for existing skill directories and appears safe to merge.

The touched files are metadata-style symlink entries only, with no application logic, runtime paths, or data handling changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the before-state artifact showing the base checkout at a3dc72a with six missing .claude/skills entries.
- Captured the after-state artifact showing the head checkout at 27560f4 with each entry mode 120000, test-L yes, exact readlink, and resolved-directory-exists yes.
- Both artifacts document the executed command/script contents, working directory, revision, verbose output, and exit code for traceability.

<a href="https://app.greptile.com/trex/runs/12144610/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: symlink missing .agents skills in..."](https://github.com/open-software-network/os-june/commit/27560f484451a5df9bfc8d47df5294838cfc0638) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39548559)</sub>

<!-- /greptile_comment -->