### PR TITLE
Teach June to clarify ambiguous first prompts

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -80,6 +80,13 @@ const JUNE_SOUL_CONTEXT_MD: &str = r#"
 June context tools: you have access to a local `june_context` MCP toolset for searching the user's June meeting notes, saved note transcripts, and dictation history. Use it when the user asks about prior meetings, calls, recordings, notes, decisions, follow-ups, or dictated text. Query it on demand instead of assuming you already know those entries, and summarize only what the retrieved results support.
 "#;
 
+/// Appended to `SOUL.md` for every runtime. This calibrates June's first-turn
+/// behavior around the existing Hermes clarify capability: ask only when the
+/// missing detail materially changes the work, and otherwise keep moving.
+const JUNE_SOUL_CLARIFY_MD: &str = r#"
+Clarifying questions: before acting on a request, especially the first user message in a new session, decide whether the user's goal, target, constraints, and success criteria are clear enough to proceed. If the request is ambiguous, has multiple reasonable interpretations, or a wrong assumption would spend meaningful time, use the clarify capability to ask one or two concise questions before using tools, modifying files, spending money, or starting long work. If a conservative path is obvious and cheap to correct, proceed and state your assumption instead of adding friction. Do not ask questions for routine, low-risk, or already clear requests.
+"#;
+
 /// Appended to `SOUL.md` for every runtime. The `web_search` and `web_fetch`
 /// tools are discovered through the `june_web` MCP server configured below;
 /// this note teaches the model when to reach for them. Web access runs through
@@ -3615,10 +3622,10 @@ fn sync_june_soul(
             JUNE_SOUL_CLI_BLOCKED_MD
         };
         format!(
-            "{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_SANDBOX_MD}{cli_section}"
+            "{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_SANDBOX_MD}{cli_section}"
         )
     } else {
-        format!("{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_WEB_MD}")
+        format!("{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}")
     };
     std::fs::write(hermes_home.join("SOUL.md"), soul)
         .map_err(|error| AppError::new("hermes_bridge_soul_failed", error.to_string()))
@@ -4840,6 +4847,20 @@ mod tests {
         assert!(soul.contains("meeting notes"));
         assert!(soul.contains("dictation history"));
         assert!(soul.contains("Query it on demand"));
+    }
+
+    #[test]
+    fn june_soul_asks_for_clarification_before_costly_ambiguous_work() {
+        let home = tempfile::tempdir().expect("tempdir");
+
+        sync_june_soul(home.path(), false, false).expect("sync soul");
+
+        let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
+        assert!(soul.contains("Clarifying questions"));
+        assert!(soul.contains("first user message in a new session"));
+        assert!(soul.contains("multiple reasonable interpretations"));
+        assert!(soul.contains("use the clarify capability"));
+        assert!(soul.contains("Do not ask questions for routine"));
     }
 
     #[test]


### PR DESCRIPTION
Closes JUN-121

## What changed
- Added a dedicated clarifying-questions section to June's generated Hermes SOUL.md.
- Calibrated the behavior to ask one or two questions before acting when the first user message is ambiguous, expensive to guess, or has multiple reasonable interpretations.
- Kept the existing fast path for clear or low-risk requests so June does not add unnecessary friction.
- Added a Hermes bridge unit test that pins the new soul guidance.

## Why
Users reported that June can start acting immediately on underspecified initial prompts. The existing clarify surface already exists, so this teaches the runtime when to use it.

## Validation
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --locked hermes_bridge
- cargo test --manifest-path src-tauri/Cargo.toml --locked

## Known gaps
- No manual Hermes runtime session was exercised in this local run.