### PR TITLE
Fix same-timestamp agent turn ordering

### DIFF
--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -140,6 +140,20 @@ export type AgentChatTurn = {
   isScheduledRun?: boolean;
 };
 
+const TURN_ROLE_ORDER: Record<AgentChatTurn["role"], number> = {
+  system: 0,
+  user: 1,
+  assistant: 2,
+};
+
+function compareAgentChatTurns(a: AgentChatTurn, b: AgentChatTurn) {
+  return (
+    a.createdAt.localeCompare(b.createdAt) ||
+    TURN_ROLE_ORDER[a.role] - TURN_ROLE_ORDER[b.role] ||
+    a.id.localeCompare(b.id)
+  );
+}
+
 export function buildAgentChatTurns(
   messages: AgentMessageDto[],
   toolEvents: AgentToolEventDto[],
@@ -152,7 +166,7 @@ export function buildAgentChatTurns(
     .filter((turn) =>
       turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
     )
-    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    .sort(compareAgentChatTurns);
 }
 
 export function buildHermesSessionChatTurns(
@@ -251,7 +265,7 @@ export function buildHermesSessionChatTurns(
     .filter((turn) =>
       turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
     )
-    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    .sort(compareAgentChatTurns);
 }
 
 // Contraction/possessive enclitics the gateway tokenizes as their own chunk

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -150,7 +150,7 @@ function compareAgentChatTurns(a: AgentChatTurn, b: AgentChatTurn) {
   return (
     a.createdAt.localeCompare(b.createdAt) ||
     TURN_ROLE_ORDER[a.role] - TURN_ROLE_ORDER[b.role] ||
-    a.id.localeCompare(b.id)
+    a.id.localeCompare(b.id, undefined, { numeric: true })
   );
 }
 

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -140,22 +140,14 @@ export type AgentChatTurn = {
   isScheduledRun?: boolean;
 };
 
-function compareAgentChatTurns(a: AgentChatTurn, b: AgentChatTurn) {
-  const timestampOrder = a.createdAt.localeCompare(b.createdAt);
-  if (timestampOrder !== 0) return timestampOrder;
-  const userAssistantOrder = compareUserAssistantTurns(a, b);
-  if (userAssistantOrder !== 0) return userAssistantOrder;
-  return 0;
-}
-
-function compareUserAssistantTurns(a: AgentChatTurn, b: AgentChatTurn) {
-  // Only force the tie that breaks the gap-vs-per-turn Thinking invariant.
-  // Other cross-role ties preserve stream insertion order, especially steering
-  // system turns inserted during an assistant response.
-  return (
-    (a.role === "user" && b.role === "assistant" ? -1 : 0) ||
-    (a.role === "assistant" && b.role === "user" ? 1 : 0)
-  );
+function sortAgentChatTurns(turns: AgentChatTurn[]) {
+  return turns
+    .map((turn, index) => ({ turn, index }))
+    .sort(
+      (a, b) =>
+        a.turn.createdAt.localeCompare(b.turn.createdAt) || a.index - b.index,
+    )
+    .map(({ turn }) => turn);
 }
 
 export function buildAgentChatTurns(
@@ -166,11 +158,11 @@ export function buildAgentChatTurns(
   const turns = messages.map(messageToTurn);
   appendPersistedToolEvents(turns, toolEvents);
   appendLiveHermesEvents(turns, liveEvents);
-  return turns
-    .filter((turn) =>
+  return sortAgentChatTurns(
+    turns.filter((turn) =>
       turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
-    )
-    .sort(compareAgentChatTurns);
+    ),
+  );
 }
 
 export function buildHermesSessionChatTurns(
@@ -265,11 +257,11 @@ export function buildHermesSessionChatTurns(
   }
 
   appendLiveHermesEvents(turns, liveEvents);
-  return turns
-    .filter((turn) =>
+  return sortAgentChatTurns(
+    turns.filter((turn) =>
       turn.parts.some((part) => part.type === "tool" || partText(part).trim()),
-    )
-    .sort(compareAgentChatTurns);
+    ),
+  );
 }
 
 // Contraction/possessive enclitics the gateway tokenizes as their own chunk

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -140,17 +140,22 @@ export type AgentChatTurn = {
   isScheduledRun?: boolean;
 };
 
-const TURN_ROLE_ORDER: Record<AgentChatTurn["role"], number> = {
-  system: 0,
-  user: 1,
-  assistant: 2,
-};
-
 function compareAgentChatTurns(a: AgentChatTurn, b: AgentChatTurn) {
+  const timestampOrder = a.createdAt.localeCompare(b.createdAt);
+  if (timestampOrder !== 0) return timestampOrder;
+  const userAssistantOrder = compareUserAssistantTurns(a, b);
+  if (userAssistantOrder !== 0) return userAssistantOrder;
+  if (a.role !== b.role) return 0;
+  return a.id.localeCompare(b.id, undefined, { numeric: true });
+}
+
+function compareUserAssistantTurns(a: AgentChatTurn, b: AgentChatTurn) {
+  // Only force the tie that breaks the gap-vs-per-turn Thinking invariant.
+  // Other cross-role ties preserve stream insertion order, especially steering
+  // system turns inserted during an assistant response.
   return (
-    a.createdAt.localeCompare(b.createdAt) ||
-    TURN_ROLE_ORDER[a.role] - TURN_ROLE_ORDER[b.role] ||
-    a.id.localeCompare(b.id, undefined, { numeric: true })
+    (a.role === "user" && b.role === "assistant" ? -1 : 0) ||
+    (a.role === "assistant" && b.role === "user" ? 1 : 0)
   );
 }
 

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -145,8 +145,7 @@ function compareAgentChatTurns(a: AgentChatTurn, b: AgentChatTurn) {
   if (timestampOrder !== 0) return timestampOrder;
   const userAssistantOrder = compareUserAssistantTurns(a, b);
   if (userAssistantOrder !== 0) return userAssistantOrder;
-  if (a.role !== b.role) return 0;
-  return a.id.localeCompare(b.id, undefined, { numeric: true });
+  return 0;
 }
 
 function compareUserAssistantTurns(a: AgentChatTurn, b: AgentChatTurn) {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -166,6 +166,26 @@ describe("Agent chat runtime", () => {
     expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
   });
 
+  it("keeps synthetic same-timestamp assistant turns in numeric suffix order", () => {
+    const receivedAt = "2026-06-11T12:00:00.000Z";
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      Array.from({ length: 12 }, (_, index) => ({
+        type: "message.complete",
+        receivedAt,
+        payload: { text: `Reply ${index}` },
+      })),
+    );
+
+    expect(
+      turns.map((turn) => {
+        const textPart = turn.parts.find((part) => part.type === "text");
+        return textPart?.type === "text" ? textPart.text : "";
+      }),
+    ).toEqual(Array.from({ length: 12 }, (_, index) => `Reply ${index}`));
+  });
+
   it("strips explicit skill context from persisted Hermes user messages", () => {
     const turns = buildHermesSessionChatTurns([
       {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -166,6 +166,60 @@ describe("Agent chat runtime", () => {
     expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
   });
 
+  it("preserves same-timestamp Hermes same-role source order", () => {
+    const createdAt = "2026-06-11T12:00:00.000Z";
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "z-message",
+        role: "assistant",
+        content: "First assistant row.",
+        timestamp: createdAt,
+      },
+      {
+        id: "a-message",
+        role: "assistant",
+        content: "Second assistant row.",
+        timestamp: createdAt,
+      },
+    ]);
+
+    expect(
+      turns.map((turn) => {
+        const textPart = turn.parts.find((part) => part.type === "text");
+        return textPart?.type === "text" ? textPart.text : "";
+      }),
+    ).toEqual(["First assistant row.", "Second assistant row."]);
+  });
+
+  it("preserves same-timestamp task same-role source order", () => {
+    const createdAt = "2026-06-11T12:00:00.000Z";
+    const messages: AgentMessageDto[] = [
+      {
+        id: "z-message",
+        taskId: "task-1",
+        role: "assistant",
+        content: "First assistant row.",
+        createdAt,
+      },
+      {
+        id: "a-message",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Second assistant row.",
+        createdAt,
+      },
+    ];
+
+    const turns = buildAgentChatTurns(messages, []);
+
+    expect(
+      turns.map((turn) => {
+        const textPart = turn.parts.find((part) => part.type === "text");
+        return textPart?.type === "text" ? textPart.text : "";
+      }),
+    ).toEqual(["First assistant row.", "Second assistant row."]);
+  });
+
   it("keeps synthetic same-timestamp assistant turns in numeric suffix order", () => {
     const receivedAt = "2026-06-11T12:00:00.000Z";
     const turns = buildAgentChatTurns(

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -122,6 +122,50 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("orders same-timestamp Hermes user turns before assistant turns", () => {
+    const createdAt = "2026-06-11T12:00:00.000Z";
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-message",
+        role: "assistant",
+        content: "Thinking about it.",
+        timestamp: createdAt,
+      },
+      {
+        id: "user-message",
+        role: "user",
+        content: "Please check this.",
+        timestamp: createdAt,
+      },
+    ]);
+
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("orders same-timestamp task user turns before assistant turns", () => {
+    const createdAt = "2026-06-11T12:00:00.000Z";
+    const messages: AgentMessageDto[] = [
+      {
+        id: "assistant-message",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Thinking about it.",
+        createdAt,
+      },
+      {
+        id: "user-message",
+        taskId: "task-1",
+        role: "user",
+        content: "Please check this.",
+        createdAt,
+      },
+    ];
+
+    const turns = buildAgentChatTurns(messages, []);
+
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
+  });
+
   it("strips explicit skill context from persisted Hermes user messages", () => {
     const turns = buildHermesSessionChatTurns([
       {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -122,19 +122,19 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
-  it("orders same-timestamp Hermes user turns before assistant turns", () => {
+  it("preserves same-timestamp Hermes user-before-assistant source order", () => {
     const createdAt = "2026-06-11T12:00:00.000Z";
     const turns = buildHermesSessionChatTurns([
-      {
-        id: "assistant-message",
-        role: "assistant",
-        content: "Thinking about it.",
-        timestamp: createdAt,
-      },
       {
         id: "user-message",
         role: "user",
         content: "Please check this.",
+        timestamp: createdAt,
+      },
+      {
+        id: "assistant-message",
+        role: "assistant",
+        content: "Thinking about it.",
         timestamp: createdAt,
       },
     ]);
@@ -142,16 +142,9 @@ describe("Agent chat runtime", () => {
     expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
   });
 
-  it("orders same-timestamp task user turns before assistant turns", () => {
+  it("preserves same-timestamp task user-before-assistant source order", () => {
     const createdAt = "2026-06-11T12:00:00.000Z";
     const messages: AgentMessageDto[] = [
-      {
-        id: "assistant-message",
-        taskId: "task-1",
-        role: "assistant",
-        content: "Thinking about it.",
-        createdAt,
-      },
       {
         id: "user-message",
         taskId: "task-1",
@@ -159,11 +152,62 @@ describe("Agent chat runtime", () => {
         content: "Please check this.",
         createdAt,
       },
+      {
+        id: "assistant-message",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Thinking about it.",
+        createdAt,
+      },
     ];
 
     const turns = buildAgentChatTurns(messages, []);
 
     expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("preserves same-timestamp Hermes assistant-before-user source order", () => {
+    const createdAt = "2026-06-11T12:00:00.000Z";
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "assistant-message",
+        role: "assistant",
+        content: "Here is the answer.",
+        timestamp: createdAt,
+      },
+      {
+        id: "user-follow-up",
+        role: "user",
+        content: "One more thing.",
+        timestamp: createdAt,
+      },
+    ]);
+
+    expect(turns.map((turn) => turn.role)).toEqual(["assistant", "user"]);
+  });
+
+  it("preserves same-timestamp task assistant-before-user source order", () => {
+    const createdAt = "2026-06-11T12:00:00.000Z";
+    const messages: AgentMessageDto[] = [
+      {
+        id: "assistant-message",
+        taskId: "task-1",
+        role: "assistant",
+        content: "Here is the answer.",
+        createdAt,
+      },
+      {
+        id: "user-follow-up",
+        taskId: "task-1",
+        role: "user",
+        content: "One more thing.",
+        createdAt,
+      },
+    ];
+
+    const turns = buildAgentChatTurns(messages, []);
+
+    expect(turns.map((turn) => turn.role)).toEqual(["assistant", "user"]);
   });
 
   it("preserves same-timestamp Hermes same-role source order", () => {
@@ -220,7 +264,7 @@ describe("Agent chat runtime", () => {
     ).toEqual(["First assistant row.", "Second assistant row."]);
   });
 
-  it("keeps synthetic same-timestamp assistant turns in numeric suffix order", () => {
+  it("keeps synthetic same-timestamp assistant turns in source order", () => {
     const receivedAt = "2026-06-11T12:00:00.000Z";
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/hermes-session-steer.test.ts
+++ b/src/test/hermes-session-steer.test.ts
@@ -123,4 +123,28 @@ describe("steering transcript item via buildHermesSessionChatTurns", () => {
     const order = turns.map((turn) => turn.parts[0]?.type);
     expect(order.at(-1)).toBe("steering");
   });
+
+  it("keeps same-millisecond steering after the assistant work it interrupts", () => {
+    const receivedAt = "2026-06-24T10:05:00.000Z";
+    const turns = buildHermesSessionChatTurns(
+      [],
+      [
+        {
+          type: "message.delta",
+          receivedAt,
+          payload: { text: "Working on the current plan." },
+        },
+        steeringLiveEvent({
+          sessionId: "sess-1",
+          text: "switch gears",
+          receivedAt,
+        }),
+      ],
+    );
+
+    expect(turns.map((turn) => turn.parts[0]?.type)).toEqual([
+      "text",
+      "steering",
+    ]);
+  });
 });


### PR DESCRIPTION
Closes JUN-115

## What changed

- Added a shared agent-chat turn sorter for both task chats and Hermes sessions.
- The sorter orders by timestamp, then uses original source order as the deterministic tie-breaker.
- Added regression coverage for same-millisecond prompt/start ordering, assistant follow-ups, same-role source order, synthetic assistant turns, and steering events.

## Why

When a user prompt and assistant stream start share the same millisecond, sorting only by `createdAt` can allow the final order to drift. That breaks the UI invariant where the gap "Thinking" indicator is only used after a trailing user turn, and can render duplicated or misplaced "Thinking" indicators.

Using source order for timestamp ties keeps live assistant starts below their triggering user prompt while also preserving already-authoritative persisted order for assistant answers, user follow-ups, same-role messages, and steering events.

## Validation

- `corepack pnpm exec vitest run src/test/agent-chat-runtime.test.ts src/test/hermes-session-steer.test.ts`
- `corepack pnpm run lint`
- `corepack pnpm test`

## Notes

- Initial `pnpm exec` used a newer bundled pnpm and stopped before tests because build-script approvals were required. Reran validation through the repo-pinned `pnpm@9.15.4` via Corepack.
