### PR TITLE
Add Escape cancel affordance to dictation HUD

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -39,6 +39,12 @@
       <span class="hud-error-layer" aria-hidden="true">
         <span id="hud-error-text" class="hud-error-message"></span>
       </span>
+      <span
+        id="hud-cancel-key"
+        class="hud-cancel-key"
+        aria-label="Press Escape to cancel dictation"
+        >Esc</span
+      >
       <span class="hud-meeting-body">
         <span class="hud-meeting-mark" aria-hidden="true"></span>
         <span class="hud-meeting-text">

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -351,6 +351,8 @@ struct ShortcutIdentity: Equatable, Hashable {
     }
 }
 
+private let shortcutHotKeySignature = OSType(0x4A_44_48_4B) // "JDHK"
+
 final class ShortcutKeyMonitor {
     static let shared = ShortcutKeyMonitor()
 
@@ -585,7 +587,7 @@ final class ShortcutKeyMonitor {
             if shortcut.modifiers.shift { carbonModifiers |= UInt32(shiftKey) }
 
             var ref: EventHotKeyRef?
-            let hotKeyId = EventHotKeyID(signature: OSType(0x4A_44_48_4B), id: nextCarbonHotKeyId) // "JDHK"
+            let hotKeyId = EventHotKeyID(signature: shortcutHotKeySignature, id: nextCarbonHotKeyId)
             let status = RegisterEventHotKey(
                 UInt32(shortcut.keyCode),
                 carbonModifiers,
@@ -862,6 +864,9 @@ private let carbonHotKeyCallback: EventHandlerUPP = { _, eventRef, userInfo in
     )
     guard status == noErr else {
         return status
+    }
+    guard hotKeyId.signature == shortcutHotKeySignature else {
+        return OSStatus(eventNotHandledErr)
     }
     let monitor = Unmanaged<ShortcutKeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
     let pressed = GetEventKind(eventRef) == UInt32(kEventHotKeyPressed)
@@ -1330,6 +1335,110 @@ enum RecordingPurpose {
 
 let micTestCapturePaddingSeconds: Double = 0.35
 
+private let escapeCancelHotKeySignature = OSType(0x4A_44_45_43) // "JDEC"
+
+final class DictationEscapeCancelMonitor {
+    static let shared = DictationEscapeCancelMonitor()
+
+    private var carbonHandlerRef: EventHandlerRef?
+    private var hotKeyRef: EventHotKeyRef?
+    private let hotKeyId = EventHotKeyID(signature: escapeCancelHotKeySignature, id: 1)
+
+    private init() {}
+
+    func start() {
+        guard hotKeyRef == nil else {
+            return
+        }
+
+        installCarbonHotKeyHandler()
+
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(kVK_Escape),
+            0,
+            hotKeyId,
+            GetEventDispatcherTarget(),
+            0,
+            &ref
+        )
+        if status == noErr, let ref {
+            hotKeyRef = ref
+        } else {
+            emit("escape_cancel_unavailable", [
+                "message": "Could not register Escape to cancel dictation.",
+            ])
+        }
+    }
+
+    func stop() {
+        guard let ref = hotKeyRef else {
+            return
+        }
+
+        UnregisterEventHotKey(ref)
+        hotKeyRef = nil
+    }
+
+    private func installCarbonHotKeyHandler() {
+        guard carbonHandlerRef == nil else {
+            return
+        }
+
+        var specs = [
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed)),
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyReleased)),
+        ]
+        let userInfo = Unmanaged.passUnretained(self).toOpaque()
+        InstallEventHandler(
+            GetEventDispatcherTarget(),
+            escapeCancelHotKeyCallback,
+            2,
+            &specs,
+            userInfo,
+            &carbonHandlerRef
+        )
+    }
+
+    fileprivate func handleCarbonHotKey(pressed: Bool) {
+        guard pressed else {
+            return
+        }
+
+        runOnMain {
+            dictation.discard()
+        }
+    }
+}
+
+private let escapeCancelHotKeyCallback: EventHandlerUPP = { _, eventRef, userInfo in
+    guard let eventRef, let userInfo else {
+        return OSStatus(eventNotHandledErr)
+    }
+
+    var hotKeyId = EventHotKeyID()
+    let status = GetEventParameter(
+        eventRef,
+        EventParamName(kEventParamDirectObject),
+        EventParamType(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &hotKeyId
+    )
+    guard status == noErr else {
+        return status
+    }
+
+    guard hotKeyId.signature == escapeCancelHotKeySignature else {
+        return OSStatus(eventNotHandledErr)
+    }
+
+    let monitor = Unmanaged<DictationEscapeCancelMonitor>.fromOpaque(userInfo).takeUnretainedValue()
+    monitor.handleCarbonHotKey(pressed: GetEventKind(eventRef) == UInt32(kEventHotKeyPressed))
+    return noErr
+}
+
 final class DictationController {
     private var audioRecorder: AVAudioRecorder?
     private var selectedDeviceRecorder: SelectedDeviceRecorder?
@@ -1628,6 +1737,7 @@ final class DictationController {
                 "microphone": microphone,
             ])
         } else {
+            DictationEscapeCancelMonitor.shared.start()
             emit("listening_started", [
                 "recognitionMode": "venice_recording",
                 "microphone": microphone,
@@ -1639,6 +1749,7 @@ final class DictationController {
         let purpose = recordingPurpose
         isListening = false
         isFinalizing = true
+        DictationEscapeCancelMonitor.shared.stop()
         micTestStopWorkItem?.cancel()
         micTestStopWorkItem = nil
         stopMetering()
@@ -1798,6 +1909,7 @@ final class DictationController {
     private func resetRecordingState(keepRecordingFile: Bool = false) {
         isListening = false
         isFinalizing = false
+        DictationEscapeCancelMonitor.shared.stop()
         maxObservedAudioLevel = 0
         recordingStartedAt = 0
         micTestStopWorkItem?.cancel()

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1863,6 +1863,10 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
 
     handle_shortcut_key_event(app, event_type, event.as_ref());
 
+    if matches!(event_type, Some("recording_discarded")) {
+        reset_shortcut_activation(app);
+    }
+
     if matches!(event_type, Some("recording_ready")) {
         if let Some(event) = event.as_ref() {
             match recording_ready_info_from_event(event) {
@@ -2776,9 +2780,13 @@ fn dictation_event_visibility(event_type: Option<&str>) -> DictationEventVisibil
             | "final_transcript"
             | "paste_target",
         ) => DictationEventVisibility::Show,
-        Some("paste_completed" | "agent_session_prompt" | "error" | "shutdown_ack") => {
-            DictationEventVisibility::Hide
-        }
+        Some(
+            "paste_completed"
+            | "recording_discarded"
+            | "agent_session_prompt"
+            | "error"
+            | "shutdown_ack",
+        ) => DictationEventVisibility::Hide,
         _ => DictationEventVisibility::Ignore,
     }
 }
@@ -3585,6 +3593,29 @@ mod tests {
     }
 
     #[test]
+    fn shortcut_reset_after_cancel_ignores_later_release() {
+        let mut controller = ShortcutActivationController::default();
+        let down = Instant::now();
+        let up = down + PUSH_TO_TALK_MIN_HOLD;
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                down
+            ),
+            Some(DictationCommand::StartListening)
+        );
+
+        controller.reset();
+
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk, up),
+            None
+        );
+    }
+
+    #[test]
     fn toggle_mode_toggles_on_down_and_ignores_up() {
         let mut controller = ShortcutActivationController::default();
         let now = Instant::now();
@@ -3898,6 +3929,14 @@ mod tests {
     fn agent_session_prompt_hides_dictation_hud() {
         assert!(matches!(
             dictation_event_visibility(Some("agent_session_prompt")),
+            DictationEventVisibility::Hide
+        ));
+    }
+
+    #[test]
+    fn recording_discarded_hides_dictation_hud() {
+        assert!(matches!(
+            dictation_event_visibility(Some("recording_discarded")),
             DictationEventVisibility::Hide
         ));
     }

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -1080,15 +1080,7 @@ function parseEvent(payload: unknown): DictationHudEvent | undefined {
   return undefined;
 }
 
-dragHandle?.addEventListener("pointerdown", (event) => {
-  if (event.button !== 0) return;
-  event.preventDefault();
-  event.stopPropagation();
-  void appWindow?.startDragging().catch(() => {});
-});
-
-stopButton?.addEventListener("click", async (event) => {
-  event.preventDefault();
+async function stopAndPasteDictation() {
   setStopHover(false);
   if (hud?.dataset.state === "listening") {
     const transition = setHud("transcribing", "Transcribing");
@@ -1101,7 +1093,48 @@ stopButton?.addEventListener("click", async (event) => {
   } catch {
     void hideHud();
   }
+}
+
+async function cancelDictation() {
+  if (!hud?.isConnected || hud.dataset.state !== "listening") return;
+  setStopHover(false);
+  try {
+    await invoke("dictation_helper_command", {
+      command: { type: "discard_recording" },
+    });
+  } finally {
+    void hideHud();
+  }
+}
+
+dragHandle?.addEventListener("pointerdown", (event) => {
+  if (event.button !== 0) return;
+  event.preventDefault();
+  event.stopPropagation();
+  void appWindow?.startDragging().catch(() => {});
 });
+
+stopButton?.addEventListener("click", async (event) => {
+  event.preventDefault();
+  await stopAndPasteDictation();
+});
+
+window.addEventListener(
+  "keydown",
+  (event) => {
+    if (
+      event.key !== "Escape" ||
+      !hud?.isConnected ||
+      hud.dataset.state !== "listening"
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    void cancelDictation();
+  },
+  { capture: true },
+);
 
 meetingStartButton?.addEventListener("click", async (event) => {
   event.preventDefault();

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -518,6 +518,25 @@ body {
   background: var(--foreground);
 }
 
+.hud-cancel-key {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 24px;
+  padding: 0 var(--sp-2);
+  border: 1px solid color-mix(in oklch, var(--foreground) 14%, transparent);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--foreground) 4%, transparent);
+  color: color-mix(in oklch, var(--foreground) 74%, transparent);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-medium);
+  line-height: 1;
+  box-shadow: inset 0 -1px 0
+    color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
 .hud-stop,
 .hud-handle {
   -webkit-user-select: none;
@@ -526,7 +545,8 @@ body {
 }
 
 .hud-stop *,
-.hud-handle * {
+.hud-handle *,
+.hud-cancel-key {
   -webkit-user-drag: none;
 }
 
@@ -605,6 +625,11 @@ body {
 
 .hud[data-state="meeting"] .hud-meeting-dismiss,
 .hud[data-state="exiting"][data-exit-state="meeting"] .hud-meeting-dismiss {
+  display: inline-flex;
+}
+
+.hud[data-state="listening"] .hud-cancel-key,
+.hud[data-state="exiting"][data-exit-state="listening"] .hud-cancel-key {
   display: inline-flex;
 }
 

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -523,6 +523,54 @@ describe("meeting detection HUD", () => {
     expect(hudShowCalls()).toBe(0);
   });
 
+  it("surfaces Escape as the listening cancel affordance", async () => {
+    await loadHud();
+
+    await emit("dictation-event", { type: "listening_started" });
+
+    expect(document.querySelector("#hud-cancel-key")).toHaveTextContent("Esc");
+    expect(document.querySelector("#hud-cancel-key")).toHaveAttribute(
+      "aria-label",
+      "Press Escape to cancel dictation",
+    );
+  });
+
+  it("cancels active dictation when Escape reaches the HUD", async () => {
+    await loadHud();
+    await emit("dictation-event", { type: "listening_started" });
+    mocks.invoke.mockClear();
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await Promise.resolve();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_helper_command", {
+      command: { type: "discard_recording" },
+    });
+  });
+
+  it("ignores Escape outside the listening state", async () => {
+    await loadHud();
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await Promise.resolve();
+
+    expect(mocks.invoke).not.toHaveBeenCalledWith("dictation_helper_command", {
+      command: { type: "discard_recording" },
+    });
+  });
+
   it("falls back to the error toast for already_listening outside the listening state", async () => {
     await loadHud();
 
@@ -738,6 +786,7 @@ function hudMarkup() {
       <span class="hud-error-layer" aria-hidden="true">
         <span id="hud-error-text" class="hud-error-message"></span>
       </span>
+      <span id="hud-cancel-key" class="hud-cancel-key" aria-label="Press Escape to cancel dictation">Esc</span>
       <span class="hud-meeting-body">
         <span class="hud-meeting-mark" aria-hidden="true"></span>
         <span class="hud-meeting-text">


### PR DESCRIPTION
Task: JUN-61, Design of Esc feature in HUD

Closes JUN-61

## What changed
- Added a compact `Esc` keycap affordance to the listening dictation HUD.
- Added a separate cancel path that discards the active dictation recording instead of stopping and pasting.
- Registered a listening-only macOS Carbon Escape hotkey in the dictation helper, then unregisters it on stop/reset.
- Reset dictation shortcut activation and clear HUD visibility state when a recording is discarded, so push-to-talk release cannot accidentally stop-and-paste after cancel.

## Why
The HUD needed an explicit Escape/cancel design and behavior for the parent cancel-dictation flow. Escape should be available while dictation is listening without activating June or stealing focus from the target app.

## Validation
- `pnpm test -- src/test/hud-meeting.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml dictation --locked`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec prettier --check hud.html src/hud.ts src/styles/hud.css src/test/hud-meeting.test.ts`
- `swiftc -target arm64-apple-macos13.0 -framework Foundation -framework AppKit -framework AVFoundation -framework Carbon -framework CoreMedia -framework CoreGraphics src-tauri/native/mac-dictation-helper/main.swift -o /tmp/june-dictation-helper-arm64-check`
- `swiftc -target x86_64-apple-macos13.0 -framework Foundation -framework AppKit -framework AVFoundation -framework Carbon -framework CoreMedia -framework CoreGraphics src-tauri/native/mac-dictation-helper/main.swift -o /tmp/june-dictation-helper-x86_64-check`

## Known gaps
- `pnpm run format` still fails on pre-existing unrelated files: `src/app/App.tsx`, `src/lib/hermes-routines.ts`, `src/lib/live-transcript-preview.ts`, `src/lib/recording-inactivity.ts`, `src/test/hermes-routines.test.ts`, `src/test/recording-inactivity.test.ts`, and `src-tauri/tauri.conf.json`.
- Live os-platform issue fetch was not available locally because `OS_PLATFORM_API_KEY` was not set, so the PR uses the screenshot-provided JUN-61 details.
