### PR TITLE
Improve agent tool activity labels

### DIFF
--- a/src/components/agent/AgentActivityDrawer.tsx
+++ b/src/components/agent/AgentActivityDrawer.tsx
@@ -33,6 +33,7 @@ import type {
   AgentActivityPhase,
   AgentActivityRecord,
 } from "../../lib/hermes-activity-store";
+import { toolActivityLabel } from "../../lib/agent-tool-labels";
 import type {
   AgentArtifact,
   ArtifactAction,
@@ -385,7 +386,7 @@ function ActivityRow({
           </span>
           {record.phase === "running" && nonEmpty(record.currentTool) ? (
             <span className="agent-activity-row-tool">
-              {record.currentTool}
+              {toolActivityLabel(record.currentTool)}
             </span>
           ) : null}
           {record.pendingActionCount > 0 ? (
@@ -585,7 +586,7 @@ function SubagentRow({
           </span>
           {working && nonEmpty(subagent.currentTool) ? (
             <span className="agent-activity-subagent-tool">
-              {subagent.currentTool}
+              {toolActivityLabel(subagent.currentTool)}
             </span>
           ) : null}
           {Number.isFinite(lastEventAt) ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -275,6 +275,7 @@ import {
   type AgentChatTurn,
   type LiveHermesEvent,
 } from "../../lib/agent-chat-runtime";
+import { toolActivityLabel } from "../../lib/agent-tool-labels";
 import {
   buildAgentChatGallery,
   buildAgentErrorGallery,
@@ -10445,16 +10446,6 @@ function stringValue(value: unknown, preserveWhitespace = false) {
   return undefined;
 }
 
-function humanizeToolName(value: string) {
-  return value
-    .replace(/^tools?[._-]/i, "")
-    .replaceAll("_", " ")
-    .replaceAll("-", " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
 function capabilityMatches(
   item: HermesSkillInfo | HermesToolsetInfo | HermesMessagingPlatformInfo,
   query: string,
@@ -10797,7 +10788,8 @@ function agentStatusSummaryFromHermesEvent(
       stringValue(payload?.name) ??
       stringValue(payload?.tool_name) ??
       stringValue(payload?.tool);
-    return name ? `Using ${humanizeToolName(name)}.` : "Using a tool.";
+    const label = toolActivityLabel(name, payload);
+    return label === "Tool" ? "Using a tool." : `Using ${label}.`;
   }
   if (event.type === "thinking.delta" || event.type === "reasoning.delta") {
     return "Thinking.";

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -275,7 +275,7 @@ import {
   type AgentChatTurn,
   type LiveHermesEvent,
 } from "../../lib/agent-chat-runtime";
-import { toolActivityLabel } from "../../lib/agent-tool-labels";
+import { toolActivitySentence } from "../../lib/agent-tool-labels";
 import {
   buildAgentChatGallery,
   buildAgentErrorGallery,
@@ -10788,8 +10788,7 @@ function agentStatusSummaryFromHermesEvent(
       stringValue(payload?.name) ??
       stringValue(payload?.tool_name) ??
       stringValue(payload?.tool);
-    const label = toolActivityLabel(name, payload);
-    return label === "Tool" ? "Using a tool." : `Using ${label}.`;
+    return toolActivitySentence(name, payload);
   }
   if (event.type === "thinking.delta" || event.type === "reasoning.delta") {
     return "Thinking.";

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -171,7 +171,7 @@ export function buildHermesSessionChatTurns(
         createAssistantTurn(turns, messageTimestamp(message));
       upsertToolPart(turn.parts, {
         id,
-        name: message.tool_name ?? "Tool",
+        name: toolActivityLabel(message.tool_name ?? undefined),
         text: textFromHermesContent(message.content) ?? "",
         status: "complete",
       });

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -14,6 +14,7 @@ import { displayedUserMessageText } from "./issue-report-prompt";
 import { displayedSkillInvocationText } from "./skill-slash-commands";
 import { STEER_EVENT_TYPE, steeringPartText } from "./hermes-session-steer";
 import { parseHermesMode } from "./hermes-control-plane";
+import { toolActivityLabel } from "./agent-tool-labels";
 
 export type LiveHermesEvent = HermesGatewayEvent & {
   receivedAt: string;
@@ -218,7 +219,7 @@ export function buildHermesSessionChatTurns(
         turn.parts.push({
           type: "tool",
           id: call.id,
-          name: humanizeToolName(call.name),
+          name: toolActivityLabel(call.name, call.arguments),
           text:
             textFromHermesContent(result?.content) ??
             stringifyObject(call.arguments) ??
@@ -546,14 +547,14 @@ function appendLiveHermesEvents(
         currentAssistant.status = "complete";
       }
       const payload = event.payload as Record<string, unknown> | undefined;
+      const name =
+        stringValue(payload?.name) ??
+        stringValue(payload?.tool_name) ??
+        stringValue(payload?.tool) ??
+        "tool";
       upsertToolPart(currentAssistant.parts, {
         id: toolEventKey(event),
-        name: humanizeToolName(
-          stringValue(payload?.name) ??
-            stringValue(payload?.tool_name) ??
-            stringValue(payload?.tool) ??
-            "tool",
-        ),
+        name: toolActivityLabel(name, payload),
         text,
         status,
       });
@@ -1345,12 +1346,4 @@ function timestampString(value: unknown) {
     return value.toISOString();
   }
   return new Date().toISOString();
-}
-
-function humanizeToolName(value: string) {
-  return value
-    .replace(/[_-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase());
 }

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -887,7 +887,8 @@ function upsertToolPart(
         (!next.id && part.name === next.name && part.status === "running")),
   );
   if (existing) {
-    existing.name = next.name || existing.name;
+    existing.name =
+      next.name && next.name !== "Tool" ? next.name : existing.name;
     existing.status = next.status;
     if (next.text && next.text !== existing.text) {
       existing.text = appendLogText(existing.text, next.text);

--- a/src/lib/agent-tool-labels.ts
+++ b/src/lib/agent-tool-labels.ts
@@ -38,6 +38,14 @@ export function toolActivityLabel(
   return humanizeToolName(rawName);
 }
 
+export function toolActivitySentence(
+  toolName: string | undefined,
+  payload?: unknown,
+) {
+  const label = toolActivityLabel(toolName, payload);
+  return label === "Tool" ? "Using a tool." : `${label}.`;
+}
+
 export function humanizeToolName(value: string) {
   const cleaned = value
     .replace(/^tools?[._-]/i, "")

--- a/src/lib/agent-tool-labels.ts
+++ b/src/lib/agent-tool-labels.ts
@@ -1,0 +1,266 @@
+type ToolPayload = Record<string, unknown>;
+
+const GENERIC_TOOL_NAMES = new Set([
+  "bash",
+  "command",
+  "exec",
+  "exec_command",
+  "run_command",
+  "shell",
+  "terminal",
+]);
+
+export function toolActivityLabel(
+  toolName: string | undefined,
+  payload?: unknown,
+) {
+  const records = payloadRecords(payload);
+  const rawName =
+    nonEmptyString(toolName) ??
+    firstString(records, ["name", "tool_name", "tool"]) ??
+    "tool";
+  const normalized = normalizeToolName(rawName);
+  const command = firstString(records, [
+    "command",
+    "cmd",
+    "script",
+    "shell_command",
+  ]);
+  const commandLabel = command ? labelFromCommand(command) : undefined;
+  if (commandLabel) return commandLabel;
+
+  const payloadLabel = labelFromPayload(records, normalized);
+  if (payloadLabel) return payloadLabel;
+
+  const nameLabel = labelFromName(normalized);
+  if (nameLabel) return nameLabel;
+
+  return humanizeToolName(rawName);
+}
+
+export function humanizeToolName(value: string) {
+  const cleaned = value
+    .replace(/^tools?[._-]/i, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_./:-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return "Tool";
+  const lower = cleaned.toLowerCase();
+  return `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`;
+}
+
+function labelFromPayload(records: ToolPayload[], normalizedName: string) {
+  if (records.some((record) => hasAnyKey(record, ["url", "href", "uri"]))) {
+    return "Browsing";
+  }
+  if (
+    records.some((record) =>
+      hasAnyKey(record, ["search_query", "web_query", "url_query"]),
+    )
+  ) {
+    return "Searching web";
+  }
+  if (
+    records.some((record) =>
+      hasAnyKey(record, ["image_query", "image_search_query"]),
+    )
+  ) {
+    return "Searching images";
+  }
+  if (records.some((record) => hasAnyKey(record, ["query", "q"]))) {
+    if (isWebToolName(normalizedName)) return "Searching web";
+    if (isFileToolName(normalizedName)) return "Searching files";
+    return "Searching";
+  }
+  if (records.some((record) => hasAnyKey(record, ["path", "file", "files"]))) {
+    if (isEditToolName(normalizedName)) return "Editing files";
+    if (isSearchToolName(normalizedName)) return "Searching files";
+    return "Reading files";
+  }
+  return undefined;
+}
+
+function labelFromCommand(command: string) {
+  const lower = command.toLowerCase();
+  if (/\bhttps?:\/\//.test(lower) || /\b(curl|wget)\b/.test(lower)) {
+    return "Browsing";
+  }
+  if (/\bgh\s+/.test(lower)) return "Using GitHub";
+  if (
+    /\bgit\s+(status|diff|show|log|grep|ls-files|branch|fetch)\b/.test(lower)
+  ) {
+    return "Inspecting repository";
+  }
+  if (/\b(rg|grep|fd|find)\b/.test(lower)) return "Searching files";
+  if (/\b(cat|sed|awk|head|tail|nl|ls|pwd|tree)\b/.test(lower)) {
+    return "Reading files";
+  }
+  if (
+    /\b(pnpm|npm|yarn|bun)\s+(run\s+)?(test|vitest)\b/.test(lower) ||
+    /\b(cargo\s+test|pytest|vitest)\b/.test(lower)
+  ) {
+    return "Running tests";
+  }
+  if (
+    /\b(pnpm|npm|yarn|bun)\s+(run\s+)?build\b/.test(lower) ||
+    /\b(cargo\s+build|tauri\s+build)\b/.test(lower)
+  ) {
+    return "Building";
+  }
+  if (
+    /\b(pnpm|npm|yarn|bun)\s+(run\s+)?(lint|check|typecheck)\b/.test(lower) ||
+    /\b(eslint|tsc|prettier)\b/.test(lower) ||
+    /\bcargo\s+(clippy|fmt|check)\b/.test(lower)
+  ) {
+    return "Checking code";
+  }
+  if (/\b(git\s+(add|apply|commit|push)|apply_patch)\b/.test(lower)) {
+    return "Editing files";
+  }
+  return undefined;
+}
+
+function labelFromName(normalizedName: string) {
+  if (GENERIC_TOOL_NAMES.has(normalizedName)) return "Running command";
+  if (isWebSearchToolName(normalizedName)) return "Searching web";
+  if (isWebToolName(normalizedName)) return "Browsing";
+  if (isImageToolName(normalizedName)) return "Working with images";
+  if (isEditToolName(normalizedName)) return "Editing files";
+  if (isSearchToolName(normalizedName)) return "Searching files";
+  if (isReadToolName(normalizedName)) return "Reading files";
+  if (hasSegment(normalizedName, ["git", "github", "gh"])) {
+    return "Using GitHub";
+  }
+  if (hasSegment(normalizedName, ["test", "vitest", "pytest"])) {
+    return "Running tests";
+  }
+  if (hasSegment(normalizedName, ["build", "compile"])) return "Building";
+  if (hasSegment(normalizedName, ["lint", "typecheck", "check"])) {
+    return "Checking code";
+  }
+  return undefined;
+}
+
+function isWebToolName(value: string) {
+  return (
+    hasSegment(value, ["browser", "browse", "web", "visit", "navigate"]) ||
+    hasPhrase(value, ["fetch_url", "open_url"]) ||
+    hasSegment(value, ["http", "url"])
+  );
+}
+
+function isWebSearchToolName(value: string) {
+  return hasPhrase(value, [
+    "web_search",
+    "search_query",
+    "search_web",
+    "internet_search",
+    "search_internet",
+  ]);
+}
+
+function isImageToolName(value: string) {
+  return hasSegment(value, ["image", "screenshot", "vision"]);
+}
+
+function isFileToolName(value: string) {
+  return (
+    isReadToolName(value) || isEditToolName(value) || isSearchToolName(value)
+  );
+}
+
+function isReadToolName(value: string) {
+  return (
+    hasSegment(value, ["read", "cat", "list", "ls", "glob", "view"]) ||
+    hasPhrase(value, ["open_file", "view_file", "file_read"])
+  );
+}
+
+function isEditToolName(value: string) {
+  return (
+    hasSegment(value, [
+      "write",
+      "edit",
+      "patch",
+      "create",
+      "delete",
+      "remove",
+      "move",
+      "copy",
+    ]) || hasPhrase(value, ["apply_patch"])
+  );
+}
+
+function isSearchToolName(value: string) {
+  return hasSegment(value, ["search", "grep", "rg", "find", "ripgrep"]);
+}
+
+function payloadRecords(payload: unknown): ToolPayload[] {
+  const root = objectRecord(payload);
+  if (!root) return [];
+  const records: ToolPayload[] = [root];
+  for (const key of ["arguments", "args", "input", "parameters"]) {
+    const child = objectRecord(root[key]);
+    if (child) records.push(child);
+  }
+  return records;
+}
+
+function objectRecord(value: unknown): ToolPayload | undefined {
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return objectRecord(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as ToolPayload;
+}
+
+function firstString(records: ToolPayload[], keys: string[]) {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = nonEmptyString(record[key]);
+      if (value) return value;
+    }
+  }
+  return undefined;
+}
+
+function hasAnyKey(record: ToolPayload, keys: string[]) {
+  return keys.some((key) => meaningfulValue(record[key]));
+}
+
+function meaningfulValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (value && typeof value === "object") return Object.keys(value).length > 0;
+  return value !== undefined && value !== null;
+}
+
+function nonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeToolName(value: string) {
+  return value
+    .replace(/^tools?[._-]/i, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-z0-9]+/gi, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+}
+
+function hasSegment(value: string, segments: string[]) {
+  const parts = new Set(value.split("_").filter(Boolean));
+  return segments.some((segment) => parts.has(segment));
+}
+
+function hasPhrase(value: string, phrases: string[]) {
+  return phrases.some((phrase) => value.includes(phrase));
+}

--- a/src/test/agent-activity-drawer.test.tsx
+++ b/src/test/agent-activity-drawer.test.tsx
@@ -76,7 +76,7 @@ describe("AgentActivityDrawer", () => {
     expect(rows).toHaveLength(1);
     const row = rows[0];
     expect(within(row).getByText("Refactor auth")).toBeInTheDocument();
-    expect(within(row).getByText(/read_file/)).toBeInTheDocument();
+    expect(within(row).getByText("Reading files")).toBeInTheDocument();
     // Phase is conveyed in text, sentence case.
     expect(within(row).getByText(/running/i)).toBeInTheDocument();
   });
@@ -145,7 +145,7 @@ describe("AgentActivityDrawer", () => {
     const toolSub = screen.getByText("Research reconnect").closest("li");
     expect(toolSub).not.toBeNull();
     expect(
-      within(toolSub as HTMLElement).getByText("grep"),
+      within(toolSub as HTMLElement).getByText("Searching files"),
     ).toBeInTheDocument();
   });
 

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -855,6 +855,30 @@ describe("Agent chat runtime", () => {
     expect(turns[0]?.status).toBe("complete");
   });
 
+  it("labels live terminal tool rows by the activity in their payload", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            tool_id: "tool-1",
+            name: "terminal",
+            command: "curl https://example.com/docs",
+          },
+        },
+      ],
+    );
+
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    expect(tool).toMatchObject({
+      name: "Browsing",
+      status: "running",
+    });
+  });
+
   it("marks the in-flight turn errored even when the error has no text", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -879,6 +879,49 @@ describe("Agent chat runtime", () => {
     });
   });
 
+  it("keeps inferred tool labels when progress frames omit the tool name", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "tool.start",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            tool_id: "tool-1",
+            name: "terminal",
+            command: "curl https://example.com/docs",
+          },
+        },
+        {
+          type: "tool.progress",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          payload: {
+            tool_id: "tool-1",
+            output: "Fetched 42 lines",
+          },
+        },
+        {
+          type: "tool.complete",
+          receivedAt: "2026-06-04T10:00:02.000Z",
+          payload: {
+            tool_id: "tool-1",
+            result: "Done",
+          },
+        },
+      ],
+    );
+
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    expect(tool).toMatchObject({
+      name: "Browsing",
+      status: "complete",
+    });
+    expect(tool?.type === "tool" ? tool.text : "").toContain(
+      "Fetched 42 lines",
+    );
+  });
+
   it("marks the in-flight turn errored even when the error has no text", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -922,6 +922,41 @@ describe("Agent chat runtime", () => {
     );
   });
 
+  it("keeps inferred labels when persisted tool result messages arrive", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-06-04T10:00:00.000Z",
+        tool_calls: JSON.stringify([
+          {
+            id: "call-1",
+            function: {
+              name: "list_files",
+              arguments: { path: "src" },
+            },
+          },
+        ]),
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        tool_call_id: "call-1",
+        tool_name: "list_files",
+        content: "src/App.tsx",
+        timestamp: "2026-06-04T10:00:01.000Z",
+      },
+    ]);
+
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    expect(tool).toMatchObject({
+      name: "Reading files",
+      status: "complete",
+    });
+    expect(tool?.type === "tool" ? tool.text : "").toContain("src/App.tsx");
+  });
+
   it("marks the in-flight turn errored even when the error has no text", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-tool-labels.test.ts
+++ b/src/test/agent-tool-labels.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { humanizeToolName, toolActivityLabel } from "../lib/agent-tool-labels";
+import {
+  humanizeToolName,
+  toolActivityLabel,
+  toolActivitySentence,
+} from "../lib/agent-tool-labels";
 
 describe("toolActivityLabel", () => {
   it("replaces generic terminal labels with the command activity", () => {
@@ -32,5 +36,11 @@ describe("toolActivityLabel", () => {
   it("keeps an understandable fallback for unknown tools", () => {
     expect(humanizeToolName("custom_deploy_tool")).toBe("Custom deploy tool");
     expect(toolActivityLabel("custom_deploy_tool")).toBe("Custom deploy tool");
+  });
+
+  it("composes activity labels as standalone status sentences", () => {
+    expect(toolActivitySentence("read_file")).toBe("Reading files.");
+    expect(toolActivitySentence("gh")).toBe("Using GitHub.");
+    expect(toolActivitySentence(undefined)).toBe("Using a tool.");
   });
 });

--- a/src/test/agent-tool-labels.test.ts
+++ b/src/test/agent-tool-labels.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { humanizeToolName, toolActivityLabel } from "../lib/agent-tool-labels";
+
+describe("toolActivityLabel", () => {
+  it("replaces generic terminal labels with the command activity", () => {
+    expect(toolActivityLabel("terminal")).toBe("Running command");
+    expect(
+      toolActivityLabel("terminal", {
+        command: "curl https://example.com/docs",
+      }),
+    ).toBe("Browsing");
+    expect(toolActivityLabel("shell", { command: "rg -n Terminal src" })).toBe(
+      "Searching files",
+    );
+  });
+
+  it("labels common web and file tools by intent", () => {
+    expect(
+      toolActivityLabel("web.run", { search_query: [{ q: "June status" }] }),
+    ).toBe("Searching web");
+    expect(toolActivityLabel("fetch_url", { url: "https://example.com" })).toBe(
+      "Browsing",
+    );
+    expect(toolActivityLabel("read_file", { path: "src/App.tsx" })).toBe(
+      "Reading files",
+    );
+    expect(toolActivityLabel("write_file", { path: "src/App.tsx" })).toBe(
+      "Editing files",
+    );
+  });
+
+  it("keeps an understandable fallback for unknown tools", () => {
+    expect(humanizeToolName("custom_deploy_tool")).toBe("Custom deploy tool");
+    expect(toolActivityLabel("custom_deploy_tool")).toBe("Custom deploy tool");
+  });
+});


### PR DESCRIPTION
Closes JUN-106

## What changed
- Added a shared agent tool activity label formatter that turns generic tool ids like `terminal`, `shell`, or `read_file` into action labels such as `Running command`, `Browsing`, `Searching files`, and `Reading files`.
- Applied the formatter to live thinking tool rows, persisted Hermes tool-call rows, status summaries, and activity drawer current-tool labels.
- Added focused coverage for terminal-to-browsing behavior and drawer label rendering.

## Why
JUN-106 reports that June exposes less informative thinking labels than Hermes desktop, especially generic labels like `Terminal`. The UI now uses tool payload hints such as command, URL, query, and path to surface a clearer activity label.

## Validation
- `pnpm test -- src/test/agent-tool-labels.test.ts src/test/agent-chat-runtime.test.ts src/test/agent-activity-drawer.test.tsx`
- `pnpm run lint`

## Known gaps
- No manual visual smoke was run; this is a formatter and render-label change covered by focused tests.