### PR TITLE
Show billing usage as remaining percentage

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -89,6 +89,8 @@ struct MeWire {
 struct BalanceWire {
     credits: i64,
     usd_millis: i64,
+    #[serde(default)]
+    usage_remaining_percent: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -151,6 +153,8 @@ pub struct AccountUser {
 pub struct AccountBalance {
     pub credits: i64,
     pub usd_millis: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_remaining_percent: Option<i64>,
 }
 
 #[derive(Serialize, Clone)]
@@ -223,6 +227,7 @@ impl From<BalanceWire> for AccountBalance {
         Self {
             credits: w.credits,
             usd_millis: w.usd_millis,
+            usage_remaining_percent: w.usage_remaining_percent,
         }
     }
 }
@@ -353,6 +358,7 @@ fn local_dev_account_status() -> AccountStatus {
         balance: Some(AccountBalance {
             credits: 0,
             usd_millis: 0,
+            usage_remaining_percent: Some(100),
         }),
         subscription: Some(AccountSubscription {
             subscribed: true,

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -102,6 +102,7 @@ struct CheckoutSessionWire {
 struct SubscriptionWire {
     subscribed: bool,
     status: Option<String>,
+    plan_credits: Option<i64>,
     trial_end: Option<String>,
     current_period_end: Option<String>,
     /// Trial length from the Stripe price config, available pre-subscription.
@@ -163,6 +164,8 @@ pub struct AccountSubscription {
     pub subscribed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_credits: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -363,6 +366,7 @@ fn local_dev_account_status() -> AccountStatus {
         subscription: Some(AccountSubscription {
             subscribed: true,
             status: Some("active".to_string()),
+            plan_credits: Some(0),
             trial_end: None,
             current_period_end: None,
             trial_period_days: None,
@@ -1150,6 +1154,7 @@ async fn fetch_snapshot(
         .map(|w| AccountSubscription {
             subscribed: w.subscribed,
             status: w.status,
+            plan_credits: w.plan_credits,
             trial_end: w.trial_end,
             current_period_end: w.current_period_end,
             trial_period_days: w.trial_period_days,

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -10,6 +10,8 @@ import {
 } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 
+const FREE_PLAN_NAME = "Free";
+
 type Props = {
   account: AccountStatus;
   loading: boolean;
@@ -190,6 +192,7 @@ export function BillingSettingsSection({
 
   const subscription = account.subscription;
   const liveSubscription = hasLiveSubscription(account);
+  const usageRemainingPercent = usagePercentFromBalance(account.balance);
   const billingRecovery =
     subscription?.subscribed === true &&
     typeof subscription.status === "string" &&
@@ -233,7 +236,7 @@ export function BillingSettingsSection({
         Billing
       </h2>
       <p className="settings-group-description">
-        Manage credits and subscription details in OpenSoftware.
+        Manage usage and subscription details in OpenSoftware.
       </p>
       {billingStatus ? (
         <p className="settings-status">{billingStatus}</p>
@@ -259,19 +262,39 @@ export function BillingSettingsSection({
               </div>
             </div>
           ) : null}
-          <div className="settings-row">
+          <div className="settings-row billing-usage-row">
             <div className="settings-row-info">
-              <p className="balance-amount">
-                {formatUsd(account.balance?.usdMillis)}
+              <p className="usage-remaining-amount">
+                {formatPercent(usageRemainingPercent)} remaining
               </p>
-              <p className="settings-row-description">Available balance</p>
+              <div
+                className="usage-remaining-progress"
+                role="progressbar"
+                aria-label="Usage remaining"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={usageRemainingPercent}
+              >
+                <div
+                  className="usage-remaining-progress-fill"
+                  style={{
+                    transform: `scaleX(${usageRemainingPercent / 100})`,
+                  }}
+                />
+              </div>
+              <div>
+                <p className="settings-row-description">
+                  Usage remaining on{" "}
+                  {liveSubscription ? "your subscription" : FREE_PLAN_NAME}
+                </p>
+              </div>
             </div>
             <div className="settings-row-control">
               <button
                 type="button"
                 className="icon-button"
-                aria-label="Refresh balance"
-                title="Refresh balance"
+                aria-label="Refresh usage"
+                title="Refresh usage"
                 disabled={refreshing || !account.signedIn}
                 onClick={() => void handleRefresh()}
               >
@@ -305,8 +328,23 @@ function displayName(account: AccountStatus) {
   );
 }
 
-function formatUsd(usdMillis?: number) {
-  return `$${((usdMillis ?? 0) / 1000).toFixed(2)}`;
+function formatPercent(percent: number) {
+  return `${clampPercent(percent)}%`;
+}
+
+function clampPercent(percent: number) {
+  if (!Number.isFinite(percent)) return 0;
+  return Math.max(0, Math.min(100, Math.round(percent)));
+}
+
+function usagePercentFromBalance(balance: AccountStatus["balance"]) {
+  if (Number.isFinite(balance?.usageRemainingPercent)) {
+    return clampPercent(balance?.usageRemainingPercent ?? 0);
+  }
+  if (Number.isFinite(balance?.usdMillis)) {
+    return (balance?.usdMillis ?? 0) > 0 ? 100 : 0;
+  }
+  return 0;
 }
 
 /** "Ends June 24" from an accounts-API timestamp, or undefined when the

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -11,6 +11,7 @@ import {
 import type { AccountStatus } from "../../lib/tauri";
 
 const FREE_PLAN_NAME = "Free";
+const FREE_PLAN_CREDITS = 5000;
 
 type Props = {
   account: AccountStatus;
@@ -192,7 +193,10 @@ export function BillingSettingsSection({
 
   const subscription = account.subscription;
   const liveSubscription = hasLiveSubscription(account);
-  const usageRemainingPercent = usagePercentFromBalance(account.balance);
+  const usageRemainingPercent = usagePercentFromBalance(
+    account.balance,
+    subscription,
+  );
   const billingRecovery =
     subscription?.subscribed === true &&
     typeof subscription.status === "string" &&
@@ -337,9 +341,27 @@ function clampPercent(percent: number) {
   return Math.max(0, Math.min(100, Math.round(percent)));
 }
 
-function usagePercentFromBalance(balance: AccountStatus["balance"]) {
+function usagePercentFromBalance(
+  balance: AccountStatus["balance"],
+  subscription: AccountStatus["subscription"],
+) {
   if (Number.isFinite(balance?.usageRemainingPercent)) {
     return clampPercent(balance?.usageRemainingPercent ?? 0);
+  }
+  if (
+    Number.isFinite(balance?.credits) &&
+    Number.isFinite(subscription?.planCredits) &&
+    (subscription?.planCredits ?? 0) > 0
+  ) {
+    return clampPercent(
+      ((balance?.credits ?? 0) / (subscription?.planCredits ?? 1)) * 100,
+    );
+  }
+  if (
+    subscription?.subscribed === false &&
+    Number.isFinite(balance?.credits)
+  ) {
+    return clampPercent(((balance?.credits ?? 0) / FREE_PLAN_CREDITS) * 100);
   }
   if (Number.isFinite(balance?.usdMillis)) {
     return (balance?.usdMillis ?? 0) > 0 ? 100 : 0;

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -193,6 +193,8 @@ export function BillingSettingsSection({
 
   const subscription = account.subscription;
   const liveSubscription = hasLiveSubscription(account);
+  const usagePlanName =
+    subscription?.subscribed === true ? "your subscription" : FREE_PLAN_NAME;
   const usageRemainingPercent = usagePercentFromBalance(
     account.balance,
     subscription,
@@ -288,8 +290,7 @@ export function BillingSettingsSection({
               </div>
               <div>
                 <p className="settings-row-description">
-                  Usage remaining on{" "}
-                  {liveSubscription ? "your subscription" : FREE_PLAN_NAME}
+                  Usage remaining on {usagePlanName}
                 </p>
               </div>
             </div>

--- a/src/lib/account-status.ts
+++ b/src/lib/account-status.ts
@@ -6,14 +6,13 @@ const EMPTY_STATUS: AccountStatus = { signedIn: false, configured: false };
 const DEMO_ACCOUNT: AccountStatus = {
   signedIn: true,
   configured: true,
-  localDev: true,
   user: {
     id: "usr_browser_demo",
     handle: "browser-demo",
     displayName: "Browser demo",
   },
-  balance: { credits: 0, usdMillis: 0 },
-  subscription: { subscribed: true, status: "active" },
+  balance: { credits: 1200, usdMillis: 1200, usageRemainingPercent: 100 },
+  subscription: { subscribed: false },
 };
 
 export type UseAccountStatusOptions = {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1232,6 +1232,9 @@ export type AccountBalance = {
   /** Present whenever the backend snapshot succeeds; optional so older
    * payload shapes (and test fixtures) without it don't lock the app. */
   credits?: number;
+  /** Normalized usage remaining for the current plan or free allowance.
+   * Optional while the app can still receive older accounts API payloads. */
+  usageRemainingPercent?: number;
   usdMillis: number;
 };
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1241,6 +1241,9 @@ export type AccountBalance = {
 export type AccountSubscription = {
   subscribed: boolean;
   status?: "trialing" | "active" | "past_due" | "canceled" | (string & {});
+  /** Monthly plan credits returned by OS Accounts. Used as a fallback for
+   * deployments whose balance endpoint does not expose usageRemainingPercent. */
+  planCredits?: number;
   trialEnd?: string;
   currentPeriodEnd?: string;
   /** Trial length from the Stripe price config, available pre-subscription.

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9586,7 +9586,7 @@ input:focus-visible,
   font-family: var(--font-mono);
 }
 
-.balance-amount {
+.usage-remaining-amount {
   margin: 0;
   color: var(--foreground);
   font-size: var(--fs-2xl);
@@ -9594,12 +9594,31 @@ input:focus-visible,
   letter-spacing: 0;
 }
 
+.usage-remaining-progress {
+  width: min(360px, 100%);
+  height: 8px;
+  margin: var(--sp-2) 0 var(--sp-1);
+  overflow: hidden;
+  border-radius: var(--r-full);
+  background: color-mix(in oklch, var(--muted) 72%, transparent);
+}
+
+.usage-remaining-progress-fill {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--success) 76%, var(--foreground));
+  transform-origin: left center;
+  transition: transform 160ms ease-out;
+}
+
 .balance-refresh-icon {
   transition: transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .balance-refresh-icon {
+  .balance-refresh-icon,
+  .usage-remaining-progress-fill {
     transition: none;
   }
 }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -131,7 +131,7 @@ const signedInAccount = {
     email: "alex@example.com",
     displayName: "Alex",
   },
-  balance: { usdMillis: 1200 },
+  balance: { usdMillis: 1200, usageRemainingPercent: 100 },
 };
 
 function stubNavigatorPlatform(platform: string, userAgent: string) {
@@ -411,6 +411,41 @@ describe("AppSettings", () => {
     expect(mocks.osAccountsUpgrade).toHaveBeenCalledTimes(1);
   });
 
+  it("shows usage remaining as a percentage instead of dollars", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          balance: {
+            credits: 1200,
+            usdMillis: 1200,
+            usageRemainingPercent: 64,
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    expect(
+      screen.getByRole("heading", { name: "Billing" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("64% remaining")).toBeInTheDocument();
+    expect(screen.getByText("Usage remaining on Free")).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Usage remaining" }),
+    ).toHaveAttribute("aria-valuenow", "64");
+    expect(screen.queryByText("$1.20")).not.toBeInTheDocument();
+  });
+
   it("runs sign-in, cancel, and sign-out actions from account settings", async () => {
     const user = userEvent.setup();
     const onAccountChanged = vi.fn();
@@ -506,7 +541,7 @@ describe("AppSettings", () => {
       await screen.findByText("Opened your account portal in the browser."),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Refresh balance" }));
+    await user.click(screen.getByRole("button", { name: "Refresh usage" }));
     await waitFor(() => expect(onAccountRefresh).toHaveBeenCalledOnce());
   });
 
@@ -516,7 +551,11 @@ describe("AppSettings", () => {
       <AppSettings
         account={{
           ...signedInAccount,
-          balance: { credits: 1200, usdMillis: 1200 },
+          balance: {
+            credits: 1200,
+            usdMillis: 1200,
+            usageRemainingPercent: 100,
+          },
           subscription: {
             subscribed: true,
             status: "past_due",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -646,6 +646,9 @@ describe("AppSettings", () => {
     await user.click(screen.getByRole("tab", { name: "Billing" }));
 
     expect(screen.getByText("Billing needs attention")).toBeInTheDocument();
+    expect(
+      screen.getByText("Usage remaining on your subscription"),
+    ).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Manage billing" }));
     expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
     expect(

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -446,6 +446,78 @@ describe("AppSettings", () => {
     expect(screen.queryByText("$1.20")).not.toBeInTheDocument();
   });
 
+  it("falls back to subscription plan credits when balance has no usage percentage", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          balance: {
+            credits: 4676,
+            usdMillis: 4676,
+          },
+          subscription: {
+            subscribed: true,
+            status: "active",
+            planCredits: 20000,
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    expect(screen.getByText("23% remaining")).toBeInTheDocument();
+    expect(
+      screen.getByText("Usage remaining on your subscription"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Usage remaining" }),
+    ).toHaveAttribute("aria-valuenow", "23");
+  });
+
+  it("falls back to the free grant for unsubscribed accounts without usage percentage", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          balance: {
+            credits: 4857,
+            usdMillis: 4857,
+          },
+          subscription: {
+            subscribed: false,
+            status: undefined,
+            planCredits: undefined,
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    expect(screen.getByText("97% remaining")).toBeInTheDocument();
+    expect(screen.getByText("Usage remaining on Free")).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Usage remaining" }),
+    ).toHaveAttribute("aria-valuenow", "97");
+  });
+
   it("runs sign-in, cancel, and sign-out actions from account settings", async () => {
     const user = userEvent.setup();
     const onAccountChanged = vi.fn();


### PR DESCRIPTION
## Summary
- Replace the billing dollar balance row with a percentage-remaining row and progress bar.
- Consume `usageRemainingPercent` from OS Accounts through the Tauri bridge when present.
- Preserve `planCredits` from the subscription endpoint and use it as the fallback denominator for subscribed accounts when `/billing/balance` does not include `usage_remaining_percent`.
- Use the known 5000-credit Free grant as the fallback denominator for unsubscribed accounts when the balance endpoint only returns wallet credits.
- Keep subscribed billing-recovery accounts labeled as subscription usage instead of Free usage.
- Make the browser demo account represent the default Free state so the Billing tab can be previewed.

## Why
The staging OS Accounts balance endpoint currently returns wallet fields such as `credits` and `usd_millis`, but not `usage_remaining_percent`. Without a denominator-aware fallback, any positive wallet balance rendered as `100% remaining`. Live staging checks showed both cases that need explicit handling:

- Subscribed account: `credits: 4676`, `plan_credits: 20000` -> `23% remaining`.
- Free account: `credits: 4857`, no `plan_credits` -> `97% remaining` against the 5000-credit starting grant.

## Testing
- `pnpm exec vitest run src/test/app-settings.test.tsx`
- `pnpm lint`
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml os_accounts`
- `git diff --check`
- Live Tauri dev against staging env: confirmed OS Accounts payload shapes for subscribed and Free accounts without exposing tokens or secrets.

## Live walkthrough
No public QA video was attached because the useful native walkthrough surface shows a real OS Accounts wallet and billing state. The deterministic settings tests cover the exact subscribed and Free payload shapes observed from staging.
