### PR TITLE
Change depleted balance copy for subscribers

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -85,6 +85,7 @@ import {
   listSessionFolders,
   openPrivacySettings,
   osAccountsLogout,
+  osAccountsOpenPortal,
   osAccountsUpgrade,
   pauseRecording,
   removeNoteFromFolder,
@@ -166,6 +167,7 @@ import {
 } from "../lib/onboarding";
 import {
   depletedBalanceActionLabel,
+  shouldOpenPortalForDepletedBalance,
   shouldBlockOnFunding,
   shouldBlockOnSignIn,
 } from "../lib/account-gate";
@@ -526,6 +528,11 @@ export function App() {
     !signInRequired &&
     shouldBlockOnFunding(account);
   const topUpLabel = depletedBalanceActionLabel(account);
+  const topUpOpensPortal = shouldOpenPortalForDepletedBalance(account);
+  const handleTopUp = useCallback(() => {
+    const action = topUpOpensPortal ? osAccountsOpenPortal : osAccountsUpgrade;
+    void action().catch((err: unknown) => setError(messageFromError(err)));
+  }, [topUpOpensPortal]);
   const [onboardingDone, setOnboardingDone] = useState(() => {
     applyOnboardingReplayFlag();
     return isOnboardingComplete();
@@ -2933,6 +2940,7 @@ export function App() {
                   initialSessionId={activeAgentSessionId}
                   onSessionSelected={setActiveAgentSession}
                   topUpLabel={topUpLabel}
+                  onTopUp={handleTopUp}
                   origin={
                     agentOriginFolder
                       ? {
@@ -3250,11 +3258,7 @@ export function App() {
                           throw err;
                         }
                       }}
-                      onTopUp={() =>
-                        void osAccountsUpgrade().catch((err: unknown) =>
-                          setError(messageFromError(err)),
-                        )
-                      }
+                      onTopUp={handleTopUp}
                       topUpLabel={topUpLabel}
                       onAssignFolder={(folderId) =>
                         void handleSetNoteFolder(selectedNote.id, folderId)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -164,7 +164,11 @@ import {
   markOnboardingComplete,
   shouldReplayOnboarding,
 } from "../lib/onboarding";
-import { shouldBlockOnFunding, shouldBlockOnSignIn } from "../lib/account-gate";
+import {
+  depletedBalanceActionLabel,
+  shouldBlockOnFunding,
+  shouldBlockOnSignIn,
+} from "../lib/account-gate";
 import {
   checkScribeUpdate,
   relaunchScribe,
@@ -521,6 +525,7 @@ export function App() {
     !devAccountsUnconfigured &&
     !signInRequired &&
     shouldBlockOnFunding(account);
+  const topUpLabel = depletedBalanceActionLabel(account);
   const [onboardingDone, setOnboardingDone] = useState(() => {
     applyOnboardingReplayFlag();
     return isOnboardingComplete();
@@ -2927,6 +2932,7 @@ export function App() {
                   initialSession={activeAgentSessionSeed}
                   initialSessionId={activeAgentSessionId}
                   onSessionSelected={setActiveAgentSession}
+                  topUpLabel={topUpLabel}
                   origin={
                     agentOriginFolder
                       ? {
@@ -3249,6 +3255,7 @@ export function App() {
                           setError(messageFromError(err)),
                         )
                       }
+                      topUpLabel={topUpLabel}
                       onAssignFolder={(folderId) =>
                         void handleSetNoteFolder(selectedNote.id, folderId)
                       }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -843,6 +843,7 @@ type AgentWorkspaceProps = {
   initialSessionId?: string;
   origin?: AgentWorkspaceOrigin;
   onSessionSelected?: (session: HermesSessionInfo | undefined) => void;
+  onTopUp?: () => void | Promise<void>;
   topUpLabel?: string;
 };
 
@@ -1252,6 +1253,7 @@ export function AgentWorkspace({
   initialSessionId: initialSessionIdProp,
   origin,
   onSessionSelected,
+  onTopUp,
   topUpLabel = "Upgrade",
 }: AgentWorkspaceProps = {}) {
   const initialSessionId = initialSession?.id ?? initialSessionIdProp;
@@ -1381,6 +1383,12 @@ export function AgentWorkspace({
     },
     [],
   );
+  const handleTopUp = useCallback(() => {
+    const result = onTopUp ? onTopUp() : osAccountsUpgrade();
+    void Promise.resolve(result).catch((err: unknown) =>
+      setError(messageFromError(err)),
+    );
+  }, [onTopUp, setError]);
   const clearErrorForSession = useCallback((sessionId: string) => {
     setErrorState((current) =>
       current?.sessionId === sessionId ? null : current,
@@ -6509,11 +6517,7 @@ export function AgentWorkspace({
               sessionUnrestricted(selectedHermesSessionId),
             )
           }
-          onTopUp={() =>
-            void osAccountsUpgrade().catch((err: unknown) =>
-              setError(messageFromError(err)),
-            )
-          }
+          onTopUp={handleTopUp}
           topUpLabel={topUpLabel}
           onClarify={(part, answer) =>
             void respondToClarify(
@@ -6616,11 +6620,7 @@ export function AgentWorkspace({
             onThinkingOpenChange={setThinkingOpen}
             onDownloadArtifact={downloadArtifact}
             onOpenArtifact={openArtifact}
-            onTopUp={() =>
-              void osAccountsUpgrade().catch((err: unknown) =>
-                setError(messageFromError(err)),
-              )
-            }
+            onTopUp={handleTopUp}
             topUpLabel={topUpLabel}
             onApproval={(part, choice) => {
               const sessionId = part.sessionId ?? selectedTask.hermesSessionId;

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -843,6 +843,7 @@ type AgentWorkspaceProps = {
   initialSessionId?: string;
   origin?: AgentWorkspaceOrigin;
   onSessionSelected?: (session: HermesSessionInfo | undefined) => void;
+  topUpLabel?: string;
 };
 
 // Mid-run continuity across remounts. While June is working, a session has
@@ -1251,6 +1252,7 @@ export function AgentWorkspace({
   initialSessionId: initialSessionIdProp,
   origin,
   onSessionSelected,
+  topUpLabel = "Upgrade",
 }: AgentWorkspaceProps = {}) {
   const initialSessionId = initialSession?.id ?? initialSessionIdProp;
   // Read once per mount (lazy initializer): the continuity snapshot the
@@ -6512,6 +6514,7 @@ export function AgentWorkspace({
               setError(messageFromError(err)),
             )
           }
+          topUpLabel={topUpLabel}
           onClarify={(part, answer) =>
             void respondToClarify(
               selectedHermesSessionId,
@@ -6618,6 +6621,7 @@ export function AgentWorkspace({
                 setError(messageFromError(err)),
               )
             }
+            topUpLabel={topUpLabel}
             onApproval={(part, choice) => {
               const sessionId = part.sessionId ?? selectedTask.hermesSessionId;
               if (!sessionId) return;
@@ -8830,6 +8834,7 @@ function AgentChatTurnRow({
   onOpenArtifact,
   onThinkingOpenChange,
   onTopUp,
+  topUpLabel,
   onBranch,
   onEditUserPrompt,
   branchingMessageId,
@@ -8865,6 +8870,7 @@ function AgentChatTurnRow({
   onOpenArtifact?: (artifact: AgentArtifact) => void;
   onThinkingOpenChange: (key: string, open: boolean) => void;
   onTopUp?: () => void;
+  topUpLabel?: string;
   onEditUserPrompt?: (text: string) => void;
   /** Fork the conversation from this turn into a new session (feature 07).
    * Optional: only Hermes-session rows pass it — task rows and the dev gallery
@@ -9142,6 +9148,7 @@ function AgentChatTurnRow({
             <CreditsNoticePart
               key={`${turn.id}:notice:${index}`}
               onTopUp={onTopUp}
+              topUpLabel={topUpLabel}
             />
           ) : part.type === "steering" ? (
             <SteeringPart
@@ -9463,7 +9470,13 @@ function visibleAgentWorkspaceError(
 // transcript — the chat runtime folds it into a notice part, and this card is
 // how the user learns the turn stopped and what to do about it. No title —
 // icon + one sentence + the action, Claude-style.
-function CreditsNoticePart({ onTopUp }: { onTopUp?: () => void }) {
+function CreditsNoticePart({
+  onTopUp,
+  topUpLabel = "Upgrade",
+}: {
+  onTopUp?: () => void;
+  topUpLabel?: string;
+}) {
   return (
     <InlineNotice
       className="agent-credits-notice"
@@ -9474,7 +9487,7 @@ function CreditsNoticePart({ onTopUp }: { onTopUp?: () => void }) {
       actions={
         onTopUp ? (
           <button type="button" className="btn btn-secondary" onClick={onTopUp}>
-            Upgrade
+            {topUpLabel}
           </button>
         ) : undefined
       }

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -56,6 +56,7 @@ type NoteEditorProps = {
   onFinishRecording: (sessionId: string) => void;
   onRetry: () => void | Promise<void>;
   onTopUp: () => void;
+  topUpLabel?: string;
   onRecoverRecording: (sessionId: string) => void;
   onDiscardRecording: (sessionId: string) => void;
   onAssignFolder: (folderId: string) => void;
@@ -143,6 +144,7 @@ export function NoteEditor({
   onFinishRecording,
   onRetry,
   onTopUp,
+  topUpLabel,
   onRecoverRecording,
   onDiscardRecording,
   onAssignFolder,
@@ -327,6 +329,7 @@ export function NoteEditor({
             audioPreserved={!!(note.audio || note.audioSources?.length)}
             onRetry={onRetry}
             onTopUp={onTopUp}
+            topUpLabel={topUpLabel}
           />
         ) : null}
         {activeTab === "transcription" ? (

--- a/src/components/note-editor/NoteFailureBanner.tsx
+++ b/src/components/note-editor/NoteFailureBanner.tsx
@@ -9,6 +9,7 @@ type Props = {
   audioPreserved: boolean;
   onRetry: () => void | Promise<void>;
   onTopUp: () => void;
+  topUpLabel?: string;
 };
 
 // String match (see isInsufficientCreditsMessage) is intentional and a known
@@ -62,10 +63,12 @@ export function NoteFailureBanner({
   audioPreserved,
   onRetry,
   onTopUp,
+  topUpLabel = "Upgrade",
 }: Props) {
   const kind = classifyFailure(errorMessage);
   const isBalanceIssue = kind === "balance_low";
   const displayMessage = userFacingFailureMessage(errorMessage);
+  const topUpAction = topUpLabel.toLowerCase();
   // Local busy flag so a fast double-click can't fire onRetry twice. The
   // banner unmounts when the note transitions out of `failed` status, so we
   // don't need to reset this state ourselves; the catch covers the case
@@ -93,8 +96,8 @@ export function NoteFailureBanner({
       <p className="note-failure-message">
         {isBalanceIssue
           ? audioPreserved
-            ? "Your balance ran out. Your recording is saved locally, so upgrade and retry."
-            : "Your balance is too low. Upgrade to continue."
+            ? `Your balance ran out. Your recording is saved locally, so ${topUpAction} and retry.`
+            : `Your balance is too low. ${topUpLabel} to continue.`
           : (displayMessage ?? "June couldn't finish processing this note.")}
         {!isBalanceIssue && audioPreserved
           ? " Your recording is saved locally, so you can retry."
@@ -108,7 +111,7 @@ export function NoteFailureBanner({
             onClick={onTopUp}
             disabled={retrying}
           >
-            Upgrade
+            {topUpLabel}
           </button>
         ) : null}
         <button

--- a/src/lib/account-gate.ts
+++ b/src/lib/account-gate.ts
@@ -14,6 +14,12 @@ export function hasLiveSubscription(account: AccountStatus): boolean {
   return status === "trialing" || status === "active";
 }
 
+export function depletedBalanceActionLabel(account: AccountStatus) {
+  return account.subscription?.subscribed === true
+    ? "Top up credits"
+    : "Upgrade";
+}
+
 function hasKnownNonLiveSubscription(account: AccountStatus): boolean {
   const subscription = account.subscription;
   if (!subscription) return false;

--- a/src/lib/account-gate.ts
+++ b/src/lib/account-gate.ts
@@ -15,9 +15,13 @@ export function hasLiveSubscription(account: AccountStatus): boolean {
 }
 
 export function depletedBalanceActionLabel(account: AccountStatus) {
-  return account.subscription?.subscribed === true
+  return shouldOpenPortalForDepletedBalance(account)
     ? "Top up credits"
     : "Upgrade";
+}
+
+export function shouldOpenPortalForDepletedBalance(account: AccountStatus) {
+  return account.subscription?.subscribed === true;
 }
 
 function hasKnownNonLiveSubscription(account: AccountStatus): boolean {

--- a/src/test/account-gate.test.ts
+++ b/src/test/account-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   depletedBalanceActionLabel,
+  shouldOpenPortalForDepletedBalance,
   shouldBlockOnFunding,
   shouldBlockOnSignIn,
 } from "../lib/account-gate";
@@ -163,5 +164,27 @@ describe("depletedBalanceActionLabel", () => {
         subscription: { subscribed: true, status: "active" },
       }),
     ).toBe("Top up credits");
+  });
+});
+
+describe("shouldOpenPortalForDepletedBalance", () => {
+  it("keeps unsubscribed users on checkout", () => {
+    expect(
+      shouldOpenPortalForDepletedBalance({
+        signedIn: true,
+        configured: true,
+        subscription: { subscribed: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("routes subscribed users to the account portal", () => {
+    expect(
+      shouldOpenPortalForDepletedBalance({
+        signedIn: true,
+        configured: true,
+        subscription: { subscribed: true, status: "active" },
+      }),
+    ).toBe(true);
   });
 });

--- a/src/test/account-gate.test.ts
+++ b/src/test/account-gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldBlockOnFunding, shouldBlockOnSignIn } from "../lib/account-gate";
+import {
+  depletedBalanceActionLabel,
+  shouldBlockOnFunding,
+  shouldBlockOnSignIn,
+} from "../lib/account-gate";
 import type { AccountStatus } from "../lib/tauri";
 
 describe("shouldBlockOnSignIn", () => {
@@ -137,5 +141,27 @@ describe("shouldBlockOnFunding", () => {
       false,
     );
     expect(shouldBlockOnFunding(signedIn())).toBe(false);
+  });
+});
+
+describe("depletedBalanceActionLabel", () => {
+  it("asks unsubscribed users to upgrade", () => {
+    expect(
+      depletedBalanceActionLabel({
+        signedIn: true,
+        configured: true,
+        subscription: { subscribed: false },
+      }),
+    ).toBe("Upgrade");
+  });
+
+  it("asks subscribed users to top up credits", () => {
+    expect(
+      depletedBalanceActionLabel({
+        signedIn: true,
+        configured: true,
+        subscription: { subscribed: true, status: "active" },
+      }),
+    ).toBe("Top up credits");
   });
 });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6545,6 +6545,36 @@ describe("AgentWorkspace", () => {
     expect(mocks.osAccountsUpgrade).toHaveBeenCalledOnce();
   });
 
+  it("renders an out-of-credits notice with a top-up action for subscribed users", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "m1",
+        role: "user",
+        content: "How are the subagents doing",
+        timestamp: "2026-06-10T10:00:00Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content:
+          "Error: Error code: 402 - {'data': None, 'success': False, 'error_code': 4301, 'message': 'insufficient_credits'}",
+        timestamp: "2026-06-10T10:00:01Z",
+      },
+    ]);
+
+    render(<AgentWorkspace topUpLabel="Top up credits" />);
+
+    expect(
+      await screen.findByText(/June stopped because your balance ran out/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Top up credits" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledOnce();
+  });
+
   it("shows every error surface via the __agentErrors() dev handle", async () => {
     const agentErrors = (
       window as unknown as { __agentErrors: (show?: boolean) => string }

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6547,7 +6547,7 @@ describe("AgentWorkspace", () => {
 
   it("renders an out-of-credits notice with a top-up action for subscribed users", async () => {
     const user = userEvent.setup();
-    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
+    const onTopUp = vi.fn();
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
         id: "m1",
@@ -6564,7 +6564,7 @@ describe("AgentWorkspace", () => {
       },
     ]);
 
-    render(<AgentWorkspace topUpLabel="Top up credits" />);
+    render(<AgentWorkspace onTopUp={onTopUp} topUpLabel="Top up credits" />);
 
     expect(
       await screen.findByText(/June stopped because your balance ran out/),
@@ -6572,7 +6572,8 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByRole("button", { name: "Upgrade" })).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Top up credits" }));
-    expect(mocks.osAccountsUpgrade).toHaveBeenCalledOnce();
+    expect(onTopUp).toHaveBeenCalledOnce();
+    expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
   });
 
   it("shows every error surface via the __agentErrors() dev handle", async () => {

--- a/src/test/note-failure-banner.test.tsx
+++ b/src/test/note-failure-banner.test.tsx
@@ -72,6 +72,29 @@ describe("NoteFailureBanner", () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
+  it("offers Top up credits + Retry with subscribed-user copy", async () => {
+    const onTopUp = vi.fn();
+    render(
+      <NoteFailureBanner
+        errorMessage="insufficient_credits"
+        audioPreserved
+        onRetry={() => undefined}
+        onTopUp={onTopUp}
+        topUpLabel="Top up credits"
+      />,
+    );
+
+    expect(
+      screen.getByText(/so top up credits and retry/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Upgrade/i })).toBeNull();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Top up credits" }),
+    );
+    expect(onTopUp).toHaveBeenCalledOnce();
+  });
+
   it("shows only Retry for generic failures and reassures audio is saved", () => {
     render(
       <NoteFailureBanner


### PR DESCRIPTION
Closes JUN-124

## What changed
- Added subscribed-aware depleted-balance copy: unsubscribed users still see `Upgrade`, subscribed users see `Top up credits`.
- Routes subscribed depleted-balance actions to the OS Accounts portal, while unsubscribed users continue through the upgrade checkout action.
- Threaded the label and action into the agent out-of-credits notice and note processing failure banner.
- Updated tests for the account label/action helper, note failure banner, and agent credits notice.

## Why
Subscribed users should not be prompted to upgrade when their balance runs out because they are already on a subscription. The prompt now asks them to top up credits and opens the account portal for that subscribed case.

## Validation
- `pnpm exec vitest run src/test/account-gate.test.ts src/test/note-failure-banner.test.tsx src/test/agent-workspace.test.tsx` - passed, 160 tests passed and 2 skipped.
- `pnpm run lint` - passed.

## Live agent walkthrough
- Surface: web preview via `pnpm dev` and background Chrome/Playwright with a safe Tauri IPC shim.
- Scenario: subscribed active account with zero credits, existing agent session containing an insufficient-credits assistant error.
- Result: visible notice said `June stopped because your balance ran out.`, the action was `Top up credits`, no `Upgrade` button was present, and clicking the action invoked `os_accounts_open_portal` instead of `os_accounts_upgrade`.
- Local artifacts: `.tmp/qa-recordings/jun-124-top-up-credits-portal.png`, `.tmp/qa-recordings/175a9e2f0642f0d57a8759d5afdb2bfd.compressed.mp4`.

## Gaps
- Did not exercise a real OS Accounts checkout, account portal, or payment flow.
- QA video was not uploaded publicly; it is available locally in the worktree.
