### PR TITLE
Fix subagent session fan-out scroll behavior

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5850,6 +5850,7 @@ export function AgentWorkspace({
   const transcriptShouldStickToBottomRef = useRef(true);
   const transcriptProgrammaticScrollRef = useRef(false);
   const transcriptProgrammaticScrollTimeoutRef = useRef<number | undefined>();
+  const transcriptLastScrollTopRef = useRef(0);
 
   // History for the selected conversation has landed: a session gets an entry
   // in hermesSessionMessages (even an empty one) once its fetch resolves;
@@ -5878,7 +5879,15 @@ export function AgentWorkspace({
       }
     };
     const updateStickiness = () => {
+      const previousScrollTop = transcriptLastScrollTopRef.current;
+      transcriptLastScrollTopRef.current = scroller.scrollTop;
       if (transcriptProgrammaticScrollRef.current) {
+        if (scroller.scrollTop < previousScrollTop) {
+          clearProgrammaticScroll();
+          transcriptShouldStickToBottomRef.current =
+            isAgentTranscriptNearBottom(scroller);
+          return;
+        }
         transcriptShouldStickToBottomRef.current = true;
         if (isAgentTranscriptNearBottom(scroller)) clearProgrammaticScroll();
         return;
@@ -5930,12 +5939,15 @@ export function AgentWorkspace({
     if (settled && !transcriptShouldStickToBottomRef.current) return;
     if (typeof scroller.scrollTo !== "function") return; // jsdom has no scrollTo
     if (settled) {
+      transcriptLastScrollTopRef.current = scroller.scrollTop;
       transcriptProgrammaticScrollRef.current = true;
       if (transcriptProgrammaticScrollTimeoutRef.current !== undefined) {
         window.clearTimeout(transcriptProgrammaticScrollTimeoutRef.current);
       }
       transcriptProgrammaticScrollTimeoutRef.current = window.setTimeout(() => {
         transcriptProgrammaticScrollRef.current = false;
+        transcriptShouldStickToBottomRef.current =
+          isAgentTranscriptNearBottom(scroller);
         transcriptProgrammaticScrollTimeoutRef.current = undefined;
       }, 800);
     } else {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5847,6 +5847,7 @@ export function AgentWorkspace({
   // history fetch that fills the new conversation in) must land at the bottom
   // instantly; only turns arriving while the user is already reading glide.
   const settledScrollSelectionRef = useRef<string>();
+  const transcriptShouldStickToBottomRef = useRef(true);
 
   // History for the selected conversation has landed: a session gets an entry
   // in hermesSessionMessages (even an empty one) once its fetch resolves;
@@ -5864,14 +5865,29 @@ export function AgentWorkspace({
     hermesSessionsLoading && !hermesSessionsHydrated;
 
   useEffect(() => {
+    if (heroMode) return;
+    const scroller = agentScrollRef.current;
+    if (!scroller) return;
+    const updateStickiness = () => {
+      transcriptShouldStickToBottomRef.current =
+        isAgentTranscriptNearBottom(scroller);
+    };
+    updateStickiness();
+    scroller.addEventListener("scroll", updateStickiness, { passive: true });
+    return () => scroller.removeEventListener("scroll", updateStickiness);
+  }, [heroMode, selectedHermesSessionId, selectedTaskId]);
+
+  useEffect(() => {
     // The conversation scrolls in .agent-scroll, which sits below the sticky
     // breadcrumb so the scrollbar can't ride up over the bar — drive that
     // scroller to the bottom as turns arrive.
     const scroller = listRef.current?.closest(".agent-scroll");
     if (!(scroller instanceof HTMLElement)) return;
-    if (typeof scroller.scrollTo !== "function") return; // jsdom has no scrollTo
     const selectionKey = `${selectedHermesSessionId ?? ""}:${selectedTaskId ?? ""}`;
     const settled = settledScrollSelectionRef.current === selectionKey;
+    if (!settled) {
+      transcriptShouldStickToBottomRef.current = true;
+    }
     if (selectedHistoryLoaded || renderedTurnsSignature > 0) {
       // The settling run itself still scrolls with the pre-write snapshot, so
       // the history fill after a switch lands instantly; everything after it
@@ -5882,10 +5898,13 @@ export function AgentWorkspace({
       // before this one settles re-lands instantly instead of gliding.
       settledScrollSelectionRef.current = undefined;
     }
+    if (settled && !transcriptShouldStickToBottomRef.current) return;
+    if (typeof scroller.scrollTo !== "function") return; // jsdom has no scrollTo
     scroller.scrollTo({
       top: scroller.scrollHeight,
       behavior: settled ? "smooth" : "auto",
     });
+    transcriptShouldStickToBottomRef.current = true;
   }, [
     renderedTurnsSignature,
     selectedHermesSessionId,
@@ -8685,6 +8704,15 @@ function chatTurnsSignature(turns: AgentChatTurn[]) {
         0,
       ),
     0,
+  );
+}
+
+const AGENT_TRANSCRIPT_BOTTOM_THRESHOLD_PX = 48;
+
+function isAgentTranscriptNearBottom(scroller: HTMLElement) {
+  return (
+    scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <=
+    AGENT_TRANSCRIPT_BOTTOM_THRESHOLD_PX
   );
 }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5848,6 +5848,8 @@ export function AgentWorkspace({
   // instantly; only turns arriving while the user is already reading glide.
   const settledScrollSelectionRef = useRef<string>();
   const transcriptShouldStickToBottomRef = useRef(true);
+  const transcriptProgrammaticScrollRef = useRef(false);
+  const transcriptProgrammaticScrollTimeoutRef = useRef<number | undefined>();
 
   // History for the selected conversation has landed: a session gets an entry
   // in hermesSessionMessages (even an empty one) once its fetch resolves;
@@ -5868,13 +5870,40 @@ export function AgentWorkspace({
     if (heroMode) return;
     const scroller = agentScrollRef.current;
     if (!scroller) return;
+    const clearProgrammaticScroll = () => {
+      transcriptProgrammaticScrollRef.current = false;
+      if (transcriptProgrammaticScrollTimeoutRef.current !== undefined) {
+        window.clearTimeout(transcriptProgrammaticScrollTimeoutRef.current);
+        transcriptProgrammaticScrollTimeoutRef.current = undefined;
+      }
+    };
     const updateStickiness = () => {
+      if (transcriptProgrammaticScrollRef.current) {
+        transcriptShouldStickToBottomRef.current = true;
+        if (isAgentTranscriptNearBottom(scroller)) clearProgrammaticScroll();
+        return;
+      }
       transcriptShouldStickToBottomRef.current =
         isAgentTranscriptNearBottom(scroller);
     };
+    const updateFromUserScroll = () => {
+      clearProgrammaticScroll();
+      window.requestAnimationFrame(updateStickiness);
+    };
     updateStickiness();
     scroller.addEventListener("scroll", updateStickiness, { passive: true });
-    return () => scroller.removeEventListener("scroll", updateStickiness);
+    scroller.addEventListener("wheel", updateFromUserScroll, {
+      passive: true,
+    });
+    scroller.addEventListener("touchmove", updateFromUserScroll, {
+      passive: true,
+    });
+    return () => {
+      scroller.removeEventListener("scroll", updateStickiness);
+      scroller.removeEventListener("wheel", updateFromUserScroll);
+      scroller.removeEventListener("touchmove", updateFromUserScroll);
+      clearProgrammaticScroll();
+    };
   }, [heroMode, selectedHermesSessionId, selectedTaskId]);
 
   useEffect(() => {
@@ -5900,6 +5929,18 @@ export function AgentWorkspace({
     }
     if (settled && !transcriptShouldStickToBottomRef.current) return;
     if (typeof scroller.scrollTo !== "function") return; // jsdom has no scrollTo
+    if (settled) {
+      transcriptProgrammaticScrollRef.current = true;
+      if (transcriptProgrammaticScrollTimeoutRef.current !== undefined) {
+        window.clearTimeout(transcriptProgrammaticScrollTimeoutRef.current);
+      }
+      transcriptProgrammaticScrollTimeoutRef.current = window.setTimeout(() => {
+        transcriptProgrammaticScrollRef.current = false;
+        transcriptProgrammaticScrollTimeoutRef.current = undefined;
+      }, 800);
+    } else {
+      transcriptProgrammaticScrollRef.current = false;
+    }
     scroller.scrollTo({
       top: scroller.scrollHeight,
       behavior: settled ? "smooth" : "auto",

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -48,8 +48,21 @@ export async function deleteHermesSession(sessionId: string) {
 export function normalizeHermesSessionsResponse(response: unknown) {
   return extractList(response, "sessions")
     .filter(isHermesSessionInfo)
+    .filter((session) => !isDelegatedSubagentSession(session))
     .map(withScheduledRunDisplay)
     .sort((a, b) => sessionTimestamp(b).localeCompare(sessionTimestamp(a)));
+}
+
+function isDelegatedSubagentSession(session: HermesSessionInfo) {
+  const parentSessionId = sessionParentSessionId(session);
+  return parentSessionId !== undefined && parentSessionId !== session.id;
+}
+
+function sessionParentSessionId(session: HermesSessionInfo) {
+  const parentSessionId = session.parent_session_id ?? session.parentSessionId;
+  return typeof parentSessionId === "string" && parentSessionId.trim()
+    ? parentSessionId.trim()
+    : undefined;
 }
 
 /** Hermes tags scheduled-routine runs with source "cron". */

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -54,15 +54,32 @@ export function normalizeHermesSessionsResponse(response: unknown) {
 }
 
 function isDelegatedSubagentSession(session: HermesSessionInfo) {
-  const parentSessionId = sessionParentSessionId(session);
-  return parentSessionId !== undefined && parentSessionId !== session.id;
+  return (
+    sessionSource(session) === "tool" ||
+    sessionKind(session) === "subagent" ||
+    sessionKind(session) === "delegate_task" ||
+    hasSubagentId(session)
+  );
 }
 
-function sessionParentSessionId(session: HermesSessionInfo) {
-  const parentSessionId = session.parent_session_id ?? session.parentSessionId;
-  return typeof parentSessionId === "string" && parentSessionId.trim()
-    ? parentSessionId.trim()
-    : undefined;
+function sessionSource(session: HermesSessionInfo) {
+  return normalizeSessionMarker(session.source);
+}
+
+function sessionKind(session: HermesSessionInfo) {
+  return normalizeSessionMarker(
+    session.session_type ?? session.sessionType ?? session.kind,
+  );
+}
+
+function hasSubagentId(session: HermesSessionInfo) {
+  return Boolean(
+    normalizeSessionMarker(session.subagent_id ?? session.subagentId),
+  );
+}
+
+function normalizeSessionMarker(value: unknown) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
 /** Hermes tags scheduled-routine runs with source "cron". */

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -508,6 +508,11 @@ export type HermesSessionInfo = {
   is_active?: boolean;
   status?: string;
   source?: string;
+  kind?: string | null;
+  session_type?: string | null;
+  sessionType?: string | null;
+  subagent_id?: string | null;
+  subagentId?: string | null;
   user_id?: string;
   model?: string;
   title?: string;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -519,6 +519,7 @@ export type HermesSessionInfo = {
   message_count?: number;
   tool_call_count?: number;
   parent_session_id?: string | null;
+  parentSessionId?: string | null;
   last_active?: string;
   lastActive?: string;
   preview?: string;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4062,7 +4062,11 @@ describe("AgentWorkspace", () => {
     await screen.findByText("Reading first source");
     expect(scrollTo).toHaveBeenCalledTimes(1);
 
-    scroller.scrollTop = 600;
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 2000,
+    });
+    scroller.scrollTop = 1460;
     fireEvent.scroll(scroller);
 
     act(() => {
@@ -4081,6 +4085,82 @@ describe("AgentWorkspace", () => {
 
     await screen.findByText(/Reading another source/);
     expect(scrollTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not pull the transcript back down after scrollbar scrolling", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "browse the web for release notes",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "browse the web for release notes",
+      }),
+    );
+
+    const scroller = document.querySelector(".agent-scroll") as HTMLElement;
+    const scrollTo = vi.fn();
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1600,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      value: 1280,
+      writable: true,
+    });
+    Object.defineProperty(scroller, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+    fireEvent.scroll(scroller);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "subagent.progress",
+          session_id: "runtime-session-2",
+          payload: {
+            subagent_id: "worker-1",
+            goal: "Browse release notes",
+            text: "Reading first source",
+          },
+        });
+      }
+    });
+    await screen.findByText("Reading first source");
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+
+    scroller.scrollTop = 900;
+    fireEvent.scroll(scroller);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "subagent.progress",
+          session_id: "runtime-session-2",
+          payload: {
+            subagent_id: "worker-1",
+            goal: "Browse release notes",
+            text: "Reading while the user reviews earlier output",
+          },
+        });
+      }
+    });
+
+    await screen.findByText(/Reading while the user reviews earlier output/);
+    expect(scrollTo).toHaveBeenCalledTimes(1);
   });
 
   it("explains a pending approval before the user chooses", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3945,6 +3945,68 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Done.")).toBeInTheDocument();
   });
 
+  it("does not force the transcript to the bottom while subagent progress streams", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "browse the web for recent launch details",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "browse the web for recent launch details",
+      }),
+    );
+    expect(
+      await screen.findByText("browse the web for recent launch details"),
+    ).toBeInTheDocument();
+
+    const scroller = document.querySelector(".agent-scroll") as HTMLElement;
+    const scrollTo = vi.fn();
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1600,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      value: 240,
+      writable: true,
+    });
+    Object.defineProperty(scroller, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+    fireEvent.scroll(scroller);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "subagent.progress",
+          session_id: "runtime-session-2",
+          payload: {
+            subagent_id: "worker-1",
+            goal: "Browse source pages",
+            text: "Reading search results",
+          },
+        });
+      }
+    });
+
+    expect(
+      await screen.findByText("Subagent: Browse source pages"),
+    ).toBeInTheDocument();
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
   it("explains a pending approval before the user chooses", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4007,6 +4007,82 @@ describe("AgentWorkspace", () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
+  it("keeps following new output during programmatic smooth scrolling", async () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "browse the web for release notes",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "browse the web for release notes",
+      }),
+    );
+
+    const scroller = document.querySelector(".agent-scroll") as HTMLElement;
+    const scrollTo = vi.fn();
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1600,
+    });
+    Object.defineProperty(scroller, "scrollTop", {
+      configurable: true,
+      value: 1280,
+      writable: true,
+    });
+    Object.defineProperty(scroller, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+    fireEvent.scroll(scroller);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "subagent.progress",
+          session_id: "runtime-session-2",
+          payload: {
+            subagent_id: "worker-1",
+            goal: "Browse release notes",
+            text: "Reading first source",
+          },
+        });
+      }
+    });
+    await screen.findByText("Reading first source");
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+
+    scroller.scrollTop = 600;
+    fireEvent.scroll(scroller);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "subagent.progress",
+          session_id: "runtime-session-2",
+          payload: {
+            subagent_id: "worker-1",
+            goal: "Browse release notes",
+            text: "Reading another source",
+          },
+        });
+      }
+    });
+
+    await screen.findByText(/Reading another source/);
+    expect(scrollTo).toHaveBeenCalledTimes(2);
+  });
+
   it("explains a pending approval before the user chooses", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -159,12 +159,14 @@ describe("Hermes adapter", () => {
         },
         {
           id: "child-worker",
+          source: "tool",
           title: "Browse source 1",
           parent_session_id: "parent-session",
           last_active: "2026-06-11T12:01:00Z",
         },
         {
           id: "camel-child-worker",
+          subagentId: "worker-2",
           title: "Browse source 2",
           parentSessionId: "parent-session",
           last_active: "2026-06-11T12:02:00Z",
@@ -173,6 +175,32 @@ describe("Hermes adapter", () => {
     });
 
     expect(sessions.map((session) => session.id)).toEqual(["parent-session"]);
+  });
+
+  it("preserves compressed continuation sessions from the top-level session list", () => {
+    const sessions = normalizeHermesSessionsResponse({
+      sessions: [
+        {
+          id: "continuation-session",
+          source: "tui",
+          title: "Long research request (2)",
+          parent_session_id: "parent-session",
+          last_active: "2026-06-11T12:02:00Z",
+        },
+        {
+          id: "parent-session",
+          source: "tui",
+          title: "Long research request",
+          end_reason: "compression",
+          last_active: "2026-06-11T12:01:00Z",
+        },
+      ],
+    });
+
+    expect(sessions.map((session) => session.id)).toEqual([
+      "continuation-session",
+      "parent-session",
+    ]);
   });
 
   it("lists only cron-sourced sessions as scheduled runs", async () => {

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -149,6 +149,32 @@ describe("Hermes adapter", () => {
     );
   });
 
+  it("hides delegated subagent sessions from the top-level session list", () => {
+    const sessions = normalizeHermesSessionsResponse({
+      sessions: [
+        {
+          id: "parent-session",
+          title: "Research request",
+          last_active: "2026-06-11T12:00:00Z",
+        },
+        {
+          id: "child-worker",
+          title: "Browse source 1",
+          parent_session_id: "parent-session",
+          last_active: "2026-06-11T12:01:00Z",
+        },
+        {
+          id: "camel-child-worker",
+          title: "Browse source 2",
+          parentSessionId: "parent-session",
+          last_active: "2026-06-11T12:02:00Z",
+        },
+      ],
+    });
+
+    expect(sessions.map((session) => session.id)).toEqual(["parent-session"]);
+  });
+
   it("lists only cron-sourced sessions as scheduled runs", async () => {
     mocks.hermesBridgeSessions.mockResolvedValue({
       sessions: [


### PR DESCRIPTION
Closes JUN-123

## What changed
- Hide delegated child/subagent sessions from the normal top-level Hermes session list by filtering sessions with a parent session id during adapter normalization.
- Preserve the transcript scroll position when streamed subagent progress arrives while the user has scrolled up to read earlier messages. Session switches and bottom-pinned conversations still land at the bottom.
- Add regression coverage for both the delegated-session filtering and the subagent-progress scroll behavior.

## Why
JUN-123 reported that web-browsing requests spawned multiple visible subagent sessions and made it impossible to scroll back to the original prompt while progress streamed. Subagent progress should remain associated with the parent conversation, and streaming updates should not fight a user who is intentionally reading earlier content.

## Validation
- `pnpm test -- --run src/test/hermes-adapter.test.ts src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `pnpm build`
- `git diff --check`

## Live QA
- Surface: background browser against local Vite preview at `http://127.0.0.1:1421/`
- Command: `.agents/skills/agent-e2e-qa/scripts/run_background_agent_prompt.mjs --prompt hi`
- Result: UI opened the agent flow, sent `hi`, rendered a visible assistant turn, and recorded video/screenshot. Hermes returned `API call failed after 3 retries: Connection error`, so this is smoke evidence for rendering only, not a provider happy path.
- Artifacts: `.tmp/qa-recordings/20260629T023147-background-agent-hi.webm`, `.tmp/qa-recordings/20260629T023147-background-agent-hi.png`

## Gaps
- The exact web-browsing subagent fan-out was verified with deterministic tests rather than a live provider run because the local Hermes provider call failed with a connection error during smoke QA.