### PR TITLE
Fix Accessibility permission refresh after grant

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -193,6 +193,8 @@ const AGENT_MENU_BAR_SESSION_LIMIT = 6;
 const AGENT_MENU_BAR_SESSION_RETRY_DELAYS_MS = [
   250, 500, 1000, 2000, 4000, 8000,
 ];
+const ACCESSIBILITY_PERMISSION_REFRESH_INTERVAL_MS = 1000;
+const ACCESSIBILITY_PERMISSION_REFRESH_TIMEOUT_MS = 120_000;
 // Floor for the note card so the sidebar can't be dragged wide enough to
 // crush it into a sliver — it always keeps a usable width plus its gutters.
 const MAIN_PANEL_MIN_WIDTH = 420;
@@ -396,6 +398,8 @@ export function App() {
     useState<RecordingSourceReadinessDto>();
   const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
   const [accessibilityStatus, setAccessibilityStatus] = useState<string>();
+  const [accessibilityRefreshRequest, setAccessibilityRefreshRequest] =
+    useState(0);
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
   const [readyUpdate, setReadyUpdate] =
     useState<UpdatePromptPayload<ScribeUpdate> | null>(null);
@@ -1637,6 +1641,37 @@ export function App() {
     return () => window.removeEventListener("focus", refresh);
   }, [appBlocked, state.recordingStatus?.state]);
 
+  // After the user asks to grant Accessibility, keep checking briefly while
+  // macOS System Settings is in front. This avoids relying on a single webview
+  // focus event, which can be missed after the native TCC prompt hands off to
+  // System Settings.
+  useEffect(() => {
+    if (
+      appBlocked ||
+      !accessibilityBlocked ||
+      accessibilityRefreshRequest === 0
+    ) {
+      return;
+    }
+    function poll() {
+      void dictationHelperCommand({ type: "get_permission_status" }).catch(
+        () => undefined,
+      );
+    }
+    poll();
+    const interval = window.setInterval(
+      poll,
+      ACCESSIBILITY_PERMISSION_REFRESH_INTERVAL_MS,
+    );
+    const timeout = window.setTimeout(() => {
+      window.clearInterval(interval);
+    }, ACCESSIBILITY_PERMISSION_REFRESH_TIMEOUT_MS);
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
+  }, [accessibilityBlocked, accessibilityRefreshRequest, appBlocked]);
+
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");
   }
@@ -1654,13 +1689,10 @@ export function App() {
   }
 
   function handleEnableAccessibility() {
-    void dictationHelperCommand({ type: "request_accessibility_permission" })
-      .catch(() => undefined)
-      .finally(() => {
-        window.setTimeout(() => {
-          void openPrivacySettings("accessibility");
-        }, 200);
-      });
+    setAccessibilityRefreshRequest((request) => request + 1);
+    void dictationHelperCommand({
+      type: "request_accessibility_permission",
+    }).catch(() => undefined);
   }
 
   useEffect(() => {
@@ -2755,7 +2787,11 @@ export function App() {
           onDragRegionPointerDown={handleTitlebarPointerDown}
         />
         <section className="main-panel">
-          {accessibilityBlocked ? <PermissionBanner /> : null}
+          {accessibilityBlocked ? (
+            <PermissionBanner
+              onEnableAccessibility={handleEnableAccessibility}
+            />
+          ) : null}
           <div
             ref={mainPanelBodyRef}
             className="main-panel-body"

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -115,15 +115,11 @@ export function PermissionsStep({
   function openAccessibilitySettings() {
     // Fire the helper's prompting check first: it registers the dictation
     // helper in the Accessibility list (so there's a toggle to flip) and
-    // shows the native dialog. Open the pane only after that IPC resolves —
-    // sequenced, not concurrent, so the registration lands before System
-    // Settings can steal focus from the prompt. (Same dance as
-    // PermissionBanner.)
-    void dictationHelperCommand({ type: "request_accessibility_permission" })
-      .catch(() => undefined)
-      .finally(() => {
-        void openPrivacySettings("accessibility");
-      });
+    // shows the native dialog. Let macOS own the System Settings handoff so
+    // the native prompt is not left open behind a programmatic settings launch.
+    void dictationHelperCommand({
+      type: "request_accessibility_permission",
+    }).catch(() => undefined);
   }
 
   return (

--- a/src/components/permissions/PermissionBanner.tsx
+++ b/src/components/permissions/PermissionBanner.tsx
@@ -1,7 +1,10 @@
 import { IconLock } from "central-icons/IconLock";
-import { dictationHelperCommand, openPrivacySettings } from "../../lib/tauri";
 
-export function PermissionBanner() {
+export function PermissionBanner({
+  onEnableAccessibility,
+}: {
+  onEnableAccessibility: () => void;
+}) {
   return (
     <section
       className="message-card permission-banner"
@@ -20,24 +23,9 @@ export function PermissionBanner() {
         <button
           type="button"
           className="btn btn-ghost"
-          onClick={() => {
-            // Fire the helper's prompting check first: it registers the
-            // dictation helper in the Accessibility list (so there's a toggle
-            // to flip) and shows the native system dialog. Open the pane only
-            // after that IPC resolves — sequenced, not concurrent, so the
-            // registration lands before System Settings can steal focus from
-            // the prompt. The pane is the fallback for repeat clicks, where
-            // macOS suppresses the one-time dialog.
-            void dictationHelperCommand({
-              type: "request_accessibility_permission",
-            })
-              .catch(() => undefined)
-              .finally(() => {
-                void openPrivacySettings("accessibility");
-              });
-          }}
+          onClick={onEnableAccessibility}
         >
-          Open System Settings
+          Grant access
         </button>
       </div>
     </section>

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
@@ -375,6 +381,46 @@ describe("App shortcuts", () => {
     expect(
       await screen.findByRole("heading", { name: "Appearance" }),
     ).toBeInTheDocument();
+  });
+
+  it("refreshes Accessibility after requesting access without opening settings over the native prompt", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.listeners.has("dictation-event")).toBe(true),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    mocks.dictationHelperCommand.mockClear();
+    mocks.openPrivacySettings.mockClear();
+
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        "Dictation can't paste into other apps until you grant accessibility access.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "request_accessibility_permission",
+    });
+    await waitFor(() =>
+      expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+        type: "get_permission_status",
+      }),
+    );
+    expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith("accessibility");
   });
 
   it("starts a session with Ctrl-N and creates a note with Ctrl-Shift-N on Windows", async () => {


### PR DESCRIPTION
Closes JUN-95

## What changed
- Route the Accessibility banner through the app-level grant handler instead of opening System Settings directly from the banner.
- Stop opening System Settings programmatically immediately after calling the native Accessibility prompt, so macOS does not leave the Open System Preferences / Deny prompt behind the settings handoff.
- Start a bounded permission-status refresh loop after the user asks to grant Accessibility, so the app notices the grant even if the webview focus event is missed.
- Apply the same native-prompt handoff behavior to onboarding's Accessibility row.
- Add a regression test for the missing-accessibility banner flow.

## Why
Granting Accessibility happens outside June in macOS System Settings. The previous flow could both show the native TCC prompt and open Settings itself, leaving the native prompt stale after access was granted. The app also only had a one-shot focus refresh in the main flow.

## Validation
- pnpm test src/test/app-shortcut.test.tsx
- pnpm test src/test/onboarding.test.tsx
- pnpm run lint

## Known gaps
- Not manually reproduced on macOS 26.5.1 in this session.