### PR TITLE
JUN-88: Fix skill editor cancel

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7470,7 +7470,7 @@ function SkillEditorPanel({
             Read-only. This skill loads from ~/.agents/skills. Edit it on disk.
           </p>
         ) : null}
-        <button type="button" disabled={saving} onClick={onCancel}>
+        <button type="button" disabled={saving || loading} onClick={onCancel}>
           Cancel
         </button>
         {readOnly ? null : (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -7313,7 +7313,7 @@ export function SkillsToolsPanel({
           skill={selectedSkill}
           value={skillDraft}
           onBack={requestCloseSkillEditor}
-          onCancel={() => setSkillDraft(skillDocument?.content ?? "")}
+          onCancel={requestCloseSkillEditor}
           onChange={setSkillDraft}
           onSave={() => void saveSkill()}
         />
@@ -7469,24 +7469,19 @@ function SkillEditorPanel({
           <p className="agent-skill-editor-readonly-note">
             Read-only. This skill loads from ~/.agents/skills. Edit it on disk.
           </p>
-        ) : (
-          <>
-            <button
-              type="button"
-              disabled={!dirty || saving || loading}
-              onClick={onCancel}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="primary-action primary-solid"
-              disabled={!dirty || saving || loading || !document}
-              onClick={onSave}
-            >
-              {saving ? "Saving..." : "Save changes"}
-            </button>
-          </>
+        ) : null}
+        <button type="button" disabled={saving} onClick={onCancel}>
+          Cancel
+        </button>
+        {readOnly ? null : (
+          <button
+            type="button"
+            className="primary-action primary-solid"
+            disabled={!dirty || saving || loading || !document}
+            onClick={onSave}
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </button>
         )}
       </footer>
     </section>

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -15,6 +15,7 @@ import {
   AGENT_SESSIONS_CHANGED_EVENT,
   AgentWorkspace,
   HERO_GREETINGS,
+  SkillsToolsPanel,
   resetAgentSessionContinuity,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
@@ -313,6 +314,129 @@ describe("AgentWorkspace", () => {
       }
       return Promise.resolve({});
     });
+  });
+
+  it("lets users cancel a clean skill editor without making changes", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SkillsToolsPanel
+        loading={false}
+        query=""
+        saving={null}
+        skills={[
+          {
+            name: "editing-skill",
+            description: "Drafts responses.",
+            category: "Writing",
+            enabled: true,
+          },
+        ]}
+        toolsets={[]}
+        onQueryChange={vi.fn()}
+        onRefresh={vi.fn()}
+        onToggleSkill={vi.fn()}
+        onToggleToolset={vi.fn()}
+        onOpenSkill={async (skill) => ({
+          name: skill.name,
+          relativePath: `${skill.name}/SKILL.md`,
+          content: "# Editing skill\n\nDo the work.",
+        })}
+        onSaveSkill={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /editing-skill/i }));
+    const editor = await screen.findByRole("textbox", {
+      name: "editing-skill skill Markdown",
+    });
+    expect(editor).toHaveValue("# Editing skill\n\nDo the work.");
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel).toBeEnabled();
+    await user.click(cancel);
+
+    expect(
+      screen.queryByRole("textbox", {
+        name: "editing-skill skill Markdown",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Skills and tools" }),
+    ).toBeInTheDocument();
+  });
+
+  it("confirms before canceling dirty skill edits", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SkillsToolsPanel
+        loading={false}
+        query=""
+        saving={null}
+        skills={[
+          {
+            name: "editing-skill",
+            description: "Drafts responses.",
+            category: "Writing",
+            enabled: true,
+          },
+        ]}
+        toolsets={[]}
+        onQueryChange={vi.fn()}
+        onRefresh={vi.fn()}
+        onToggleSkill={vi.fn()}
+        onToggleToolset={vi.fn()}
+        onOpenSkill={async (skill) => ({
+          name: skill.name,
+          relativePath: `${skill.name}/SKILL.md`,
+          content: "# Editing skill\n\nDo the work.",
+        })}
+        onSaveSkill={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /editing-skill/i }));
+    const editor = await screen.findByRole("textbox", {
+      name: "editing-skill skill Markdown",
+    });
+    await user.type(editor, "\nAdd more detail.");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Discard skill edits?",
+    });
+    expect(
+      screen.getByRole("textbox", {
+        name: "editing-skill skill Markdown",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("dialog", { name: "Discard skill edits?" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", {
+        name: "editing-skill skill Markdown",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    const confirmDialog = await screen.findByRole("dialog", {
+      name: "Discard skill edits?",
+    });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "Discard" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("textbox", {
+          name: "editing-skill skill Markdown",
+        }),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   it("honors a pending New Session request instead of selecting existing work", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -366,6 +366,39 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps skill editor cancel disabled while the document loads", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SkillsToolsPanel
+        loading={false}
+        query=""
+        saving={null}
+        skills={[
+          {
+            name: "editing-skill",
+            description: "Drafts responses.",
+            category: "Writing",
+            enabled: true,
+          },
+        ]}
+        toolsets={[]}
+        onQueryChange={vi.fn()}
+        onRefresh={vi.fn()}
+        onToggleSkill={vi.fn()}
+        onToggleToolset={vi.fn()}
+        onOpenSkill={() => new Promise<never>(() => undefined)}
+        onSaveSkill={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /editing-skill/i }));
+
+    expect(
+      await screen.findByRole("button", { name: "Cancel" }),
+    ).toBeDisabled();
+  });
+
   it("confirms before canceling dirty skill edits", async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
Closes JUN-88

## What changed
- Made the skill editor footer Cancel button always available while the editor is idle.
- Routed footer Cancel through the existing editor close flow, so clean editors close immediately and dirty editors still show the discard confirmation.
- Kept the scope to canceling only. This PR does not add delete or remove skill behavior.

## Why
Opening a skill editor with no edits left the footer Cancel action disabled, making it look like users had to modify the skill before they could leave.

## Validation
- `pnpm test -- src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/test/agent-workspace.test.tsx`

## Known gaps
- No delete or remove skill option was added by request.
