### PR TITLE
Retry duration-invalid saved recordings

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1105,6 +1105,17 @@ pub async fn retry_processing(
     let paths = app_paths(&app)?;
     let repos = repositories(&app).await?;
     let sources = retry_audio_sources(&repos, &paths, &request.note_id).await?;
+    let retry_source_mode = if let Some(session_id) = sources
+        .first()
+        .map(|(_id, _source, _path, session_id)| session_id)
+    {
+        repos
+            .recording_session_source_mode(session_id)
+            .await?
+            .unwrap_or(RecordingSourceMode::MicrophoneOnly)
+    } else {
+        RecordingSourceMode::MicrophoneOnly
+    };
     let (ticket, depth) = processing_queue::enqueue(&request.note_id);
     if depth <= 1 {
         repos
@@ -1117,6 +1128,7 @@ pub async fn retry_processing(
 
     let task_repos = repos.clone();
     let task_note_id = request.note_id.clone();
+    let task_source_mode = retry_source_mode;
     tokio::spawn(async move {
         let queue_lock = ticket.lock();
         let _guard = queue_lock.lock().await;
@@ -1130,7 +1142,7 @@ pub async fn retry_processing(
         let title = note.title.clone();
         let existing_generated_note = note.generated_content.clone();
         let manual_notes = manual_notes_for_generation(&note);
-        let result = if sources.len() == 1 {
+        let result = if retry_uses_single_source_processing(task_source_mode, sources.len()) {
             let (audio_artifact_id, _source, audio_path, session_id) = sources
                 .into_iter()
                 .next()
@@ -1155,7 +1167,7 @@ pub async fn retry_processing(
                 &task_repos,
                 &task_note_id,
                 &session_id,
-                RecordingSourceMode::MicrophonePlusSystem,
+                task_source_mode,
                 sources
                     .into_iter()
                     .map(|(id, source, path, _session_id)| (id, source, path))
@@ -1174,6 +1186,13 @@ pub async fn retry_processing(
         ticket.finish();
     });
     Ok(note)
+}
+
+fn retry_uses_single_source_processing(
+    source_mode: RecordingSourceMode,
+    source_count: usize,
+) -> bool {
+    source_mode == RecordingSourceMode::MicrophoneOnly && source_count == 1
 }
 
 async fn retry_audio_sources(
@@ -1772,7 +1791,11 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{recovery_validation_expected_duration_ms, should_probe_system_audio_permission};
+    use super::{
+        recovery_validation_expected_duration_ms, retry_uses_single_source_processing,
+        should_probe_system_audio_permission,
+    };
+    use crate::domain::types::RecordingSourceMode;
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
@@ -1821,6 +1844,26 @@ mod tests {
             2_500
         );
         assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1);
+    }
+
+    #[test]
+    fn retry_uses_single_source_processing_for_microphone_only_audio() {
+        assert!(retry_uses_single_source_processing(
+            RecordingSourceMode::MicrophoneOnly,
+            1
+        ));
+    }
+
+    #[test]
+    fn retry_keeps_dual_source_sessions_on_source_processing_path() {
+        assert!(!retry_uses_single_source_processing(
+            RecordingSourceMode::MicrophonePlusSystem,
+            1
+        ));
+        assert!(!retry_uses_single_source_processing(
+            RecordingSourceMode::MicrophonePlusSystem,
+            2
+        ));
     }
 
     fn write_one_second_wav() -> (tempfile::TempDir, std::path::PathBuf) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1197,12 +1197,13 @@ async fn retry_audio_sources(
         }
 
         let source = RecordingSource::from(artifact.source.as_str());
-        let validation = validate_audio_artifact(
+        let Ok(validation) = validate_audio_artifact(
             &path,
             artifact.expected_duration_ms,
             validation_config_for_source(source),
-        )
-        .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
+        ) else {
+            continue;
+        };
         if !source_audio_passes_validation(source, &validation) {
             continue;
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1181,17 +1181,57 @@ async fn retry_audio_sources(
     paths: &AppPaths,
     note_id: &str,
 ) -> Result<Vec<(String, String, PathBuf, String)>, AppError> {
-    let sources = repos
-        .latest_valid_audio_artifact_paths(note_id)
-        .await?
-        .into_iter()
-        .filter_map(|(id, source, path, session_id)| {
-            paths
-                .contained_recording_file(path)
-                .ok()
-                .map(|path| (id, source, path, session_id))
-        })
-        .collect::<Vec<_>>();
+    let mut sources = Vec::new();
+    for artifact in repos.latest_retryable_audio_artifact_paths(note_id).await? {
+        let Ok(path) = paths.contained_recording_file(&artifact.path) else {
+            continue;
+        };
+        if artifact.status == "valid" {
+            sources.push((
+                artifact.id,
+                artifact.source,
+                path,
+                artifact.recording_session_id,
+            ));
+            continue;
+        }
+
+        let source = RecordingSource::from(artifact.source.as_str());
+        let validation = validate_audio_artifact(
+            &path,
+            artifact.expected_duration_ms,
+            validation_config_for_source(source),
+        )
+        .map_err(|error| AppError::new("audio_validation_failed", error.to_string()))?;
+        if !source_audio_passes_validation(source, &validation) {
+            continue;
+        }
+
+        let checksum = checksum_file(&path).unwrap_or_default();
+        let file_size = std::fs::metadata(&path)
+            .map(|metadata| metadata.len() as i64)
+            .unwrap_or_default();
+        let path_string = path.to_string_lossy().into_owned();
+        repos
+            .finalize_source_artifact(
+                &artifact.id,
+                &path_string,
+                "valid",
+                validation.actual_duration_ms,
+                file_size,
+                &checksum,
+                artifact.expected_duration_ms,
+                Some(serde_json::to_string(&validation).unwrap_or_default()),
+                None,
+            )
+            .await?;
+        sources.push((
+            artifact.id,
+            artifact.source,
+            path,
+            artifact.recording_session_id,
+        ));
+    }
     if sources.is_empty() {
         return Err(AppError::new(
             "audio_artifact_missing",

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1742,85 +1742,84 @@ impl Repositories {
         &self,
         note_id: &str,
     ) -> Result<Vec<RetryableAudioArtifactPath>, sqlx::error::Error> {
-        let session = query(
+        let sessions = query(
             "SELECT recording_session_id
              FROM audio_artifacts
              WHERE note_id = ?
                AND status IN ('valid', 'invalid')
                AND path IS NOT NULL
                AND path != ''
-             ORDER BY created_at DESC, rowid DESC
-             LIMIT 1",
+             GROUP BY recording_session_id
+             ORDER BY MAX(created_at) DESC, MAX(rowid) DESC",
         )
         .bind(note_id)
-        .fetch_optional(&self.pool)
-        .await?;
-        let Some(session) = session else {
-            return Ok(Vec::new());
-        };
-        let session_id: String = session.get("recording_session_id");
-        let rows = query(
-            "SELECT id, source, path, recording_session_id, status, expected_duration_ms
-             FROM audio_artifacts
-             WHERE note_id = ?
-               AND recording_session_id = ?
-               AND status IN ('valid', 'invalid')
-               AND path IS NOT NULL
-               AND path != ''
-             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
-        )
-        .bind(note_id)
-        .bind(session_id)
         .fetch_all(&self.pool)
         .await?;
-        Ok(rows
-            .into_iter()
-            .map(|row| RetryableAudioArtifactPath {
-                id: row.get("id"),
-                source: row.get("source"),
-                path: row.get("path"),
-                recording_session_id: row.get("recording_session_id"),
-                status: row.get("status"),
-                expected_duration_ms: row.get("expected_duration_ms"),
-            })
-            .collect())
+        for session in sessions {
+            let session_id: String = session.get("recording_session_id");
+            let rows = query(
+                "SELECT id, source, path, recording_session_id, status, expected_duration_ms, validation_summary
+                 FROM audio_artifacts
+                 WHERE note_id = ?
+                   AND recording_session_id = ?
+                   AND status IN ('valid', 'invalid')
+                   AND path IS NOT NULL
+                   AND path != ''
+                 ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+            )
+            .bind(note_id)
+            .bind(session_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let artifacts: Vec<_> = rows
+                .into_iter()
+                .filter_map(retryable_audio_artifact_path_from_row)
+                .collect();
+            if !artifacts.is_empty() {
+                return Ok(artifacts);
+            }
+        }
+        Ok(Vec::new())
     }
 
     async fn latest_audio_sources(
         &self,
         note_id: &str,
     ) -> Result<Vec<AudioArtifactDto>, sqlx::error::Error> {
-        let session = query(
+        let sessions = query(
             "SELECT recording_session_id
              FROM audio_artifacts
              WHERE note_id = ?
                AND status IN ('valid', 'invalid')
-             ORDER BY created_at DESC, rowid DESC
-             LIMIT 1",
+             GROUP BY recording_session_id
+             ORDER BY MAX(created_at) DESC, MAX(rowid) DESC",
         )
         .bind(note_id)
-        .fetch_optional(&self.pool)
-        .await?;
-        let Some(session) = session else {
-            return Ok(Vec::new());
-        };
-        let session_id: String = session.get("recording_session_id");
-        let rows = query(
-            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at, status, validation_summary
-             FROM audio_artifacts
-             WHERE note_id = ?
-               AND recording_session_id = ?
-               AND status IN ('valid', 'invalid')
-             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
-        )
-        .bind(note_id)
-        .bind(session_id)
         .fetch_all(&self.pool)
         .await?;
-        Ok(rows
-            .into_iter()
-            .filter_map(audio_artifact_from_preserved_row)
-            .collect())
+        for session in sessions {
+            let session_id: String = session.get("recording_session_id");
+            let rows = query(
+                "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at, status, validation_summary
+                 FROM audio_artifacts
+                 WHERE note_id = ?
+                   AND recording_session_id = ?
+                   AND status IN ('valid', 'invalid')
+                 ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+            )
+            .bind(note_id)
+            .bind(session_id)
+            .fetch_all(&self.pool)
+            .await?;
+            let artifacts: Vec<_> = rows
+                .into_iter()
+                .filter_map(audio_artifact_from_preserved_row)
+                .collect();
+            if !artifacts.is_empty() {
+                return Ok(artifacts);
+            }
+        }
+        Ok(Vec::new())
     }
 
     async fn latest_transcript(
@@ -2619,6 +2618,29 @@ fn audio_artifact_from_preserved_row(row: sqlx_sqlite::SqliteRow) -> Option<Audi
         size_bytes: row.get("size_bytes"),
         checksum: row.get("checksum"),
         created_at: row.get("created_at"),
+    })
+}
+
+fn retryable_audio_artifact_path_from_row(
+    row: sqlx_sqlite::SqliteRow,
+) -> Option<RetryableAudioArtifactPath> {
+    let status: String = row.get("status");
+    let source: String = row.get("source");
+    if status != "valid"
+        && !invalid_audio_artifact_is_retryable(
+            &source,
+            row.get::<Option<String>, _>("validation_summary"),
+        )
+    {
+        return None;
+    }
+    Some(RetryableAudioArtifactPath {
+        id: row.get("id"),
+        source,
+        path: row.get("path"),
+        recording_session_id: row.get("recording_session_id"),
+        status,
+        expected_duration_ms: row.get("expected_duration_ms"),
     })
 }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1743,14 +1743,16 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Vec<RetryableAudioArtifactPath>, sqlx::error::Error> {
         let sessions = query(
-            "SELECT recording_session_id
-             FROM audio_artifacts
-             WHERE note_id = ?
-               AND status IN ('valid', 'invalid')
-               AND path IS NOT NULL
-               AND path != ''
-             GROUP BY recording_session_id
-             ORDER BY MAX(created_at) DESC, MAX(rowid) DESC",
+            "SELECT aa.recording_session_id
+             FROM audio_artifacts aa
+             INNER JOIN recording_sessions rs ON rs.id = aa.recording_session_id
+             WHERE aa.note_id = ?
+               AND aa.status IN ('valid', 'invalid')
+               AND aa.path IS NOT NULL
+               AND aa.path != ''
+               AND rs.status != 'failed'
+             GROUP BY aa.recording_session_id
+             ORDER BY MAX(aa.created_at) DESC, MAX(aa.rowid) DESC",
         )
         .bind(note_id)
         .fetch_all(&self.pool)
@@ -1787,12 +1789,14 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Vec<AudioArtifactDto>, sqlx::error::Error> {
         let sessions = query(
-            "SELECT recording_session_id
-             FROM audio_artifacts
-             WHERE note_id = ?
-               AND status IN ('valid', 'invalid')
-             GROUP BY recording_session_id
-             ORDER BY MAX(created_at) DESC, MAX(rowid) DESC",
+            "SELECT aa.recording_session_id
+             FROM audio_artifacts aa
+             INNER JOIN recording_sessions rs ON rs.id = aa.recording_session_id
+             WHERE aa.note_id = ?
+               AND aa.status IN ('valid', 'invalid')
+               AND rs.status != 'failed'
+             GROUP BY aa.recording_session_id
+             ORDER BY MAX(aa.created_at) DESC, MAX(aa.rowid) DESC",
         )
         .bind(note_id)
         .fetch_all(&self.pool)

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1693,7 +1693,7 @@ impl Repositories {
         let row = query(
             "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
              FROM audio_artifacts
-             WHERE note_id = ? AND status = 'valid'
+             WHERE note_id = ? AND status IN ('valid', 'invalid')
              ORDER BY created_at DESC
              LIMIT 1",
         )
@@ -1752,6 +1752,54 @@ impl Repositories {
             .collect())
     }
 
+    pub async fn latest_retryable_audio_artifact_paths(
+        &self,
+        note_id: &str,
+    ) -> Result<Vec<RetryableAudioArtifactPath>, sqlx::error::Error> {
+        let session = query(
+            "SELECT recording_session_id
+             FROM audio_artifacts
+             WHERE note_id = ?
+               AND status IN ('valid', 'invalid')
+               AND path IS NOT NULL
+               AND path != ''
+             ORDER BY created_at DESC, rowid DESC
+             LIMIT 1",
+        )
+        .bind(note_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some(session) = session else {
+            return Ok(Vec::new());
+        };
+        let session_id: String = session.get("recording_session_id");
+        let rows = query(
+            "SELECT id, source, path, recording_session_id, status, expected_duration_ms
+             FROM audio_artifacts
+             WHERE note_id = ?
+               AND recording_session_id = ?
+               AND status IN ('valid', 'invalid')
+               AND path IS NOT NULL
+               AND path != ''
+             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+        )
+        .bind(note_id)
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| RetryableAudioArtifactPath {
+                id: row.get("id"),
+                source: row.get("source"),
+                path: row.get("path"),
+                recording_session_id: row.get("recording_session_id"),
+                status: row.get("status"),
+                expected_duration_ms: row.get("expected_duration_ms"),
+            })
+            .collect())
+    }
+
     async fn latest_audio_sources(
         &self,
         note_id: &str,
@@ -1759,7 +1807,7 @@ impl Repositories {
         let rows = query(
             "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
              FROM audio_artifacts
-             WHERE note_id = ? AND status = 'valid'
+             WHERE note_id = ? AND status IN ('valid', 'invalid')
              ORDER BY created_at DESC",
         )
         .bind(note_id)
@@ -2573,6 +2621,16 @@ pub struct SourceArtifactPath {
     pub source: String,
     pub partial_path: Option<String>,
     pub final_path: Option<String>,
+    pub expected_duration_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct RetryableAudioArtifactPath {
+    pub id: String,
+    pub source: String,
+    pub path: String,
+    pub recording_session_id: String,
+    pub status: String,
     pub expected_duration_ms: i64,
 }
 

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1,9 +1,13 @@
-use crate::domain::types::{
-    AgentMessageDto, AgentMessageRole, AgentSafetyProfile, AgentTaskDto, AgentTaskListResponse,
-    AgentTaskStatus, AgentToolEventDto, AgentToolEventStatus, AppError, AudioArtifactDto,
-    DictationHistoryItemDto, DictionaryEntryDto, FolderDto, ListDictationHistoryResponse,
-    ListNotesResponse, NoteDto, NoteListItemDto, ProcessingStatus, RecordingSourceMode,
-    RecordingState, SessionFolderDto, TranscriptDto,
+use crate::{
+    audio::validation::source_audio_passes_validation,
+    domain::types::{
+        AgentMessageDto, AgentMessageRole, AgentSafetyProfile, AgentTaskDto, AgentTaskListResponse,
+        AgentTaskStatus, AgentToolEventDto, AgentToolEventStatus, AppError, AudioArtifactDto,
+        AudioValidationDto, DictationHistoryItemDto, DictionaryEntryDto, FolderDto,
+        ListDictationHistoryResponse, ListNotesResponse, NoteDto, NoteListItemDto,
+        ProcessingStatus, RecordingSource, RecordingSourceMode, RecordingState, SessionFolderDto,
+        TranscriptDto,
+    },
 };
 use chrono::{Duration, SecondsFormat, Utc};
 use sqlx::query::query;
@@ -1690,25 +1694,7 @@ impl Repositories {
         &self,
         note_id: &str,
     ) -> Result<Option<AudioArtifactDto>, sqlx::error::Error> {
-        let row = query(
-            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
-             FROM audio_artifacts
-             WHERE note_id = ? AND status IN ('valid', 'invalid')
-             ORDER BY created_at DESC
-             LIMIT 1",
-        )
-        .bind(note_id)
-        .fetch_optional(&self.pool)
-        .await?;
-        Ok(row.map(|row| AudioArtifactDto {
-            id: row.get("id"),
-            source: row.get("source"),
-            format: row.get("format"),
-            duration_ms: row.get("duration_ms"),
-            size_bytes: row.get("size_bytes"),
-            checksum: row.get("checksum"),
-            created_at: row.get("created_at"),
-        }))
+        Ok(self.latest_audio_sources(note_id).await?.into_iter().next())
     }
 
     pub async fn latest_valid_audio_artifact_paths(
@@ -1804,26 +1790,36 @@ impl Repositories {
         &self,
         note_id: &str,
     ) -> Result<Vec<AudioArtifactDto>, sqlx::error::Error> {
-        let rows = query(
-            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at
+        let session = query(
+            "SELECT recording_session_id
              FROM audio_artifacts
-             WHERE note_id = ? AND status IN ('valid', 'invalid')
-             ORDER BY created_at DESC",
+             WHERE note_id = ?
+               AND status IN ('valid', 'invalid')
+             ORDER BY created_at DESC, rowid DESC
+             LIMIT 1",
         )
         .bind(note_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some(session) = session else {
+            return Ok(Vec::new());
+        };
+        let session_id: String = session.get("recording_session_id");
+        let rows = query(
+            "SELECT id, source, format, duration_ms, size_bytes, checksum, created_at, status, validation_summary
+             FROM audio_artifacts
+             WHERE note_id = ?
+               AND recording_session_id = ?
+               AND status IN ('valid', 'invalid')
+             ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
+        )
+        .bind(note_id)
+        .bind(session_id)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows
             .into_iter()
-            .map(|row| AudioArtifactDto {
-                id: row.get("id"),
-                source: row.get("source"),
-                format: row.get("format"),
-                duration_ms: row.get("duration_ms"),
-                size_bytes: row.get("size_bytes"),
-                checksum: row.get("checksum"),
-                created_at: row.get("created_at"),
-            })
+            .filter_map(audio_artifact_from_preserved_row)
             .collect())
     }
 
@@ -2602,6 +2598,38 @@ fn manual_tail_for_append(generated: Option<&str>, edited: Option<&str>) -> Opti
             Some(rest.to_string())
         }
     })
+}
+
+fn audio_artifact_from_preserved_row(row: sqlx_sqlite::SqliteRow) -> Option<AudioArtifactDto> {
+    let status: String = row.get("status");
+    let source: String = row.get("source");
+    if status != "valid"
+        && !invalid_audio_artifact_is_retryable(
+            &source,
+            row.get::<Option<String>, _>("validation_summary"),
+        )
+    {
+        return None;
+    }
+    Some(AudioArtifactDto {
+        id: row.get("id"),
+        source,
+        format: row.get("format"),
+        duration_ms: row.get("duration_ms"),
+        size_bytes: row.get("size_bytes"),
+        checksum: row.get("checksum"),
+        created_at: row.get("created_at"),
+    })
+}
+
+fn invalid_audio_artifact_is_retryable(source: &str, validation_summary: Option<String>) -> bool {
+    let Some(summary) = validation_summary else {
+        return false;
+    };
+    let Ok(validation) = serde_json::from_str::<AudioValidationDto>(&summary) else {
+        return false;
+    };
+    source_audio_passes_validation(RecordingSource::from(source), &validation)
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -2,6 +2,7 @@ use os_june_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
     domain::types::{AudioValidationDto, ProcessingStatus, RecordingSourceMode},
 };
+use sqlx::query::query;
 use sqlx_sqlite::SqlitePoolOptions;
 
 async fn repos() -> Repositories {
@@ -754,6 +755,58 @@ async fn get_note_hides_non_retryable_invalid_saved_audio() {
         )
         .await
         .expect("invalid artifact");
+
+    let loaded = repos.get_note(&note.id).await.expect("loaded note");
+
+    assert!(loaded.audio.is_none());
+    assert!(loaded.audio_sources.is_empty());
+}
+
+#[tokio::test]
+async fn get_note_hides_invalid_audio_from_failed_session() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    let session_id = "session-1";
+    repos
+        .create_recording_session(
+            &note.id,
+            session_id,
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+            None,
+        )
+        .await
+        .expect("session");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            session_id,
+            "microphone",
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+        )
+        .await
+        .expect("artifact");
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "/tmp/session.wav",
+            "invalid",
+            2_515_414,
+            4096,
+            "checksum",
+            2_082_511,
+            Some(validation_summary(2_082_511, 2_515_414)),
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("invalid artifact");
+    query("UPDATE recording_sessions SET status = 'failed', last_error = 'Discarded by user' WHERE id = ?")
+        .bind(session_id)
+        .execute(&repos.pool)
+        .await
+        .expect("failed session");
 
     let loaded = repos.get_note(&note.id).await.expect("loaded note");
 

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -762,6 +762,70 @@ async fn get_note_hides_non_retryable_invalid_saved_audio() {
 }
 
 #[tokio::test]
+async fn get_note_falls_back_to_valid_audio_when_latest_invalid_is_not_retryable() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/old.partial.wav",
+            "/tmp/old.wav",
+            None,
+        )
+        .await
+        .expect("old session");
+    let old_artifact = repos
+        .create_audio_artifact(&note.id, "session-1", "/tmp/old.wav", 1_000, 100, "old")
+        .await
+        .expect("old artifact");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-2",
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/new.partial.wav",
+            "/tmp/new.wav",
+            None,
+        )
+        .await
+        .expect("latest session");
+    let latest_artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-2",
+            "microphone",
+            "/tmp/new.partial.wav",
+            "/tmp/new.wav",
+        )
+        .await
+        .expect("latest artifact");
+    repos
+        .finalize_source_artifact(
+            &latest_artifact.id,
+            "/tmp/new.wav",
+            "invalid",
+            1_000,
+            4096,
+            "checksum",
+            10_000,
+            Some(validation_summary(10_000, 1_000)),
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("invalid artifact");
+
+    let loaded = repos.get_note(&note.id).await.expect("loaded note");
+
+    assert_eq!(loaded.audio.expect("audio").id, old_artifact.id);
+    assert_eq!(loaded.audio_sources.len(), 1);
+    assert_eq!(loaded.audio_sources[0].id, old_artifact.id);
+}
+
+#[tokio::test]
 async fn get_note_returns_only_timed_source_transcript_rows() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -1,6 +1,6 @@
 use os_june_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
-    domain::types::{ProcessingStatus, RecordingSourceMode},
+    domain::types::{AudioValidationDto, ProcessingStatus, RecordingSourceMode},
 };
 use sqlx_sqlite::SqlitePoolOptions;
 
@@ -12,6 +12,22 @@ async fn repos() -> Repositories {
         .expect("sqlite memory");
     run_migrations(&pool).await.expect("migrations");
     Repositories::new(pool)
+}
+
+fn validation_summary(expected_duration_ms: i64, actual_duration_ms: i64) -> String {
+    serde_json::to_string(&AudioValidationDto {
+        file_exists: true,
+        non_zero_size: true,
+        readable_audio: true,
+        expected_duration_ms,
+        actual_duration_ms,
+        duration_within_tolerance: false,
+        non_silent_signal: true,
+        peak_amplitude: 0.2,
+        rms_amplitude: 0.1,
+        warnings: vec!["audio duration mismatch".to_string()],
+    })
+    .expect("validation summary should serialize")
 }
 
 #[tokio::test]
@@ -685,7 +701,7 @@ async fn get_note_exposes_invalid_saved_audio_for_retry() {
             4096,
             "checksum",
             2_082_511,
-            None,
+            Some(validation_summary(2_082_511, 2_515_414)),
             Some("audio duration mismatch".to_string()),
         )
         .await
@@ -696,6 +712,53 @@ async fn get_note_exposes_invalid_saved_audio_for_retry() {
     assert_eq!(loaded.audio.expect("audio").id, artifact.id);
     assert_eq!(loaded.audio_sources.len(), 1);
     assert_eq!(loaded.audio_sources[0].id, artifact.id);
+}
+
+#[tokio::test]
+async fn get_note_hides_non_retryable_invalid_saved_audio() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    let session_id = "session-1";
+    repos
+        .create_recording_session(
+            &note.id,
+            session_id,
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+            None,
+        )
+        .await
+        .expect("session");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            session_id,
+            "microphone",
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+        )
+        .await
+        .expect("artifact");
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "/tmp/session.wav",
+            "invalid",
+            1_000,
+            4096,
+            "checksum",
+            10_000,
+            Some(validation_summary(10_000, 1_000)),
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("invalid artifact");
+
+    let loaded = repos.get_note(&note.id).await.expect("loaded note");
+
+    assert!(loaded.audio.is_none());
+    assert!(loaded.audio_sources.is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -651,6 +651,54 @@ async fn discarded_recording_no_longer_exposes_retryable_audio() {
 }
 
 #[tokio::test]
+async fn get_note_exposes_invalid_saved_audio_for_retry() {
+    let repos = repos().await;
+    let note = repos.create_note(None).await.expect("note");
+    let session_id = "session-1";
+    repos
+        .create_recording_session(
+            &note.id,
+            session_id,
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+            None,
+        )
+        .await
+        .expect("session");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            session_id,
+            "microphone",
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+        )
+        .await
+        .expect("artifact");
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "/tmp/session.wav",
+            "invalid",
+            2_515_414,
+            4096,
+            "checksum",
+            2_082_511,
+            None,
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("invalid artifact");
+
+    let loaded = repos.get_note(&note.id).await.expect("loaded note");
+
+    assert_eq!(loaded.audio.expect("audio").id, artifact.id);
+    assert_eq!(loaded.audio_sources.len(), 1);
+    assert_eq!(loaded.audio_sources[0].id, artifact.id);
+}
+
+#[tokio::test]
 async fn get_note_returns_only_timed_source_transcript_rows() {
     let repos = repos().await;
     let note = repos.create_note(None).await.expect("note");

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -242,6 +242,60 @@ async fn latest_retryable_audio_paths_fall_back_to_valid_session() {
 }
 
 #[tokio::test]
+async fn latest_retryable_audio_paths_ignore_failed_sessions() {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note should exist");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+            None,
+        )
+        .await
+        .expect("session should be created");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-1",
+            "microphone",
+            "/tmp/session.partial.wav",
+            "/tmp/session.wav",
+        )
+        .await
+        .expect("artifact should be created");
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "/tmp/session.wav",
+            "invalid",
+            2_515_414,
+            4096,
+            "checksum",
+            2_082_511,
+            Some(validation_summary(2_082_511, 2_515_414)),
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("artifact should be finalized as invalid");
+    query("UPDATE recording_sessions SET status = 'failed', last_error = 'Discarded by user' WHERE id = ?")
+        .bind("session-1")
+        .execute(&repos.pool)
+        .await
+        .expect("session should be marked failed");
+
+    let retryable = repos
+        .latest_retryable_audio_artifact_paths(&note.id)
+        .await
+        .expect("retryable paths should load");
+
+    assert!(retryable.is_empty());
+}
+
+#[tokio::test]
 async fn upserts_source_turn_transcripts_for_retry() {
     let repos = test_repositories().await;
     let note = repos.create_note(None).await.expect("note should exist");

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -1,6 +1,6 @@
 use os_june_lib::{
     db::{migrations::run_migrations, repositories::Repositories},
-    domain::types::RecordingSourceMode,
+    domain::types::{AudioValidationDto, RecordingSourceMode},
 };
 use sqlx::query::query;
 use sqlx_sqlite::SqlitePoolOptions;
@@ -13,6 +13,22 @@ async fn test_repositories() -> Repositories {
         .expect("in-memory sqlite should open");
     run_migrations(&pool).await.expect("migrations should run");
     Repositories::new(pool)
+}
+
+fn validation_summary(expected_duration_ms: i64, actual_duration_ms: i64) -> String {
+    serde_json::to_string(&AudioValidationDto {
+        file_exists: true,
+        non_zero_size: true,
+        readable_audio: true,
+        expected_duration_ms,
+        actual_duration_ms,
+        duration_within_tolerance: false,
+        non_silent_signal: true,
+        peak_amplitude: 0.2,
+        rms_amplitude: 0.1,
+        warnings: vec!["audio duration mismatch".to_string()],
+    })
+    .expect("validation summary should serialize")
 }
 
 #[tokio::test]
@@ -141,7 +157,7 @@ async fn latest_retryable_audio_paths_include_invalid_saved_artifacts() {
             4096,
             "checksum",
             2_082_511,
-            None,
+            Some(validation_summary(2_082_511, 2_515_414)),
             Some("audio duration mismatch".to_string()),
         )
         .await
@@ -156,6 +172,73 @@ async fn latest_retryable_audio_paths_include_invalid_saved_artifacts() {
     assert_eq!(retryable[0].recording_session_id, "session-2");
     assert_eq!(retryable[0].status, "invalid");
     assert_eq!(retryable[0].expected_duration_ms, 2_082_511);
+}
+
+#[tokio::test]
+async fn latest_retryable_audio_paths_fall_back_to_valid_session() {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note should exist");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/old.partial.wav",
+            "/tmp/old.wav",
+            None,
+        )
+        .await
+        .expect("old session should be created");
+    repos
+        .create_audio_artifact(&note.id, "session-1", "/tmp/old.wav", 1_000, 100, "old")
+        .await
+        .expect("old artifact should be valid");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-2",
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/new.partial.wav",
+            "/tmp/new.wav",
+            None,
+        )
+        .await
+        .expect("latest session should be created");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-2",
+            "microphone",
+            "/tmp/new.partial.wav",
+            "/tmp/new.wav",
+        )
+        .await
+        .expect("latest artifact should be created");
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "/tmp/new.wav",
+            "invalid",
+            1_000,
+            4096,
+            "checksum",
+            10_000,
+            Some(validation_summary(10_000, 1_000)),
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("latest artifact should be finalized as invalid");
+
+    let retryable = repos
+        .latest_retryable_audio_artifact_paths(&note.id)
+        .await
+        .expect("retryable paths should load");
+
+    assert_eq!(retryable.len(), 1);
+    assert_eq!(retryable[0].recording_session_id, "session-1");
+    assert_eq!(retryable[0].status, "valid");
 }
 
 #[tokio::test]

--- a/src-tauri/tests/source_modes.rs
+++ b/src-tauri/tests/source_modes.rs
@@ -91,6 +91,74 @@ async fn stores_source_artifacts_independently() {
 }
 
 #[tokio::test]
+async fn latest_retryable_audio_paths_include_invalid_saved_artifacts() {
+    let repos = test_repositories().await;
+    let note = repos.create_note(None).await.expect("note should exist");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-1",
+            RecordingSourceMode::MicrophoneOnly,
+            "/tmp/old.partial.wav",
+            "/tmp/old.wav",
+            None,
+        )
+        .await
+        .expect("old session should be created");
+    repos
+        .create_audio_artifact(&note.id, "session-1", "/tmp/old.wav", 1_000, 100, "old")
+        .await
+        .expect("old artifact should be valid");
+
+    repos
+        .create_recording_session(
+            &note.id,
+            "session-2",
+            RecordingSourceMode::MicrophonePlusSystem,
+            "/tmp/mic.partial.wav",
+            "/tmp/mic.wav",
+            None,
+        )
+        .await
+        .expect("latest session should be created");
+    let artifact = repos
+        .create_pending_source_artifact(
+            &note.id,
+            "session-2",
+            "microphone",
+            "/tmp/mic.partial.wav",
+            "/tmp/mic.wav",
+        )
+        .await
+        .expect("microphone artifact should be created");
+    repos
+        .finalize_source_artifact(
+            &artifact.id,
+            "/tmp/mic.wav",
+            "invalid",
+            2_515_414,
+            4096,
+            "checksum",
+            2_082_511,
+            None,
+            Some("audio duration mismatch".to_string()),
+        )
+        .await
+        .expect("artifact should be finalized as invalid");
+
+    let retryable = repos
+        .latest_retryable_audio_artifact_paths(&note.id)
+        .await
+        .expect("retryable paths should load");
+
+    assert_eq!(retryable.len(), 1);
+    assert_eq!(retryable[0].recording_session_id, "session-2");
+    assert_eq!(retryable[0].status, "invalid");
+    assert_eq!(retryable[0].expected_duration_ms, 2_082_511);
+}
+
+#[tokio::test]
 async fn upserts_source_turn_transcripts_for_retry() {
     let repos = test_repositories().await;
     let note = repos.create_note(None).await.expect("note should exist");


### PR DESCRIPTION
## Summary
- let failed notes expose invalid saved audio artifacts as preserved local audio so the Retry button stays available
- make retry_processing revalidate invalid saved artifacts under the current duration rules before promoting them to valid and processing them
- keep discarded recordings hidden and keep truly unreadable or truncated invalid artifacts rejected

## Why
PR #504 fixed future recordings that produce a longer saved WAV than the app elapsed estimate, but recordings that already failed under the old duration rule may have persisted their audio artifacts as invalid. This follow-up makes Retry recover those saved artifacts when they now pass validation.

## Validation
- cargo test --manifest-path src-tauri/Cargo.toml --test notes --test source_modes --locked
- cargo test --manifest-path src-tauri/Cargo.toml --locked
- git diff --check

## Live QA
- Not run. Proving this end to end requires a long native microphone/system-audio recording or a local database fixture with private recording paths. The repository and retry behavior is covered by deterministic Rust tests.