### PR TITLE
Fix bug report chip seeding

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2664,7 +2664,9 @@ export function AgentWorkspace({
 
     const pending = pendingNewSessionRequest();
     if (pending) {
-      void windowEventHandlersRef.current.startNewTask(pending);
+      void windowEventHandlersRef.current.startNewTask(pending, {
+        deferCategorySeed: true,
+      });
     }
 
     window.addEventListener(AGENT_NEW_SESSION_EVENT, handleNewSession);
@@ -4492,7 +4494,10 @@ export function AgentWorkspace({
     );
   }
 
-  async function startNewTask(request?: AgentNewSessionDetail) {
+  async function startNewTask(
+    request?: AgentNewSessionDetail,
+    options: { deferCategorySeed?: boolean } = {},
+  ) {
     clearPendingNewSessionRequest();
     const seedCategory = request?.category ?? null;
     // A seeded report never auto-submits: the category chip lands in the
@@ -4528,7 +4533,7 @@ export function AgentWorkspace({
     pendingSeedCategoryRef.current = seedCategory;
     if (seedCategory) {
       clearComposerDraft(NEW_SESSION_DRAFT_KEY);
-      seedComposerCategory();
+      seedComposerCategory({ defer: options.deferCategorySeed });
     } else if (initialPrompt) {
       rememberComposerDraft(NEW_SESSION_DRAFT_KEY, initialPrompt, null);
       composerEditorRef.current?.setContent(initialPrompt);
@@ -4612,18 +4617,29 @@ export function AgentWorkspace({
   /** Applies any pending seed category to the composer chip once the editor is
    * available. Called from startNewTask (best-effort, the editor may not be
    * mounted yet) and again from ComposerEditor's onReady. */
-  function seedComposerCategory() {
-    const seed = pendingSeedCategoryRef.current;
-    if (!seed) return;
+  function seedComposerCategory(options: { defer?: boolean } = {}) {
+    if (!pendingSeedCategoryRef.current) return;
     const editor = composerEditorRef.current;
     // Not mounted yet (cold open) — leave it pending for onReady to apply.
     if (!editor) return;
-    pendingSeedCategoryRef.current = null;
-    window.setTimeout(() => {
-      if (pendingSeedCategoryRef.current) return;
-      editor.setContent("", seed);
+    const applySeed = () => {
+      const seed = pendingSeedCategoryRef.current;
+      const currentEditor = composerEditorRef.current;
+      if (!seed || !currentEditor) return;
+      pendingSeedCategoryRef.current = null;
+      draftRef.current = "";
+      categoryRef.current = seed;
+      setDraft("");
+      setCategory(seed);
       rememberComposerDraft(NEW_SESSION_DRAFT_KEY, "", seed);
-    }, 0);
+      restoredComposerDraftKeyRef.current = NEW_SESSION_DRAFT_KEY;
+      currentEditor.setContent("", seed);
+    };
+    if (options.defer) {
+      window.setTimeout(applySeed, 0);
+    } else {
+      applySeed();
+    }
   }
 
   // Run shortcuts fire the session directly — the prompt never touches the
@@ -5520,7 +5536,7 @@ export function AgentWorkspace({
             onSubmit={() => void submit()}
             onReady={() => {
               restoreComposerDraft(composerDraftKeyRef.current);
-              seedComposerCategory();
+              seedComposerCategory({ defer: true });
             }}
           />
           <div className="agent-composer-toolbar">

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -519,6 +519,31 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("seeds a report chip immediately when the composer is already open", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByRole("textbox")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+          detail: { category: "bug" },
+        }),
+      );
+    });
+
+    expect(screen.getByText("Bug report")).toBeInTheDocument();
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith(
+      "session.create",
+      expect.anything(),
+    );
+  });
+
   it("wraps a submitted issue report for June and waits for explicit send", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(


### PR DESCRIPTION
Closes JUN-109

## What changed
- Seed the report category chip synchronously for already-mounted agent composers, so the first bug-report action attaches the tag immediately.
- Keep mount-time pending-marker hydration deferred to avoid editor lifecycle warnings.
- Added a regression test that dispatches the bug-report category event against an open composer and asserts the chip appears before any timer tick.

## Why
The report flow can deliver the same fresh-session request through session storage and a window event. The previous category seed always waited for a zero-delay timer, which left a timing window where the first visible press could appear to do nothing until another action refreshed the composer state.

## Validation
- pnpm test -- src/test/agent-workspace.test.tsx
- pnpm run lint

## Known gaps
- Full app build not run; this is a scoped frontend state-management fix covered by the focused test file and TypeScript check.