### PR TITLE
release: v0.0.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-june",
-  "version": "0.0.20",
+  "version": "0.0.22",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "os-june"
-version = "0.0.20"
+version = "0.0.22"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-june"
-version = "0.0.20"
+version = "0.0.22"
 description = "June"
 authors = ["Open Software Network"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "June",
-  "version": "0.0.20",
+  "version": "0.0.22",
   "identifier": "co.opensoftware.june",
   "build": {
     "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",
@@ -80,21 +80,32 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' 'sha256-5zseCXEQXMrhVnLDc5/8D6srY3KbB1TDtKXlkC9HSao='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' asset: data:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; media-src 'self' asset: data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
       "assetProtocol": {
         "enable": true,
-        "scope": ["$TEMP/os-june-dictation-*.m4a"]
+        "scope": [
+          "$TEMP/os-june-dictation-*.m4a"
+        ]
       },
-      "capabilities": ["main", "hud", "agent-hud", "meeting-hud"]
+      "capabilities": [
+        "main",
+        "hud",
+        "agent-hud",
+        "meeting-hud"
+      ]
     }
   },
   "plugins": {
     "deep-link": {
       "mobile": [
         {
-          "scheme": ["osjune"],
+          "scheme": [
+            "osjune"
+          ],
           "appLink": false
         }
       ],
       "desktop": {
-        "schemes": ["osjune"]
+        "schemes": [
+          "osjune"
+        ]
       }
     },
     "updater": {


### PR DESCRIPTION
Bumps desktop release version files to v0.0.22.

The release artifacts were already published by the production desktop release workflow. Merge this PR to record the version bump on main.

Release: https://github.com/open-software-network/os-june-releases/releases/tag/v0.0.22
Workflow run: https://github.com/open-software-network/os-june/actions/runs/28372673773