### PR TITLE
Polish onboarding welcome copy

### DIFF
--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -55,10 +55,25 @@ type Props = {
 };
 
 function initialStepIndex(steps: StepId[]): number {
+  const demoStep = browserOnboardingDemoStep();
+  if (demoStep) {
+    const demoIndex = steps.indexOf(demoStep);
+    if (demoIndex !== -1) return demoIndex;
+  }
   const saved = onboardingResumeStep();
   if (!saved) return 0;
   const index = steps.indexOf(saved as StepId);
   return index === -1 ? 0 : index;
+}
+
+function browserOnboardingDemoStep(): StepId | null {
+  if (!import.meta.env.DEV || typeof window === "undefined") return null;
+  const step = new URLSearchParams(window.location.search).get("juneDemoStep");
+  return step === "sign-in" ||
+    step === "permissions" ||
+    step === "dictation-practice"
+    ? step
+    : null;
 }
 
 export function OnboardingFlow({

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -27,13 +27,13 @@ const JUNE_POINTS = [
   {
     icon: IconCalendar1,
     title: "Effortlessly capture meetings",
-    detail: "June takes the notes without ever joining the meeting.",
+    detail: "June takes meeting notes without ever having to join the meeting.",
   },
   {
     icon: IconLock,
     title: "Private by default",
     detail:
-      "Prompts leave your device only for inference, on zero-retention private models.",
+      "Prompts leverage private, zero-retention Venice AI models by default.",
   },
 ];
 

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -61,12 +61,16 @@ export function useSystemAudioStatus(active: boolean): {
   status: SystemAudioStatus;
   probe: () => void;
 } {
-  const [status, setStatus] = useState<SystemAudioStatus>("unknown");
+  const demoEnabled = browserOnboardingDemoEnabled();
+  const [status, setStatus] = useState<SystemAudioStatus>(
+    demoEnabled ? "granted" : "unknown",
+  );
   const statusRef = useRef(status);
   statusRef.current = status;
   const inflightRef = useRef(false);
 
   const probe = useCallback(() => {
+    if (demoEnabled) return;
     if (inflightRef.current) return;
     inflightRef.current = true;
     // Only the first probe shows the pending row; re-probes after a denial
@@ -94,7 +98,7 @@ export function useSystemAudioStatus(active: boolean): {
       .finally(() => {
         inflightRef.current = false;
       });
-  }, []);
+  }, [demoEnabled]);
 
   useEffect(() => {
     if (!active || statusRef.current !== "unknown") return;
@@ -117,11 +121,15 @@ export function useSystemAudioStatus(active: boolean): {
 }
 
 export function usePermissionStatuses(active: boolean): PermissionStatuses {
+  const demoEnabled = browserOnboardingDemoEnabled();
   const [statuses, setStatuses] = useState<PermissionStatuses>({
-    checked: false,
+    checked: demoEnabled,
+    microphone: demoEnabled ? "granted" : undefined,
+    accessibility: demoEnabled ? "granted" : undefined,
   });
 
   useEffect(() => {
+    if (demoEnabled) return;
     let aborted = false;
     let unlisten: (() => void) | undefined;
     void listen<string>("dictation-event", (event) => {
@@ -152,9 +160,10 @@ export function usePermissionStatuses(active: boolean): PermissionStatuses {
       aborted = true;
       unlisten?.();
     };
-  }, []);
+  }, [demoEnabled]);
 
   useEffect(() => {
+    if (demoEnabled) return;
     if (!active) return;
     function poll() {
       void dictationHelperCommand({ type: "get_permission_status" }).catch(
@@ -168,7 +177,14 @@ export function usePermissionStatuses(active: boolean): PermissionStatuses {
       window.clearInterval(interval);
       window.removeEventListener("focus", poll);
     };
-  }, [active]);
+  }, [active, demoEnabled]);
 
   return statuses;
+}
+
+function browserOnboardingDemoEnabled() {
+  if (!import.meta.env.DEV || typeof window === "undefined") return false;
+  return (
+    new URLSearchParams(window.location.search).get("juneDemoAccount") === "1"
+  );
 }

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -3,6 +3,18 @@ import { osAccountsLogout, osAccountsStatus } from "./tauri";
 import type { AccountStatus } from "./tauri";
 
 const EMPTY_STATUS: AccountStatus = { signedIn: false, configured: false };
+const DEMO_ACCOUNT: AccountStatus = {
+  signedIn: true,
+  configured: true,
+  localDev: true,
+  user: {
+    id: "usr_browser_demo",
+    handle: "browser-demo",
+    displayName: "Browser demo",
+  },
+  balance: { credits: 0, usdMillis: 0 },
+  subscription: { subscribed: true, status: "active" },
+};
 
 export type UseAccountStatusOptions = {
   forceLogoutOnMount?: boolean;
@@ -25,6 +37,11 @@ export function useAccountStatus(
   const [error, setError] = useState<string>();
 
   const refresh = useCallback(async () => {
+    if (browserOnboardingDemoEnabled()) {
+      setAccount(DEMO_ACCOUNT);
+      setError(undefined);
+      return DEMO_ACCOUNT;
+    }
     try {
       const next = await osAccountsStatus();
       setAccount(next);
@@ -40,7 +57,7 @@ export function useAccountStatus(
     let cancelled = false;
     setLoading(true);
     async function loadInitialStatus() {
-      if (forceLogoutOnMount) {
+      if (forceLogoutOnMount && !browserOnboardingDemoEnabled()) {
         await osAccountsLogout();
       }
       await refresh();
@@ -76,6 +93,13 @@ export function useAccountStatus(
   }, [refresh]);
 
   return { account, loading, error, refresh, setAccount };
+}
+
+function browserOnboardingDemoEnabled() {
+  if (!import.meta.env.DEV || typeof window === "undefined") return false;
+  return (
+    new URLSearchParams(window.location.search).get("juneDemoAccount") === "1"
+  );
 }
 
 function messageFromError(err: unknown) {


### PR DESCRIPTION
## Summary
- tighten June onboarding welcome copy for meeting notes and private model language
- add dev-only query params for reviewing onboarding locally in a plain browser

## Tests
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/test/onboarding.test.tsx

Note: the trial-screen edits from the local browser review target a stale local branch. Current main no longer has that onboarding trial screen, so this PR only includes changes that apply cleanly to main.