### PR TITLE
Fix Hermes new-session bridge race

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3909,7 +3909,17 @@ export function AgentWorkspace({
       rememberSessionMode(storedSessionId, fullModeDraftRef.current);
     }
     const sessionDisplayTitle = sessionTitle || fallbackSessionTitle;
+    const ensureStoredHermesSession = () =>
+      withTimeout(
+        ensureHermesBridgeSession({
+          sessionId: storedSessionId,
+          title: sessionDisplayTitle,
+          ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
+        }),
+        2500,
+      ).catch(() => undefined);
     if (optimisticSession) {
+      await ensureStoredHermesSession();
       migrateOptimisticHermesSession({
         createdAt: optimisticSession.createdAt,
         displayContent,
@@ -3930,14 +3940,9 @@ export function AgentWorkspace({
       // bridge closure). Re-map the current list so the order doesn't matter.
       setHermesSessionItems((current) => applySessionTitleOverrides(current));
     }
-    await withTimeout(
-      ensureHermesBridgeSession({
-        sessionId: storedSessionId,
-        title: sessionDisplayTitle,
-        ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
-      }),
-      2500,
-    ).catch(() => undefined);
+    if (!optimisticSession) {
+      await ensureStoredHermesSession();
+    }
     let runtimeSessionId: string | undefined;
     try {
       runtimeSessionId =

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3910,16 +3910,13 @@ export function AgentWorkspace({
     }
     const sessionDisplayTitle = sessionTitle || fallbackSessionTitle;
     const ensureStoredHermesSession = () =>
-      withTimeout(
-        ensureHermesBridgeSession({
-          sessionId: storedSessionId,
-          title: sessionDisplayTitle,
-          ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
-        }),
-        2500,
-      ).catch(() => undefined);
+      ensureHermesBridgeSession({
+        sessionId: storedSessionId,
+        title: sessionDisplayTitle,
+        ...(targetSessionModelId ? { model: targetSessionModelId } : {}),
+      });
     if (optimisticSession) {
-      await ensureStoredHermesSession();
+      await ensureStoredHermesSession().catch(rollbackOptimisticBeforePrompt);
       migrateOptimisticHermesSession({
         createdAt: optimisticSession.createdAt,
         displayContent,
@@ -3941,7 +3938,9 @@ export function AgentWorkspace({
       setHermesSessionItems((current) => applySessionTitleOverrides(current));
     }
     if (!optimisticSession) {
-      await ensureStoredHermesSession();
+      await withTimeout(ensureStoredHermesSession(), 2500).catch(
+        () => undefined,
+      );
     }
     let runtimeSessionId: string | undefined;
     try {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5895,6 +5895,70 @@ describe("AgentWorkspace", () => {
     expect(screen.getAllByText("first task").length).toBeGreaterThan(0);
   });
 
+  it("waits for the bridge session before selecting a new persisted Hermes session", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+    let bridgeSessionPersisted = false;
+    let releaseEnsure: (() => void) | undefined;
+    mocks.ensureHermesBridgeSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseEnsure = () => {
+            bridgeSessionPersisted = true;
+            resolve({});
+          };
+        }),
+    );
+    mocks.listHermesSessionMessages.mockImplementation(
+      async (sessionId: string) => {
+        if (sessionId === "session-2" && !bridgeSessionPersisted) {
+          throw new Error(
+            'Hermes API returned 404 Not Found: {"detail":"Session not found"}',
+          );
+        }
+        return [];
+      },
+    );
+
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+
+    await user.type(await screen.findByRole("textbox"), "first task");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+
+    await waitFor(() =>
+      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: "session-2" }),
+      ),
+    );
+    expect(releaseEnsure).toBeDefined();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.listHermesSessionMessages).not.toHaveBeenCalledWith(
+      "session-2",
+    );
+    expect(screen.queryByText(/Hermes API returned 404/)).toBeNull();
+
+    act(() => releaseEnsure?.());
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "first task",
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-2"),
+    );
+    expect(screen.queryByText(/Hermes API returned 404/)).toBeNull();
+  });
+
   it("restores the hero when optimistic session creation fails", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5935,17 +5935,22 @@ describe("AgentWorkspace", () => {
     );
     expect(releaseEnsure).toBeDefined();
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    vi.useFakeTimers();
+    try {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+        await Promise.resolve();
+      });
 
-    expect(mocks.listHermesSessionMessages).not.toHaveBeenCalledWith(
-      "session-2",
-    );
-    expect(screen.queryByText(/Hermes API returned 404/)).toBeNull();
+      expect(mocks.listHermesSessionMessages).not.toHaveBeenCalledWith(
+        "session-2",
+      );
+      expect(screen.queryByText(/Hermes API returned 404/)).toBeNull();
 
-    act(() => releaseEnsure?.());
+      act(() => releaseEnsure?.());
+    } finally {
+      vi.useRealTimers();
+    }
 
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {


### PR DESCRIPTION
Closes JUN-116

## What changed

- Wait for `ensureHermesBridgeSession` before migrating a new optimistic Hermes session to its persisted session id.
- Preserve the existing bridge-session ensure path for sends into already persisted sessions.
- Add a regression test that holds bridge-session persistence open and verifies the message fetch does not target the persisted id early or surface the transient 404.

## Why

The selected-session messages effect starts fetching as soon as `selectedHermesSessionId` switches to the persisted id. For new-session sends, that switch happened before the bridge HTTP session had been persisted, so the fetch could briefly hit a missing session and show a 404 banner.

## Validation

- `./node_modules/.bin/vitest run src/test/agent-workspace.test.tsx` (131 passed, 2 skipped)
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Notes

- `pnpm test -- src/test/agent-workspace.test.tsx` and `pnpm run lint` were attempted, but pnpm stopped during its install preflight on the ignored-builds approval gate for `central-icons`, `esbuild`, and `unicode-animations`. The direct local binary commands above validated the focused test suite and the lint-equivalent TypeScript check without changing dependency policy.
