### PR TITLE
Hide image attachment fallback scaffolding

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -223,12 +223,8 @@ import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
 } from "../../lib/hermes-messaging";
+import { categoryPrompt } from "../../lib/issue-report-prompt";
 import {
-  categoryPrompt,
-  displayedUserMessageText,
-} from "../../lib/issue-report-prompt";
-import {
-  displayedSkillInvocationText,
   explicitSkillInvocationPrompt,
   isPathLikeSlashToken,
   parseSkillSlashCommands,
@@ -274,6 +270,7 @@ import {
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
+  displayedComposerUserMessageText,
   repairContractionSpacing,
   textFromHermesContent,
   type AgentApprovalChoice,
@@ -11656,16 +11653,6 @@ function commandTokensForResolutions(
 
 function slashCommandKey(name: string) {
   return name.trim().toLowerCase();
-}
-
-function displayedComposerUserMessageText(content: string): string {
-  let text = content;
-  for (let index = 0; index < 3; index += 1) {
-    const next = displayedUserMessageText(displayedSkillInvocationText(text));
-    if (next === text) return text;
-    text = next;
-  }
-  return text;
 }
 
 function sameVisibleMessageText(left: string, right: string) {

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -1143,7 +1143,9 @@ function displayContentForHermesMessage(message: HermesSessionMessage) {
   // Scheduled runs lead with the cron delivery preamble; show the routine's
   // own instructions, not the machine scaffolding.
   return displayedUserPromptText(
-    stripScheduledRunPreamble(stripHermesContextMarkers(content)),
+    stripImageAnalysisFailureNotice(
+      stripScheduledRunPreamble(stripHermesContextMarkers(content)),
+    ),
   );
 }
 
@@ -1155,6 +1157,28 @@ function displayedUserPromptText(content: string) {
     text = next;
   }
   return text;
+}
+
+export function displayedComposerUserMessageText(content: string): string {
+  return stripAttachmentPromptBlock(
+    displayedUserPromptText(stripImageAnalysisFailureNotice(content)),
+  );
+}
+
+function stripImageAnalysisFailureNotice(content: string): string {
+  return content.replace(
+    /^\s*(?:\[[^\]]*(?:attached an image but analysis failed|vision_analyze)[^\]]*\]\s*)+/i,
+    "",
+  );
+}
+
+function stripAttachmentPromptBlock(content: string): string {
+  return content
+    .replace(
+      /\n+Attached files copied into the June workspace:\n[\s\S]*?\n+Use these file paths when inspecting or operating on the files\.\s*$/i,
+      "",
+    )
+    .trim();
 }
 
 function isScheduledRunMessage(message: HermesSessionMessage) {

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -3,6 +3,7 @@ import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   completedHermesMessageText,
+  displayedComposerUserMessageText,
   repairContractionSpacing,
   toolEventKey,
 } from "../lib/agent-chat-runtime";
@@ -341,6 +342,62 @@ describe("Agent chat runtime", () => {
         status: "complete",
       },
     ]);
+  });
+
+  it("strips image-analysis failure scaffolding from persisted Hermes user messages", () => {
+    const turns = buildHermesSessionChatTurns([
+      {
+        id: "1",
+        role: "user",
+        content: [
+          "[The user attached an image but analysis failed.]",
+          "[You can examine it with vision_analyze using image_url:",
+          "/Users/alex/Library/Application Support/co.opensoftware.june-dev/hermes/images/upload_20260629_144756_1.png]",
+          "",
+          "wdyt?",
+          "",
+          "Attached files copied into the June workspace:",
+          "- CleanShot.png (Workspace): uploads/CleanShot.png",
+          "",
+          "Use these file paths when inspecting or operating on the files.",
+        ].join("\n"),
+        timestamp: "2026-06-11T12:00:00.000Z",
+      },
+    ]);
+
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "text",
+        text: [
+          "wdyt?",
+          "",
+          "Attached files copied into the June workspace:",
+          "- CleanShot.png (Workspace): uploads/CleanShot.png",
+          "",
+          "Use these file paths when inspecting or operating on the files.",
+        ].join("\n"),
+        status: "complete",
+      },
+    ]);
+  });
+
+  it("hides attachment and image-analysis scaffolding from composer user display text", () => {
+    expect(
+      displayedComposerUserMessageText(
+        [
+          "[The user attached an image but analysis failed.]",
+          "[You can examine it with vision_analyze using image_url:",
+          "/Users/alex/Library/Application Support/co.opensoftware.june-dev/hermes/images/upload_20260629_144756_1.png]",
+          "",
+          "wdyt?",
+          "",
+          "Attached files copied into the June workspace:",
+          "- CleanShot.png (Workspace): uploads/CleanShot.png",
+          "",
+          "Use these file paths when inspecting or operating on the files.",
+        ].join("\n"),
+      ),
+    ).toBe("wdyt?");
   });
 
   it("extracts text from Hermes structured content payloads", () => {


### PR DESCRIPTION
## Summary
- hide provider image-analysis failure scaffolding from persisted user turns
- hide attachment path plumbing from user bubble display, copy, edit, and pending-message matching
- keep raw attachment paths in turn data so workspace file attribution still works

## Verification
- ./node_modules/.bin/vitest run src/test/agent-chat-runtime.test.ts
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run src/test/agent-workspace.test.tsx

Note: pnpm exec vitest hit the known no-TTY pnpm install/purge wrapper failure before tests ran, so I used the repo-local test binaries.