### PR TITLE
Show agent action rows outside Thought

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9101,11 +9101,11 @@ function AgentChatTurnRow({
     (part): part is Extract<AgentChatPart, { type: "tool" }> =>
       part.type === "tool",
   );
-  // Reasoning + the tool/terminal calls it made fold into one "Thinking" /
-  // "Thought" disclosure so the conversation isn't littered with terminal rows.
-  const thinkingRunning =
-    reasoningParts.some((part) => part.status === "running") ||
-    toolParts.some((part) => part.status === "running");
+  // The disclosure owns internal reasoning only. Tool/action rows stay visible
+  // outside it so users can see what June is doing without expanding Thought.
+  const thinkingRunning = reasoningParts.some(
+    (part) => part.status === "running",
+  );
   const completedThinkingKey = `turn:${turn.id}:thinking`;
   const thinkingKey =
     thinkingRunning && activeThinkingKey
@@ -9128,7 +9128,7 @@ function AgentChatTurnRow({
       !wasRunning ||
       thinkingRunning ||
       activeThinkingKey === undefined ||
-      reasoningParts.length + toolParts.length === 0 ||
+      reasoningParts.length === 0 ||
       !thinkingOpen(activeThinkingKey)
     ) {
       return;
@@ -9281,14 +9281,20 @@ function AgentChatTurnRow({
   return (
     <article className="agent-assistant-turn" data-status={turn.status}>
       <div className="agent-assistant-turn-body">
-        {reasoningParts.length > 0 || toolParts.length > 0 ? (
+        {reasoningParts.length > 0 ? (
           <AgentThinkingGroup
             reasoning={reasoningParts}
-            tools={toolParts}
             running={thinkingRunning}
             open={thinkingIsOpen}
             onOpenChange={(open) => onThinkingOpenChange(thinkingKey, open)}
           />
+        ) : null}
+        {toolParts.length > 0 ? (
+          <div className="agent-tool-stack">
+            {toolParts.map((tool) => (
+              <AgentToolPartRow key={`tool:${tool.id}`} part={tool} />
+            ))}
+          </div>
         ) : null}
         {turn.parts.map((part, index) =>
           part.type === "text" ? (
@@ -10539,18 +10545,16 @@ function AgentThinkingGroup({
   open,
   onOpenChange,
   reasoning,
-  tools,
   running,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   reasoning: Extract<AgentChatPart, { type: "reasoning" }>[];
-  tools: Extract<AgentChatPart, { type: "tool" }>[];
   running: boolean;
 }) {
   // Collapsed by default to a short label — "Thinking" while it works, "Thought"
-  // once done (terracotta while live). Expanding reveals the reasoning prose and
-  // any terminal calls it ran, nested together.
+  // once done (terracotta while live). Expanding reveals only the reasoning
+  // prose; tool/action rows render outside this disclosure.
   const reasoningText = reasoning
     .map((part) => part.text)
     .join("\n\n")
@@ -10572,9 +10576,6 @@ function AgentThinkingGroup({
         {reasoningText ? (
           <div className="agent-reasoning-text">{reasoningText}</div>
         ) : null}
-        {tools.map((tool) => (
-          <AgentToolPartRow key={`tool:${tool.id}`} part={tool} />
-        ))}
       </div>
     </details>
   );

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2077,6 +2077,13 @@ input:focus-visible,
 /* Collapsed-by-default tool row: a single quiet line (icon · name · status),
  * with the raw output tucked behind a disclosure so it never floods the
  * conversation. */
+.agent-tool-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  width: 100%;
+}
+
 .agent-tool-disclosure {
   width: min(760px, 100%);
   color: var(--muted-foreground);
@@ -3633,8 +3640,8 @@ input:focus-visible,
   font-size: var(--fs-lg);
 }
 
-/* Direct-child selectors only — tool rows nest their own <summary> inside the
- * reasoning body, and a descendant selector here would shrink-wrap them. */
+/* Direct-child selectors only. The Thought body has its own reveal affordance,
+ * so descendant summaries should keep their own layout if new ones are added. */
 .agent-reasoning > summary {
   display: inline-flex;
   align-items: center;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4822,6 +4822,75 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("keeps tool rows visible outside the thinking disclosure", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "inspect the project",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "inspect the project",
+      }),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "thinking.delta",
+          session_id: "runtime-session-2",
+          payload: { delta: "Checking the project state." },
+        });
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: {
+            tool_id: "tool-1",
+            tool_name: "read_file",
+            path: "src/components/agent/AgentWorkspace.tsx",
+          },
+        });
+      }
+    });
+
+    const thinkingDetails = (await screen.findByText("Thinking")).closest(
+      "details",
+    );
+    expect(thinkingDetails).toHaveClass("agent-reasoning");
+    expect(
+      within(thinkingDetails as HTMLElement).getByText(
+        "Checking the project state.",
+      ),
+    ).toBeInTheDocument();
+
+    const toolLabel = await screen.findByText("Reading files");
+    expect(thinkingDetails).not.toContainElement(toolLabel);
+    expect(toolLabel.closest(".agent-tool-stack")).toBeTruthy();
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "message.complete",
+          session_id: "runtime-session-2",
+          payload: { text: "Done." },
+        });
+      }
+    });
+
+    const thoughtDetails = (await screen.findByText("Thought")).closest(
+      "details",
+    );
+    expect(thoughtDetails).toHaveClass("agent-reasoning");
+    expect(thoughtDetails).not.toContainElement(toolLabel);
+    expect(await screen.findByText("Done.")).toBeInTheDocument();
+  });
+
   it("explains a pending approval before the user chooses", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(


### PR DESCRIPTION
Closes JUN-118
Closes JUN-119

## What changed
- Render tool rows in a visible stack outside the Thinking/Thought disclosure.
- Keep AgentThinkingGroup scoped to reasoning text only, so Thought contains reasoning without absorbing action rows.
- Add a regression test asserting tool rows stay outside the disclosure while reasoning stays inside.

## Why
Users need to see observable agent actions without expanding internal reasoning, while thought content stays contained under Thought.

## Validation
- ./node_modules/.bin/vitest run src/test/agent-workspace.test.tsx (143 passed, 2 skipped)
- ./node_modules/.bin/tsc --noEmit
- git diff --check

## Known gaps
- Did not run the full pnpm test suite. pnpm v11 auto-install stopped on build-script approval in the fresh worktree, so I used local binaries after the partial install.