### PR TITLE
release: v0.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-scribe",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "os-scribe"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-scribe"
-version = "0.0.20"
+version = "0.0.21"
 description = "June"
 authors = ["Open Software Network"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "June",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "identifier": "co.opensoftware.scribe",
   "build": {
     "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",


### PR DESCRIPTION
## Summary
- Bump June release metadata from 0.0.20 to 0.0.21.
- Mirrors the release commit attempted by the production macOS release workflow.

## Context
The `production-desktop-release` run for `v0.0.21` published the signed/notarized macOS artifacts and updater manifest, then failed when pushing this version commit directly to protected `main`.

Release: https://github.com/open-software-network/os-june-releases/releases/tag/v0.0.21
Run: https://github.com/open-software-network/os-june/actions/runs/28299010743

## Validation
- `git diff --check`
- Production workflow passed release checks (`pnpm lint`, `pnpm test`, `pnpm test:rust`) before publishing the `v0.0.21` artifacts.
