### PR TITLE
release: v0.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "os-june",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "os-june"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "os-june"
-version = "0.0.23"
+version = "0.0.24"
 description = "June"
 authors = ["Open Software Network"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "June",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "identifier": "co.opensoftware.june",
   "build": {
     "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",


### PR DESCRIPTION
Bumps desktop release version files to v0.0.24.

The release artifacts were already published by production-desktop-release run 28446604481. Merge this PR to record the version bump on main and unblock the matching Windows production release.