### PR TITLE
Fix agent tab session restore

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -331,15 +331,6 @@ export function App() {
   const [activeAgentSessionId, setActiveAgentSessionId] = useState<string>();
   const [activeAgentSessionSeed, setActiveAgentSessionSeed] =
     useState<HermesSessionInfo>();
-  const activeAgentSession = useMemo(
-    () =>
-      activeAgentSessionId
-        ? (agentSessions.find(
-            (session) => session.id === activeAgentSessionId,
-          ) ?? activeAgentSessionSeed)
-        : undefined,
-    [activeAgentSessionId, activeAgentSessionSeed, agentSessions],
-  );
   const setActiveAgentSession = useCallback(
     (session: HermesSessionInfo | undefined) => {
       setActiveAgentSessionId(session?.id);
@@ -1256,8 +1247,8 @@ export function App() {
         const selectedSessionId = detail.selectedSessionId;
         if (selectedSessionId) {
           setActiveAgentSessionId(selectedSessionId);
-          setActiveAgentSessionSeed(
-            detail.sessions.find((session) => session.id === selectedSessionId),
+          setActiveAgentSessionSeed((current) =>
+            current?.id === selectedSessionId ? current : undefined,
           );
         } else {
           setActiveAgentSession(undefined);
@@ -2867,7 +2858,7 @@ export function App() {
                 // The origin crumbs render inside the workspace's own sticky
                 // session bar, so they persist while the chat scrolls beneath.
                 <AgentWorkspace
-                  initialSession={activeAgentSession}
+                  initialSession={activeAgentSessionSeed}
                   initialSessionId={activeAgentSessionId}
                   origin={
                     agentOriginFolder

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -324,12 +324,29 @@ export function App() {
   // skips writes until live navigation settles onto the target (note loads are
   // async), so a half-applied snapshot never overwrites the tab it came from.
   const restoreTargetRef = useRef<TabNav | null>(null);
-  const [activeAgentSession, setActiveAgentSession] =
-    useState<HermesSessionInfo>();
   // Reactive copy of the known agent sessions for the "view all" list and
   // project (folder) surfaces; the menu-bar refs below stay the source for
   // native menu state.
   const [agentSessions, setAgentSessions] = useState<HermesSessionInfo[]>([]);
+  const [activeAgentSessionId, setActiveAgentSessionId] = useState<string>();
+  const [activeAgentSessionSeed, setActiveAgentSessionSeed] =
+    useState<HermesSessionInfo>();
+  const activeAgentSession = useMemo(
+    () =>
+      activeAgentSessionId
+        ? (agentSessions.find(
+            (session) => session.id === activeAgentSessionId,
+          ) ?? activeAgentSessionSeed)
+        : undefined,
+    [activeAgentSessionId, activeAgentSessionSeed, agentSessions],
+  );
+  const setActiveAgentSession = useCallback(
+    (session: HermesSessionInfo | undefined) => {
+      setActiveAgentSessionId(session?.id);
+      setActiveAgentSessionSeed(session);
+    },
+    [],
+  );
   const [agentWorkingSessionIds, setAgentWorkingSessionIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
@@ -567,8 +584,7 @@ export function App() {
       originFolderId: activeView === "meetings" ? originFolderId : undefined,
       originAllNotes: activeView === "meetings" ? originAllNotes : undefined,
       folderId: activeView === "folders" ? state.selectedFolderId : undefined,
-      agentSessionId:
-        activeView === "agent" ? activeAgentSession?.id : undefined,
+      agentSessionId: activeView === "agent" ? activeAgentSessionId : undefined,
       agentOrigin: activeView === "agent" ? agentOrigin : undefined,
     }),
     [
@@ -577,7 +593,7 @@ export function App() {
       originFolderId,
       originAllNotes,
       state.selectedFolderId,
-      activeAgentSession?.id,
+      activeAgentSessionId,
       agentOrigin,
     ],
   );
@@ -648,7 +664,8 @@ export function App() {
         const session = nav.agentSessionId
           ? agentSessions.find((s) => s.id === nav.agentSessionId)
           : undefined;
-        setActiveAgentSession(session);
+        setActiveAgentSessionId(nav.agentSessionId);
+        setActiveAgentSessionSeed(session);
       } else {
         setActiveAgentSession(undefined);
       }
@@ -1235,6 +1252,17 @@ export function App() {
       if (!detail) return;
       agentMenuBarSessionsRef.current = detail.sessions;
       setAgentSessions(detail.sessions);
+      if (activeViewRef.current === "agent") {
+        const selectedSessionId = detail.selectedSessionId;
+        if (selectedSessionId) {
+          setActiveAgentSessionId(selectedSessionId);
+          setActiveAgentSessionSeed(
+            detail.sessions.find((session) => session.id === selectedSessionId),
+          );
+        } else {
+          setActiveAgentSession(undefined);
+        }
+      }
       // "New session" started from a project: file the first brand-new
       // session that gets selected; switching to a known session instead
       // abandons the intent.
@@ -1407,9 +1435,12 @@ export function App() {
       (sessionId) => {
         setAgentOrigin(undefined);
         if (!sessionId) {
+          setActiveAgentSession(undefined);
           setActiveView("agent");
           return;
         }
+        setActiveAgentSessionId(sessionId);
+        setActiveAgentSessionSeed(undefined);
         const cachedSession = agentMenuBarSessionsRef.current.find(
           (session) => session.id === sessionId,
         );
@@ -2437,21 +2468,24 @@ export function App() {
     const tick = window.setInterval(() => {
       setRecordingInactivityNow(Date.now());
     }, 1000);
-    const timeout = window.setTimeout(() => {
-      const currentStatus = recordingStatusRef.current;
-      const sessionId = recordingInactivityPrompt.sessionId;
-      recordingInactivityTrackerRef.current = { sessionId };
-      setRecordingInactivityPrompt(null);
-      if (
-        currentStatus?.sessionId !== sessionId ||
-        currentStatus.state !== "recording"
-      ) {
-        return;
-      }
-      void handlePauseRecording(sessionId).then((paused) => {
-        if (paused) void notifyRecordingAutoPaused(sessionId);
-      });
-    }, Math.max(0, recordingInactivityPrompt.expiresAt - Date.now()));
+    const timeout = window.setTimeout(
+      () => {
+        const currentStatus = recordingStatusRef.current;
+        const sessionId = recordingInactivityPrompt.sessionId;
+        recordingInactivityTrackerRef.current = { sessionId };
+        setRecordingInactivityPrompt(null);
+        if (
+          currentStatus?.sessionId !== sessionId ||
+          currentStatus.state !== "recording"
+        ) {
+          return;
+        }
+        void handlePauseRecording(sessionId).then((paused) => {
+          if (paused) void notifyRecordingAutoPaused(sessionId);
+        });
+      },
+      Math.max(0, recordingInactivityPrompt.expiresAt - Date.now()),
+    );
 
     return () => {
       window.clearInterval(tick);
@@ -2834,6 +2868,7 @@ export function App() {
                 // session bar, so they persist while the chat scrolls beneath.
                 <AgentWorkspace
                   initialSession={activeAgentSession}
+                  initialSessionId={activeAgentSessionId}
                   origin={
                     agentOriginFolder
                       ? {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -833,6 +833,7 @@ export type AgentWorkspaceOrigin = {
 
 type AgentWorkspaceProps = {
   initialSession?: HermesSessionInfo;
+  initialSessionId?: string;
   origin?: AgentWorkspaceOrigin;
 };
 
@@ -1205,9 +1206,10 @@ export function resetAgentSessionContinuity() {
 
 export function AgentWorkspace({
   initialSession,
+  initialSessionId: initialSessionIdProp,
   origin,
 }: AgentWorkspaceProps = {}) {
-  const initialSessionId = initialSession?.id;
+  const initialSessionId = initialSession?.id ?? initialSessionIdProp;
   // Read once per mount (lazy initializer): the continuity snapshot the
   // previous mount captured on unmount, if any session was still mid-run.
   const [continuity] = useState(() => sessionContinuity);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2588,13 +2588,15 @@ export function AgentWorkspace({
     selectedHermesSessionIdRef.current = initialSessionId;
     setSelectedHermesSessionId(initialSessionId);
     setSelectedTaskId(undefined);
-    if (initialSession) {
-      setHermesSessionItems((current) =>
-        current.some((session) => session.id === initialSession.id)
-          ? current
-          : [initialSession, ...current],
-      );
-    }
+  }, [initialSessionId]);
+
+  useEffect(() => {
+    if (!initialSession || initialSession.id !== initialSessionId) return;
+    setHermesSessionItems((current) =>
+      current.some((session) => session.id === initialSession.id)
+        ? current
+        : [initialSession, ...current],
+    );
   }, [initialSession, initialSessionId]);
 
   // Remember the open conversation for the restore-on-mount above. Entering

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2791,6 +2791,29 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Newer session")).toBeNull();
   });
 
+  it("honors an initial session id before session metadata is available", async () => {
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Newer session",
+        preview: "More recent work",
+        last_active: "2026-06-05T12:00:00Z",
+      },
+      existingSession,
+    ]);
+
+    render(<AgentWorkspace initialSessionId="session-1" />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-1"),
+    );
+    expect(mocks.listHermesSessionMessages).not.toHaveBeenCalledWith(
+      "session-2",
+    );
+    expect(screen.queryByText("Newer session")).toBeNull();
+  });
+
   it("restores an in-flight new session across a remount (settings round trip)", async () => {
     // Start a brand-new session whose first turn is still running: Hermes has
     // persisted nothing yet (no messages, absent from the server session

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1,9 +1,18 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
-import { AGENT_NEW_SESSION_EVENT } from "../lib/agent-events";
+import {
+  AGENT_NEW_SESSION_EVENT,
+  AGENT_SESSIONS_CHANGED_EVENT,
+} from "../lib/agent-events";
 import { CLOSE_TAB_EVENT, OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
 import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
 
@@ -270,6 +279,86 @@ describe("App shortcuts", () => {
       expect(mocks.createNote).not.toHaveBeenCalled();
     } finally {
       window.removeEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);
+    }
+  });
+
+  it("keeps each agent tab tied to its selected session", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    const user = userEvent.setup();
+
+    try {
+      render(<App />);
+
+      expect(
+        await screen.findByRole("heading", { name: HERO_GREETING }),
+      ).toBeInTheDocument();
+
+      const firstSession = {
+        id: "session-1",
+        title: "First session",
+        preview: "First preview",
+        last_active: "2026-06-04T12:00:00Z",
+      };
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, {
+            detail: {
+              sessions: [firstSession],
+              selectedSessionId: firstSession.id,
+              workingSessionIds: [],
+            },
+          }),
+        );
+      });
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("tab", { name: "First session" }),
+        ).toHaveAttribute("data-active", "true"),
+      );
+
+      await user.click(screen.getByRole("button", { name: "New tab" }));
+      expect(
+        await screen.findByRole("tab", { name: "New session" }),
+      ).toHaveAttribute("data-active", "true");
+
+      const secondSession = {
+        id: "session-2",
+        title: "Second session",
+        preview: "Second preview",
+        last_active: "2026-06-05T12:00:00Z",
+      };
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, {
+            detail: {
+              sessions: [secondSession, firstSession],
+              selectedSessionId: secondSession.id,
+              workingSessionIds: [],
+            },
+          }),
+        );
+      });
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("tab", { name: "Second session" }),
+        ).toHaveAttribute("data-active", "true"),
+      );
+
+      await user.click(screen.getByRole("button", { name: "Show all 2 tabs" }));
+      await user.click(screen.getByRole("menuitem", { name: "First session" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("tab", { name: "First session" }),
+        ).toHaveAttribute("data-active", "true"),
+      );
+    } finally {
+      restoreNavigator();
     }
   });
 


### PR DESCRIPTION
JUN-93

## What changed
- Store the active agent session ID separately from the hydrated session object in App tab state.
- Feed that ID into AgentWorkspace so a restored tab can hydrate the intended session before metadata is loaded.
- Mirror AgentWorkspace selectedSessionId events back into the active tab so newly-created sessions claim their tab snapshot.

## Why
Multiple agent tabs could remain as generic New session snapshots. On tab restore, AgentWorkspace then fell back to the most recent Hermes session, making every tab display the latest session.

## Validation
- pnpm test -- src/test/app-shortcut.test.tsx src/test/agent-workspace.test.tsx
- pnpm run lint
- pnpm exec prettier --check src/app/App.tsx src/components/agent/AgentWorkspace.tsx src/test/agent-workspace.test.tsx src/test/app-shortcut.test.tsx
- git diff --check

## Known gaps
- Full pnpm test and pnpm build were not run; this is a scoped frontend/session-state change covered by targeted suites and TypeScript lint.