### PR TITLE
Fix approval card link overflow

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1331,6 +1331,10 @@ input:focus-visible,
   color: var(--warm-strong);
 }
 
+.agent-approval-card > div {
+  min-width: 0;
+}
+
 .agent-approval-card .agent-tool-title > span:first-child {
   color: var(--foreground);
   font-weight: 600;
@@ -1343,6 +1347,10 @@ input:focus-visible,
   font-size: var(--fs-sm);
   line-height: 1.45;
   white-space: pre-wrap;
+}
+
+.agent-approval-card p {
+  overflow-wrap: anywhere;
 }
 
 .agent-clarify-card {
@@ -1439,6 +1447,8 @@ input:focus-visible,
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
   line-height: 1.45;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 

--- a/src/test/approval-card-css.test.ts
+++ b/src/test/approval-card-css.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import appCss from "../styles/app.css?raw";
+
+function cssRuleFor(selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{`).exec(appCss);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  let depth = 0;
+  for (let index = openIndex; index < appCss.length; index += 1) {
+    if (appCss[index] === "{") depth += 1;
+    if (appCss[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return appCss.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
+}
+
+describe("approval card styles", () => {
+  it("keeps long links inside approval cards", () => {
+    expect(cssRuleFor(".agent-approval-card > div")).toContain("min-width: 0;");
+    expect(cssRuleFor(".agent-approval-card p")).toContain(
+      "overflow-wrap: anywhere;",
+    );
+    expect(cssRuleFor(".agent-approval-card pre")).toContain(
+      "max-width: 100%;",
+    );
+    expect(cssRuleFor(".agent-approval-card pre")).toContain(
+      "overflow-wrap: anywhere;",
+    );
+  });
+});


### PR DESCRIPTION
Closes JUN-90

## What changed
- Allow approval-card content to shrink inside its grid column.
- Wrap long unbroken strings in approval descriptions and command blocks so URLs stay inside the card.
- Add a raw CSS regression test for the approval-card wrapping contract.

## Why
Long links in approval request cards could force the card content past its bounds because the inner grid item kept its min-content width and approval text did not break unbroken strings.

## Validation
- pnpm test -- src/test/approval-card-css.test.ts
- pnpm run lint
- pnpm exec prettier --check src/styles/app.css src/test/approval-card-css.test.ts
- pnpm build (passes; Vite reports the existing large chunk warning)

## Known gaps
- None.