### PR TITLE
Allow short onboarding practice replies

### DIFF
--- a/src/components/onboarding/steps/PracticeStep.tsx
+++ b/src/components/onboarding/steps/PracticeStep.tsx
@@ -31,7 +31,7 @@ export function DictationPracticeStep({
 }) {
   const [value, setValue] = useState("");
   const [greeted, setGreeted] = useState(false);
-  const succeeded = value.trim().length >= 4;
+  const succeeded = value.trim().length > 0;
 
   const capture = useShortcutCapture({
     kind: "push_to_talk",

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -236,6 +236,22 @@ describe("OnboardingFlow", () => {
     await screen.findByPlaceholderText(/Tell June what to do/i);
   }
 
+  it("enables practice completion for a one-character reply", async () => {
+    const user = userEvent.setup();
+    await renderFlow();
+    await walkToPractice(user);
+
+    const startButton = screen.getByRole("button", {
+      name: "Start using June",
+    });
+    expect(startButton).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText(/Tell June what to do/i), "h");
+
+    await screen.findByRole("status", { name: "Dictation is working" });
+    expect(startButton).toBeEnabled();
+  });
+
   it("normalizes the factory-default shortcut to fn", async () => {
     // A fresh install still carries the Rust-side Ctrl+Opt+D default; only
     // then does onboarding write the bare-fn product default.


### PR DESCRIPTION
## What changed
- Treat any non-empty trimmed onboarding practice reply as a successful dictation practice response.
- Added an onboarding test proving a one-character reply enables Start using June.

## Why
Users can reasonably answer the practice prompt with very short text such as "hi". The previous four-character threshold kept the primary action disabled even though text had arrived.

## Validation
- pnpm test -- src/test/onboarding.test.tsx
- pnpm run lint

## Known gaps
- None.