### PR TITLE
JUN-58: Add dictation HUD discard button

### DIFF
--- a/hud.html
+++ b/hud.html
@@ -45,6 +45,12 @@
         aria-label="Press Escape to cancel dictation"
         >Esc</span
       >
+      <button
+        id="hud-cancel"
+        class="hud-cancel"
+        type="button"
+        aria-label="Discard dictation"
+      ></button>
       <span class="hud-meeting-body">
         <span class="hud-meeting-mark" aria-hidden="true"></span>
         <span class="hud-meeting-text">

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -74,12 +74,14 @@ pub struct HudClientRect {
 /// Hover state for HUD controls. Polled by [`spawn_hud_hover_thread`]; we
 /// don't poll from JS because WebKit throttles timers on the non-key HUD
 /// panel (and CSS :hover is unreliable there for the same reason). The
-/// stop button and the meeting prompt's corner dismiss each get a rect.
+/// stop button, cancel button, and the meeting prompt controls each get a rect.
 /// (The window is sized exactly to the pill, so there's no click
 /// pass-through to manage — the whole window is interactive.)
 pub struct HudHoverState {
     stop_bounds: Mutex<Option<HudClientRect>>,
     last_hover: std::sync::atomic::AtomicBool,
+    cancel_bounds: Mutex<Option<HudClientRect>>,
+    last_cancel_hover: std::sync::atomic::AtomicBool,
     dismiss_bounds: Mutex<Option<HudClientRect>>,
     last_dismiss_hover: std::sync::atomic::AtomicBool,
     record_bounds: Mutex<Option<HudClientRect>>,
@@ -586,6 +588,8 @@ pub fn setup(app: &mut tauri::App) {
     app.manage(HudHoverState {
         stop_bounds: Mutex::new(None),
         last_hover: std::sync::atomic::AtomicBool::new(false),
+        cancel_bounds: Mutex::new(None),
+        last_cancel_hover: std::sync::atomic::AtomicBool::new(false),
         dismiss_bounds: Mutex::new(None),
         last_dismiss_hover: std::sync::atomic::AtomicBool::new(false),
         record_bounds: Mutex::new(None),
@@ -841,6 +845,16 @@ fn cursor_position_via_cg() -> Option<(f64, f64)> {
 #[tauri::command]
 pub fn dictation_hud_set_stop_bounds(state: State<'_, HudHoverState>, rect: Option<HudClientRect>) {
     if let Ok(mut guard) = state.stop_bounds.lock() {
+        *guard = rect;
+    }
+}
+
+#[tauri::command]
+pub fn dictation_hud_set_cancel_bounds(
+    state: State<'_, HudHoverState>,
+    rect: Option<HudClientRect>,
+) {
+    if let Ok(mut guard) = state.cancel_bounds.lock() {
         *guard = rect;
     }
 }
@@ -1227,8 +1241,8 @@ fn rect_contains(
     cx >= left && cx <= right && cy >= top && cy <= bottom
 }
 
-/// Polls the cursor against the cached control bounds (stop button, meeting
-/// dismiss) and emits hover state changes. Short-circuits when no bounds
+/// Polls the cursor against the cached control bounds (stop button, cancel
+/// button, meeting dismiss) and emits hover state changes. Short-circuits when no bounds
 /// are registered.
 fn spawn_hud_hover_thread(app: AppHandle) {
     thread::spawn(move || {
@@ -1248,6 +1262,11 @@ fn spawn_hud_hover_thread(app: AppHandle) {
             let visible = hud.is_visible().unwrap_or(false);
 
             let stop_rect = hover_state.stop_bounds.lock().ok().and_then(|g| g.clone());
+            let cancel_rect = hover_state
+                .cancel_bounds
+                .lock()
+                .ok()
+                .and_then(|g| g.clone());
             let dismiss_rect = hover_state
                 .dismiss_bounds
                 .lock()
@@ -1260,10 +1279,17 @@ fn spawn_hud_hover_thread(app: AppHandle) {
                 .and_then(|g| g.clone());
 
             // Hidden or no hoverable controls on screen: drop stale hover.
-            if !visible || (stop_rect.is_none() && dismiss_rect.is_none() && record_rect.is_none())
+            if !visible
+                || (stop_rect.is_none()
+                    && cancel_rect.is_none()
+                    && dismiss_rect.is_none()
+                    && record_rect.is_none())
             {
                 if hover_state.last_hover.swap(false, Ordering::Relaxed) {
                     let _ = app.emit("hud-stop-hover", false);
+                }
+                if hover_state.last_cancel_hover.swap(false, Ordering::Relaxed) {
+                    let _ = app.emit("hud-cancel-hover", false);
                 }
                 if hover_state
                     .last_dismiss_hover
@@ -1299,6 +1325,17 @@ fn spawn_hud_hover_thread(app: AppHandle) {
                     .last_hover
                     .store(stop_hovered, Ordering::Relaxed);
                 let _ = app.emit("hud-stop-hover", stop_hovered);
+            }
+
+            let cancel_hovered = match cancel_rect.as_ref() {
+                Some(rect) => rect_contains(rect, position, scale_factor, cx, cy),
+                None => false,
+            };
+            if cancel_hovered != hover_state.last_cancel_hover.load(Ordering::Relaxed) {
+                hover_state
+                    .last_cancel_hover
+                    .store(cancel_hovered, Ordering::Relaxed);
+                let _ = app.emit("hud-cancel-hover", cancel_hovered);
             }
 
             let dismiss_hovered = match dismiss_rect.as_ref() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,6 +214,7 @@ pub fn run() {
             dictation::set_dictation_language,
             dictation::dictation_helper_command,
             dictation::dictation_hud_set_stop_bounds,
+            dictation::dictation_hud_set_cancel_bounds,
             dictation::dictation_hud_set_dismiss_bounds,
             dictation::dictation_hud_set_record_bounds,
             dictation::dictation_hud_preferred_error_placement,

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -60,6 +60,7 @@ const errorText = document.querySelector<HTMLElement>("#hud-error-text");
 const errorIcon = document.querySelector<HTMLElement>(".hud-error-icon");
 const errorLayer = document.querySelector<HTMLElement>(".hud-error-layer");
 const stopButton = document.querySelector<HTMLButtonElement>("#hud-stop");
+const cancelButton = document.querySelector<HTMLButtonElement>("#hud-cancel");
 const meetingStartButton =
   document.querySelector<HTMLButtonElement>("#hud-meeting-start");
 const meetingAppLabel = document.querySelector<HTMLElement>("#hud-meeting-app");
@@ -71,6 +72,15 @@ const statusText = document.querySelector<HTMLElement>("#hud-status");
 // House iconography (central-icons), injected like the agent HUD does.
 if (meetingDismissButton) {
   meetingDismissButton.innerHTML = renderToStaticMarkup(
+    createElement(IconCrossSmall, {
+      size: 12,
+      ariaHidden: true,
+      focusable: false,
+    }),
+  );
+}
+if (cancelButton) {
+  cancelButton.innerHTML = renderToStaticMarkup(
     createElement(IconCrossSmall, {
       size: 12,
       ariaHidden: true,
@@ -244,6 +254,7 @@ function setHud(state: string, status: string): HudTransition {
     startBarLoop();
     if (previous !== "listening") {
       pushStopBoundsToNative();
+      pushCancelBoundsToNative();
     }
   } else if (previous === "listening") {
     clearStopHover();
@@ -410,6 +421,10 @@ function setStopHover(isHovered: boolean) {
   stopButton?.classList.toggle("is-hovered", isHovered);
 }
 
+function setCancelHover(isHovered: boolean) {
+  cancelButton?.classList.toggle("is-hovered", isHovered);
+}
+
 function setDismissHover(isHovered: boolean) {
   meetingDismissButton?.classList.toggle("is-hovered", isHovered);
 }
@@ -468,6 +483,17 @@ function pushStopBoundsToNative() {
   }
   const { left, right, top, bottom } = stopButton.getBoundingClientRect();
   invokeBestEffort("dictation_hud_set_stop_bounds", {
+    rect: { left, right, top, bottom },
+  });
+}
+
+function pushCancelBoundsToNative() {
+  if (!cancelButton || hud?.dataset.state !== "listening") {
+    invokeBestEffort("dictation_hud_set_cancel_bounds", { rect: null });
+    return;
+  }
+  const { left, right, top, bottom } = cancelButton.getBoundingClientRect();
+  invokeBestEffort("dictation_hud_set_cancel_bounds", {
     rect: { left, right, top, bottom },
   });
 }
@@ -552,6 +578,7 @@ async function syncWindowToPill(options?: {
     window.requestAnimationFrame(() => {
       hud?.classList.remove("is-morphing");
       pushStopBoundsToNative();
+      pushCancelBoundsToNative();
       pushDismissBoundsToNative();
     });
   });
@@ -610,7 +637,9 @@ function triggerShake() {
 
 function clearStopHover() {
   setStopHover(false);
+  setCancelHover(false);
   invokeBestEffort("dictation_hud_set_stop_bounds", { rect: null });
+  invokeBestEffort("dictation_hud_set_cancel_bounds", { rect: null });
 }
 
 function clearHideTimer() {
@@ -774,6 +803,7 @@ async function showHudNow(
     pushDismissBoundsToNative();
   } else {
     pushStopBoundsToNative();
+    pushCancelBoundsToNative();
     pushDismissBoundsToNative();
   }
   assertWindowMatchesPill();
@@ -1098,6 +1128,7 @@ async function stopAndPasteDictation() {
 async function cancelDictation() {
   if (!hud?.isConnected || hud.dataset.state !== "listening") return;
   setStopHover(false);
+  setCancelHover(false);
   try {
     await invoke("dictation_helper_command", {
       command: { type: "discard_recording" },
@@ -1117,6 +1148,12 @@ dragHandle?.addEventListener("pointerdown", (event) => {
 stopButton?.addEventListener("click", async (event) => {
   event.preventDefault();
   await stopAndPasteDictation();
+});
+
+cancelButton?.addEventListener("click", async (event) => {
+  event.preventDefault();
+  event.stopPropagation();
+  await cancelDictation();
 });
 
 window.addEventListener(
@@ -1181,6 +1218,10 @@ void listen(AGENT_SESSION_STATUS_EVENT, async (event) => {
 
 void listen<boolean>("hud-stop-hover", (event) => {
   setStopHover(Boolean(event.payload));
+}).catch(() => {});
+
+void listen<boolean>("hud-cancel-hover", (event) => {
+  setCancelHover(Boolean(event.payload));
 }).catch(() => {});
 
 void listen<boolean>("hud-dismiss-hover", (event) => {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -470,8 +470,9 @@ body {
   transform: translateY(0.5px);
 }
 
-/* Stop button ---------------------------------------------------------- */
-.hud-stop {
+/* Listening action buttons -------------------------------------------- */
+.hud-stop,
+.hud-cancel {
   position: relative;
   display: grid;
   place-items: center;
@@ -487,7 +488,12 @@ body {
   contain: paint;
 }
 
-.hud-stop::before {
+.hud-cancel {
+  display: none;
+}
+
+.hud-stop::before,
+.hud-cancel::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -500,11 +506,13 @@ body {
 /* Hover is driven by the native polling thread via the `.is-hovered` class.
  * No `:hover` selector — WebKit can latch :hover state when the panel is
  * briefly key and not release it, which manifests as auto-highlighting. */
-.hud-stop.is-hovered::before {
+.hud-stop.is-hovered::before,
+.hud-cancel.is-hovered::before {
   opacity: 1;
 }
 
-.hud-stop:focus-visible {
+.hud-stop:focus-visible,
+.hud-cancel:focus-visible {
   outline: 2px solid color-mix(in oklch, var(--foreground) 40%, transparent);
   outline-offset: 1px;
 }
@@ -516,6 +524,12 @@ body {
   height: 8px;
   border-radius: 2px;
   background: var(--foreground);
+}
+
+.hud-cancel svg {
+  position: relative;
+  z-index: 1;
+  display: block;
 }
 
 .hud-cancel-key {
@@ -538,6 +552,7 @@ body {
 }
 
 .hud-stop,
+.hud-cancel,
 .hud-handle {
   -webkit-user-select: none;
   user-select: none;
@@ -545,6 +560,7 @@ body {
 }
 
 .hud-stop *,
+.hud-cancel *,
 .hud-handle *,
 .hud-cancel-key {
   -webkit-user-drag: none;
@@ -631,6 +647,11 @@ body {
 .hud[data-state="listening"] .hud-cancel-key,
 .hud[data-state="exiting"][data-exit-state="listening"] .hud-cancel-key {
   display: inline-flex;
+}
+
+.hud[data-state="listening"] .hud-cancel,
+.hud[data-state="exiting"][data-exit-state="listening"] .hud-cancel {
+  display: grid;
 }
 
 /* Error pill (the fixed anchor): the compact handle + error-icon pill that
@@ -743,6 +764,8 @@ body {
   .hud > *,
   .hud-stop,
   .hud-stop::before,
+  .hud-cancel,
+  .hud-cancel::before,
   .hud-bar::before {
     transition: none;
   }

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -535,7 +535,18 @@ describe("meeting detection HUD", () => {
     );
   });
 
+  it("surfaces the listening discard button", async () => {
+    await loadHud();
+
+    await emit("dictation-event", { type: "listening_started" });
+
+    const cancel = document.querySelector<HTMLButtonElement>("#hud-cancel");
+    expect(cancel).toHaveAttribute("aria-label", "Discard dictation");
+    expect(cancel?.querySelector("svg")).toBeTruthy();
+  });
+
   it("cancels active dictation when Escape reaches the HUD", async () => {
+    vi.useFakeTimers();
     await loadHud();
     await emit("dictation-event", { type: "listening_started" });
     mocks.invoke.mockClear();
@@ -552,6 +563,41 @@ describe("meeting detection HUD", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("dictation_helper_command", {
       command: { type: "discard_recording" },
     });
+    await vi.advanceTimersByTimeAsync(320);
+  });
+
+  it("cancels active dictation when the discard button is clicked", async () => {
+    vi.useFakeTimers();
+    await loadHud();
+    await emit("dictation-event", { type: "listening_started" });
+    mocks.invoke.mockClear();
+
+    document.querySelector<HTMLButtonElement>("#hud-cancel")?.click();
+    await Promise.resolve();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("dictation_helper_command", {
+      command: { type: "discard_recording" },
+    });
+    await vi.advanceTimersByTimeAsync(320);
+  });
+
+  it("ignores discard button clicks outside the listening state", async () => {
+    await loadHud();
+
+    document.querySelector<HTMLButtonElement>("#hud-cancel")?.click();
+    await Promise.resolve();
+
+    expect(mocks.invoke).not.toHaveBeenCalledWith("dictation_helper_command", {
+      command: { type: "discard_recording" },
+    });
+  });
+
+  it("paints the native hover state on the discard button", async () => {
+    await loadHud();
+
+    await emit("hud-cancel-hover", true);
+
+    expect(document.querySelector("#hud-cancel")).toHaveClass("is-hovered");
   });
 
   it("ignores Escape outside the listening state", async () => {
@@ -787,6 +833,7 @@ function hudMarkup() {
         <span id="hud-error-text" class="hud-error-message"></span>
       </span>
       <span id="hud-cancel-key" class="hud-cancel-key" aria-label="Press Escape to cancel dictation">Esc</span>
+      <button id="hud-cancel" class="hud-cancel" type="button" aria-label="Discard dictation"></button>
       <span class="hud-meeting-body">
         <span class="hud-meeting-mark" aria-hidden="true"></span>
         <span class="hud-meeting-text">


### PR DESCRIPTION
Closes JUN-58

## What changed

- Added a listening-state X button in the dictation HUD using the existing central-icons cross glyph.
- Routed the X button and Escape through the existing `discard_recording` helper command. The stop button still uses `stop_and_paste`.
- Added native hover bounds and a `hud-cancel-hover` event so the non-key HUD panel handles cancel-button hover like the existing stop button.
- Covered the affordance, discard click, non-listening guard, and hover state in HUD tests.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/test/hud-meeting.test.ts`
- `./node_modules/.bin/vitest run`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Notes

- Built on `codex/jun-61-esc-hud` as requested.
- `pnpm run lint` and `pnpm test` were blocked locally because the Codex runtime's pnpm wrapper attempted an install and stopped on ignored build scripts / no TTY. The direct underlying commands above passed.
