### PR TITLE
Disable production native context menus

### DIFF
--- a/src/lib/native-context-menu.ts
+++ b/src/lib/native-context-menu.ts
@@ -8,7 +8,7 @@ type NativeContextMenuGuardOptions = {
 
 export function installNativeContextMenuGuard({
   isDev = import.meta.env.DEV,
-  allowEditableFields = true,
+  allowEditableFields = false,
 }: NativeContextMenuGuardOptions = {}) {
   if (isDev) {
     return () => {};

--- a/src/test/native-context-menu.test.ts
+++ b/src/test/native-context-menu.test.ts
@@ -47,29 +47,29 @@ describe("native context menu guard", () => {
     button.remove();
   });
 
-  it("allows editable-field native context menus", () => {
+  it("suppresses editable-field native context menus by default", () => {
     const cleanup = installNativeContextMenuGuard({ isDev: false });
     const input = document.createElement("input");
     document.body.append(input);
 
     const event = dispatchContextMenu(input);
 
-    expect(event.defaultPrevented).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
     cleanup();
     input.remove();
   });
 
-  it("suppresses editable-field native context menus when editable fields are not allowed", () => {
+  it("allows editable-field native context menus when explicitly enabled", () => {
     const cleanup = installNativeContextMenuGuard({
       isDev: false,
-      allowEditableFields: false,
+      allowEditableFields: true,
     });
     const input = document.createElement("input");
     document.body.append(input);
 
     const event = dispatchContextMenu(input);
 
-    expect(event.defaultPrevented).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
     cleanup();
     input.remove();
   });


### PR DESCRIPTION
## Summary

- Disable native context menus in production by default, including editable fields where WebView menus can expose Inspect Element.
- Keep app-owned context menus and development inspection behavior intact.

## Validation

- pnpm test src/test/native-context-menu.test.ts
- pnpm run lint

## Security and release checklist

- [x] No secrets, local .env values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.