### PR TITLE
[codex] Add June website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
   <img alt="Built with Tauri" src="https://img.shields.io/badge/desktop-Tauri-orange">
 </p>
 
+<p align="center">
+  <a href="https://opensoftware.co/june">opensoftware.co/june</a>
+</p>
+
 June is an open source desktop app for turning spoken work into useful work. It
 records reliable local audio, generates editable meeting notes, pastes cleaned
 dictation into any app, and runs a local agent that can help with files,


### PR DESCRIPTION
## Summary

- Adds a centered link to `https://opensoftware.co/june` near the top of the README, above the introductory June description.

## Validation

- `pnpm exec prettier --check README.md`

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (No security-sensitive changes.)
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. (No such changes.)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (No backend changes.)
- [x] User-facing copy follows the repo UI conventions.
