### PR TITLE
Clarify Free plan usage label

### DIFF
--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 
-const FREE_PLAN_NAME = "Free";
+const FREE_PLAN_NAME = "Free plan";
 const FREE_PLAN_CREDITS = 5000;
 
 type Props = {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -439,7 +439,7 @@ describe("AppSettings", () => {
       screen.getByRole("heading", { name: "Billing" }),
     ).toBeInTheDocument();
     expect(screen.getByText("64% remaining")).toBeInTheDocument();
-    expect(screen.getByText("Usage remaining on Free")).toBeInTheDocument();
+    expect(screen.getByText("Usage remaining on Free plan")).toBeInTheDocument();
     expect(
       screen.getByRole("progressbar", { name: "Usage remaining" }),
     ).toHaveAttribute("aria-valuenow", "64");
@@ -512,7 +512,7 @@ describe("AppSettings", () => {
     await user.click(screen.getByRole("tab", { name: "Billing" }));
 
     expect(screen.getByText("97% remaining")).toBeInTheDocument();
-    expect(screen.getByText("Usage remaining on Free")).toBeInTheDocument();
+    expect(screen.getByText("Usage remaining on Free plan")).toBeInTheDocument();
     expect(
       screen.getByRole("progressbar", { name: "Usage remaining" }),
     ).toHaveAttribute("aria-valuenow", "97");


### PR DESCRIPTION
## Summary
- Change the Free billing usage label from `Usage remaining on Free` to `Usage remaining on Free plan`.
- Update Billing settings tests to assert the clearer copy in both direct percentage and Free grant fallback states.

## Testing
- `pnpm exec vitest run src/test/app-settings.test.tsx`
- `pnpm lint`
- `git diff --check`

## Live walkthrough
Skipped: this is a copy-only Billing settings label change covered by focused UI assertions.
