### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,51 @@ parentheses), design tokens from
 `src/styles/tokens.css`, and **icons from `central-icons` /
 `central-icons-filled` only (never lucide-react or any other icon set;
 lucide was deliberately removed from the dependencies)**.
+
+## Cursor Cloud specific instructions
+
+The Cloud Agent VM is **Linux**. Standard commands live in the README
+"Development commands" section and `package.json` scripts; only the
+non-obvious caveats are noted here.
+
+### What runs on this Linux VM vs. what does not
+
+- **Runnable here:** the React/Vite frontend (`pnpm dev` → `http://127.0.0.1:1421`)
+  and the `june-api` Rust backend (`cd june-api && cargo run -- serve` →
+  `http://127.0.0.1:8080`). Lint (`pnpm lint`), frontend tests (`pnpm test`),
+  and `june-api` tests (`pnpm test:june-api`) all run here.
+- **Not runnable here:** the **Tauri desktop app** (`src-tauri`,
+  `pnpm tauri:dev`/`pnpm tauri:build`) is macOS/Windows-only (native macOS
+  system-audio helper, `Info.plist`, Seatbelt write-jail; `scripts/tauri-dev.mjs`
+  ships only `darwin`/`win32` configs). Its Rust tests (`pnpm test:rust`) run
+  only on `macos-latest` in CI (`.github/workflows/desktop.yml`). Do not try to
+  build/run the desktop app on Linux.
+- Opening the frontend in a plain browser renders the real welcome screen but
+  most interactive flows (recording, notes) need the Tauri IPC runtime and will
+  throw `transformCallback` errors in a browser. That is expected, not a bug.
+
+### Node version gotcha (affects `pnpm test`)
+
+The system `/exec-daemon/node` is **22.14.0**, whose `BroadcastChannel`/jsdom
+interaction throws hundreds of uncaught exceptions on vitest teardown and makes
+`pnpm test` exit non-zero **even though every test passes**. The fix is already
+applied: `~/.bashrc` prepends nvm **Node 22.22.2** (which also bundles the
+pinned `pnpm 9.15.4`) ahead of the system node, so login shells run the good
+version. If `node -v` ever reports `22.14.0`, run tests with
+`PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH"` (or `nvm use default`).
+
+### june-api backend
+
+- Requires Rust **1.95** (pinned in `june-api/rust-toolchain.toml`); rustup
+  auto-installs it on first `cargo` run, and the update script pre-installs it.
+- No database or other external service is needed; tests mock upstreams with
+  `wiremock`.
+- Runs in **open source local mode** by default (`.env` + `june-api/.env` copied
+  from the `*.env.example` files). Local mode needs **no OS Accounts login**: the
+  desktop client and `june-api` share the bearer token `local-dev-token`.
+- **Real note transcription/generation/dictation requires a provider key.** Set
+  `JUNE__UPSTREAMS__VENICE__API_KEY` (and optionally
+  `JUNE__UPSTREAMS__OPENAI__API_KEY`) in `june-api/.env`. Without it, `/v1/models`
+  returns `[]` and the notes endpoints reject with `model_not_priced`. The
+  health (`/livez`, `/readyz`, `/healthz`) and auth/validation paths work without
+  any key.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Set up and validated the development environment for the Linux Cloud Agent VM and documented the durable, non-obvious caveats in `AGENTS.md` under `## Cursor Cloud specific instructions`.
- The only code/repo change is `AGENTS.md`; no application code was modified.

What the new section covers:
- Which services run on this Linux VM (React/Vite frontend + `june-api` Rust backend) vs. the **macOS/Windows-only Tauri desktop app**, which cannot build/run here (its Rust tests run on `macos-latest` in CI).
- The **Node 22.14.0 `BroadcastChannel`/jsdom gotcha** that makes `pnpm test` exit non-zero even though all tests pass, and the applied fix (prefer nvm Node 22.22.2, which bundles the pinned pnpm 9.15.4).
- `june-api` requires **Rust 1.95** (pinned in `june-api/rust-toolchain.toml`); needs no database.
- Open source **local-dev mode** needs no OS Accounts login; real transcription/generation requires a Venice provider key (`JUNE__UPSTREAMS__VENICE__API_KEY`).

## Validation

- `pnpm lint` (tsc) — pass.
- `pnpm test` — 96 files / 1263 tests pass (run under nvm Node 22.22.2; the system 22.14.0 crashes on teardown).
- `pnpm test:june-api` (`cargo test --all-targets --all-features --locked`) — pass.
- `june-api` built and ran (`cargo run -- serve` on `127.0.0.1:8080`): `/healthz` 200; auth + validation pipeline verified (`401 missing_bearer_token` → `401 invalid_access_token` → `422 model_not_priced`).
- Vite dev server (`pnpm dev` on `127.0.0.1:1421`) renders the real June welcome screen in a browser.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95f7aa4b-6924-4593-b6ef-528ba6d293a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95f7aa4b-6924-4593-b6ef-528ba6d293a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

