### PR TITLE
Remove service branding from verify page

### DIFF
--- a/june-api/crates/api/src/handlers/verify.rs
+++ b/june-api/crates/api/src/handlers/verify.rs
@@ -57,7 +57,6 @@ fn render_page(info: &AttestationInfo) -> String {
     };
 
     PAGE_TEMPLATE
-        .replace("@SERVICE@", env!("CARGO_PKG_NAME"))
         .replace("@VERSION@", env!("CARGO_PKG_VERSION"))
         .replace("@COMMIT_VALUE@", &commit_value)
         .replace("@SHORT_SHA@", &short_sha)
@@ -71,7 +70,7 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Verify this server · @SERVICE@</title>
+<title>Verify this server</title>
 <style>
   :root {
     color-scheme: light dark;
@@ -167,14 +166,14 @@ const PAGE_TEMPLATE: &str = r#"<!doctype html>
 <header>
   <span class="badge">Intel TDX · Phala Cloud</span>
   <h1>Verify this server</h1>
-  <p class="lede">@SERVICE@ runs inside an Intel TDX confidential VM. This page is
+  <p class="lede">This server runs inside an Intel TDX confidential VM. This page is
   served from inside that VM and explains how to check, without trusting us,
   that the code running here is exactly the public source code.</p>
 </header>
 
 <h2>This deployment</h2>
 <dl class="facts">
-  <div><dt>Service</dt><dd><code>@SERVICE@</code> v@VERSION@</dd></div>
+  <div><dt>Version</dt><dd><code>v@VERSION@</code></dd></div>
   <div><dt>Source commit</dt><dd>@COMMIT_VALUE@</dd></div>
   <div><dt>Source code</dt><dd><a href="@REPO_URL@">@REPO_URL@</a></dd></div>
   <div><dt>Image</dt><dd><code>@IMAGE_REPO@:@SHORT_SHA@</code></dd></div>
@@ -289,6 +288,28 @@ mod tests {
         assert!(html.contains("ghcr.io/open-software-network/june-api:0123abc"));
         assert!(html.contains("https://trust.phala.com/app/15f8d2fd"));
         assert!(!html.contains("@SHORT_SHA@"));
+    }
+
+    #[test]
+    fn render_uses_product_neutral_verify_copy() {
+        let html = render_page(&info());
+
+        assert!(html.contains("<title>Verify this server</title>"));
+        assert!(html.contains("This server runs inside an Intel TDX confidential VM."));
+        assert!(html.contains(&format!(
+            "<div><dt>Version</dt><dd><code>v{}</code></dd></div>",
+            env!("CARGO_PKG_VERSION")
+        )));
+        assert!(!html.contains(&format!("Verify this server · {}", env!("CARGO_PKG_NAME"))));
+        assert!(!html.contains(&format!(
+            "{} runs inside an Intel TDX confidential VM",
+            env!("CARGO_PKG_NAME")
+        )));
+        assert!(!html.contains(&format!(
+            "<dt>Service</dt><dd><code>{}</code>",
+            env!("CARGO_PKG_NAME")
+        )));
+        assert!(!html.contains("@SERVICE@"));
     }
 
     #[test]

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -434,6 +434,13 @@ async fn integration_verify_page_is_public_html() -> Result<(), Box<dyn Error>> 
     );
     let body = response_text(response).await?;
     assert!(body.contains("Verify this server"));
+    assert!(body.contains("<title>Verify this server</title>"));
+    assert!(body.contains("This server runs inside an Intel TDX confidential VM."));
+    assert!(body.contains("<dt>Version</dt>"));
+    assert!(!body.contains("Verify this server ·"));
+    assert!(!body.contains("<dt>Service</dt>"));
+    assert!(!body.to_ascii_lowercase().contains("scribe-api"));
+    assert!(!body.to_ascii_lowercase().contains("scribe api"));
     assert!(body.contains("ghcr.io/open-software-network/june-api:0123abc"));
     assert!(body.contains(&format!(
         "https://github.com/open-software-network/os-june/commit/{TEST_COMMIT}"


### PR DESCRIPTION
Closes JUN-125.

## What changed

- Removed Cargo package/service-name interpolation from the `/verify` page title, lede, and deployment facts.
- Replaced the service fact row with a neutral version row.
- Added renderer and HTTP boundary assertions so the public verify HTML no longer shows legacy `scribe-api`/`scribe api` naming or a service row.

## Why

The legacy `scribe-api.opensoftware.co/verify` deployment currently exposes stale `scribe-api` naming in the verify page copy. The verify page should describe the server and attestation flow without deriving visible copy from package or service identifiers.

## Validation

- `cargo test -p june-api verify --locked -- --test-threads=1`
- `pnpm test:june-api`

## Live walkthrough

Skipped. This is a static backend HTML endpoint, and the HTTP boundary test renders the exact public `/verify` response. A QA video would not add useful reviewer evidence for this change.

## Deployment note

The live legacy host is currently serving an older pre-rename image. This PR removes the package-name branding path in source; the host will need a current June API deployment before the live page reflects the change.
