### PR TITLE
[codex] Update Conductor env setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -8,9 +8,9 @@
 [scripts]
 # pnpm is the repo's declared package manager (packageManager: pnpm@9.15.4).
 # Installs the front-end deps; the Rust crates (src-tauri, june-api) compile
-# on the first `tauri:dev` run. The .env files are copied in via
-# .worktreeinclude, so setup doesn't need to handle them.
-setup = "pnpm install"
+# on the first `tauri:dev` run. The .env files live in the root checkout and
+# are symlinked into each workspace so updates do not drift.
+setup = "mkdir -p june-api && if [ -n \"$CONDUCTOR_ROOT_PATH\" ]; then ln -sf \"$CONDUCTOR_ROOT_PATH/.env\" .env && ln -sf \"$CONDUCTOR_ROOT_PATH/june-api/.env\" june-api/.env; fi && pnpm install"
 
 # Launch the Tauri desktop app in dev (migrated verbatim from conductor.json).
 # `tauri:dev` also starts the june-api backend via the beforeDevCommand hook.


### PR DESCRIPTION
## Summary

- Update Conductor setup so workspaces symlink the root `.env` and `june-api/.env` files from the root checkout.
- Keep the root checkout as the source of truth so workspace env files do not drift.
- Document the June API env location in the setup comments.

## Validation

- Ran `git diff --check` on the Conductor config change.
- Scanned the diff for common secret, key, and token patterns.

No env files or secret values are included in this PR.