### PR TITLE
JUN-114: Reduce message action control height

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1670,7 +1670,7 @@ input:focus-visible,
   display: flex;
   gap: var(--sp-1);
   width: 100%;
-  margin-top: var(--sp-1);
+  margin-top: var(--sp-px);
   opacity: 0;
   transition: opacity 0.12s ease-out;
 }
@@ -1690,7 +1690,7 @@ input:focus-visible,
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);
-  padding: var(--sp-1) var(--sp-2);
+  padding: var(--sp-px) var(--sp-1);
   border: none;
   border-radius: var(--r-sm);
   background: transparent;

--- a/src/test/agent-turn-actions-css.test.ts
+++ b/src/test/agent-turn-actions-css.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import appCss from "../styles/app.css?raw";
+
+function cssRuleFor(selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{`).exec(appCss);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  let depth = 0;
+  for (let index = openIndex; index < appCss.length; index += 1) {
+    if (appCss[index] === "{") depth += 1;
+    if (appCss[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return appCss.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
+}
+
+describe("agent turn action styles", () => {
+  it("keeps hidden per-message controls compact in flow", () => {
+    expect(cssRuleFor(".agent-turn-actions")).toContain(
+      "margin-top: var(--sp-px);",
+    );
+    expect(cssRuleFor(".agent-turn-action")).toContain(
+      "padding: var(--sp-px) var(--sp-1);",
+    );
+  });
+});


### PR DESCRIPTION
Closes JUN-114

## What changed
- Reduced the message action row reserved top margin from `--sp-1` to `--sp-px`.
- Reduced per-action padding to compact spacing tokens.
- Added a raw CSS regression test for the compact hidden controls.

## Why
Hidden controls use opacity for hover reveal, so they still occupy flow space when not visible. Tightening the row and action padding reduces non-hovered message spacing without changing behavior.

## Validation
- `./node_modules/.bin/vitest run src/test/agent-turn-actions-css.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check src/styles/app.css src/test/agent-turn-actions-css.test.ts`

## Known gaps
- Used direct local binaries because `pnpm exec` attempted to hydrate dependencies with pnpm 11 and stopped at its build approval gate before running Vitest.