### PR TITLE
Add generated release changelogs

### DIFF
--- a/.github/workflows/production-desktop-dmg.yml
+++ b/.github/workflows/production-desktop-dmg.yml
@@ -168,6 +168,13 @@ jobs:
           # dependency exactly as committed.
           cargo update --workspace --manifest-path src-tauri/Cargo.toml
 
+      - name: Generate release changelog
+        run: |
+          set -euo pipefail
+          changelog_path="$RUNNER_TEMP/release-changelog.md"
+          node scripts/generate-release-changelog.mjs "$VERSION" "$changelog_path"
+          echo "RELEASE_CHANGELOG_PATH=$changelog_path" >> "$GITHUB_ENV"
+
       - name: Run release checks
         run: |
           set -euo pipefail
@@ -329,16 +336,20 @@ jobs:
 
           SIGNATURE_PATH="$app_signature" \
           LATEST_JSON_PATH="$latest_json" \
+          RELEASE_CHANGELOG_PATH="$RELEASE_CHANGELOG_PATH" \
           node <<'NODE'
           const fs = require("node:fs");
 
           const version = process.env.VERSION;
           const signature = fs.readFileSync(process.env.SIGNATURE_PATH, "utf8");
+          const notes = fs
+            .readFileSync(process.env.RELEASE_CHANGELOG_PATH, "utf8")
+            .trim();
           const url = `https://github.com/open-software-network/os-june-releases/releases/download/v${version}/June_universal.app.tar.gz`;
           const platform = { signature, url };
           const latest = {
             version,
-            notes: `Stable June release v${version}.`,
+            notes,
             pub_date: new Date().toISOString(),
             platforms: {
               "darwin-aarch64": platform,
@@ -353,17 +364,17 @@ jobs:
           );
           NODE
 
-          release_notes="Stable June release v$VERSION."
+          release_notes_file="${RELEASE_CHANGELOG_PATH:?}"
           if gh release view "v$VERSION" --repo open-software-network/os-june-releases >/dev/null 2>&1; then
             gh release edit "v$VERSION" \
               --repo open-software-network/os-june-releases \
               --title "June v$VERSION" \
-              --notes "$release_notes"
+              --notes-file "$release_notes_file"
           else
             gh release create "v$VERSION" \
               --repo open-software-network/os-june-releases \
               --title "June v$VERSION" \
-              --notes "$release_notes" \
+              --notes-file "$release_notes_file" \
               --target main
           fi
 

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -70,19 +70,23 @@ The workflow performs the release steps in order:
 4. Bumps `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and
    `package.json`, refreshes `src-tauri/Cargo.lock`, commits
    `release: vX.Y.Z`, and pushes to `main`.
-5. Runs `pnpm lint`, `pnpm test`, and `pnpm test:rust`.
-6. Builds the bundled Hermes runtime (`scripts/bundle-hermes-runtime.sh`):
+5. Generates a changelog from first-parent source commits since the previous
+   `release: v...` commit.
+6. Runs `pnpm lint`, `pnpm test`, and `pnpm test:rust`.
+7. Builds the bundled Hermes runtime (`scripts/bundle-hermes-runtime.sh`):
    the pinned hermes-agent checkout, a relocatable CPython, hash-verified
    Python deps, and the prebuilt dashboard UI, signed Mach-O by Mach-O and
    shipped under `Resources/native/hermes` so first launch needs no network
    install. Adds roughly 110 MB compressed to the DMG.
-7. Builds the `universal-apple-darwin` app and DMG with `tauri-action`.
-8. Signs with the Apple Developer ID cert, notarizes the app with Apple API key
+8. Builds the `universal-apple-darwin` app and DMG with `tauri-action`.
+9. Signs with the Apple Developer ID cert, notarizes the app with Apple API key
    credentials, and signs updater artifacts with the Ed25519 updater key.
-9. Submits the generated DMG itself to Apple notarization, staples the DMG
-   ticket, verifies Gatekeeper install assessment, then overwrites the
-   versioned DMG asset plus the stable download aliases in
-   `open-software-network/os-june-releases`.
+10. Submits the generated DMG itself to Apple notarization, staples the DMG
+    ticket, verifies Gatekeeper install assessment, then overwrites the
+    versioned DMG asset plus the stable download aliases in
+    `open-software-network/os-june-releases`.
+11. Publishes the generated changelog as the GitHub release notes and embeds it
+    in `latest.json` so the in-app updater prompt shows the same release notes.
 
 The app polls:
 

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -83,7 +83,8 @@ The Windows workflow performs the release steps in order:
     bundled Hermes launcher and Python runtime.
 11. Uploads the NSIS output as a workflow artifact.
 12. Uploads Windows release assets and merges `windows-x86_64` into
-    `latest.json` without removing macOS updater entries.
+    `latest.json` without removing macOS updater entries or the generated
+    release changelog.
 
 ## Validation
 

--- a/scripts/generate-release-changelog.mjs
+++ b/scripts/generate-release-changelog.mjs
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import process from "node:process";
+
+const RELEASE_SUBJECT_RE = /^release: v(\d+\.\d+\.\d+)(?:\b|[^0-9])/;
+const FIELD_SEPARATOR = "\x1f";
+const RECORD_SEPARATOR = "\x1e";
+
+export function parsePreviousReleaseLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  const [hash, subject] = trimmed.split(FIELD_SEPARATOR);
+  const match = RELEASE_SUBJECT_RE.exec(subject ?? "");
+  if (!hash || !match) return undefined;
+  return { hash, version: match[1] };
+}
+
+export function parseGitLogRecords(log) {
+  return log
+    .split(RECORD_SEPARATOR)
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [hash = "", subject = "", body = ""] =
+        record.split(FIELD_SEPARATOR);
+      return {
+        hash: hash.trim(),
+        subject: subject.trim(),
+        body: body.trim(),
+      };
+    })
+    .filter((entry) => entry.hash && entry.subject);
+}
+
+export function releaseNoteTitleForCommit(commit) {
+  const release = RELEASE_SUBJECT_RE.exec(commit.subject);
+  if (release) return undefined;
+
+  const merge = /^Merge pull request #(\d+) from .+/.exec(commit.subject);
+  if (merge) {
+    const title = commit.body
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    return title ? `${title} (#${merge[1]})` : undefined;
+  }
+
+  return commit.subject;
+}
+
+export function formatChangelog({ version, previousVersion, commits }) {
+  const lines = [`## June v${version}`, ""];
+  if (previousVersion) {
+    lines.push(`Changes since v${previousVersion}.`, "");
+  } else {
+    lines.push("Initial release changelog.", "");
+  }
+
+  const titles = commits
+    .map(releaseNoteTitleForCommit)
+    .filter((title) => title && !RELEASE_SUBJECT_RE.test(title));
+
+  lines.push("### Changes");
+  if (titles.length === 0) {
+    lines.push("- No source changes recorded since the previous release.");
+  } else {
+    for (const title of titles) {
+      lines.push(`- ${title}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function previousRelease() {
+  const output = git([
+    "log",
+    "--first-parent",
+    "--grep=^release: v[0-9]",
+    `--format=%H${FIELD_SEPARATOR}%s`,
+    "-n",
+    "1",
+    "HEAD",
+  ]);
+  return parsePreviousReleaseLine(output);
+}
+
+function commitsSince(hash) {
+  const range = hash ? `${hash}..HEAD` : "HEAD";
+  const output = git([
+    "log",
+    "--first-parent",
+    "--reverse",
+    `--format=%H${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%b${RECORD_SEPARATOR}`,
+    range,
+  ]);
+  return parseGitLogRecords(output);
+}
+
+async function main() {
+  const version = process.argv[2];
+  const outputPath = process.argv[3];
+  if (!version || !outputPath) {
+    throw new Error(
+      "Usage: node scripts/generate-release-changelog.mjs <version> <output-path>",
+    );
+  }
+
+  const release = previousRelease();
+  const changelog = formatChangelog({
+    version,
+    previousVersion: release?.version,
+    commits: commitsSince(release?.hash),
+  });
+  await writeFile(outputPath, changelog);
+  process.stdout.write(changelog);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/generate-release-changelog.mjs
+++ b/scripts/generate-release-changelog.mjs
@@ -15,6 +15,10 @@ export function parsePreviousReleaseLine(line) {
   return { hash, version: match[1] };
 }
 
+export function findPreviousRelease(log) {
+  return log.split("\n").map(parsePreviousReleaseLine).find(Boolean);
+}
+
 export function parseGitLogRecords(log) {
   return log
     .split(RECORD_SEPARATOR)
@@ -83,13 +87,10 @@ function previousRelease() {
   const output = git([
     "log",
     "--first-parent",
-    "--grep=^release: v[0-9]",
     `--format=%H${FIELD_SEPARATOR}%s`,
-    "-n",
-    "1",
     "HEAD",
   ]);
-  return parsePreviousReleaseLine(output);
+  return findPreviousRelease(output);
 }
 
 function commitsSince(hash) {

--- a/src/test/release-changelog.test.mjs
+++ b/src/test/release-changelog.test.mjs
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatChangelog,
+  parseGitLogRecords,
+  parsePreviousReleaseLine,
+  releaseNoteTitleForCommit,
+} from "../../scripts/generate-release-changelog.mjs";
+
+const field = "\x1f";
+const record = "\x1e";
+
+describe("parsePreviousReleaseLine", () => {
+  it("extracts the release commit and version from the latest release subject", () => {
+    expect(
+      parsePreviousReleaseLine(`64be701${field}release: v0.0.22 (#508)`),
+    ).toEqual({
+      hash: "64be701",
+      version: "0.0.22",
+    });
+  });
+
+  it("ignores unrelated commits", () => {
+    expect(
+      parsePreviousReleaseLine(`b1fc9eb${field}Fix system audio (#511)`),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseGitLogRecords", () => {
+  it("parses git log records separated by control characters", () => {
+    expect(
+      parseGitLogRecords(
+        [
+          `abc123${field}Fix updater notes (#1)${field}`,
+          `def456${field}Merge pull request #2 from branch${field}Add the feature`,
+        ].join(record),
+      ),
+    ).toEqual([
+      {
+        hash: "abc123",
+        subject: "Fix updater notes (#1)",
+        body: "",
+      },
+      {
+        hash: "def456",
+        subject: "Merge pull request #2 from branch",
+        body: "Add the feature",
+      },
+    ]);
+  });
+});
+
+describe("releaseNoteTitleForCommit", () => {
+  it("uses squash commit subjects directly", () => {
+    expect(
+      releaseNoteTitleForCommit({
+        hash: "abc123",
+        subject: "Fix system audio permission refresh (#511)",
+        body: "",
+      }),
+    ).toBe("Fix system audio permission refresh (#511)");
+  });
+
+  it("uses merge commit body titles with the PR number", () => {
+    expect(
+      releaseNoteTitleForCommit({
+        hash: "abc123",
+        subject: "Merge pull request #476 from open-software-network/topic",
+        body: "\nAllow short onboarding practice replies\n",
+      }),
+    ).toBe("Allow short onboarding practice replies (#476)");
+  });
+
+  it("omits release commits", () => {
+    expect(
+      releaseNoteTitleForCommit({
+        hash: "abc123",
+        subject: "release: v0.0.22 (#508)",
+        body: "",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("formatChangelog", () => {
+  it("formats a release changelog from commit titles", () => {
+    expect(
+      formatChangelog({
+        version: "0.0.23",
+        previousVersion: "0.0.22",
+        commits: [
+          {
+            hash: "b1fc9eb",
+            subject: "Fix system audio permission refresh (#511)",
+            body: "",
+          },
+          {
+            hash: "d164dc7",
+            subject: "Update Conductor env setup (#512)",
+            body: "",
+          },
+        ],
+      }),
+    ).toBe(
+      [
+        "## June v0.0.23",
+        "",
+        "Changes since v0.0.22.",
+        "",
+        "### Changes",
+        "- Fix system audio permission refresh (#511)",
+        "- Update Conductor env setup (#512)",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps releases with no source changes explicit", () => {
+    expect(
+      formatChangelog({
+        version: "0.0.23",
+        previousVersion: "0.0.22",
+        commits: [],
+      }),
+    ).toContain("- No source changes recorded since the previous release.");
+  });
+});

--- a/src/test/release-changelog.test.mjs
+++ b/src/test/release-changelog.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  findPreviousRelease,
   formatChangelog,
   parseGitLogRecords,
   parsePreviousReleaseLine,
@@ -23,6 +24,20 @@ describe("parsePreviousReleaseLine", () => {
     expect(
       parsePreviousReleaseLine(`b1fc9eb${field}Fix system audio (#511)`),
     ).toBeUndefined();
+  });
+});
+
+describe("findPreviousRelease", () => {
+  it("ignores newer non-release subjects even if they mention release commits elsewhere", () => {
+    const log = [
+      `newer${field}Document release: v0.0.22 rollback notes`,
+      `older${field}release: v0.0.22 (#508)`,
+    ].join("\n");
+
+    expect(findPreviousRelease(log)).toEqual({
+      hash: "older",
+      version: "0.0.22",
+    });
   });
 });
 


### PR DESCRIPTION
## Task

Generate a changelog for each production desktop release.

## What changed

- Added `scripts/generate-release-changelog.mjs` to build markdown release notes from first-parent commits since the previous `release: v...` commit.
- Wired `production-desktop-release` to generate the changelog once, embed it in `latest.json`, and use it as the GitHub release body through `gh release create/edit --notes-file`.
- Added unit coverage for release commit parsing, merge commit title extraction, release commit filtering, and empty-release fallback.
- Updated macOS and Windows release runbooks to describe the generated changelog behavior.

## Why

The release workflow previously published a fixed note for every release. The new flow gives each release a real changelog in both the public GitHub release and the in-app updater notes.

## Validation

- `pnpm exec vitest run src/test/release-changelog.test.mjs`
- `pnpm lint`
- `pnpm test`
- `pnpm exec prettier --check scripts/generate-release-changelog.mjs src/test/release-changelog.test.mjs .github/workflows/production-desktop-dmg.yml docs/release-macos.md docs/release-windows.md`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/production-desktop-dmg.yml"); YAML.load_file(".github/workflows/production-desktop-windows.yml")'`
- `node scripts/generate-release-changelog.mjs 0.0.24 /tmp/os-june-release-changelog.md`

## Live QA

Skipped. This is a release workflow, script, and docs change with no user-visible app workflow to click through locally.

## Known gaps

- The production release workflow itself was not executed locally because it requires production signing and release secrets.
