### PR TITLE
[codex] Remove brittle agent recommendations

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -24,7 +24,6 @@ import { createPortal } from "react-dom";
 import { IconAnonymous } from "central-icons/IconAnonymous";
 import { IconArrowCornerDownRight } from "central-icons/IconArrowCornerDownRight";
 import { IconArrowUp } from "central-icons/IconArrowUp";
-import { IconCameraSparkle } from "central-icons/IconCameraSparkle";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
@@ -619,24 +618,6 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     description: "Describe what you remember; June tracks it down.",
     prompt:
       "Find <a file I half-remember> on my computer and tell me where it is.",
-    action: "prefill",
-  },
-  {
-    key: "describe-screenshots",
-    icon: <IconCameraSparkle size={18} />,
-    title: "Find the right screenshot",
-    description: "June looks through them so you don't have to.",
-    prompt:
-      "Look through the recent screenshots on my Desktop and in my Downloads folder, open each one, and tell me what it shows so I can find the one I'm looking for. Don't rename, move, or change anything.",
-    action: "run",
-  },
-  {
-    key: "draft-document",
-    icon: <IconPencilLine size={18} />,
-    title: "Draft a document",
-    description: "Start a write-up and get it as a downloadable file.",
-    prompt:
-      "Draft a <kind of document> about <topic>, then save it as a Markdown file in your workspace so I can download it.",
     action: "prefill",
   },
   {


### PR DESCRIPTION
## Summary

Removes two recommended agent shortcuts from the new-session recommendation pool:

- `describe-screenshots` / "Find the right screenshot"
- `draft-document` / "Draft a document"

Also removes the now-unused screenshot shortcut icon import.

## Why

The actual agent QA run showed these recommendations were not reliable enough to keep in the suggested prompt set. The screenshot shortcut hit repeated vision-provider/request-size failures before blocking on an OCR approval request. The draft-document shortcut also blocked on a shell write approval instead of completing cleanly as a recommendation.

## Impact

The hero recommendation rotation now excludes those two brittle prompts. The remaining recommendations continue to render and behave through the existing shortcut flow.

## Validation

- `pnpm exec vitest run src/test/agent-workspace.test.tsx` passed: 132 passed, 2 skipped
- `pnpm run lint` passed
- `pnpm exec prettier --check src/components/agent/AgentWorkspace.tsx` passed
- `pnpm run format` still fails on pre-existing formatting issues outside this change: `src/lib/hermes-routines.ts`, `src/lib/live-transcript-preview.ts`, `src/lib/recording-inactivity.ts`, `src/test/hermes-routines.test.ts`, `src/test/recording-inactivity.test.ts`, `src-tauri/tauri.conf.json`