### PR TITLE
Harden Hermes trace redaction

### DIFF
--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -13,7 +13,7 @@ import {
 import { displayedUserMessageText } from "./issue-report-prompt";
 import { displayedSkillInvocationText } from "./skill-slash-commands";
 import { STEER_EVENT_TYPE, steeringPartText } from "./hermes-session-steer";
-import { parseHermesMode } from "./hermes-control-plane";
+import { parseHermesMode, sanitizeText } from "./hermes-control-plane";
 import { toolActivityLabel } from "./agent-tool-labels";
 
 export type LiveHermesEvent = HermesGatewayEvent & {
@@ -737,14 +737,15 @@ function appendLiveHermesEvents(
 
     if (event.type === "error") {
       currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      const notice = text ? creditsNotice(text) : undefined;
+      const safeText = text ? sanitizeText(text) : "";
+      const notice = safeText ? creditsNotice(safeText) : undefined;
       if (notice) {
         currentAssistant.parts.push(notice);
       } else {
         upsertToolPart(currentAssistant.parts, {
           id: `error:${event.receivedAt}`,
           name: "Error",
-          text: text || "The agent reported an error.",
+          text: safeText || "The agent reported an error.",
           status: "failed",
         });
       }

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -41,6 +41,7 @@ import type { HermesMode, JuneHermesEvent } from "./hermes-control-plane";
 import {
   artifactLocationsFromPayload,
   asRecord,
+  isArtifactUrlLocation,
   nonEmpty,
 } from "./hermes-control-plane";
 
@@ -308,10 +309,20 @@ export function artifactsFromToolEvent(
 
   const payload = asRecord(event.payload) ?? {};
 
-  const locations =
+  const preservedNavigationLocations =
     event.artifactLocations && event.artifactLocations.length > 0
       ? dedupeLocations(event.artifactLocations)
-      : artifactLocationsFromPayload(payload);
+      : [];
+  const sanitizedPayloadLocations = artifactLocationsFromPayload(payload);
+  const locations =
+    preservedNavigationLocations.length > 0
+      ? dedupeLocations([
+          ...preservedNavigationLocations,
+          ...sanitizedPayloadLocations.filter(
+            (location) => !isArtifactUrlLocation(location),
+          ),
+        ])
+      : sanitizedPayloadLocations;
   if (locations.length === 0) return [];
 
   const failed = hasError(payload);

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -38,7 +38,11 @@
  */
 
 import type { HermesMode, JuneHermesEvent } from "./hermes-control-plane";
-import { asRecord, nonEmpty } from "./hermes-control-plane";
+import {
+  artifactLocationsFromPayload,
+  asRecord,
+  nonEmpty,
+} from "./hermes-control-plane";
 
 /**
  * Cap on the number of artifacts kept per session. A long agent run touches many
@@ -290,8 +294,10 @@ export const hermesArtifactStore = createHermesArtifactStore();
  *   modified, read → read, download → downloaded, import → downloaded), and any
  *   error field on the payload downgrades it to `failed`.
  *
- * The payload here is already sanitized by the classifier, so secret-bearing
- * fields are redacted before we ever read them.
+ * The classifier also carries a narrow pre-redaction `artifactLocations` list
+ * for navigation-only fields, so signed download URLs stay clickable while the
+ * trace/tool-card payload remains sanitized. Older/manual events fall back to
+ * extracting from the sanitized payload.
  */
 export function artifactsFromToolEvent(
   event: JuneHermesEvent,
@@ -300,10 +306,12 @@ export function artifactsFromToolEvent(
   const sessionId = nonEmpty(event.sessionId);
   if (!sessionId) return [];
 
-  const payload = asRecord(event.payload);
-  if (!payload) return [];
+  const payload = asRecord(event.payload) ?? {};
 
-  const locations = locationsFromPayload(payload);
+  const locations =
+    event.artifactLocations && event.artifactLocations.length > 0
+      ? dedupeLocations(event.artifactLocations)
+      : artifactLocationsFromPayload(payload);
   if (locations.length === 0) return [];
 
   const failed = hasError(payload);
@@ -330,59 +338,15 @@ export function artifactsFromToolEvent(
   });
 }
 
-/**
- * Pull location strings out of the known fields, in priority order. Singular
- * fields first, then array fields. Deduped, preserving order.
- */
-function locationsFromPayload(payload: Record<string, unknown>): string[] {
+function dedupeLocations(values: readonly string[]): string[] {
   const out: string[] = [];
   const push = (value: unknown) => {
     const str = nonEmpty(typeof value === "string" ? value : undefined);
     if (str && !out.includes(str)) out.push(str);
   };
-
-  for (const key of SINGULAR_LOCATION_KEYS) push(payload[key]);
-  // Ambiguous keys (a "destination"/"dest" is just as often a queue name,
-  // channel, or host as a file path): only accept their value when it actually
-  // looks like a filesystem path or url, so a `send_to_queue {destination:
-  // "my-queue"}` never mints a phantom artifact. Conservative by design.
-  for (const key of PATH_SHAPED_LOCATION_KEYS) {
-    const value = payload[key];
-    if (typeof value === "string" && looksLikeLocation(value)) push(value);
-  }
-  for (const key of ARRAY_LOCATION_KEYS) {
-    const value = payload[key];
-    if (Array.isArray(value)) for (const item of value) push(item);
-  }
+  for (const value of values) push(value);
   return out;
 }
-
-// Known singular payload keys that hold a file path or url. Mirrors the field
-// names the rest of the runtime already reads (snake_case + camelCase).
-const SINGULAR_LOCATION_KEYS = [
-  "path",
-  "file_path",
-  "filePath",
-  "filename",
-  "file",
-  "target_path",
-  "targetPath",
-  "url",
-  "uri",
-] as const;
-
-// Singular keys whose names DON'T guarantee a filesystem meaning. We only treat
-// their value as a location when it has a path/url shape (see
-// {@link looksLikeLocation}).
-const PATH_SHAPED_LOCATION_KEYS = ["destination", "dest"] as const;
-
-// Known array payload keys holding multiple paths.
-const ARRAY_LOCATION_KEYS = [
-  "paths",
-  "file_paths",
-  "filePaths",
-  "files",
-] as const;
 
 /**
  * Infer the action from the tool name. Defaults to `read` (the least-privileged,
@@ -432,17 +396,6 @@ function kindForLocation(location: string): ArtifactKind {
 
 function isImageExtension(name: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg|heic|bmp|tiff?)$/i.test(name);
-}
-
-/** Whether a string carries a filesystem-path or url shape: a `scheme://`, or a
- * `/` or `\` separator somewhere in it. Used to gate ambiguous payload keys
- * (`destination`/`dest`) so a bare queue/channel/host name doesn't mint an
- * artifact. */
-function looksLikeLocation(value: string): boolean {
-  const trimmed = value.trim();
-  if (!trimmed) return false;
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return true;
-  return trimmed.includes("/") || trimmed.includes("\\");
 }
 
 /** A cheap "we could show this inline" hint. The actual preview is fetched

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -43,6 +43,7 @@ import {
   asRecord,
   isArtifactUrlLocation,
   nonEmpty,
+  sanitizeText,
 } from "./hermes-control-plane";
 
 /**
@@ -314,12 +315,18 @@ export function artifactsFromToolEvent(
       ? dedupeLocations(event.artifactLocations)
       : [];
   const sanitizedPayloadLocations = artifactLocationsFromPayload(payload);
+  const sanitizedPreservedNavigationLocations = new Set(
+    preservedNavigationLocations.map((location) => sanitizeText(location)),
+  );
   const locations =
     preservedNavigationLocations.length > 0
       ? dedupeLocations([
           ...preservedNavigationLocations,
           ...sanitizedPayloadLocations.filter(
-            (location) => !isArtifactUrlLocation(location),
+            (location) =>
+              !isArtifactUrlLocation(location) &&
+              !preservedNavigationLocations.includes(location) &&
+              !sanitizedPreservedNavigationLocations.has(location),
           ),
         ])
       : sanitizedPayloadLocations;

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -314,8 +314,8 @@ export function artifactsFromToolEvent(
       ? dedupeLocations(event.artifactLocations)
       : [];
   const sanitizedPayloadLocations = artifactLocationsFromPayload(payload);
-  const sanitizedPreservedNavigationLocations = new Set(
-    preservedNavigationLocations.map((location) => sanitizeText(location)),
+  const preservedNavigationLocationKeys = new Set(
+    preservedNavigationLocations.map((location) => locationDedupeKey(location)),
   );
   const locations =
     preservedNavigationLocations.length > 0
@@ -324,7 +324,9 @@ export function artifactsFromToolEvent(
           ...sanitizedPayloadLocations.filter(
             (location) =>
               !preservedNavigationLocations.includes(location) &&
-              !sanitizedPreservedNavigationLocations.has(location),
+              !preservedNavigationLocationKeys.has(
+                locationDedupeKey(location),
+              ),
           ),
         ])
       : sanitizedPayloadLocations;
@@ -362,6 +364,18 @@ function dedupeLocations(values: readonly string[]): string[] {
   };
   for (const value of values) push(value);
   return out;
+}
+
+function locationDedupeKey(location: string): string {
+  const sanitized = sanitizeText(location);
+  try {
+    const url = new URL(sanitized);
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return sanitized;
+  }
 }
 
 /**

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -41,7 +41,6 @@ import type { HermesMode, JuneHermesEvent } from "./hermes-control-plane";
 import {
   artifactLocationsFromPayload,
   asRecord,
-  isArtifactUrlLocation,
   nonEmpty,
   sanitizeText,
 } from "./hermes-control-plane";
@@ -324,7 +323,6 @@ export function artifactsFromToolEvent(
           ...preservedNavigationLocations,
           ...sanitizedPayloadLocations.filter(
             (location) =>
-              !isArtifactUrlLocation(location) &&
               !preservedNavigationLocations.includes(location) &&
               !sanitizedPreservedNavigationLocations.has(location),
           ),

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -67,23 +67,27 @@ export function artifactNavigationLocationsFromPayload(
   if (!record) return [];
 
   const out: string[] = [];
-  const push = (value: unknown) => {
+  const push = (value: unknown, key?: string) => {
     const str = nonEmptyString(value);
     const location = str ? stripUrlUserinfo(str) : undefined;
     if (!location) return;
     if (isArtifactUrlLocation(location)) {
       if (!shouldPreserveRawArtifactUrl(location)) return;
-    } else if (!shouldPreserveRawFilesystemLocation(location)) {
+    } else if (
+      !shouldPreserveRawFilesystemLocation(location, isUrlLocationKey(key))
+    ) {
       return;
     }
     if (!out.includes(location)) out.push(location);
   };
 
-  for (const key of SINGULAR_LOCATION_KEYS) push(record[key]);
+  for (const key of SINGULAR_LOCATION_KEYS) push(record[key], key);
 
   for (const key of PATH_SHAPED_LOCATION_KEYS) {
     const value = record[key];
-    if (typeof value === "string" && looksLikeLocation(value)) push(value);
+    if (typeof value === "string" && looksLikeLocation(value)) {
+      push(value, key);
+    }
   }
 
   for (const key of ARRAY_LOCATION_KEYS) {
@@ -190,9 +194,14 @@ function hasSensitiveUrlPathToken(value: string): boolean {
   }
 }
 
-function shouldPreserveRawFilesystemLocation(value: string): boolean {
+function shouldPreserveRawFilesystemLocation(
+  value: string,
+  useUrlRouteGate: boolean,
+): boolean {
   if (!looksLikeFilesystemPath(value)) return false;
-  if (hasSensitiveRoutePathToken(locationPathname(value), false)) return false;
+  if (hasSensitiveRoutePathToken(locationPathname(value), useUrlRouteGate)) {
+    return false;
+  }
   if (!hasSensitiveRelativeLocationParam(value)) return true;
   return isLikelyArtifactPathname(locationPathname(value));
 }
@@ -258,6 +267,10 @@ function isLikelyArtifactPathname(pathname: string): boolean {
       part,
     ),
   );
+}
+
+function isUrlLocationKey(key: string | undefined): boolean {
+  return key === "url" || key === "uri";
 }
 
 function hasSensitiveRoutePathToken(

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -1,4 +1,5 @@
 import { asRecord, nonEmptyString } from "./parse";
+import { isSensitiveKey } from "./sanitize";
 
 // Known singular payload keys that hold a file path or url. Mirrors the field
 // names the artifact timeline understands (snake_case + camelCase).
@@ -72,7 +73,7 @@ export function artifactNavigationLocationsFromPayload(
     if (!location) return;
     if (isArtifactUrlLocation(location)) {
       if (!shouldPreserveRawArtifactUrl(location)) return;
-    } else if (!looksLikeFilesystemPath(location)) {
+    } else if (!shouldPreserveRawFilesystemLocation(location)) {
       return;
     }
     if (!out.includes(location)) out.push(location);
@@ -152,42 +153,94 @@ function hasSensitiveUrlParam(value: string): boolean {
           : hash.includes("=")
             ? hash
             : "";
-    if (!hashQuery) return false;
-    for (const key of new URLSearchParams(hashQuery).keys()) {
-      if (isSensitiveUrlParamKey(key)) return true;
-    }
-    return false;
+    return hasSensitiveQueryParam(hashQuery);
   } catch {
     return false;
   }
 }
 
 function isSensitiveUrlParamKey(key: string): boolean {
-  return /(?:^|[_-])(?:access[_-]?token|auth|code|credential|id[_-]?token|jwt|key|password|refresh[_-]?token|secret|session|sid|signature|sig|token)(?:[_-]|$)/i.test(
-    key,
+  return (
+    isSensitiveKey(key) ||
+    /^key$/i.test(key) ||
+    /^(?:code|jwt|session|sid|sig|signature)$/i.test(key)
   );
 }
 
 function isLikelyArtifactUrl(value: string): boolean {
   try {
     const url = new URL(value);
-    const pathname = url.pathname.toLowerCase();
-    if (
-      /(?:^|\/)(?:auth|authorize|callback|login|oauth|reset|token)(?:\/|$)/.test(
-        pathname,
-      )
-    ) {
-      return false;
-    }
-    const parts = pathname.split("/").filter(Boolean);
-    const basename = parts[parts.length - 1] ?? "";
-    if (/\.[a-z0-9]{1,12}$/.test(basename)) return true;
-    return parts.some((part) =>
-      /^(?:artifact|artifacts|attachment|attachments|download|downloads|export|exports|file|files|image|images)$/.test(
-        part,
-      ),
-    );
+    return isLikelyArtifactPathname(url.pathname);
   } catch {
     return false;
   }
+}
+
+function shouldPreserveRawFilesystemLocation(value: string): boolean {
+  if (!looksLikeFilesystemPath(value)) return false;
+  if (!hasSensitiveRelativeLocationParam(value)) return true;
+  return isLikelyArtifactPathname(locationPathname(value));
+}
+
+function hasSensitiveRelativeLocationParam(value: string): boolean {
+  const queryIndex = value.indexOf("?");
+  if (queryIndex !== -1) {
+    const hashAfterQuery = value.indexOf("#", queryIndex);
+    const query =
+      hashAfterQuery === -1
+        ? value.slice(queryIndex + 1)
+        : value.slice(queryIndex + 1, hashAfterQuery);
+    if (hasSensitiveQueryParam(query)) return true;
+  }
+
+  const hashIndex = value.indexOf("#");
+  if (hashIndex === -1) return false;
+  const hash = value.slice(hashIndex + 1);
+  const hashQueryIndex = hash.indexOf("?");
+  const hashQuery =
+    hashQueryIndex !== -1
+      ? hash.slice(hashQueryIndex + 1)
+      : hash.includes("=")
+        ? hash
+        : "";
+  return hasSensitiveQueryParam(hashQuery);
+}
+
+function hasSensitiveQueryParam(query: string): boolean {
+  if (!query) return false;
+  for (const key of new URLSearchParams(query).keys()) {
+    if (isSensitiveUrlParamKey(key)) return true;
+  }
+  return false;
+}
+
+function locationPathname(value: string): string {
+  const queryIndex = value.indexOf("?");
+  const hashIndex = value.indexOf("#");
+  const suffixIndex =
+    queryIndex === -1
+      ? hashIndex
+      : hashIndex === -1
+        ? queryIndex
+        : Math.min(queryIndex, hashIndex);
+  return suffixIndex === -1 ? value : value.slice(0, suffixIndex);
+}
+
+function isLikelyArtifactPathname(pathname: string): boolean {
+  const lower = pathname.toLowerCase();
+  if (
+    /(?:^|\/)(?:auth|authorize|callback|login|oauth|reset|token)(?:\/|$)/.test(
+      lower,
+    )
+  ) {
+    return false;
+  }
+  const parts = lower.split("/").filter(Boolean);
+  const basename = parts[parts.length - 1] ?? "";
+  if (/\.[a-z0-9]{1,12}$/.test(basename)) return true;
+  return parts.some((part) =>
+    /^(?:artifact|artifacts|attachment|attachments|download|downloads|export|exports|file|files|image|images)$/.test(
+      part,
+    ),
+  );
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -62,11 +62,35 @@ export function artifactLocationsFromPayload(payload: unknown): string[] {
 export function artifactNavigationLocationsFromPayload(
   payload: unknown,
 ): string[] {
-  const locations = artifactLocationsFromPayload(payload);
-  return locations.filter(
-    (location) =>
-      isArtifactUrlLocation(location) || looksLikeFilesystemPath(location),
-  );
+  const record = asRecord(payload);
+  if (!record) return [];
+
+  const out: string[] = [];
+  const push = (value: unknown) => {
+    const str = nonEmptyString(value);
+    const location = str ? stripUrlUserinfo(str) : undefined;
+    if (!location) return;
+    if (isArtifactUrlLocation(location)) {
+      if (!shouldPreserveRawArtifactUrl(location)) return;
+    } else if (!looksLikeFilesystemPath(location)) {
+      return;
+    }
+    if (!out.includes(location)) out.push(location);
+  };
+
+  for (const key of SINGULAR_LOCATION_KEYS) push(record[key]);
+
+  for (const key of PATH_SHAPED_LOCATION_KEYS) {
+    const value = record[key];
+    if (typeof value === "string" && looksLikeLocation(value)) push(value);
+  }
+
+  for (const key of ARRAY_LOCATION_KEYS) {
+    const value = record[key];
+    if (Array.isArray(value)) for (const item of value) push(item);
+  }
+
+  return out;
 }
 
 function stripUrlUserinfo(value: string): string {
@@ -105,4 +129,65 @@ function looksLikeFilesystemPath(value: string): boolean {
     trimmed.startsWith("~/") ||
     /^[a-z]:[\\/]/i.test(trimmed)
   );
+}
+
+function shouldPreserveRawArtifactUrl(value: string): boolean {
+  if (!hasSensitiveUrlParam(value)) return true;
+  return isLikelyArtifactUrl(value);
+}
+
+function hasSensitiveUrlParam(value: string): boolean {
+  try {
+    const url = new URL(value);
+    for (const key of url.searchParams.keys()) {
+      if (isSensitiveUrlParamKey(key)) return true;
+    }
+    const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+    const hashQueryIndex = hash.indexOf("?");
+    const hashQuery =
+      hashQueryIndex !== -1
+        ? hash.slice(hashQueryIndex + 1)
+        : hash.startsWith("?")
+          ? hash.slice(1)
+          : hash.includes("=")
+            ? hash
+            : "";
+    if (!hashQuery) return false;
+    for (const key of new URLSearchParams(hashQuery).keys()) {
+      if (isSensitiveUrlParamKey(key)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function isSensitiveUrlParamKey(key: string): boolean {
+  return /(?:^|[_-])(?:access[_-]?token|auth|code|credential|id[_-]?token|jwt|key|password|refresh[_-]?token|secret|session|sid|signature|sig|token)(?:[_-]|$)/i.test(
+    key,
+  );
+}
+
+function isLikelyArtifactUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname.toLowerCase();
+    if (
+      /(?:^|\/)(?:auth|authorize|callback|login|oauth|reset|token)(?:\/|$)/.test(
+        pathname,
+      )
+    ) {
+      return false;
+    }
+    const parts = pathname.split("/").filter(Boolean);
+    const basename = parts[parts.length - 1] ?? "";
+    if (/\.[a-z0-9]{1,12}$/.test(basename)) return true;
+    return parts.some((part) =>
+      /^(?:artifact|artifacts|attachment|attachments|download|downloads|export|exports|file|files|image|images)$/.test(
+        part,
+      ),
+    );
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -318,8 +318,9 @@ function isRouteSecretSegment(segment: string): boolean {
   }
   return (
     normalized.length >= 4 &&
-    /^[A-Za-z0-9_-]+$/u.test(normalized) &&
-    /[A-Za-z0-9]/u.test(normalized)
+    ((/^[A-Za-z0-9_-]+$/u.test(normalized) &&
+      /[A-Za-z0-9]/u.test(normalized)) ||
+      /^[A-Za-z0-9+/]+={0,2}$/u.test(normalized))
   );
 }
 

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -182,8 +182,8 @@ function hasSensitiveUrlPathToken(value: string): boolean {
   try {
     const url = new URL(value);
     return (
-      hasSensitiveRoutePathToken(url.pathname) ||
-      hasSensitiveRoutePathToken(hashPathname(url.hash))
+      hasSensitiveRoutePathToken(url.pathname, true) ||
+      hasSensitiveRoutePathToken(hashPathname(url.hash), true)
     );
   } catch {
     return false;
@@ -192,7 +192,7 @@ function hasSensitiveUrlPathToken(value: string): boolean {
 
 function shouldPreserveRawFilesystemLocation(value: string): boolean {
   if (!looksLikeFilesystemPath(value)) return false;
-  if (hasSensitiveRoutePathToken(locationPathname(value))) return false;
+  if (hasSensitiveRoutePathToken(locationPathname(value), false)) return false;
   if (!hasSensitiveRelativeLocationParam(value)) return true;
   return isLikelyArtifactPathname(locationPathname(value));
 }
@@ -260,10 +260,15 @@ function isLikelyArtifactPathname(pathname: string): boolean {
   );
 }
 
-function hasSensitiveRoutePathToken(pathname: string): boolean {
+function hasSensitiveRoutePathToken(
+  pathname: string,
+  includeArtifactRoutePrefixes: boolean,
+): boolean {
   if (!pathname) return false;
   const parts = pathname.split("/").filter(Boolean);
-  const sensitiveIndex = parts.findIndex(isSensitiveRawRouteSegment);
+  const sensitiveIndex = parts.findIndex((part) =>
+    isSensitiveRawRouteSegment(part, includeArtifactRoutePrefixes),
+  );
   if (sensitiveIndex === -1) return false;
   return parts
     .slice(sensitiveIndex + 1)
@@ -278,11 +283,15 @@ function hashPathname(hash: string): string {
   return fragment.includes("=") ? "" : fragment;
 }
 
-function isSensitiveRawRouteSegment(segment: string): boolean {
+function isSensitiveRawRouteSegment(
+  segment: string,
+  includeArtifactRoutePrefixes: boolean,
+): boolean {
   const normalized = safeDecodeURIComponent(segment).toLowerCase();
-  return /(?:^|[-_])(?:auth|authorize|callback|callbacks|credential|credentials|invite|invites|login|oauth|password|passwords|reset|secret|secrets|share|shares|signed|token|tokens)(?:[-_]|$)/.test(
-    normalized,
-  );
+  const routePattern = includeArtifactRoutePrefixes
+    ? /(?:^|[-_])(?:auth|authorize|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|login|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)(?:[-_]|$)/
+    : /(?:^|[-_])(?:auth|authorize|callback|callbacks|credential|credentials|invite|invites|login|oauth|password|passwords|reset|secret|secrets|share|shares|signed|token|tokens)(?:[-_]|$)/;
+  return routePattern.test(normalized);
 }
 
 function isRouteSecretSegment(segment: string): boolean {

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -60,7 +60,7 @@ export function artifactLocationsFromPayload(payload: unknown): string[] {
 }
 
 function stripUrlUserinfo(value: string): string {
-  if (!looksLikeUrl(value)) return value;
+  if (!isArtifactUrlLocation(value)) return value;
   try {
     const url = new URL(value);
     if (!url.username && !url.password) return value;
@@ -76,10 +76,10 @@ function stripUrlUserinfo(value: string): string {
 function looksLikeLocation(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
-  if (looksLikeUrl(trimmed)) return true;
+  if (isArtifactUrlLocation(trimmed)) return true;
   return trimmed.includes("/") || trimmed.includes("\\");
 }
 
-function looksLikeUrl(value: string): boolean {
+export function isArtifactUrlLocation(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -309,6 +309,7 @@ function isSensitiveRawRouteSegment(
 
 function isRouteSecretSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment);
+  if (/^\d+$/u.test(normalized)) return false;
   if (
     /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{6,}$/u.test(
       normalized,

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -133,8 +133,10 @@ function looksLikeFilesystemPath(value: string): boolean {
 }
 
 function shouldPreserveRawArtifactUrl(value: string): boolean {
-  if (!hasSensitiveUrlParam(value)) return true;
-  return isLikelyArtifactUrl(value);
+  const likelyArtifactUrl = isLikelyArtifactUrl(value);
+  if (hasSensitiveUrlParam(value)) return likelyArtifactUrl;
+  if (hasSensitiveUrlPathToken(value)) return false;
+  return true;
 }
 
 function hasSensitiveUrlParam(value: string): boolean {
@@ -171,6 +173,20 @@ function isLikelyArtifactUrl(value: string): boolean {
   try {
     const url = new URL(value);
     return isLikelyArtifactPathname(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function hasSensitiveUrlPathToken(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const sensitiveIndex = parts.findIndex(isSensitiveAuthRouteSegment);
+    if (sensitiveIndex === -1) return false;
+    return parts
+      .slice(sensitiveIndex + 1)
+      .some((part) => isRouteSecretSegment(part));
   } catch {
     return false;
   }
@@ -243,4 +259,24 @@ function isLikelyArtifactPathname(pathname: string): boolean {
       part,
     ),
   );
+}
+
+function isSensitiveAuthRouteSegment(segment: string): boolean {
+  const normalized = safeDecodeURIComponent(segment).toLowerCase();
+  return /(?:^|[-_])(?:auth|authorize|callback|login|oauth|password|reset|secret|token)(?:[-_]|$)/.test(
+    normalized,
+  );
+}
+
+function isRouteSecretSegment(segment: string): boolean {
+  const normalized = safeDecodeURIComponent(segment);
+  return normalized.length >= 4 && /^[A-Za-z0-9_-]+$/u.test(normalized);
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -1,0 +1,67 @@
+import { asRecord, nonEmptyString } from "./parse";
+
+// Known singular payload keys that hold a file path or url. Mirrors the field
+// names the artifact timeline understands (snake_case + camelCase).
+const SINGULAR_LOCATION_KEYS = [
+  "path",
+  "file_path",
+  "filePath",
+  "filename",
+  "file",
+  "target_path",
+  "targetPath",
+  "url",
+  "uri",
+] as const;
+
+// Singular keys whose names do not guarantee a filesystem meaning. Accept their
+// values only when they look like paths/urls, so queue/channel names do not mint
+// phantom artifacts.
+const PATH_SHAPED_LOCATION_KEYS = ["destination", "dest"] as const;
+
+// Known array payload keys holding multiple paths.
+const ARRAY_LOCATION_KEYS = [
+  "paths",
+  "file_paths",
+  "filePaths",
+  "files",
+] as const;
+
+/**
+ * Pull artifact navigation locations out of an opaque Hermes tool payload.
+ * This is intentionally a tiny allowlist, never prose parsing: it may preserve
+ * signed URL query strings, so callers should only use the result for artifact
+ * open targets, not trace/debug previews.
+ */
+export function artifactLocationsFromPayload(payload: unknown): string[] {
+  const record = asRecord(payload);
+  if (!record) return [];
+
+  const out: string[] = [];
+  const push = (value: unknown) => {
+    const str = nonEmptyString(value);
+    if (str && !out.includes(str)) out.push(str);
+  };
+
+  for (const key of SINGULAR_LOCATION_KEYS) push(record[key]);
+
+  for (const key of PATH_SHAPED_LOCATION_KEYS) {
+    const value = record[key];
+    if (typeof value === "string" && looksLikeLocation(value)) push(value);
+  }
+
+  for (const key of ARRAY_LOCATION_KEYS) {
+    const value = record[key];
+    if (Array.isArray(value)) for (const item of value) push(item);
+  }
+
+  return out;
+}
+
+/** Whether a string carries a filesystem-path or URL shape. */
+function looksLikeLocation(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return true;
+  return trimmed.includes("/") || trimmed.includes("\\");
+}

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -59,6 +59,16 @@ export function artifactLocationsFromPayload(payload: unknown): string[] {
   return out;
 }
 
+export function artifactNavigationLocationsFromPayload(
+  payload: unknown,
+): string[] {
+  const locations = artifactLocationsFromPayload(payload);
+  return locations.filter(
+    (location) =>
+      isArtifactUrlLocation(location) || looksLikeFilesystemPath(location),
+  );
+}
+
 function stripUrlUserinfo(value: string): string {
   if (!isArtifactUrlLocation(value)) return value;
   try {
@@ -82,4 +92,17 @@ function looksLikeLocation(value: string): boolean {
 
 export function isArtifactUrlLocation(value: string): boolean {
   return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+}
+
+function looksLikeFilesystemPath(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("\\") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../") ||
+    trimmed.startsWith("~/") ||
+    /^[a-z]:[\\/]/i.test(trimmed)
+  );
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -287,7 +287,11 @@ function isSensitiveRawRouteSegment(segment: string): boolean {
 
 function isRouteSecretSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment);
-  return normalized.length >= 4 && /^[A-Za-z0-9_-]+$/u.test(normalized);
+  return (
+    normalized.length >= 4 &&
+    /^[A-Za-z0-9_.-]+$/u.test(normalized) &&
+    /[A-Za-z0-9]/u.test(normalized)
+  );
 }
 
 function safeDecodeURIComponent(value: string): string {

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -40,7 +40,8 @@ export function artifactLocationsFromPayload(payload: unknown): string[] {
   const out: string[] = [];
   const push = (value: unknown) => {
     const str = nonEmptyString(value);
-    if (str && !out.includes(str)) out.push(str);
+    const location = str ? stripUrlUserinfo(str) : undefined;
+    if (location && !out.includes(location)) out.push(location);
   };
 
   for (const key of SINGULAR_LOCATION_KEYS) push(record[key]);
@@ -58,10 +59,27 @@ export function artifactLocationsFromPayload(payload: unknown): string[] {
   return out;
 }
 
+function stripUrlUserinfo(value: string): string {
+  if (!looksLikeUrl(value)) return value;
+  try {
+    const url = new URL(value);
+    if (!url.username && !url.password) return value;
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
 /** Whether a string carries a filesystem-path or URL shape. */
 function looksLikeLocation(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return true;
+  if (looksLikeUrl(trimmed)) return true;
   return trimmed.includes("/") || trimmed.includes("\\");
+}
+
+function looksLikeUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -181,12 +181,10 @@ function isLikelyArtifactUrl(value: string): boolean {
 function hasSensitiveUrlPathToken(value: string): boolean {
   try {
     const url = new URL(value);
-    const parts = url.pathname.split("/").filter(Boolean);
-    const sensitiveIndex = parts.findIndex(isSensitiveAuthRouteSegment);
-    if (sensitiveIndex === -1) return false;
-    return parts
-      .slice(sensitiveIndex + 1)
-      .some((part) => isRouteSecretSegment(part));
+    return (
+      hasSensitiveRoutePathToken(url.pathname) ||
+      hasSensitiveRoutePathToken(hashPathname(url.hash))
+    );
   } catch {
     return false;
   }
@@ -194,6 +192,7 @@ function hasSensitiveUrlPathToken(value: string): boolean {
 
 function shouldPreserveRawFilesystemLocation(value: string): boolean {
   if (!looksLikeFilesystemPath(value)) return false;
+  if (hasSensitiveRoutePathToken(locationPathname(value))) return false;
   if (!hasSensitiveRelativeLocationParam(value)) return true;
   return isLikelyArtifactPathname(locationPathname(value));
 }
@@ -261,9 +260,27 @@ function isLikelyArtifactPathname(pathname: string): boolean {
   );
 }
 
-function isSensitiveAuthRouteSegment(segment: string): boolean {
+function hasSensitiveRoutePathToken(pathname: string): boolean {
+  if (!pathname) return false;
+  const parts = pathname.split("/").filter(Boolean);
+  const sensitiveIndex = parts.findIndex(isSensitiveRawRouteSegment);
+  if (sensitiveIndex === -1) return false;
+  return parts
+    .slice(sensitiveIndex + 1)
+    .some((part) => isRouteSecretSegment(part));
+}
+
+function hashPathname(hash: string): string {
+  const fragment = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!fragment) return "";
+  const queryIndex = fragment.indexOf("?");
+  if (queryIndex !== -1) return fragment.slice(0, queryIndex);
+  return fragment.includes("=") ? "" : fragment;
+}
+
+function isSensitiveRawRouteSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment).toLowerCase();
-  return /(?:^|[-_])(?:auth|authorize|callback|login|oauth|password|reset|secret|token)(?:[-_]|$)/.test(
+  return /(?:^|[-_])(?:auth|authorize|callback|callbacks|credential|credentials|invite|invites|login|oauth|password|passwords|reset|secret|secrets|share|shares|signed|token|tokens)(?:[-_]|$)/.test(
     normalized,
   );
 }

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -134,8 +134,8 @@ function looksLikeFilesystemPath(value: string): boolean {
 
 function shouldPreserveRawArtifactUrl(value: string): boolean {
   const likelyArtifactUrl = isLikelyArtifactUrl(value);
-  if (hasSensitiveUrlParam(value)) return likelyArtifactUrl;
   if (hasSensitiveUrlPathToken(value)) return false;
+  if (hasSensitiveUrlParam(value)) return likelyArtifactUrl;
   return true;
 }
 

--- a/src/lib/hermes-control-plane/artifact-locations.ts
+++ b/src/lib/hermes-control-plane/artifact-locations.ts
@@ -287,9 +287,16 @@ function isSensitiveRawRouteSegment(segment: string): boolean {
 
 function isRouteSecretSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment);
+  if (
+    /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{6,}$/u.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
   return (
     normalized.length >= 4 &&
-    /^[A-Za-z0-9_.-]+$/u.test(normalized) &&
+    /^[A-Za-z0-9_-]+$/u.test(normalized) &&
     /[A-Za-z0-9]/u.test(normalized)
   );
 }

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -7,6 +7,7 @@ import type {
 } from "./events";
 import { parseHermesMode } from "./events";
 import type { RawHermesPayload } from "./raw-types";
+import { artifactLocationsFromPayload } from "./artifact-locations";
 import { sanitizePayload, sanitizeText } from "./sanitize";
 
 /**
@@ -118,7 +119,9 @@ function classifyTool(
       : type === "tool.progress"
         ? "progress"
         : "complete";
-  return {
+  const artifactLocations =
+    payload === undefined ? [] : artifactLocationsFromPayload(payload);
+  const event: JuneHermesEvent = {
     kind: "tool",
     sessionId: sessionId ?? "",
     toolCallId:
@@ -135,6 +138,12 @@ function classifyTool(
     // case a tool's args happen to embed a secret.
     payload: payload === undefined ? undefined : sanitizePayload(payload),
   };
+  if (artifactLocations.length === 0) return event;
+  Object.defineProperty(event, "artifactLocations", {
+    value: artifactLocations,
+    enumerable: false,
+  });
+  return event;
 }
 
 function classifyPendingAction(

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -8,8 +8,7 @@ import type {
 import { parseHermesMode } from "./events";
 import type { RawHermesPayload } from "./raw-types";
 import {
-  artifactLocationsFromPayload,
-  isArtifactUrlLocation,
+  artifactNavigationLocationsFromPayload,
 } from "./artifact-locations";
 import { sanitizePayload, sanitizeText } from "./sanitize";
 
@@ -125,7 +124,7 @@ function classifyTool(
   const artifactLocations =
     payload === undefined
       ? []
-      : artifactLocationsFromPayload(payload).filter(isArtifactUrlLocation);
+      : artifactNavigationLocationsFromPayload(payload);
   const event: JuneHermesEvent = {
     kind: "tool",
     sessionId: sessionId ?? "",

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -7,7 +7,10 @@ import type {
 } from "./events";
 import { parseHermesMode } from "./events";
 import type { RawHermesPayload } from "./raw-types";
-import { artifactLocationsFromPayload } from "./artifact-locations";
+import {
+  artifactLocationsFromPayload,
+  isArtifactUrlLocation,
+} from "./artifact-locations";
 import { sanitizePayload, sanitizeText } from "./sanitize";
 
 /**
@@ -120,7 +123,9 @@ function classifyTool(
         ? "progress"
         : "complete";
   const artifactLocations =
-    payload === undefined ? [] : artifactLocationsFromPayload(payload);
+    payload === undefined
+      ? []
+      : artifactLocationsFromPayload(payload).filter(isArtifactUrlLocation);
   const event: JuneHermesEvent = {
     kind: "tool",
     sessionId: sessionId ?? "",

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -7,7 +7,7 @@ import type {
 } from "./events";
 import { parseHermesMode } from "./events";
 import type { RawHermesPayload } from "./raw-types";
-import { sanitizePayload } from "./sanitize";
+import { sanitizePayload, sanitizeText } from "./sanitize";
 
 /**
  * Turns one raw Hermes gateway frame into exactly one typed
@@ -238,12 +238,11 @@ function classifyError(
   return {
     kind: "error",
     sessionId,
-    // The human-readable message is safe to surface; everything else stays out
-    // unless explicitly modeled, so a secret in some other field can't leak.
-    message:
+    message: sanitizeText(
       stringValue(payload?.message, true) ??
-      stringValue(payload?.text, true) ??
-      "The agent reported an error.",
+        stringValue(payload?.text, true) ??
+        "The agent reported an error.",
+    ),
     code: numberValue(payload?.code),
     recoverable:
       typeof payload?.recoverable === "boolean"

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -127,6 +127,14 @@ export type JuneHermesEvent =
       phase: "start" | "progress" | "complete";
       name?: string;
       payload?: unknown;
+      /**
+       * Raw, allow-listed file/url fields captured before payload redaction so
+       * artifact navigation can open signed URLs and long paths verbatim. This
+       * is deliberately narrower than `payload` and attached as a non-enumerable
+       * classifier property; trace/debug surfaces must keep using the sanitized
+       * payload/preview fields.
+       */
+      artifactLocations?: string[];
     }
   | { kind: "pending_action"; sessionId: string; action: PendingHermesAction }
   | {

--- a/src/lib/hermes-control-plane/index.ts
+++ b/src/lib/hermes-control-plane/index.ts
@@ -44,6 +44,7 @@ export * from "./event-classifier";
 export * from "./methods";
 export * from "./sanitize";
 export * from "./raw-types";
+export * from "./artifact-locations";
 export * from "./replay";
 export * from "./compatibility";
 export * from "./parse";

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -15,7 +15,7 @@ const SENSITIVE_KEY_PATTERN =
 
 const REDACTED = "[redacted]";
 const URL_REDACTION_VALUE = "redacted";
-const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi;
+const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
 const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -39,7 +39,9 @@ const KNOWN_SECRET_PATTERN =
   /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{16,}|AKIA[0-9A-Z]{16})\b/g;
 const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
-const LONG_OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{40,}\b/g;
+const OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
+const RELATIVE_PATH_CANDIDATE_PATTERN =
+  /(^|[\s"'(])((?:[A-Z]+\s+)?(?:\.{0,2}\/)[^\s"'<>),;]+)/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
   /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =
@@ -135,6 +137,7 @@ function isSensitiveAssignmentKey(key: string): boolean {
 }
 
 type RedactTokenOptions = {
+  minOpaqueTokenLength?: number;
   preservePathSegments?: boolean;
 };
 
@@ -142,7 +145,7 @@ function redactTokenFragments(
   value: string,
   options: RedactTokenOptions = { preservePathSegments: true },
 ): string {
-  return redactSensitiveAssignments(value)
+  return redactSensitiveRelativePathTokens(redactSensitiveAssignments(value))
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),
     )
@@ -151,9 +154,70 @@ function redactTokenFragments(
     .replace(NAMED_SECRET_FRAGMENT_PATTERN, (match) =>
       match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match,
     )
-    .replace(LONG_OPAQUE_TOKEN_PATTERN, (match, offset, source) =>
+    .replace(OPAQUE_TOKEN_PATTERN, (match, offset, source) =>
       redactLongOpaqueToken(match, offset, source, options),
     );
+}
+
+function redactSensitiveRelativePathTokens(value: string): string {
+  return value.replace(
+    RELATIVE_PATH_CANDIDATE_PATTERN,
+    (_match, prefix: string, candidate: string) => {
+      let path = candidate;
+      let suffix = "";
+      while (/[),.;!?]$/u.test(path)) {
+        suffix = `${path.at(-1) ?? ""}${suffix}`;
+        path = path.slice(0, -1);
+      }
+      return `${prefix}${redactSensitiveRelativePath(path)}${suffix}`;
+    },
+  );
+}
+
+function redactSensitiveRelativePath(candidate: string): string {
+  const methodMatch = /^([A-Z]+\s+)(.+)$/u.exec(candidate);
+  const methodPrefix = methodMatch?.[1] ?? "";
+  const path = methodMatch?.[2] ?? candidate;
+  const suffixStart = firstPathSuffixIndex(path);
+  const pathname = suffixStart === -1 ? path : path.slice(0, suffixStart);
+  const suffix = suffixStart === -1 ? "" : path.slice(suffixStart);
+  const segments = pathname.split("/");
+  const meaningful = segments.filter(
+    (segment) => segment && segment !== "." && segment !== "..",
+  );
+  const sensitivePosition = meaningful.findIndex((segment) =>
+    isSensitivePathSegment(segment),
+  );
+
+  if (sensitivePosition === -1) return candidate;
+  // Avoid treating arbitrary filesystem paths as URLs: without an HTTP-ish
+  // method prefix, require the sensitive route to appear near the path root.
+  if (!methodPrefix && sensitivePosition > 1) return candidate;
+
+  let seenSensitiveSegment = false;
+  const redacted = segments.map((segment) => {
+    if (isSensitivePathSegment(segment)) {
+      seenSensitiveSegment = true;
+      return segment;
+    }
+    if (seenSensitiveSegment && isOpaquePathToken(segment, 32)) {
+      return REDACTED;
+    }
+    return segment;
+  });
+  return `${methodPrefix}${redacted.join("/")}${suffix}`;
+}
+
+function firstPathSuffixIndex(path: string): number {
+  const query = path.indexOf("?");
+  const hash = path.indexOf("#");
+  if (query === -1) return hash;
+  if (hash === -1) return query;
+  return Math.min(query, hash);
+}
+
+function isOpaquePathToken(segment: string, minLength: number): boolean {
+  return segment.length >= minLength && /^[A-Za-z0-9_-]+$/u.test(segment);
 }
 
 function redactLongOpaqueToken(
@@ -162,6 +226,7 @@ function redactLongOpaqueToken(
   source: string,
   options: RedactTokenOptions,
 ): string {
+  if (match.length < (options.minOpaqueTokenLength ?? 40)) return match;
   const before = offset > 0 ? source.at(offset - 1) : undefined;
   const after = source.at(offset + match.length);
   if (
@@ -287,6 +352,7 @@ function sanitizeUrl(value: string): string | undefined {
     if (sanitizeUrlFragment(url, sensitiveUrlContext)) changed = true;
 
     return redactTokenFragments(changed ? url.toString() : value, {
+      minOpaqueTokenLength: sensitiveUrlContext ? 32 : undefined,
       preservePathSegments: !(
         changed || sensitiveUrlContext
       ),

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -72,7 +72,11 @@ export function isSensitiveKey(key: string): boolean {
 }
 
 function isSensitiveUrlQueryKey(key: string): boolean {
-  return isSensitiveKey(key) || /^key$/i.test(key);
+  return (
+    isSensitiveKey(key) ||
+    /^key$/i.test(key) ||
+    /^(?:jwt|session|sid|sig|signature)$/i.test(key)
+  );
 }
 
 function isSensitiveUrlContextQueryKey(key: string): boolean {
@@ -547,9 +551,11 @@ function hasSensitivePathSegments(path: string): boolean {
 function isSensitivePathSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment);
   if (SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(normalized)) return true;
-  return normalized
-    .split(/[-_]+/)
-    .some((part) => SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(part));
+  const parts = normalized.split(/[-_]+/).filter(Boolean);
+  return (
+    parts.length > 0 &&
+    parts.every((part) => SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(part))
+  );
 }
 
 function safeDecodeURIComponent(value: string): string {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -438,7 +438,7 @@ function sanitizeUrl(value: string): string | undefined {
     if (sanitizeUrlFragment(url, sensitiveUrlContext)) changed = true;
     if (sanitizeUrlRoutePathTokens(url)) changed = true;
 
-    return redactTokenFragments(changed ? url.toString() : value, {
+    return redactTokenFragments(changed ? sanitizedUrlString(url) : value, {
       minOpaqueTokenLength: sensitiveUrlContext ? 32 : undefined,
       preservePathSegments: !(
         changed || sensitiveUrlContext
@@ -447,6 +447,10 @@ function sanitizeUrl(value: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function sanitizedUrlString(url: URL): string {
+  return url.toString().replace(/%5Bredacted%5D/gi, REDACTED);
 }
 
 function redactSensitiveUrlParams(

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -14,6 +14,14 @@ const SENSITIVE_KEY_PATTERN =
   /(token|api[_-]?key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp)/i;
 
 const REDACTED = "[redacted]";
+const URL_REDACTION_VALUE = "redacted";
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi;
+const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
+const JWT_PATTERN =
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+const KNOWN_SECRET_PATTERN =
+  /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{16,}|AKIA[0-9A-Z]{16})\b/g;
+const LONG_OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{40,}\b/g;
 
 /** Cap on how deep we recurse, so a cyclic or pathologically nested payload
  * can't hang or blow the stack. Beyond this, the subtree is dropped. */
@@ -35,6 +43,22 @@ export function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERN.test(key);
 }
 
+/**
+ * Redacts secret-shaped fragments inside otherwise human-readable text. Use this
+ * for fields that are intentionally surfaced as strings, such as error
+ * messages, where structural key-based redaction cannot help.
+ */
+export function sanitizeText(value: string): string {
+  return value
+    .replace(URL_PATTERN, sanitizeUrlMatch)
+    .replace(BEARER_PATTERN, (match) =>
+      match.replace(/\s+\S+$/u, " [redacted]"),
+    )
+    .replace(JWT_PATTERN, REDACTED)
+    .replace(KNOWN_SECRET_PATTERN, REDACTED)
+    .replace(LONG_OPAQUE_TOKEN_PATTERN, REDACTED);
+}
+
 function sanitize(
   value: unknown,
   depth: number,
@@ -44,7 +68,7 @@ function sanitize(
 
   const type = typeof value;
   if (type === "string") {
-    return isLikelySecretValue(value as string) ? REDACTED : value;
+    return sanitizeString(value as string);
   }
   if (type === "number" || type === "boolean" || type === "bigint") {
     return value;
@@ -99,7 +123,7 @@ function isLikelySecretValue(value: string): boolean {
   const trimmed = value.trim();
   if (/^bearer\s+\S+/i.test(trimmed)) return true;
   // A path or url is a location, not a credential: never mask it on shape alone.
-  if (looksLikePathOrUrl(trimmed)) return false;
+  if (looksLikeStandalonePathOrUrl(trimmed)) return false;
   // A long, unbroken token (no whitespace) is almost never user-facing copy.
   if (
     trimmed.length >= 32 &&
@@ -111,13 +135,69 @@ function isLikelySecretValue(value: string): boolean {
   return false;
 }
 
+function sanitizeString(value: string): string {
+  const sanitizedUrl = sanitizeUrl(value);
+  if (sanitizedUrl !== undefined) return sanitizedUrl;
+  if (isLikelySecretValue(value)) return REDACTED;
+  if (looksLikeStandalonePathOrUrl(value.trim())) return value;
+  return sanitizeText(value);
+}
+
+function sanitizeUrl(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!looksLikeUrl(trimmed)) return undefined;
+
+  try {
+    const url = new URL(trimmed);
+    let changed = false;
+
+    if (url.username) {
+      url.username = URL_REDACTION_VALUE;
+      changed = true;
+    }
+    if (url.password) {
+      url.password = URL_REDACTION_VALUE;
+      changed = true;
+    }
+
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (isSensitiveKey(key)) {
+        url.searchParams.set(key, REDACTED);
+        changed = true;
+      }
+    }
+
+    return changed ? url.toString() : value;
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeUrlMatch(match: string): string {
+  let url = match;
+  let suffix = "";
+  while (/[),.;!?]$/u.test(url)) {
+    suffix = `${url.at(-1) ?? ""}${suffix}`;
+    url = url.slice(0, -1);
+  }
+  return `${sanitizeUrl(url) ?? url}${suffix}`;
+}
+
 /** Whether a string is clearly a filesystem path or URL rather than an opaque
  * token: it has a `/` or `\` separator, a `scheme://` prefix, a `~/` home
  * prefix, or a Windows drive (`C:\`). Used only to exempt such values from the
  * value-shape secret backstop. */
+function looksLikeStandalonePathOrUrl(value: string): boolean {
+  return value.length > 0 && !/\s/.test(value) && looksLikePathOrUrl(value);
+}
+
 function looksLikePathOrUrl(value: string): boolean {
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return true;
+  if (looksLikeUrl(value)) return true;
   if (value.startsWith("~/")) return true;
   if (/^[A-Za-z]:[\\/]/.test(value)) return true;
   return value.includes("/") || value.includes("\\");
+}
+
+function looksLikeUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
 }

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -18,7 +18,7 @@ const URL_REDACTION_VALUE = "redacted";
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
 const SENSITIVE_ASSIGNMENT_KEY =
-  "token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp";
+  "token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp";
 const SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
   `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)"((?:\\\\.|[^"\\\\\\r\\n])*)"`,
   "gi",
@@ -28,7 +28,7 @@ const SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
   "gi",
 );
 const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
-  /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp)\2(\s*[:=]\s*)(?:(?:bearer|basic)\s+)?([^\s"'<>),;&]+)/gi;
+  /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp)\2(\s*[:=]\s*)(?:(?:bearer|basic)\s+)?([^\s"'<>),;&]+)/gi;
 const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const KNOWN_SECRET_PATTERN =
@@ -227,10 +227,13 @@ function isLikelySecretValue(value: string): boolean {
 }
 
 function sanitizeString(value: string): string {
-  const sanitizedUrl = sanitizeUrl(value);
-  if (sanitizedUrl !== undefined) return sanitizedUrl;
+  const trimmed = value.trim();
+  if (looksLikeStandalonePathOrUrl(trimmed) && looksLikeUrl(trimmed)) {
+    const sanitizedUrl = sanitizeUrl(value);
+    if (sanitizedUrl !== undefined) return sanitizedUrl;
+  }
   if (isLikelySecretValue(value)) return REDACTED;
-  if (looksLikeStandalonePathOrUrl(value.trim())) return sanitizeText(value);
+  if (looksLikeStandalonePathOrUrl(trimmed)) return sanitizeText(value);
   return sanitizeText(value);
 }
 

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -65,6 +65,10 @@ function isSensitiveUrlQueryKey(key: string): boolean {
   return isSensitiveKey(key) || /^key$/i.test(key);
 }
 
+function isSensitiveUrlContextQueryKey(key: string): boolean {
+  return /^code$/i.test(key);
+}
+
 /**
  * Redacts secret-shaped fragments inside otherwise human-readable text. Use this
  * for fields that are intentionally surfaced as strings, such as error
@@ -258,8 +262,12 @@ function sanitizeUrl(value: string): string | undefined {
       changed = true;
     }
 
+    const sensitiveUrlContext = hasSensitiveUrlPathContext(url);
     for (const key of Array.from(url.searchParams.keys())) {
-      if (isSensitiveUrlQueryKey(key)) {
+      if (
+        isSensitiveUrlQueryKey(key) ||
+        (sensitiveUrlContext && isSensitiveUrlContextQueryKey(key))
+      ) {
         url.searchParams.set(key, REDACTED);
         changed = true;
       }
@@ -267,7 +275,7 @@ function sanitizeUrl(value: string): string | undefined {
 
     return redactTokenFragments(changed ? url.toString() : value, {
       preservePathSegments: !(
-        changed || hasSensitiveUrlPathContext(url)
+        changed || sensitiveUrlContext
       ),
     });
   } catch {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -27,6 +27,10 @@ const SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
   `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY_PATTERN})\\2(\\s*[:=]\\s*)'((?:\\\\.|[^'\\\\\\r\\n])*)'`,
   "gi",
 );
+const SENSITIVE_ESCAPED_DOUBLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
+  `(^|[?#&\\s,;({\\[])(\\\\")(${SENSITIVE_ASSIGNMENT_KEY_PATTERN})(\\\\")(\\s*:\\s*)(\\\\")((?:(?!\\\\").)*)(\\\\")`,
+  "gi",
+);
 const SENSITIVE_TEXT_ASSIGNMENT_PATTERN = new RegExp(
   `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY_PATTERN})\\2(\\s*[:=]\\s*)(?:(?:bearer|basic)\\s+)?([^\\s"'<>),;&]+)`,
   "gi",
@@ -89,6 +93,23 @@ function redactSensitiveAssignments(value: string): string {
     .replace(
       SENSITIVE_RELATIVE_CALLBACK_CODE_PATTERN,
       (_match, prefix: string) => `${prefix}${REDACTED}`,
+    )
+    .replace(
+      SENSITIVE_ESCAPED_DOUBLE_QUOTED_ASSIGNMENT_PATTERN,
+      (
+        match: string,
+        prefix: string,
+        keyOpenQuote: string,
+        key: string,
+        keyCloseQuote: string,
+        separator: string,
+        valueOpenQuote: string,
+        _value: string,
+        valueCloseQuote: string,
+      ) => {
+        if (!isSensitiveAssignmentKey(key)) return match;
+        return `${prefix}${keyOpenQuote}${key}${keyCloseQuote}${separator}${valueOpenQuote}${REDACTED}${valueCloseQuote}`;
+      },
     )
     .replace(
       SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN,
@@ -227,13 +248,15 @@ function redactSensitiveRelativePath(
   ) {
     return candidate;
   }
-  // Avoid treating arbitrary filesystem paths as URLs: without an HTTP-ish
-  // method/hash-route prefix, require the sensitive route to appear near the
-  // path root.
-  if (
-    !hasRouteContext && sensitivePosition > 1
-  )
-    return candidate;
+  // Avoid treating arbitrary filesystem paths as URLs. For unlabeled paths,
+  // only root-sensitive routes get path-segment redaction; nested callback
+  // routes still get sensitive query/hash params scrubbed below.
+  if (!hasRouteContext && sensitivePosition > 0) {
+    const redactedSuffix = redactSensitiveContextParams(suffix);
+    return redactedSuffix === suffix
+      ? candidate
+      : `${methodPrefix}${routePrefix}${pathname}${redactedSuffix}`;
+  }
 
   let seenSensitiveSegment = false;
   const redacted = segments.map((segment) => {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -132,8 +132,7 @@ function redactLongOpaqueToken(
     before === "/" ||
     before === "\\" ||
     after === "/" ||
-    after === "\\" ||
-    after === "."
+    after === "\\"
   ) {
     return match;
   }

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -51,8 +51,11 @@ export function isSensitiveKey(key: string): boolean {
  * messages, where structural key-based redaction cannot help.
  */
 export function sanitizeText(value: string): string {
+  return redactTokenFragments(value.replace(URL_PATTERN, sanitizeUrlMatch));
+}
+
+function redactTokenFragments(value: string): string {
   return value
-    .replace(URL_PATTERN, sanitizeUrlMatch)
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),
     )
@@ -172,7 +175,7 @@ function sanitizeUrl(value: string): string | undefined {
       }
     }
 
-    return changed ? url.toString() : value;
+    return redactTokenFragments(changed ? url.toString() : value);
   } catch {
     return undefined;
   }

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -36,6 +36,10 @@ const KNOWN_SECRET_PATTERN =
 const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const LONG_OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{40,}\b/g;
+const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
+  /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
+const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =
+  /(?:^|[.-])(?:auth|download|downloads|file|files|private|reset|secret|share|signed|token)(?:[.-]|$)/i;
 
 /** Cap on how deep we recurse, so a cyclic or pathologically nested payload
  * can't hang or blow the stack. Beyond this, the subtree is dropped. */
@@ -262,11 +266,20 @@ function sanitizeUrl(value: string): string | undefined {
     }
 
     return redactTokenFragments(changed ? url.toString() : value, {
-      preservePathSegments: false,
+      preservePathSegments: !(
+        changed || hasSensitiveUrlPathContext(url)
+      ),
     });
   } catch {
     return undefined;
   }
+}
+
+function hasSensitiveUrlPathContext(url: URL): boolean {
+  if (SENSITIVE_URL_HOST_FRAGMENT_PATTERN.test(url.hostname)) return true;
+  return url.pathname
+    .split("/")
+    .some((segment) => SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(segment));
 }
 
 function sanitizeUrlMatch(match: string): string {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -17,8 +17,14 @@ const REDACTED = "[redacted]";
 const URL_REDACTION_VALUE = "redacted";
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
+const SENSITIVE_ASSIGNMENT_KEY =
+  "token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp";
+const SENSITIVE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
+  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)(["'])([^\\r\\n]*?)\\5`,
+  "gi",
+);
 const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
-  /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp)\2(\s*[:=]\s*)(?:bearer\s+)?(["']?)([^\s"'<>),;&]+)(["']?)/gi;
+  /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp)\2(\s*[:=]\s*)(?:(?:bearer|basic)\s+)?([^\s"'<>),;&]+)/gi;
 const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const KNOWN_SECRET_PATTERN =
@@ -63,7 +69,7 @@ export function sanitizeText(value: string): string {
 function redactTokenFragments(value: string): string {
   return value
     .replace(
-      SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
+      SENSITIVE_QUOTED_ASSIGNMENT_PATTERN,
       (
         _match,
         prefix: string,
@@ -71,10 +77,20 @@ function redactTokenFragments(value: string): string {
         key: string,
         separator: string,
         valueQuote: string,
-        _value: string,
-        valueEndQuote: string,
       ) =>
-        `${prefix}${keyQuote}${key}${keyQuote}${separator}${valueQuote}${REDACTED}${valueEndQuote}`,
+        `${prefix}${keyQuote}${key}${keyQuote}${separator}${valueQuote}${REDACTED}${valueQuote}`,
+    )
+    .replace(
+      SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
+      (
+        _match,
+        prefix: string,
+        keyQuote: string,
+        key: string,
+        separator: string,
+        _value: string,
+      ) =>
+        `${prefix}${keyQuote}${key}${keyQuote}${separator}${REDACTED}`,
     )
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -17,18 +17,20 @@ const REDACTED = "[redacted]";
 const URL_REDACTION_VALUE = "redacted";
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
-const SENSITIVE_ASSIGNMENT_KEY =
-  "token|access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp";
+const SENSITIVE_ASSIGNMENT_KEY_PATTERN =
+  "(?:key|[A-Za-z0-9_-]*(?:(?:token|secret|password|passphrase|credential|authorization|value|pin|otp)|api[_-]?key|private[_-]?key)[A-Za-z0-9_-]*)";
 const SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
-  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)"((?:\\\\.|[^"\\\\\\r\\n])*)"`,
+  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY_PATTERN})\\2(\\s*[:=]\\s*)"((?:\\\\.|[^"\\\\\\r\\n])*)"`,
   "gi",
 );
 const SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
-  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)'((?:\\\\.|[^'\\\\\\r\\n])*)'`,
+  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY_PATTERN})\\2(\\s*[:=]\\s*)'((?:\\\\.|[^'\\\\\\r\\n])*)'`,
   "gi",
 );
-const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
-  /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp)\2(\s*[:=]\s*)(?:(?:bearer|basic)\s+)?([^\s"'<>),;&]+)/gi;
+const SENSITIVE_TEXT_ASSIGNMENT_PATTERN = new RegExp(
+  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY_PATTERN})\\2(\\s*[:=]\\s*)(?:(?:bearer|basic)\\s+)?([^\\s"'<>),;&]+)`,
+  "gi",
+);
 const SENSITIVE_RELATIVE_CALLBACK_CODE_PATTERN =
   /((?:^|[\s"'(])(?:[A-Z]+\s+)?(?:\.{0,2}\/)[^\s"'<>]*?(?:auth|oauth|callback)[^\s"'<>]*?[?&#]code=)([^&#\s"'<>),;]+)/gi;
 const JWT_PATTERN =
@@ -39,7 +41,7 @@ const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const LONG_OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{40,}\b/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
-  /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
+  /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =
   /(?:^|[.-])(?:auth|download|downloads|file|files|private|reset|secret|share|signed|token)(?:[.-]|$)/i;
 
@@ -89,37 +91,47 @@ function redactSensitiveAssignments(value: string): string {
     .replace(
       SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN,
       (
-        _match,
+        match: string,
         prefix: string,
         keyQuote: string,
         key: string,
         separator: string,
-      ) =>
-        `${prefix}${keyQuote}${key}${keyQuote}${separator}"${REDACTED}"`,
+      ) => {
+        if (!isSensitiveAssignmentKey(key)) return match;
+        return `${prefix}${keyQuote}${key}${keyQuote}${separator}"${REDACTED}"`;
+      },
     )
     .replace(
       SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN,
       (
-        _match,
+        match: string,
         prefix: string,
         keyQuote: string,
         key: string,
         separator: string,
-      ) =>
-        `${prefix}${keyQuote}${key}${keyQuote}${separator}'${REDACTED}'`,
+      ) => {
+        if (!isSensitiveAssignmentKey(key)) return match;
+        return `${prefix}${keyQuote}${key}${keyQuote}${separator}'${REDACTED}'`;
+      },
     )
     .replace(
       SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
       (
-        _match,
+        match: string,
         prefix: string,
         keyQuote: string,
         key: string,
         separator: string,
         _value: string,
-      ) =>
-        `${prefix}${keyQuote}${key}${keyQuote}${separator}${REDACTED}`,
+      ) => {
+        if (!isSensitiveAssignmentKey(key)) return match;
+        return `${prefix}${keyQuote}${key}${keyQuote}${separator}${REDACTED}`;
+      },
     );
+}
+
+function isSensitiveAssignmentKey(key: string): boolean {
+  return isSensitiveKey(key) || /^key$/i.test(key);
 }
 
 type RedactTokenOptions = {
@@ -331,7 +343,23 @@ function hasSensitiveUrlPathContext(url: URL): boolean {
 function hasSensitivePathSegments(path: string): boolean {
   return path
     .split("/")
-    .some((segment) => SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(segment));
+    .some((segment) => isSensitivePathSegment(segment));
+}
+
+function isSensitivePathSegment(segment: string): boolean {
+  const normalized = safeDecodeURIComponent(segment);
+  if (SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(normalized)) return true;
+  return normalized
+    .split(/[-_]+/)
+    .some((part) => SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(part));
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function sanitizeUrlMatch(match: string): string {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -290,7 +290,11 @@ function isOpaquePathToken(segment: string, minLength: number): boolean {
 
 function isSensitiveRouteSecretSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment);
-  return normalized.length >= 4 && /^[A-Za-z0-9_-]+$/u.test(normalized);
+  return (
+    normalized.length >= 4 &&
+    (/^[A-Za-z0-9_-]+$/u.test(normalized) ||
+      /^[A-Za-z0-9+/]+={0,2}$/u.test(normalized))
+  );
 }
 
 function redactSensitiveContextParams(value: string): string {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -108,7 +108,14 @@ function redactSensitiveAssignments(value: string): string {
     );
 }
 
-function redactTokenFragments(value: string): string {
+type RedactTokenOptions = {
+  preservePathSegments?: boolean;
+};
+
+function redactTokenFragments(
+  value: string,
+  options: RedactTokenOptions = { preservePathSegments: true },
+): string {
   return redactSensitiveAssignments(value)
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),
@@ -118,21 +125,25 @@ function redactTokenFragments(value: string): string {
     .replace(NAMED_SECRET_FRAGMENT_PATTERN, (match) =>
       match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match,
     )
-    .replace(LONG_OPAQUE_TOKEN_PATTERN, redactLongOpaqueToken);
+    .replace(LONG_OPAQUE_TOKEN_PATTERN, (match, offset, source) =>
+      redactLongOpaqueToken(match, offset, source, options),
+    );
 }
 
 function redactLongOpaqueToken(
   match: string,
   offset: number,
   source: string,
+  options: RedactTokenOptions,
 ): string {
   const before = offset > 0 ? source.at(offset - 1) : undefined;
   const after = source.at(offset + match.length);
   if (
-    before === "/" ||
-    before === "\\" ||
-    after === "/" ||
-    after === "\\"
+    options.preservePathSegments &&
+    (before === "/" ||
+      before === "\\" ||
+      after === "/" ||
+      after === "\\")
   ) {
     return match;
   }
@@ -247,7 +258,9 @@ function sanitizeUrl(value: string): string | undefined {
       }
     }
 
-    return redactTokenFragments(changed ? url.toString() : value);
+    return redactTokenFragments(changed ? url.toString() : value, {
+      preservePathSegments: false,
+    });
   } catch {
     return undefined;
   }

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -217,14 +217,21 @@ function redactSensitiveRelativePath(
   );
 
   if (sensitivePosition === -1) return candidate;
+  const hasRouteContext = Boolean(
+    methodPrefix || routePrefix || hasRouteLabelPrefix,
+  );
+  if (
+    !hasRouteContext &&
+    sensitivePosition === 0 &&
+    /^private$/i.test(meaningful[0] ?? "")
+  ) {
+    return candidate;
+  }
   // Avoid treating arbitrary filesystem paths as URLs: without an HTTP-ish
   // method/hash-route prefix, require the sensitive route to appear near the
   // path root.
   if (
-    !methodPrefix &&
-    !routePrefix &&
-    !hasRouteLabelPrefix &&
-    sensitivePosition > 1
+    !hasRouteContext && sensitivePosition > 1
   )
     return candidate;
 

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -29,6 +29,8 @@ const SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
 );
 const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
   /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp)\2(\s*[:=]\s*)(?:(?:bearer|basic)\s+)?([^\s"'<>),;&]+)/gi;
+const SENSITIVE_RELATIVE_CALLBACK_CODE_PATTERN =
+  /((?:^|[\s"'(])(?:[A-Z]+\s+)?(?:\.{0,2}\/)[^\s"'<>]*?(?:auth|oauth|callback)[^\s"'<>]*?[?&#]code=)([^&#\s"'<>),;]+)/gi;
 const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const KNOWN_SECRET_PATTERN =
@@ -80,6 +82,10 @@ export function sanitizeText(value: string): string {
 
 function redactSensitiveAssignments(value: string): string {
   return value
+    .replace(
+      SENSITIVE_RELATIVE_CALLBACK_CODE_PATTERN,
+      (_match, prefix: string) => `${prefix}${REDACTED}`,
+    )
     .replace(
       SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN,
       (

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -215,8 +215,9 @@ function redactSensitiveRelativePath(candidate: string): string {
 
   if (sensitivePosition === -1) return candidate;
   // Avoid treating arbitrary filesystem paths as URLs: without an HTTP-ish
-  // method prefix, require the sensitive route to appear near the path root.
-  if (!methodPrefix && sensitivePosition > 1) return candidate;
+  // method/hash-route prefix, require the sensitive route to appear near the
+  // path root.
+  if (!methodPrefix && !routePrefix && sensitivePosition > 1) return candidate;
 
   let seenSensitiveSegment = false;
   const redacted = segments.map((segment) => {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -151,8 +151,8 @@ function redactTokenFragments(
     )
     .replace(JWT_PATTERN, REDACTED)
     .replace(KNOWN_SECRET_PATTERN, REDACTED)
-    .replace(NAMED_SECRET_FRAGMENT_PATTERN, (match) =>
-      match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match,
+    .replace(NAMED_SECRET_FRAGMENT_PATTERN, (match, offset, source) =>
+      redactNamedSecretFragment(match, offset, source),
     )
     .replace(OPAQUE_TOKEN_PATTERN, (match, offset, source) =>
       redactLongOpaqueToken(match, offset, source, options),
@@ -172,6 +172,25 @@ function redactSensitiveRelativePathTokens(value: string): string {
       return `${prefix}${redactSensitiveRelativePath(path)}${suffix}`;
     },
   );
+}
+
+function redactNamedSecretFragment(
+  match: string,
+  offset: number,
+  source: string,
+): string {
+  const before = offset > 0 ? source.at(offset - 1) : undefined;
+  const after = source.at(offset + match.length);
+  if (
+    before === "/" ||
+    before === "\\" ||
+    after === "/" ||
+    after === "\\" ||
+    after === "."
+  ) {
+    return match;
+  }
+  return match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match;
 }
 
 function redactSensitiveRelativePath(candidate: string): string {
@@ -200,12 +219,12 @@ function redactSensitiveRelativePath(candidate: string): string {
       seenSensitiveSegment = true;
       return segment;
     }
-    if (seenSensitiveSegment && isOpaquePathToken(segment, 32)) {
+    if (seenSensitiveSegment && isSensitiveRouteSecretSegment(segment)) {
       return REDACTED;
     }
     return segment;
   });
-  return `${methodPrefix}${redacted.join("/")}${suffix}`;
+  return `${methodPrefix}${redacted.join("/")}${redactSensitiveContextParams(suffix)}`;
 }
 
 function firstPathSuffixIndex(path: string): number {
@@ -218,6 +237,23 @@ function firstPathSuffixIndex(path: string): number {
 
 function isOpaquePathToken(segment: string, minLength: number): boolean {
   return segment.length >= minLength && /^[A-Za-z0-9_-]+$/u.test(segment);
+}
+
+function isSensitiveRouteSecretSegment(segment: string): boolean {
+  const normalized = safeDecodeURIComponent(segment);
+  return normalized.length >= 4 && /^[A-Za-z0-9_-]+$/u.test(normalized);
+}
+
+function redactSensitiveContextParams(value: string): string {
+  return value.replace(
+    /([?&#])([^=&#\s]+)=([^&#\s]*)/g,
+    (match, prefix: string, key: string) => {
+      if (isSensitiveUrlQueryKey(key) || isSensitiveUrlContextQueryKey(key)) {
+        return `${prefix}${key}=${REDACTED}`;
+      }
+      return match;
+    },
+  );
 }
 
 function redactLongOpaqueToken(
@@ -351,6 +387,7 @@ function sanitizeUrl(value: string): string | undefined {
       changed = true;
     }
     if (sanitizeUrlFragment(url, sensitiveUrlContext)) changed = true;
+    if (sanitizeUrlRoutePathTokens(url)) changed = true;
 
     return redactTokenFragments(changed ? url.toString() : value, {
       minOpaqueTokenLength: sensitiveUrlContext ? 32 : undefined,
@@ -400,6 +437,46 @@ function sanitizeUrlFragment(url: URL, sensitiveUrlContext: boolean): boolean {
   const prefix = queryStart === -1 ? "" : `${fragmentPath}?`;
   url.hash = `${prefix}${params.toString()}`;
   return true;
+}
+
+function sanitizeUrlRoutePathTokens(url: URL): boolean {
+  let changed = false;
+  const pathname = redactSensitivePathRouteTokens(url.pathname);
+  if (pathname !== url.pathname) {
+    url.pathname = pathname;
+    changed = true;
+  }
+
+  const fragment = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+  if (fragment) {
+    const suffixStart = firstPathSuffixIndex(fragment);
+    const fragmentPath =
+      suffixStart === -1 ? fragment : fragment.slice(0, suffixStart);
+    const suffix = suffixStart === -1 ? "" : fragment.slice(suffixStart);
+    const redactedPath = redactSensitivePathRouteTokens(fragmentPath);
+    if (redactedPath !== fragmentPath) {
+      url.hash = `${redactedPath}${suffix}`;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+function redactSensitivePathRouteTokens(pathname: string): string {
+  const segments = pathname.split("/");
+  let seenSensitiveSegment = false;
+  const redacted = segments.map((segment) => {
+    if (isSensitivePathSegment(segment)) {
+      seenSensitiveSegment = true;
+      return segment;
+    }
+    if (seenSensitiveSegment && isSensitiveRouteSecretSegment(segment)) {
+      return REDACTED;
+    }
+    return segment;
+  });
+  return redacted.join("/");
 }
 
 function hasSensitiveUrlPathContext(url: URL): boolean {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -290,6 +290,7 @@ function isOpaquePathToken(segment: string, minLength: number): boolean {
 
 function isSensitiveRouteSecretSegment(segment: string): boolean {
   const normalized = safeDecodeURIComponent(segment);
+  if (/^\d+$/u.test(normalized)) return false;
   return (
     normalized.length >= 4 &&
     (/^[A-Za-z0-9_-]+$/u.test(normalized) ||

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -47,7 +47,7 @@ const OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
 const RELATIVE_PATH_CANDIDATE_PATTERN =
   /(^|[\s"'(=:])((?:[A-Z]+\s+)?(?:#\/|\.{0,2}\/)[^\s"'<>),;&]+)/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
-  /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
+  /^(?:auth|authorize|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|login|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =
   /(?:^|[.-])(?:auth|download|downloads|file|files|private|reset|secret|share|signed|token)(?:[.-]|$)/i;
 

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -18,7 +18,7 @@ const URL_REDACTION_VALUE = "redacted";
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
 const SENSITIVE_ASSIGNMENT_KEY =
-  "token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp";
+  "token|access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|value|pin|otp";
 const SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
   `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)"((?:\\\\.|[^"\\\\\\r\\n])*)"`,
   "gi",
@@ -269,15 +269,10 @@ function sanitizeUrl(value: string): string | undefined {
     }
 
     const sensitiveUrlContext = hasSensitiveUrlPathContext(url);
-    for (const key of Array.from(url.searchParams.keys())) {
-      if (
-        isSensitiveUrlQueryKey(key) ||
-        (sensitiveUrlContext && isSensitiveUrlContextQueryKey(key))
-      ) {
-        url.searchParams.set(key, REDACTED);
-        changed = true;
-      }
+    if (redactSensitiveUrlParams(url.searchParams, sensitiveUrlContext)) {
+      changed = true;
     }
+    if (sanitizeUrlFragment(url, sensitiveUrlContext)) changed = true;
 
     return redactTokenFragments(changed ? url.toString() : value, {
       preservePathSegments: !(
@@ -289,9 +284,52 @@ function sanitizeUrl(value: string): string | undefined {
   }
 }
 
+function redactSensitiveUrlParams(
+  params: URLSearchParams,
+  sensitiveUrlContext: boolean,
+): boolean {
+  let changed = false;
+  for (const key of Array.from(params.keys())) {
+    if (
+      isSensitiveUrlQueryKey(key) ||
+      (sensitiveUrlContext && isSensitiveUrlContextQueryKey(key))
+    ) {
+      params.set(key, REDACTED);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function sanitizeUrlFragment(url: URL, sensitiveUrlContext: boolean): boolean {
+  const fragment = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+  if (!fragment || !fragment.includes("=")) return false;
+
+  const queryStart = fragment.indexOf("?");
+  const fragmentPath = queryStart === -1 ? "" : fragment.slice(0, queryStart);
+  const paramText =
+    queryStart === -1 ? fragment : fragment.slice(queryStart + 1);
+  if (!paramText.includes("=")) return false;
+
+  const fragmentSensitiveContext =
+    sensitiveUrlContext || hasSensitivePathSegments(fragmentPath);
+  const params = new URLSearchParams(paramText);
+  if (!redactSensitiveUrlParams(params, fragmentSensitiveContext)) {
+    return false;
+  }
+
+  const prefix = queryStart === -1 ? "" : `${fragmentPath}?`;
+  url.hash = `${prefix}${params.toString()}`;
+  return true;
+}
+
 function hasSensitiveUrlPathContext(url: URL): boolean {
   if (SENSITIVE_URL_HOST_FRAGMENT_PATTERN.test(url.hostname)) return true;
-  return url.pathname
+  return hasSensitivePathSegments(url.pathname);
+}
+
+function hasSensitivePathSegments(path: string): boolean {
+  return path
     .split("/")
     .some((segment) => SENSITIVE_URL_PATH_SEGMENT_PATTERN.test(segment));
 }

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -19,8 +19,12 @@ const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
 const SENSITIVE_ASSIGNMENT_KEY =
   "token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp";
-const SENSITIVE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
-  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)(["'])([^\\r\\n]*?)\\5`,
+const SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
+  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)"((?:\\\\.|[^"\\\\\\r\\n])*)"`,
+  "gi",
+);
+const SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN = new RegExp(
+  `(^|[?#&\\s,;({\\[])(["']?)(${SENSITIVE_ASSIGNMENT_KEY})\\2(\\s*[:=]\\s*)'((?:\\\\.|[^'\\\\\\r\\n])*)'`,
   "gi",
 );
 const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
@@ -66,19 +70,29 @@ export function sanitizeText(value: string): string {
   return redactTokenFragments(value.replace(URL_PATTERN, sanitizeUrlMatch));
 }
 
-function redactTokenFragments(value: string): string {
+function redactSensitiveAssignments(value: string): string {
   return value
     .replace(
-      SENSITIVE_QUOTED_ASSIGNMENT_PATTERN,
+      SENSITIVE_DOUBLE_QUOTED_ASSIGNMENT_PATTERN,
       (
         _match,
         prefix: string,
         keyQuote: string,
         key: string,
         separator: string,
-        valueQuote: string,
       ) =>
-        `${prefix}${keyQuote}${key}${keyQuote}${separator}${valueQuote}${REDACTED}${valueQuote}`,
+        `${prefix}${keyQuote}${key}${keyQuote}${separator}"${REDACTED}"`,
+    )
+    .replace(
+      SENSITIVE_SINGLE_QUOTED_ASSIGNMENT_PATTERN,
+      (
+        _match,
+        prefix: string,
+        keyQuote: string,
+        key: string,
+        separator: string,
+      ) =>
+        `${prefix}${keyQuote}${key}${keyQuote}${separator}'${REDACTED}'`,
     )
     .replace(
       SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
@@ -91,7 +105,11 @@ function redactTokenFragments(value: string): string {
         _value: string,
       ) =>
         `${prefix}${keyQuote}${key}${keyQuote}${separator}${REDACTED}`,
-    )
+    );
+}
+
+function redactTokenFragments(value: string): string {
+  return redactSensitiveAssignments(value)
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),
     )
@@ -100,7 +118,26 @@ function redactTokenFragments(value: string): string {
     .replace(NAMED_SECRET_FRAGMENT_PATTERN, (match) =>
       match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match,
     )
-    .replace(LONG_OPAQUE_TOKEN_PATTERN, REDACTED);
+    .replace(LONG_OPAQUE_TOKEN_PATTERN, redactLongOpaqueToken);
+}
+
+function redactLongOpaqueToken(
+  match: string,
+  offset: number,
+  source: string,
+): string {
+  const before = offset > 0 ? source.at(offset - 1) : undefined;
+  const after = source.at(offset + match.length);
+  if (
+    before === "/" ||
+    before === "\\" ||
+    after === "/" ||
+    after === "\\" ||
+    after === "."
+  ) {
+    return match;
+  }
+  return REDACTED;
 }
 
 function sanitize(

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -17,6 +17,8 @@ const REDACTED = "[redacted]";
 const URL_REDACTION_VALUE = "redacted";
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
+const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
+  /(^|[?&\s,;({[])(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp)(\s*[:=]\s*)(?:bearer\s+)?([^\s"'<>),;&]+)/gi;
 const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const KNOWN_SECRET_PATTERN =
@@ -60,6 +62,11 @@ export function sanitizeText(value: string): string {
 
 function redactTokenFragments(value: string): string {
   return value
+    .replace(
+      SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
+      (_match, prefix: string, key: string, separator: string) =>
+        `${prefix}${key}${separator}${REDACTED}`,
+    )
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),
     )
@@ -151,7 +158,7 @@ function sanitizeString(value: string): string {
   const sanitizedUrl = sanitizeUrl(value);
   if (sanitizedUrl !== undefined) return sanitizedUrl;
   if (isLikelySecretValue(value)) return REDACTED;
-  if (looksLikeStandalonePathOrUrl(value.trim())) return value;
+  if (looksLikeStandalonePathOrUrl(value.trim())) return sanitizeText(value);
   return sanitizeText(value);
 }
 

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -41,7 +41,7 @@ const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
 const RELATIVE_PATH_CANDIDATE_PATTERN =
-  /(^|[\s"'(=])((?:[A-Z]+\s+)?(?:#\/|\.{0,2}\/)[^\s"'<>),;]+)/g;
+  /(^|[\s"'(=:])((?:[A-Z]+\s+)?(?:#\/|\.{0,2}\/)[^\s"'<>),;]+)/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
   /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -18,7 +18,7 @@ const URL_REDACTION_VALUE = "redacted";
 const URL_PATTERN = /\b[a-z][a-z0-9+.-]*:\/\/[^\s<>"'`]+/gi;
 const BEARER_PATTERN = /\bbearer\s+[^\s"'<>]+/gi;
 const SENSITIVE_TEXT_ASSIGNMENT_PATTERN =
-  /(^|[?&\s,;({[])(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp)(\s*[:=]\s*)(?:bearer\s+)?([^\s"'<>),;&]+)/gi;
+  /(^|[?#&\s,;({\[])(["']?)(token|access[_-]?token|refresh[_-]?token|api[_-]?key|key|secret|password|passphrase|private[_-]?key|credential|authorization|pin|otp)\2(\s*[:=]\s*)(?:bearer\s+)?(["']?)([^\s"'<>),;&]+)(["']?)/gi;
 const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const KNOWN_SECRET_PATTERN =
@@ -64,8 +64,17 @@ function redactTokenFragments(value: string): string {
   return value
     .replace(
       SENSITIVE_TEXT_ASSIGNMENT_PATTERN,
-      (_match, prefix: string, key: string, separator: string) =>
-        `${prefix}${key}${separator}${REDACTED}`,
+      (
+        _match,
+        prefix: string,
+        keyQuote: string,
+        key: string,
+        separator: string,
+        valueQuote: string,
+        _value: string,
+        valueEndQuote: string,
+      ) =>
+        `${prefix}${keyQuote}${key}${keyQuote}${separator}${valueQuote}${REDACTED}${valueEndQuote}`,
     )
     .replace(BEARER_PATTERN, (match) =>
       match.replace(/\s+\S+$/u, " [redacted]"),

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -21,6 +21,8 @@ const JWT_PATTERN =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const KNOWN_SECRET_PATTERN =
   /\b(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{16,}|AKIA[0-9A-Z]{16})\b/g;
+const NAMED_SECRET_FRAGMENT_PATTERN =
+  /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const LONG_OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{40,}\b/g;
 
 /** Cap on how deep we recurse, so a cyclic or pathologically nested payload
@@ -56,6 +58,9 @@ export function sanitizeText(value: string): string {
     )
     .replace(JWT_PATTERN, REDACTED)
     .replace(KNOWN_SECRET_PATTERN, REDACTED)
+    .replace(NAMED_SECRET_FRAGMENT_PATTERN, (match) =>
+      match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match,
+    )
     .replace(LONG_OPAQUE_TOKEN_PATTERN, REDACTED);
 }
 

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -45,7 +45,7 @@ const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
 const RELATIVE_PATH_CANDIDATE_PATTERN =
-  /(^|[\s"'(=:])((?:[A-Z]+\s+)?(?:#\/|\.{0,2}\/)[^\s"'<>),;]+)/g;
+  /(^|[\s"'(=:])((?:[A-Z]+\s+)?(?:#\/|\.{0,2}\/)[^\s"'<>),;&]+)/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
   /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -169,7 +169,7 @@ function redactSensitiveRelativePathTokens(value: string): string {
         suffix = `${path.at(-1) ?? ""}${suffix}`;
         path = path.slice(0, -1);
       }
-      return `${prefix}${redactSensitiveRelativePath(path)}${suffix}`;
+      return `${prefix}${redactSensitiveRelativePath(path, prefix === ":" || prefix === "=")}${suffix}`;
     },
   );
 }
@@ -193,7 +193,10 @@ function redactNamedSecretFragment(
   return match.length >= 16 && /[0-9_-]/u.test(match) ? REDACTED : match;
 }
 
-function redactSensitiveRelativePath(candidate: string): string {
+function redactSensitiveRelativePath(
+  candidate: string,
+  hasRouteLabelPrefix = false,
+): string {
   const methodMatch = /^([A-Z]+\s+)(.+)$/u.exec(candidate);
   const methodPrefix = methodMatch?.[1] ?? "";
   let path = methodMatch?.[2] ?? candidate;
@@ -217,7 +220,13 @@ function redactSensitiveRelativePath(candidate: string): string {
   // Avoid treating arbitrary filesystem paths as URLs: without an HTTP-ish
   // method/hash-route prefix, require the sensitive route to appear near the
   // path root.
-  if (!methodPrefix && !routePrefix && sensitivePosition > 1) return candidate;
+  if (
+    !methodPrefix &&
+    !routePrefix &&
+    !hasRouteLabelPrefix &&
+    sensitivePosition > 1
+  )
+    return candidate;
 
   let seenSensitiveSegment = false;
   const redacted = segments.map((segment) => {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -45,6 +45,10 @@ export function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERN.test(key);
 }
 
+function isSensitiveUrlQueryKey(key: string): boolean {
+  return isSensitiveKey(key) || /^key$/i.test(key);
+}
+
 /**
  * Redacts secret-shaped fragments inside otherwise human-readable text. Use this
  * for fields that are intentionally surfaced as strings, such as error
@@ -169,7 +173,7 @@ function sanitizeUrl(value: string): string | undefined {
     }
 
     for (const key of Array.from(url.searchParams.keys())) {
-      if (isSensitiveKey(key)) {
+      if (isSensitiveUrlQueryKey(key)) {
         url.searchParams.set(key, REDACTED);
         changed = true;
       }

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -41,7 +41,7 @@ const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
 const RELATIVE_PATH_CANDIDATE_PATTERN =
-  /(^|[\s"'(])((?:[A-Z]+\s+)?(?:\.{0,2}\/)[^\s"'<>),;]+)/g;
+  /(^|[\s"'(=])((?:[A-Z]+\s+)?(?:\.{0,2}\/)[^\s"'<>),;]+)/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
   /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =
@@ -345,7 +345,8 @@ function sanitizeUrl(value: string): string | undefined {
       changed = true;
     }
 
-    const sensitiveUrlContext = hasSensitiveUrlPathContext(url);
+    const sensitiveUrlContext =
+      hasSensitiveUrlPathContext(url) || hasSensitiveUrlHashPathContext(url);
     if (redactSensitiveUrlParams(url.searchParams, sensitiveUrlContext)) {
       changed = true;
     }
@@ -404,6 +405,15 @@ function sanitizeUrlFragment(url: URL, sensitiveUrlContext: boolean): boolean {
 function hasSensitiveUrlPathContext(url: URL): boolean {
   if (SENSITIVE_URL_HOST_FRAGMENT_PATTERN.test(url.hostname)) return true;
   return hasSensitivePathSegments(url.pathname);
+}
+
+function hasSensitiveUrlHashPathContext(url: URL): boolean {
+  const fragment = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+  if (!fragment) return false;
+  const suffixStart = firstPathSuffixIndex(fragment);
+  const fragmentPath =
+    suffixStart === -1 ? fragment : fragment.slice(0, suffixStart);
+  return hasSensitivePathSegments(fragmentPath);
 }
 
 function hasSensitivePathSegments(path: string): boolean {

--- a/src/lib/hermes-control-plane/sanitize.ts
+++ b/src/lib/hermes-control-plane/sanitize.ts
@@ -41,7 +41,7 @@ const NAMED_SECRET_FRAGMENT_PATTERN =
   /\b[A-Za-z0-9_-]*(?:token|secret|credential|password|api[_-]?key)[A-Za-z0-9_-]*\b/gi;
 const OPAQUE_TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
 const RELATIVE_PATH_CANDIDATE_PATTERN =
-  /(^|[\s"'(=])((?:[A-Z]+\s+)?(?:\.{0,2}\/)[^\s"'<>),;]+)/g;
+  /(^|[\s"'(=])((?:[A-Z]+\s+)?(?:#\/|\.{0,2}\/)[^\s"'<>),;]+)/g;
 const SENSITIVE_URL_PATH_SEGMENT_PATTERN =
   /^(?:auth|callback|callbacks|credential|credentials|download|downloads|file|files|invite|invites|oauth|password|passwords|private|reset|secret|secrets|share|shares|signed|token|tokens)$/i;
 const SENSITIVE_URL_HOST_FRAGMENT_PATTERN =
@@ -196,7 +196,12 @@ function redactNamedSecretFragment(
 function redactSensitiveRelativePath(candidate: string): string {
   const methodMatch = /^([A-Z]+\s+)(.+)$/u.exec(candidate);
   const methodPrefix = methodMatch?.[1] ?? "";
-  const path = methodMatch?.[2] ?? candidate;
+  let path = methodMatch?.[2] ?? candidate;
+  let routePrefix = "";
+  if (path.startsWith("#/")) {
+    routePrefix = "#";
+    path = path.slice(1);
+  }
   const suffixStart = firstPathSuffixIndex(path);
   const pathname = suffixStart === -1 ? path : path.slice(0, suffixStart);
   const suffix = suffixStart === -1 ? "" : path.slice(suffixStart);
@@ -224,7 +229,7 @@ function redactSensitiveRelativePath(candidate: string): string {
     }
     return segment;
   });
-  return `${methodPrefix}${redacted.join("/")}${redactSensitiveContextParams(suffix)}`;
+  return `${methodPrefix}${routePrefix}${redacted.join("/")}${redactSensitiveContextParams(suffix)}`;
 }
 
 function firstPathSuffixIndex(path: string): number {

--- a/src/lib/hermes-trace-buffer.ts
+++ b/src/lib/hermes-trace-buffer.ts
@@ -26,6 +26,7 @@ import {
   classifyHermesEvent,
   nonEmpty,
   sanitizePayload,
+  sanitizeText,
   type JuneHermesEvent,
   type JuneHermesEventKind,
 } from "./hermes-control-plane";
@@ -183,7 +184,7 @@ export function createHermesTraceBuffer(): HermesTraceBuffer {
       observedAt: new Date().toISOString(),
       sessionId,
       method: nonEmpty(error.method),
-      message: error.message,
+      message: sanitizeText(error.message),
       payloadKeys: [],
     });
   }

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -471,6 +471,35 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("sanitizes live Hermes error text before rendering it in chat", () => {
+    const bearer = "abcdef0123456789abcdef0123456789";
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        {
+          type: "error",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          payload: {
+            message: `Gateway failed with Bearer ${bearer} token=abc123`,
+          },
+        },
+      ],
+    );
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "tool",
+        id: "error:2026-06-04T10:00:00.000Z",
+        name: "Error",
+        text: "Gateway failed with Bearer [redacted] token=[redacted]",
+        status: "failed",
+      },
+    ]);
+    expect(JSON.stringify(turns)).not.toContain(bearer);
+    expect(JSON.stringify(turns)).not.toContain("abc123");
+  });
+
   it("marks clarify requests resolved after responses or tool completion", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -273,6 +273,22 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("/download/[redacted]");
   });
 
+  it("does not preserve raw encoded relative download url tokens", () => {
+    const downloadUrl = "/download/YWJjZA%3D%3D";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: downloadUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("YWJjZA%3D%3D");
+    expect(JSON.stringify(event)).not.toContain("YWJjZA%3D%3D");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("YWJjZA%3D%3D");
+    expect(artifact.path).toContain("/download/[redacted]");
+  });
+
   it("preserves signed download urls with filenames", () => {
     const signedUrl =
       "https://app.example.com/download/report.pdf?token=signed-token-123&view=1";

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -308,6 +308,23 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("signed-token-123");
   });
 
+  it("preserves signed download urls with numeric subdirectories", () => {
+    const signedUrl =
+      "https://files.example.com/download/2024/report.pdf?token=signed-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+    });
+
+    expect(event.artifactLocations).toEqual([signedUrl]);
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).toBe(signedUrl);
+    expect(artifact.path).toContain("signed-token-123");
+  });
+
   it("does not preserve signed artifact urls with dotted route tokens", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzaGFyZSJ9.signature123";

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -240,6 +240,40 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("signed-token-123");
   });
 
+  it("does not preserve raw download url path tokens", () => {
+    const downloadUrl =
+      "https://app.example.com/download/download-token-123?view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: downloadUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("download-token-123");
+    expect(JSON.stringify(event)).not.toContain("download-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("download-token-123");
+    expect(artifact.path).toContain("/download/[redacted]");
+  });
+
+  it("preserves signed download urls with filenames", () => {
+    const signedUrl =
+      "https://app.example.com/download/report.pdf?token=signed-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+    });
+
+    expect(event.artifactLocations).toEqual([signedUrl]);
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).toBe(signedUrl);
+    expect(artifact.path).toContain("signed-token-123");
+  });
+
   it("does not preserve signed artifact urls with dotted route tokens", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzaGFyZSJ9.signature123";

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -142,6 +142,39 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("code=[redacted]");
   });
 
+  it("does not preserve raw sensitive relative auth routes", () => {
+    const callbackRoute = "/oauth/callback?code=oauth-code-123&state=ok";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "fetch_url",
+      url: callbackRoute,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("oauth-code-123");
+    expect(JSON.stringify(event)).not.toContain("oauth-code-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("oauth-code-123");
+    expect(artifact.path).toContain("code=[redacted]");
+  });
+
+  it("does not preserve raw non-artifact urls with authorization params", () => {
+    const authUrl =
+      "https://api.example.com/me?authorization=Bearer%20secret-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "fetch_url",
+      url: authUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("secret-token-123");
+    expect(JSON.stringify(event)).not.toContain("secret-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("secret-token-123");
+    expect(artifact.path).toContain("authorization=");
+  });
+
   it("does not preserve credential-shaped non-url artifact fields", () => {
     const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
     const event = toolClassified("tool.complete", "s1", {
@@ -167,7 +200,9 @@ describe("artifactsFromToolEvent", () => {
     expect(JSON.stringify(event)).not.toContain(path);
     expect(event.artifactLocations).toEqual([path]);
 
-    const [artifact] = artifactsFromToolEvent(event);
+    const artifacts = artifactsFromToolEvent(event);
+    expect(artifacts).toHaveLength(1);
+    const [artifact] = artifacts;
     expect(artifact.path).toBe(path);
     expect(artifact.path).not.toContain("[redacted]");
     expect(artifact.displayName).toBe("a".repeat(32));

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -125,6 +125,20 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).not.toContain("user:pass");
   });
 
+  it("does not preserve credential-shaped non-url artifact fields", () => {
+    const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "write_file",
+      file: secret,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event)).not.toContain(secret);
+
+    const artifacts = artifactsFromToolEvent(event);
+    expect(JSON.stringify(artifacts)).not.toContain(secret);
+  });
+
   it("derives the display name from the path basename", () => {
     const event = toolClassified("tool.complete", "s1", {
       name: "write_file",

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -257,6 +257,22 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("/download/[redacted]");
   });
 
+  it("does not preserve raw relative download url path tokens", () => {
+    const downloadUrl = "/download/download-token-123";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: downloadUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("download-token-123");
+    expect(JSON.stringify(event)).not.toContain("download-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("download-token-123");
+    expect(artifact.path).toContain("/download/[redacted]");
+  });
+
   it("preserves signed download urls with filenames", () => {
     const signedUrl =
       "https://app.example.com/download/report.pdf?token=signed-token-123&view=1";

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -196,6 +196,27 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("report.pdf");
   });
 
+  it("does not preserve signed artifact urls with dotted route tokens", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzaGFyZSJ9.signature123";
+    const signedUrl = `https://app.example.com/share/${jwt}/report.pdf?token=signed-token-123&view=1`;
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain(jwt);
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event)).not.toContain(jwt);
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain(jwt);
+    expect(artifact.path).not.toContain("signed-token-123");
+    expect(artifact.path).toContain("report.pdf");
+  });
+
   it("does not preserve raw relative share route path tokens", () => {
     const shareRoute = "/share/share-token-123";
     const event = toolClassified("tool.complete", "s1", {

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -139,6 +139,23 @@ describe("artifactsFromToolEvent", () => {
     expect(JSON.stringify(artifacts)).not.toContain(secret);
   });
 
+  it("preserves extensionless local artifact paths before payload redaction", () => {
+    const path = `/download/${"a".repeat(32)}`;
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      path,
+    });
+
+    expect(JSON.stringify(event.payload)).toContain("/download/[redacted]");
+    expect(JSON.stringify(event)).not.toContain(path);
+    expect(event.artifactLocations).toEqual([path]);
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).toBe(path);
+    expect(artifact.path).not.toContain("[redacted]");
+    expect(artifact.displayName).toBe("a".repeat(32));
+  });
+
   it("derives the display name from the path basename", () => {
     const event = toolClassified("tool.complete", "s1", {
       name: "write_file",

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -120,7 +120,9 @@ describe("artifactsFromToolEvent", () => {
     expect(JSON.stringify(event)).not.toContain("signed-token-123");
     expect(event.artifactLocations).toEqual([safeNavigationUrl]);
 
-    const [artifact] = artifactsFromToolEvent(event);
+    const artifacts = artifactsFromToolEvent(event);
+    expect(artifacts).toHaveLength(1);
+    const [artifact] = artifacts;
     expect(artifact.path).toBe(safeNavigationUrl);
     expect(artifact.path).not.toContain("user:pass");
   });

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -125,6 +125,23 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).not.toContain("user:pass");
   });
 
+  it("does not preserve raw sensitive non-artifact urls", () => {
+    const callbackUrl =
+      "https://auth.example.com/oauth/callback?code=oauth-code-123&state=ok";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "fetch_url",
+      url: callbackUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("oauth-code-123");
+    expect(JSON.stringify(event)).not.toContain("oauth-code-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("oauth-code-123");
+    expect(artifact.path).toContain("code=[redacted]");
+  });
+
   it("does not preserve credential-shaped non-url artifact fields", () => {
     const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
     const event = toolClassified("tool.complete", "s1", {

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -142,6 +142,23 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("code=[redacted]");
   });
 
+  it("does not preserve raw auth url path tokens", () => {
+    const resetUrl =
+      "https://app.example.com/reset-password/reset-token-123?view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "fetch_url",
+      url: resetUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("reset-token-123");
+    expect(JSON.stringify(event)).not.toContain("reset-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("reset-token-123");
+    expect(artifact.path).toContain("reset-password/[redacted]");
+  });
+
   it("does not preserve raw sensitive relative auth routes", () => {
     const callbackRoute = "/oauth/callback?code=oauth-code-123&state=ok";
     const event = toolClassified("tool.complete", "s1", {

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -87,6 +87,25 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toBe("https://example.com/report.pdf");
   });
 
+  it("opens signed artifact urls while keeping the tool payload redacted", () => {
+    const signedUrl =
+      "https://files.example.com/report.pdf?token=signed-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+    });
+
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+    expect(event.artifactLocations).toEqual([signedUrl]);
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.kind).toBe("url");
+    expect(artifact.action).toBe("downloaded");
+    expect(artifact.path).toBe(signedUrl);
+    expect(artifact.displayName).toBe("report.pdf");
+  });
+
   it("derives the display name from the path basename", () => {
     const event = toolClassified("tool.complete", "s1", {
       name: "write_file",

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -159,6 +159,39 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("reset-password/[redacted]");
   });
 
+  it("does not preserve raw SPA hash route path tokens", () => {
+    const resetUrl =
+      "https://app.example.com/#/reset-password/hash-token-123";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "fetch_url",
+      url: resetUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("hash-token-123");
+    expect(JSON.stringify(event)).not.toContain("hash-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("hash-token-123");
+    expect(artifact.path).toContain("#/reset-password/[redacted]");
+  });
+
+  it("does not preserve raw relative share route path tokens", () => {
+    const shareRoute = "/share/share-token-123";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "fetch_url",
+      path: shareRoute,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("share-token-123");
+    expect(JSON.stringify(event)).not.toContain("share-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("share-token-123");
+    expect(artifact.path).toContain("/share/[redacted]");
+  });
+
   it("does not preserve raw sensitive relative auth routes", () => {
     const callbackRoute = "/oauth/callback?code=oauth-code-123&state=ok";
     const event = toolClassified("tool.complete", "s1", {

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -106,6 +106,25 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.displayName).toBe("report.pdf");
   });
 
+  it("strips URL userinfo from artifact navigation locations", () => {
+    const signedUrlWithUserinfo =
+      "https://user:pass@files.example.com/report.pdf?token=signed-token-123&view=1";
+    const safeNavigationUrl =
+      "https://files.example.com/report.pdf?token=signed-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrlWithUserinfo,
+    });
+
+    expect(JSON.stringify(event.payload)).not.toContain("user:pass");
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+    expect(event.artifactLocations).toEqual([safeNavigationUrl]);
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).toBe(safeNavigationUrl);
+    expect(artifact.path).not.toContain("user:pass");
+  });
+
   it("derives the display name from the path basename", () => {
     const event = toolClassified("tool.complete", "s1", {
       name: "write_file",

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -176,6 +176,26 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("#/reset-password/[redacted]");
   });
 
+  it("does not preserve signed artifact urls with sensitive route tokens", () => {
+    const signedUrl =
+      "https://app.example.com/share/share-token-123/report.pdf?token=signed-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+    });
+
+    expect(event.artifactLocations).toBeUndefined();
+    expect(JSON.stringify(event.payload)).not.toContain("share-token-123");
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event)).not.toContain("share-token-123");
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).not.toContain("share-token-123");
+    expect(artifact.path).not.toContain("signed-token-123");
+    expect(artifact.path).toContain("report.pdf");
+  });
+
   it("does not preserve raw relative share route path tokens", () => {
     const shareRoute = "/share/share-token-123";
     const event = toolClassified("tool.complete", "s1", {

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -196,6 +196,50 @@ describe("artifactsFromToolEvent", () => {
     expect(artifact.path).toContain("report.pdf");
   });
 
+  it("keeps sanitized URL artifacts alongside preserved raw URLs", () => {
+    const signedUrl =
+      "https://files.example.com/report.pdf?token=signed-token-123&view=1";
+    const sanitizedOnlyUrl =
+      "https://app.example.com/share/share-token-123/report2.pdf?token=other-token-456&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+      uri: sanitizedOnlyUrl,
+    });
+
+    expect(event.artifactLocations).toEqual([signedUrl]);
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event.payload)).not.toContain("share-token-123");
+    expect(JSON.stringify(event.payload)).not.toContain("other-token-456");
+
+    const artifacts = artifactsFromToolEvent(event);
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts.map((artifact) => artifact.path)).toContain(signedUrl);
+    const sanitizedArtifact = artifacts.find(
+      (artifact) => artifact.path !== signedUrl,
+    );
+    expect(sanitizedArtifact?.path).toContain("report2.pdf");
+    expect(sanitizedArtifact?.path).not.toContain("share-token-123");
+    expect(sanitizedArtifact?.path).not.toContain("other-token-456");
+  });
+
+  it("preserves signed artifact urls with filenames under share routes", () => {
+    const signedUrl =
+      "https://app.example.com/share/report.pdf?token=signed-token-123&view=1";
+    const event = toolClassified("tool.complete", "s1", {
+      name: "download_file",
+      url: signedUrl,
+    });
+
+    expect(event.artifactLocations).toEqual([signedUrl]);
+    expect(JSON.stringify(event.payload)).not.toContain("signed-token-123");
+    expect(JSON.stringify(event)).not.toContain("signed-token-123");
+
+    const [artifact] = artifactsFromToolEvent(event);
+    expect(artifact.path).toBe(signedUrl);
+    expect(artifact.path).toContain("signed-token-123");
+  });
+
   it("does not preserve signed artifact urls with dotted route tokens", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzaGFyZSJ9.signature123";

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -372,6 +372,21 @@ describe("classifyHermesEvent — error redaction", () => {
       expect(result.message).toBeTruthy();
     }
   });
+
+  it("redacts secret fragments inside the surfaced error message", () => {
+    const result = classifyHermesEvent(
+      event("error", {
+        message:
+          "Upstream auth failed with Bearer abcdef0123456789abcdef0123456789",
+      }),
+    );
+
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("Bearer [redacted]");
+      expect(result.message).not.toContain("abcdef0123456789abcdef0123456789");
+    }
+  });
 });
 
 describe("classifyHermesEvent — unsupported sanitization", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -133,6 +133,15 @@ describe("sanitizeText", () => {
     expect(out).toContain("view=1");
     expect(out).not.toContain("secret-token-123");
   });
+
+  it("redacts websocket URL tokens inside longer text", () => {
+    const out = sanitizeText(
+      "Gateway failed at ws://127.0.0.1:51234/api/ws?token=secret-token-123&profile=default",
+    );
+
+    expect(out).toContain("profile=default");
+    expect(out).not.toContain("secret-token-123");
+  });
 });
 
 describe("sanitizePayload — cycle detection", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -391,6 +391,18 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("sig123");
   });
 
+  it("keeps redaction markers unencoded in sanitized URLs", () => {
+    const out = sanitizeText(
+      "Reset failed at https://app.example.com/reset-password/abc123?session=sid123&view=1",
+    );
+
+    expect(out).toContain("/reset-password/[redacted]");
+    expect(out).toContain("session=[redacted]");
+    expect(out).not.toContain("%5Bredacted%5D");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("sid123");
+  });
+
   it("redacts short OAuth codes in sensitive callback URLs", () => {
     const out = sanitizeText(
       "Auth failed at https://auth.example.com/oauth/callback?code=abc123&state=ok",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isSensitiveKey, sanitizePayload } from "../lib/hermes-control-plane";
+import {
+  isSensitiveKey,
+  sanitizePayload,
+  sanitizeText,
+} from "../lib/hermes-control-plane";
 
 describe("sanitizePayload — key-based redaction", () => {
   it("redacts a SHORT value under `value` (the literal key secret/sudo responses use)", () => {
@@ -53,6 +57,26 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
     expect(out.url).toBe(url);
   });
 
+  it("redacts sensitive query params in a URL under a benign key", () => {
+    const out = sanitizePayload({
+      url: "https://example.com/callback?token=secret-token-123&view=1",
+    }) as Record<string, unknown>;
+
+    expect(out.url).toContain("view=1");
+    expect(out.url).toContain("token=");
+    expect(out.url).not.toContain("secret-token-123");
+  });
+
+  it("redacts URL credentials under a benign key", () => {
+    const out = sanitizePayload({
+      url: "https://user:supersecret@example.com/private",
+    }) as Record<string, unknown>;
+
+    expect(out.url).toContain("example.com/private");
+    expect(out.url).not.toContain("user");
+    expect(out.url).not.toContain("supersecret");
+  });
+
   it("preserves a ~/ home path and a Windows drive path", () => {
     const out = sanitizePayload({
       home: "~/code/project/src/components/AgentWorkspace.tsx",
@@ -85,6 +109,29 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
       token: "/Users/x/code/secret/with/slashes/and/a/long/path.txt",
     }) as Record<string, unknown>;
     expect(out.token).toBe("[redacted]");
+  });
+});
+
+describe("sanitizeText", () => {
+  it("redacts embedded bearer tokens and secret-looking values", () => {
+    const text =
+      "Request failed with Bearer abcdef0123456789abcdef0123456789 and sk-abcdefghijklmnopqrstuvwxyz123456";
+
+    const out = sanitizeText(text);
+
+    expect(out).toContain("Request failed");
+    expect(out).toContain("Bearer [redacted]");
+    expect(out).not.toContain("abcdef0123456789abcdef0123456789");
+    expect(out).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
+  });
+
+  it("redacts sensitive URL params inside longer text", () => {
+    const out = sanitizeText(
+      "Fetch failed for https://example.com/callback?token=secret-token-123&view=1.",
+    );
+
+    expect(out).toContain("view=1");
+    expect(out).not.toContain("secret-token-123");
   });
 });
 

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -174,16 +174,20 @@ describe("sanitizeText", () => {
 
   it("redacts quoted key-value token fragments inside longer text", () => {
     const out = sanitizeText(
-      `Request failed: {"access_token":"abc123"} token: "1234" password: 'pw' note="safe"`,
+      `Request failed: {"access_token":"abc123"} token: "1234" password: 'abc def' password='abc,def' authorization: Basic dXNlcjpwYXNz note="safe"`,
     );
 
     expect(out).toContain(`"access_token":"[redacted]"`);
     expect(out).toContain(`token: "[redacted]"`);
     expect(out).toContain(`password: '[redacted]'`);
+    expect(out).toContain(`password='[redacted]'`);
+    expect(out).toContain(`authorization: [redacted]`);
     expect(out).toContain(`note="safe"`);
     expect(out).not.toContain("abc123");
     expect(out).not.toContain("1234");
-    expect(out).not.toContain("'pw'");
+    expect(out).not.toContain("abc def");
+    expect(out).not.toContain("abc,def");
+    expect(out).not.toContain("dXNlcjpwYXNz");
   });
 
   it("redacts websocket URL tokens inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -310,6 +310,14 @@ describe("sanitizeText", () => {
     expect(out).toContain("/tmp/access_token_notes.md");
   });
 
+  it("preserves plain macOS private temp paths", () => {
+    const path =
+      "/private/var/folders/abcdef1234567890abcdef1234567890/T/report.txt";
+    const out = sanitizeText(`Read ${path}`);
+
+    expect(out).toContain(path);
+  });
+
   it("preserves opaque-looking path segments in ordinary URLs", () => {
     const docId = "abcdef0123456789abcdef0123456789abcdef01";
     const out = sanitizeText(

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -150,6 +150,18 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("opaque-token-value-987654321");
   });
 
+  it("redacts generic opaque tokens before sentence periods without breaking artifact paths", () => {
+    const token = "a".repeat(40);
+    const artifactId = "1234567890abcdef1234567890abcdef12345678";
+    const out = sanitizeText(
+      `Request failed with ${token}. Artifact at /tmp/artifacts/${artifactId}.png.`,
+    );
+
+    expect(out).toContain("[redacted].");
+    expect(out).not.toContain(token);
+    expect(out).toContain(`/tmp/artifacts/${artifactId}.png`);
+  });
+
   it("redacts sensitive URL params inside longer text", () => {
     const out = sanitizeText(
       "Fetch failed for https://example.com/callback?key=plain-api-key-123&token=secret-token-123&view=1.",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -205,6 +205,16 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("abc123");
   });
 
+  it("redacts short OAuth codes in relative callback URLs", () => {
+    const out = sanitizeText(
+      "Auth failed: GET /oauth/callback?code=abc123&state=ok",
+    );
+
+    expect(out).toContain("state=ok");
+    expect(out).toContain("code=[redacted]");
+    expect(out).not.toContain("abc123");
+  });
+
   it("redacts short key-value token fragments inside longer text", () => {
     const out = sanitizeText(
       "Request failed: token=1234 access_token=abc123 value=4321 url=/callback?key=short-key&view=1 hash=#access_token=hash-token&state=ok monkey=banana",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -277,6 +277,17 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("abc123");
   });
 
+  it("redacts codes in bare nested relative callback routes", () => {
+    const out = sanitizeText(
+      "Auth failed at /projects/123/oauth/callback?code=abc123&state=ok",
+    );
+
+    expect(out).toContain(
+      "/projects/123/oauth/callback?code=[redacted]&state=ok",
+    );
+    expect(out).not.toContain("abc123");
+  });
+
   it("redacts codes in relative sensitive route query strings", () => {
     const out = sanitizeText(
       "Request failed: url=/reset-password?code=abc123&state=ok path=/share?code=def456",
@@ -313,6 +324,13 @@ describe("sanitizeText", () => {
   it("preserves plain macOS private temp paths", () => {
     const path =
       "/private/var/folders/abcdef1234567890abcdef1234567890/T/report.txt";
+    const out = sanitizeText(`Read ${path}`);
+
+    expect(out).toContain(path);
+  });
+
+  it("preserves extensionless artifact paths under common directories", () => {
+    const path = `/tmp/download/${"j".repeat(40)}`;
     const out = sanitizeText(`Read ${path}`);
 
     expect(out).toContain(path);
@@ -461,6 +479,16 @@ describe("sanitizeText", () => {
     expect(out).not.toContain(String.raw`abc\'def`);
     expect(out).not.toContain("abc");
     expect(out).not.toContain("def");
+  });
+
+  it("redacts escaped JSON sensitive fields inside longer text", () => {
+    const out = sanitizeText(
+      String.raw`Request failed: {\"access_token\":\"abc123\",\"note\":\"safe\"}`,
+    );
+
+    expect(out).toContain(String.raw`\"access_token\":\"[redacted]\"`);
+    expect(out).toContain(String.raw`\"note\":\"safe\"`);
+    expect(out).not.toContain("abc123");
   });
 
   it("redacts websocket URL tokens inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -174,6 +174,17 @@ describe("sanitizeText", () => {
     expect(out).toContain(`/tmp/artifacts/${artifactId}.png`);
   });
 
+  it("redacts opaque tokens after compound sensitive URL path segments", () => {
+    const resetToken = "c".repeat(40);
+    const out = sanitizeText(
+      `Reset at https://app.example/reset-password/${resetToken}?view=1 or https://app.example/password_reset/${resetToken}.`,
+    );
+
+    expect(out).toContain("https://app.example/reset-password/[redacted]");
+    expect(out).toContain("https://app.example/password_reset/[redacted]");
+    expect(out).not.toContain(resetToken);
+  });
+
   it("preserves opaque-looking path segments in ordinary URLs", () => {
     const docId = "abcdef0123456789abcdef0123456789abcdef01";
     const out = sanitizeText(
@@ -255,12 +266,27 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("hash-token");
   });
 
+  it("redacts suffixed sensitive assignment keys inside longer text", () => {
+    const out = sanitizeText(
+      "Request failed: client_secret=abc123 session_token=def456 id_token=ghi789 note=safe",
+    );
+
+    expect(out).toContain("client_secret=[redacted]");
+    expect(out).toContain("session_token=[redacted]");
+    expect(out).toContain("id_token=[redacted]");
+    expect(out).toContain("note=safe");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
+    expect(out).not.toContain("ghi789");
+  });
+
   it("redacts quoted key-value token fragments inside longer text", () => {
     const out = sanitizeText(
-      `Request failed: {"access_token":"abc123"} token: "1234" password: 'abc def' value: 'secret value' password='abc,def' authorization: Basic dXNlcjpwYXNz note="safe"`,
+      `Request failed: {"access_token":"abc123","client_secret":"def456"} token: "1234" password: 'abc def' value: 'secret value' password='abc,def' authorization: Basic dXNlcjpwYXNz note="safe"`,
     );
 
     expect(out).toContain(`"access_token":"[redacted]"`);
+    expect(out).toContain(`"client_secret":"[redacted]"`);
     expect(out).toContain(`token: "[redacted]"`);
     expect(out).toContain(`password: '[redacted]'`);
     expect(out).toContain(`value: '[redacted]'`);
@@ -268,6 +294,7 @@ describe("sanitizeText", () => {
     expect(out).toContain(`authorization: [redacted]`);
     expect(out).toContain(`note="safe"`);
     expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
     expect(out).not.toContain("1234");
     expect(out).not.toContain("abc def");
     expect(out).not.toContain("secret value");

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -162,7 +162,7 @@ describe("sanitizeText", () => {
     expect(out).toContain(`/tmp/artifacts/${artifactId}.png`);
   });
 
-  it("redacts opaque tokens in absolute URL paths without breaking filesystem paths", () => {
+  it("redacts opaque tokens in sensitive absolute URL paths without breaking filesystem paths", () => {
     const urlToken = "b".repeat(40);
     const artifactId = "1234567890abcdef1234567890abcdef12345678";
     const out = sanitizeText(
@@ -172,6 +172,17 @@ describe("sanitizeText", () => {
     expect(out).toContain("https://files.example/download/[redacted]?view=1");
     expect(out).not.toContain(urlToken);
     expect(out).toContain(`/tmp/artifacts/${artifactId}.png`);
+  });
+
+  it("preserves opaque-looking path segments in ordinary URLs", () => {
+    const docId = "abcdef0123456789abcdef0123456789abcdef01";
+    const out = sanitizeText(
+      `See https://docs.example.com/path/${docId}?view=compact#section`,
+    );
+
+    expect(out).toContain(
+      `https://docs.example.com/path/${docId}?view=compact#section`,
+    );
   });
 
   it("redacts sensitive URL params inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -185,6 +185,29 @@ describe("sanitizeText", () => {
     expect(out).not.toContain(resetToken);
   });
 
+  it("redacts 32-character opaque tokens in sensitive absolute URL paths", () => {
+    const resetToken = "d".repeat(32);
+    const out = sanitizeText(
+      `Reset at https://app.example/reset-password/${resetToken}?view=1`,
+    );
+
+    expect(out).toContain("https://app.example/reset-password/[redacted]");
+    expect(out).not.toContain(resetToken);
+  });
+
+  it("redacts opaque tokens in relative sensitive URL paths", () => {
+    const resetToken = "e".repeat(40);
+    const shareToken = "f".repeat(32);
+    const out = sanitizeText(
+      `Request failed: GET /reset-password/${resetToken}?view=1 and ./share/${shareToken}.`,
+    );
+
+    expect(out).toContain("GET /reset-password/[redacted]?view=1");
+    expect(out).toContain("./share/[redacted]");
+    expect(out).not.toContain(resetToken);
+    expect(out).not.toContain(shareToken);
+  });
+
   it("preserves opaque-looking path segments in ordinary URLs", () => {
     const docId = "abcdef0123456789abcdef0123456789abcdef01";
     const out = sanitizeText(

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -403,6 +403,16 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("sid123");
   });
 
+  it("redacts encoded base64 route tokens", () => {
+    const out = sanitizeText(
+      "Download failed at https://host.example/download/YWJjZA%3D%3D?view=1",
+    );
+
+    expect(out).toContain("/download/[redacted]?view=1");
+    expect(out).not.toContain("YWJjZA%3D%3D");
+    expect(out).not.toContain("YWJjZA==");
+  });
+
   it("redacts short OAuth codes in sensitive callback URLs", () => {
     const out = sanitizeText(
       "Auth failed at https://auth.example.com/oauth/callback?code=abc123&state=ok",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -195,6 +195,16 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("secret-token-123");
   });
 
+  it("redacts short OAuth codes in sensitive callback URLs", () => {
+    const out = sanitizeText(
+      "Auth failed at https://auth.example.com/oauth/callback?code=abc123&state=ok",
+    );
+
+    expect(out).toContain("state=ok");
+    expect(out).toContain("code=");
+    expect(out).not.toContain("abc123");
+  });
+
   it("redacts short key-value token fragments inside longer text", () => {
     const out = sanitizeText(
       "Request failed: token=1234 access_token=abc123 value=4321 url=/callback?key=short-key&view=1 hash=#access_token=hash-token&state=ok monkey=banana",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -77,6 +77,18 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
     expect(out.url).not.toContain("supersecret");
   });
 
+  it("redacts token substrings inside a standalone URL", () => {
+    const jwt = "eyJaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc";
+    const out = sanitizePayload({
+      pathUrl: "https://api.example.com/sk-abcdefghijklmnopqrstuvwxyz123456",
+      callbackUrl: `https://host.example/callback?code=${jwt}&view=1`,
+    }) as Record<string, unknown>;
+
+    expect(out.pathUrl).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
+    expect(out.callbackUrl).toContain("view=1");
+    expect(out.callbackUrl).not.toContain(jwt);
+  });
+
   it("preserves a ~/ home path and a Windows drive path", () => {
     const out = sanitizePayload({
       home: "~/code/project/src/components/AgentWorkspace.tsx",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -186,36 +186,54 @@ describe("sanitizeText", () => {
 
   it("redacts short key-value token fragments inside longer text", () => {
     const out = sanitizeText(
-      "Request failed: token=1234 access_token=abc123 url=/callback?key=short-key&view=1 hash=#access_token=hash-token&state=ok monkey=banana",
+      "Request failed: token=1234 access_token=abc123 value=4321 url=/callback?key=short-key&view=1 hash=#access_token=hash-token&state=ok monkey=banana",
     );
 
     expect(out).toContain("token=[redacted]");
     expect(out).toContain("access_token=[redacted]");
+    expect(out).toContain("value=[redacted]");
     expect(out).toContain("view=1");
     expect(out).toContain("state=ok");
     expect(out).toContain("monkey=banana");
     expect(out).not.toContain("1234");
     expect(out).not.toContain("abc123");
+    expect(out).not.toContain("4321");
     expect(out).not.toContain("short-key");
     expect(out).not.toContain("hash-token");
   });
 
   it("redacts quoted key-value token fragments inside longer text", () => {
     const out = sanitizeText(
-      `Request failed: {"access_token":"abc123"} token: "1234" password: 'abc def' password='abc,def' authorization: Basic dXNlcjpwYXNz note="safe"`,
+      `Request failed: {"access_token":"abc123"} token: "1234" password: 'abc def' value: 'secret value' password='abc,def' authorization: Basic dXNlcjpwYXNz note="safe"`,
     );
 
     expect(out).toContain(`"access_token":"[redacted]"`);
     expect(out).toContain(`token: "[redacted]"`);
     expect(out).toContain(`password: '[redacted]'`);
+    expect(out).toContain(`value: '[redacted]'`);
     expect(out).toContain(`password='[redacted]'`);
     expect(out).toContain(`authorization: [redacted]`);
     expect(out).toContain(`note="safe"`);
     expect(out).not.toContain("abc123");
     expect(out).not.toContain("1234");
     expect(out).not.toContain("abc def");
+    expect(out).not.toContain("secret value");
     expect(out).not.toContain("abc,def");
     expect(out).not.toContain("dXNlcjpwYXNz");
+  });
+
+  it("redacts mixed text that starts with a credentialed URL", () => {
+    const out = sanitizePayload({
+      message: "https://user:pass@example.com/foo token=abc123",
+    }) as Record<string, unknown>;
+
+    expect(out.message).toContain(
+      "https://redacted:redacted@example.com/foo",
+    );
+    expect(out.message).toContain("token=[redacted]");
+    expect(out.message).not.toContain("user:pass");
+    expect(out.message).not.toContain("abc123");
+    expect(out.message).not.toContain("%20token");
   });
 
   it("redacts escaped quoted key-value token fragments inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -357,6 +357,18 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("secret-token-123");
   });
 
+  it("redacts short session and signature URL params", () => {
+    const out = sanitizeText(
+      "Fetch failed for https://app.example.com/callback?session=abc123&signature=sig123&view=1.",
+    );
+
+    expect(out).toContain("view=1");
+    expect(out).toContain("session=");
+    expect(out).toContain("signature=");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("sig123");
+  });
+
   it("redacts short OAuth codes in sensitive callback URLs", () => {
     const out = sanitizeText(
       "Auth failed at https://auth.example.com/oauth/callback?code=abc123&state=ok",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -162,6 +162,18 @@ describe("sanitizeText", () => {
     expect(out).toContain(`/tmp/artifacts/${artifactId}.png`);
   });
 
+  it("redacts opaque tokens in absolute URL paths without breaking filesystem paths", () => {
+    const urlToken = "b".repeat(40);
+    const artifactId = "1234567890abcdef1234567890abcdef12345678";
+    const out = sanitizeText(
+      `Download https://files.example/download/${urlToken}?view=1 and inspect /tmp/artifacts/${artifactId}.png`,
+    );
+
+    expect(out).toContain("https://files.example/download/[redacted]?view=1");
+    expect(out).not.toContain(urlToken);
+    expect(out).toContain(`/tmp/artifacts/${artifactId}.png`);
+  });
+
   it("redacts sensitive URL params inside longer text", () => {
     const out = sanitizeText(
       "Fetch failed for https://example.com/callback?key=plain-api-key-123&token=secret-token-123&view=1.",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -208,6 +208,31 @@ describe("sanitizeText", () => {
     expect(out).not.toContain(shareToken);
   });
 
+  it("redacts opaque tokens in SPA hash-route sensitive URL paths", () => {
+    const resetToken = "g".repeat(32);
+    const out = sanitizeText(
+      `Reset at https://app.example.com/#/reset-password/${resetToken}?view=1`,
+    );
+
+    expect(out).toContain(
+      "https://app.example.com/#/reset-password/[redacted]?view=1",
+    );
+    expect(out).not.toContain(resetToken);
+  });
+
+  it("redacts relative sensitive URL paths inside key-value assignments", () => {
+    const resetToken = "h".repeat(40);
+    const shareToken = "i".repeat(32);
+    const out = sanitizeText(
+      `Request failed: url=/reset-password/${resetToken}?view=1 path=/share/${shareToken}`,
+    );
+
+    expect(out).toContain("url=/reset-password/[redacted]?view=1");
+    expect(out).toContain("path=/share/[redacted]");
+    expect(out).not.toContain(resetToken);
+    expect(out).not.toContain(shareToken);
+  });
+
   it("preserves opaque-looking path segments in ordinary URLs", () => {
     const docId = "abcdef0123456789abcdef0123456789abcdef01";
     const out = sanitizeText(

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -84,12 +84,15 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
     const out = sanitizePayload({
       pathUrl: "https://api.example.com/sk-abcdefghijklmnopqrstuvwxyz123456",
       callbackUrl: `https://host.example/callback?code=${jwt}&view=1`,
+      hashUrl: "https://host.example/callback#access_token=abc123&state=ok",
       relativeUrl: "/callback?key=short-secret&view=1",
     }) as Record<string, unknown>;
 
     expect(out.pathUrl).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
     expect(out.callbackUrl).toContain("view=1");
     expect(out.callbackUrl).not.toContain(jwt);
+    expect(out.hashUrl).toContain("state=ok");
+    expect(out.hashUrl).not.toContain("abc123");
     expect(out.relativeUrl).toContain("view=1");
     expect(out.relativeUrl).not.toContain("short-secret");
   });
@@ -155,16 +158,32 @@ describe("sanitizeText", () => {
 
   it("redacts short key-value token fragments inside longer text", () => {
     const out = sanitizeText(
-      "Request failed: token=1234 access_token=abc123 url=/callback?key=short-key&view=1 monkey=banana",
+      "Request failed: token=1234 access_token=abc123 url=/callback?key=short-key&view=1 hash=#access_token=hash-token&state=ok monkey=banana",
     );
 
     expect(out).toContain("token=[redacted]");
     expect(out).toContain("access_token=[redacted]");
     expect(out).toContain("view=1");
+    expect(out).toContain("state=ok");
     expect(out).toContain("monkey=banana");
     expect(out).not.toContain("1234");
     expect(out).not.toContain("abc123");
     expect(out).not.toContain("short-key");
+    expect(out).not.toContain("hash-token");
+  });
+
+  it("redacts quoted key-value token fragments inside longer text", () => {
+    const out = sanitizeText(
+      `Request failed: {"access_token":"abc123"} token: "1234" password: 'pw' note="safe"`,
+    );
+
+    expect(out).toContain(`"access_token":"[redacted]"`);
+    expect(out).toContain(`token: "[redacted]"`);
+    expect(out).toContain(`password: '[redacted]'`);
+    expect(out).toContain(`note="safe"`);
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("1234");
+    expect(out).not.toContain("'pw'");
   });
 
   it("redacts websocket URL tokens inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -81,11 +81,14 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
 
   it("redacts token substrings inside a standalone URL", () => {
     const jwt = "eyJaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc";
+    const artifactPath =
+      "/tmp/artifacts/1234567890abcdef1234567890abcdef12345678.png";
     const out = sanitizePayload({
       pathUrl: "https://api.example.com/sk-abcdefghijklmnopqrstuvwxyz123456",
       callbackUrl: `https://host.example/callback?code=${jwt}&view=1`,
       hashUrl: "https://host.example/callback#access_token=abc123&state=ok",
       relativeUrl: "/callback?key=short-secret&view=1",
+      artifactPath,
     }) as Record<string, unknown>;
 
     expect(out.pathUrl).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
@@ -95,6 +98,7 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
     expect(out.hashUrl).not.toContain("abc123");
     expect(out.relativeUrl).toContain("view=1");
     expect(out.relativeUrl).not.toContain("short-secret");
+    expect(out.artifactPath).toBe(artifactPath);
   });
 
   it("preserves a ~/ home path and a Windows drive path", () => {
@@ -188,6 +192,20 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("abc def");
     expect(out).not.toContain("abc,def");
     expect(out).not.toContain("dXNlcjpwYXNz");
+  });
+
+  it("redacts escaped quoted key-value token fragments inside longer text", () => {
+    const out = sanitizeText(
+      String.raw`Request failed: {"password":"abc\"def"} token='abc\'def' note="safe"`,
+    );
+
+    expect(out).toContain(`"password":"[redacted]"`);
+    expect(out).toContain(`token='[redacted]'`);
+    expect(out).toContain(`note="safe"`);
+    expect(out).not.toContain(String.raw`abc\"def`);
+    expect(out).not.toContain(String.raw`abc\'def`);
+    expect(out).not.toContain("abc");
+    expect(out).not.toContain("def");
   });
 
   it("redacts websocket URL tokens inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -312,6 +312,17 @@ describe("sanitizeText", () => {
     expect(out).not.toContain(shareToken);
   });
 
+  it("redacts relative route tokens before query assignment delimiters", () => {
+    const out = sanitizeText(
+      "Request failed: redirect=/reset-password/abc123&state=ok next=/share/def456&view=1",
+    );
+
+    expect(out).toContain("redirect=/reset-password/[redacted]&state=ok");
+    expect(out).toContain("next=/share/[redacted]&view=1");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
+  });
+
   it("preserves benign path segments that contain token words", () => {
     const out = sanitizeText(
       "Read /tmp/tokenizer_config.json and /tmp/access_token_notes.md",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -220,6 +220,28 @@ describe("sanitizeText", () => {
     expect(out).not.toContain(resetToken);
   });
 
+  it("redacts short route tokens after sensitive URL path segments", () => {
+    const out = sanitizeText(
+      "Reset at https://app.example.com/#/reset-password/abc123 and url=/share/def456",
+    );
+
+    expect(out).toContain("https://app.example.com/#/reset-password/[redacted]");
+    expect(out).toContain("url=/share/[redacted]");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
+  });
+
+  it("redacts codes in relative sensitive route query strings", () => {
+    const out = sanitizeText(
+      "Request failed: url=/reset-password?code=abc123&state=ok path=/share?code=def456",
+    );
+
+    expect(out).toContain("url=/reset-password?code=[redacted]&state=ok");
+    expect(out).toContain("path=/share?code=[redacted]");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
+  });
+
   it("redacts relative sensitive URL paths inside key-value assignments", () => {
     const resetToken = "h".repeat(40);
     const shareToken = "i".repeat(32);
@@ -231,6 +253,15 @@ describe("sanitizeText", () => {
     expect(out).toContain("path=/share/[redacted]");
     expect(out).not.toContain(resetToken);
     expect(out).not.toContain(shareToken);
+  });
+
+  it("preserves benign path segments that contain token words", () => {
+    const out = sanitizeText(
+      "Read /tmp/tokenizer_config.json and /tmp/access_token_notes.md",
+    );
+
+    expect(out).toContain("/tmp/tokenizer_config.json");
+    expect(out).toContain("/tmp/access_token_notes.md");
   });
 
   it("preserves opaque-looking path segments in ordinary URLs", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -59,11 +59,13 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
 
   it("redacts sensitive query params in a URL under a benign key", () => {
     const out = sanitizePayload({
-      url: "https://example.com/callback?token=secret-token-123&view=1",
+      url: "https://example.com/callback?key=plain-api-key-123&token=secret-token-123&view=1",
     }) as Record<string, unknown>;
 
     expect(out.url).toContain("view=1");
+    expect(out.url).toContain("key=");
     expect(out.url).toContain("token=");
+    expect(out.url).not.toContain("plain-api-key-123");
     expect(out.url).not.toContain("secret-token-123");
   });
 
@@ -140,10 +142,11 @@ describe("sanitizeText", () => {
 
   it("redacts sensitive URL params inside longer text", () => {
     const out = sanitizeText(
-      "Fetch failed for https://example.com/callback?token=secret-token-123&view=1.",
+      "Fetch failed for https://example.com/callback?key=plain-api-key-123&token=secret-token-123&view=1.",
     );
 
     expect(out).toContain("view=1");
+    expect(out).not.toContain("plain-api-key-123");
     expect(out).not.toContain("secret-token-123");
   });
 

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -266,6 +266,17 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("def456");
   });
 
+  it("redacts codes in nested colon-prefixed relative callback routes", () => {
+    const out = sanitizeText(
+      "Auth failed: url:/projects/123/oauth/callback?code=abc123&state=ok",
+    );
+
+    expect(out).toContain(
+      "url:/projects/123/oauth/callback?code=[redacted]&state=ok",
+    );
+    expect(out).not.toContain("abc123");
+  });
+
   it("redacts codes in relative sensitive route query strings", () => {
     const out = sanitizeText(
       "Request failed: url=/reset-password?code=abc123&state=ok path=/share?code=def456",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -253,6 +253,19 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("abc123");
   });
 
+  it("redacts codes in colon-prefixed relative sensitive routes", () => {
+    const out = sanitizeText(
+      "Auth failed: hash:#/projects/123/oauth/callback?code=abc123 url:/oauth/callback?code=def456&state=ok",
+    );
+
+    expect(out).toContain(
+      "hash:#/projects/123/oauth/callback?code=[redacted]",
+    );
+    expect(out).toContain("url:/oauth/callback?code=[redacted]&state=ok");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
+  });
+
   it("redacts codes in relative sensitive route query strings", () => {
     const out = sanitizeText(
       "Request failed: url=/reset-password?code=abc123&state=ok path=/share?code=def456",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -242,6 +242,17 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("def456");
   });
 
+  it("redacts codes in nested SPA callback hash routes", () => {
+    const out = sanitizeText(
+      "Auth failed: hash=#/projects/123/oauth/callback?code=abc123&state=ok",
+    );
+
+    expect(out).toContain(
+      "hash=#/projects/123/oauth/callback?code=[redacted]&state=ok",
+    );
+    expect(out).not.toContain("abc123");
+  });
+
   it("redacts codes in relative sensitive route query strings", () => {
     const out = sanitizeText(
       "Request failed: url=/reset-password?code=abc123&state=ok path=/share?code=def456",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -413,6 +413,16 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("YWJjZA==");
   });
 
+  it("preserves numeric artifact URL subdirectories while redacting query tokens", () => {
+    const out = sanitizeText(
+      "Download https://files.example.com/download/2024/report.pdf?token=signed-token-123&view=1",
+    );
+
+    expect(out).toContain("/download/2024/report.pdf");
+    expect(out).toContain("token=[redacted]");
+    expect(out).not.toContain("signed-token-123");
+  });
+
   it("redacts short OAuth codes in sensitive callback URLs", () => {
     const out = sanitizeText(
       "Auth failed at https://auth.example.com/oauth/callback?code=abc123&state=ok",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -323,6 +323,17 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("def456");
   });
 
+  it("redacts login and authorize route tokens", () => {
+    const out = sanitizeText(
+      "Auth failed at https://app.example.com/login/abc123 and redirect=/authorize/abcd1234",
+    );
+
+    expect(out).toContain("https://app.example.com/login/[redacted]");
+    expect(out).toContain("redirect=/authorize/[redacted]");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("abcd1234");
+  });
+
   it("preserves benign path segments that contain token words", () => {
     const out = sanitizeText(
       "Read /tmp/tokenizer_config.json and /tmp/access_token_notes.md",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -84,11 +84,14 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
     const out = sanitizePayload({
       pathUrl: "https://api.example.com/sk-abcdefghijklmnopqrstuvwxyz123456",
       callbackUrl: `https://host.example/callback?code=${jwt}&view=1`,
+      relativeUrl: "/callback?key=short-secret&view=1",
     }) as Record<string, unknown>;
 
     expect(out.pathUrl).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
     expect(out.callbackUrl).toContain("view=1");
     expect(out.callbackUrl).not.toContain(jwt);
+    expect(out.relativeUrl).toContain("view=1");
+    expect(out.relativeUrl).not.toContain("short-secret");
   });
 
   it("preserves a ~/ home path and a Windows drive path", () => {
@@ -148,6 +151,20 @@ describe("sanitizeText", () => {
     expect(out).toContain("view=1");
     expect(out).not.toContain("plain-api-key-123");
     expect(out).not.toContain("secret-token-123");
+  });
+
+  it("redacts short key-value token fragments inside longer text", () => {
+    const out = sanitizeText(
+      "Request failed: token=1234 access_token=abc123 url=/callback?key=short-key&view=1 monkey=banana",
+    );
+
+    expect(out).toContain("token=[redacted]");
+    expect(out).toContain("access_token=[redacted]");
+    expect(out).toContain("view=1");
+    expect(out).toContain("monkey=banana");
+    expect(out).not.toContain("1234");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("short-key");
   });
 
   it("redacts websocket URL tokens inside longer text", () => {

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -205,6 +205,28 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("abc123");
   });
 
+  it("redacts short OAuth codes in sensitive callback URL fragments", () => {
+    const out = sanitizeText(
+      "Auth failed at https://auth.example.com/oauth/callback#code=abc123&state=ok",
+    );
+
+    expect(out).toContain("state=ok");
+    expect(out).toContain("code=");
+    expect(out).not.toContain("abc123");
+  });
+
+  it("redacts sensitive params in SPA callback URL fragments", () => {
+    const out = sanitizeText(
+      "Auth failed at https://app.example.com/#/oauth/callback?code=abc123&id_token=short-id-token&state=ok",
+    );
+
+    expect(out).toContain("state=ok");
+    expect(out).toContain("code=");
+    expect(out).toContain("id_token=");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("short-id-token");
+  });
+
   it("redacts short OAuth codes in relative callback URLs", () => {
     const out = sanitizeText(
       "Auth failed: GET /oauth/callback?code=abc123&state=ok",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -231,6 +231,17 @@ describe("sanitizeText", () => {
     expect(out).not.toContain("def456");
   });
 
+  it("redacts short route tokens in standalone hash-route strings", () => {
+    const out = sanitizeText(
+      "Request failed: hash=#/reset-password/abc123 next=#/share/def456",
+    );
+
+    expect(out).toContain("hash=#/reset-password/[redacted]");
+    expect(out).toContain("next=#/share/[redacted]");
+    expect(out).not.toContain("abc123");
+    expect(out).not.toContain("def456");
+  });
+
   it("redacts codes in relative sensitive route query strings", () => {
     const out = sanitizeText(
       "Request failed: url=/reset-password?code=abc123&state=ok path=/share?code=def456",

--- a/src/test/hermes-sanitize.test.ts
+++ b/src/test/hermes-sanitize.test.ts
@@ -115,7 +115,7 @@ describe("sanitizePayload — value-shape backstop exempts paths/urls", () => {
 describe("sanitizeText", () => {
   it("redacts embedded bearer tokens and secret-looking values", () => {
     const text =
-      "Request failed with Bearer abcdef0123456789abcdef0123456789 and sk-abcdefghijklmnopqrstuvwxyz123456";
+      "Request failed with Bearer abcdef0123456789abcdef0123456789, sk-abcdefghijklmnopqrstuvwxyz123456, and opaque-token-value-987654321";
 
     const out = sanitizeText(text);
 
@@ -123,6 +123,7 @@ describe("sanitizeText", () => {
     expect(out).toContain("Bearer [redacted]");
     expect(out).not.toContain("abcdef0123456789abcdef0123456789");
     expect(out).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
+    expect(out).not.toContain("opaque-token-value-987654321");
   });
 
   it("redacts sensitive URL params inside longer text", () => {

--- a/src/test/hermes-trace-buffer.test.ts
+++ b/src/test/hermes-trace-buffer.test.ts
@@ -204,6 +204,21 @@ describe("createHermesTraceBuffer", () => {
       // Safe text is preserved.
       expect(entry.payloadPreview).toContain("safe-text");
     });
+
+    it("redacts signed artifact url tokens in inbound trace previews", () => {
+      const buffer = createHermesTraceBuffer();
+      buffer.recordInbound(
+        rawFrame("tool.complete", "s1", {
+          name: "download_file",
+          url: "https://files.example.com/report.pdf?token=signed-token-123&view=1",
+        }),
+      );
+
+      const entry = buffer.entriesFor("s1")[0];
+      expect(entry.payloadPreview).toContain("view=1");
+      expect(entry.payloadPreview).toContain("token=");
+      expect(entry.payloadPreview).not.toContain("signed-token-123");
+    });
   });
 
   describe("exportSanitizedTrace", () => {

--- a/src/test/hermes-trace-buffer.test.ts
+++ b/src/test/hermes-trace-buffer.test.ts
@@ -78,6 +78,22 @@ describe("createHermesTraceBuffer", () => {
     expect(entries[0].message).toBe("Hermes request timed out: session.steer");
   });
 
+  it("redacts secret fragments in error/rejection messages", () => {
+    const buffer = createHermesTraceBuffer();
+    buffer.recordError({
+      sessionId: "s1",
+      method: "session.steer",
+      message:
+        "Hermes request failed with Bearer abcdef0123456789abcdef0123456789",
+    });
+
+    const entry = buffer.entriesFor("s1")[0];
+    expect(entry.message).toContain("Bearer [redacted]");
+    expect(JSON.stringify(entry)).not.toContain(
+      "abcdef0123456789abcdef0123456789",
+    );
+  });
+
   it("drops the oldest entry once the per-session cap is exceeded", () => {
     const buffer = createHermesTraceBuffer();
     for (let i = 0; i < TRACE_ENTRIES_PER_SESSION_CAP + 5; i += 1) {

--- a/src/test/hermes-trace-buffer.test.ts
+++ b/src/test/hermes-trace-buffer.test.ts
@@ -84,14 +84,12 @@ describe("createHermesTraceBuffer", () => {
       sessionId: "s1",
       method: "session.steer",
       message:
-        "Hermes request failed with Bearer abcdef0123456789abcdef0123456789",
+        "Hermes request failed with opaque token opaque-token-value-987654321",
     });
 
     const entry = buffer.entriesFor("s1")[0];
-    expect(entry.message).toContain("Bearer [redacted]");
-    expect(JSON.stringify(entry)).not.toContain(
-      "abcdef0123456789abcdef0123456789",
-    );
+    expect(entry.message).toContain("[redacted]");
+    expect(JSON.stringify(entry)).not.toContain("opaque-token-value-987654321");
   });
 
   it("drops the oldest entry once the per-session cap is exceeded", () => {


### PR DESCRIPTION
## Summary

- Redact sensitive URL query params, URL credentials, bearer/API/JWT/opaque token substrings from Hermes sanitized payload strings.
- Sanitize surfaced Hermes error messages before classification and trace-buffer storage so issue-report trace exports do not preserve raw credentials.
- Keep standalone file paths and ordinary URLs intact when they do not contain sensitive pieces.

## Validation

- `pnpm test -- src/test/hermes-sanitize.test.ts src/test/hermes-control-plane-classifier.test.ts src/test/hermes-trace-buffer.test.ts`
- `pnpm run lint`

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.
