### PR TITLE
Fix Scribe JWKS config observability

### DIFF
--- a/scribe-api/Cargo.lock
+++ b/scribe-api/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/scribe-api/Cargo.toml
+++ b/scribe-api/Cargo.toml
@@ -39,6 +39,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "timeout", "limit", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+url = "2"
 zeroize = { version = "1", features = ["derive"] }
 
 pretty_assertions = "1"

--- a/scribe-api/crates/config/Cargo.toml
+++ b/scribe-api/crates/config/Cargo.toml
@@ -15,6 +15,7 @@ figment.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/scribe-api/crates/config/src/lib.rs
+++ b/scribe-api/crates/config/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::{self, Debug},
 };
 use thiserror::Error;
+use url::Url;
 
 const REDACTED: &str = "<redacted>";
 pub const LOCAL_DEV_BEARER_TOKEN_PLACEHOLDER: &str = "local-dev-token";
@@ -592,7 +593,7 @@ fn validate(config: &AppConfig) -> Result<(), ConfigError> {
             });
         }
     } else {
-        validate_required_text("os_accounts.api_url", &config.os_accounts.api_url)?;
+        validate_absolute_http_url("os_accounts.api_url", &config.os_accounts.api_url)?;
         validate_required_secret(
             "os_accounts.app_api_key",
             &config.os_accounts.app_api_key,
@@ -721,6 +722,21 @@ fn validate_required_secret(
     Ok(())
 }
 
+fn validate_absolute_http_url(field: &'static str, value: &str) -> Result<(), ConfigError> {
+    validate_required_text(field, value)?;
+    let parsed = Url::parse(value.trim()).map_err(|_| ConfigError::InvalidRequired {
+        field,
+        reason: "must be an absolute http or https URL",
+    })?;
+    if matches!(parsed.scheme(), "http" | "https") && parsed.has_host() {
+        return Ok(());
+    }
+    Err(ConfigError::InvalidRequired {
+        field,
+        reason: "must be an absolute http or https URL",
+    })
+}
+
 fn validate_positive_config(field: &'static str, value: u64) -> Result<(), ConfigError> {
     if value == 0 {
         return Err(ConfigError::InvalidRequired {
@@ -748,8 +764,9 @@ fn validate_positive_rate(
 #[cfg(test)]
 mod tests {
     use super::{
-        AppConfig, ModelPriceConfig, ModelProvider, ModelType, OPENAI_API_KEY_PLACEHOLDERS,
-        OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, PriceUnit, VENICE_API_KEY_PLACEHOLDERS, validate,
+        AppConfig, ConfigError, ModelPriceConfig, ModelProvider, ModelType,
+        OPENAI_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, PriceUnit,
+        VENICE_API_KEY_PLACEHOLDERS, validate,
     };
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
@@ -866,6 +883,22 @@ mod tests {
         let result = validate(&config);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_schemeless_os_accounts_api_url() {
+        let mut config = valid_config();
+        config.os_accounts.api_url = "accounts.opensoftware.co/api".to_string();
+
+        let result = validate(&config);
+
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidRequired {
+                field: "os_accounts.api_url",
+                reason: "must be an absolute http or https URL"
+            })
+        ));
     }
 
     #[test]

--- a/scribe-api/crates/providers/src/jwks.rs
+++ b/scribe-api/crates/providers/src/jwks.rs
@@ -158,23 +158,30 @@ impl JwksTokenVerifier {
 
     async fn refresh_jwks(&self) -> Result<(), AuthError> {
         self.mark_attempt()?;
-        let jwks = self
-            .http
-            .get(&self.jwks_url)
-            .send()
-            .await
-            .map_err(|_| AuthError::InvalidToken)?
-            .error_for_status()
-            .map_err(|_| AuthError::InvalidToken)?
-            .json::<JwkSet>()
-            .await
-            .map_err(|_| AuthError::InvalidToken)?;
+        let jwks = self.fetch_jwks().await.map_err(|error| {
+            tracing::warn!(
+                %error,
+                jwks_url = %self.jwks_url,
+                "JWKS refresh failed"
+            );
+            AuthError::InvalidToken
+        })?;
         let mut cache = self.cache.lock().map_err(|_| AuthError::InvalidToken)?;
         cache.jwks = Some(CachedJwks {
             jwks,
             fetched_at: Instant::now(),
         });
         Ok(())
+    }
+
+    async fn fetch_jwks(&self) -> Result<JwkSet, reqwest::Error> {
+        self.http
+            .get(&self.jwks_url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<JwkSet>()
+            .await
     }
 
     fn mark_attempt(&self) -> Result<(), AuthError> {


### PR DESCRIPTION
Closes JUN-101

What changed:
- Validate `os_accounts.api_url` at Scribe API startup as an absolute `http` or `https` URL, so schemeless values fail fast before the verifier is built.
- Add a config regression test for schemeless OS Accounts API URLs.
- Log `tracing::warn!` when JWKS fetch, status, or JSON parsing fails before returning `invalid_access_token`.

Why:
- A malformed or unreachable JWKS URL previously made every token look invalid without any server-side clue because decoding never ran.

Validation:
- `cargo +1.95.0-aarch64-apple-darwin fmt --manifest-path scribe-api/Cargo.toml --all`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml -p scribe-config --locked`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml -p scribe-providers jwks --locked`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml -p scribe-providers --lib --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`

Known gaps:
- The unserialized full Scribe suite compiled but hit the local macOS file descriptor limit (`ulimit -n` is 256) while many wiremock servers started in parallel, producing unrelated `Too many open files` failures. The same suite passed when serialized.