### PR TITLE
Fix queued steering during tool calls

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1928,10 +1928,16 @@ export function AgentWorkspace({
     event: HermesGatewayEvent,
     phase: HermesToolEventPhase,
   ) {
-    const key = toolEventActivityKey(event);
+    const eventKey = toolEventActivityKey(event);
     const current = new Map(
       activeToolCallsBySessionRef.current.get(sessionId) ?? [],
     );
+
+    if (phase === "progress" && eventKey === undefined) {
+      return current.size > 0;
+    }
+
+    const key = eventKey ?? "__anonymous_tool__";
 
     if (phase === "start") {
       current.set(key, (current.get(key) ?? 0) + 1);
@@ -11736,8 +11742,7 @@ function toolEventActivityKey(event: HermesGatewayEvent) {
     stringValue(payload?.tool_call_id) ??
     stringValue(payload?.call_id) ??
     stringValue(payload?.id) ??
-    stringValue(payload?.request_id) ??
-    "__anonymous_tool__"
+    stringValue(payload?.request_id)
   );
 }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -772,6 +772,8 @@ type QueuedSteerInstruction = {
   error?: string;
 };
 
+type HermesToolEventPhase = "start" | "progress" | "complete";
+
 type AgentWorkspaceError = {
   message: string;
   /** Null means the error belongs to the no-session workspace surface. */
@@ -1420,6 +1422,9 @@ export function AgentWorkspace({
   const queuedSteerRetryTimersRef = useRef<
     Map<string, ReturnType<typeof window.setTimeout>>
   >(new Map());
+  const activeToolCallsBySessionRef = useRef<Map<string, Map<string, number>>>(
+    new Map(),
+  );
   const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
     () => new Set(continuity?.waitingSessionIds),
   );
@@ -1805,6 +1810,45 @@ export function AgentWorkspace({
     [],
   );
 
+  function clearSessionToolCalls(sessionId: string) {
+    activeToolCallsBySessionRef.current.delete(sessionId);
+    setSessionToolCallActive(sessionId, false);
+  }
+
+  function updateSessionToolCallActivity(
+    sessionId: string,
+    event: HermesGatewayEvent,
+    phase: HermesToolEventPhase,
+  ) {
+    const key = toolEventActivityKey(event);
+    const current = new Map(
+      activeToolCallsBySessionRef.current.get(sessionId) ?? [],
+    );
+
+    if (phase === "start") {
+      current.set(key, (current.get(key) ?? 0) + 1);
+    } else if (phase === "progress") {
+      if (!current.has(key)) current.set(key, 1);
+    } else {
+      const count = current.get(key) ?? 0;
+      if (count > 1) {
+        current.set(key, count - 1);
+      } else {
+        current.delete(key);
+      }
+    }
+
+    if (current.size > 0) {
+      activeToolCallsBySessionRef.current.set(sessionId, current);
+      setSessionToolCallActive(sessionId, true);
+      return true;
+    }
+
+    activeToolCallsBySessionRef.current.delete(sessionId);
+    setSessionToolCallActive(sessionId, false);
+    return false;
+  }
+
   const setSessionWorking = useCallback(
     (sessionId: string, working: boolean) => {
       setWorkingSessionIds((current) => {
@@ -1839,7 +1883,7 @@ export function AgentWorkspace({
 
   const clearSessionActivity = useCallback(
     (sessionId: string) => {
-      setSessionToolCallActive(sessionId, false);
+      clearSessionToolCalls(sessionId);
       clearQueuedSteerInstruction(sessionId);
 
       const nextWorking = new Set(workingSessionIdsRef.current);
@@ -4162,10 +4206,15 @@ export function AgentWorkspace({
       };
       setLiveEvents(liveEventsRef.current);
       const toolEventPhase = hermesToolEventPhase(event.type);
-      if (toolEventPhase === "active") {
-        setSessionToolCallActive(storedSessionId, true);
-      } else if (toolEventPhase === "complete") {
-        setSessionToolCallActive(storedSessionId, false);
+      const hasActiveToolCalls =
+        toolEventPhase !== undefined
+          ? updateSessionToolCallActivity(
+              storedSessionId,
+              event,
+              toolEventPhase,
+            )
+          : toolCallSessionIdsRef.current.has(storedSessionId);
+      if (toolEventPhase === "complete" && !hasActiveToolCalls) {
         window.setTimeout(() => {
           void flushQueuedSteerInstruction(storedSessionId);
         }, 0);
@@ -11450,13 +11499,24 @@ function isTerminalHermesEvent(type: string) {
   );
 }
 
-function hermesToolEventPhase(type: string): "active" | "complete" | undefined {
+function hermesToolEventPhase(type: string): HermesToolEventPhase | undefined {
   const normalized = type.toLowerCase();
   if (normalized === "tool.complete") return "complete";
-  if (normalized === "tool.start" || normalized === "tool.progress") {
-    return "active";
-  }
+  if (normalized === "tool.start") return "start";
+  if (normalized === "tool.progress") return "progress";
   return undefined;
+}
+
+function toolEventActivityKey(event: HermesGatewayEvent) {
+  const payload = event.payload as Record<string, unknown> | undefined;
+  return (
+    stringValue(payload?.tool_id) ??
+    stringValue(payload?.tool_call_id) ??
+    stringValue(payload?.call_id) ??
+    stringValue(payload?.id) ??
+    stringValue(payload?.request_id) ??
+    "__anonymous_tool__"
+  );
 }
 
 function agentStatusFromHermesEvent(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5224,6 +5224,9 @@ export function AgentWorkspace({
     const instruction = normalizeSteerText(text);
     if (!instruction) return;
     const shouldRetryAfterQueue = !toolCallSessionIdsRef.current.has(sessionId);
+    const shouldReconcileRestoredTool =
+      !shouldRetryAfterQueue &&
+      restoredToolCallSessionIdsRef.current.has(sessionId);
     cancelQueuedSteerRetry(sessionId);
     setQueuedSteerBySessionId((current) => {
       const next = {
@@ -5238,6 +5241,8 @@ export function AgentWorkspace({
     });
     if (shouldRetryAfterQueue) {
       scheduleQueuedSteerRetry(sessionId);
+    } else if (shouldReconcileRestoredTool) {
+      scheduleRestoredQueuedSteerReconcile(sessionId);
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -765,6 +765,13 @@ type PendingIssueReport = {
   diagnosisStartedAt?: string;
 };
 
+type QueuedSteerInstruction = {
+  text: string;
+  queuedAt: string;
+  flushing?: boolean;
+  error?: string;
+};
+
 type AgentWorkspaceError = {
   message: string;
   /** Null means the error belongs to the no-session workspace surface. */
@@ -1402,6 +1409,14 @@ export function AgentWorkspace({
     () => new Set(continuity?.workingSessionIds),
   );
   const workingSessionIdsRef = useRef<Set<string>>(workingSessionIds);
+  const [toolCallSessionIds, setToolCallSessionIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toolCallSessionIdsRef = useRef<Set<string>>(toolCallSessionIds);
+  const [queuedSteerBySessionId, setQueuedSteerBySessionId] = useState<
+    Record<string, QueuedSteerInstruction>
+  >({});
+  const queuedSteerBySessionIdRef = useRef(queuedSteerBySessionId);
   const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
     () => new Set(continuity?.waitingSessionIds),
   );
@@ -1746,16 +1761,45 @@ export function AgentWorkspace({
   useEffect(() => {
     selectedHermesSessionIdRef.current = selectedHermesSessionId;
     workingSessionIdsRef.current = workingSessionIds;
+    toolCallSessionIdsRef.current = toolCallSessionIds;
+    queuedSteerBySessionIdRef.current = queuedSteerBySessionId;
     waitingSessionIdsRef.current = waitingSessionIds;
     pendingHermesMessagesRef.current = pendingHermesMessages;
     hermesSessionItemsRef.current = hermesSessionItems;
   }, [
     hermesSessionItems,
     pendingHermesMessages,
+    queuedSteerBySessionId,
     selectedHermesSessionId,
+    toolCallSessionIds,
     waitingSessionIds,
     workingSessionIds,
   ]);
+
+  const clearQueuedSteerInstruction = useCallback((sessionId: string) => {
+    setQueuedSteerBySessionId((current) => {
+      if (!current[sessionId]) return current;
+      const next = omitRecordKey(current, sessionId);
+      queuedSteerBySessionIdRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const setSessionToolCallActive = useCallback(
+    (sessionId: string, active: boolean) => {
+      setToolCallSessionIds((current) => {
+        const next = new Set(current);
+        if (active) {
+          next.add(sessionId);
+        } else {
+          next.delete(sessionId);
+        }
+        toolCallSessionIdsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
 
   const setSessionWorking = useCallback(
     (sessionId: string, working: boolean) => {
@@ -1789,22 +1833,27 @@ export function AgentWorkspace({
     [],
   );
 
-  const clearSessionActivity = useCallback((sessionId: string) => {
-    const nextWorking = new Set(workingSessionIdsRef.current);
-    nextWorking.delete(sessionId);
-    workingSessionIdsRef.current = nextWorking;
-    setWorkingSessionIds(nextWorking);
+  const clearSessionActivity = useCallback(
+    (sessionId: string) => {
+      setSessionToolCallActive(sessionId, false);
 
-    const nextWaiting = new Set(waitingSessionIdsRef.current);
-    nextWaiting.delete(sessionId);
-    waitingSessionIdsRef.current = nextWaiting;
-    setWaitingSessionIds(nextWaiting);
+      const nextWorking = new Set(workingSessionIdsRef.current);
+      nextWorking.delete(sessionId);
+      workingSessionIdsRef.current = nextWorking;
+      setWorkingSessionIds(nextWorking);
 
-    return {
-      activeCount: nextWorking.size + nextWaiting.size,
-      needsUserCount: nextWaiting.size,
-    };
-  }, []);
+      const nextWaiting = new Set(waitingSessionIdsRef.current);
+      nextWaiting.delete(sessionId);
+      waitingSessionIdsRef.current = nextWaiting;
+      setWaitingSessionIds(nextWaiting);
+
+      return {
+        activeCount: nextWorking.size + nextWaiting.size,
+        needsUserCount: nextWaiting.size,
+      };
+    },
+    [setSessionToolCallActive],
+  );
 
   // Shared teardown for a session that is going away: its messages, pending
   // sends, working/waiting flags, live gateway listener, and buffered live
@@ -1819,6 +1868,7 @@ export function AgentWorkspace({
         return next;
       });
       clearSessionActivity(sessionId);
+      clearQueuedSteerInstruction(sessionId);
       // Feature 11: a deleted session has no activity to show, so drop its row
       // from the activity drawer's store as well.
       hermesActivityStore.clearSession(sessionId);
@@ -1830,7 +1880,7 @@ export function AgentWorkspace({
       // A deleted session must not be the restore target on the next mount.
       forgetLastOpenSessionId(sessionId);
     },
-    [clearSessionActivity],
+    [clearQueuedSteerInstruction, clearSessionActivity],
   );
 
   const selectedTask = useMemo(
@@ -4106,6 +4156,15 @@ export function AgentWorkspace({
         [storedSessionId]: nextSessionEvents,
       };
       setLiveEvents(liveEventsRef.current);
+      const toolEventPhase = hermesToolEventPhase(event.type);
+      if (toolEventPhase === "active") {
+        setSessionToolCallActive(storedSessionId, true);
+      } else if (toolEventPhase === "complete") {
+        setSessionToolCallActive(storedSessionId, false);
+        window.setTimeout(() => {
+          void flushQueuedSteerInstruction(storedSessionId);
+        }, 0);
+      }
       const status = agentStatusFromHermesEvent(event);
       if (status === "waitingForUser") {
         setSessionWorking(storedSessionId, false);
@@ -4860,6 +4919,67 @@ export function AgentWorkspace({
         receivedAt: new Date().toISOString(),
       }),
     );
+  }
+
+  function queueSteerInstruction(sessionId: string, text: string) {
+    const instruction = normalizeSteerText(text);
+    if (!instruction) return;
+    setQueuedSteerBySessionId((current) => {
+      const next = {
+        ...current,
+        [sessionId]: {
+          text: instruction,
+          queuedAt: new Date().toISOString(),
+        },
+      };
+      queuedSteerBySessionIdRef.current = next;
+      return next;
+    });
+  }
+
+  async function flushQueuedSteerInstruction(sessionId: string) {
+    const queued = queuedSteerBySessionIdRef.current[sessionId];
+    if (!queued || queued.flushing) return;
+    if (toolCallSessionIdsRef.current.has(sessionId)) return;
+
+    setQueuedSteerBySessionId((current) => {
+      const currentQueued = current[sessionId];
+      if (!currentQueued || currentQueued.text !== queued.text) return current;
+      const next = {
+        ...current,
+        [sessionId]: {
+          ...currentQueued,
+          flushing: true,
+          error: undefined,
+        },
+      };
+      queuedSteerBySessionIdRef.current = next;
+      return next;
+    });
+
+    try {
+      await steerActiveSession(sessionId, queued.text);
+      clearQueuedSteerInstruction(sessionId);
+    } catch (err) {
+      setQueuedSteerBySessionId((current) => {
+        const currentQueued = current[sessionId];
+        if (!currentQueued || currentQueued.text !== queued.text) {
+          return current;
+        }
+        const next = {
+          ...current,
+          [sessionId]: {
+            ...currentQueued,
+            flushing: false,
+            error: isSessionBusyError(err)
+              ? "June is finishing that tool call. The instruction is still queued."
+              : steerErrorNotice(err),
+          },
+        };
+        queuedSteerBySessionIdRef.current = next;
+        return next;
+      });
+    }
   }
 
   async function startNewTask(
@@ -5840,6 +5960,13 @@ export function AgentWorkspace({
             onSteer={(text) =>
               steerActiveSession(selectedHermesSessionId, text)
             }
+            onQueue={(text) =>
+              queueSteerInstruction(selectedHermesSessionId, text)
+            }
+            queueWhileToolActive={toolCallSessionIds.has(
+              selectedHermesSessionId,
+            )}
+            queuedInstruction={queuedSteerBySessionId[selectedHermesSessionId]}
           />
         ) : null}
         <div ref={composerBoxRef} className="agent-composer-box">
@@ -9206,23 +9333,43 @@ function CreditsNoticePart({ onTopUp }: { onTopUp?: () => void }) {
  * Compact instruction input shown while a session is working (feature 06). It
  * lets the user steer the running turn through the dedicated `session.steer`
  * method (injected as `onSteer`) WITHOUT touching the Stop control that owns the
- * send slot. Submit (Enter or the send button) sends the trimmed text; a blank
- * instruction is inert. On success the field clears; on a rejection it keeps the
- * unsent text and shows a clear, recoverable message (busy / dropped connection
- * / generic) so a failed steer never crashes the composer.
+ * send slot. Submit (Enter or the send button) sends or queues the trimmed
+ * text; a blank instruction is inert. On success the field clears; on a
+ * rejection it keeps the unsent text and shows a clear, recoverable message
+ * (busy / dropped connection / generic) so a failed steer never crashes the
+ * composer.
  */
 export function ComposerSteerInput({
   onSteer,
+  onQueue,
+  queueWhileToolActive = false,
+  queuedInstruction,
 }: {
   onSteer: (text: string) => Promise<unknown>;
+  onQueue?: (text: string) => void;
+  queueWhileToolActive?: boolean;
+  queuedInstruction?: QueuedSteerInstruction;
 }) {
   const [text, setText] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const trimmed = normalizeSteerText(text);
+  const queuedText = queuedInstruction?.text;
+  const disabled = sending || Boolean(queuedInstruction?.flushing);
+  const submitLabel = queueWhileToolActive
+    ? queuedText
+      ? "Replace queued instruction"
+      : "Queue instruction"
+    : "Send instruction";
 
   async function send() {
-    if (!trimmed || sending) return;
+    if (!trimmed || disabled) return;
+    if (queueWhileToolActive && onQueue) {
+      onQueue(trimmed);
+      setText("");
+      setError(null);
+      return;
+    }
     setSending(true);
     setError(null);
     try {
@@ -9239,13 +9386,7 @@ export function ComposerSteerInput({
 
   return (
     <div className="agent-composer-steer">
-      <form
-        className="agent-composer-steer-row"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void send();
-        }}
-      >
+      <div className="agent-composer-steer-row">
         <span className="agent-composer-steer-icon" aria-hidden>
           <IconArrowCornerDownRight size={14} />
         </span>
@@ -9253,27 +9394,61 @@ export function ComposerSteerInput({
           type="text"
           className="agent-composer-steer-input"
           aria-label="Add instruction"
-          placeholder="Add an instruction while June works"
+          placeholder={
+            queuedText
+              ? "Replace queued instruction"
+              : queueWhileToolActive
+                ? "Queue after this tool call"
+                : "Add an instruction while June works"
+          }
           value={text}
-          disabled={sending}
+          disabled={disabled}
           onChange={(event) => {
             setText(event.target.value);
             if (error) setError(null);
           }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            void send();
+          }}
         />
         <button
-          type="submit"
+          type="button"
           className="agent-composer-steer-send"
-          aria-label="Send instruction"
-          title="Send instruction"
-          disabled={!trimmed || sending}
+          aria-label={submitLabel}
+          title={submitLabel}
+          disabled={!trimmed || disabled}
+          onClick={() => {
+            void send();
+          }}
         >
-          {sending ? <Spinner /> : <IconArrowUp size={14} />}
+          {sending || queuedInstruction?.flushing ? (
+            <Spinner />
+          ) : (
+            <IconArrowUp size={14} />
+          )}
         </button>
-      </form>
+      </div>
+      {queuedInstruction ? (
+        <p className="agent-composer-steer-queued" role="status">
+          {queuedInstruction.flushing ? (
+            "Sending queued instruction..."
+          ) : (
+            <>
+              Queued to run after this tool call:{" "}
+              <span>{queuedInstruction.text}</span>
+            </>
+          )}
+        </p>
+      ) : null}
       {error ? (
         <p className="agent-composer-steer-error" role="alert">
           {error}
+        </p>
+      ) : queuedInstruction?.error ? (
+        <p className="agent-composer-steer-error" role="alert">
+          {queuedInstruction.error}
         </p>
       ) : null}
     </div>
@@ -11246,6 +11421,15 @@ function isTerminalHermesEvent(type: string) {
     normalized === "background.complete" ||
     normalized === "background.completed"
   );
+}
+
+function hermesToolEventPhase(type: string): "active" | "complete" | undefined {
+  const normalized = type.toLowerCase();
+  if (normalized === "tool.complete") return "complete";
+  if (normalized === "tool.start" || normalized === "tool.progress") {
+    return "active";
+  }
+  return undefined;
 }
 
 function agentStatusFromHermesEvent(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1820,8 +1820,44 @@ export function AgentWorkspace({
   }, [runtimeSessionIds]);
 
   useEffect(() => {
+    const restoredSessionIds = continuity?.workingSessionIds ?? [];
+    if (!restoredSessionIds.length) return;
+    let cancelled = false;
+
+    void (async () => {
+      for (const sessionId of restoredSessionIds) {
+        const runtimeSessionId = runtimeSessionIdsRef.current[sessionId];
+        if (!runtimeSessionId) continue;
+        try {
+          const gateway = await ensureHermesGateway(
+            sessionUnrestricted(sessionId),
+          );
+          if (cancelled || !workingSessionIdsRef.current.has(sessionId)) {
+            continue;
+          }
+          attachHermesSessionEventListener({
+            gateway,
+            runtimeSessionId,
+            sessionDisplayTitle:
+              hermesSessionItemsRef.current.find(
+                (session) => session.id === sessionId,
+              )?.title ?? "Agent session",
+            storedSessionId: sessionId,
+          });
+        } catch {
+          // The working-session poll still reconciles if reconnecting fails.
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     for (const sessionId of Object.keys(queuedSteerBySessionIdRef.current)) {
-      scheduleQueuedSteerRetry(sessionId, { ignoreActiveToolGuard: true });
+      scheduleQueuedSteerRetry(sessionId);
     }
   }, []);
 
@@ -3957,6 +3993,153 @@ export function AgentWorkspace({
     }
   }
 
+  function attachHermesSessionEventListener({
+    gateway,
+    runtimeSessionId,
+    sessionDisplayTitle,
+    storedSessionId,
+  }: {
+    gateway: HermesGatewayClient;
+    runtimeSessionId: string;
+    sessionDisplayTitle: string;
+    storedSessionId: string;
+  }) {
+    sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
+    let unlisten = () => {};
+    const removeListener = gateway.onEvent((event) => {
+      if (
+        event.session_id !== runtimeSessionId &&
+        event.session_id !== storedSessionId
+      )
+        return;
+      const liveEvent = { ...event, receivedAt: new Date().toISOString() };
+      // Run every live frame through the typed control plane alongside the
+      // existing string-based handling below. This is the first consumer of
+      // the classifier: it doesn't drive rendering yet (later features migrate
+      // families onto it incrementally), but it proves the live path is typed
+      // and surfaces any raw type June can't yet model. Unknown frames classify
+      // as `unsupported` rather than being dropped, so a Hermes upgrade that
+      // adds an event shows up in dev instead of silently doing nothing.
+      const classified = classifyHermesEvent(liveEvent);
+      // Feature 15: record every inbound frame (raw type + the kind it
+      // classified to) into the bounded, sanitized trace buffer so the dev/debug
+      // trace panel can reconstruct the session. recordInbound re-classifies and
+      // sanitizes internally; nothing raw is retained.
+      hermesTraceBuffer.recordInbound(liveEvent);
+      if (classified.kind === "unsupported") {
+        // Feed the bounded per-session store so the user gets a recoverable
+        // notice (when this is the active session) and developers get a
+        // sanitized, issue-report-safe export. The payload is already sanitized
+        // by the classifier; nothing raw is retained or logged.
+        unsupportedEventStore.record(classified);
+        if (import.meta.env.DEV) {
+          console.debug(
+            "[hermes] unsupported event",
+            classified.rawType,
+            classified.sanitizedPayload,
+          );
+        }
+      } else if (classified.kind === "pending_action") {
+        // Feature 04: aggregate this blocker into the global "Needs you" tray,
+        // keyed by mode + session + request. The session's mode comes from its
+        // recorded opt-in (sudo carries its own; the rest derive it here). A
+        // fresh event for a known request also re-confirms a row that went
+        // stale across a reconnect (see the store's reconcile logic).
+        pendingActionStore.record(classified, hermesModeFor(storedSessionId));
+      }
+      // Feature 11: roll EVERY classified event into the global activity store
+      // that backs the Agent activity drawer. The store is total and ignores
+      // unattributable events, so one unconditional call covers all kinds; it
+      // derives the session's phase (running/waiting/background/error/complete),
+      // current tool, and subagent count from the normalized event — never from
+      // the raw frame (raw JSON belongs to feature 15's trace panel).
+      hermesActivityStore.record(classified, hermesModeFor(storedSessionId));
+      // Feature 14: extract any file/artifact reference this event carries into
+      // the per-session artifact timeline behind the drawer's "Artifacts"
+      // section. The store is total and only acts on `tool` completions that
+      // name a known file/url field (conservative — never parses prose), so one
+      // unconditional call is safe for every kind. Mode rides along so each
+      // artifact can show its blast radius (sandboxed copy vs unrestricted path).
+      hermesArtifactStore.record(classified, hermesModeFor(storedSessionId));
+      const nextSessionEvents = [
+        ...(liveEventsRef.current[storedSessionId] ?? []),
+        liveEvent,
+      ].slice(-200);
+      liveEventsRef.current = {
+        ...liveEventsRef.current,
+        [storedSessionId]: nextSessionEvents,
+      };
+      setLiveEvents(liveEventsRef.current);
+      const toolEventPhase = hermesToolEventPhase(event.type);
+      const hasActiveToolCalls =
+        toolEventPhase !== undefined
+          ? updateSessionToolCallActivity(
+              storedSessionId,
+              event,
+              toolEventPhase,
+            )
+          : toolCallSessionIdsRef.current.has(storedSessionId);
+      if (toolEventPhase === "complete" && !hasActiveToolCalls) {
+        window.setTimeout(() => {
+          void flushQueuedSteerInstruction(storedSessionId);
+        }, 0);
+      }
+      const status = agentStatusFromHermesEvent(event);
+      if (status === "waitingForUser") {
+        setSessionWorking(storedSessionId, false);
+        setSessionWaiting(storedSessionId, true);
+      } else if (status === "running") {
+        setSessionWaiting(storedSessionId, false);
+        setSessionWorking(storedSessionId, true);
+      }
+      const activityCounts =
+        status === "completed" || status === "failed" || status === "cancelled"
+          ? clearSessionActivity(storedSessionId)
+          : undefined;
+      if (activityCounts) {
+        // Feature 04: the session reached a terminal state (completed, a
+        // terminal error, or an interrupt) — the agent is no longer blocked, so
+        // any of its outstanding "Needs you" rows are moot. Clear them so the
+        // tray never shows a dead blocker for a finished session.
+        pendingActionStore.resolveSession(storedSessionId);
+      }
+      if (status) {
+        dispatchAgentSessionStatus({
+          sessionId: storedSessionId,
+          title: sessionDisplayTitle,
+          status,
+          summary: agentStatusSummaryFromHermesEvent(event, status),
+          ...activityCounts,
+        });
+      }
+      if (isTerminalHermesEvent(event.type)) {
+        unlisten();
+        if (!activityCounts) {
+          clearSessionActivity(storedSessionId);
+        }
+        // The diagnostic turn is over (even on error): let the user append
+        // anything June's summary surfaced before sending the bundled report.
+        const promotedIssueReport = promotePendingIssueReportToReview(
+          storedSessionId,
+          { queueDiagnosisRefresh: true },
+        );
+        if (!promotedIssueReport) {
+          window.setTimeout(() => {
+            void refreshHermesSession(storedSessionId);
+          }, 300);
+        }
+      }
+    });
+    unlisten = () => {
+      removeListener();
+      if (sessionGatewayUnlistenRef.current.get(storedSessionId) === unlisten) {
+        sessionGatewayUnlistenRef.current.delete(storedSessionId);
+      }
+    };
+    sessionGatewayUnlistenRef.current.set(storedSessionId, unlisten);
+    return unlisten;
+  }
+
   async function submitHermesSession(
     content: string,
     explicitSession?: HermesSessionInfo,
@@ -4207,138 +4390,12 @@ export function AgentWorkspace({
       status: "running",
       summary: "June is working.",
     });
-    sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
-    const removeListener = gateway.onEvent((event) => {
-      if (
-        event.session_id !== runtimeSessionId &&
-        event.session_id !== storedSessionId
-      )
-        return;
-      const liveEvent = { ...event, receivedAt: new Date().toISOString() };
-      // Run every live frame through the typed control plane alongside the
-      // existing string-based handling below. This is the first consumer of
-      // the classifier: it doesn't drive rendering yet (later features migrate
-      // families onto it incrementally), but it proves the live path is typed
-      // and surfaces any raw type June can't yet model. Unknown frames classify
-      // as `unsupported` rather than being dropped, so a Hermes upgrade that
-      // adds an event shows up in dev instead of silently doing nothing.
-      const classified = classifyHermesEvent(liveEvent);
-      // Feature 15: record every inbound frame (raw type + the kind it
-      // classified to) into the bounded, sanitized trace buffer so the dev/debug
-      // trace panel can reconstruct the session. recordInbound re-classifies and
-      // sanitizes internally; nothing raw is retained.
-      hermesTraceBuffer.recordInbound(liveEvent);
-      if (classified.kind === "unsupported") {
-        // Feed the bounded per-session store so the user gets a recoverable
-        // notice (when this is the active session) and developers get a
-        // sanitized, issue-report-safe export. The payload is already sanitized
-        // by the classifier; nothing raw is retained or logged.
-        unsupportedEventStore.record(classified);
-        if (import.meta.env.DEV) {
-          console.debug(
-            "[hermes] unsupported event",
-            classified.rawType,
-            classified.sanitizedPayload,
-          );
-        }
-      } else if (classified.kind === "pending_action") {
-        // Feature 04: aggregate this blocker into the global "Needs you" tray,
-        // keyed by mode + session + request. The session's mode comes from its
-        // recorded opt-in (sudo carries its own; the rest derive it here). A
-        // fresh event for a known request also re-confirms a row that went
-        // stale across a reconnect (see the store's reconcile logic).
-        pendingActionStore.record(classified, hermesModeFor(storedSessionId));
-      }
-      // Feature 11: roll EVERY classified event into the global activity store
-      // that backs the Agent activity drawer. The store is total and ignores
-      // unattributable events, so one unconditional call covers all kinds; it
-      // derives the session's phase (running/waiting/background/error/complete),
-      // current tool, and subagent count from the normalized event — never from
-      // the raw frame (raw JSON belongs to feature 15's trace panel).
-      hermesActivityStore.record(classified, hermesModeFor(storedSessionId));
-      // Feature 14: extract any file/artifact reference this event carries into
-      // the per-session artifact timeline behind the drawer's "Artifacts"
-      // section. The store is total and only acts on `tool` completions that
-      // name a known file/url field (conservative — never parses prose), so one
-      // unconditional call is safe for every kind. Mode rides along so each
-      // artifact can show its blast radius (sandboxed copy vs unrestricted path).
-      hermesArtifactStore.record(classified, hermesModeFor(storedSessionId));
-      const nextSessionEvents = [
-        ...(liveEventsRef.current[storedSessionId] ?? []),
-        liveEvent,
-      ].slice(-200);
-      liveEventsRef.current = {
-        ...liveEventsRef.current,
-        [storedSessionId]: nextSessionEvents,
-      };
-      setLiveEvents(liveEventsRef.current);
-      const toolEventPhase = hermesToolEventPhase(event.type);
-      const hasActiveToolCalls =
-        toolEventPhase !== undefined
-          ? updateSessionToolCallActivity(
-              storedSessionId,
-              event,
-              toolEventPhase,
-            )
-          : toolCallSessionIdsRef.current.has(storedSessionId);
-      if (toolEventPhase === "complete" && !hasActiveToolCalls) {
-        window.setTimeout(() => {
-          void flushQueuedSteerInstruction(storedSessionId);
-        }, 0);
-      }
-      const status = agentStatusFromHermesEvent(event);
-      if (status === "waitingForUser") {
-        setSessionWorking(storedSessionId, false);
-        setSessionWaiting(storedSessionId, true);
-      } else if (status === "running") {
-        setSessionWaiting(storedSessionId, false);
-        setSessionWorking(storedSessionId, true);
-      }
-      const activityCounts =
-        status === "completed" || status === "failed" || status === "cancelled"
-          ? clearSessionActivity(storedSessionId)
-          : undefined;
-      if (activityCounts) {
-        // Feature 04: the session reached a terminal state (completed, a
-        // terminal error, or an interrupt) — the agent is no longer blocked, so
-        // any of its outstanding "Needs you" rows are moot. Clear them so the
-        // tray never shows a dead blocker for a finished session.
-        pendingActionStore.resolveSession(storedSessionId);
-      }
-      if (status) {
-        dispatchAgentSessionStatus({
-          sessionId: storedSessionId,
-          title: sessionDisplayTitle,
-          status,
-          summary: agentStatusSummaryFromHermesEvent(event, status),
-          ...activityCounts,
-        });
-      }
-      if (isTerminalHermesEvent(event.type)) {
-        unlisten();
-        if (!activityCounts) {
-          clearSessionActivity(storedSessionId);
-        }
-        // The diagnostic turn is over (even on error): let the user append
-        // anything June's summary surfaced before sending the bundled report.
-        const promotedIssueReport = promotePendingIssueReportToReview(
-          storedSessionId,
-          { queueDiagnosisRefresh: true },
-        );
-        if (!promotedIssueReport) {
-          window.setTimeout(() => {
-            void refreshHermesSession(storedSessionId);
-          }, 300);
-        }
-      }
+    attachHermesSessionEventListener({
+      gateway,
+      runtimeSessionId,
+      sessionDisplayTitle,
+      storedSessionId,
     });
-    const unlisten = () => {
-      removeListener();
-      if (sessionGatewayUnlistenRef.current.get(storedSessionId) === unlisten) {
-        sessionGatewayUnlistenRef.current.delete(storedSessionId);
-      }
-    };
-    sessionGatewayUnlistenRef.current.set(storedSessionId, unlisten);
     try {
       // Feature 15: record the outbound prompt.submit in the trace buffer. Its
       // params are sanitized before storage (the text is the user's own prompt,
@@ -4387,7 +4444,7 @@ export function AgentWorkspace({
         // working state. Callers translate this into the composer notice.
         throw err;
       }
-      unlisten();
+      sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
       setSessionWorking(storedSessionId, false);
       setSessionWaiting(storedSessionId, false);
       dispatchAgentSessionStatus({

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5111,27 +5111,29 @@ export function AgentWorkspace({
       clearQueuedSteerInstruction(sessionId);
     } catch (err) {
       const busy = isSessionBusyError(err);
-      setQueuedSteerBySessionId((current) => {
-        const currentQueued = current[sessionId];
-        if (!currentQueued || currentQueued.text !== queued.text) {
-          return current;
-        }
-        const next = {
-          ...current,
-          [sessionId]: {
-            ...currentQueued,
-            flushing: false,
-            error: busy
-              ? "June is finishing that tool call. The instruction is still queued."
-              : steerErrorNotice(err),
-          },
-        };
-        queuedSteerBySessionIdRef.current = next;
-        return next;
-      });
       if (busy) {
+        setQueuedSteerBySessionId((current) => {
+          const currentQueued = current[sessionId];
+          if (!currentQueued || currentQueued.text !== queued.text) {
+            return current;
+          }
+          const next = {
+            ...current,
+            [sessionId]: {
+              ...currentQueued,
+              flushing: false,
+              error:
+                "June is finishing that tool call. The instruction is still queued.",
+            },
+          };
+          queuedSteerBySessionIdRef.current = next;
+          return next;
+        });
         scheduleQueuedSteerRetry(sessionId, { ignoreActiveToolGuard: true });
+        return;
       }
+      setError(steerErrorNotice(err), { sessionId });
+      clearQueuedSteerInstruction(sessionId);
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -305,6 +305,7 @@ const AGENT_WORKSPACE_MAX_SESSION_RETRY_DELAY_MS =
   ] ?? 2000;
 const QUEUED_STEER_RETRY_DELAY_MS = 300;
 const RESTORED_QUEUED_STEER_RECONCILE_DELAY_MS = 1000;
+const RESTORED_QUEUED_STEER_BUSY_RECONCILE_DELAY_MS = 3000;
 
 // What the user reads instead of the gateway's "session busy" rejection. No
 // action in the pill — the composer's send slot already shows stop while
@@ -5148,7 +5149,10 @@ export function AgentWorkspace({
 
   function scheduleQueuedSteerRetry(
     sessionId: string,
-    options: { ignoreActiveToolGuard?: boolean } = {},
+    options: {
+      ignoreActiveToolGuard?: boolean;
+      restoredToolProbe?: boolean;
+    } = {},
   ) {
     cancelQueuedSteerRetry(sessionId);
     const timer = window.setTimeout(() => {
@@ -5171,13 +5175,16 @@ export function AgentWorkspace({
     restoredToolCallSessionIdsRef.current.delete(sessionId);
   }
 
-  function scheduleRestoredQueuedSteerReconcile(sessionId: string) {
+  function scheduleRestoredQueuedSteerReconcile(
+    sessionId: string,
+    delayMs = RESTORED_QUEUED_STEER_RECONCILE_DELAY_MS,
+  ) {
     cancelRestoredQueuedSteerReconcile(sessionId);
     if (!restoredToolCallSessionIdsRef.current.has(sessionId)) return;
     const timer = window.setTimeout(() => {
       restoredQueuedSteerReconcileTimersRef.current.delete(sessionId);
       void reconcileRestoredQueuedSteer(sessionId);
-    }, RESTORED_QUEUED_STEER_RECONCILE_DELAY_MS);
+    }, delayMs);
     restoredQueuedSteerReconcileTimersRef.current.set(sessionId, timer);
   }
 
@@ -5200,11 +5207,17 @@ export function AgentWorkspace({
       return;
     }
 
+    if (runtimeSnapshotHasSession(snapshot, sessionId)) {
+      scheduleQueuedSteerRetry(sessionId, {
+        ignoreActiveToolGuard: true,
+        restoredToolProbe: true,
+      });
+      return;
+    }
+
     clearRestoredQueuedSteerReconcile(sessionId);
     clearSessionToolCalls(sessionId);
-    scheduleQueuedSteerRetry(sessionId, {
-      ignoreActiveToolGuard: runtimeSnapshotHasSession(snapshot, sessionId),
-    });
+    scheduleQueuedSteerRetry(sessionId);
   }
 
   function queueSteerInstruction(sessionId: string, text: string) {
@@ -5230,7 +5243,10 @@ export function AgentWorkspace({
 
   async function flushQueuedSteerInstruction(
     sessionId: string,
-    options: { ignoreActiveToolGuard?: boolean } = {},
+    options: {
+      ignoreActiveToolGuard?: boolean;
+      restoredToolProbe?: boolean;
+    } = {},
   ) {
     const queued = queuedSteerBySessionIdRef.current[sessionId];
     if (!queued || queued.flushing) return;
@@ -5257,6 +5273,9 @@ export function AgentWorkspace({
 
     try {
       await steerActiveSession(sessionId, queued.text);
+      if (options.restoredToolProbe) {
+        clearSessionToolCalls(sessionId);
+      }
       clearQueuedSteerInstruction(sessionId);
     } catch (err) {
       const busy = isSessionBusyError(err);
@@ -5278,7 +5297,14 @@ export function AgentWorkspace({
           queuedSteerBySessionIdRef.current = next;
           return next;
         });
-        scheduleQueuedSteerRetry(sessionId, { ignoreActiveToolGuard: true });
+        if (options.restoredToolProbe) {
+          scheduleRestoredQueuedSteerReconcile(
+            sessionId,
+            RESTORED_QUEUED_STEER_BUSY_RECONCILE_DELAY_MS,
+          );
+        } else {
+          scheduleQueuedSteerRetry(sessionId, { ignoreActiveToolGuard: true });
+        }
         return;
       }
       setError(steerErrorNotice(err), { sessionId });

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9568,15 +9568,15 @@ export function ComposerSteerInput({
   const trimmed = normalizeSteerText(text);
   const queuedText = queuedInstruction?.text;
   const disabled = sending || Boolean(queuedInstruction?.flushing);
-  const submitLabel = queueWhileToolActive
-    ? queuedText
-      ? "Replace queued instruction"
-      : "Queue instruction"
-    : "Send instruction";
+  const submitLabel = queuedText
+    ? "Replace queued instruction"
+    : queueWhileToolActive
+      ? "Queue instruction"
+      : "Send instruction";
 
   async function send() {
     if (!trimmed || disabled) return;
-    if (queueWhileToolActive && onQueue) {
+    if ((queueWhileToolActive || queuedInstruction) && onQueue) {
       onQueue(trimmed);
       setText("");
       setError(null);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -891,6 +891,8 @@ type AgentSessionContinuity = {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  queuedSteerBySessionId: Record<string, QueuedSteerInstruction>;
+  activeToolCallsBySession: Record<string, Record<string, number>>;
   pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
   diagnosisRefreshIssueReportSessionIds: string[];
@@ -951,6 +953,32 @@ function forgetComposerDraft(key: string | null) {
   if (key) agentComposerDrafts.delete(key);
 }
 
+function activeToolCallsRecord(
+  activeToolCallsBySession: Map<string, Map<string, number>>,
+): Record<string, Record<string, number>> {
+  return Object.fromEntries(
+    Array.from(activeToolCallsBySession.entries())
+      .filter(([, tools]) => tools.size > 0)
+      .map(([sessionId, tools]) => [sessionId, Object.fromEntries(tools)]),
+  );
+}
+
+function activeToolCallsMap(
+  activeToolCallsBySession: Record<string, Record<string, number>> | undefined,
+) {
+  return new Map(
+    Object.entries(activeToolCallsBySession ?? {}).map(([sessionId, tools]) => [
+      sessionId,
+      new Map(
+        Object.entries(tools).filter(
+          (entry): entry is [string, number] =>
+            Number.isFinite(entry[1]) && entry[1] > 0,
+        ),
+      ),
+    ]),
+  );
+}
+
 function captureSessionContinuity(state: {
   sessionItems: HermesSessionInfo[];
   pendingMessages: Record<string, HermesSessionMessage[]>;
@@ -959,6 +987,8 @@ function captureSessionContinuity(state: {
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, LiveHermesEvent[]>;
   titleOverrides: Record<string, string>;
+  queuedSteerBySessionId: Record<string, QueuedSteerInstruction>;
+  activeToolCallsBySession: Record<string, Record<string, number>>;
   pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
   diagnosisRefreshIssueReportSessionIds: Set<string>;
@@ -983,11 +1013,28 @@ function captureSessionContinuity(state: {
   for (const sessionId of state.submittingIssueReportSessionIds) {
     activeIds.add(sessionId);
   }
+  for (const sessionId of Object.keys(state.queuedSteerBySessionId)) {
+    activeIds.add(sessionId);
+  }
+  for (const sessionId of Object.keys(state.activeToolCallsBySession)) {
+    activeIds.add(sessionId);
+  }
   if (activeIds.size === 0) return null;
   const pick = <T,>(record: Record<string, T>) =>
     Object.fromEntries(
       Object.entries(record).filter(([sessionId]) => activeIds.has(sessionId)),
     );
+  const queuedSteerBySessionId = Object.fromEntries(
+    Object.entries(pick(state.queuedSteerBySessionId)).map(
+      ([sessionId, queued]) => [
+        sessionId,
+        {
+          ...queued,
+          flushing: false,
+        },
+      ],
+    ),
+  );
   return {
     sessionItems: state.sessionItems.filter((session) =>
       activeIds.has(session.id),
@@ -998,6 +1045,8 @@ function captureSessionContinuity(state: {
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
+    queuedSteerBySessionId,
+    activeToolCallsBySession: pick(state.activeToolCallsBySession),
     pendingIssueReports: pick(state.pendingIssueReports),
     reviewableIssueReports: pick(state.reviewableIssueReports),
     diagnosisRefreshIssueReportSessionIds: [
@@ -1115,6 +1164,8 @@ function updateContinuityAfterIssueReportDelivery(
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
+    queuedSteerBySessionId: sessionContinuity.queuedSteerBySessionId,
+    activeToolCallsBySession: sessionContinuity.activeToolCallsBySession,
     pendingIssueReports,
     reviewableIssueReports,
     diagnosisRefreshIssueReportSessionIds,
@@ -1149,6 +1200,8 @@ function updateContinuityAfterIssueReportFollowUpSubmitFailed(
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
+    queuedSteerBySessionId: sessionContinuity.queuedSteerBySessionId,
+    activeToolCallsBySession: sessionContinuity.activeToolCallsBySession,
     pendingIssueReports,
     reviewableIssueReports,
     diagnosisRefreshIssueReportSessionIds: new Set(
@@ -1412,18 +1465,18 @@ export function AgentWorkspace({
   );
   const workingSessionIdsRef = useRef<Set<string>>(workingSessionIds);
   const [toolCallSessionIds, setToolCallSessionIds] = useState<Set<string>>(
-    () => new Set(),
+    () => new Set(Object.keys(continuity?.activeToolCallsBySession ?? {})),
   );
   const toolCallSessionIdsRef = useRef<Set<string>>(toolCallSessionIds);
   const [queuedSteerBySessionId, setQueuedSteerBySessionId] = useState<
     Record<string, QueuedSteerInstruction>
-  >({});
+  >(() => continuity?.queuedSteerBySessionId ?? {});
   const queuedSteerBySessionIdRef = useRef(queuedSteerBySessionId);
   const queuedSteerRetryTimersRef = useRef<
     Map<string, ReturnType<typeof window.setTimeout>>
   >(new Map());
   const activeToolCallsBySessionRef = useRef<Map<string, Map<string, number>>>(
-    new Map(),
+    activeToolCallsMap(continuity?.activeToolCallsBySession),
   );
   const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
     () => new Set(continuity?.waitingSessionIds),
@@ -1765,6 +1818,12 @@ export function AgentWorkspace({
   useEffect(() => {
     runtimeSessionIdsRef.current = runtimeSessionIds;
   }, [runtimeSessionIds]);
+
+  useEffect(() => {
+    for (const sessionId of Object.keys(queuedSteerBySessionIdRef.current)) {
+      scheduleQueuedSteerRetry(sessionId, { ignoreActiveToolGuard: true });
+    }
+  }, []);
 
   useEffect(() => {
     selectedHermesSessionIdRef.current = selectedHermesSessionId;
@@ -2963,6 +3022,10 @@ export function AgentWorkspace({
         runtimeSessionIds: runtimeSessionIdsRef.current,
         liveEvents: liveEventsRef.current,
         titleOverrides: sessionTitleOverridesRef.current,
+        queuedSteerBySessionId: queuedSteerBySessionIdRef.current,
+        activeToolCallsBySession: activeToolCallsRecord(
+          activeToolCallsBySessionRef.current,
+        ),
         pendingIssueReports: Object.fromEntries(pendingIssueReportsRef.current),
         reviewableIssueReports: reviewableIssueReportsRef.current,
         diagnosisRefreshIssueReportSessionIds:
@@ -2970,6 +3033,10 @@ export function AgentWorkspace({
         submittingIssueReportSessionIds:
           submittingIssueReportSessionIdsRef.current,
       });
+      for (const timer of queuedSteerRetryTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      queuedSteerRetryTimersRef.current.clear();
       for (const gateway of gatewaysRef.current.values()) {
         gateway.close();
       }
@@ -4983,11 +5050,14 @@ export function AgentWorkspace({
     }
   }
 
-  function scheduleQueuedSteerRetry(sessionId: string) {
+  function scheduleQueuedSteerRetry(
+    sessionId: string,
+    options: { ignoreActiveToolGuard?: boolean } = {},
+  ) {
     cancelQueuedSteerRetry(sessionId);
     const timer = window.setTimeout(() => {
       queuedSteerRetryTimersRef.current.delete(sessionId);
-      void flushQueuedSteerInstruction(sessionId);
+      void flushQueuedSteerInstruction(sessionId, options);
     }, 300);
     queuedSteerRetryTimersRef.current.set(sessionId, timer);
   }
@@ -5009,10 +5079,17 @@ export function AgentWorkspace({
     });
   }
 
-  async function flushQueuedSteerInstruction(sessionId: string) {
+  async function flushQueuedSteerInstruction(
+    sessionId: string,
+    options: { ignoreActiveToolGuard?: boolean } = {},
+  ) {
     const queued = queuedSteerBySessionIdRef.current[sessionId];
     if (!queued || queued.flushing) return;
-    if (toolCallSessionIdsRef.current.has(sessionId)) return;
+    if (
+      !options.ignoreActiveToolGuard &&
+      toolCallSessionIdsRef.current.has(sessionId)
+    )
+      return;
 
     setQueuedSteerBySessionId((current) => {
       const currentQueued = current[sessionId];
@@ -5053,7 +5130,7 @@ export function AgentWorkspace({
         return next;
       });
       if (busy) {
-        scheduleQueuedSteerRetry(sessionId);
+        scheduleQueuedSteerRetry(sessionId, { ignoreActiveToolGuard: true });
       }
     }
   }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -303,6 +303,8 @@ const AGENT_WORKSPACE_MAX_SESSION_RETRY_DELAY_MS =
   AGENT_WORKSPACE_SESSION_RETRY_DELAYS_MS[
     AGENT_WORKSPACE_SESSION_RETRY_DELAYS_MS.length - 1
   ] ?? 2000;
+const QUEUED_STEER_RETRY_DELAY_MS = 300;
+const RESTORED_QUEUED_STEER_RECONCILE_DELAY_MS = 1000;
 
 // What the user reads instead of the gateway's "session busy" rejection. No
 // action in the pill — the composer's send slot already shows stop while
@@ -1468,11 +1470,17 @@ export function AgentWorkspace({
     () => new Set(Object.keys(continuity?.activeToolCallsBySession ?? {})),
   );
   const toolCallSessionIdsRef = useRef<Set<string>>(toolCallSessionIds);
+  const restoredToolCallSessionIdsRef = useRef(
+    new Set(Object.keys(continuity?.activeToolCallsBySession ?? {})),
+  );
   const [queuedSteerBySessionId, setQueuedSteerBySessionId] = useState<
     Record<string, QueuedSteerInstruction>
   >(() => continuity?.queuedSteerBySessionId ?? {});
   const queuedSteerBySessionIdRef = useRef(queuedSteerBySessionId);
   const queuedSteerRetryTimersRef = useRef<
+    Map<string, ReturnType<typeof window.setTimeout>>
+  >(new Map());
+  const restoredQueuedSteerReconcileTimersRef = useRef<
     Map<string, ReturnType<typeof window.setTimeout>>
   >(new Map());
   const activeToolCallsBySessionRef = useRef<Map<string, Map<string, number>>>(
@@ -1857,7 +1865,11 @@ export function AgentWorkspace({
 
   useEffect(() => {
     for (const sessionId of Object.keys(queuedSteerBySessionIdRef.current)) {
-      scheduleQueuedSteerRetry(sessionId);
+      if (restoredToolCallSessionIdsRef.current.has(sessionId)) {
+        scheduleRestoredQueuedSteerReconcile(sessionId);
+      } else {
+        scheduleQueuedSteerRetry(sessionId);
+      }
     }
   }, []);
 
@@ -1881,6 +1893,7 @@ export function AgentWorkspace({
 
   const clearQueuedSteerInstruction = useCallback((sessionId: string) => {
     cancelQueuedSteerRetry(sessionId);
+    clearRestoredQueuedSteerReconcile(sessionId);
     setQueuedSteerBySessionId((current) => {
       if (!current[sessionId]) return current;
       const next = omitRecordKey(current, sessionId);
@@ -3073,6 +3086,10 @@ export function AgentWorkspace({
         window.clearTimeout(timer);
       }
       queuedSteerRetryTimersRef.current.clear();
+      for (const timer of restoredQueuedSteerReconcileTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      restoredQueuedSteerReconcileTimersRef.current.clear();
       for (const gateway of gatewaysRef.current.values()) {
         gateway.close();
       }
@@ -4071,6 +4088,9 @@ export function AgentWorkspace({
       };
       setLiveEvents(liveEventsRef.current);
       const toolEventPhase = hermesToolEventPhase(event.type);
+      if (toolEventPhase !== undefined) {
+        clearRestoredQueuedSteerReconcile(storedSessionId);
+      }
       const hasActiveToolCalls =
         toolEventPhase !== undefined
           ? updateSessionToolCallActivity(
@@ -4640,20 +4660,7 @@ export function AgentWorkspace({
   // locally-working session absent from it (or sitting idle) for two
   // consecutive polls gets its activity cleared. Two misses, not one: a
   // just-submitted prompt can race the runtime session registering.
-  async function reconcileWorkingSessionsAgainstRuntime() {
-    const working = Array.from(workingSessionIdsRef.current);
-    const misses = workingReconcileMissesRef.current;
-    for (const sessionId of misses.keys()) {
-      if (!working.includes(sessionId)) misses.delete(sessionId);
-    }
-    if (working.length === 0) return;
-    // Working sessions may span both runtime processes; ask each mode that
-    // has one and union the answers. A mode we can't reach keeps its
-    // sessions' current state rather than guessing — so a one-gateway
-    // failure must not mark the other mode's sessions dead either.
-    const modes = Array.from(
-      new Set(working.map((sessionId) => sessionUnrestricted(sessionId))),
-    );
+  async function liveRuntimeSessionsForModes(modes: boolean[]) {
     let rows: Array<{ id?: string; session_key?: string; status?: string }> =
       [];
     const reachableModes = new Set<boolean>();
@@ -4676,7 +4683,6 @@ export function AgentWorkspace({
         // than guess, while the reachable mode still reconciles below.
       }
     }
-    if (reachableModes.size === 0) return;
     const live = new Set<string>();
     for (const row of rows) {
       // "idle" means the runtime session exists but isn't processing a turn.
@@ -4684,15 +4690,42 @@ export function AgentWorkspace({
       if (row.session_key) live.add(String(row.session_key));
       if (row.id) live.add(String(row.id));
     }
+    return { live, reachableModes };
+  }
+
+  function runtimeSnapshotHasSession(
+    snapshot: { live: Set<string> },
+    sessionId: string,
+  ) {
+    const runtimeSessionId = runtimeSessionIdsRef.current[sessionId];
+    return (
+      snapshot.live.has(sessionId) ||
+      Boolean(runtimeSessionId && snapshot.live.has(runtimeSessionId))
+    );
+  }
+
+  async function reconcileWorkingSessionsAgainstRuntime() {
+    const working = Array.from(workingSessionIdsRef.current);
+    const misses = workingReconcileMissesRef.current;
+    for (const sessionId of misses.keys()) {
+      if (!working.includes(sessionId)) misses.delete(sessionId);
+    }
+    if (working.length === 0) return;
+    // Working sessions may span both runtime processes; ask each mode that
+    // has one and union the answers. A mode we can't reach keeps its
+    // sessions' current state rather than guessing — so a one-gateway
+    // failure must not mark the other mode's sessions dead either.
+    const modes = Array.from(
+      new Set(working.map((sessionId) => sessionUnrestricted(sessionId))),
+    );
+    const snapshot = await liveRuntimeSessionsForModes(modes);
+    if (snapshot.reachableModes.size === 0) return;
     for (const sessionId of working) {
       // Sessions of an unreachable mode were not in any answer we got;
       // counting them as misses would mark live work dead.
-      if (!reachableModes.has(sessionUnrestricted(sessionId))) continue;
-      const runtimeSessionId = runtimeSessionIdsRef.current[sessionId];
-      if (
-        live.has(sessionId) ||
-        (runtimeSessionId && live.has(runtimeSessionId))
-      ) {
+      if (!snapshot.reachableModes.has(sessionUnrestricted(sessionId)))
+        continue;
+      if (runtimeSnapshotHasSession(snapshot, sessionId)) {
         misses.delete(sessionId);
         continue;
       }
@@ -5115,13 +5148,63 @@ export function AgentWorkspace({
     const timer = window.setTimeout(() => {
       queuedSteerRetryTimersRef.current.delete(sessionId);
       void flushQueuedSteerInstruction(sessionId, options);
-    }, 300);
+    }, QUEUED_STEER_RETRY_DELAY_MS);
     queuedSteerRetryTimersRef.current.set(sessionId, timer);
+  }
+
+  function cancelRestoredQueuedSteerReconcile(sessionId: string) {
+    const timer = restoredQueuedSteerReconcileTimersRef.current.get(sessionId);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      restoredQueuedSteerReconcileTimersRef.current.delete(sessionId);
+    }
+  }
+
+  function clearRestoredQueuedSteerReconcile(sessionId: string) {
+    cancelRestoredQueuedSteerReconcile(sessionId);
+    restoredToolCallSessionIdsRef.current.delete(sessionId);
+  }
+
+  function scheduleRestoredQueuedSteerReconcile(sessionId: string) {
+    cancelRestoredQueuedSteerReconcile(sessionId);
+    if (!restoredToolCallSessionIdsRef.current.has(sessionId)) return;
+    const timer = window.setTimeout(() => {
+      restoredQueuedSteerReconcileTimersRef.current.delete(sessionId);
+      void reconcileRestoredQueuedSteer(sessionId);
+    }, RESTORED_QUEUED_STEER_RECONCILE_DELAY_MS);
+    restoredQueuedSteerReconcileTimersRef.current.set(sessionId, timer);
+  }
+
+  async function reconcileRestoredQueuedSteer(sessionId: string) {
+    if (!queuedSteerBySessionIdRef.current[sessionId]) return;
+    if (!restoredToolCallSessionIdsRef.current.has(sessionId)) return;
+    if (!toolCallSessionIdsRef.current.has(sessionId)) {
+      clearRestoredQueuedSteerReconcile(sessionId);
+      scheduleQueuedSteerRetry(sessionId);
+      return;
+    }
+
+    const snapshot = await liveRuntimeSessionsForModes([
+      sessionUnrestricted(sessionId),
+    ]);
+    if (!queuedSteerBySessionIdRef.current[sessionId]) return;
+    if (!restoredToolCallSessionIdsRef.current.has(sessionId)) return;
+    if (!snapshot.reachableModes.has(sessionUnrestricted(sessionId))) {
+      scheduleRestoredQueuedSteerReconcile(sessionId);
+      return;
+    }
+
+    clearRestoredQueuedSteerReconcile(sessionId);
+    clearSessionToolCalls(sessionId);
+    scheduleQueuedSteerRetry(sessionId, {
+      ignoreActiveToolGuard: runtimeSnapshotHasSession(snapshot, sessionId),
+    });
   }
 
   function queueSteerInstruction(sessionId: string, text: string) {
     const instruction = normalizeSteerText(text);
     if (!instruction) return;
+    const shouldRetryAfterQueue = !toolCallSessionIdsRef.current.has(sessionId);
     cancelQueuedSteerRetry(sessionId);
     setQueuedSteerBySessionId((current) => {
       const next = {
@@ -5134,6 +5217,9 @@ export function AgentWorkspace({
       queuedSteerBySessionIdRef.current = next;
       return next;
     });
+    if (shouldRetryAfterQueue) {
+      scheduleQueuedSteerRetry(sessionId);
+    }
   }
 
   async function flushQueuedSteerInstruction(

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1417,6 +1417,9 @@ export function AgentWorkspace({
     Record<string, QueuedSteerInstruction>
   >({});
   const queuedSteerBySessionIdRef = useRef(queuedSteerBySessionId);
+  const queuedSteerRetryTimersRef = useRef<
+    Map<string, ReturnType<typeof window.setTimeout>>
+  >(new Map());
   const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
     () => new Set(continuity?.waitingSessionIds),
   );
@@ -1777,6 +1780,7 @@ export function AgentWorkspace({
   ]);
 
   const clearQueuedSteerInstruction = useCallback((sessionId: string) => {
+    cancelQueuedSteerRetry(sessionId);
     setQueuedSteerBySessionId((current) => {
       if (!current[sessionId]) return current;
       const next = omitRecordKey(current, sessionId);
@@ -1836,6 +1840,7 @@ export function AgentWorkspace({
   const clearSessionActivity = useCallback(
     (sessionId: string) => {
       setSessionToolCallActive(sessionId, false);
+      clearQueuedSteerInstruction(sessionId);
 
       const nextWorking = new Set(workingSessionIdsRef.current);
       nextWorking.delete(sessionId);
@@ -1852,7 +1857,7 @@ export function AgentWorkspace({
         needsUserCount: nextWaiting.size,
       };
     },
-    [setSessionToolCallActive],
+    [clearQueuedSteerInstruction, setSessionToolCallActive],
   );
 
   // Shared teardown for a session that is going away: its messages, pending
@@ -4921,9 +4926,27 @@ export function AgentWorkspace({
     );
   }
 
+  function cancelQueuedSteerRetry(sessionId: string) {
+    const timer = queuedSteerRetryTimersRef.current.get(sessionId);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      queuedSteerRetryTimersRef.current.delete(sessionId);
+    }
+  }
+
+  function scheduleQueuedSteerRetry(sessionId: string) {
+    cancelQueuedSteerRetry(sessionId);
+    const timer = window.setTimeout(() => {
+      queuedSteerRetryTimersRef.current.delete(sessionId);
+      void flushQueuedSteerInstruction(sessionId);
+    }, 300);
+    queuedSteerRetryTimersRef.current.set(sessionId, timer);
+  }
+
   function queueSteerInstruction(sessionId: string, text: string) {
     const instruction = normalizeSteerText(text);
     if (!instruction) return;
+    cancelQueuedSteerRetry(sessionId);
     setQueuedSteerBySessionId((current) => {
       const next = {
         ...current,
@@ -4961,6 +4984,7 @@ export function AgentWorkspace({
       await steerActiveSession(sessionId, queued.text);
       clearQueuedSteerInstruction(sessionId);
     } catch (err) {
+      const busy = isSessionBusyError(err);
       setQueuedSteerBySessionId((current) => {
         const currentQueued = current[sessionId];
         if (!currentQueued || currentQueued.text !== queued.text) {
@@ -4971,7 +4995,7 @@ export function AgentWorkspace({
           [sessionId]: {
             ...currentQueued,
             flushing: false,
-            error: isSessionBusyError(err)
+            error: busy
               ? "June is finishing that tool call. The instruction is still queued."
               : steerErrorNotice(err),
           },
@@ -4979,6 +5003,9 @@ export function AgentWorkspace({
         queuedSteerBySessionIdRef.current = next;
         return next;
       });
+      if (busy) {
+        scheduleQueuedSteerRetry(sessionId);
+      }
     }
   }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4003,6 +4003,18 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
+.agent-composer-steer-queued {
+  margin: var(--sp-2) 0 0;
+  padding: 0 var(--sp-3);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  overflow-wrap: anywhere;
+}
+
+.agent-composer-steer-queued span {
+  color: var(--foreground);
+}
+
 .agent-composer-notice-action {
   flex-wrap: wrap;
   justify-content: center;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4135,6 +4135,86 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("reconciles restored tool state when queueing after remount", async () => {
+    const user = userEvent.setup();
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.active_list") {
+        return Promise.resolve({
+          sessions: [
+            {
+              id: "runtime-session-2",
+              session_key: "session-2",
+              status: "working",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    const first = render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    first.unmount();
+    mocks.gatewayEventHandlers.clear();
+    render(<AgentWorkspace />);
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    await waitFor(
+      () =>
+        expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+          session_id: "session-2",
+          text: "focus on the failing test",
+        }),
+      { timeout: 2500 },
+    );
+  });
+
   it("backs off restored queued-steer probes while the restored tool is still busy", async () => {
     const user = userEvent.setup();
     let steerAttempts = 0;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3800,6 +3800,90 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("waits for all active tool calls before flushing a queued steer", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "read_file" },
+        });
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-2", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "read_file", status: "ok" },
+        });
+      }
+    });
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+    expect(
+      mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "session.steer",
+      ),
+    ).toHaveLength(0);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-2", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+        session_id: "session-2",
+        text: "focus on the failing test",
+      }),
+    );
+  });
+
   it("clears a queued steer when a working session is stopped", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3800,6 +3800,72 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("does not let anonymous tool progress block a queued steer flush", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+        handler({
+          type: "tool.progress",
+          session_id: "runtime-session-2",
+          payload: { message: "still running" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+        session_id: "session-2",
+        text: "focus on the failing test",
+      }),
+    );
+  });
+
   it("waits for all active tool calls before flushing a queued steer", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3725,6 +3725,81 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayEventHandlers.size).toBe(0);
   });
 
+  it("queues a steer during a tool call and flushes it when the tool completes", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    expect(
+      await screen.findByText(/Queued to run after this tool call/),
+    ).toHaveTextContent("focus on the failing test");
+    expect(
+      mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "session.steer",
+      ),
+    ).toHaveLength(0);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+        session_id: "session-2",
+        text: "focus on the failing test",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Queued to run after this tool call/),
+      ).toBeNull(),
+    );
+  });
+
   it("stops instantly even when the interrupt request hasn't resolved", async () => {
     // Immediacy regression: the stopped UI must not wait on the gateway
     // round-trip. Make session.interrupt hang forever and assert the Stop

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3800,6 +3800,162 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("clears a queued steer when a working session is stopped", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+    expect(
+      await screen.findByText(/Queued to run after this tool call/),
+    ).toBeInTheDocument();
+
+    await user.click(await screen.findByRole("button", { name: "Stop June" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.interrupt", {
+        session_id: "runtime-session-2",
+      }),
+    );
+
+    const composer = screen.getByRole("textbox");
+    await user.type(composer, "continue");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "continue",
+      }),
+    );
+    expect(screen.queryByText(/Queued to run after this tool call/)).toBeNull();
+  });
+
+  it("retries a queued steer when the first flush still hits session busy", async () => {
+    const user = userEvent.setup();
+    let steerAttempts = 0;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.steer") {
+        steerAttempts += 1;
+        return steerAttempts === 1
+          ? Promise.reject(new HermesGatewayError("session busy", 4009))
+          : Promise.resolve({});
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(
+        mocks.gatewayRequest.mock.calls.filter(
+          ([method]) => method === "session.steer",
+        ),
+      ).toHaveLength(2),
+    );
+    expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+      session_id: "session-2",
+      text: "focus on the failing test",
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Queued to run after this tool call/),
+      ).toBeNull(),
+    );
+  });
+
   it("stops instantly even when the interrupt request hasn't resolved", async () => {
     // Immediacy regression: the stopped UI must not wait on the gateway
     // round-trip. Make session.interrupt hang forever and assert the Stop

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4135,6 +4135,94 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("backs off restored queued-steer probes while the restored tool is still busy", async () => {
+    const user = userEvent.setup();
+    let steerAttempts = 0;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.active_list") {
+        return Promise.resolve({
+          sessions: [
+            {
+              id: "runtime-session-2",
+              session_key: "session-2",
+              status: "working",
+            },
+          ],
+        });
+      }
+      if (method === "session.steer") {
+        steerAttempts += 1;
+        return Promise.reject(new HermesGatewayError("session busy", 4009));
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    const first = render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    first.unmount();
+    mocks.gatewayEventHandlers.clear();
+    render(<AgentWorkspace />);
+
+    await waitFor(() => expect(steerAttempts).toBe(1), { timeout: 2500 });
+    expect(
+      await screen.findByText(
+        "June is finishing that tool call. The instruction is still queued.",
+      ),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 700));
+    });
+    expect(steerAttempts).toBe(1);
+  });
+
   it("clears a queued steer when a working session is stopped", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4114,6 +4114,115 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("clears a queued steer after a non-busy flush failure", async () => {
+    const user = userEvent.setup();
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.steer") {
+        return Promise.reject(new Error("gateway rejected the steer"));
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    expect(
+      await screen.findByText(
+        "Couldn't send that instruction. Please try again.",
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Queued to run after this tool call/),
+      ).toBeNull(),
+    );
+    expect(
+      mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "session.steer",
+      ),
+    ).toHaveLength(1);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-2", tool_name: "shell" },
+        });
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-2", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+
+    expect(
+      mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "session.steer",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("stops instantly even when the interrupt request hasn't resolved", async () => {
     // Immediacy regression: the stopped UI must not wait on the gateway
     // round-trip. Make session.interrupt hang forever and assert the Stop

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3939,6 +3939,18 @@ describe("AgentWorkspace", () => {
     expect(
       await screen.findByText(/Queued to run after this tool call/),
     ).toHaveTextContent("focus on the failing test");
+    await waitFor(() =>
+      expect(mocks.gatewayEventHandlers.size).toBeGreaterThan(0),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 350));
+    });
+    expect(
+      mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "session.steer",
+      ),
+    ).toHaveLength(0);
 
     act(() => {
       for (const handler of mocks.gatewayEventHandlers) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3884,6 +3884,80 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("preserves a queued steer across a workspace remount", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    const first = render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+    expect(
+      await screen.findByText(/Queued to run after this tool call/),
+    ).toHaveTextContent("focus on the failing test");
+
+    first.unmount();
+    // The real gateway close tears down live listeners; the mock keeps the
+    // callbacks in a Set, so clear it before mounting the replacement surface.
+    mocks.gatewayEventHandlers.clear();
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByText(/Queued to run after this tool call/),
+    ).toHaveTextContent("focus on the failing test");
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+        session_id: "session-2",
+        text: "focus on the failing test",
+      }),
+    );
+  });
+
   it("clears a queued steer when a working session is stopped", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3970,6 +3970,105 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("flushes a restored queued steer when a tool completion is missed while unmounted", async () => {
+    const user = userEvent.setup();
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-session-2",
+          stored_session_id: "session-2",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "session.active_list") {
+        return Promise.resolve({
+          sessions: [
+            {
+              id: "runtime-session-2",
+              session_key: "session-2",
+              status: "working",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    const first = render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+    expect(
+      await screen.findByText(/Queued to run after this tool call/),
+    ).toHaveTextContent("focus on the failing test");
+
+    first.unmount();
+    mocks.gatewayEventHandlers.clear();
+    render(<AgentWorkspace />);
+
+    expect(
+      await screen.findByText(/Queued to run after this tool call/),
+    ).toHaveTextContent("focus on the failing test");
+    await waitFor(() =>
+      expect(mocks.gatewayEventHandlers.size).toBeGreaterThan(0),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 350));
+    });
+    expect(
+      mocks.gatewayRequest.mock.calls.filter(
+        ([method]) => method === "session.steer",
+      ),
+    ).toHaveLength(0);
+
+    await waitFor(
+      () =>
+        expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.steer", {
+          session_id: "session-2",
+          text: "focus on the failing test",
+        }),
+      { timeout: 2500 },
+    );
+  });
+
   it("clears a queued steer when a working session is stopped", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(
@@ -4119,6 +4218,107 @@ describe("AgentWorkspace", () => {
       session_id: "session-2",
       text: "focus on the failing test",
     });
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Queued to run after this tool call/),
+      ).toBeNull(),
+    );
+  });
+
+  it("reschedules a busy queued-steer retry after replacing the queued text", async () => {
+    const user = userEvent.setup();
+    const steerTexts: string[] = [];
+    mocks.gatewayRequest.mockImplementation(
+      (method: string, params?: { text?: string }) => {
+        if (method === "session.create") {
+          return Promise.resolve({
+            session_id: "runtime-session-2",
+            stored_session_id: "session-2",
+          });
+        }
+        if (method === "session.resume") {
+          return Promise.resolve({ session_id: "runtime-session-1" });
+        }
+        if (method === "session.steer") {
+          steerTexts.push(params?.text ?? "");
+          return steerTexts.length === 1
+            ? Promise.reject(new HermesGatewayError("session busy", 4009))
+            : Promise.resolve({});
+        }
+        return Promise.resolve({});
+      },
+    );
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the project checks",
+      }),
+    );
+    mocks.listHermesSessions.mockResolvedValue([
+      {
+        id: "session-2",
+        title: "Untitled session",
+        preview: "run the project checks",
+        last_active: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the project checks",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell" },
+        });
+      }
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Add instruction" }),
+      "focus on the failing test",
+    );
+    await user.click(screen.getByRole("button", { name: "Queue instruction" }));
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: { tool_id: "tool-1", tool_name: "shell", status: "ok" },
+        });
+      }
+    });
+
+    expect(
+      await screen.findByText(
+        "June is finishing that tool call. The instruction is still queued.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Add instruction" }),
+      "use the replacement",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Replace queued instruction" }),
+    );
+
+    await waitFor(() =>
+      expect(steerTexts).toEqual([
+        "focus on the failing test",
+        "use the replacement",
+      ]),
+    );
     await waitFor(() =>
       expect(
         screen.queryByText(/Queued to run after this tool call/),

--- a/src/test/hermes-session-steer.test.tsx
+++ b/src/test/hermes-session-steer.test.tsx
@@ -71,6 +71,44 @@ describe("ComposerSteerInput", () => {
     });
   });
 
+  it("queues instead of steering while a tool call is active", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onQueue = vi.fn();
+    const { rerender } = render(
+      <ComposerSteerInput
+        onSteer={onSteer}
+        onQueue={onQueue}
+        queueWhileToolActive
+      />,
+    );
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /add instruction|steer june/i }),
+      "  focus after this command  ",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Queue instruction" }),
+    );
+
+    expect(onQueue).toHaveBeenCalledWith("focus after this command");
+    expect(onSteer).not.toHaveBeenCalled();
+    rerender(
+      <ComposerSteerInput
+        onSteer={onSteer}
+        onQueue={onQueue}
+        queueWhileToolActive
+        queuedInstruction={{
+          text: "focus after this command",
+          queuedAt: "2026-06-26T10:00:00Z",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Queued to run after this tool call/),
+    ).toHaveTextContent("focus after this command");
+  });
+
   it("clears the input after a successful steer", async () => {
     const steer = vi.fn().mockResolvedValue(undefined);
     render(<ComposerSteerInput onSteer={steer} />);
@@ -82,6 +120,19 @@ describe("ComposerSteerInput", () => {
       screen.getByRole("button", { name: /send|add instruction|steer/i }),
     );
     await waitFor(() => expect(input).toHaveValue(""));
+  });
+
+  it("submits with Enter without relying on a nested form", async () => {
+    const steer = vi.fn().mockResolvedValue(undefined);
+    render(<ComposerSteerInput onSteer={steer} />);
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /add instruction|steer june/i }),
+      "keep the current plan{Enter}",
+    );
+
+    await waitFor(() =>
+      expect(steer).toHaveBeenCalledWith("keep the current plan"),
+    );
   });
 
   it("shows a visible error and keeps the text when Hermes rejects the steer", async () => {

--- a/src/test/hermes-session-steer.test.tsx
+++ b/src/test/hermes-session-steer.test.tsx
@@ -109,6 +109,34 @@ describe("ComposerSteerInput", () => {
     ).toHaveTextContent("focus after this command");
   });
 
+  it("replaces a queued instruction through the queue after the active tool flag drops", async () => {
+    const onSteer = vi.fn().mockResolvedValue(undefined);
+    const onQueue = vi.fn();
+    render(
+      <ComposerSteerInput
+        onSteer={onSteer}
+        onQueue={onQueue}
+        queuedInstruction={{
+          text: "original queued instruction",
+          queuedAt: "2026-06-26T10:00:00Z",
+          error:
+            "June is finishing that tool call. The instruction is still queued.",
+        }}
+      />,
+    );
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /add instruction|steer june/i }),
+      "use the correction instead",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Replace queued instruction" }),
+    );
+
+    expect(onQueue).toHaveBeenCalledWith("use the correction instead");
+    expect(onSteer).not.toHaveBeenCalled();
+  });
+
   it("clears the input after a successful steer", async () => {
     const steer = vi.fn().mockResolvedValue(undefined);
     render(<ComposerSteerInput onSteer={steer} />);


### PR DESCRIPTION
Closes JUN-117

## What changed
- Track per-session active tool-call state from live Hermes tool events.
- Queue or replace steering instructions submitted while a tool call is active, then flush them through session.steer after tool.complete.
- Show queued and flushing states in the steer composer without exposing raw 4009 errors.
- Remove the nested steer form inside the main composer while preserving Enter submission.

## Why
Users could type an instruction while a tool was running, but June sent it immediately and could hit the Hermes 4009 busy guard. The composer now accepts the instruction immediately and releases it at the next safe tool boundary.

## Validation
- node_modules/.bin/tsc --noEmit
- node_modules/.bin/vitest run src/test/hermes-session-steer.test.ts src/test/hermes-session-steer.test.tsx src/test/agent-workspace.test.tsx
- node_modules/.bin/prettier --check src/components/agent/AgentWorkspace.tsx src/styles/app.css src/test/hermes-session-steer.test.tsx src/test/agent-workspace.test.tsx

## Known gaps
- Not manually verified against a live Hermes tool call in the desktop app.