### PR TITLE
Add copy and edit actions to agent messages

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -8,6 +8,7 @@ import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconBubbleWide } from "central-icons/IconBubbleWide";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconCircleQuestionmark } from "central-icons/IconCircleQuestionmark";
+import { IconClipboard } from "central-icons/IconClipboard";
 import { IconCrossMedium } from "central-icons/IconCrossMedium";
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconFolder1 } from "central-icons/IconFolder1";
@@ -4590,6 +4591,16 @@ export function AgentWorkspace({
     });
   }
 
+  function editUserPrompt(text: string) {
+    composerEditorRef.current?.setContent(text, null);
+    setDraft(text);
+    setCategory(null);
+    draftRef.current = text;
+    categoryRef.current = null;
+    setComposerAttachments([]);
+    rememberComposerDraft(composerDraftKeyRef.current, text, null, []);
+  }
+
   function setComposerAttachments(
     nextValue:
       | AgentAttachment[]
@@ -5869,6 +5880,7 @@ export function AgentWorkspace({
             void branchFromMessage(selectedHermesSessionId, messageId)
           }
           branchingMessageId={branchingMessageId}
+          onEditUserPrompt={editUserPrompt}
         />
       ))}
       {workingSessionIds.has(selectedHermesSessionId) &&
@@ -5981,6 +5993,7 @@ export function AgentWorkspace({
                 sessionUnrestricted(selectedTask.hermesSessionId),
               );
             }}
+            onEditUserPrompt={editUserPrompt}
           />
         ))}
         {workingTaskIds.has(selectedTask.id) &&
@@ -8155,6 +8168,7 @@ function AgentChatTurnRow({
   onThinkingOpenChange,
   onTopUp,
   onBranch,
+  onEditUserPrompt,
   branchingMessageId,
   turn,
 }: {
@@ -8188,6 +8202,7 @@ function AgentChatTurnRow({
   onOpenArtifact?: (artifact: AgentArtifact) => void;
   onThinkingOpenChange: (key: string, open: boolean) => void;
   onTopUp?: () => void;
+  onEditUserPrompt?: (text: string) => void;
   /** Fork the conversation from this turn into a new session (feature 07).
    * Optional: only Hermes-session rows pass it — task rows and the dev gallery
    * omit it, so the action is absent there. */
@@ -8226,6 +8241,8 @@ function AgentChatTurnRow({
     activeThinkingKey !== undefined &&
     thinkingOpen(activeThinkingKey);
   const thinkingIsOpen = thinkingOpen(thinkingKey) || carriedOpen;
+  const [copied, setCopied] = useState(false);
+  const copyResetTimerRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
     const wasRunning = wasThinkingRunningRef.current;
@@ -8251,24 +8268,93 @@ function AgentChatTurnRow({
     toolParts.length,
   ]);
 
+  useEffect(
+    () => () => {
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    },
+    [],
+  );
+
   const contextParts = turn.parts.filter(
     (part): part is Extract<AgentChatPart, { type: "context" }> =>
       part.type === "context",
   );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
+  const copyText = copyableTextForTurn(turn);
+  const userPromptText =
+    turn.role === "user" ? userPromptTextForTurn(turn) : "";
 
-  // Feature 07: the per-turn "Branch from here" control. Rendered only on
-  // Hermes-session rows (which pass `onBranch`); the action self-disables when
-  // the turn id is not a persisted message id (see isBranchableMessageId).
+  async function copyTurn() {
+    if (!copyText) return;
+    try {
+      if (!navigator.clipboard?.writeText) return;
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+      if (copyResetTimerRef.current !== undefined) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+      copyResetTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copyResetTimerRef.current = undefined;
+      }, 1400);
+    } catch {
+      // Clipboard can fail in restricted contexts; leave the transcript alone.
+    }
+  }
+
+  // Per-turn transcript actions. Branch is rendered only on Hermes-session rows
+  // (which pass `onBranch`); it self-disables when the turn id is not a
+  // persisted message id (see isBranchableMessageId).
   const branchAction = onBranch ? (
-    <div className="agent-turn-actions">
-      <BranchFromHereAction
-        messageId={turn.id}
-        onBranch={onBranch}
-        submitting={branchingMessageId === turn.id}
-      />
-    </div>
+    <BranchFromHereAction
+      messageId={turn.id}
+      onBranch={onBranch}
+      submitting={branchingMessageId === turn.id}
+    />
   ) : null;
+  const copyAction = copyText ? (
+    <button
+      type="button"
+      className="agent-turn-action"
+      aria-label={copied ? "Copied message" : "Copy message"}
+      title={copied ? "Copied" : "Copy message"}
+      data-copied={copied ? "true" : undefined}
+      onClick={() => void copyTurn()}
+    >
+      {copied ? (
+        <IconCheckmark1Small size={13} aria-hidden />
+      ) : (
+        <IconClipboard size={13} aria-hidden />
+      )}
+      <span>{copied ? "Copied" : "Copy"}</span>
+    </button>
+  ) : null;
+  const editAction =
+    turn.role === "user" &&
+    !turn.isScheduledRun &&
+    userPromptText &&
+    onEditUserPrompt ? (
+      <button
+        type="button"
+        className="agent-turn-action"
+        aria-label="Edit message"
+        title="Edit message"
+        onClick={() => onEditUserPrompt(userPromptText)}
+      >
+        <IconPencilLine size={13} aria-hidden />
+        <span>Edit</span>
+      </button>
+    ) : null;
+  const turnActions =
+    copyAction || editAction || branchAction ? (
+      <div className="agent-turn-actions">
+        {copyAction}
+        {editAction}
+        {branchAction}
+      </div>
+    ) : null;
 
   if (
     contextParts.length &&
@@ -8309,7 +8395,7 @@ function AgentChatTurnRow({
             />
           ))}
         </div>
-        {branchAction}
+        {turnActions}
       </article>
     );
   }
@@ -8403,13 +8489,39 @@ function AgentChatTurnRow({
             <span className="text-shimmer">Thinking…</span>
           </p>
         ) : (
-          // No branch action on an empty/in-flight turn — there is nothing to
-          // fork from yet.
-          branchAction
+          // No actions on an empty/in-flight turn. There is nothing useful to
+          // copy or fork from yet.
+          turnActions
         )}
       </div>
     </article>
   );
+}
+
+function copyableTextForTurn(turn: AgentChatTurn): string {
+  if (turn.role === "user") return userPromptTextForTurn(turn);
+  if (turn.role !== "assistant") return "";
+  return turn.parts
+    .filter(
+      (part): part is Extract<AgentChatPart, { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => stripAgentCliAccessRequest(part.text).trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+}
+
+function userPromptTextForTurn(turn: AgentChatTurn): string {
+  return turn.parts
+    .filter(
+      (part): part is Extract<AgentChatPart, { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => displayedComposerUserMessageText(part.text).trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
 }
 
 function ContextCompactionPart({

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -8283,8 +8283,7 @@ function AgentChatTurnRow({
   );
   const nonTextParts = turn.parts.filter((part) => part.type !== "text");
   const copyText = copyableTextForTurn(turn);
-  const userPromptText =
-    turn.role === "user" ? userPromptTextForTurn(turn) : "";
+  const userPromptText = turn.role === "user" ? copyText : "";
 
   async function copyTurn() {
     if (!copyText) return;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1658,6 +1658,7 @@ input:focus-visible,
 
 .agent-turn-actions {
   display: flex;
+  gap: var(--sp-1);
   width: 100%;
   margin-top: var(--sp-1);
   opacity: 0;
@@ -1693,6 +1694,10 @@ input:focus-visible,
 .agent-turn-action:hover:not(:disabled) {
   background: var(--accent);
   color: var(--accent-foreground);
+}
+
+.agent-turn-action[data-copied] {
+  color: var(--success);
 }
 
 .agent-turn-action:disabled {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2957,6 +2957,99 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("copies visible user and assistant messages", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "Draft the launch plan",
+        timestamp: "2026-06-12T10:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here is the launch plan.",
+        timestamp: "2026-06-12T10:00:05Z",
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    const userTurn = (await screen.findByText("Draft the launch plan")).closest(
+      "article",
+    );
+    const assistantTurn = (
+      await screen.findByText("Here is the launch plan.")
+    ).closest("article");
+    expect(userTurn).not.toBeNull();
+    expect(assistantTurn).not.toBeNull();
+
+    await user.click(
+      within(assistantTurn as HTMLElement).getByRole("button", {
+        name: "Copy message",
+      }),
+    );
+    expect(writeText).toHaveBeenLastCalledWith("Here is the launch plan.");
+
+    await user.click(
+      within(userTurn as HTMLElement).getByRole("button", {
+        name: "Copy message",
+      }),
+    );
+    expect(writeText).toHaveBeenLastCalledWith("Draft the launch plan");
+  });
+
+  it("prefills a user prompt for editing and resubmits the revision", async () => {
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        content: "Draft the launch plan",
+        timestamp: "2026-06-12T10:00:00Z",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Here is the launch plan.",
+        timestamp: "2026-06-12T10:00:05Z",
+      },
+    ]);
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    const userTurn = (await screen.findByText("Draft the launch plan")).closest(
+      "article",
+    );
+    expect(userTurn).not.toBeNull();
+    await user.click(
+      within(userTurn as HTMLElement).getByRole("button", {
+        name: "Edit message",
+      }),
+    );
+
+    const composer = screen.getByRole("textbox");
+    expect(composer).toHaveTextContent("Draft the launch plan");
+    await user.type(composer, " for sales");
+
+    const send = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(send).not.toBeDisabled());
+    await user.click(send);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "Draft the launch plan for sales",
+      }),
+    );
+  });
+
   it("repairs gateway-glued contractions in assistant prose but not code or user text", async () => {
     mocks.listHermesSessionMessages.mockResolvedValue([
       {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2959,11 +2959,9 @@ describe("AgentWorkspace", () => {
 
   it("copies visible user and assistant messages", async () => {
     const user = userEvent.setup();
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
         id: "u1",
@@ -2979,30 +2977,34 @@ describe("AgentWorkspace", () => {
       },
     ]);
 
-    render(<AgentWorkspace initialSession={existingSession} />);
+    try {
+      render(<AgentWorkspace initialSession={existingSession} />);
 
-    const userTurn = (await screen.findByText("Draft the launch plan")).closest(
-      "article",
-    );
-    const assistantTurn = (
-      await screen.findByText("Here is the launch plan.")
-    ).closest("article");
-    expect(userTurn).not.toBeNull();
-    expect(assistantTurn).not.toBeNull();
+      const userTurn = (
+        await screen.findByText("Draft the launch plan")
+      ).closest("article");
+      const assistantTurn = (
+        await screen.findByText("Here is the launch plan.")
+      ).closest("article");
+      expect(userTurn).not.toBeNull();
+      expect(assistantTurn).not.toBeNull();
 
-    await user.click(
-      within(assistantTurn as HTMLElement).getByRole("button", {
-        name: "Copy message",
-      }),
-    );
-    expect(writeText).toHaveBeenLastCalledWith("Here is the launch plan.");
+      await user.click(
+        within(assistantTurn as HTMLElement).getByRole("button", {
+          name: "Copy message",
+        }),
+      );
+      expect(writeText).toHaveBeenLastCalledWith("Here is the launch plan.");
 
-    await user.click(
-      within(userTurn as HTMLElement).getByRole("button", {
-        name: "Copy message",
-      }),
-    );
-    expect(writeText).toHaveBeenLastCalledWith("Draft the launch plan");
+      await user.click(
+        within(userTurn as HTMLElement).getByRole("button", {
+          name: "Copy message",
+        }),
+      );
+      expect(writeText).toHaveBeenLastCalledWith("Draft the launch plan");
+    } finally {
+      writeText.mockRestore();
+    }
   });
 
   it("prefills a user prompt for editing and resubmits the revision", async () => {


### PR DESCRIPTION
Closes JUN-65

## What changed
- Added per-turn Copy actions for visible user and assistant transcript text.
- Added an Edit action for user prompts that prefills the composer so the prompt can be revised and sent again.
- Kept existing Branch from here behavior in the same hover action row.
- Added focused AgentWorkspace coverage for copy and edit/resubmit behavior.

## Why
JUN-65 asks for Codex-style prompt affordances: copy input/output messages and edit submitted user prompts for resubmission.

## Validation
- pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx src/styles/app.css src/test/agent-workspace.test.tsx
- pnpm run lint
- pnpm exec vitest run src/test/agent-workspace.test.tsx

## Known gaps
None. The full AgentWorkspace test run still prints existing test warnings/debug logs, but passes.