### PR TITLE
Speed up dictation push-to-talk start

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -94,6 +94,11 @@ enum RecordingCueSound: String {
 enum RecordingCuePlayer {
     private static var sounds: [RecordingCueSound: NSSound] = [:]
 
+    static func prepare() {
+        _ = sounds[.start] ?? load(.start)
+        _ = sounds[.stop] ?? load(.stop)
+    }
+
     static func play(_ cue: RecordingCueSound) {
         let sound = sounds[cue] ?? load(cue)
         guard let sound else {
@@ -1373,7 +1378,7 @@ final class DictationController {
         emitMicrophones()
     }
 
-    /// Invalidates pending dictation starts. `AVCaptureDevice.requestAccess`
+    /// Invalidates pending recording starts. `AVCaptureDevice.requestAccess`
     /// can fire its callback long after the request — the user reading the
     /// macOS permission prompt — and a graze's discard arrives in between:
     /// without this, accepting the prompt later would open the microphone
@@ -1389,22 +1394,11 @@ final class DictationController {
 
         dictationStartGeneration += 1
         let generation = dictationStartGeneration
-        AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
-            // Hop to main: commands (including the discard that may have
-            // cancelled this start) are handled there, so the generation
-            // comparison is ordered against them.
-            DispatchQueue.main.async {
-                guard let self, self.dictationStartGeneration == generation else {
-                    return
-                }
-                guard microphoneAllowed else {
-                    emit("error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
-                    emit("permission_status", permissionPayload())
-                    return
-                }
-                self.startRecording(purpose: .dictation, durationSeconds: nil)
-            }
-        }
+        startAfterMicrophoneAccess(
+            generation: generation,
+            purpose: .dictation,
+            durationSeconds: nil
+        )
     }
 
     func stop() {
@@ -1422,20 +1416,17 @@ final class DictationController {
             return
         }
 
-        AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
-            guard microphoneAllowed else {
-                emit("mic_test_error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
-                emit("permission_status", permissionPayload())
-                return
-            }
-            self?.startRecording(
-                purpose: .micTest,
-                durationSeconds: max(1, min(15, durationSeconds))
-            )
-        }
+        dictationStartGeneration += 1
+        let generation = dictationStartGeneration
+        startAfterMicrophoneAccess(
+            generation: generation,
+            purpose: .micTest,
+            durationSeconds: max(1, min(15, durationSeconds))
+        )
     }
 
     func discardMicTest() {
+        dictationStartGeneration += 1
         if isListening, recordingPurpose == .micTest {
             resetRecordingState()
         }
@@ -1466,6 +1457,46 @@ final class DictationController {
         if wasListening {
             emit("recording_discarded")
         }
+    }
+
+    private func startAfterMicrophoneAccess(
+        generation: Int,
+        purpose: RecordingPurpose,
+        durationSeconds: Double?
+    ) {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+            startRecording(purpose: purpose, durationSeconds: durationSeconds)
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
+                // Hop to main: commands (including the discard that may have
+                // cancelled this start) are handled there, so the generation
+                // comparison is ordered against them.
+                DispatchQueue.main.async {
+                    guard let self, self.dictationStartGeneration == generation else {
+                        return
+                    }
+                    guard microphoneAllowed else {
+                        self.emitMicrophonePermissionMissing(purpose: purpose)
+                        return
+                    }
+                    self.startRecording(purpose: purpose, durationSeconds: durationSeconds)
+                }
+            }
+        case .denied, .restricted:
+            emitMicrophonePermissionMissing(purpose: purpose)
+        @unknown default:
+            emitMicrophonePermissionMissing(purpose: purpose)
+        }
+    }
+
+    private func emitMicrophonePermissionMissing(purpose: RecordingPurpose) {
+        emitRecordingError(
+            purpose: purpose,
+            code: "microphone_permission_missing",
+            message: "Microphone permission is required."
+        )
+        emit("permission_status", permissionPayload())
     }
 
     func shutdown() {
@@ -1620,7 +1651,6 @@ final class DictationController {
         durationSeconds: Double?
     ) {
         isListening = true
-        RecordingCuePlayer.play(.start)
         if purpose == .micTest {
             scheduleMicTestStop(after: durationSeconds ?? 5)
             emitJSON("mic_test_started", [
@@ -1633,6 +1663,7 @@ final class DictationController {
                 "microphone": microphone,
             ])
         }
+        RecordingCuePlayer.play(.start)
     }
 
     private func stopActiveRecording() {
@@ -2005,6 +2036,7 @@ emit("ready")
 ShortcutKeyMonitor.shared.start()
 FocusTargetController.shared.start()
 dictation.emitDiagnostics()
+RecordingCuePlayer.prepare()
 
 Thread.detachNewThread {
     while let line = readLine() {


### PR DESCRIPTION
## Summary
- avoid calling `AVCaptureDevice.requestAccess` on every dictation start once microphone access is already granted
- keep the prompt path only for first-run microphone permission and preserve stale-start cancellation for grazed push-to-talk presses
- preload dictation cue sounds and emit the listening/mic-test start event before playing the cue so the HUD can react immediately

## Root cause
Push-to-talk starts on the key-down edge, but the native helper still ran the asynchronous macOS microphone permission request on every start. Even when permission was already granted, that inserted a callback/main-queue hop before recorder startup, which could be intermittently slow under desktop load. The first use could also pay lazy `NSSound` loading before the helper emitted `listening_started`.

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml push_to_talk`

Note: both commands still report the existing `unused import: Manager` warning in `src/commands.rs`.
