### PR TITLE
Fix push-to-talk after hands-free dictation

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -774,7 +774,9 @@ pub fn dictation_helper_command(
     command: serde_json::Value,
 ) -> Result<(), AppError> {
     #[cfg(target_os = "macos")]
-    let _ = &app;
+    if helper_command_resets_shortcut_activation(&command) {
+        reset_shortcut_activation(&app);
+    }
 
     #[cfg(not(target_os = "macos"))]
     if state
@@ -787,6 +789,13 @@ pub fn dictation_helper_command(
     }
 
     send_helper_command(&state, command)
+}
+
+fn helper_command_resets_shortcut_activation(command: &serde_json::Value) -> bool {
+    matches!(
+        command.get("type").and_then(serde_json::Value::as_str),
+        Some("stop_and_paste" | "discard_recording" | "toggle_listening")
+    )
 }
 
 #[tauri::command]
@@ -3660,6 +3669,52 @@ mod tests {
             controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::PushToTalk, now),
             None
         );
+    }
+
+    #[test]
+    fn external_hands_free_stop_allows_push_to_talk_again() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
+            Some(DictationCommand::ToggleListening)
+        );
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                now + Duration::from_millis(1)
+            ),
+            None
+        );
+
+        controller.reset();
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                now + Duration::from_millis(2)
+            ),
+            Some(DictationCommand::StartListening)
+        );
+    }
+
+    #[test]
+    fn direct_helper_listening_commands_reset_shortcut_activation() {
+        assert!(helper_command_resets_shortcut_activation(
+            &serde_json::json!({ "type": "stop_and_paste" })
+        ));
+        assert!(helper_command_resets_shortcut_activation(
+            &serde_json::json!({ "type": "discard_recording" })
+        ));
+        assert!(helper_command_resets_shortcut_activation(
+            &serde_json::json!({ "type": "toggle_listening" })
+        ));
+        assert!(!helper_command_resets_shortcut_activation(
+            &serde_json::json!({ "type": "start_shortcut_capture" })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Task: user-reported bug, no tracker issue. After using Hands-free mode, push-to-talk could not be triggered anymore.

What changed:
- Reset the shortcut activation controller when direct helper listening commands bypass the shortcut down/up path.
- Added regression coverage for a hands-free toggle state being cleared before push-to-talk starts again.
- Added command classification coverage for direct stop, discard, and toggle helper commands.

Why:
- The shortcut controller intentionally blocks push-to-talk while toggle dictation is active. Stopping hands-free through the HUD sends `stop_and_paste` directly, so the controller never saw the second toggle press that would clear `active_mode`.

Validation:
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked external_hands_free_stop_allows_push_to_talk_again`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked direct_helper_listening_commands_reset_shortcut_activation`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked dictation::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

Known gaps:
- Not manually verified against the packaged macOS helper in a running app from this worktree.