### PR TITLE
chore: gitignore agent worktree dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ keys/
 .tmp/
 coverage
 .tauri-hermes/
+
+# Agent worktrees
+.claude/worktrees/
+.worktrees/


### PR DESCRIPTION
Ignore agent-created worktree directories so they don't show up as untracked.

- `.claude/worktrees/` — created by background/cloud agents (Claude Code worktree isolation)
- `.worktrees/` — generic worktrees folder

No code changes; `.gitignore` only.