### PR TITLE
Route June upgrades through subscription checkout

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -238,7 +238,7 @@ pub fn run() {
             os_accounts::os_accounts_login,
             os_accounts::os_accounts_cancel_login,
             os_accounts::os_accounts_logout,
-            os_accounts::os_accounts_top_up,
+            os_accounts::os_accounts_upgrade,
             os_accounts::os_accounts_open_portal,
             os_accounts::os_accounts_referral_summary,
         ])

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -30,10 +30,10 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const DEFAULT_LOOPBACK_PORT: u16 = 8765;
 // Scopes Scribe needs. profile:read for /me, billing:read for /billing/balance,
-// and credits:spend so Scribe API can authorize-and-charge against the user's
-// credits for transcription / generation / dictation work. Billing writes stay
-// in the accounts portal instead of the desktop login grant.
-const OAUTH_SCOPES: &str = "profile:read billing:read credits:spend";
+// billing:write for subscription checkout, and credits:spend so Scribe API can
+// authorize-and-charge against the user's credits for transcription /
+// generation / dictation work.
+const OAUTH_SCOPES: &str = "profile:read billing:read billing:write credits:spend";
 // Scribe's OS Accounts token store. Keep this app-scoped so Scribe does not
 // touch credentials written by other Open Software apps on startup.
 const KEYCHAIN_SERVICE: &str = "co.opensoftware.scribe.accounts";
@@ -65,6 +65,7 @@ struct Envelope<T> {
     data: Option<T>,
     success: bool,
     error_code: Option<i64>,
+    message: Option<String>,
 }
 
 /// Token pair. Stored in the OS keychain by default, **never** handed to the webview.
@@ -88,6 +89,11 @@ struct MeWire {
 struct BalanceWire {
     credits: i64,
     usd_millis: i64,
+}
+
+#[derive(Deserialize)]
+struct CheckoutSessionWire {
+    url: String,
 }
 
 #[derive(Deserialize)]
@@ -523,13 +529,27 @@ pub async fn os_accounts_logout() -> Result<(), AppError> {
 }
 
 #[tauri::command]
-pub fn os_accounts_top_up() -> Result<(), AppError> {
+pub async fn os_accounts_upgrade() -> Result<(), AppError> {
     if local_dev_enabled() {
         return Ok(());
     }
     let cfg = Config::load();
-    let url = credits_url(&cfg)?;
-    open_in_browser(&url)
+    if !cfg.configured() {
+        return Err(AppError::new(
+            "os_accounts_unconfigured",
+            "OS Accounts is not configured for this build.",
+        ));
+    }
+    let session: CheckoutSessionWire =
+        authed_post(&cfg, "/billing/subscription", serde_json::json!({})).await?;
+    let url = session.url.trim();
+    if url.is_empty() {
+        return Err(AppError::new(
+            "empty_response",
+            "OS Accounts returned no checkout URL.",
+        ));
+    }
+    open_in_browser(url)
 }
 
 /// Opens the accounts portal in the default browser. The webview swallows
@@ -1030,10 +1050,59 @@ async fn authed_get<T: for<'de> Deserialize<'de>>(cfg: &Config, path: &str) -> R
         }
         return Err(AppError::new(
             "request_failed",
-            "OS Accounts request failed.",
+            accounts_request_failed_message(resp.message),
         ));
     }
     Err(AppError::new("unauthorized", "Not signed in."))
+}
+
+async fn authed_post<T: for<'de> Deserialize<'de>>(
+    cfg: &Config,
+    path: &str,
+    body: serde_json::Value,
+) -> Result<T, AppError> {
+    let url = format!("{}{}", cfg.api_url.trim_end_matches('/'), path);
+    let mut access = access_token().await?;
+    for attempt in 0..2 {
+        let response = http_client()
+            .post(&url)
+            .bearer_auth(&access)
+            .json(&body)
+            .send()
+            .await
+            .map_err(net_error)?;
+        let status = response.status();
+        let body = response.text().await.map_err(net_error)?;
+        if body.trim().is_empty() {
+            return Err(empty_accounts_response(path, status));
+        }
+        let resp: Envelope<T> = serde_json::from_str(&body)
+            .map_err(|error| decode_accounts_response_error(path, error))?;
+        if resp.success {
+            return resp
+                .data
+                .ok_or_else(|| AppError::new("empty_response", "OS Accounts returned no data."));
+        }
+        if resp.error_code == Some(ERR_TOKEN_EXPIRED) && attempt == 0 {
+            access = refresh_locked(cfg).await?;
+            continue;
+        }
+        return Err(AppError::new(
+            "request_failed",
+            accounts_request_failed_message(resp.message),
+        ));
+    }
+    Err(AppError::new("unauthorized", "Not signed in."))
+}
+
+fn accounts_request_failed_message(message: Option<String>) -> String {
+    match message.as_deref() {
+        Some("access token is missing required scope") => {
+            "Sign in again to refresh your billing permissions.".to_string()
+        }
+        Some(message) => message.to_string(),
+        None => "OS Accounts request failed.".to_string(),
+    }
 }
 
 fn empty_accounts_response(path: &str, status: reqwest::StatusCode) -> AppError {
@@ -1085,17 +1154,6 @@ async fn fetch_snapshot(
 fn portal_url(cfg: &Config) -> Option<String> {
     let url = cfg.accounts_url.trim_end_matches('/');
     (!url.is_empty()).then(|| url.to_string())
-}
-
-fn credits_url(cfg: &Config) -> Result<String, AppError> {
-    let url = cfg.accounts_url.trim().trim_end_matches('/');
-    if url.is_empty() {
-        return Err(AppError::new(
-            "os_accounts_unconfigured",
-            "OS Accounts is not configured for this build.",
-        ));
-    }
-    Ok(format!("{url}/billing/credits"))
 }
 
 fn net_error(e: reqwest::Error) -> AppError {
@@ -1407,30 +1465,8 @@ mod tests {
     }
 
     #[test]
-    fn credits_url_targets_billing_credits_page() {
-        let cfg = Config {
-            accounts_url: "https://accounts.example/".to_string(),
-            api_url: String::new(),
-            client_id: String::new(),
-            loopback_port: DEFAULT_LOOPBACK_PORT,
-        };
-
-        assert_eq!(
-            credits_url(&cfg).expect("credits url"),
-            "https://accounts.example/billing/credits"
-        );
-    }
-
-    #[test]
-    fn credits_url_rejects_missing_accounts_url() {
-        let cfg = Config {
-            accounts_url: "   ".to_string(),
-            api_url: String::new(),
-            client_id: String::new(),
-            loopback_port: DEFAULT_LOOPBACK_PORT,
-        };
-
-        let error = credits_url(&cfg).expect_err("missing accounts url");
-        assert_eq!(error.code, "os_accounts_unconfigured");
+    fn oauth_scope_allows_checkout_and_credit_spend() {
+        assert!(OAUTH_SCOPES.contains("billing:write"));
+        assert!(OAUTH_SCOPES.contains("credits:spend"));
     }
 }

--- a/src-tauri/src/scribe_api.rs
+++ b/src-tauri/src/scribe_api.rs
@@ -998,7 +998,7 @@ where
     if envelope.error_code == Some(ERR_INSUFFICIENT_CREDITS) {
         return Err(AppError::new(
             "insufficient_credits",
-            "Your balance is too low. Add funds to continue.",
+            "Your balance is too low. Upgrade to continue.",
         ));
     }
     let _ = path;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -85,7 +85,7 @@ import {
   listSessionFolders,
   openPrivacySettings,
   osAccountsLogout,
-  osAccountsTopUp,
+  osAccountsUpgrade,
   pauseRecording,
   removeNoteFromFolder,
   removeSessionFromFolder,
@@ -3215,7 +3215,7 @@ export function App() {
                         }
                       }}
                       onTopUp={() =>
-                        void osAccountsTopUp().catch((err: unknown) =>
+                        void osAccountsUpgrade().catch((err: unknown) =>
                           setError(messageFromError(err)),
                         )
                       }

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -6,7 +6,7 @@ import {
   osAccountsLogin,
   osAccountsLogout,
   osAccountsOpenPortal,
-  osAccountsTopUp,
+  osAccountsUpgrade,
 } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 
@@ -170,12 +170,10 @@ export function BillingSettingsSection({
   const [billingStatus, setBillingStatus] = useState<string>();
   const [spins, setSpins] = useState(0);
 
-  async function handleTopUp() {
+  async function handleUpgrade() {
     try {
-      await osAccountsTopUp();
-      setBillingStatus(
-        "Opened OS Accounts. Check again here after adding credits.",
-      );
+      await osAccountsUpgrade();
+      setBillingStatus("Opened checkout in your browser.");
     } catch (error) {
       setBillingStatus(messageFromError(error));
     }
@@ -191,32 +189,30 @@ export function BillingSettingsSection({
   }
 
   const subscription = account.subscription;
+  const liveSubscription = hasLiveSubscription(account);
   const billingRecovery =
     subscription?.subscribed === true &&
     typeof subscription.status === "string" &&
     subscription.status.length > 0 &&
-    !hasLiveSubscription(account);
-  const subscriptionRow =
-    subscription?.status === "trialing"
+    !liveSubscription;
+  const subscriptionRow = liveSubscription
+    ? {
+        title: "Subscription",
+        detail:
+          subscription?.status === "trialing"
+            ? (describeEnd("Billing starts", subscription.trialEnd) ?? "Active")
+            : (describeEnd("Renews", subscription?.currentPeriodEnd) ??
+              "Active"),
+        cta: "Manage billing",
+      }
+    : billingRecovery
       ? {
-          title: "Free trial",
-          detail: describeEnd("Ends", subscription.trialEnd) ?? "Active now",
-          cta: "Manage subscription",
+          title: "Billing needs attention",
+          detail: "Open your account portal to update billing.",
+          cta: "Manage billing",
         }
-      : subscription?.status === "active"
-        ? {
-            title: "Subscription",
-            detail:
-              describeEnd("Renews", subscription.currentPeriodEnd) ?? "Active",
-            cta: "Manage subscription",
-          }
-        : billingRecovery
-          ? {
-              title: "Billing needs attention",
-              detail: "Open your account portal to update billing.",
-              cta: "Manage billing",
-            }
-          : undefined;
+      : undefined;
+  const canUpgrade = account.signedIn && !liveSubscription && !billingRecovery;
 
   async function handleRefresh() {
     setRefreshing(true);
@@ -285,14 +281,15 @@ export function BillingSettingsSection({
                   style={{ transform: `rotate(${spins * 360}deg)` }}
                 />
               </button>
-              <button
-                type="button"
-                className="btn btn-secondary"
-                disabled={!account.signedIn}
-                onClick={() => void handleTopUp()}
-              >
-                Add funds
-              </button>
+              {canUpgrade ? (
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => void handleUpgrade()}
+                >
+                  Upgrade
+                </button>
+              ) : null}
             </div>
           </div>
         </div>

--- a/src/components/account/FundingGate.tsx
+++ b/src/components/account/FundingGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { hasLiveSubscription } from "../../lib/account-gate";
-import { osAccountsOpenPortal, osAccountsTopUp } from "../../lib/tauri";
+import { osAccountsOpenPortal, osAccountsUpgrade } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 import { Spinner } from "../ui/Spinner";
 import { JuneMark } from "./AccountGate";
@@ -29,16 +29,18 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
     ? {
         title: "Update billing",
         subtitle:
-          "Your payment needs attention. Update billing, or add credits, to keep using June.",
+          "Your payment needs attention. Update billing to keep using June.",
         cta: "Manage billing",
         waiting: "Waiting for your billing update",
+        reopen: "Reopen billing",
       }
     : {
-        title: "Add credits to continue",
+        title: "Upgrade to continue",
         subtitle:
-          "June uses credits for recordings, dictation, and agent work. Add credits in your OpenSoftware account to keep going.",
-        cta: "Add credits",
-        waiting: "Waiting for your credits",
+          "Your starter credits are used up. Upgrade to a paid plan to keep using June.",
+        cta: "Upgrade",
+        waiting: "Waiting for your upgrade",
+        reopen: "Reopen checkout",
       };
 
   useEffect(() => {
@@ -54,7 +56,7 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
       if (billingRecovery) {
         await osAccountsOpenPortal();
       } else {
-        await osAccountsTopUp();
+        await osAccountsUpgrade();
       }
       setOpenedPortal(true);
     } catch (error) {
@@ -108,7 +110,7 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
                   className="funding-gate-link"
                   onClick={() => void handleOpenPortal()}
                 >
-                  Reopen account
+                  {copy.reopen}
                 </button>
               </p>
             </>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -99,7 +99,7 @@ import {
   listAgentTasks,
   downloadHermesBridgeFile,
   openHermesTuiDebug,
-  osAccountsTopUp,
+  osAccountsUpgrade,
   providerModelSettings,
   retryAgentTask,
   sendAgentMessage,
@@ -6645,7 +6645,7 @@ export function AgentWorkspace({
             )
           }
           onTopUp={() =>
-            void osAccountsTopUp().catch((err: unknown) =>
+            void osAccountsUpgrade().catch((err: unknown) =>
               setError(messageFromError(err)),
             )
           }
@@ -6751,7 +6751,7 @@ export function AgentWorkspace({
             onDownloadArtifact={downloadArtifact}
             onOpenArtifact={openArtifact}
             onTopUp={() =>
-              void osAccountsTopUp().catch((err: unknown) =>
+              void osAccountsUpgrade().catch((err: unknown) =>
                 setError(messageFromError(err)),
               )
             }
@@ -9609,7 +9609,7 @@ function CreditsNoticePart({ onTopUp }: { onTopUp?: () => void }) {
       actions={
         onTopUp ? (
           <button type="button" className="btn btn-secondary" onClick={onTopUp}>
-            Add funds
+            Upgrade
           </button>
         ) : undefined
       }
@@ -9783,10 +9783,7 @@ function ClarifyPart({
   const disabled = part.status !== "pending" || submitting !== undefined;
 
   return (
-    <article
-      className="agent-clarify-card"
-      data-status={part.status}
-    >
+    <article className="agent-clarify-card" data-status={part.status}>
       <span className="agent-tool-icon">
         <IconBubbleWide size={14} />
       </span>
@@ -10018,10 +10015,7 @@ function ApprovalPart({
   }
 
   return (
-    <article
-      className="agent-approval-card"
-      data-status={part.status}
-    >
+    <article className="agent-approval-card" data-status={part.status}>
       <span className="agent-tool-icon">
         <IconShieldCheck size={14} />
       </span>
@@ -10229,10 +10223,7 @@ export function SudoPart({
     part.approved ?? (submitting ? submitting === "approve" : undefined);
 
   return (
-    <article
-      className="agent-approval-card"
-      data-status={part.status}
-    >
+    <article className="agent-approval-card" data-status={part.status}>
       <span className="agent-tool-icon">
         {unrestricted ? (
           <IconShieldCrossed size={14} />
@@ -10362,10 +10353,7 @@ export function SecretPart({
   }
 
   return (
-    <article
-      className="agent-approval-card"
-      data-status={part.status}
-    >
+    <article className="agent-approval-card" data-status={part.status}>
       <span className="agent-tool-icon">
         <IconLock size={14} />
       </span>

--- a/src/components/note-editor/NoteFailureBanner.tsx
+++ b/src/components/note-editor/NoteFailureBanner.tsx
@@ -93,8 +93,8 @@ export function NoteFailureBanner({
       <p className="note-failure-message">
         {isBalanceIssue
           ? audioPreserved
-            ? "Your balance ran out. Your recording is saved locally, so add funds and retry."
-            : "Your balance is too low. Add funds to continue."
+            ? "Your balance ran out. Your recording is saved locally, so upgrade and retry."
+            : "Your balance is too low. Upgrade to continue."
           : (displayMessage ?? "June couldn't finish processing this note.")}
         {!isBalanceIssue && audioPreserved
           ? " Your recording is saved locally, so you can retry."
@@ -108,7 +108,7 @@ export function NoteFailureBanner({
             onClick={onTopUp}
             disabled={retrying}
           >
-            Add funds
+            Upgrade
           </button>
         ) : null}
         <button

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -53,7 +53,7 @@ export function useAccountStatus(
     };
   }, [forceLogoutOnMount, refresh]);
 
-  // Refetch when the app regains attention so the user sees their post-top-up
+  // Refetch when the app regains attention so the user sees their post-upgrade
   // balance without hunting for a refresh button. `focus` and `visibilitychange`
   // both fire in Tauri webviews; the inFlight flag de-dupes a focus event that
   // arrives while the on-mount fetch is still pending.

--- a/src/lib/agent-chat-gallery.ts
+++ b/src/lib/agent-chat-gallery.ts
@@ -219,7 +219,7 @@ export function buildAgentChatGallery(): AgentChatGallerySection[] {
     {
       label: CREDITS_SECTION_LABEL,
       description:
-        "A turn that died on a billing failure renders as a notice card with a top-up action instead of the raw provider error.",
+        "A turn that died on a billing failure renders as a notice card with an upgrade action instead of the raw provider error.",
       turns: [
         assistantTurn("credits", [
           {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1279,8 +1279,8 @@ export async function osAccountsLogout() {
   return invoke<void>("os_accounts_logout");
 }
 
-export async function osAccountsTopUp() {
-  return invoke<void>("os_accounts_top_up");
+export async function osAccountsUpgrade() {
+  return invoke<void>("os_accounts_upgrade");
 }
 
 /** Opens the accounts portal in the default browser — the webview swallows

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1231,7 +1231,7 @@ describe("Agent chat runtime", () => {
 
   it("keeps assistant prose about credits as ordinary text", () => {
     const prose =
-      "If you see insufficient_credits errors, top up from settings.";
+      "If you see insufficient_credits errors, upgrade from settings.";
     const turns = buildHermesSessionChatTurns([
       {
         id: "1",

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -53,7 +53,7 @@ const mocks = vi.hoisted(() => ({
   listVeniceModels: vi.fn(),
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
-  osAccountsTopUp: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
   setVeniceModel: vi.fn(),
   providerModelSettings: vi.fn(),
   retryAgentTask: vi.fn(),
@@ -112,7 +112,7 @@ vi.mock("../lib/tauri", () => ({
   listVeniceModels: mocks.listVeniceModels,
   listAgentTasks: mocks.listAgentTasks,
   downloadHermesBridgeFile: mocks.downloadHermesBridgeFile,
-  osAccountsTopUp: mocks.osAccountsTopUp,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
   providerModelSettings: mocks.providerModelSettings,
   retryAgentTask: mocks.retryAgentTask,
   setHermesAgentCliAccess: mocks.setHermesAgentCliAccess,
@@ -7459,9 +7459,9 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Hermes gateway is not connected.")).toBeNull();
   });
 
-  it("renders an out-of-credits notice with a top-up action instead of the raw 402 error", async () => {
+  it("renders an out-of-credits notice with an upgrade action instead of the raw 402 error", async () => {
     const user = userEvent.setup();
-    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
         id: "m1",
@@ -7485,8 +7485,8 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/Error code: 402/)).toBeNull();
 
-    await user.click(screen.getByRole("button", { name: "Add funds" }));
-    expect(mocks.osAccountsTopUp).toHaveBeenCalledOnce();
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledOnce();
   });
 
   it("shows every error surface via the __agentErrors() dev handle", async () => {
@@ -7505,7 +7505,7 @@ describe("AgentWorkspace", () => {
       // Turn-level samples from the catalog (section label + the card itself)…
       expect(screen.getAllByText("Out of credits").length).toBeGreaterThan(0);
       expect(
-        screen.getByRole("button", { name: "Add funds" }),
+        screen.getByRole("button", { name: "Upgrade" }),
       ).toBeInTheDocument();
       // …plus the forced chrome samples the turn gallery can't represent.
       expect(

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -44,7 +44,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsLogin: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
-  osAccountsTopUp: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
   agentHudShow: vi.fn(),
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
@@ -95,7 +95,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsLogin: mocks.osAccountsLogin,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
-  osAccountsTopUp: mocks.osAccountsTopUp,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
   agentHudShow: mocks.agentHudShow,
   agentHudHide: mocks.agentHudHide,
   // The agent workspace mounts at launch; a quiet, not-running bridge keeps
@@ -204,7 +204,7 @@ describe("meeting start transcription event", () => {
     mocks.osAccountsLogin.mockResolvedValue(account);
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
-    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
     mocks.updateNote.mockImplementation(async (input) => ({
       ...first,
       ...input,

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -51,7 +51,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsLogin: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
-  osAccountsTopUp: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
   agentHudShow: vi.fn(),
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
@@ -106,7 +106,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsLogin: mocks.osAccountsLogin,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
-  osAccountsTopUp: mocks.osAccountsTopUp,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
   agentHudShow: mocks.agentHudShow,
   agentHudHide: mocks.agentHudHide,
   // The agent workspace mounts at launch; a quiet, not-running bridge keeps
@@ -280,7 +280,7 @@ describe("notes recording reliability", () => {
     mocks.osAccountsLogin.mockResolvedValue(account);
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
-    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
     mocks.updateNote.mockImplementation(async (input) => ({
       ...first,
       ...input,

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
   osAccountsOpenPortal: vi.fn(),
-  osAccountsTopUp: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
   hermesBridgeSkills: vi.fn(),
   hermesBridgeToolsets: vi.fn(),
   hermesBridgeMessagingPlatforms: vi.fn(),
@@ -66,7 +66,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
   osAccountsOpenPortal: mocks.osAccountsOpenPortal,
-  osAccountsTopUp: mocks.osAccountsTopUp,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
   hermesBridgeMessagingPlatforms: mocks.hermesBridgeMessagingPlatforms,
@@ -324,7 +324,7 @@ describe("AppSettings", () => {
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
-    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
     mocks.agentHudShow.mockResolvedValue(undefined);
     mocks.agentHudHide.mockResolvedValue(undefined);
     mocks.hermesAgentCliAccess.mockResolvedValue({ enabled: false });
@@ -391,7 +391,7 @@ describe("AppSettings", () => {
     });
   });
 
-  it("opens OS Accounts from Add funds in billing settings", async () => {
+  it("opens checkout from Upgrade in billing settings", async () => {
     const user = userEvent.setup();
     render(
       <AppSettings
@@ -407,8 +407,8 @@ describe("AppSettings", () => {
     );
 
     await user.click(screen.getByRole("tab", { name: "Billing" }));
-    await user.click(screen.getByRole("button", { name: "Add funds" }));
-    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledTimes(1);
   });
 
   it("runs sign-in, cancel, and sign-out actions from account settings", async () => {
@@ -500,9 +500,7 @@ describe("AppSettings", () => {
     );
 
     await user.click(screen.getByRole("tab", { name: "Billing" }));
-    await user.click(
-      screen.getByRole("button", { name: "Manage subscription" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Manage billing" }));
     expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
     expect(
       await screen.findByText("Opened your account portal in the browser."),

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -76,7 +76,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsLogin: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
-  osAccountsTopUp: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
   agentHudShow: vi.fn(),
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
@@ -138,7 +138,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsLogin: mocks.osAccountsLogin,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
-  osAccountsTopUp: mocks.osAccountsTopUp,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
   agentHudShow: mocks.agentHudShow,
   agentHudHide: mocks.agentHudHide,
   // The agent workspace mounts at launch; a quiet, not-running bridge keeps
@@ -228,7 +228,7 @@ describe("App shortcuts", () => {
     });
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
-    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
     mocks.startPeriodicScribeUpdateChecks.mockReturnValue(vi.fn());
     mocks.listeners.clear();
     mocks.listen.mockImplementation(

--- a/src/test/funding-gate.test.tsx
+++ b/src/test/funding-gate.test.tsx
@@ -6,12 +6,12 @@ import type { AccountStatus } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   osAccountsOpenPortal: vi.fn(),
-  osAccountsTopUp: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
 }));
 
 vi.mock("../lib/tauri", () => ({
   osAccountsOpenPortal: mocks.osAccountsOpenPortal,
-  osAccountsTopUp: mocks.osAccountsTopUp,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
 }));
 
 const baseAccount: AccountStatus = {
@@ -36,10 +36,10 @@ describe("FundingGate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
-    mocks.osAccountsTopUp.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
   });
 
-  it("asks users with no credits to add credits, not start a card trial", async () => {
+  it("asks users with no credits to upgrade, not add credits", async () => {
     const user = userEvent.setup();
     const onSignOut = vi.fn();
     render(
@@ -51,7 +51,7 @@ describe("FundingGate", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Add credits to continue" }),
+      screen.getByRole("heading", { name: "Upgrade to continue" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Start free trial" }),
@@ -60,10 +60,10 @@ describe("FundingGate", () => {
       screen.queryByRole("list", { name: "How your free trial works" }),
     ).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Add credits" }));
-    expect(mocks.osAccountsTopUp).toHaveBeenCalledOnce();
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledOnce();
     expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
-    await screen.findByText("Waiting for your credits");
+    await screen.findByText("Waiting for your upgrade");
 
     await user.click(screen.getByRole("button", { name: "Sign out" }));
     expect(onSignOut).toHaveBeenCalledOnce();
@@ -82,7 +82,7 @@ describe("FundingGate", () => {
 
     await user.click(screen.getByRole("button", { name: "Manage billing" }));
     expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
-    expect(mocks.osAccountsTopUp).not.toHaveBeenCalled();
+    expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
   });
 
   it("opens billing management for incomplete subscriptions", async () => {
@@ -96,12 +96,12 @@ describe("FundingGate", () => {
       screen.getByRole("heading", { name: "Update billing" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("heading", { name: "Add credits to continue" }),
+      screen.queryByRole("heading", { name: "Upgrade to continue" }),
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Manage billing" }));
     expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
-    expect(mocks.osAccountsTopUp).not.toHaveBeenCalled();
+    expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
   });
 
   it("lets a waiting account update be checked or reopened", async () => {
@@ -115,14 +115,14 @@ describe("FundingGate", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Add credits" }));
-    await screen.findByText("Waiting for your credits");
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+    await screen.findByText("Waiting for your upgrade");
 
     await user.click(screen.getByRole("button", { name: "Check again" }));
     expect(onRefresh).toHaveBeenCalledOnce();
 
-    await user.click(screen.getByRole("button", { name: "Reopen account" }));
-    expect(mocks.osAccountsTopUp).toHaveBeenCalledTimes(2);
+    await user.click(screen.getByRole("button", { name: "Reopen checkout" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledTimes(2);
   });
 
   it("polls account refresh while the gate is visible", async () => {

--- a/src/test/note-failure-banner.test.tsx
+++ b/src/test/note-failure-banner.test.tsx
@@ -10,7 +10,7 @@ import {
 describe("classifyFailure", () => {
   it("treats Scribe's low-balance message as a balance issue", () => {
     expect(
-      classifyFailure("Your balance is too low. Add funds to continue."),
+      classifyFailure("Your balance is too low. Upgrade to continue."),
     ).toBe("balance_low");
   });
 
@@ -46,12 +46,12 @@ describe("userFacingFailureMessage", () => {
 });
 
 describe("NoteFailureBanner", () => {
-  it("offers Add funds + Retry when the balance is too low", async () => {
+  it("offers Upgrade + Retry when the balance is too low", async () => {
     const onTopUp = vi.fn();
     const onRetry = vi.fn();
     render(
       <NoteFailureBanner
-        errorMessage="Your balance is too low. Add funds to continue."
+        errorMessage="Your balance is too low. Upgrade to continue."
         audioPreserved
         onRetry={onRetry}
         onTopUp={onTopUp}
@@ -65,7 +65,7 @@ describe("NoteFailureBanner", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("heading")).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: /Add funds/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Upgrade/i }));
     expect(onTopUp).toHaveBeenCalledOnce();
 
     await userEvent.click(screen.getByRole("button", { name: /Retry/i }));
@@ -83,7 +83,7 @@ describe("NoteFailureBanner", () => {
     );
     expect(screen.getByText(/Network unreachable/i)).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Add funds/i }),
+      screen.queryByRole("button", { name: /Upgrade/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Retry/i })).toBeEnabled();
     expect(


### PR DESCRIPTION
## Summary
- Change low-balance and settings CTAs from add-funds/top-up language to Upgrade before a paid plan is active.
- Add a Tauri `os_accounts_upgrade` command that calls OS Accounts `POST /billing/subscription` and opens the returned Stripe checkout URL directly.
- Keep Manage billing routed to the accounts portal for active or billing-recovery subscription states.
- Request `billing:write` during OS Accounts login and surface a clearer re-sign-in message for old tokens missing the new scope.

## Validation
- `pnpm test src/test/app-settings.test.tsx src/test/funding-gate.test.tsx src/test/note-failure-banner.test.tsx src/test/agent-workspace.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml os_accounts --locked`
- `pnpm lint`
- `pnpm build`

## Notes
- `pnpm format` still reports pre-existing formatting drift in unrelated files: `src/lib/hermes-routines.ts`, `src/lib/live-transcript-preview.ts`, `src/lib/recording-inactivity.ts`, `src/test/hermes-routines.test.ts`, `src/test/recording-inactivity.test.ts`, and `src-tauri/tauri.conf.json`.
