### PR TITLE
Show failed transcript turn evidence

### DIFF
--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -940,8 +940,7 @@ function orderedVisibleSourceTranscripts(
   return (note.sourceTranscripts ?? [])
     .filter((turn) => {
       if (turn.text.trim()) return true;
-      if (note.processingStatus === "failed" || !turn.lastError) return false;
-      return true;
+      return Boolean(turn.lastError);
     })
     .map((turn, index) => ({ turn, index }))
     .sort(compareSourceTranscriptOrder)

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -407,7 +407,7 @@ describe("NoteEditor", () => {
     expect(screen.getByText("0:15-0:18")).toBeInTheDocument();
   });
 
-  it("does not render whole-note failures as transcript turns", () => {
+  it("renders whole-note source failures as transcript evidence", () => {
     render(
       <NoteEditor
         {...props}
@@ -438,7 +438,12 @@ describe("NoteEditor", () => {
         "Microphone: No speech detected. Try speaking louder or moving closer to the microphone.",
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText("0:15-0:18")).not.toBeInTheDocument();
+    expect(screen.getByText("0:15-0:18")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No speech detected. Try speaking louder or moving closer to the microphone.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("requests tab change when Transcription is selected", async () => {


### PR DESCRIPTION
## Issue

Closes JUN-134

JUN-134 reports a failed meeting note that stayed as an empty `Untitled note` with no transcript or generated note content. The source-turn pipeline can persist failed turn rows with source, timing, and safe failure text, but the Transcription tab hid those rows whenever the whole note was marked `failed`, leaving the tab at a dead-end empty state.

## What changed

- Keep source transcript rows visible when they have either transcript text or a saved `lastError`, including notes whose overall `processingStatus` is `failed`.
- Update the NoteEditor regression test so a failed whole-note recording still shows the timestamped source failure evidence.

## Why

Failed recordings should remain inspectable when the backend has persisted per-source/turn evidence. This lets the user see which source failed and when, while preserving the existing retry banner and friendly error copy.

## Validation

- `pnpm test -- src/test/note-editor.test.tsx` - 29 tests passed.
- `pnpm run lint` - passed.
- Live QA via Vite component harness: PASS. A failed `Untitled note` on the Transcription tab showed the saved retry banner, enabled Retry button, Microphone source row, `0:15-0:18` timestamp, and friendly source failure message; `No transcript was produced.` was absent.

## Live QA artifacts

- Screenshot: `.tmp/qa-recordings/jun-134-failed-note-transcription.png`
- Raw video: `.tmp/qa-recordings/81222da4eaa6513bac504ef7a546f815.webm`
- Compressed video: `.tmp/qa-recordings/81222da4eaa6513bac504ef7a546f815.compressed.mp4`

QA video (os-platform): https://app.opensoftware.co/api/v1/files/fil_suElMk39oQag/download

## Known gaps

- The live walkthrough used a Vite component harness seeded with the failed-note state. It did not perform real microphone/system-audio capture or provider transcription.
