### PR TITLE
Fix command palette backdrop sitting under titlebar tabs

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4381,7 +4381,9 @@ input:focus-visible,
 .command-palette-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 90;
+  /* Above the titlebar chrome (drag layer 100, tab bar 101, sidebar toggle
+   * 110) so the scrim dims the tabs too. Matches the dialog system (112). */
+  z-index: 112;
   display: flex;
   align-items: flex-start;
   justify-content: center;


### PR DESCRIPTION
## What

Raise the command palette backdrop from `z-index: 90` to `112` so its dimmed/blurred scrim covers the titlebar chrome.

## Why

The titlebar chrome stacks higher than the old backdrop value:
- titlebar drag layer — `100`
- tab bar — `101`
- sidebar toggle — `110`

So when the command palette opened, the tabs (and the rest of the chrome) rendered *above* the scrim instead of being dimmed under it. `112` matches the app's existing `.dialog-backdrop`, which already sits above the chrome for this same reason.

One line changed in `src/styles/app.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)