### PR TITLE
Disable turn action hover animation

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1660,31 +1660,29 @@ input:focus-visible,
 
 /* Feature 07: the per-turn "Branch from here" control. Quiet by default and
  * revealed on hover/focus so it doesn't clutter the transcript, mirroring the
- * restraint of the tool-row affordances. The user turn right-aligns its bubble,
- * so the actions row wraps full-width beneath and right-aligns to match. */
+ * restraint of the tool-row affordances. The row is positioned outside normal
+ * flow so the hover reveal cannot expand the message height. */
 .agent-user-turn {
   flex-wrap: wrap;
+  position: relative;
 }
 
 .agent-turn-actions {
-  display: grid;
-  grid-template-rows: 0fr;
+  position: absolute;
+  z-index: 1;
+  inset-block-start: 100%;
+  inset-inline-start: 0;
   width: 100%;
   opacity: 0;
-  /* Collapse the action row to zero height when not hovered so non-hovered
-   * messages sit tight. opacity alone (the JUN-114 bug) left the row in flow,
-   * reserving its full height under every message; the grid-rows 0fr->1fr trick
-   * animates it open on hover without reserving the space when hidden. */
-  transition:
-    grid-template-rows 0.14s ease-out,
-    opacity 0.12s ease-out;
+  pointer-events: none;
+  /* The row sits in the existing inter-turn space instead of participating in
+   * layout, so hover can reveal it without expanding the message height. */
+  transition: none;
 }
 
 .agent-turn-actions-inner {
   display: flex;
   gap: var(--sp-1);
-  min-height: 0;
-  overflow: hidden;
   padding-top: var(--sp-px);
 }
 
@@ -1692,12 +1690,16 @@ input:focus-visible,
   justify-content: flex-end;
 }
 
+.agent-assistant-turn-body {
+  position: relative;
+}
+
 .agent-user-turn:hover .agent-turn-actions,
 .agent-user-turn:focus-within .agent-turn-actions,
 .agent-assistant-turn:hover .agent-turn-actions,
 .agent-assistant-turn:focus-within .agent-turn-actions {
-  grid-template-rows: 1fr;
   opacity: 1;
+  pointer-events: auto;
 }
 
 .agent-turn-action {

--- a/src/test/agent-turn-actions-css.test.ts
+++ b/src/test/agent-turn-actions-css.test.ts
@@ -18,18 +18,21 @@ function cssRuleFor(selector: string) {
 }
 
 describe("agent turn action styles", () => {
-  it("collapses hidden per-message controls to zero height so non-hovered rows stay tight", () => {
-    // opacity alone (the JUN-114 regression) left the row in flow and reserved
-    // its full height under every message. Collapse it to a 0fr grid row when
-    // hidden so non-hovered messages sit tight; hover opens it to 1fr.
-    expect(cssRuleFor(".agent-turn-actions")).toContain(
-      "grid-template-rows: 0fr;",
-    );
-    // The inner row is clipped so the collapse actually hides the buttons.
-    const inner = cssRuleFor(".agent-turn-actions-inner");
-    expect(inner).toContain("min-height: 0;");
-    expect(inner).toContain("overflow: hidden;");
-    // Hover reveals it without reserving space when hidden.
-    expect(appCss).toContain("grid-template-rows: 1fr;");
+  it("reveals per-message controls without animating or changing row height", () => {
+    const actions = cssRuleFor(".agent-turn-actions");
+    expect(actions).toContain("position: absolute;");
+    expect(actions).toContain("inset-block-start: 100%;");
+    expect(actions).toContain("opacity: 0;");
+    expect(actions).toContain("pointer-events: none;");
+    expect(actions).toContain("transition: none;");
+    expect(actions).not.toContain("grid-template-rows");
+
+    expect(appCss).toContain(`.agent-user-turn:hover .agent-turn-actions,
+.agent-user-turn:focus-within .agent-turn-actions,
+.agent-assistant-turn:hover .agent-turn-actions,
+.agent-assistant-turn:focus-within .agent-turn-actions {
+  opacity: 1;
+  pointer-events: auto;
+}`);
   });
 });


### PR DESCRIPTION
## Summary
- Keep per-message action controls out of normal layout so hover reveal cannot expand the message row
- Reveal copy/edit/branch controls instantly with opacity and pointer-event toggles instead of grid-row animation
- Update the focused CSS regression test to lock in no height-changing action-row reveal

## Validation
- `pnpm exec vitest run src/test/agent-turn-actions-css.test.ts`
- `pnpm run lint`
- `pnpm exec prettier --check src/styles/app.css src/test/agent-turn-actions-css.test.ts`

## Known gaps
- No tracker issue was provided in the prompt.