### PR TITLE
ci: make release version PR step best-effort

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -321,29 +321,55 @@ jobs:
           The release artifacts were already published by this workflow. Merge this PR to record the version bump on main.
           EOF
 
-          pr_number="$(
-            gh pr list \
-              --repo open-software-network/os-june \
-              --base main \
-              --head "$release_branch" \
-              --state open \
-              --json number \
-              --jq '.[0].number // empty'
-          )"
+          # Opening/updating the PR requires the release GitHub App to hold
+          # "Pull requests: write". The workflow `permissions:` block only governs
+          # GITHUB_TOKEN, which this repo blocks from creating PRs anyway
+          # (org "Allow GitHub Actions to create and approve pull requests" is off),
+          # so the App token is the only viable identity here.
+          #
+          # The release artifacts are already published by this point, so a missing
+          # App permission must NOT fail the job: surface a manual-PR link and a job
+          # summary note instead of going red and skipping the Slack notify.
+          manual_pr_url="https://github.com/open-software-network/os-june/compare/main...${release_branch}?expand=1"
 
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" \
-              --repo open-software-network/os-june \
-              --title "release: v$VERSION" \
-              --body-file "$body_file"
-            echo "Updated release version PR #$pr_number."
+          open_or_update_pr() {
+            local pr_number
+            pr_number="$(
+              gh pr list \
+                --repo open-software-network/os-june \
+                --base main \
+                --head "$release_branch" \
+                --state open \
+                --json number \
+                --jq '.[0].number // empty'
+            )" || return 1
+
+            if [ -n "$pr_number" ]; then
+              gh pr edit "$pr_number" \
+                --repo open-software-network/os-june \
+                --title "release: v$VERSION" \
+                --body-file "$body_file" || return 1
+              echo "Updated release version PR #$pr_number."
+            else
+              gh pr create \
+                --repo open-software-network/os-june \
+                --base main \
+                --head "$release_branch" \
+                --title "release: v$VERSION" \
+                --body-file "$body_file" || return 1
+            fi
+          }
+
+          if open_or_update_pr; then
+            echo "Release version PR is up to date."
           else
-            gh pr create \
-              --repo open-software-network/os-june \
-              --base main \
-              --head "$release_branch" \
-              --title "release: v$VERSION" \
-              --body-file "$body_file"
+            echo "::warning::Could not open the release version PR automatically (the release GitHub App likely lacks 'Pull requests: write'). The release shipped; open the version-bump PR manually: $manual_pr_url"
+            {
+              echo "### Manual action required: open the release version PR"
+              echo "- The release artifacts for \`v$VERSION\` were published successfully."
+              echo "- Automated PR creation failed, most likely because the release GitHub App is missing the **Pull requests: write** permission."
+              echo "- Branch \`$release_branch\` is pushed. Open the PR manually: $manual_pr_url"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Notify Slack on release


### PR DESCRIPTION
## Problem

The production macOS release job failed at the final **Open release version PR** step:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

The release itself succeeded (artifacts built, signed, notarized, published; DMG uploaded). Only the bookkeeping PR failed. `gh pr create` runs as the release **GitHub App** token, which has `contents:write` (the branch push worked) but lacks **Pull requests: write**. Because the failure tripped `set -e`, the whole job went red and the `if: success()` Slack notify was skipped, even though the release shipped.

`GITHUB_TOKEN` can't substitute: the repo has `can_approve_pull_request_reviews: false`, so Actions tokens are also blocked from creating PRs, and `main`'s ruleset requires a PR to merge.

## Change

Makes the PR list/edit/create in the **Open release version PR** step best-effort. The branch push stays fatal (it must work, and does). If the PR call fails, the step now:

- emits a `::warning::` with a manual-PR compare link,
- writes a "Manual action required" note to the job summary,
- exits 0 so the job goes green and the Slack notify fires.

A published release no longer reports failure over bookkeeping. Once the App is granted **Pull requests: write**, automated PR creation works with no further changes.

## Follow-up (not in this PR)

The permanent fix is an org-admin action: grant the release GitHub App **Pull requests: Read and write** and approve the new permission on the installation. No workflow change can mint a permission the App doesn't hold.