### PR TITLE
Fix issue report attachments

### DIFF
--- a/june-api/crates/providers/src/issue_reports.rs
+++ b/june-api/crates/providers/src/issue_reports.rs
@@ -118,7 +118,9 @@ impl OsPlatformIssueReportSink {
                     continue;
                 }
             };
-            let form = reqwest::multipart::Form::new().part("file", part);
+            let form = reqwest::multipart::Form::new()
+                .text("is_public", "true")
+                .part("file", part);
             let uploaded: Result<FellowEnvelope<FellowFile>, _> = async {
                 self.http
                     .post(format!("{}/v1/files", self.api_url))
@@ -1152,7 +1154,7 @@ mod issue_title_tests {
 mod os_platform_tests {
     use super::*;
     use june_domain::UserId;
-    use wiremock::matchers::{body_partial_json, method, path};
+    use wiremock::matchers::{body_partial_json, body_string_contains, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn report() -> IssueReport {
@@ -1349,6 +1351,8 @@ mod os_platform_tests {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/files"))
+            .and(body_string_contains(r#"name="is_public""#))
+            .and(body_string_contains("true"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "data": { "id": "fil_1" },
                 "success": true,


### PR DESCRIPTION
Closes JUN-148

## What changed

- Mark issue report attachment uploads to os-platform as public files by sending `is_public=true` to `POST /v1/files`.
- Extended the os-platform issue report sink regression test to verify the public upload field is present before the returned file id is attached to the Issue create request.

## Why

Issue reports with screenshots/files were uploaded successfully, but os-platform rejects private file ids when creating Issues. Since June files these reports as tracker Issues and attaches the file ids during Issue creation, those uploaded files must be public attachments.

## Validation

- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path june-api/Cargo.toml -p june-providers os_platform_sink_files_a_bug_tagged_issue_with_attachments --locked`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path june-api/Cargo.toml -p june-providers --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`

## Live walkthrough

Skipped: this is a backend-only `june-api` provider fix with no UI layout or desktop interaction change. The production os-platform issue API requires `OS_PLATFORM_API_KEY`, which was not set locally, so I used the public issue metadata plus local os-platform code inspection to confirm the `FileNotPublic` failure path.

## Known gaps

- I did not submit a live production issue report, to avoid creating tracker data and because the local environment does not have `OS_PLATFORM_API_KEY`.
