### PR TITLE
[codex] Fix Hermes MCP web search

### DIFF
--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -90,13 +90,14 @@ def main() -> None:
 
 
 def read_message() -> dict[str, Any] | None:
-    first = sys.stdin.buffer.readline()
-    if first == b"":
-        return None
+    while True:
+        first = sys.stdin.buffer.readline()
+        if first == b"":
+            return None
+        if first.strip():
+            break
     if not first.lower().startswith(b"content-length:"):
         stripped = first.strip()
-        if not stripped:
-            return None
         return json.loads(stripped.decode("utf-8"))
 
     headers: dict[str, str] = {}

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -90,7 +90,18 @@ def main() -> None:
 
 
 def read_message() -> dict[str, Any] | None:
+    first = sys.stdin.buffer.readline()
+    if first == b"":
+        return None
+    if not first.lower().startswith(b"content-length:"):
+        stripped = first.strip()
+        if not stripped:
+            return None
+        return json.loads(stripped.decode("utf-8"))
+
     headers: dict[str, str] = {}
+    name, _, value = first.decode("ascii", "replace").partition(":")
+    headers[name.lower()] = value.strip()
     while True:
         line = sys.stdin.buffer.readline()
         if line == b"":
@@ -108,10 +119,9 @@ def read_message() -> dict[str, Any] | None:
 
 
 def write_message(payload: dict[str, Any]) -> None:
-    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
-    sys.stdout.buffer.write(body)
-    sys.stdout.buffer.flush()
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
 
 
 def handle_message(db_path: Path, message: dict[str, Any]) -> dict[str, Any] | None:

--- a/src-tauri/src/hermes/june_web_mcp.py
+++ b/src-tauri/src/hermes/june_web_mcp.py
@@ -103,13 +103,14 @@ def main() -> None:
 
 
 def read_message() -> dict[str, Any] | None:
-    first = sys.stdin.buffer.readline()
-    if first == b"":
-        return None
+    while True:
+        first = sys.stdin.buffer.readline()
+        if first == b"":
+            return None
+        if first.strip():
+            break
     if not first.lower().startswith(b"content-length:"):
         stripped = first.strip()
-        if not stripped:
-            return None
         return json.loads(stripped.decode("utf-8"))
 
     headers: dict[str, str] = {}

--- a/src-tauri/src/hermes/june_web_mcp.py
+++ b/src-tauri/src/hermes/june_web_mcp.py
@@ -103,7 +103,18 @@ def main() -> None:
 
 
 def read_message() -> dict[str, Any] | None:
+    first = sys.stdin.buffer.readline()
+    if first == b"":
+        return None
+    if not first.lower().startswith(b"content-length:"):
+        stripped = first.strip()
+        if not stripped:
+            return None
+        return json.loads(stripped.decode("utf-8"))
+
     headers: dict[str, str] = {}
+    name, _, value = first.decode("ascii", "replace").partition(":")
+    headers[name.lower()] = value.strip()
     while True:
         line = sys.stdin.buffer.readline()
         if line == b"":
@@ -121,10 +132,9 @@ def read_message() -> dict[str, Any] | None:
 
 
 def write_message(payload: dict[str, Any]) -> None:
-    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
-    sys.stdout.buffer.write(body)
-    sys.stdout.buffer.flush()
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
 
 
 def handle_message(

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1356,8 +1356,9 @@ pub async fn ensure_hermes_bridge_session(
     // session is created through the gateway; REST is only a best-effort title
     // update for the sidebar/session browser. Model-only switches stay in the
     // frontend session override and live gateway dispatch path.
-    let Some(title) = title else {
-        return Ok(unchanged());
+    let title = match title {
+        Some(title) => title,
+        None => return Ok(unchanged()),
     };
     let patch_body = serde_json::json!({ "title": title.clone() });
     match hermes_api_json(

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1354,7 +1354,8 @@ pub async fn ensure_hermes_bridge_session(
 
     // Hermes dashboard v0.17 no longer creates sessions over REST. The live
     // session is created through the gateway; REST is only a best-effort title
-    // update for the sidebar/session browser.
+    // update for the sidebar/session browser. Model-only switches stay in the
+    // frontend session override and live gateway dispatch path.
     let Some(title) = title else {
         return Ok(unchanged());
     };

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -1331,37 +1331,76 @@ pub async fn ensure_hermes_bridge_session(
             "Hermes session ID is required.",
         ));
     }
-    let mut body = serde_json::json!({ "id": session_id });
-    if let Some(title) = request
+    let title = request
         .title
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-    {
-        body["title"] = serde_json::Value::String(title.to_string());
-    }
-    if let Some(model) = request
+        .map(ToString::to_string);
+    let model = request
         .model
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let unchanged = || {
+        serde_json::json!({
+            "object": "hermes.session.ensure",
+            "id": session_id,
+            "created": false,
+            "updated": false
+        })
+    };
+
+    // Hermes dashboard v0.17 no longer creates sessions over REST. The live
+    // session is created through the gateway; REST is only a best-effort title
+    // update for the sidebar/session browser.
+    let Some(title) = title else {
+        return Ok(unchanged());
+    };
+    let patch_body = serde_json::json!({ "title": title.clone() });
+    match hermes_api_json(
+        &bridge,
+        reqwest::Method::PATCH,
+        &format!("/api/sessions/{}", urlencoding::encode(session_id)),
+        Some(patch_body),
+    )
+    .await
     {
-        body["model"] = serde_json::Value::String(model.to_string());
-    }
-    match hermes_api_json(&bridge, reqwest::Method::POST, "/api/sessions", Some(body)).await {
-        Ok(value) => Ok(value),
-        Err(error)
-            if error.code == "hermes_bridge_api_failed"
-                && error.message.starts_with("Hermes API returned 409") =>
-        {
-            Ok(serde_json::json!({
-                "object": "hermes.session.ensure",
-                "id": session_id,
-                "created": false
-            }))
+        Ok(value) => return Ok(value),
+        Err(error) if hermes_api_status(&error, 404) || hermes_api_status(&error, 405) => {
+            let mut legacy_body = serde_json::json!({ "id": session_id, "title": title });
+            if let Some(model) = model {
+                legacy_body["model"] = serde_json::Value::String(model);
+            }
+            match hermes_api_json(
+                &bridge,
+                reqwest::Method::POST,
+                "/api/sessions",
+                Some(legacy_body),
+            )
+            .await
+            {
+                Ok(value) => Ok(value),
+                Err(error)
+                    if hermes_api_status(&error, 404)
+                        || hermes_api_status(&error, 405)
+                        || hermes_api_status(&error, 409) =>
+                {
+                    Ok(unchanged())
+                }
+                Err(error) => Err(error),
+            }
         }
         Err(error) => Err(error),
     }
+}
+
+fn hermes_api_status(error: &AppError, status_code: u16) -> bool {
+    error.code == "hermes_bridge_api_failed"
+        && error
+            .message
+            .starts_with(&format!("Hermes API returned {status_code}"))
 }
 
 #[tauri::command]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -2695,13 +2695,9 @@ export function AgentWorkspace({
     }
 
     // Open chat: override the model for THIS chat only (never the global
-    // default), persist it on the bridge, and ALSO dispatch /model to the live
-    // session so the running turn switches immediately. The per-chat override
-    // is the source of truth for the next session; the dispatch is best-effort.
-    const previousModel = hermesSessionItemsRef.current.find(
-      (session) => session.id === sessionId,
-    )?.model;
-    const previousOverride = sessionModelOverridesRef.current[sessionId];
+    // default), then dispatch /model to the live session so the running turn
+    // switches immediately. Hermes session metadata updates are title-only, so
+    // the local per-chat override is the source of truth for this row.
     sessionModelOverridesRef.current = {
       ...sessionModelOverridesRef.current,
       [sessionId]: modelId,
@@ -2711,30 +2707,6 @@ export function AgentWorkspace({
         session.id === sessionId ? { ...session, model: modelId } : session,
       ),
     );
-    try {
-      await ensureHermesBridgeSession({ sessionId, model: modelId });
-    } catch (err) {
-      // Roll back the optimistic override + session model, then surface it.
-      if (previousOverride) {
-        sessionModelOverridesRef.current = {
-          ...sessionModelOverridesRef.current,
-          [sessionId]: previousOverride,
-        };
-      } else {
-        const { [sessionId]: _removed, ...remainingOverrides } =
-          sessionModelOverridesRef.current;
-        sessionModelOverridesRef.current = remainingOverrides;
-      }
-      setHermesSessionItems((current) =>
-        current.map((session) =>
-          session.id === sessionId && session.model === modelId
-            ? { ...session, model: previousModel }
-            : session,
-        ),
-      );
-      setError(messageFromError(err));
-      return false;
-    }
     let dispatchSucceeded = false;
     try {
       const gateway = await ensureHermesGateway(sessionUnrestricted(sessionId));

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -2581,18 +2581,16 @@ describe("AgentWorkspace", () => {
       within(panel).getByRole("option", { name: /Anonymous Only/ }),
     );
 
-    await waitFor(() =>
-      expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
-        sessionId: "session-1",
-        model: "anonymous-only",
-      }),
-    );
     expect(mocks.setVeniceModel).not.toHaveBeenCalled();
     // The composer trigger reflects the new model and the session bar badge
     // its privacy mode.
     expect(
       await screen.findByRole("button", { name: "Model: Anonymous Only" }),
     ).toBeInTheDocument();
+    expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+      sessionId: "session-1",
+      model: "anonymous-only",
+    });
     expect(await screen.findByText("Anonymous mode")).toBeInTheDocument();
     expect(screen.queryByText("Private mode")).not.toBeInTheDocument();
   });
@@ -7706,13 +7704,12 @@ describe("AgentWorkspace", () => {
         within(dialog).getByRole("option", { name: /Kimi K2\.6/ }),
       );
 
-      // The model is overridden for this chat only and persisted on the bridge.
-      await waitFor(() =>
-        expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
-          sessionId: "session-1",
-          model: "kimi-k2-6",
-        }),
-      );
+      // The model is overridden for this chat only. The bridge session ensure
+      // path is title-only, so model changes are not persisted through REST.
+      expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+        sessionId: "session-1",
+        model: "kimi-k2-6",
+      });
       // The global default is left untouched.
       expect(mocks.setVeniceModel).not.toHaveBeenCalled();
       // …AND the live session is switched via command.dispatch (/model …).
@@ -7745,17 +7742,15 @@ describe("AgentWorkspace", () => {
       await user.click(screen.getByRole("button", { name: "Send message" }));
 
       await waitFor(() =>
-        expect(mocks.ensureHermesBridgeSession).toHaveBeenCalledWith({
-          sessionId: "session-1",
-          model: "kimi-k2-6",
-        }),
-      );
-      await waitFor(() =>
         expect(mocks.gatewayRequest).toHaveBeenCalledWith("command.dispatch", {
           session_id: "session-1",
           command: "/model kimi-k2-6",
         }),
       );
+      expect(mocks.ensureHermesBridgeSession).not.toHaveBeenCalledWith({
+        sessionId: "session-1",
+        model: "kimi-k2-6",
+      });
       expect(
         mocks.gatewayRequest.mock.calls.some(
           ([method]) => method === "prompt.submit",


### PR DESCRIPTION
## Summary

- Update the bundled `june_web` and `june_context` MCP stdio scripts to read newline-delimited JSON while keeping compatibility with `Content-Length` input framing.
- Emit newline-delimited JSON responses so Hermes' installed MCP SDK can complete the stdio handshake.
- Make Hermes session ensure use a best-effort title patch with legacy fallback instead of failing the chat surface on `405 Method Not Allowed`.

## Root Cause

Hermes was configured with `june_web` enabled, but the bundled Python MCP scripts spoke `Content-Length` framed stdio. The installed Hermes MCP client sends and reads newline-delimited JSON, so startup timed out and Hermes registered zero MCP tools.

## Impact

After restart, Hermes registers `mcp_june_web_web_search`, `mcp_june_web_web_fetch`, and the June context tools. The chat surface also no longer shows the session ensure `405` error when Hermes dashboard REST session creation is unavailable.

## Validation

- `python3 -m py_compile src-tauri/src/hermes/june_web_mcp.py src-tauri/src/hermes/june_context_mcp.py`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- Verified Hermes logs show `MCP: registered 4 tool(s) from 2 server(s)` after the generated runtime scripts updated.

`cargo check` still reports the existing unused `Manager` import warning in `src/commands.rs`.