### PR TITLE
Allow longer recording audio to process

### DIFF
--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -4,6 +4,9 @@ use sha2::{Digest, Sha256};
 use std::{fs::File, io::Read, path::Path};
 
 pub const MIN_RECORDING_MS: i64 = 1_000;
+const MIN_POSITIVE_DURATION_DRIFT_MS: i64 = 60_000;
+const MAX_POSITIVE_DURATION_DRIFT_MS: i64 = 10 * 60_000;
+const POSITIVE_DURATION_DRIFT_RATIO_DENOMINATOR: i64 = 4;
 
 #[derive(Debug, Clone, Copy)]
 pub struct AudioValidationConfig {
@@ -111,14 +114,33 @@ pub fn source_audio_passes_validation(
 ) -> bool {
     let has_usable_audio = validation.non_zero_size && validation.readable_audio;
     let config = validation_config_for_source(source);
-    // A longer WAV can still be processed. A shorter WAV means local capture
-    // likely lost audio, which should block transcription.
-    let is_not_truncated = validation.actual_duration_ms + config.duration_tolerance_ms
-        >= validation.expected_duration_ms;
+    let expected_duration_ms = validation.expected_duration_ms.max(0);
+    let positive_tolerance_ms =
+        positive_duration_drift_tolerance_ms(expected_duration_ms, config.duration_tolerance_ms);
+    // A slightly longer WAV can still be processed because long recordings can
+    // drift from the app clock. Keep an upper bound so stale long files do not
+    // get transcribed for short sessions.
+    let is_not_truncated = validation
+        .actual_duration_ms
+        .saturating_add(config.duration_tolerance_ms)
+        >= expected_duration_ms;
+    let is_not_stale_long_audio =
+        validation.actual_duration_ms <= expected_duration_ms.saturating_add(positive_tolerance_ms);
     match source {
-        RecordingSource::Microphone => has_usable_audio && is_not_truncated,
-        RecordingSource::System => has_usable_audio && is_not_truncated,
+        RecordingSource::Microphone => {
+            has_usable_audio && is_not_truncated && is_not_stale_long_audio
+        }
+        RecordingSource::System => has_usable_audio && is_not_truncated && is_not_stale_long_audio,
     }
+}
+
+fn positive_duration_drift_tolerance_ms(expected_duration_ms: i64, base_tolerance_ms: i64) -> i64 {
+    let proportional_tolerance_ms =
+        expected_duration_ms / POSITIVE_DURATION_DRIFT_RATIO_DENOMINATOR;
+    proportional_tolerance_ms
+        .max(MIN_POSITIVE_DURATION_DRIFT_MS)
+        .min(MAX_POSITIVE_DURATION_DRIFT_MS)
+        .max(base_tolerance_ms)
 }
 
 pub fn checksum_file(path: &Path) -> Result<String, std::io::Error> {

--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -110,9 +110,14 @@ pub fn source_audio_passes_validation(
     validation: &AudioValidationDto,
 ) -> bool {
     let has_usable_audio = validation.non_zero_size && validation.readable_audio;
+    let config = validation_config_for_source(source);
+    // A longer WAV can still be processed. A shorter WAV means local capture
+    // likely lost audio, which should block transcription.
+    let is_not_truncated = validation.actual_duration_ms + config.duration_tolerance_ms
+        >= validation.expected_duration_ms;
     match source {
-        RecordingSource::Microphone => has_usable_audio && validation.duration_within_tolerance,
-        RecordingSource::System => has_usable_audio && validation.duration_within_tolerance,
+        RecordingSource::Microphone => has_usable_audio && is_not_truncated,
+        RecordingSource::System => has_usable_audio && is_not_truncated,
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -906,6 +906,7 @@ async fn finish_recording_session(
             rms_amplitude: 0.0,
             warnings: vec!["No microphone validation was available.".to_string()],
         });
+    let primary_valid = source_audio_passes_validation(RecordingSource::Microphone, &validation);
     repos
         .update_recording_session(
             &finished.session_id,
@@ -921,7 +922,7 @@ async fn finish_recording_session(
             Some(validation.peak_amplitude),
             Some(validation.rms_amplitude),
             Some(serde_json::to_string(&validation).unwrap_or_default()),
-            if validation.duration_within_tolerance {
+            if primary_valid {
                 None
             } else {
                 Some(validation.warnings.join("; "))
@@ -1342,17 +1343,14 @@ pub async fn recover_recording(
             Some(validation.peak_amplitude),
             Some(validation.rms_amplitude),
             Some(serde_json::to_string(&validation).unwrap_or_default()),
-            if validation.duration_within_tolerance {
+            if source_audio_passes_validation(RecordingSource::Microphone, &validation) {
                 None
             } else {
                 Some(validation.warnings.join("; "))
             },
         )
         .await?;
-    if !(validation.non_zero_size
-        && validation.readable_audio
-        && validation.duration_within_tolerance)
-    {
+    if !source_audio_passes_validation(RecordingSource::Microphone, &validation) {
         repos
             .set_note_status(
                 &info.note_id,

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -137,6 +137,31 @@ fn rejects_truncated_system_audio() {
 }
 
 #[test]
+fn accepts_longer_audio_with_duration_mismatch_warning() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("longer-than-clock.wav");
+    write_stereo_wav(&path, 6_000, 3_000);
+
+    let result = validate_audio_artifact(&path, 1_000, AudioValidationConfig::default())
+        .expect("validation should run");
+
+    assert_eq!(result.actual_duration_ms, 3_000);
+    assert!(!result.duration_within_tolerance);
+    assert!(result
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("duration mismatch")));
+    assert!(source_audio_passes_validation(
+        RecordingSource::System,
+        &result
+    ));
+    assert!(source_audio_passes_validation(
+        RecordingSource::Microphone,
+        &result
+    ));
+}
+
+#[test]
 fn accepts_low_rms_audio_without_loudness_thresholds() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("quiet.wav");

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -3,7 +3,7 @@ use os_june_lib::{
     audio::validation::{
         source_audio_passes_validation, validate_audio_artifact, AudioValidationConfig,
     },
-    domain::types::RecordingSource,
+    domain::types::{AudioValidationDto, RecordingSource},
 };
 use std::path::Path;
 use tempfile::tempdir;
@@ -84,6 +84,21 @@ fn write_sparse_peak_wav(path: &Path, amplitude: i16, duration_ms: u32, every_n_
     writer.finalize().expect("wav finalize");
 }
 
+fn readable_validation(expected_duration_ms: i64, actual_duration_ms: i64) -> AudioValidationDto {
+    AudioValidationDto {
+        file_exists: true,
+        non_zero_size: true,
+        readable_audio: true,
+        expected_duration_ms,
+        actual_duration_ms,
+        duration_within_tolerance: false,
+        non_silent_signal: true,
+        peak_amplitude: 0.2,
+        rms_amplitude: 0.1,
+        warnings: vec!["audio duration mismatch".to_string()],
+    }
+}
+
 #[test]
 fn accepts_readable_non_silent_wav_with_expected_duration() {
     let dir = tempdir().expect("tempdir");
@@ -158,6 +173,34 @@ fn accepts_longer_audio_with_duration_mismatch_warning() {
     assert!(source_audio_passes_validation(
         RecordingSource::Microphone,
         &result
+    ));
+}
+
+#[test]
+fn accepts_reasonable_positive_drift_for_long_recordings() {
+    let validation = readable_validation(2_082_511, 2_515_414);
+
+    assert!(source_audio_passes_validation(
+        RecordingSource::Microphone,
+        &validation
+    ));
+    assert!(source_audio_passes_validation(
+        RecordingSource::System,
+        &validation
+    ));
+}
+
+#[test]
+fn rejects_excessively_long_audio_for_short_recordings() {
+    let validation = readable_validation(1_000, 121_000);
+
+    assert!(!source_audio_passes_validation(
+        RecordingSource::Microphone,
+        &validation
+    ));
+    assert!(!source_audio_passes_validation(
+        RecordingSource::System,
+        &validation
     ));
 }
 


### PR DESCRIPTION
## Summary
- allow readable recording audio with bounded positive duration drift to continue processing
- keep blocking audio that is shorter than expected beyond tolerance, since that indicates likely truncation
- reject stale long audio for short sessions by capping positive drift to a proportional window with a 10 minute maximum
- apply the same validation decision to interrupted recording recovery and add regression coverage for accepted drift and rejected excessive overrun

## Why
A long recording can produce a saved WAV whose sample duration is greater than the elapsed duration stored by the app, especially around long sessions, helper timeline padding, drift, or pause/resume edges. The previous validation treated both longer and shorter mismatches as fatal, causing recoverable audio to fail before transcription. This keeps those recoverable cases working without allowing obviously stale long artifacts through short sessions.

## Validation
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --test recording_validation --locked
- cargo test --manifest-path src-tauri/Cargo.toml --locked
- git diff --check
- CI: Changed paths, Frontend lint and tests, Tauri Rust tests, Repository hygiene, and Socket checks passed on commit e736d447d5

## Reviews
- Greptile: second pass reviewed e736d447d5 with confidence 5/5 and no merge-blocking issues
- Codex: reviewed e736d447d5 and found no major issues

## Live QA
- Not run. Reproducing this exact flow requires a long native microphone/system-audio recording. The repo QA instructions require explicit confirmation before recording microphone audio. The backend regression is covered deterministically in Rust.