### PR TITLE
release: v0.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-scribe",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "os-scribe"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-scribe"
-version = "0.0.19"
+version = "0.0.20"
 description = "June"
 authors = ["Open Software Network"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "June",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "identifier": "co.opensoftware.scribe",
   "build": {
     "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",


### PR DESCRIPTION
## Summary
- Reconcile source versions to the published June v0.0.20 macOS release.
- The production release artifacts were already published by workflow run 28260129530; only the direct push of this version bump to protected main was rejected.

## Verification
- Version-only diff: package.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock, src-tauri/tauri.conf.json.
- Published release: https://github.com/open-software-network/os-june-releases/releases/tag/v0.0.20