### PR TITLE
Fix image attachment upload RPC

### DIFF
--- a/june-api/crates/api/src/validation.rs
+++ b/june-api/crates/api/src/validation.rs
@@ -82,7 +82,7 @@ fn validate_json_shape(
     match value {
         Value::String(text) => {
             let chars = text.chars().count();
-            if chars > MAX_AGENT_STRING_CHARS {
+            if chars > MAX_AGENT_STRING_CHARS && !is_agent_image_data_url(text) {
                 return Err(ApiError::bad_request("string_too_long"));
             }
             *total_string_chars = total_string_chars.saturating_add(chars);
@@ -112,6 +112,17 @@ fn validate_json_shape(
         Value::Null | Value::Bool(_) | Value::Number(_) => {}
     }
     Ok(())
+}
+
+fn is_agent_image_data_url(text: &str) -> bool {
+    let Some((mime, data)) = text.split_once(";base64,") else {
+        return false;
+    };
+    mime.starts_with("data:image/")
+        && !data.is_empty()
+        && data.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/' | b'=' | b'\r' | b'\n')
+        })
 }
 
 #[cfg(test)]
@@ -188,5 +199,43 @@ mod tests {
             }))
             .is_err()
         );
+    }
+
+    #[test]
+    fn agent_body_accepts_image_data_url_over_single_string_limit() {
+        let image = format!(
+            "data:image/png;base64,{}",
+            "a".repeat(MAX_AGENT_STRING_CHARS + 1)
+        );
+
+        assert!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "image_url",
+                        "image_url": { "url": image },
+                    }],
+                }],
+            }))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn agent_body_rejects_non_image_data_url_over_single_string_limit() {
+        let text = format!(
+            "data:text/plain;base64,{}",
+            "a".repeat(MAX_AGENT_STRING_CHARS + 1)
+        );
+
+        assert!(matches!(
+            validate_agent_chat_body(&json!({
+                "model": "text-model",
+                "messages": [{ "role": "user", "content": text }],
+            })),
+            Err(ApiError::BadRequest { message, .. }) if message == "string_too_long"
+        ));
     }
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -778,7 +778,7 @@ type AgentArtifact = {
 type AgentAttachment = ImportedHermesFile & {
   id: string;
   /** Structured attach status (feature 19). Tracks whether this import has been
-   * sent to the model via image.attach: imported (ready) → attached (acked) →
+   * sent to the model via image.attach_bytes: imported (ready) → attached (acked) →
    * or failed. Carries file refs only, never the image bytes. Files stay
    * `imported` (they only ride along as a path in the prompt). */
   attach: HermesAttachmentState;
@@ -3509,7 +3509,7 @@ export function AgentWorkspace({
           ...file,
           id: `${file.path}:${Date.now()}:${Math.random().toString(36)}`,
           // Seed the structured attach status (feature 19). Images become
-          // `kind:"image"`, status `imported` — eligible for image.attach on
+          // `kind:"image"`, status `imported` — eligible for structured attach on
           // the next submit. No bytes are kept here.
           attach: attachmentStateFrom(file),
         })),
@@ -3689,7 +3689,7 @@ export function AgentWorkspace({
   }
 
   /**
-   * Attach this turn's pending images to the live session via image.attach
+   * Attach this turn's pending images to the live session via image.attach_bytes
    * (feature 19), updating each chip's status and feeding the artifact timeline.
    * The base64 is read on demand from the workspace file (hermesBridgeFilePreview
    * returns a data url), passed straight to the typed attachImage, and discarded;
@@ -3711,7 +3711,7 @@ export function AgentWorkspace({
     const deps = {
       attachImage: methods.attachImage,
       readImageData: (path: string) => hermesBridgeFilePreview(path),
-      isSupported: () => isHermesFeatureSupported("image.attach"),
+      isSupported: () => isHermesFeatureSupported("image.attach_bytes"),
     };
     const mode = hermesModeFor(storedSessionId);
     const failures: string[] = [];
@@ -4144,7 +4144,7 @@ export function AgentWorkspace({
       displayContent?: string;
       titleContent?: string;
       /** Imported attachments for this turn. Image attachments are sent to the
-       * session via the structured image.attach flow (feature 19) once the
+       * session via the structured image attach flow (feature 19) once the
        * session id is known and before prompt.submit; a failed attach throws to
        * block the send so the user can retry. */
       attachments?: AgentAttachment[];
@@ -4318,7 +4318,7 @@ export function AgentWorkspace({
       );
     }
     // Feature 19: send any imported images to the session through the
-    // structured image.attach flow before the prompt, so the model/tools see
+    // structured image attach flow before the prompt, so the model/tools see
     // them as first-class inputs (not just a path mentioned in prose) and an
     // image-edit prompt names a concrete source. A failed attach throws here,
     // which the submit() catch turns into a restored composer the user can

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -202,6 +202,7 @@ import {
   PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
   dispatchProviderModelSettingsChanged,
   modelPrivacyBadge,
+  modelSupportsImageInput,
   modelSupportsTools,
   type ModelPrivacyBadge,
   type ProviderModelSettingsChangedDetail,
@@ -4164,6 +4165,27 @@ export function AgentWorkspace({
           ?.model?.trim() ||
         defaultGenerationModelId
       : defaultGenerationModelId;
+    const turnAttachments = options?.attachments ?? [];
+    const pendingImages = pendingImageAttachments(
+      turnAttachments.map((attachment) => attachment.attach),
+    );
+    const targetGenerationModel = targetSessionModelId
+      ? selectedModelOption(generationModelsRef.current, targetSessionModelId)
+      : undefined;
+    const imageInputFallbackContent =
+      pendingImages.length &&
+      (!targetGenerationModel ||
+        !modelSupportsImageInput(targetGenerationModel))
+        ? unsupportedImageInputPrompt({
+            displayContent,
+            imageNames: pendingImages.map(
+              (attachment) => attachment.displayName,
+            ),
+            modelName: targetGenerationModel?.name ?? targetSessionModelId,
+            runtimeContent: content,
+          })
+        : undefined;
+    const promptSubmitContent = imageInputFallbackContent ?? content;
     // Issue reports skip title suggestion: the content is the wrapped
     // investigation prompt, which would title the session after the wrapper.
     const titlePromise =
@@ -4317,22 +4339,24 @@ export function AgentWorkspace({
         new Error("Hermes did not resume the session."),
       );
     }
-    // Feature 19: send any imported images to the session through the
-    // structured image attach flow before the prompt, so the model/tools see
-    // them as first-class inputs (not just a path mentioned in prose) and an
-    // image-edit prompt names a concrete source. A failed attach throws here,
-    // which the submit() catch turns into a restored composer the user can
-    // retry — the prompt is NOT sent with a silently-missing image.
-    try {
-      await attachPendingImages(
-        gateway,
-        runtimeSessionId,
-        storedSessionId,
-        options?.attachments ?? [],
-      );
-    } catch (err) {
-      clearQueuedIssueReport();
-      rollbackOptimisticBeforePrompt(err);
+    if (!imageInputFallbackContent) {
+      // Feature 19: send any imported images to the session through the
+      // structured image attach flow before the prompt, so the model/tools see
+      // them as first-class inputs (not just a path mentioned in prose) and an
+      // image-edit prompt names a concrete source. A failed attach throws here,
+      // which the submit() catch turns into a restored composer the user can
+      // retry — the prompt is NOT sent with a silently-missing image.
+      try {
+        await attachPendingImages(
+          gateway,
+          runtimeSessionId,
+          storedSessionId,
+          turnAttachments,
+        );
+      } catch (err) {
+        clearQueuedIssueReport();
+        rollbackOptimisticBeforePrompt(err);
+      }
     }
     const createdAt = optimisticSession?.createdAt ?? new Date().toISOString();
     setRuntimeSessionIds((current) => ({
@@ -4426,11 +4450,11 @@ export function AgentWorkspace({
       hermesTraceBuffer.recordOutbound({
         sessionId: storedSessionId,
         method: "prompt.submit",
-        params: { session_id: runtimeSessionId, text: content },
+        params: { session_id: runtimeSessionId, text: promptSubmitContent },
       });
       await gateway.request("prompt.submit", {
         session_id: runtimeSessionId,
-        text: content,
+        text: promptSubmitContent,
       });
       await loadHermesSessions({
         suppressStartupRequestError: !hermesSessionsHydratedRef.current,
@@ -11293,6 +11317,37 @@ function promptWithAttachments(
     "",
     "Use these file paths when inspecting or operating on the files.",
   ].join("\n");
+}
+
+function unsupportedImageInputPrompt({
+  displayContent,
+  imageNames,
+  modelName,
+  runtimeContent,
+}: {
+  displayContent: string;
+  imageNames: string[];
+  modelName?: string;
+  runtimeContent: string;
+}) {
+  const modelLabel = modelName?.trim() || "The selected model";
+  return [
+    displayContent,
+    "",
+    "--- Attached Context ---",
+    `${modelLabel} does not support image input in June.`,
+    "The user attached image file(s), but this model cannot read their visual contents.",
+    imageNames.length
+      ? `Attached image file(s): ${imageNames.join(", ")}.`
+      : undefined,
+    "Do not call vision_analyze, image tools, shell, filesystem tools, or any other tool to inspect the image files.",
+    "Reply directly and briefly. Say that you cannot view the attached image with the current model, then ask the user to describe the image or paste the relevant text. If they expected the image to be readable, suggest choosing a model with image support and sending the image again.",
+    runtimeContent !== displayContent
+      ? ["", "Original routed prompt:", runtimeContent].join("\n")
+      : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
 }
 
 function attachmentPromptPath(path: string) {

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -58,7 +58,7 @@ export type ArtifactKind = "file" | "image" | "directory" | "url" | "unknown";
  * What the agent did with the artifact. `failed` means the access errored (e.g.
  * a sandboxed write to an unrestricted path was denied). `attached` (feature 19)
  * means the user attached an image into the session via the structured
- * `image.attach` flow — it shows in the timeline like any other artifact.
+ * `image.attach_bytes` flow — it shows in the timeline like any other artifact.
  */
 export type ArtifactAction =
   | "created"

--- a/src/lib/hermes-control-plane/compatibility/matrix.ts
+++ b/src/lib/hermes-control-plane/compatibility/matrix.ts
@@ -80,7 +80,7 @@ const PIN = PINNED_HERMES_VERSION;
  * steer/branch/compress/usage/dispatch/sudo/secret/subagent/image surfaces; each
  * flips to `supported` as its owning feature ships UI + tests (see OWNERSHIP).
  * subagent.interrupt is `supported` (feature 13's drawer stop button) and
- * image.attach is `supported` (feature 19's composer image-attach flow). The
+ * image.attach_bytes is `supported` (feature 19's composer image-attach flow). The
  * four baseline methods June already calls live (grep-confirmed in
  * `AgentWorkspace.tsx`) are `supported`.
  */
@@ -149,9 +149,15 @@ const methods: HermesCompatibilitySection = {
     since: PIN,
   },
   "image.attach": {
+    status: "unsupported",
+    rationale:
+      "The pinned Hermes runtime exposes path-based image.attach, but June's desktop composer uploads client-side image bytes instead so it does not depend on gateway-local file paths.",
+    since: PIN,
+  },
+  "image.attach_bytes": {
     status: "supported",
     rationale:
-      "Feature 19 wires the composer's imported images into image.attach (attachImage): on submit each pending image is read from the workspace and attached, the chip shows imported/attached/failed, a failed attach blocks the send, and the attachment lands in feature 14's artifact timeline; covered by hermes-image-attach and agent-workspace tests. The base64 is read on demand and never stored in React state or the trace.",
+      "Feature 19 wires the composer's imported images into image.attach_bytes (attachImage): on submit each pending image is read from the workspace and attached, the chip shows imported/attached/failed, a failed attach blocks the send, and the attachment lands in feature 14's artifact timeline; covered by hermes-image-attach and agent-workspace tests. The base64 is read on demand and never stored in React state or the trace.",
     since: PIN,
   },
   "sudo.respond": {
@@ -257,7 +263,7 @@ const features: HermesCompatibilitySection = {
   imageEditing: {
     status: "partial",
     rationale:
-      "Feature 19 ships explicit source-image selection: imported images attach to the session via image.attach (so an edit prompt names a concrete image instead of relying on a path in prose), with imported/attached/failed status and the attachment in the artifact timeline. June does not yet render the edited image_generate OUTPUT back inline, so this stays partial rather than supported; covered by hermes-image-attach and agent-workspace tests.",
+      "Feature 19 ships explicit source-image selection: imported images attach to the session via image.attach_bytes (so an edit prompt names a concrete image instead of relying on a path in prose), with imported/attached/failed status and the attachment in the artifact timeline. June does not yet render the edited image_generate OUTPUT back inline, so this stays partial rather than supported; covered by hermes-image-attach and agent-workspace tests.",
     since: PIN,
   },
   automationBlueprints: {
@@ -308,5 +314,5 @@ export const OWNERSHIP: Readonly<Record<string, readonly string[]>> =
     "11": ["events.subagent"],
     "12": ["events.subagent", "features.backgroundSubagentWatch"],
     "13": ["methods.subagent.interrupt"],
-    "19": ["methods.image.attach", "features.imageEditing"],
+    "19": ["methods.image.attach_bytes", "features.imageEditing"],
   });

--- a/src/lib/hermes-control-plane/methods.ts
+++ b/src/lib/hermes-control-plane/methods.ts
@@ -72,6 +72,7 @@ export type AttachImageParams = {
   sessionId: string;
   mimeType: string;
   dataBase64: string;
+  fileName?: string;
 };
 
 /** The typed command surface. Each call resolves to whatever the gateway
@@ -154,11 +155,11 @@ export function createHermesMethods(client: HermesRequestLike): HermesMethods {
         subagent_id: subagentId,
       });
     },
-    attachImage({ sessionId, mimeType, dataBase64 }) {
-      return request("image.attach", {
+    attachImage({ sessionId, dataBase64, fileName }) {
+      return request("image.attach_bytes", {
         session_id: sessionId,
-        mime_type: mimeType,
-        data_base64: dataBase64,
+        content_base64: dataBase64,
+        ...defined({ filename: fileName }),
       });
     },
   };

--- a/src/lib/hermes-control-plane/methods.ts
+++ b/src/lib/hermes-control-plane/methods.ts
@@ -155,9 +155,10 @@ export function createHermesMethods(client: HermesRequestLike): HermesMethods {
         subagent_id: subagentId,
       });
     },
-    attachImage({ sessionId, dataBase64, fileName }) {
+    attachImage({ sessionId, mimeType, dataBase64, fileName }) {
       return request("image.attach_bytes", {
         session_id: sessionId,
+        mime_type: mimeType,
         content_base64: dataBase64,
         ...defined({ filename: fileName }),
       });

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -90,6 +90,7 @@ export type RawHermesMethodName =
   | "secret.respond"
   | "subagent.interrupt"
   | "image.attach"
+  | "image.attach_bytes"
   | (string & {});
 
 /**

--- a/src/lib/hermes-image-attach.ts
+++ b/src/lib/hermes-image-attach.ts
@@ -5,7 +5,7 @@
  * Hermes workspace (`<hermes_home>/workspace/uploads/…`, via the
  * `import_hermes_bridge_file*` bridge commands) and references its PATH in the
  * prompt text. That keeps working. This module adds the STRUCTURED path on top:
- * for image attachments it calls the typed `image.attach` control-plane method
+ * for image attachments it calls the typed image byte-attach control-plane method
  * (`createHermesMethods(...).attachImage`), so the model/tools receive the image
  * as a first-class input rather than only a path mentioned in prose. Explicit
  * source-image selection is what makes image EDITING reliable (the upstream
@@ -37,7 +37,7 @@ import { messageFromError } from "./errors";
  * - `pending`: created, import not finished (transient; the importer flips it).
  * - `imported`: copied into the workspace; for a file this is terminal, for an
  *   image it is the "ready to attach" state.
- * - `attached`: the structured `image.attach` RPC acked — visible to model/tools.
+ * - `attached`: the structured image attach RPC acked — visible to model/tools.
  * - `failed`: import or attach errored; `error` carries the user-facing copy.
  */
 export type HermesAttachmentStatus =
@@ -90,7 +90,7 @@ export type AttachImageResult = {
 /** Injected side effects. `attachImage` is `createHermesMethods(...).attachImage`;
  * `readImageData` reads the workspace file as a `data:…;base64,…` url (or null
  * if it can't be read as an image); `isSupported` is the feature gate
- * (`() => isHermesFeatureSupported("image.attach")`). */
+ * (`() => isHermesFeatureSupported("image.attach_bytes")`). */
 export type AttachImageDeps = {
   attachImage: (params: AttachImageParams) => Promise<unknown>;
   readImageData: (path: string) => Promise<string | null>;
@@ -116,7 +116,7 @@ const IMAGE_EXTENSION = /\.(png|jpe?g|gif|webp|tiff?)$/i;
 export const ATTACH_UNSUPPORTED_NOTICE =
   "This version of June can't attach images to the model directly. The image is in the workspace and its path is included in your message instead.";
 
-/** Whether a mime type is an image June can attach via image.attach. */
+/** Whether a mime type is an image June can attach. */
 export function isAttachableImageType(mimeType: string): boolean {
   return ATTACHABLE_IMAGE_MIME.has(mimeType.trim().toLowerCase());
 }
@@ -149,7 +149,7 @@ function isImageImport(file: ImportedHermesFile): boolean {
 let localIdSeq = 0;
 
 /** Build the initial chip state for a freshly imported file. Images become
- * `kind:"image"` (eligible for image.attach); everything else is `kind:"file"`.
+ * `kind:"image"` (eligible for structured attach); everything else is `kind:"file"`.
  * Status starts at `imported` (the import already completed). No bytes. */
 export function attachmentStateFrom(
   file: ImportedHermesFile,
@@ -167,7 +167,7 @@ export function attachmentStateFrom(
 }
 
 /** The imported images still awaiting a structured attach (eligible to send to
- * image.attach before the next prompt). Skips files and already-attached/failed
+ * structured attach before the next prompt). Skips files and already-attached/failed
  * images. */
 export function pendingImageAttachments(
   states: HermesAttachmentState[],
@@ -197,7 +197,7 @@ export function attachErrorNotice(displayName: string, err: unknown): string {
 }
 
 /**
- * Attach one imported image to a Hermes session through the typed `image.attach`
+ * Attach one imported image to a Hermes session through the typed image bytes
  * method. Pure w.r.t. injected {@link AttachImageDeps}. Resolves to the next
  * chip {@link HermesAttachmentState} plus, on success, an artifact seed and a
  * REDACTED outbound trace entry; on failure, `state.status` is `failed` and
@@ -263,6 +263,7 @@ export async function attachImageToSession(
       sessionId,
       mimeType: parsed.mimeType,
       dataBase64: parsed.dataBase64,
+      fileName: attachment.displayName,
     });
     return {
       state: {
@@ -280,11 +281,11 @@ export async function attachImageToSession(
       },
       // REDACTED on purpose: the trace records that an attach happened and how
       // big it was, never the base64 itself (the trace buffer would otherwise
-      // stringify it into its payload preview — `data_base64` is not a
+      // stringify it into its payload preview; the raw content base64 is not a
       // sanitizer-recognized secret key).
       trace: {
         sessionId,
-        method: "image.attach",
+        method: "image.attach_bytes",
         params: {
           session_id: sessionId,
           mime_type: parsed.mimeType,

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -62,6 +62,23 @@ export function modelSupportsTools(
   });
 }
 
+export function modelSupportsImageInput(
+  model: Partial<Pick<VeniceModelDto, "capabilities" | "traits">>,
+) {
+  return [...(model.capabilities ?? []), ...(model.traits ?? [])].some(
+    (capability) => {
+      const normalized = capability.toLowerCase().replace(/[^a-z]/g, "");
+      return (
+        normalized.includes("supportsvision") ||
+        normalized.includes("vision") ||
+        normalized.includes("imageinput") ||
+        normalized.includes("imageunderstanding") ||
+        normalized.includes("multimodal")
+      );
+    },
+  );
+}
+
 // Strongest claim wins: E2EE models are also private, but "encrypted into the
 // enclave" is the property worth surfacing.
 export function modelPrivacyBadge(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -264,7 +264,7 @@ describe("AgentWorkspace", () => {
     }));
     mocks.hermesBridgeFilesystemSnapshot.mockResolvedValue({ roots: [] });
     // Mirrors the Rust image_preview_data_url: an image path yields a
-    // data url, anything else null. Feature 19's structured image.attach reads
+    // data url, anything else null. Feature 19's structured image attach reads
     // the bytes through this command at attach time.
     mocks.hermesBridgeFilePreview.mockImplementation(async (path: string) =>
       /\.(png|jpe?g|gif|webp|tiff?)$/i.test(path)
@@ -5635,9 +5635,9 @@ describe("AgentWorkspace", () => {
     ).toBe(false);
   });
 
-  it("attaches a dropped image to the session via image.attach and marks it attached", async () => {
+  it("attaches a dropped image to the session via image.attach_bytes and marks it attached", async () => {
     // Feature 19: on submit, an imported image is sent to the session through
-    // the structured image.attach RPC, the chip flips to "Attached", and the
+    // the structured image.attach_bytes RPC, the chip flips to "Attached", and the
     // attachment lands in the artifact timeline — without the base64 ever
     // reaching the sanitized trace export.
     const user = userEvent.setup();
@@ -5665,15 +5665,15 @@ describe("AgentWorkspace", () => {
     await user.click(sendButton);
 
     await waitFor(() =>
-      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach", {
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
         session_id: "runtime-session-1",
-        mime_type: "image/png",
-        data_base64: "cHJldmlldw==",
+        content_base64: "cHJldmlldw==",
+        filename: "screenshot.png",
       }),
     );
-    // image.attach precedes prompt.submit for the same turn.
+    // image.attach_bytes precedes prompt.submit for the same turn.
     const attachIndex = mocks.gatewayRequest.mock.calls.findIndex(
-      ([method]) => method === "image.attach",
+      ([method]) => method === "image.attach_bytes",
     );
     const submitIndex = mocks.gatewayRequest.mock.calls.findIndex(
       ([method]) => method === "prompt.submit",
@@ -5695,13 +5695,13 @@ describe("AgentWorkspace", () => {
     const trace = JSON.stringify(
       hermesTraceBuffer.exportSanitizedTrace("session-1"),
     );
-    expect(trace).toContain("image.attach");
+    expect(trace).toContain("image.attach_bytes");
     expect(trace).not.toContain("cHJldmlldw==");
-    expect(trace).not.toContain("data_base64");
+    expect(trace).not.toContain("content_base64");
   });
 
   it("blocks the prompt and warns when an image attach fails", async () => {
-    // A failed image.attach must not silently send the prompt with a missing
+    // A failed image.attach_bytes must not silently send the prompt with a missing
     // image: the send is blocked, the chip surfaces the failure, and the
     // composer text is restored for a retry.
     const user = userEvent.setup();
@@ -5715,7 +5715,7 @@ describe("AgentWorkspace", () => {
       if (method === "session.resume") {
         return Promise.resolve({ session_id: "runtime-session-1" });
       }
-      if (method === "image.attach") {
+      if (method === "image.attach_bytes") {
         return Promise.reject(new Error("attach exploded"));
       }
       return Promise.resolve({});
@@ -5747,7 +5747,7 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(
         mocks.gatewayRequest.mock.calls.some(
-          ([method]) => method === "image.attach",
+          ([method]) => method === "image.attach_bytes",
         ),
       ).toBe(true),
     );

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -186,6 +186,34 @@ const existingSession = {
   last_active: "2026-06-04T12:00:00Z",
 };
 
+function mockGlmCapabilities(capabilities: string[]) {
+  mocks.listVeniceModels.mockResolvedValue({
+    mode: "generation",
+    modelType: "text",
+    selectedModel: "zai-org-glm-5-2",
+    models: [
+      {
+        provider: "venice",
+        id: "zai-org-glm-5-2",
+        name: "GLM 5.2",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities,
+      },
+      {
+        provider: "venice",
+        id: "kimi-k2-6",
+        name: "Kimi K2.6",
+        modelType: "text",
+        privacy: "private",
+        traits: [],
+        capabilities: [],
+      },
+    ],
+  });
+}
+
 describe("AgentWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -5635,11 +5663,66 @@ describe("AgentWorkspace", () => {
     ).toBe(false);
   });
 
+  it("uses a text fallback when the selected model cannot read image attachments", async () => {
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listen).toHaveBeenCalledWith(
+        "tauri://drag-drop",
+        expect.any(Function),
+      ),
+    );
+
+    mocks.eventHandlers.get("tauri://drag-drop")?.({
+      payload: {
+        paths: [
+          "/Users/alex/Library/Application Support/CleanShot/media/screenshot.png",
+        ],
+      },
+    });
+
+    expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "what is in this image?");
+    const sendButton = screen.getByRole("button", { name: "Send message" });
+    await waitFor(() => expect(sendButton).not.toBeDisabled());
+    await user.click(sendButton);
+
+    await waitFor(() =>
+      expect(
+        mocks.gatewayRequest.mock.calls.some(
+          ([method]) => method === "prompt.submit",
+        ),
+      ).toBe(true),
+    );
+    expect(
+      mocks.gatewayRequest.mock.calls.some(
+        ([method]) => method === "image.attach_bytes",
+      ),
+    ).toBe(false);
+
+    const submitted = mocks.gatewayRequest.mock.calls.find(
+      ([method]) => method === "prompt.submit",
+    )?.[1] as { text: string };
+    expect(submitted.text).toContain(
+      "Attached files copied into the June workspace:",
+    );
+    expect(submitted.text).toContain("--- Attached Context ---");
+    expect(submitted.text).toContain(
+      "GLM 5.2 does not support image input in June.",
+    );
+    expect(submitted.text).toContain("Do not call vision_analyze");
+    expect(submitted.text).toContain(
+      "ask the user to describe the image or paste the relevant text",
+    );
+  });
+
   it("attaches a dropped image to the session via image.attach_bytes and marks it attached", async () => {
     // Feature 19: on submit, an imported image is sent to the session through
     // the structured image.attach_bytes RPC, the chip flips to "Attached", and the
     // attachment lands in the artifact timeline — without the base64 ever
     // reaching the sanitized trace export.
+    mockGlmCapabilities(["functionCalling", "supportsVision"]);
     const user = userEvent.setup();
     render(<AgentWorkspace />);
     expect(await screen.findByText("Existing session")).toBeInTheDocument();
@@ -5705,6 +5788,7 @@ describe("AgentWorkspace", () => {
     // A failed image.attach_bytes must not silently send the prompt with a missing
     // image: the send is blocked, the chip surfaces the failure, and the
     // composer text is restored for a retry.
+    mockGlmCapabilities(["functionCalling", "supportsVision"]);
     const user = userEvent.setup();
     mocks.gatewayRequest.mockImplementation((method: string) => {
       if (method === "session.create") {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5667,6 +5667,7 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("image.attach_bytes", {
         session_id: "runtime-session-1",
+        mime_type: "image/png",
         content_base64: "cHJldmlldw==",
         filename: "screenshot.png",
       }),

--- a/src/test/hermes-compatibility-matrix.test.ts
+++ b/src/test/hermes-compatibility-matrix.test.ts
@@ -55,6 +55,7 @@ describe("hermes compatibility matrix — required keys", () => {
       "command.dispatch",
       "subagent.interrupt",
       "image.attach",
+      "image.attach_bytes",
       "sudo.respond",
       "secret.respond",
       // Baseline methods June already calls today (grep-confirmed in
@@ -114,16 +115,18 @@ describe("isHermesFeatureSupported — honest support gate", () => {
     expect(isHermesFeatureSupported("automationBlueprints")).toBe(false);
   });
 
-  it("reports feature 19's image.attach + image editing once shipped", () => {
-    // Feature 19 wires the composer's imported images into image.attach
+  it("reports feature 19's image.attach_bytes + image editing once shipped", () => {
+    // Feature 19 wires the composer's imported images into image.attach_bytes
     // (attachImage) with imported/attached/failed status, a failed-attach submit
     // block, and the attachment fed into feature 14's artifact timeline, so its
     // owned method key flips planned → supported; the imageEditing feature is
     // partial (explicit source-image selection ships; the edited output is not
     // rendered inline yet). Covered by hermes-image-attach and agent-workspace
     // tests.
-    expect(getFeatureStatus("image.attach")).toBe("supported");
-    expect(isHermesFeatureSupported("image.attach")).toBe(true);
+    expect(getFeatureStatus("image.attach")).toBe("unsupported");
+    expect(isHermesFeatureSupported("image.attach")).toBe(false);
+    expect(getFeatureStatus("image.attach_bytes")).toBe("supported");
+    expect(isHermesFeatureSupported("image.attach_bytes")).toBe(true);
     expect(getFeatureStatus("imageEditing")).toBe("partial");
     expect(isHermesFeatureSupported("imageEditing")).toBe(false);
   });

--- a/src/test/hermes-control-plane-methods.test.ts
+++ b/src/test/hermes-control-plane-methods.test.ts
@@ -109,17 +109,18 @@ describe("createHermesMethods — typed command wrappers", () => {
     });
   });
 
-  it("attachImage forwards image data to image.attach", async () => {
+  it("attachImage forwards image data to image.attach_bytes", async () => {
     const { request, methods } = setup();
     await methods.attachImage({
       sessionId: "s1",
       mimeType: "image/png",
       dataBase64: "AAAA",
+      fileName: "diagram.png",
     });
-    expect(request).toHaveBeenCalledWith("image.attach", {
+    expect(request).toHaveBeenCalledWith("image.attach_bytes", {
       session_id: "s1",
-      mime_type: "image/png",
-      data_base64: "AAAA",
+      content_base64: "AAAA",
+      filename: "diagram.png",
     });
   });
 

--- a/src/test/hermes-control-plane-methods.test.ts
+++ b/src/test/hermes-control-plane-methods.test.ts
@@ -119,6 +119,7 @@ describe("createHermesMethods — typed command wrappers", () => {
     });
     expect(request).toHaveBeenCalledWith("image.attach_bytes", {
       session_id: "s1",
+      mime_type: "image/png",
       content_base64: "AAAA",
       filename: "diagram.png",
     });

--- a/src/test/hermes-image-attach.test.tsx
+++ b/src/test/hermes-image-attach.test.tsx
@@ -73,7 +73,7 @@ describe("attachmentStateFrom", () => {
     expect(state.sessionId).toBe("ws-1");
   });
 
-  it("marks a non-image import as a file (not for image.attach)", () => {
+  it("marks a non-image import as a file (not for structured attach)", () => {
     const state = attachmentStateFrom(TEXT, "ws-1");
     expect(state.kind).toBe("file");
     expect(state.status).toBe("imported");
@@ -110,7 +110,7 @@ describe("attachImageToSession", () => {
     };
   }
 
-  it("reads bytes, calls image.attach, and flips status to attached", async () => {
+  it("reads bytes, calls image.attach_bytes, and flips status to attached", async () => {
     const deps = baseDeps();
     const result = await attachImageToSession(
       attachmentStateFrom(PNG, "ws-1"),
@@ -123,6 +123,7 @@ describe("attachImageToSession", () => {
       sessionId: "ws-1",
       mimeType: "image/png",
       dataBase64: "aGVsbG8=",
+      fileName: "diagram.png",
     });
     expect(result.state.status).toBe("attached");
     expect(result.state.hermesAttachmentId).toBe("att-9");
@@ -152,10 +153,10 @@ describe("attachImageToSession", () => {
       deps,
     );
     expect(result.trace).toBeDefined();
-    expect(result.trace?.method).toBe("image.attach");
+    expect(result.trace?.method).toBe("image.attach_bytes");
     const serialized = JSON.stringify(result.trace);
     expect(serialized).not.toContain("aGVsbG8=");
-    expect(serialized).not.toContain("data_base64");
+    expect(serialized).not.toContain("content_base64");
   });
 
   it("blocks with a failed status when the RPC rejects", async () => {

--- a/src/test/hermes-image-attach.test.tsx
+++ b/src/test/hermes-image-attach.test.tsx
@@ -131,6 +131,32 @@ describe("attachImageToSession", () => {
     expect(result.error).toBeUndefined();
   });
 
+  it("uses the preview mime when the filename has no useful extension", async () => {
+    const deps = baseDeps();
+    deps.readImageData.mockResolvedValue("data:image/webp;base64,d2VicA==");
+    const imported: ImportedHermesFile = {
+      name: "screenshot",
+      path: "/ws/uploads/screenshot",
+      rootLabel: "Workspace",
+      size: 456,
+      previewDataUrl: "data:image/webp;base64,d2VicA==",
+    };
+
+    const result = await attachImageToSession(
+      attachmentStateFrom(imported, "ws-1"),
+      "ws-1",
+      deps,
+    );
+
+    expect(deps.attachImage).toHaveBeenCalledWith({
+      sessionId: "ws-1",
+      mimeType: "image/webp",
+      dataBase64: "d2VicA==",
+      fileName: "screenshot",
+    });
+    expect(result.state.status).toBe("attached");
+  });
+
   it("emits an artifact seed with the attached action and no base64", async () => {
     const deps = baseDeps();
     const result = await attachImageToSession(


### PR DESCRIPTION
## Summary
- route structured image attachments through Hermes `image.attach_bytes` instead of path-based `image.attach`
- send the original filename with the base64 upload so Hermes can preserve/sniff the image extension
- update the Hermes compatibility gate, trace label, and attachment tests for the byte-upload method

## Why
June was importing screenshots into the workspace successfully, then blocking send because the frontend called `image.attach` with `{ mime_type, data_base64 }`. The pinned Hermes runtime expects path-based `image.attach` or byte-based `image.attach_bytes`, so the structured attach failed after import.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run src/test/hermes-control-plane-methods.test.ts src/test/hermes-image-attach.test.tsx src/test/hermes-compatibility-matrix.test.ts src/test/agent-workspace.test.tsx`
- `pnpm run lint`
- `pnpm build`
- `pnpm test`

## Live QA
- BLOCKED: native Tauri file-drop plus Hermes gateway walkthrough was not run in this Codex surface because no native Computer Use control surface is available here. The PR instead broadens deterministic coverage across the exact composer, wrapper, compatibility, and full frontend test paths.

## Known gaps
- No live QA video attached for the native drag/drop flow.
