### PR TITLE
Fix Hermes chunk spacing in visible messages

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -270,6 +270,7 @@ import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   repairContractionSpacing,
+  textFromHermesContent,
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
@@ -10807,8 +10808,8 @@ function agentStatusSummaryFromHermesEvent(
 
 function visibleHermesMessageText(message: HermesSessionMessage) {
   const text =
-    textFromHermesValue(message.content) ??
-    textFromHermesValue(message.text) ??
+    textFromHermesContent(message.content) ??
+    textFromHermesContent(message.text) ??
     "";
   return displayedComposerUserMessageText(stripHermesVisibleContext(text));
 }
@@ -10870,25 +10871,6 @@ function displayedComposerUserMessageText(content: string): string {
     text = next;
   }
   return text;
-}
-
-function textFromHermesValue(value: unknown): string | undefined {
-  if (value === null || value === undefined) return undefined;
-  if (typeof value === "string") return value.trim() ? value.trim() : undefined;
-  if (typeof value === "number" || typeof value === "boolean")
-    return String(value);
-  if (Array.isArray(value)) {
-    const text = value.map((item) => textFromHermesValue(item) ?? "").join("");
-    return text.trim() ? text.trim() : undefined;
-  }
-  if (typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    for (const key of ["text", "content", "message", "output_text"]) {
-      const text = textFromHermesValue(record[key]);
-      if (text) return text;
-    }
-  }
-  return undefined;
 }
 
 function sameVisibleMessageText(left: string, right: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -1168,7 +1168,10 @@ function contextCompactionPreview(value: string) {
     : "Earlier turns were compacted into a reference summary.";
 }
 
-function textFromHermesContent(value: unknown, depth = 0): string | undefined {
+export function textFromHermesContent(
+  value: unknown,
+  depth = 0,
+): string | undefined {
   if (value === null || value === undefined || depth > 4) return undefined;
   if (typeof value === "string") {
     if (!value.trim()) return undefined;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -753,6 +753,71 @@ describe("AgentWorkspace", () => {
     await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
   });
 
+  it("keeps chunk boundary spaces in issue report agent diagnosis", async () => {
+    const user = userEvent.setup();
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockResolvedValue([]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Attach files or tag this message",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Bug report" }),
+    );
+    await user.type(
+      await screen.findByRole("textbox"),
+      "Agent response text is losing spaces",
+    );
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-1",
+        text: expect.stringContaining("---USER REPORT---"),
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({ type: "turn.completed", session_id: "runtime-session-1" });
+      }
+    });
+
+    expect(await screen.findByText(/Report ready/)).toBeInTheDocument();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "assistant",
+        content: [
+          "Let me get the full",
+          " details: ",
+          { text: "read releases to get detailed" },
+          { text: " information" },
+          " more",
+          " efficiently.",
+        ],
+        timestamp: new Date(Date.now() + 1000).toISOString(),
+      },
+    ]);
+    await user.click(screen.getByRole("button", { name: "Send report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: "Agent response text is losing spaces",
+        agentDiagnosis:
+          "Let me get the full details: read releases to get detailed information more efficiently.",
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-1",
+      }),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 400)));
+  });
+
   it("allows second-precision diagnosis timestamps near the report boundary", async () => {
     const user = userEvent.setup();
     mocks.submitIssueReport.mockResolvedValue({ received: true });
@@ -2855,6 +2920,36 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
 
     expect(await screen.findByText("CLI Run Tracking")).toBeInTheDocument();
+  });
+
+  it("keeps chunk boundary spaces when suggesting session titles", async () => {
+    const rawTitle = "I want you to find the release details";
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-raw",
+        title: rawTitle,
+        preview: rawTitle,
+        last_active: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "message-1",
+        role: "user",
+        content: ["Find the full", " details", " more", " efficiently"],
+        timestamp: "2026-06-04T12:00:00Z",
+      },
+    ]);
+    mocks.suggestAgentSessionTitle.mockResolvedValue({
+      title: "Release Details",
+    });
+
+    render(<AgentWorkspace />);
+
+    expect(await screen.findByText("Release Details")).toBeInTheDocument();
+    expect(mocks.suggestAgentSessionTitle).toHaveBeenCalledWith(
+      "Find the full details more efficiently",
+    );
   });
 
   it("renders June's CLI access request as a card and enables the setting", async () => {


### PR DESCRIPTION
## Task

Closes JUN-30.

## What changed

- Reused the runtime Hermes content extractor for visible session message text in the workspace.
- Removed the duplicate workspace extractor that trimmed each chunk before joining arrays, which could turn chunked text like "full" + " details" into "fulldetails" in issue-report diagnostics, title prompts, and pending-message comparisons.
- Added regression coverage for chunk boundary spaces in issue report diagnostics and session title suggestion prompts.

## Why

The transcript renderer already preserves chunk boundary whitespace through `textFromHermesContent`, but the workspace had a second local extractor for non-rendered visible-message uses. That extractor trimmed nested string chunks and could preserve the same kind of concatenated words shown in the JUN-30 screenshot when those paths read Hermes messages.

## Validation

- `pnpm test -- src/test/agent-workspace.test.tsx`
- `pnpm test -- src/test/agent-chat-runtime.test.ts`
- `pnpm run lint`

## Known gaps

- The live platform issue data could not be fetched locally because `OS_PLATFORM_API_KEY` is not set, so the build used the supplied screenshot as the source of truth.
