### PR TITLE
Fix agent message turn ordering

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1352,6 +1352,9 @@ export function AgentWorkspace({
   const [hermesSessionMessages, setHermesSessionMessages] = useState<
     Record<string, HermesSessionMessage[]>
   >({});
+  const hermesSessionMessagesRef = useRef<
+    Record<string, HermesSessionMessage[]>
+  >({});
   const [pendingHermesMessages, setPendingHermesMessages] = useState<
     Record<string, HermesSessionMessage[]>
   >(() => continuity?.pendingMessages ?? {});
@@ -1718,12 +1721,14 @@ export function AgentWorkspace({
   }, [runtimeSessionIds]);
 
   useEffect(() => {
+    hermesSessionMessagesRef.current = hermesSessionMessages;
     selectedHermesSessionIdRef.current = selectedHermesSessionId;
     workingSessionIdsRef.current = workingSessionIds;
     waitingSessionIdsRef.current = waitingSessionIds;
     pendingHermesMessagesRef.current = pendingHermesMessages;
     hermesSessionItemsRef.current = hermesSessionItems;
   }, [
+    hermesSessionMessages,
     hermesSessionItems,
     pendingHermesMessages,
     selectedHermesSessionId,
@@ -1786,7 +1791,11 @@ export function AgentWorkspace({
   // neither leaves a phantom "working" session with a leaked listener behind.
   const scrubHermesSessionState = useCallback(
     (sessionId: string) => {
-      setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
+      setHermesSessionMessages((current) => {
+        const next = omitRecordKey(current, sessionId);
+        hermesSessionMessagesRef.current = next;
+        return next;
+      });
       setPendingHermesMessages((current) => {
         const next = omitRecordKey(current, sessionId);
         pendingHermesMessagesRef.current = next;
@@ -1834,10 +1843,10 @@ export function AgentWorkspace({
     : undefined;
   const selectedHermesMessages = useMemo(() => {
     if (!selectedHermesSessionId) return [];
-    return [
-      ...(hermesSessionMessages[selectedHermesSessionId] ?? []),
-      ...(pendingHermesMessages[selectedHermesSessionId] ?? []),
-    ];
+    return mergeHermesMessagesForDisplay(
+      hermesSessionMessages[selectedHermesSessionId] ?? [],
+      pendingHermesMessages[selectedHermesSessionId] ?? [],
+    );
   }, [hermesSessionMessages, pendingHermesMessages, selectedHermesSessionId]);
   const composerDraftKey = selectedHermesSessionId
     ? sessionComposerDraftKey(selectedHermesSessionId)
@@ -2688,10 +2697,14 @@ export function AgentWorkspace({
           pendingHermesMessagesRef.current[selectedHermesSessionId] ?? [],
           messages,
         );
-        setHermesSessionMessages((current) => ({
-          ...current,
-          [selectedHermesSessionId]: messages,
-        }));
+        setHermesSessionMessages((current) => {
+          const next = {
+            ...current,
+            [selectedHermesSessionId]: messages,
+          };
+          hermesSessionMessagesRef.current = next;
+          return next;
+        });
         setPendingHermesMessages((current) => {
           const next = {
             ...current,
@@ -2701,7 +2714,10 @@ export function AgentWorkspace({
           return next;
         });
         void suggestTitleForUntitledSession(selectedHermesSessionId, messages);
-        const combined = [...messages, ...retainedPending];
+        const combined = mergeHermesMessagesForDisplay(
+          messages,
+          retainedPending,
+        );
         if (
           shouldResumeSessionActivity(combined) &&
           !waitingSessionIdsRef.current.has(selectedHermesSessionId)
@@ -3645,11 +3661,22 @@ export function AgentWorkspace({
         ...current,
       ];
     });
+    const knownSessionMessages =
+      hermesSessionMessagesRef.current[storedSessionId];
+    const insertAfterMessageId =
+      knownSessionMessages !== undefined
+        ? (knownSessionMessages.at(-1)?.id ?? null)
+        : targetSessionId
+          ? undefined
+          : null;
     const pendingUserMessage: HermesSessionMessage = {
       id: `pending:user:${Date.now()}`,
       role: "user",
       content: displayContent,
       timestamp: createdAt,
+      ...(insertAfterMessageId !== undefined
+        ? { client_insert_after_message_id: insertAfterMessageId }
+        : {}),
     };
     setPendingHermesMessages((current) => {
       const next = {
@@ -4139,10 +4166,14 @@ export function AgentWorkspace({
         pendingHermesMessagesRef.current[sessionId] ?? [],
         messages,
       );
-      setHermesSessionMessages((current) => ({
-        ...current,
-        [sessionId]: messages,
-      }));
+      setHermesSessionMessages((current) => {
+        const next = {
+          ...current,
+          [sessionId]: messages,
+        };
+        hermesSessionMessagesRef.current = next;
+        return next;
+      });
       setPendingHermesMessages((current) => {
         const next = {
           ...current,
@@ -4153,7 +4184,9 @@ export function AgentWorkspace({
       });
       void suggestTitleForUntitledSession(sessionId, messages);
       if (
-        sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])
+        sessionHasAssistantAfterLatestUser(
+          mergeHermesMessagesForDisplay(messages, retainedPending),
+        )
       ) {
         promotePendingIssueReportToReview(sessionId, {
           queueDiagnosisRefresh: false,
@@ -10679,6 +10712,59 @@ function retainUnpersistedPendingMessages(
       );
     });
   });
+}
+
+function mergeHermesMessagesForDisplay(
+  persisted: HermesSessionMessage[],
+  pending: HermesSessionMessage[],
+) {
+  if (!pending.length) return persisted;
+  const merged = [...persisted];
+  for (const pendingMessage of pending) {
+    const insertAt = pendingHermesMessageInsertIndex(merged, pendingMessage);
+    merged.splice(insertAt, 0, pendingMessage);
+  }
+  return merged;
+}
+
+function pendingHermesMessageInsertIndex(
+  messages: HermesSessionMessage[],
+  pendingMessage: HermesSessionMessage,
+) {
+  if (
+    Object.prototype.hasOwnProperty.call(
+      pendingMessage,
+      "client_insert_after_message_id",
+    )
+  ) {
+    const anchorId = pendingMessage.client_insert_after_message_id;
+    if (!anchorId) return advancePastLocalPendingMessages(messages, 0);
+    const anchorIndex = messages.findIndex((message) => message.id === anchorId);
+    if (anchorIndex >= 0) {
+      return advancePastLocalPendingMessages(messages, anchorIndex + 1);
+    }
+  }
+
+  const pendingAt = hermesMessageTimestampMs(pendingMessage);
+  if (pendingAt === undefined) return messages.length;
+  const matchingIndex = messages.findIndex((message) => {
+    const messageAt = hermesMessageTimestampMs(message);
+    if (messageAt === undefined) return false;
+    if (pendingMessage.role === "user" && message.role === "assistant") {
+      return messageAt >= pendingAt - PENDING_MATCH_SKEW_MS;
+    }
+    return messageAt > pendingAt;
+  });
+  return matchingIndex >= 0 ? matchingIndex : messages.length;
+}
+
+function advancePastLocalPendingMessages(
+  messages: HermesSessionMessage[],
+  startIndex: number,
+) {
+  let index = startIndex;
+  while (messages[index]?.id.startsWith("pending:")) index += 1;
+  return index;
 }
 
 function hermesMessageTimestampMs(message: HermesSessionMessage) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -144,14 +144,16 @@ export function buildAgentChatTurns(
   toolEvents: AgentToolEventDto[],
   liveEvents: LiveHermesEvent[] = [],
 ): AgentChatTurn[] {
-  const turns = messages.map(messageToTurn);
+  const turnOrder = new Map<string, number>();
+  const turns = messages.map((message, index) => {
+    const turn = messageToTurn(message);
+    turnOrder.set(turn.id, index);
+    return turn;
+  });
   appendPersistedToolEvents(turns, toolEvents);
   appendLiveHermesEvents(turns, liveEvents);
-  return turns
-    .filter((turn) =>
-      turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
-    )
-    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  assignMissingTurnOrder(turns, turnOrder, messages.length);
+  return filterAndSortChatTurns(turns, turnOrder);
 }
 
 export function buildHermesSessionChatTurns(
@@ -160,14 +162,16 @@ export function buildHermesSessionChatTurns(
 ): AgentChatTurn[] {
   const turns: AgentChatTurn[] = [];
   const toolResults = new Map<string, HermesSessionMessage>();
+  const turnOrder = new Map<string, number>();
 
-  for (const message of messages) {
+  for (const [messageIndex, message] of messages.entries()) {
     if (message.role === "tool") {
       const id = message.tool_call_id ?? message.id;
       toolResults.set(id, message);
       const turn =
         lastAssistantTurn(turns) ??
         createAssistantTurn(turns, messageTimestamp(message));
+      if (!turnOrder.has(turn.id)) turnOrder.set(turn.id, messageIndex);
       upsertToolPart(turn.parts, {
         id,
         name: message.tool_name ?? "Tool",
@@ -242,15 +246,97 @@ export function buildHermesSessionChatTurns(
 
     if (turn.parts.length) {
       turns.push(turn);
+      turnOrder.set(turn.id, messageIndex);
     }
   }
 
   appendLiveHermesEvents(turns, liveEvents);
+  assignMissingTurnOrder(turns, turnOrder, messages.length);
+  return filterAndSortChatTurns(turns, turnOrder);
+}
+
+const PENDING_USER_ASSISTANT_ORDER_SKEW_MS = 1500;
+
+function filterAndSortChatTurns(
+  turns: AgentChatTurn[],
+  turnOrder: Map<string, number>,
+) {
   return turns
     .filter((turn) =>
       turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
     )
-    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    .sort((a, b) => compareAgentChatTurns(a, b, turnOrder));
+}
+
+function assignMissingTurnOrder(
+  turns: AgentChatTurn[],
+  turnOrder: Map<string, number>,
+  offset: number,
+) {
+  turns.forEach((turn, index) => {
+    if (!turnOrder.has(turn.id)) turnOrder.set(turn.id, offset + index);
+  });
+}
+
+function compareAgentChatTurns(
+  a: AgentChatTurn,
+  b: AgentChatTurn,
+  turnOrder: Map<string, number>,
+) {
+  const sourceOrder = (turnOrder.get(a.id) ?? 0) - (turnOrder.get(b.id) ?? 0);
+  const aMs = turnTimestampMs(a.createdAt);
+  const bMs = turnTimestampMs(b.createdAt);
+
+  if (
+    sourceOrder !== 0 &&
+    shouldKeepPendingUserSourceOrder(a, b, aMs, bMs)
+  ) {
+    return sourceOrder;
+  }
+
+  if (aMs !== undefined && bMs !== undefined && aMs !== bMs) {
+    return aMs - bMs;
+  }
+
+  const lexical = a.createdAt.localeCompare(b.createdAt);
+  if ((aMs === undefined || bMs === undefined) && lexical !== 0) {
+    return lexical;
+  }
+
+  const roleOrder = chatTurnRoleOrder(a.role) - chatTurnRoleOrder(b.role);
+  if (roleOrder !== 0) return roleOrder;
+  return sourceOrder;
+}
+
+function shouldKeepPendingUserSourceOrder(
+  a: AgentChatTurn,
+  b: AgentChatTurn,
+  aMs: number | undefined,
+  bMs: number | undefined,
+) {
+  if (aMs === undefined || bMs === undefined) return false;
+  if (Math.abs(aMs - bMs) > PENDING_USER_ASSISTANT_ORDER_SKEW_MS) {
+    return false;
+  }
+  return (
+    (isPendingUserTurn(a) && b.role === "assistant") ||
+    (isPendingUserTurn(b) && a.role === "assistant")
+  );
+}
+
+function isPendingUserTurn(turn: AgentChatTurn) {
+  return turn.role === "user" && turn.id.startsWith("pending:user:");
+}
+
+function chatTurnRoleOrder(role: AgentChatTurn["role"]) {
+  if (role === "system") return 0;
+  if (role === "user") return 1;
+  return 2;
+}
+
+function turnTimestampMs(value: string) {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 // Contraction/possessive enclitics the gateway tokenizes as their own chunk

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -555,6 +555,7 @@ export type HermesSessionMessage = {
   reasoning_details?: unknown;
   codex_reasoning_items?: unknown;
   codex_message_items?: unknown;
+  client_insert_after_message_id?: string | null;
 };
 
 export type HermesSessionMessagesResponse = {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -122,6 +122,51 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("orders same-timestamp Hermes user turns before assistant turns", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "2",
+        role: "assistant",
+        content: "Fast answer",
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+      {
+        id: "1",
+        role: "user",
+        content: "Fast question",
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: "Fast question", status: "complete" },
+    ]);
+  });
+
+  it("keeps an anchored pending user turn before a coarse assistant timestamp", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "pending:user:1781179200900",
+        role: "user",
+        content: "Follow up",
+        timestamp: "2026-06-11T12:00:00.900Z",
+        client_insert_after_message_id: "previous",
+      },
+      {
+        id: "3",
+        role: "assistant",
+        content: "Fast follow-up answer",
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
+    expect(turns[0]?.parts).toEqual([
+      { type: "text", text: "Follow up", status: "complete" },
+    ]);
+  });
+
   it("strips explicit skill context from persisted Hermes user messages", () => {
     const turns = buildHermesSessionChatTurns([
       {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2029,8 +2029,14 @@ describe("AgentWorkspace", () => {
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now(), category: "bug" }),
     );
+    let rejectFirstReport: ((error: Error) => void) | undefined;
     mocks.submitIssueReport
-      .mockRejectedValueOnce(new Error("upstream_provider_failed"))
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirstReport = reject;
+          }),
+      )
       .mockResolvedValue({ received: true });
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
@@ -2065,6 +2071,10 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Send report" }));
     expect(await screen.findByText("Sending")).toBeInTheDocument();
+    await act(async () => {
+      rejectFirstReport?.(new Error("upstream_provider_failed"));
+      await Promise.resolve();
+    });
     expect(
       await screen.findByText(/The issue report could not be sent/),
     ).toBeInTheDocument();
@@ -4000,6 +4010,86 @@ describe("AgentWorkspace", () => {
       expect(mocks.listHermesSessions).toHaveBeenCalledTimes(
         sessionListCallsAfterSubmit + 1,
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a pending follow-up above a fetched assistant reply that arrives first", async () => {
+    const user = userEvent.setup();
+    const oldHistory = [
+      {
+        id: "m1",
+        role: "user",
+        content: "previous request",
+        timestamp: "2026-06-04T12:00:00.000Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: "previous answer",
+        timestamp: "2026-06-04T12:00:01.000Z",
+      },
+    ];
+    let submitted = false;
+    mocks.listHermesSessionMessages.mockImplementation(async () =>
+      submitted
+        ? [
+            ...oldHistory,
+            {
+              id: "m3",
+              role: "assistant",
+              content: "new ordering answer",
+              timestamp: "2026-06-25T15:00:00.000Z",
+            },
+          ]
+        : oldHistory,
+    );
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "prompt.submit") {
+        submitted = true;
+      }
+      return Promise.resolve({});
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("previous answer")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "follow up ordering");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-25T15:00:00.900Z"));
+    try {
+      fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: "follow up ordering",
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      const rows = Array.from(
+        document.querySelectorAll(".agent-user-turn, .agent-assistant-turn"),
+      ).map((element) => element.textContent ?? "");
+      const userIndex = rows.findIndex((text) =>
+        text.includes("follow up ordering"),
+      );
+      const assistantIndex = rows.findIndex((text) =>
+        text.includes("new ordering answer"),
+      );
+      expect(userIndex).toBeGreaterThan(-1);
+      expect(assistantIndex).toBeGreaterThan(-1);
+      expect(userIndex).toBeLessThan(assistantIndex);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Closes JUN-105

## What changed
- Anchor optimistic Hermes user messages to the last persisted message known at send time, then merge pending messages back into the display list at that anchor.
- Add deterministic chat-turn sorting for same-timestamp user/assistant messages and pending-user versus coarse assistant timestamps.
- Add regression coverage for the fetched-assistant-before-user race and same-timestamp turn ordering.
- Stabilize the existing issue-report retry test so it asserts the sending state while the submit promise is actually pending.

## Why
Hermes can return or stream an assistant reply before the matching user row is persisted, and Hermes timestamps can be coarse. The previous UI displayed `persisted + pending` and sorted mostly by timestamp, so the assistant reply could render above the pending user question.

## Validation
- `pnpm run lint`
- `pnpm test src/test/agent-chat-runtime.test.ts src/test/agent-workspace.test.tsx`
- `pnpm test`

## Known gaps
- No manual Tauri app smoke test run; this is covered by the frontend runtime and workspace regression tests.