### PR TITLE
JUN-113: Fix branching from delegated session parts

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4781,13 +4781,27 @@ export function AgentWorkspace({
   // and the new session inherits the source's write-access mode so a follow-up
   // routes to the right runtime. On failure the UI stays in the source session
   // with an actionable banner.
-  async function branchFromMessage(sessionId: string, fromMessageId: string) {
+  async function branchFromMessage(
+    sessionId: string | undefined,
+    fromMessageId: string,
+    modeSessionId = sessionId,
+  ) {
     if (branchingMessageId) return;
+    if (!sessionId) {
+      setError(
+        "Cannot branch from this message because its session is unavailable.",
+        {
+          sessionId: modeSessionId ?? null,
+        },
+      );
+      return;
+    }
     setBranchingMessageId(fromMessageId);
     const sourceTitle =
-      hermesSessionItems.find((session) => session.id === sessionId)?.title ??
-      "this session";
-    const unrestricted = sessionUnrestricted(sessionId);
+      hermesSessionItems.find(
+        (session) => session.id === sessionId || session.id === modeSessionId,
+      )?.title ?? "this session";
+    const unrestricted = sessionUnrestricted(modeSessionId);
     try {
       const gateway = await ensureHermesGateway(unrestricted);
       const raw = await createHermesMethods(gateway).branchSession({
@@ -6263,8 +6277,12 @@ export function AgentWorkspace({
               sessionUnrestricted(selectedHermesSessionId),
             )
           }
-          onBranch={(messageId) =>
-            void branchFromMessage(selectedHermesSessionId, messageId)
+          onBranch={(messageId, sessionId) =>
+            void branchFromMessage(
+              sessionId ?? selectedHermesSessionId,
+              messageId,
+              selectedHermesSessionId,
+            )
           }
           branchingMessageId={branchingMessageId}
           onEditUserPrompt={editUserPrompt}
@@ -8599,7 +8617,7 @@ function AgentChatTurnRow({
   /** Fork the conversation from this turn into a new session (feature 07).
    * Optional: only Hermes-session rows pass it — task rows and the dev gallery
    * omit it, so the action is absent there. */
-  onBranch?: (messageId: string) => void;
+  onBranch?: (messageId: string, sessionId?: string) => void;
   /** The message id a branch is currently in flight for, so its action shows a
    * working/disabled state. */
   branchingMessageId?: string | null;
@@ -8699,9 +8717,11 @@ function AgentChatTurnRow({
   // Per-turn transcript actions. Branch is rendered only on Hermes-session rows
   // (which pass `onBranch`); it self-disables when the turn id is not a
   // persisted message id (see isBranchableMessageId).
+  const branchSessionId = branchSourceSessionIdForTurn(turn);
   const branchAction = onBranch ? (
     <BranchFromHereAction
       messageId={turn.id}
+      sessionId={branchSessionId}
       onBranch={onBranch}
       submitting={branchingMessageId === turn.id}
     />
@@ -9692,6 +9712,17 @@ function approvalChoiceLabel(choice?: AgentApprovalChoice, pending = false) {
   return "Resolved";
 }
 
+export function branchSourceSessionIdForTurn(
+  turn: Pick<AgentChatTurn, "parts">,
+) {
+  for (const part of turn.parts) {
+    if (!("sessionId" in part)) continue;
+    const sessionId = part.sessionId?.trim();
+    if (sessionId) return sessionId;
+  }
+  return undefined;
+}
+
 /** The per-message "Branch from here" action (feature 07). Forks the
  * conversation into a NEW session that starts from this message, leaving the
  * source session untouched. Message-level branching is honest only when the
@@ -9702,10 +9733,12 @@ function approvalChoiceLabel(choice?: AgentApprovalChoice, pending = false) {
 export function BranchFromHereAction({
   messageId,
   onBranch,
+  sessionId,
   submitting,
 }: {
   messageId: string;
-  onBranch: (messageId: string) => void;
+  onBranch: (messageId: string, sessionId?: string) => void;
+  sessionId?: string;
   submitting?: boolean;
 }) {
   const branchable = isBranchableMessageId(messageId);
@@ -9723,7 +9756,7 @@ export function BranchFromHereAction({
       }
       aria-label="Branch from here"
       disabled={disabled}
-      onClick={() => onBranch(messageId)}
+      onClick={() => onBranch(messageId, sessionId)}
     >
       <IconBranchSimple size={13} aria-hidden />
       <span>Branch from here</span>

--- a/src/test/hermes-session-branch.test.tsx
+++ b/src/test/hermes-session-branch.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { BranchFromHereAction } from "../components/agent/AgentWorkspace";
+import {
+  BranchFromHereAction,
+  branchSourceSessionIdForTurn,
+} from "../components/agent/AgentWorkspace";
 import { createHermesMethods } from "../lib/hermes-control-plane";
+import type { AgentChatPart } from "../lib/agent-chat-runtime";
 import {
   isBranchableMessageId,
   parseBranchSessionResult,
@@ -117,6 +121,70 @@ describe("isBranchableMessageId", () => {
   });
 });
 
+describe("branchSourceSessionIdForTurn", () => {
+  function turnWith(part: AgentChatPart) {
+    return { parts: [part] };
+  }
+
+  it("uses delegated action part session ids as the branch source", () => {
+    expect(
+      branchSourceSessionIdForTurn(
+        turnWith({
+          type: "approval",
+          id: "approval-1",
+          sessionId: "delegated-approval",
+          command: "pnpm test",
+          description: "Run tests",
+          allowPermanent: true,
+          status: "pending",
+        }),
+      ),
+    ).toBe("delegated-approval");
+    expect(
+      branchSourceSessionIdForTurn(
+        turnWith({
+          type: "clarify",
+          id: "clarify-1",
+          sessionId: "delegated-clarify",
+          question: "Which path?",
+          choices: [],
+          status: "pending",
+        }),
+      ),
+    ).toBe("delegated-clarify");
+    expect(
+      branchSourceSessionIdForTurn(
+        turnWith({
+          type: "sudo",
+          id: "sudo-1",
+          sessionId: "delegated-sudo",
+          command: "make install",
+          status: "pending",
+        }),
+      ),
+    ).toBe("delegated-sudo");
+    expect(
+      branchSourceSessionIdForTurn(
+        turnWith({
+          type: "secret",
+          id: "secret-1",
+          sessionId: "delegated-secret",
+          keyName: "OPENAI_API_KEY",
+          status: "pending",
+        }),
+      ),
+    ).toBe("delegated-secret");
+  });
+
+  it("leaves normal assistant turns on the selected session fallback", () => {
+    expect(
+      branchSourceSessionIdForTurn(
+        turnWith({ type: "text", text: "Done", status: "complete" }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
 describe("BranchFromHereAction", () => {
   it("sends session.branch with the session and from_message_id when clicked", async () => {
     const request = vi.fn().mockResolvedValue({
@@ -133,9 +201,39 @@ describe("BranchFromHereAction", () => {
       screen.getByRole("button", { name: /branch from here/i }),
     );
 
-    expect(onBranch).toHaveBeenCalledWith("m-3");
+    expect(onBranch).toHaveBeenCalledWith("m-3", undefined);
     expect(request).toHaveBeenCalledWith("session.branch", {
       session_id: "sess-1",
+      from_message_id: "m-3",
+    });
+  });
+
+  it("threads a delegated session id to session.branch when provided", async () => {
+    const request = vi.fn().mockResolvedValue({
+      new_session_id: "sess-fork",
+    });
+    const methods = createHermesMethods(request);
+    const onBranch = vi.fn((messageId: string, sessionId?: string) =>
+      methods.branchSession({
+        sessionId: sessionId ?? "sess-parent",
+        fromMessageId: messageId,
+      }),
+    );
+
+    render(
+      <BranchFromHereAction
+        messageId="m-3"
+        sessionId="sess-delegated"
+        onBranch={onBranch}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /branch from here/i }),
+    );
+
+    expect(onBranch).toHaveBeenCalledWith("m-3", "sess-delegated");
+    expect(request).toHaveBeenCalledWith("session.branch", {
+      session_id: "sess-delegated",
       from_message_id: "m-3",
     });
   });


### PR DESCRIPTION
Closes JUN-113

## What changed
- Threaded an optional source session id through the Branch from here action.
- Derived the branch source from session-bearing approval, clarify, sudo, and secret parts so delegated subagent turns call session.branch with the delegated session id.
- Kept the selected parent session as the fallback and mode-routing source.

## Why
Delegated prompt parts can belong to a subagent session even while the parent session is selected. Branching with the parent id can make Hermes reject the request with session not found.

## Validation
- ./node_modules/.bin/vitest run src/test/hermes-session-branch.test.tsx
- ./node_modules/.bin/tsc --noEmit
- git diff --check