### PR TITLE
Fix long dictation transcription fallback

### DIFF
--- a/scribe-api/crates/app/src/main.rs
+++ b/scribe-api/crates/app/src/main.rs
@@ -7,15 +7,15 @@ use scribe_config::{
 use scribe_providers::{
     JwksTokenVerifier, LocalDevOsAccountsClient, LocalDevTokenVerifier, LogIssueReportSink,
     MultiFormatDurationProbe, OsAccountsHttpClient, OsPlatformIssueReportSink, RoutingTranscriber,
-    VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog, default_client,
-    jwks_client,
+    VeniceAgentChat, VeniceCleaner, VeniceGenerator, VeniceModelCatalog, client_with_timeout,
+    default_client, jwks_client,
 };
 use scribe_services::{
     AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps,
     NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeService, NoteTranscribeServiceDeps,
     PricingTable,
 };
-use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
+use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Duration};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, Parser)]
@@ -43,8 +43,11 @@ async fn serve() -> anyhow::Result<()> {
     let config = scribe_config::load()?;
     let address: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
     let http = default_client();
-    let pricing = load_pricing(&config, http.clone()).await;
-    let app = build_router(&config, &http, pricing);
+    let upstream_http = client_with_timeout(Duration::from_secs(
+        config.server.request_timeout_secs.max(1),
+    ));
+    let pricing = load_pricing(&config, upstream_http.clone()).await;
+    let app = build_router(&config, &http, &upstream_http, pricing);
     let listener = tokio::net::TcpListener::bind(address).await?;
     tracing::info!(%address, "scribe-api listening");
     axum::serve(listener, app).await?;
@@ -79,6 +82,7 @@ async fn load_pricing(
 fn build_router(
     config: &AppConfig,
     http: &reqwest::Client,
+    upstream_http: &reqwest::Client,
     mut pricing_config: BTreeMap<String, ModelPriceConfig>,
 ) -> axum::Router {
     if config.local_dev.enabled {
@@ -94,18 +98,18 @@ fn build_router(
     let pricing = Arc::new(PricingTable::new(pricing_config));
     let os_accounts = build_os_accounts_client(config, http);
     let transcriber: Arc<dyn scribe_domain::Transcriber> = Arc::new(
-        RoutingTranscriber::from_config(http.clone(), &config.upstreams, openai_model_ids),
+        RoutingTranscriber::from_config(upstream_http.clone(), &config.upstreams, openai_model_ids),
     );
     let generator: Arc<dyn scribe_domain::Generator> = Arc::new(VeniceGenerator::from_config(
-        http.clone(),
+        upstream_http.clone(),
         &config.upstreams.venice,
     ));
     let cleaner: Arc<dyn scribe_domain::Cleaner> = Arc::new(VeniceCleaner::from_config(
-        http.clone(),
+        upstream_http.clone(),
         &config.upstreams.venice,
     ));
     let agent_chat_completer: Arc<dyn scribe_domain::AgentChatCompleter> = Arc::new(
-        VeniceAgentChat::from_config(http.clone(), &config.upstreams.venice),
+        VeniceAgentChat::from_config(upstream_http.clone(), &config.upstreams.venice),
     );
     let duration_probe: Arc<dyn scribe_domain::AudioDurationProbe> =
         Arc::new(MultiFormatDurationProbe);

--- a/scribe-api/crates/providers/src/http.rs
+++ b/scribe-api/crates/providers/src/http.rs
@@ -8,6 +8,10 @@ pub fn default_client() -> Client {
     build_client(DEFAULT_TIMEOUT)
 }
 
+pub fn client_with_timeout(timeout: Duration) -> Client {
+    build_client(timeout)
+}
+
 pub fn jwks_client() -> Client {
     build_client(Duration::from_secs(5))
 }

--- a/scribe-api/crates/providers/src/lib.rs
+++ b/scribe-api/crates/providers/src/lib.rs
@@ -16,7 +16,7 @@ mod retry;
 mod transcription;
 
 pub use audio_probe::MultiFormatDurationProbe;
-pub use http::{default_client, jwks_client};
+pub use http::{client_with_timeout, default_client, jwks_client};
 pub use issue_reports::{LogIssueReportSink, OsPlatformIssueReportSink};
 pub use jwks::{JwksTokenVerifier, JwksTokenVerifierParams};
 pub use local_dev::{LocalDevOsAccountsClient, LocalDevTokenVerifier};

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -2096,8 +2096,10 @@ fn emit_dictation_cleanup_skipped(app: &AppHandle, provider: &str, error: &AppEr
 
 fn looks_like_instruction_response(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
-    normalized.starts_with("sure")
+    looks_like_report_summary_response(&normalized)
+        || normalized.starts_with("sure")
         || normalized.starts_with("here")
+        || normalized.starts_with("summary:")
         || normalized.starts_with("the transcript ")
         || normalized.starts_with("the user expresses")
         || normalized.starts_with("the user did")
@@ -2118,6 +2120,27 @@ fn looks_like_instruction_response(value: &str) -> bool {
         || normalized.contains(" spelled correctly ")
         || normalized.contains("rewritten text")
         || normalized.contains("normalized transcript")
+}
+
+fn looks_like_report_summary_response(normalized: &str) -> bool {
+    normalized.starts_with("bug report assessment")
+        || normalized.starts_with("user report summary")
+        || normalized.starts_with("what likely happened")
+        || normalized.starts_with("likely affected component")
+        || normalized.starts_with("notes for the team")
+        || normalized.contains(" user report summary")
+        || normalized.contains(" bug report assessment")
+        || normalized.contains(" what likely happened")
+        || normalized.contains(" likely affected component")
+        || normalized.contains(" notes for the team")
+        || ((normalized.starts_with("user performed ")
+            || normalized.starts_with("user reported ")
+            || normalized.starts_with("the user performed")
+            || normalized.starts_with("the user reported"))
+            && (normalized.contains("long dictation")
+                || normalized.contains("instead of producing")
+                || normalized.contains("summary-like")
+                || normalized.contains("transcription pipeline")))
 }
 
 fn spawn_dictation_history_write(app: AppHandle, transcript: TranscriptionProviderResult) {
@@ -2225,6 +2248,19 @@ fn outcome_from_clean_transcript(
             event: Some(no_text_event_for_observed_audio(observed_audio_level)),
             transcript: None,
         },
+        transcript if looks_like_instruction_response(&transcript.text) => {
+            DictationTranscriptionOutcome {
+                helper_command: serde_json::json!({ "type": "discard_recording" }),
+                event: Some(serde_json::json!({
+                    "type": "error",
+                    "payload": {
+                        "code": "dictation_response_invalid",
+                        "message": "Dictation returned a summary instead of dictated text. Try again.",
+                    },
+                })),
+                transcript: None,
+            }
+        }
         transcript => {
             if let Some(prompt) = agent_session_prompt_from_dictation(&transcript.text) {
                 DictationTranscriptionOutcome {
@@ -3653,6 +3689,28 @@ mod tests {
     }
 
     #[test]
+    fn summary_like_transcription_discards_with_visible_error() {
+        let outcome = outcome_from_transcription_result(
+            Ok(TranscriptionProviderResult {
+                text: "User performed a very long dictation session. Instead of producing a full transcription, the app emitted an error.".to_string(),
+                language: Some("en".to_string()),
+                provider: crate::providers::VENICE_PROVIDER.to_string(),
+            }),
+            None,
+            DictationStyle::Standard,
+        );
+
+        assert_eq!(
+            outcome.helper_command,
+            serde_json::json!({ "type": "discard_recording" })
+        );
+        assert!(outcome.transcript.is_none());
+        let event = outcome.event.expect("summary-like text emits an error");
+        assert_eq!(event["payload"]["code"], "dictation_response_invalid");
+        assert!(!is_silent_transcription_error(&event));
+    }
+
+    #[test]
     fn filler_only_transcription_discards_silently() {
         let outcome = outcome_from_transcription_result(
             Ok(TranscriptionProviderResult {
@@ -4128,9 +4186,18 @@ mod tests {
         assert!(looks_like_instruction_response(
             "The transcript ends here without additional context. The user did not ask a question."
         ));
+        assert!(looks_like_instruction_response(
+            "Bug Report Assessment: The user performed a long dictation session."
+        ));
+        assert!(looks_like_instruction_response(
+            "User report summary: User performed a long dictation session."
+        ));
         assert!(!looks_like_instruction_response("Hello, \"testing\"."));
         assert!(!looks_like_instruction_response(
             "The user story for this sprint covers the dictation page."
+        ));
+        assert!(!looks_like_instruction_response(
+            "User reported the bug to support."
         ));
     }
 

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -15,7 +15,7 @@ use std::{
 // record, and the v0.0.3 DMG shipped pointing at it.
 const DEFAULT_SCRIBE_API_URL: &str = "https://scribe-api.opensoftware.co";
 const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "nvidia-nemotron-3-nano-30b-a3b";
-const HTTP_TIMEOUT: Duration = Duration::from_secs(60);
+const HTTP_TIMEOUT: Duration = Duration::from_secs(600);
 const AGENT_HTTP_TIMEOUT: Duration = Duration::from_secs(600);
 const AGENT_PROXY_MAX_MESSAGES: usize = 64;
 const AGENT_PROXY_MAX_INSTRUCTION_MESSAGES: usize = 4;


### PR DESCRIPTION
Closes JUN-104

## What changed
- Extended the desktop Scribe API HTTP timeout to 600 seconds so long transcription requests are not cut off after one minute.
- Added a configurable upstream HTTP client in scribe-api and wired transcription, generation, cleanup, and agent-chat providers to the server request timeout instead of the one-minute default client.
- Hardened dictation output handling so summary or report-diagnosis shaped text is discarded with a visible error instead of being pasted or saved as valid dictation.
- Added dictation tests for summary-like transcription rejection and a false-positive guard for normal dictated text.

## Why
Very long dictations could exceed the one-minute client/provider HTTP timeout even though the API request budget is longer. If a model returned summary-like text after a partial or failed path, the desktop dictation flow could treat that non-transcript text as pasteable output.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml dictation --locked`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --locked`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml -p scribe-providers --lib --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml -p scribe --locked`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path scribe-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`

## Notes
- A parallel `scribe-providers` run initially hit local file descriptor exhaustion from many wiremock tests running at once. The same provider suite passed serially, and the full scribe-api workspace passed serially.
- Desktop Rust tests still emit the pre-existing unused `Manager` import warning in `src/commands.rs`.
