### PR TITLE
JUN-86 Add composer slash commands

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -241,6 +241,13 @@ import {
   skillSlashResolutionError,
 } from "../../lib/skill-slash-commands";
 import {
+  isBuiltinComposerSlashCommand,
+  parseBuiltinComposerSlashCommand,
+  parseSlashFileArguments,
+  resolveSlashModel,
+  slashModelResolutionError,
+} from "../../lib/agent-composer-slash-commands";
+import {
   ComposerEditor,
   type ComposerEditorHandle,
 } from "./composer/ComposerEditor";
@@ -1406,6 +1413,7 @@ export function AgentWorkspace({
   const [generationModels, setGenerationModels] = useState<VeniceModelDto[]>(
     [],
   );
+  const generationModelsRef = useRef<VeniceModelDto[]>([]);
   const [composerModelOpen, setComposerModelOpen] = useState(false);
   const [composerModelFlyout, setComposerModelFlyout] =
     useState<ComposerModelFlyout>(null);
@@ -2380,14 +2388,18 @@ export function AgentWorkspace({
         modelsResponse.selectedModel;
       if (requestId === generationModelRequestSequence.current) {
         defaultGenerationModelIdRef.current = selectedModelId;
+        generationModelsRef.current = modelsResponse.models;
         setGenerationModels(modelsResponse.models);
         setDefaultGenerationModelId(selectedModelId);
       }
+      return { models: modelsResponse.models, selectedModelId };
     } catch {
       if (requestId === generationModelRequestSequence.current) {
         defaultGenerationModelIdRef.current = "";
+        generationModelsRef.current = [];
         setDefaultGenerationModelId("");
       }
+      return null;
     }
   }, []);
 
@@ -2448,14 +2460,16 @@ export function AgentWorkspace({
   // unsupported, so there is no confirming event to wait on.
   async function handleSelectGenerationModel(modelId: string) {
     setComposerModelOpen(false);
-    const chosen = generationModels.find((model) => model.id === modelId);
+    const chosen = generationModelsRef.current.find(
+      (model) => model.id === modelId,
+    );
     // Defense in depth: the picker already hides tool-less models, but the
     // agent bricks without function calling, so refuse one rather than switch.
     if (chosen && !modelSupportsTools(chosen)) {
       setError(
         `${chosen.name} can't run June's tools, so it can't be used for the agent.`,
       );
-      return;
+      return false;
     }
     const modelName = chosen?.name ?? modelId;
     const sessionId = newSessionModeRef.current
@@ -2472,7 +2486,7 @@ export function AgentWorkspace({
         setError(null);
       } catch (err) {
         setError(messageFromError(err));
-        return;
+        return false;
       }
       setModelSwitchNotice({
         message: resolveModelSwitchOutcome({
@@ -2482,7 +2496,7 @@ export function AgentWorkspace({
         }).notice,
         sessionId: null,
       });
-      return;
+      return true;
     }
 
     // Open chat: override the model for THIS chat only (never the global
@@ -2524,7 +2538,7 @@ export function AgentWorkspace({
         ),
       );
       setError(messageFromError(err));
-      return;
+      return false;
     }
     let dispatchSucceeded = false;
     try {
@@ -2549,6 +2563,7 @@ export function AgentWorkspace({
       }).notice,
       sessionId,
     });
+    return true;
   }
 
   useEffect(() => {
@@ -3004,11 +3019,94 @@ export function AgentWorkspace({
     };
   }
 
+  async function handleBuiltinComposerSlashCommand(commandText: string) {
+    if (categoryRef.current) return false;
+    const parsed = parseBuiltinComposerSlashCommand(commandText);
+    if (!parsed) return false;
+
+    if (parsed.name === "model") {
+      await runModelSlashCommand(parsed.argument, commandText);
+      return true;
+    }
+
+    await runFileSlashCommand(parsed.argument, commandText);
+    return true;
+  }
+
+  async function runModelSlashCommand(argument: string, commandText: string) {
+    const query = argument.trim();
+    if (!query) {
+      clearComposerCommandDraft(commandText);
+      openComposerModelPicker();
+      return;
+    }
+
+    const models = await generationModelsForSlashCommand();
+    if (!models.length) {
+      setError("Could not load models. Try again in a moment.");
+      return;
+    }
+
+    const resolution = resolveSlashModel(query, models);
+    if (resolution.status !== "resolved") {
+      setError(slashModelResolutionError(resolution));
+      return;
+    }
+
+    const selected = await handleSelectGenerationModel(resolution.model.id);
+    if (selected) clearComposerCommandDraft(commandText);
+  }
+
+  async function generationModelsForSlashCommand() {
+    if (generationModelsRef.current.length) return generationModelsRef.current;
+    const loaded = await loadGenerationModel();
+    return loaded?.models ?? generationModelsRef.current;
+  }
+
+  async function runFileSlashCommand(argument: string, commandText: string) {
+    if (!argument.trim()) {
+      clearComposerCommandDraft(commandText);
+      await pickAttachments();
+      return;
+    }
+
+    const parsed = parseSlashFileArguments(argument);
+    if (parsed.status === "error") {
+      setError(parsed.message);
+      return;
+    }
+    if (!parsed.paths.length) {
+      clearComposerCommandDraft(commandText);
+      await pickAttachments();
+      return;
+    }
+
+    const imported = await importDroppedFilePaths(parsed.paths);
+    if (imported) clearComposerCommandDraft(commandText);
+  }
+
+  function clearComposerCommandDraft(commandText: string) {
+    if (draftRef.current.trim() !== commandText.trim()) return;
+    if (categoryRef.current) return;
+    composerEditorRef.current?.clear();
+    draftRef.current = "";
+    categoryRef.current = null;
+    setDraft("");
+    setCategory(null);
+    rememberComposerDraft(
+      composerDraftKeyRef.current,
+      "",
+      null,
+      attachmentsRef.current,
+    );
+  }
+
   async function submit(event?: FormEvent) {
     event?.preventDefault();
     const message = draft.trim();
     if ((!message && !attachments.length) || submitting || importingFiles)
       return;
+    if (message && (await handleBuiltinComposerSlashCommand(message))) return;
     // The composer's category chip makes this a report: wrap the prompt to
     // frame it for the team and queue the delivery. Captured before the
     // composer clears so a failed send can restore the chip on retry.
@@ -3201,7 +3299,7 @@ export function AgentWorkspace({
     items: T[],
     importItem: (item: T) => Promise<ImportedHermesFile>,
   ) {
-    if (!items.length) return;
+    if (!items.length) return true;
     setImportingFiles(true);
     try {
       // One at a time on purpose: a dropped file's bytes can be 50 MB, so
@@ -3224,8 +3322,10 @@ export function AgentWorkspace({
       ]);
       setError(null);
       void loadFilesystemSnapshot();
+      return true;
     } catch (err) {
       setError(messageFromError(err));
+      return false;
     } finally {
       setImportingFiles(false);
     }
@@ -3236,7 +3336,7 @@ export function AgentWorkspace({
     const uniquePaths = Array.from(new Set(paths.map((path) => path.trim())))
       .filter(Boolean)
       .slice(0, 8);
-    await importAttachments(uniquePaths, importHermesBridgeFile);
+    return importAttachments(uniquePaths, importHermesBridgeFile);
   }
 
   // DOM drops are how Finder files actually arrive: Tauri's drag-drop
@@ -3303,11 +3403,12 @@ export function AgentWorkspace({
         multiple: true,
         title: "Attach files",
       });
-      if (!selected) return;
+      if (!selected) return false;
       const paths = Array.isArray(selected) ? selected : [selected];
-      await importDroppedFilePaths(paths);
+      return await importDroppedFilePaths(paths);
     } catch (err) {
       setError(messageFromError(err));
+      return false;
     }
   }
 
@@ -5506,7 +5607,8 @@ export function AgentWorkspace({
               if (
                 !skills &&
                 !skillCommandLoading &&
-                text.trimStart().startsWith("/")
+                text.trimStart().startsWith("/") &&
+                !isBuiltinComposerSlashCommand(text)
               ) {
                 void loadSkillCommands({ silent: true });
               }

--- a/src/components/agent/composer/CategorySuggestionList.tsx
+++ b/src/components/agent/composer/CategorySuggestionList.tsx
@@ -8,15 +8,19 @@ import {
   useState,
 } from "react";
 import { IconBuildingBlocks } from "central-icons/IconBuildingBlocks";
+import { IconConsoleSimple } from "central-icons/IconConsoleSimple";
+import { IconFileText } from "central-icons/IconFileText";
 
 import { CategoryIcon } from "./CategoryIcon";
 import type { ReportCategoryDef } from "./reportCategory";
 import type { HermesSkillInfo } from "../../../lib/tauri";
+import type { BuiltinComposerSlashCommandDef } from "../../../lib/agent-composer-slash-commands";
 
 const SKILL_DETAIL_HOVER_INTENT_MS = 150;
 
 export type ComposerSlashCommandItem =
   | { kind: "category"; category: ReportCategoryDef }
+  | { kind: "builtin"; command: BuiltinComposerSlashCommandDef }
   | { kind: "skill"; skill: HermesSkillInfo };
 
 export type CategorySuggestionListProps = {
@@ -113,11 +117,11 @@ export const CategorySuggestionList = forwardRef<
     [items, command],
   );
 
-  const showSkillDetail = useCallback(
+  const showCommandDetail = useCallback(
     (index: number, row = rowRefs.current.get(index) ?? null) => {
       const item = items[index];
       const menu = menuRef.current;
-      if (item?.kind !== "skill" || !menu || !row || !skillHasDetail(item)) {
+      if (!item || !menu || !row || !commandHasDetail(item)) {
         setDetail(null);
         return;
       }
@@ -161,7 +165,7 @@ export const CategorySuggestionList = forwardRef<
             const next = (index + 1) % items.length;
             setActiveSource("keyboard");
             cancelHoverIntent();
-            window.requestAnimationFrame(() => showSkillDetail(next));
+            window.requestAnimationFrame(() => showCommandDetail(next));
             return next;
           });
           return true;
@@ -171,7 +175,7 @@ export const CategorySuggestionList = forwardRef<
             const next = (index - 1 + items.length) % items.length;
             setActiveSource("keyboard");
             cancelHoverIntent();
-            window.requestAnimationFrame(() => showSkillDetail(next));
+            window.requestAnimationFrame(() => showCommandDetail(next));
             return next;
           });
           return true;
@@ -183,7 +187,7 @@ export const CategorySuggestionList = forwardRef<
         return false;
       },
     }),
-    [items, selected, choose, showSkillDetail, cancelHoverIntent],
+    [items, selected, choose, showCommandDetail, cancelHoverIntent],
   );
 
   if (items.length === 0) {
@@ -199,13 +203,15 @@ export const CategorySuggestionList = forwardRef<
     detail &&
     detail.index === selected &&
     detailItem &&
-    commandItemKey(detailItem) === detail.key &&
-    detailItem.kind === "skill"
+    commandItemKey(detailItem) === detail.key
       ? detailItem
       : null;
   const categories = items
     .map((item, index) => ({ item, index }))
     .filter(({ item }) => item.kind === "category");
+  const builtins = items
+    .map((item, index) => ({ item, index }))
+    .filter(({ item }) => item.kind === "builtin");
   const skills = items
     .map((item, index) => ({ item, index }))
     .filter(({ item }) => item.kind === "skill");
@@ -234,6 +240,12 @@ export const CategorySuggestionList = forwardRef<
             setDetail(null);
           }}
         >
+          {builtins.length ? (
+            <div className="agent-category-menu-section" role="presentation">
+              <div className="agent-category-menu-section-label">Commands</div>
+              {builtins.map(({ item, index }) => renderCommandRow(item, index))}
+            </div>
+          ) : null}
           {categories.map(({ item, index }) => renderCommandRow(item, index))}
           {skills.length ? (
             <div className="agent-category-menu-section" role="presentation">
@@ -243,23 +255,23 @@ export const CategorySuggestionList = forwardRef<
           ) : null}
         </div>
       </div>
-      {activeDetail?.kind === "skill" ? (
+      {activeDetail && commandHasDetail(activeDetail) ? (
         <div
           className="agent-category-menu-detail-card"
           data-side={detail?.side}
           style={{ top: detail?.top ?? 0 }}
         >
           <p className="agent-category-menu-detail-title">
-            {activeDetail.skill.name}
+            {commandItemDetailTitle(activeDetail)}
           </p>
-          {activeDetail.skill.category ? (
+          {commandItemDetailMeta(activeDetail) ? (
             <p className="agent-category-menu-detail-meta">
-              {activeDetail.skill.category}
+              {commandItemDetailMeta(activeDetail)}
             </p>
           ) : null}
-          {activeDetail.skill.description?.trim() ? (
+          {commandItemDetailDescription(activeDetail) ? (
             <p className="agent-category-menu-detail-desc">
-              {activeDetail.skill.description.trim()}
+              {commandItemDetailDescription(activeDetail)}
             </p>
           ) : null}
         </div>
@@ -290,13 +302,13 @@ export const CategorySuggestionList = forwardRef<
           setSelected(index);
           setActiveSource("pointer");
           const row = event.currentTarget;
-          hoverIntent(() => showSkillDetail(index, row));
+          hoverIntent(() => showCommandDetail(index, row));
         }}
         onFocus={(event) => {
           setSelected(index);
           setActiveSource("keyboard");
           cancelHoverIntent();
-          showSkillDetail(index, event.currentTarget);
+          showCommandDetail(index, event.currentTarget);
         }}
       >
         <span
@@ -307,6 +319,8 @@ export const CategorySuggestionList = forwardRef<
         >
           {item.kind === "category" ? (
             <CategoryIcon category={item.category.key} size={16} />
+          ) : item.kind === "builtin" ? (
+            commandItemIcon(item)
           ) : (
             <IconBuildingBlocks size={16} aria-hidden />
           )}
@@ -323,18 +337,50 @@ export const CategorySuggestionList = forwardRef<
 CategorySuggestionList.displayName = "CategorySuggestionList";
 
 function commandItemKey(item: ComposerSlashCommandItem) {
-  return item.kind === "category"
-    ? `category:${item.category.key}`
-    : `skill:${item.skill.name}`;
+  if (item.kind === "category") return `category:${item.category.key}`;
+  if (item.kind === "builtin") return `builtin:${item.command.name}`;
+  return `skill:${item.skill.name}`;
 }
 
 function commandItemLabel(item: ComposerSlashCommandItem) {
-  return item.kind === "category" ? item.category.label : item.skill.name;
+  if (item.kind === "category") return item.category.label;
+  if (item.kind === "builtin") return item.command.label;
+  return item.skill.name;
 }
 
-function skillHasDetail(item: ComposerSlashCommandItem) {
-  return (
-    item.kind === "skill" &&
-    Boolean(item.skill.description?.trim() || item.skill.category?.trim())
+function commandHasDetail(item: ComposerSlashCommandItem) {
+  if (item.kind === "builtin") return Boolean(item.command.description.trim());
+  if (item.kind === "skill") {
+    return Boolean(
+      item.skill.description?.trim() || item.skill.category?.trim(),
+    );
+  }
+  return false;
+}
+
+function commandItemDetailTitle(item: ComposerSlashCommandItem) {
+  if (item.kind === "builtin") return `/${item.command.name}`;
+  if (item.kind === "skill") return item.skill.name;
+  return item.category.label;
+}
+
+function commandItemDetailMeta(item: ComposerSlashCommandItem) {
+  if (item.kind === "skill") return item.skill.category?.trim() ?? "";
+  return "";
+}
+
+function commandItemDetailDescription(item: ComposerSlashCommandItem) {
+  if (item.kind === "builtin") return item.command.description.trim();
+  if (item.kind === "skill") return item.skill.description?.trim() ?? "";
+  return "";
+}
+
+function commandItemIcon(
+  item: Extract<ComposerSlashCommandItem, { kind: "builtin" }>,
+) {
+  return item.command.name === "file" ? (
+    <IconFileText size={16} aria-hidden />
+  ) : (
+    <IconConsoleSimple size={16} aria-hidden />
   );
 }

--- a/src/components/agent/composer/categoryChip.ts
+++ b/src/components/agent/composer/categoryChip.ts
@@ -19,6 +19,7 @@ import {
 } from "./reportCategory";
 import type { HermesSkillInfo } from "../../../lib/tauri";
 import { matchSkillSlashSuggestions } from "../../../lib/skill-slash-commands";
+import { matchBuiltinComposerSlashCommands } from "../../../lib/agent-composer-slash-commands";
 
 /** Node name for the inline category chip. Distinct from the generic
  * "mention" node so the composer's chip styling never bleeds into (or
@@ -181,7 +182,11 @@ export function createCategoryChip(options: CategoryChipOptions = {}) {
             .run();
           return;
         }
-        insertSkillSlashCommand(editor, item.skill.name, range);
+        if (item.kind === "builtin") {
+          insertSlashCommandText(editor, item.command.insertText, range);
+          return;
+        }
+        insertSlashCommandText(editor, `/${item.skill.name} `, range);
       },
       render: () => {
         let renderer: ReactRenderer<
@@ -351,11 +356,16 @@ function composerSlashCommandItems(
   query: string,
   skills: HermesSkillInfo[] | null | undefined,
 ): ComposerSlashCommandItem[] {
+  const builtins = matchBuiltinComposerSlashCommands(query).map((command) => ({
+    kind: "builtin" as const,
+    command,
+  }));
   const categories = matchReportCategories(query).map((category) => ({
     kind: "category" as const,
     category,
   }));
   return [
+    ...builtins,
     ...categories,
     ...matchSkillSlashSuggestions(query, skills, SLASH_MENU_SKILL_LIMIT).map(
       (skill) => ({
@@ -366,12 +376,11 @@ function composerSlashCommandItems(
   ];
 }
 
-function insertSkillSlashCommand(
+function insertSlashCommandText(
   editor: Editor,
-  skillName: string,
+  text: string,
   range: { from: number; to: number },
 ) {
-  const text = `/${skillName} `;
   editor
     .chain()
     .focus()

--- a/src/lib/agent-composer-slash-commands.ts
+++ b/src/lib/agent-composer-slash-commands.ts
@@ -1,0 +1,207 @@
+export type BuiltinComposerSlashCommandName = "model" | "file";
+
+export type BuiltinComposerSlashCommandDef = {
+  name: BuiltinComposerSlashCommandName;
+  label: string;
+  description: string;
+  insertText: string;
+};
+
+export type ParsedBuiltinComposerSlashCommand = {
+  name: BuiltinComposerSlashCommandName;
+  argument: string;
+};
+
+export type SlashFileArgumentsResult =
+  | { status: "ok"; paths: string[] }
+  | { status: "error"; message: string };
+
+export type ComposerSlashModelOption = {
+  id: string;
+  name: string;
+};
+
+export type SlashModelResolution =
+  | { status: "resolved"; model: ComposerSlashModelOption }
+  | { status: "missing"; query: string }
+  | { status: "ambiguous"; query: string; matches: ComposerSlashModelOption[] };
+
+export const BUILTIN_COMPOSER_SLASH_COMMANDS: BuiltinComposerSlashCommandDef[] =
+  [
+    {
+      name: "model",
+      label: "Model",
+      description: "Change the text model.",
+      insertText: "/model ",
+    },
+    {
+      name: "file",
+      label: "File",
+      description: "Attach files to this message.",
+      insertText: "/file ",
+    },
+  ];
+
+export function parseBuiltinComposerSlashCommand(
+  input: string,
+): ParsedBuiltinComposerSlashCommand | null {
+  const text = input.trim();
+  const match = /^\/([a-z]+)(?:\s+([\s\S]*))?$/i.exec(text);
+  if (!match) return null;
+  const name = match[1].toLowerCase();
+  if (!isBuiltinComposerSlashCommandName(name)) return null;
+  return {
+    name,
+    argument: match[2]?.trim() ?? "",
+  };
+}
+
+export function matchBuiltinComposerSlashCommands(query: string) {
+  const normalized = normalizeSlashCommandQuery(query);
+  return BUILTIN_COMPOSER_SLASH_COMMANDS.filter((command) => {
+    if (!normalized) return true;
+    return (
+      normalizeSlashCommandQuery(command.name).startsWith(normalized) ||
+      normalizeSlashCommandQuery(command.label).startsWith(normalized)
+    );
+  });
+}
+
+export function isBuiltinComposerSlashCommand(input: string) {
+  return Boolean(parseBuiltinComposerSlashCommand(input));
+}
+
+export function parseSlashFileArguments(
+  argument: string,
+): SlashFileArgumentsResult {
+  const paths: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escaping = false;
+  const text = argument.trim();
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        paths.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaping) current += "\\";
+  if (quote) {
+    return {
+      status: "error",
+      message: "Could not parse /file paths. Close the quote and try again.",
+    };
+  }
+  if (current) paths.push(current);
+  return { status: "ok", paths };
+}
+
+export function resolveSlashModel(
+  query: string,
+  models: ComposerSlashModelOption[],
+): SlashModelResolution {
+  const normalizedQuery = normalizeModelQuery(query);
+  const rawQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return { status: "missing", query };
+
+  const ranked = models
+    .map((model) => ({
+      model,
+      score: modelMatchScore(model, normalizedQuery, rawQuery),
+    }))
+    .filter((item) => item.score > 0)
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.model.name.localeCompare(b.model.name) ||
+        a.model.id.localeCompare(b.model.id),
+    );
+  const best = ranked[0];
+  if (!best) return { status: "missing", query };
+  const matches = ranked.filter((item) => item.score === best.score);
+  if (matches.length > 1) {
+    return {
+      status: "ambiguous",
+      query,
+      matches: matches.slice(0, 4).map((item) => item.model),
+    };
+  }
+  return { status: "resolved", model: best.model };
+}
+
+export function slashModelResolutionError(
+  resolution: Exclude<SlashModelResolution, { status: "resolved" }>,
+) {
+  if (resolution.status === "ambiguous") {
+    const names = resolution.matches.map((model) => model.name).join(", ");
+    return `Model "${resolution.query}" matches ${names}. Type a longer name.`;
+  }
+  return `Could not find model "${resolution.query}".`;
+}
+
+function isBuiltinComposerSlashCommandName(
+  name: string,
+): name is BuiltinComposerSlashCommandName {
+  return name === "model" || name === "file";
+}
+
+function normalizeSlashCommandQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function normalizeModelQuery(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function modelMatchScore(
+  model: ComposerSlashModelOption,
+  normalizedQuery: string,
+  rawQuery: string,
+) {
+  const idRaw = model.id.trim().toLowerCase();
+  const nameRaw = model.name.trim().toLowerCase();
+  const id = normalizeModelQuery(model.id);
+  const name = normalizeModelQuery(model.name);
+
+  if (idRaw === rawQuery) return 100;
+  if (nameRaw === rawQuery) return 95;
+  if (id === normalizedQuery) return 90;
+  if (name === normalizedQuery) return 85;
+  if (name.startsWith(normalizedQuery)) return 80;
+  if (id.endsWith(normalizedQuery)) return 75;
+  if (id.startsWith(normalizedQuery)) return 70;
+  if (name.includes(normalizedQuery)) return 65;
+  if (id.includes(normalizedQuery)) return 60;
+  return 0;
+}

--- a/src/lib/agent-composer-slash-commands.ts
+++ b/src/lib/agent-composer-slash-commands.ts
@@ -77,18 +77,18 @@ export function parseSlashFileArguments(
   const paths: string[] = [];
   let current = "";
   let quote: '"' | "'" | null = null;
-  let escaping = false;
   const text = argument.trim();
 
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index];
-    if (escaping) {
-      current += char;
-      escaping = false;
-      continue;
-    }
     if (char === "\\") {
-      escaping = true;
+      const next = text[index + 1];
+      if (next && shouldEscapeFileArgumentChar(next)) {
+        current += next;
+        index += 1;
+      } else {
+        current += char;
+      }
       continue;
     }
     if (quote) {
@@ -113,7 +113,6 @@ export function parseSlashFileArguments(
     current += char;
   }
 
-  if (escaping) current += "\\";
   if (quote) {
     return {
       status: "error",
@@ -175,6 +174,10 @@ function isBuiltinComposerSlashCommandName(
 
 function normalizeSlashCommandQuery(value: string) {
   return value.trim().toLowerCase();
+}
+
+function shouldEscapeFileArgumentChar(char: string) {
+  return char === "\\" || char === '"' || char === "'" || /\s/.test(char);
 }
 
 function normalizeModelQuery(value: string) {

--- a/src/test/agent-composer-slash-commands.test.ts
+++ b/src/test/agent-composer-slash-commands.test.ts
@@ -36,6 +36,15 @@ describe("agent composer built-in slash commands", () => {
     });
   });
 
+  it("preserves quoted Windows file paths", () => {
+    expect(
+      parseSlashFileArguments('"C:\\Users\\alex\\Desktop\\Q2 report.pdf"'),
+    ).toEqual({
+      status: "ok",
+      paths: ["C:\\Users\\alex\\Desktop\\Q2 report.pdf"],
+    });
+  });
+
   it("reports unmatched quotes without dropping the command", () => {
     expect(
       parseSlashFileArguments('"/Users/alex/Desktop/Q2 report.pdf'),

--- a/src/test/agent-composer-slash-commands.test.ts
+++ b/src/test/agent-composer-slash-commands.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseBuiltinComposerSlashCommand,
+  parseSlashFileArguments,
+  resolveSlashModel,
+  slashModelResolutionError,
+} from "../lib/agent-composer-slash-commands";
+
+describe("agent composer built-in slash commands", () => {
+  it("parses reserved model and file commands", () => {
+    expect(parseBuiltinComposerSlashCommand("/model kimi")).toEqual({
+      name: "model",
+      argument: "kimi",
+    });
+    expect(parseBuiltinComposerSlashCommand("  /file ./notes.md  ")).toEqual({
+      name: "file",
+      argument: "./notes.md",
+    });
+    expect(
+      parseBuiltinComposerSlashCommand("/repo-build-pr fix it"),
+    ).toBeNull();
+    expect(
+      parseBuiltinComposerSlashCommand(
+        "/Users/alex/Desktop/report.pdf summarize",
+      ),
+    ).toBeNull();
+  });
+
+  it("parses quoted file paths", () => {
+    expect(
+      parseSlashFileArguments('"/Users/alex/Desktop/Q2 report.pdf" ./notes.md'),
+    ).toEqual({
+      status: "ok",
+      paths: ["/Users/alex/Desktop/Q2 report.pdf", "./notes.md"],
+    });
+  });
+
+  it("reports unmatched quotes without dropping the command", () => {
+    expect(
+      parseSlashFileArguments('"/Users/alex/Desktop/Q2 report.pdf'),
+    ).toEqual({
+      status: "error",
+      message: "Could not parse /file paths. Close the quote and try again.",
+    });
+  });
+
+  it("resolves model ids and friendly model names", () => {
+    const models = [
+      { id: "zai-org-glm-5-2", name: "GLM 5.2" },
+      { id: "moonshotai-kimi-k2-6", name: "Kimi K2.6" },
+    ];
+
+    expect(resolveSlashModel("glm-5", models)).toEqual({
+      status: "resolved",
+      model: models[0],
+    });
+    expect(resolveSlashModel("moonshotai-kimi-k2-6", models)).toEqual({
+      status: "resolved",
+      model: models[1],
+    });
+  });
+
+  it("reports ambiguous model aliases", () => {
+    const resolution = resolveSlashModel("kimi", [
+      { id: "provider-a-kimi", name: "Kimi base" },
+      { id: "provider-b-kimi", name: "Kimi tuned" },
+    ]);
+
+    expect(resolution.status).toBe("ambiguous");
+    if (resolution.status !== "resolved") {
+      expect(slashModelResolutionError(resolution)).toBe(
+        'Model "kimi" matches Kimi base, Kimi tuned. Type a longer name.',
+      );
+    }
+  });
+});

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4932,6 +4932,29 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("imports typed file paths from the /file slash command", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    const composer = screen.getByRole("textbox");
+    await user.type(composer, '/file "/Users/alex/Desktop/Q2 report.pdf"');
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.importHermesBridgeFile).toHaveBeenCalledWith(
+        "/Users/alex/Desktop/Q2 report.pdf",
+      ),
+    );
+    expect(await screen.findByText("Q2 report.pdf")).toBeInTheDocument();
+    expect(composer.textContent).toBe("");
+    expect(
+      mocks.gatewayRequest.mock.calls.some(
+        ([method]) => method === "prompt.submit",
+      ),
+    ).toBe(false);
+  });
+
   it("attaches a dropped image to the session via image.attach and marks it attached", async () => {
     // Feature 19: on submit, an imported image is sent to the session through
     // the structured image.attach RPC, the chip flips to "Attached", and the
@@ -6152,6 +6175,46 @@ describe("AgentWorkspace", () => {
           command: "/model kimi-k2-6",
         }),
       );
+      expect(
+        await screen.findByText("Switched this session to Kimi K2.6."),
+      ).toBeInTheDocument();
+    });
+
+    it("dispatches /model from the composer slash command", async () => {
+      mocks.listVeniceModels.mockResolvedValue({
+        mode: "generation",
+        modelType: "text",
+        selectedModel: "zai-org-glm-5-2",
+        models: toolCapableCatalog,
+      });
+      const user = userEvent.setup();
+
+      render(<AgentWorkspace initialSession={existingSession} />);
+
+      const composer = await screen.findByRole("textbox", {
+        name: "Message June",
+      });
+      await user.type(composer, "/model kimi");
+      await user.click(screen.getByRole("button", { name: "Send message" }));
+
+      await waitFor(() =>
+        expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
+          sessionId: "session-1",
+          model: "kimi-k2-6",
+        }),
+      );
+      await waitFor(() =>
+        expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
+          session_id: "session-1",
+          command: "/model kimi-k2-6",
+        }),
+      );
+      expect(
+        mocks.gatewayRequest.mock.calls.some(
+          ([method]) => method === "prompt.submit",
+        ),
+      ).toBe(false);
+      expect(composer.textContent).toBe("");
       expect(
         await screen.findByText("Switched this session to Kimi K2.6."),
       ).toBeInTheDocument();

--- a/src/test/composer-editor-slash-menu.test.tsx
+++ b/src/test/composer-editor-slash-menu.test.tsx
@@ -36,6 +36,8 @@ describe("composer slash menu", () => {
     await waitFor(() =>
       expect(document.querySelector(".agent-category-menu-host")).toBeTruthy(),
     );
+    expect(screen.getByRole("option", { name: "Model" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "File" })).toBeInTheDocument();
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Outside" }));
 


### PR DESCRIPTION
Closes JUN-86

## What changed
- Added built-in composer slash command parsing for /model and /file.
- Wired /model to the existing generation model switch path, including live-session command.dispatch when a chat is open.
- Wired /file to the existing Hermes workspace file import path, including quoted typed paths and the existing picker fallback when no path is supplied.
- Added Model and File to the existing slash palette for keyboard discovery.

## Why
JUN-86 asks for keyboard-driven model switching and file attachment so users can avoid leaving the composer for core chat actions.

## Validation
- pnpm exec vitest run src/test/agent-composer-slash-commands.test.ts src/test/composer-editor-slash-menu.test.tsx src/test/agent-workspace.test.tsx
- pnpm run lint
- pnpm test
- pnpm run build

## Known gaps
- /file accepts typed paths and quoted paths, then leaves prompt composition to the next message. It does not combine a file path and freeform prompt in the same slash command.