### PR TITLE
Fix system audio permission refresh

### DIFF
--- a/src-tauri/native/mac-system-audio-recorder/main.swift
+++ b/src-tauri/native/mac-system-audio-recorder/main.swift
@@ -180,6 +180,8 @@ final class SystemAudioRecorder {
 
         let tapDescription = CATapDescription(excludingProcesses: [], deviceUID: outputUID, stream: 0)
         tapDescription.uuid = UUID()
+        tapDescription.isMixdown = true
+        tapDescription.isMono = false
         tapDescription.muteBehavior = .unmuted
         tapDescription.name = "June System Audio"
 
@@ -193,8 +195,9 @@ final class SystemAudioRecorder {
         processTapID = tapID
 
         var streamDescription = try tapID.readAudioTapStreamBasicDescription()
+        log("tap format \(describeAudioFormat(streamDescription))")
         guard let inputFormat = AVAudioFormat(streamDescription: &streamDescription) else {
-            throw "Failed to create audio format for system tap."
+            throw "Failed to create audio format for system tap: \(describeAudioFormat(streamDescription))."
         }
         let targetFormat: AVAudioFormat
         if let fileFormat {
@@ -662,6 +665,19 @@ private func describeError(_ error: Error) -> String {
         return message
     }
     return error.localizedDescription
+}
+
+private func describeAudioFormat(_ description: AudioStreamBasicDescription) -> String {
+    [
+        "sampleRate=\(description.mSampleRate)",
+        "formatID=\(description.mFormatID)",
+        "flags=\(description.mFormatFlags)",
+        "bytesPerPacket=\(description.mBytesPerPacket)",
+        "framesPerPacket=\(description.mFramesPerPacket)",
+        "bytesPerFrame=\(description.mBytesPerFrame)",
+        "channels=\(description.mChannelsPerFrame)",
+        "bits=\(description.mBitsPerChannel)",
+    ].joined(separator: " ")
 }
 
 private func loadTCCFunction<T>(_ name: String, as type: T.Type, logURL: URL?) -> T? {

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -95,12 +95,11 @@ impl SystemAudioCapture {
         };
         if ready.event == "error" {
             abort_failed_helper_start(&partial_path, &status_path, &pid_path);
-            return Err(AppError::new(
-                "system_audio_permission_denied",
-                ready
-                    .message
-                    .unwrap_or_else(|| "System audio capture failed.".to_string()),
-            ));
+            dump_helper_log(&log_path);
+            let message = ready
+                .message
+                .unwrap_or_else(|| "System audio capture failed.".to_string());
+            return Err(AppError::new(helper_error_code(&message), message));
         }
         let Some(pid) = read_pid(&pid_path) else {
             abort_failed_helper_start(&partial_path, &status_path, &pid_path);
@@ -317,12 +316,13 @@ pub fn helper_permission_check() -> Result<(), AppError> {
     }
     let result = match status {
         Ok(status) if status.event == "ready" || status.event == "level" => Ok(()),
-        Ok(status) if status.event == "error" => Err(AppError::new(
-            "system_audio_permission_denied",
-            status
+        Ok(status) if status.event == "error" => {
+            dump_helper_log(&log_path);
+            let message = status
                 .message
-                .unwrap_or_else(|| "System audio capture probe failed.".to_string()),
-        )),
+                .unwrap_or_else(|| "System audio capture probe failed.".to_string());
+            Err(AppError::new(helper_error_code(&message), message))
+        }
         Ok(status) => {
             dump_helper_log(&log_path);
             Err(AppError::new(
@@ -345,6 +345,22 @@ pub fn helper_permission_check() -> Result<(), AppError> {
     let _ = std::fs::remove_file(&pid_path);
     let _ = std::fs::remove_file(&log_path);
     result
+}
+
+fn helper_error_code(message: &str) -> &'static str {
+    if helper_error_is_permission_denied(message) {
+        "system_audio_permission_denied"
+    } else {
+        "system_audio_capture_unavailable"
+    }
+}
+
+fn helper_error_is_permission_denied(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("permission is denied")
+        || normalized.contains("permission was not granted")
+        || normalized.contains("permission has not been granted")
+        || normalized.contains("timed out waiting for system audio recording permission")
 }
 
 #[cfg(target_os = "macos")]
@@ -606,13 +622,25 @@ fn dump_helper_log(_path: &Path) {}
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_helper_status, macos_version_string_supports_system_audio,
+        apply_helper_status, helper_error_code, macos_version_string_supports_system_audio,
         system_audio_min_macos_version_label, HelperStatus, SystemAudioStats,
     };
 
     #[test]
     fn system_audio_support_label_uses_shared_minimum_version() {
         assert_eq!(system_audio_min_macos_version_label(), "14.2");
+    }
+
+    #[test]
+    fn helper_error_code_distinguishes_permission_from_capture_failures() {
+        assert_eq!(
+            helper_error_code("System Audio Recording permission was not granted."),
+            "system_audio_permission_denied"
+        );
+        assert_eq!(
+            helper_error_code("Failed to create audio format for system tap."),
+            "system_audio_capture_unavailable"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1073,12 +1073,10 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
         let mut system = crate::audio::system_macos::system_audio_readiness();
         if should_probe_system_audio_permission(system.ready, is_capture_active()) {
-            if let Err(error) = crate::audio::system_macos::helper_permission_check() {
-                system.ready = false;
-                system.permission_state = "denied".to_string();
-                system.capture_available = false;
-                system.message = Some(error.message);
-            }
+            system = apply_system_audio_permission_probe_result(
+                system,
+                crate::audio::system_macos::helper_permission_check(),
+            );
         }
         sources.push(system);
     }
@@ -1095,6 +1093,24 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
 
 fn should_probe_system_audio_permission(system_ready: bool, capture_active: bool) -> bool {
     system_ready && !capture_active
+}
+
+fn apply_system_audio_permission_probe_result(
+    mut system: SourceReadinessDto,
+    result: Result<(), AppError>,
+) -> SourceReadinessDto {
+    match result {
+        Ok(()) => {
+            system.permission_state = "granted".to_string();
+        }
+        Err(error) => {
+            system.ready = false;
+            system.permission_state = "denied".to_string();
+            system.capture_available = false;
+            system.message = Some(error.message);
+        }
+    }
+    system
 }
 
 #[tauri::command]
@@ -1731,7 +1747,11 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{recovery_validation_expected_duration_ms, should_probe_system_audio_permission};
+    use super::{
+        apply_system_audio_permission_probe_result, recovery_validation_expected_duration_ms,
+        should_probe_system_audio_permission,
+    };
+    use crate::domain::types::{AppError, RecordingSource, SourceReadinessDto};
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
@@ -1745,11 +1765,49 @@ mod tests {
     }
 
     #[test]
+    fn successful_system_audio_permission_probe_reports_granted() {
+        let readiness = apply_system_audio_permission_probe_result(system_readiness(), Ok(()));
+
+        assert!(readiness.ready);
+        assert_eq!(readiness.permission_state, "granted");
+        assert!(readiness.capture_available);
+    }
+
+    #[test]
+    fn failed_system_audio_permission_probe_blocks_capture() {
+        let readiness = apply_system_audio_permission_probe_result(
+            system_readiness(),
+            Err(AppError::new(
+                "system_audio_permission_denied",
+                "Grant access.",
+            )),
+        );
+
+        assert!(!readiness.ready);
+        assert_eq!(readiness.permission_state, "denied");
+        assert!(!readiness.capture_available);
+        assert_eq!(readiness.message.as_deref(), Some("Grant access."));
+    }
+
+    #[test]
     fn recovered_wav_duration_overrides_stale_stored_duration() {
         let (_dir, path) = write_one_second_wav();
 
         assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1_000);
         assert_eq!(recovery_validation_expected_duration_ms(&path, 1), 1_000);
+    }
+
+    fn system_readiness() -> SourceReadinessDto {
+        SourceReadinessDto {
+            source: RecordingSource::System,
+            required: true,
+            ready: true,
+            permission_state: "unknown".to_string(),
+            device_available: true,
+            capture_available: true,
+            recovery_action: Some("openSystemAudioSettings".to_string()),
+            message: None,
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1105,8 +1105,21 @@ fn apply_system_audio_permission_probe_result(
         }
         Err(error) => {
             system.ready = false;
-            system.permission_state = "denied".to_string();
             system.capture_available = false;
+            match error.code.as_str() {
+                "system_audio_permission_denied" => {
+                    system.permission_state = "denied".to_string();
+                    system.recovery_action = Some("openSystemAudioSettings".to_string());
+                }
+                "system_audio_capture_unavailable" => {
+                    system.permission_state = "granted".to_string();
+                    system.recovery_action = Some("restartApp".to_string());
+                }
+                _ => {
+                    system.permission_state = "unknown".to_string();
+                    system.recovery_action = Some("restartApp".to_string());
+                }
+            }
             system.message = Some(error.message);
         }
     }
@@ -1787,6 +1800,26 @@ mod tests {
         assert_eq!(readiness.permission_state, "denied");
         assert!(!readiness.capture_available);
         assert_eq!(readiness.message.as_deref(), Some("Grant access."));
+    }
+
+    #[test]
+    fn failed_system_audio_capture_probe_keeps_permission_granted() {
+        let readiness = apply_system_audio_permission_probe_result(
+            system_readiness(),
+            Err(AppError::new(
+                "system_audio_capture_unavailable",
+                "Failed to create audio format for system tap.",
+            )),
+        );
+
+        assert!(!readiness.ready);
+        assert_eq!(readiness.permission_state, "granted");
+        assert!(!readiness.capture_available);
+        assert_eq!(readiness.recovery_action.as_deref(), Some("restartApp"));
+        assert_eq!(
+            readiness.message.as_deref(),
+            Some("Failed to create audio format for system tap.")
+        );
     }
 
     #[test]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1744,12 +1744,18 @@ export function App() {
       return;
     }
     let cancelled = false;
+    let inFlight = false;
     function poll() {
+      if (inFlight) return;
+      inFlight = true;
       void checkRecordingSourceReadiness("microphonePlusSystem")
         .then((readiness) => {
           if (!cancelled) setSourceReadiness(readiness);
         })
-        .catch(() => undefined);
+        .catch(() => undefined)
+        .finally(() => {
+          inFlight = false;
+        });
     }
     poll();
     const interval = window.setInterval(

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -197,6 +197,8 @@ const AGENT_MENU_BAR_SESSION_RETRY_DELAYS_MS = [
 ];
 const ACCESSIBILITY_PERMISSION_REFRESH_INTERVAL_MS = 1000;
 const ACCESSIBILITY_PERMISSION_REFRESH_TIMEOUT_MS = 120_000;
+const SYSTEM_AUDIO_PERMISSION_REFRESH_INTERVAL_MS = 1000;
+const SYSTEM_AUDIO_PERMISSION_REFRESH_TIMEOUT_MS = 120_000;
 // Floor for the note card so the sidebar can't be dragged wide enough to
 // crush it into a sliver — it always keeps a usable width plus its gutters.
 const MAIN_PANEL_MIN_WIDTH = 420;
@@ -430,6 +432,7 @@ export function App() {
   const [accessibilityStatus, setAccessibilityStatus] = useState<string>();
   const [accessibilityRefreshRequest, setAccessibilityRefreshRequest] =
     useState(0);
+  const [systemAudioRefreshRequest, setSystemAudioRefreshRequest] = useState(0);
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
   const [readyUpdate, setReadyUpdate] =
     useState<UpdatePromptPayload<JuneUpdate> | null>(null);
@@ -1733,6 +1736,36 @@ export function App() {
     };
   }, [accessibilityBlocked, accessibilityRefreshRequest, appBlocked]);
 
+  // After the user opens System Settings for System Audio Recording, keep
+  // checking briefly while macOS is in front. This matches Accessibility's
+  // permission flow and avoids relying on a single webview focus event.
+  useEffect(() => {
+    if (appBlocked || systemGranted || systemAudioRefreshRequest === 0) {
+      return;
+    }
+    let cancelled = false;
+    function poll() {
+      void checkRecordingSourceReadiness("microphonePlusSystem")
+        .then((readiness) => {
+          if (!cancelled) setSourceReadiness(readiness);
+        })
+        .catch(() => undefined);
+    }
+    poll();
+    const interval = window.setInterval(
+      poll,
+      SYSTEM_AUDIO_PERMISSION_REFRESH_INTERVAL_MS,
+    );
+    const timeout = window.setTimeout(() => {
+      window.clearInterval(interval);
+    }, SYSTEM_AUDIO_PERMISSION_REFRESH_TIMEOUT_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
+  }, [appBlocked, systemAudioRefreshRequest, systemGranted]);
+
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");
   }
@@ -1742,6 +1775,7 @@ export function App() {
   // the user to the System Settings pane.
   function handleEnableSystemAudio() {
     setUserWantsSystemAudio(true);
+    setSystemAudioRefreshRequest((request) => request + 1);
     void openPrivacySettings("systemAudio");
   }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -444,6 +444,12 @@ export function App() {
   const systemGranted = !!sourceReadiness?.sources.find(
     (source) => source.source === "system",
   )?.ready;
+  const recordingState = state.recordingStatus?.state;
+  const captureActive =
+    recordingState === "recording" ||
+    recordingState === "paused" ||
+    recordingState === "finalizing" ||
+    recordingState === "validating";
   const sourceMode: RecordingSourceMode =
     userWantsSystemAudio && systemGranted
       ? "microphonePlusSystem"
@@ -1686,12 +1692,6 @@ export function App() {
   // accessibility state via the dictation-event listener above.
   useEffect(() => {
     if (appBlocked) return;
-    const recordingState = state.recordingStatus?.state;
-    const captureActive =
-      recordingState === "recording" ||
-      recordingState === "paused" ||
-      recordingState === "finalizing" ||
-      recordingState === "validating";
     function refresh() {
       void dictationHelperCommand({ type: "get_permission_status" }).catch(
         () => undefined,
@@ -1703,7 +1703,7 @@ export function App() {
     }
     window.addEventListener("focus", refresh);
     return () => window.removeEventListener("focus", refresh);
-  }, [appBlocked, state.recordingStatus?.state]);
+  }, [appBlocked, captureActive]);
 
   // After the user asks to grant Accessibility, keep checking briefly while
   // macOS System Settings is in front. This avoids relying on a single webview
@@ -1740,7 +1740,12 @@ export function App() {
   // checking briefly while macOS is in front. This matches Accessibility's
   // permission flow and avoids relying on a single webview focus event.
   useEffect(() => {
-    if (appBlocked || systemGranted || systemAudioRefreshRequest === 0) {
+    if (
+      appBlocked ||
+      captureActive ||
+      systemGranted ||
+      systemAudioRefreshRequest === 0
+    ) {
       return;
     }
     let cancelled = false;
@@ -1770,7 +1775,7 @@ export function App() {
       window.clearInterval(interval);
       window.clearTimeout(timeout);
     };
-  }, [appBlocked, systemAudioRefreshRequest, systemGranted]);
+  }, [appBlocked, captureActive, systemAudioRefreshRequest, systemGranted]);
 
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -84,8 +84,15 @@ export function useSystemAudioStatus(active: boolean): {
         );
         if (!system || system.permissionState === "unsupported") {
           setStatus("unsupported");
+        } else if (system.permissionState === "granted") {
+          setStatus("granted");
+        } else if (
+          system.permissionState === "denied" ||
+          system.permissionState === "restricted"
+        ) {
+          setStatus("denied");
         } else {
-          setStatus(system.ready ? "granted" : "denied");
+          setStatus(system.ready ? "granted" : "unknown");
         }
       })
       .catch(() => {

--- a/src/components/onboarding/use-permission-status.ts
+++ b/src/components/onboarding/use-permission-status.ts
@@ -85,8 +85,6 @@ export function useSystemAudioStatus(active: boolean): {
         if (!system || system.permissionState === "unsupported") {
           setStatus("unsupported");
         } else {
-          // The probe leaves permissionState "unknown" on success; ready is
-          // the granted signal.
           setStatus(system.ready ? "granted" : "denied");
         }
       })

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
 import { HERO_GREETINGS } from "../components/agent/AgentWorkspace";
+import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_NEW_SESSION_EVENT,
   AGENT_SESSIONS_CHANGED_EVENT,
@@ -19,6 +20,7 @@ import type {
   AccountStatus,
   BootstrapResponse,
   NoteDto,
+  RecordingSessionDto,
   RecordingSourceReadinessDto,
 } from "../lib/tauri";
 
@@ -233,6 +235,38 @@ function recordingReadiness(systemReady: boolean): RecordingSourceReadinessDto {
         recoveryAction: "openSystemAudioSettings",
       },
     ],
+  };
+}
+
+function microphoneOnlyReadiness(): RecordingSourceReadinessDto {
+  return {
+    sourceMode: "microphoneOnly",
+    ready: true,
+    sources: [
+      {
+        source: "microphone",
+        required: true,
+        ready: true,
+        permissionState: "granted",
+        deviceAvailable: true,
+        captureAvailable: true,
+      },
+    ],
+  };
+}
+
+function recordingSession(
+  overrides: Partial<RecordingSessionDto> = {},
+): RecordingSessionDto {
+  return {
+    id: "rec-1",
+    noteId: "note-1",
+    sourceMode: "microphoneOnly",
+    state: "recording",
+    startedAt: now,
+    elapsedMs: 0,
+    level: { peak: 0, rms: 0, recentPeaks: [] },
+    ...overrides,
   };
 }
 
@@ -864,6 +898,103 @@ describe("App shortcuts", () => {
         expect(
           within(allowedRow as HTMLElement).getByLabelText("Allowed"),
         ).toBeInTheDocument();
+      });
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("pauses system audio readiness polling while recording is active", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    let resolveProbe: (value: RecordingSourceReadinessDto) => void = () => {};
+    const pendingProbe = new Promise<RecordingSourceReadinessDto>((resolve) => {
+      resolveProbe = resolve;
+    });
+    let systemReadinessCalls = 0;
+    mocks.checkRecordingSourceReadiness.mockImplementation(
+      async (mode: string) => {
+        if (mode === "microphoneOnly") return microphoneOnlyReadiness();
+        systemReadinessCalls += 1;
+        if (systemReadinessCalls === 1) return recordingReadiness(false);
+        return pendingProbe;
+      },
+    );
+    mocks.startRecording.mockImplementation(
+      async (noteId: string, sourceMode: string) =>
+        recordingSession({
+          noteId,
+          sourceMode: sourceMode as RecordingSessionDto["sourceMode"],
+        }),
+    );
+    mocks.getRecordingStatus.mockResolvedValue({
+      sessionId: "rec-1",
+      noteId: "note-1",
+      sourceMode: "microphoneOnly",
+      state: "recording",
+      elapsedMs: 0,
+      level: { peak: 0, rms: 0, recentPeaks: [] },
+      silenceWarning: false,
+      bytesWritten: 0,
+    });
+
+    try {
+      render(<App />);
+
+      await waitFor(() =>
+        expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true),
+      );
+      await waitFor(() =>
+        expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(
+          true,
+        ),
+      );
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      act(() => {
+        mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+      });
+
+      expect(
+        await screen.findByRole("heading", { name: "Appearance" }),
+      ).toBeInTheDocument();
+      const blockedRow = screen
+        .getByText("System audio")
+        .closest(".settings-row");
+      expect(blockedRow).not.toBeNull();
+
+      fireEvent.click(
+        within(blockedRow as HTMLElement).getByRole("button", {
+          name: "Manage System audio permission",
+        }),
+      );
+
+      await waitFor(() => expect(systemReadinessCalls).toBe(2));
+
+      await waitFor(async () => {
+        if (mocks.startRecording.mock.calls.length === 0) {
+          await act(async () => {
+            await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+              payload: undefined,
+            });
+          });
+        }
+        expect(mocks.startRecording).toHaveBeenCalled();
+      });
+      expect(mocks.startRecording).toHaveBeenCalledWith(
+        expect.any(String),
+        "microphoneOnly",
+      );
+
+      await new Promise((resolve) => window.setTimeout(resolve, 1_200));
+
+      expect(systemReadinessCalls).toBe(2);
+
+      await act(async () => {
+        resolveProbe(recordingReadiness(false));
+        await pendingProbe;
       });
     } finally {
       restoreNavigator();

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -15,7 +15,12 @@ import {
   AGENT_SESSIONS_CHANGED_EVENT,
 } from "../lib/agent-events";
 import { CLOSE_TAB_EVENT, OPEN_SETTINGS_EVENT } from "../lib/menu-bar";
-import type { AccountStatus, BootstrapResponse, NoteDto } from "../lib/tauri";
+import type {
+  AccountStatus,
+  BootstrapResponse,
+  NoteDto,
+  RecordingSourceReadinessDto,
+} from "../lib/tauri";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
@@ -202,6 +207,32 @@ function note(overrides: Partial<NoteDto> = {}): NoteDto {
     generatedContent: "Existing note",
     activeTab: "notes",
     ...overrides,
+  };
+}
+
+function recordingReadiness(systemReady: boolean): RecordingSourceReadinessDto {
+  return {
+    sourceMode: "microphonePlusSystem",
+    ready: systemReady,
+    sources: [
+      {
+        source: "microphone",
+        required: true,
+        ready: true,
+        permissionState: "granted",
+        deviceAvailable: true,
+        captureAvailable: true,
+      },
+      {
+        source: "system",
+        required: true,
+        ready: systemReady,
+        permissionState: systemReady ? "granted" : "denied",
+        deviceAvailable: true,
+        captureAvailable: systemReady,
+        recoveryAction: "openSystemAudioSettings",
+      },
+    ],
   };
 }
 
@@ -721,43 +752,8 @@ describe("App shortcuts", () => {
       "MacIntel",
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
     );
-    const deniedReadiness = {
-      sourceMode: "microphonePlusSystem",
-      ready: false,
-      sources: [
-        {
-          source: "microphone",
-          required: true,
-          ready: true,
-          permissionState: "granted",
-          deviceAvailable: true,
-          captureAvailable: true,
-        },
-        {
-          source: "system",
-          required: true,
-          ready: false,
-          permissionState: "denied",
-          deviceAvailable: true,
-          captureAvailable: false,
-          recoveryAction: "openSystemAudioSettings",
-        },
-      ],
-    };
-    const grantedReadiness = {
-      ...deniedReadiness,
-      ready: true,
-      sources: deniedReadiness.sources.map((source) =>
-        source.source === "system"
-          ? {
-              ...source,
-              ready: true,
-              permissionState: "granted",
-              captureAvailable: true,
-            }
-          : source,
-      ),
-    };
+    const deniedReadiness = recordingReadiness(false);
+    const grantedReadiness = recordingReadiness(true);
     mocks.checkRecordingSourceReadiness
       .mockResolvedValueOnce(deniedReadiness)
       .mockResolvedValue(grantedReadiness);
@@ -795,6 +791,71 @@ describe("App shortcuts", () => {
       await waitFor(() =>
         expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledTimes(2),
       );
+      await waitFor(() => {
+        const allowedRow = screen
+          .getByText("System audio")
+          .closest(".settings-row");
+        expect(allowedRow).not.toBeNull();
+        expect(
+          within(allowedRow as HTMLElement).getByLabelText("Allowed"),
+        ).toBeInTheDocument();
+      });
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("does not overlap system audio readiness polls while a probe is pending", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    let resolveProbe: (value: RecordingSourceReadinessDto) => void = () => {};
+    const pendingProbe = new Promise<RecordingSourceReadinessDto>((resolve) => {
+      resolveProbe = resolve;
+    });
+    mocks.checkRecordingSourceReadiness
+      .mockResolvedValueOnce(recordingReadiness(false))
+      .mockReturnValue(pendingProbe);
+
+    try {
+      render(<App />);
+
+      await waitFor(() =>
+        expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true),
+      );
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      act(() => {
+        mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+      });
+
+      expect(
+        await screen.findByRole("heading", { name: "Appearance" }),
+      ).toBeInTheDocument();
+      const blockedRow = screen
+        .getByText("System audio")
+        .closest(".settings-row");
+      expect(blockedRow).not.toBeNull();
+
+      fireEvent.click(
+        within(blockedRow as HTMLElement).getByRole("button", {
+          name: "Manage System audio permission",
+        }),
+      );
+
+      await waitFor(() =>
+        expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledTimes(2),
+      );
+
+      await new Promise((resolve) => window.setTimeout(resolve, 1_200));
+
+      expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        resolveProbe(recordingReadiness(true));
+        await pendingProbe;
+      });
       await waitFor(() => {
         const allowedRow = screen
           .getByText("System audio")

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -712,6 +713,100 @@ describe("App shortcuts", () => {
       }),
     );
     expect(mocks.openPrivacySettings).not.toHaveBeenCalledWith("accessibility");
+  });
+
+  it("polls system audio readiness after opening the macOS permission pane", async () => {
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "MacIntel",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    const deniedReadiness = {
+      sourceMode: "microphonePlusSystem",
+      ready: false,
+      sources: [
+        {
+          source: "microphone",
+          required: true,
+          ready: true,
+          permissionState: "granted",
+          deviceAvailable: true,
+          captureAvailable: true,
+        },
+        {
+          source: "system",
+          required: true,
+          ready: false,
+          permissionState: "denied",
+          deviceAvailable: true,
+          captureAvailable: false,
+          recoveryAction: "openSystemAudioSettings",
+        },
+      ],
+    };
+    const grantedReadiness = {
+      ...deniedReadiness,
+      ready: true,
+      sources: deniedReadiness.sources.map((source) =>
+        source.source === "system"
+          ? {
+              ...source,
+              ready: true,
+              permissionState: "granted",
+              captureAvailable: true,
+            }
+          : source,
+      ),
+    };
+    mocks.checkRecordingSourceReadiness
+      .mockResolvedValueOnce(deniedReadiness)
+      .mockResolvedValue(grantedReadiness);
+
+    try {
+      render(<App />);
+
+      await waitFor(() =>
+        expect(mocks.listeners.has(OPEN_SETTINGS_EVENT)).toBe(true),
+      );
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      act(() => {
+        mocks.listeners.get(OPEN_SETTINGS_EVENT)?.({});
+      });
+
+      expect(
+        await screen.findByRole("heading", { name: "Appearance" }),
+      ).toBeInTheDocument();
+      const blockedRow = screen
+        .getByText("System audio")
+        .closest(".settings-row");
+      expect(blockedRow).not.toBeNull();
+      expect(
+        within(blockedRow as HTMLElement).getByLabelText("Blocked"),
+      ).toBeInTheDocument();
+
+      await user.click(
+        within(blockedRow as HTMLElement).getByRole("button", {
+          name: "Manage System audio permission",
+        }),
+      );
+
+      expect(mocks.openPrivacySettings).toHaveBeenCalledWith("systemAudio");
+      await waitFor(() =>
+        expect(mocks.checkRecordingSourceReadiness).toHaveBeenCalledTimes(2),
+      );
+      await waitFor(() => {
+        const allowedRow = screen
+          .getByText("System audio")
+          .closest(".settings-row");
+        expect(allowedRow).not.toBeNull();
+        expect(
+          within(allowedRow as HTMLElement).getByLabelText("Allowed"),
+        ).toBeInTheDocument();
+      });
+    } finally {
+      restoreNavigator();
+    }
   });
 
   it("starts a session with Ctrl-N and creates a note with Ctrl-Shift-N on Windows", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -95,6 +95,19 @@ function systemAudioReadiness(granted: boolean): RecordingSourceReadinessDto {
   };
 }
 
+function systemAudioCaptureUnavailableReadiness(): RecordingSourceReadinessDto {
+  const readiness = systemAudioReadiness(false);
+  const system = readiness.sources.find((source) => source.source === "system");
+  if (system) {
+    system.permissionState = "granted";
+    system.deviceAvailable = true;
+    system.captureAvailable = false;
+    system.recoveryAction = "restartApp";
+    system.message = "Failed to create audio format for system tap.";
+  }
+  return readiness;
+}
+
 function shortcut(label: string) {
   return {
     code: "Fn",
@@ -627,6 +640,28 @@ describe("OnboardingFlow", () => {
       grantPermissions();
 
       await screen.findByText("Needs macOS 14.2 or later.");
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
+      );
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("does not show System Settings copy when system audio permission is granted but capture is unavailable", async () => {
+    const restoreNavigator = stubMacNavigatorPlatform();
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(
+      systemAudioCaptureUnavailableReadiness(),
+    );
+    try {
+      await renderFlow();
+      grantPermissions();
+
+      expect(
+        screen.queryByText(
+          "Turned off in System Settings. Flip the toggle and June will notice.",
+        ),
+      ).not.toBeInTheDocument();
       await waitFor(() =>
         expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled(),
       );

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -67,8 +67,8 @@ const signedOutAccount: AccountStatus = {
 type ListenHandler = (event: { payload: string }) => void;
 
 // What check_recording_source_readiness returns after the capture-helper
-// probe: a passing probe leaves the system permissionState at "unknown" and
-// signals the grant via ready; a denial flips both.
+// probe: a passing probe reports the system source as granted; a denial
+// flips both ready and permissionState.
 function systemAudioReadiness(granted: boolean): RecordingSourceReadinessDto {
   return {
     sourceMode: "microphonePlusSystem",
@@ -86,7 +86,7 @@ function systemAudioReadiness(granted: boolean): RecordingSourceReadinessDto {
         source: "system",
         required: true,
         ready: granted,
-        permissionState: granted ? "unknown" : "denied",
+        permissionState: granted ? "granted" : "denied",
         deviceAvailable: granted,
         captureAvailable: granted,
         recoveryAction: "openSystemAudioSettings",


### PR DESCRIPTION
## Summary
- Report system audio permission as `granted` after a successful helper probe instead of leaving the readiness state as `unknown`.
- Poll `checkRecordingSourceReadiness` after the System audio Manage action so Settings notices grants made in macOS System Settings without depending on a focus event.
- Update onboarding and app-level regression tests for the new granted state and refresh path.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml system_audio_permission_probe`
- `pnpm test -- src/test/app-shortcut.test.tsx src/test/onboarding.test.tsx src/test/app-settings.test.tsx`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `pnpm exec prettier --check src/app/App.tsx src/test/app-shortcut.test.tsx src/test/onboarding.test.tsx src/components/onboarding/use-permission-status.ts`

## Live QA
- BLOCKED: native macOS validation would require opening System Settings and inspecting local permission/TCC state, which exposes private OS data and may trigger permission side effects without explicit user confirmation.

## Known gaps
- `pnpm run format` still fails on unrelated files outside this diff: `src/components/note-editor/NoteFailureBanner.tsx`, `src/test/agent-workspace.test.tsx`, and `src-tauri/tauri.conf.json`.