### PR TITLE
Prompt for Accessibility access from onboarding

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -40,6 +40,7 @@ use crate::{
     },
 };
 use chrono::{TimeZone, Utc};
+use serde::Serialize;
 use sqlx::query::query;
 use sqlx::row::Row;
 use sqlx_sqlite::SqlitePool;
@@ -53,6 +54,12 @@ use std::{
 };
 use tauri::AppHandle;
 use tokio::sync::OnceCell;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessibilityPermissionResponse {
+    state: String,
+}
 
 #[tauri::command]
 pub async fn bootstrap_app(app: AppHandle) -> Result<BootstrapResponse, AppError> {
@@ -551,6 +558,27 @@ pub async fn get_microphone_permission_state() -> Result<MicrophonePermissionRes
 }
 
 #[tauri::command]
+pub fn request_accessibility_permission() -> AccessibilityPermissionResponse {
+    AccessibilityPermissionResponse {
+        state: request_accessibility_permission_state(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn request_accessibility_permission_state() -> String {
+    if macos_accessibility::request_permission_prompt() {
+        "granted".to_string()
+    } else {
+        "missing".to_string()
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn request_accessibility_permission_state() -> String {
+    "granted".to_string()
+}
+
+#[tauri::command]
 pub async fn check_recording_source_readiness(
     request: CheckRecordingSourceReadinessRequest,
 ) -> Result<RecordingSourceReadinessDto, AppError> {
@@ -624,6 +652,57 @@ fn open_non_macos_privacy_settings(request: OpenPrivacySettingsRequest) -> Resul
         "settings_open_unsupported",
         "Privacy settings shortcuts are only supported on macOS.",
     ))
+}
+
+#[cfg(target_os = "macos")]
+mod macos_accessibility {
+    use std::ffi::c_void;
+
+    type CFTypeRef = *const c_void;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    #[allow(non_upper_case_globals)]
+    extern "C" {
+        static kAXTrustedCheckOptionPrompt: CFTypeRef;
+        fn AXIsProcessTrustedWithOptions(options: CFTypeRef) -> u8;
+        fn AXIsProcessTrusted() -> u8;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    #[allow(non_upper_case_globals)]
+    extern "C" {
+        static kCFBooleanTrue: CFTypeRef;
+        fn CFDictionaryCreate(
+            allocator: CFTypeRef,
+            keys: *const CFTypeRef,
+            values: *const CFTypeRef,
+            num_values: isize,
+            key_callbacks: CFTypeRef,
+            value_callbacks: CFTypeRef,
+        ) -> CFTypeRef;
+        fn CFRelease(cf: CFTypeRef);
+    }
+
+    pub(super) fn request_permission_prompt() -> bool {
+        unsafe {
+            let keys = [kAXTrustedCheckOptionPrompt];
+            let values = [kCFBooleanTrue];
+            let options = CFDictionaryCreate(
+                std::ptr::null(),
+                keys.as_ptr(),
+                values.as_ptr(),
+                1,
+                std::ptr::null(),
+                std::ptr::null(),
+            );
+            if options.is_null() {
+                return AXIsProcessTrusted() != 0;
+            }
+            let trusted = AXIsProcessTrustedWithOptions(options) != 0;
+            CFRelease(options);
+            trusted
+        }
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -194,6 +194,7 @@ pub fn run() {
             hermes_bridge::set_hermes_agent_cli_access,
             hermes_bridge::open_hermes_tui_debug,
             commands::get_microphone_permission_state,
+            commands::request_accessibility_permission,
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,
             commands::june_open_verify_page,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -66,6 +66,7 @@ import { IconZap } from "central-icons/IconZap";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSettingsGear4 } from "central-icons/IconSettingsGear4";
 import { Dialog } from "../components/ui/Dialog";
+import { requestDictationAccessibilityPermission } from "../lib/accessibility-permission";
 import {
   assignNoteToFolder,
   assignSessionToFolder,
@@ -1751,9 +1752,7 @@ export function App() {
 
   function handleEnableAccessibility() {
     setAccessibilityRefreshRequest((request) => request + 1);
-    void dictationHelperCommand({
-      type: "request_accessibility_permission",
-    }).catch(() => undefined);
+    void requestDictationAccessibilityPermission().catch(() => undefined);
   }
 
   useEffect(() => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1752,7 +1752,9 @@ export function App() {
 
   function handleEnableAccessibility() {
     setAccessibilityRefreshRequest((request) => request + 1);
-    void requestDictationAccessibilityPermission().catch(() => undefined);
+    void requestDictationAccessibilityPermission().catch(() => {
+      void openPrivacySettings("accessibility");
+    });
   }
 
   useEffect(() => {

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -116,7 +116,9 @@ export function PermissionsStep({
   function openAccessibilitySettings() {
     // Ask macOS for the native Accessibility prompt in context. Let macOS own
     // any Settings handoff so the prompt is not hidden behind our own launch.
-    void requestDictationAccessibilityPermission().catch(() => undefined);
+    void requestDictationAccessibilityPermission().catch(() => {
+      void openPrivacySettings("accessibility");
+    });
   }
 
   return (

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -4,6 +4,7 @@ import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconTextIndicator } from "central-icons/IconTextIndicator";
 import { IconVolumeFull } from "central-icons/IconVolumeFull";
+import { requestDictationAccessibilityPermission } from "../../../lib/accessibility-permission";
 import {
   dictationHelperCommand,
   openPrivacySettings,
@@ -113,13 +114,9 @@ export function PermissionsStep({
   }, [statuses.checked]);
 
   function openAccessibilitySettings() {
-    // Fire the helper's prompting check first: it registers the dictation
-    // helper in the Accessibility list (so there's a toggle to flip) and
-    // shows the native dialog. Let macOS own the System Settings handoff so
-    // the native prompt is not left open behind a programmatic settings launch.
-    void dictationHelperCommand({
-      type: "request_accessibility_permission",
-    }).catch(() => undefined);
+    // Ask macOS for the native Accessibility prompt in context. Let macOS own
+    // any Settings handoff so the prompt is not hidden behind our own launch.
+    void requestDictationAccessibilityPermission().catch(() => undefined);
   }
 
   return (

--- a/src/lib/accessibility-permission.ts
+++ b/src/lib/accessibility-permission.ts
@@ -1,0 +1,23 @@
+import {
+  dictationHelperCommand,
+  requestAccessibilityPermission,
+} from "./tauri";
+
+export async function requestDictationAccessibilityPermission() {
+  // June has moved Accessibility-owned work between the app process and the
+  // dictation helper; prompt both so the visible action is never a no-op.
+  const appPrompt = requestAccessibilityPermission();
+  const helperPrompt = dictationHelperCommand({
+    type: "request_accessibility_permission",
+  });
+  const results = await Promise.allSettled([appPrompt, helperPrompt]);
+  const firstRejected = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (
+    firstRejected &&
+    results.every((result) => result.status === "rejected")
+  ) {
+    throw firstRejected.reason;
+  }
+}

--- a/src/lib/accessibility-permission.ts
+++ b/src/lib/accessibility-permission.ts
@@ -4,20 +4,19 @@ import {
 } from "./tauri";
 
 export async function requestDictationAccessibilityPermission() {
-  // June has moved Accessibility-owned work between the app process and the
-  // dictation helper; prompt both so the visible action is never a no-op.
-  const appPrompt = requestAccessibilityPermission();
-  const helperPrompt = dictationHelperCommand({
-    type: "request_accessibility_permission",
-  });
-  const results = await Promise.allSettled([appPrompt, helperPrompt]);
-  const firstRejected = results.find(
-    (result): result is PromiseRejectedResult => result.status === "rejected",
-  );
-  if (
-    firstRejected &&
-    results.every((result) => result.status === "rejected")
-  ) {
-    throw firstRejected.reason;
+  try {
+    await dictationHelperCommand({
+      type: "request_accessibility_permission",
+    });
+  } catch (error) {
+    // The dictation helper owns the paste event, so helper failure cannot be
+    // treated as success. Prompt the app process as a best-effort fallback, but
+    // still surface the helper failure so callers can offer System Settings.
+    try {
+      await requestAccessibilityPermission();
+    } catch {
+      // Keep the helper error because it points at the required permission owner.
+    }
+    throw error;
   }
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -645,6 +645,10 @@ export type RecordingSourceReadinessDto = {
   sources: SourceReadinessDto[];
 };
 
+export type AccessibilityPermissionResponse = {
+  state: string;
+};
+
 export async function bootstrapApp() {
   return invoke<BootstrapResponse>("bootstrap_app");
 }
@@ -1161,6 +1165,12 @@ export async function openPrivacySettings(
   pane: "microphone" | "accessibility" | "systemAudio",
 ) {
   return invoke<void>("open_privacy_settings", { request: { pane } });
+}
+
+export async function requestAccessibilityPermission() {
+  return invoke<AccessibilityPermissionResponse>(
+    "request_accessibility_permission",
+  );
 }
 
 export async function startRecording(

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   retryProcessing: vi.fn(),
   recoverRecording: vi.fn(),
   dictationHelperCommand: vi.fn(),
+  requestAccessibilityPermission: vi.fn(),
   listDictationHistory: vi.fn(),
   osAccountsStatus: vi.fn(),
   osAccountsLogin: vi.fn(),
@@ -90,6 +91,7 @@ vi.mock("../lib/tauri", () => ({
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,
   dictationHelperCommand: mocks.dictationHelperCommand,
+  requestAccessibilityPermission: mocks.requestAccessibilityPermission,
   listDictationHistory: mocks.listDictationHistory,
   osAccountsStatus: mocks.osAccountsStatus,
   osAccountsLogin: mocks.osAccountsLogin,
@@ -196,6 +198,9 @@ describe("meeting start transcription event", () => {
       bytesWritten: 2048,
     });
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.requestAccessibilityPermission.mockResolvedValue({
+      state: "missing",
+    });
     mocks.listDictationHistory.mockResolvedValue({
       items: [],
       retentionDays: 7,

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => ({
   retryProcessing: vi.fn(),
   recoverRecording: vi.fn(),
   dictationHelperCommand: vi.fn(),
+  requestAccessibilityPermission: vi.fn(),
   dictationSettings: vi.fn(),
   listDictationHistory: vi.fn(),
   listDictionaryEntries: vi.fn(),
@@ -98,6 +99,7 @@ vi.mock("../lib/tauri", () => ({
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,
   dictationHelperCommand: mocks.dictationHelperCommand,
+  requestAccessibilityPermission: mocks.requestAccessibilityPermission,
   dictationSettings: mocks.dictationSettings,
   listDictationHistory: mocks.listDictationHistory,
   listDictionaryEntries: mocks.listDictionaryEntries,
@@ -240,6 +242,9 @@ describe("notes recording reliability", () => {
       bytesWritten: 2048,
     });
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.requestAccessibilityPermission.mockResolvedValue({
+      state: "missing",
+    });
     mocks.dictationSettings.mockResolvedValue({
       settings: {
         pushToTalkShortcut: {

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -71,6 +71,7 @@ const mocks = vi.hoisted(() => ({
   retryProcessing: vi.fn(),
   recoverRecording: vi.fn(),
   dictationHelperCommand: vi.fn(),
+  requestAccessibilityPermission: vi.fn(),
   listDictationHistory: vi.fn(),
   osAccountsStatus: vi.fn(),
   osAccountsLogin: vi.fn(),
@@ -167,6 +168,7 @@ vi.mock("../lib/tauri", () => ({
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,
   dictationHelperCommand: mocks.dictationHelperCommand,
+  requestAccessibilityPermission: mocks.requestAccessibilityPermission,
   listDictationHistory: mocks.listDictationHistory,
   osAccountsStatus: mocks.osAccountsStatus,
   osAccountsLogin: mocks.osAccountsLogin,
@@ -237,6 +239,9 @@ describe("App shortcuts", () => {
       ],
     });
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.requestAccessibilityPermission.mockResolvedValue({
+      state: "missing",
+    });
     mocks.listDictationHistory.mockResolvedValue({
       items: [],
       retentionDays: 7,
@@ -684,6 +689,7 @@ describe("App shortcuts", () => {
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
 
     mocks.dictationHelperCommand.mockClear();
+    mocks.requestAccessibilityPermission.mockClear();
     mocks.openPrivacySettings.mockClear();
 
     await act(async () => {
@@ -703,6 +709,7 @@ describe("App shortcuts", () => {
 
     await user.click(screen.getByRole("button", { name: "Grant access" }));
 
+    expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce();
     expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
       type: "request_accessibility_permission",
     });
@@ -711,6 +718,41 @@ describe("App shortcuts", () => {
         type: "get_permission_status",
       }),
     );
+    expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith("accessibility");
+  });
+
+  it("requests Accessibility from the settings Manage button", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+    });
+    mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+
+    mocks.dictationHelperCommand.mockClear();
+    mocks.requestAccessibilityPermission.mockClear();
+    mocks.openPrivacySettings.mockClear();
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Manage Accessibility permission",
+      }),
+    );
+
+    expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce();
+    expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+      type: "request_accessibility_permission",
+    });
     expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith("accessibility");
   });
 

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -709,10 +709,10 @@ describe("App shortcuts", () => {
 
     await user.click(screen.getByRole("button", { name: "Grant access" }));
 
-    expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce();
     expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
       type: "request_accessibility_permission",
     });
+    expect(mocks.requestAccessibilityPermission).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
         type: "get_permission_status",
@@ -749,11 +749,53 @@ describe("App shortcuts", () => {
       }),
     );
 
-    expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce();
     expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
       type: "request_accessibility_permission",
     });
+    expect(mocks.requestAccessibilityPermission).not.toHaveBeenCalled();
     expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith("accessibility");
+  });
+
+  it("opens Accessibility settings when the settings Manage prompt cannot reach the helper", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+    });
+    mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+
+    mocks.dictationHelperCommand.mockImplementation((command) => {
+      if (command?.type === "request_accessibility_permission") {
+        return Promise.reject(new Error("Helper unavailable"));
+      }
+      return Promise.resolve(undefined);
+    });
+    mocks.requestAccessibilityPermission.mockClear();
+    mocks.openPrivacySettings.mockClear();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Manage Accessibility permission",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce(),
+    );
+    await waitFor(() =>
+      expect(mocks.openPrivacySettings).toHaveBeenCalledWith("accessibility"),
+    );
   });
 
   it("starts a session with Ctrl-N and creates a note with Ctrl-Shift-N on Windows", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -18,6 +18,7 @@ import type { AccountStatus, RecordingSourceReadinessDto } from "../lib/tauri";
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
   dictationHelperCommand: vi.fn(),
+  requestAccessibilityPermission: vi.fn(),
   checkRecordingSourceReadiness: vi.fn(),
   openPrivacySettings: vi.fn(),
   setDictationLanguage: vi.fn(),
@@ -32,6 +33,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../lib/tauri", () => ({
   dictationSettings: mocks.dictationSettings,
   dictationHelperCommand: mocks.dictationHelperCommand,
+  requestAccessibilityPermission: mocks.requestAccessibilityPermission,
   checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
   openPrivacySettings: mocks.openPrivacySettings,
   setDictationLanguage: mocks.setDictationLanguage,
@@ -124,6 +126,9 @@ describe("OnboardingFlow", () => {
       },
     );
     mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.requestAccessibilityPermission.mockResolvedValue({
+      state: "missing",
+    });
     mocks.checkRecordingSourceReadiness.mockResolvedValue(
       systemAudioReadiness(true),
     );
@@ -525,6 +530,38 @@ describe("OnboardingFlow", () => {
         type: "request_microphone_permission",
       }),
     );
+  });
+
+  it("requests the native Accessibility prompt from the Allow button", async () => {
+    const user = userEvent.setup();
+    const restoreNavigator = stubMacNavigatorPlatform();
+    try {
+      await renderFlow();
+      emitDictationEvent?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+      const allowAccessibility = await screen.findByRole("button", {
+        name: "Allow accessibility access",
+      });
+
+      mocks.requestAccessibilityPermission.mockClear();
+      mocks.dictationHelperCommand.mockClear();
+      mocks.openPrivacySettings.mockClear();
+      await user.click(allowAccessibility);
+
+      expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce();
+      expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
+        type: "request_accessibility_permission",
+      });
+      expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith(
+        "accessibility",
+      );
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("only requires microphone access on Windows", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -552,12 +552,48 @@ describe("OnboardingFlow", () => {
       mocks.openPrivacySettings.mockClear();
       await user.click(allowAccessibility);
 
-      expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce();
       expect(mocks.dictationHelperCommand).toHaveBeenCalledWith({
         type: "request_accessibility_permission",
       });
+      expect(mocks.requestAccessibilityPermission).not.toHaveBeenCalled();
       expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith(
         "accessibility",
+      );
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("falls back to Accessibility settings when the helper prompt cannot be requested", async () => {
+    const user = userEvent.setup();
+    const restoreNavigator = stubMacNavigatorPlatform();
+    try {
+      await renderFlow();
+      emitDictationEvent?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+      const allowAccessibility = await screen.findByRole("button", {
+        name: "Allow accessibility access",
+      });
+
+      mocks.requestAccessibilityPermission.mockClear();
+      mocks.dictationHelperCommand.mockImplementation((command) => {
+        if (command?.type === "request_accessibility_permission") {
+          return Promise.reject(new Error("Helper unavailable"));
+        }
+        return Promise.resolve(undefined);
+      });
+      mocks.openPrivacySettings.mockClear();
+      await user.click(allowAccessibility);
+
+      await waitFor(() =>
+        expect(mocks.requestAccessibilityPermission).toHaveBeenCalledOnce(),
+      );
+      await waitFor(() =>
+        expect(mocks.openPrivacySettings).toHaveBeenCalledWith("accessibility"),
       );
     } finally {
       restoreNavigator();


### PR DESCRIPTION
## What changed

- Added a Tauri `request_accessibility_permission` command that calls macOS `AXIsProcessTrustedWithOptions` with the prompt option instead of only opening System Settings.
- Added a shared frontend `requestDictationAccessibilityPermission` helper used by onboarding, the Accessibility banner, and the Settings System permissions Manage button.
- Kept the dictation-helper prompt as the required path so the helper process that owns dictation paste can register with TCC.
- Added an app-process prompt only as a best-effort fallback when the helper request cannot be delivered, while still surfacing helper failure so the UI opens the Accessibility settings fallback.
- Added regressions for onboarding's Accessibility Allow button, the Settings Manage Accessibility button, and helper failure fallback behavior.

## Why

Clicking Accessibility in onboarding should ask macOS for the native Accessibility permission in context. The System permissions Manage action should take the same working path instead of silently doing nothing.

## Review feedback addressed

- Greptile flagged concurrent app/helper prompting and swallowed helper failures. Fixed by requesting the helper first, avoiding the app prompt on the normal path, and opening Accessibility settings only when the helper request fails.
- Codex reported no major issues on the first pass.

## Validation

- `pnpm test -- src/test/onboarding.test.tsx src/test/app-shortcut.test.tsx`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `pnpm test`
- `pnpm build`
- `pnpm run format`
- `git diff --check`

## Live walkthrough

BLOCKED for the actual macOS Accessibility prompt: clicking through the real prompt would mutate this Mac's TCC privacy state and requires explicit confirmation at action time. The native command was compiled in the full Tauri Rust test suite, and the user-visible paths are covered by App/onboarding tests that assert no System Settings handoff happens for the prompt path.

## QA video

Skipped. The proof point is a macOS privacy prompt, and recording/clicking it would require the same explicit OS-permission side-effect confirmation.
