### PR TITLE
Unblock Windows release publishing without Authenticode secrets

### DIFF
--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -74,6 +74,7 @@ jobs:
           "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Validate release secrets
+        id: release-secrets
         shell: pwsh
         env:
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
@@ -88,8 +89,6 @@ jobs:
         run: |
           $missing = 0
           $required = @(
-            "WINDOWS_CERTIFICATE",
-            "WINDOWS_CERTIFICATE_PASSWORD",
             "TAURI_SIGNING_PRIVATE_KEY",
             "RELEASE_APP_ID",
             "RELEASE_APP_PRIVATE_KEY",
@@ -105,6 +104,22 @@ jobs:
               Write-Host "::error::$name is required for a production Windows release."
               $missing = 1
             }
+          }
+
+          $hasWindowsCertificate = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)
+          $hasWindowsCertificatePassword = -not [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)
+          if ($hasWindowsCertificate -xor $hasWindowsCertificatePassword) {
+            Write-Host "::error::WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD must be configured together for Authenticode signing."
+            $missing = 1
+          }
+
+          if ($hasWindowsCertificate -and $hasWindowsCertificatePassword) {
+            "authenticode=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "WINDOWS_AUTHENTICODE_ENABLED=1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          } else {
+            Write-Host "::warning::WINDOWS_CERTIFICATE and WINDOWS_CERTIFICATE_PASSWORD are not configured; publishing an unsigned Windows installer."
+            "authenticode=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "WINDOWS_AUTHENTICODE_ENABLED=0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           }
 
           exit $missing
@@ -159,6 +174,7 @@ jobs:
           "RELEASE_MANIFEST_PATH=$manifestPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Write Windows signing certificate
+        if: steps.release-secrets.outputs.authenticode == 'true'
         shell: pwsh
         env:
           WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
@@ -177,6 +193,7 @@ jobs:
         run: ./scripts/bundle-hermes-runtime-windows.ps1
 
       - name: Sign bundled Hermes runtime
+        if: steps.release-secrets.outputs.authenticode == 'true'
         shell: pwsh
         env:
           WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
@@ -210,7 +227,10 @@ jobs:
 
       - name: Verify Windows signatures and payload
         shell: pwsh
+        env:
+          WINDOWS_AUTHENTICODE_ENABLED: ${{ steps.release-secrets.outputs.authenticode }}
         run: |
+          $authenticodeEnabled = $env:WINDOWS_AUTHENTICODE_ENABLED -eq "true"
           $exe = Get-Item "src-tauri/target/release/os-june.exe" -ErrorAction Stop
           $setup = Get-ChildItem "src-tauri/target/release/bundle/nsis" -Filter "*-setup.exe" | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
           if ($null -eq $setup) {
@@ -223,8 +243,11 @@ jobs:
               throw "$($file.FullName) is empty."
             }
             $signature = Get-AuthenticodeSignature -FilePath $file.FullName
-            if ($signature.Status -ne "Valid") {
+            if ($authenticodeEnabled -and $signature.Status -ne "Valid") {
               throw "Authenticode signature is $($signature.Status) for $($file.FullName). $($signature.StatusMessage)"
+            }
+            if (-not $authenticodeEnabled) {
+              Write-Host "::warning::Authenticode signature check skipped for $($file.FullName). Status: $($signature.Status)."
             }
           }
 
@@ -312,10 +335,16 @@ jobs:
       - name: Summary
         shell: pwsh
         run: |
+          $authenticode = if ($env:WINDOWS_AUTHENTICODE_ENABLED -eq "1") {
+            "signed"
+          } else {
+            "not signed (certificate secrets not configured)"
+          }
           @(
             "### Production Windows release",
             "- Version: ``$env:VERSION``",
             "- Release repo: ``open-software-network/os-june-releases``",
             "- Marketing download: ``https://github.com/open-software-network/os-june-releases/releases/latest/download/June_x64-setup.exe``",
-            "- Updater platform key: ``windows-x86_64``"
+            "- Updater platform key: ``windows-x86_64``",
+            "- Authenticode: ``$authenticode``"
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/README.md
+++ b/README.md
@@ -280,8 +280,9 @@ Architecture and product notes:
 ## Release notes
 
 Production desktop releases are cut from GitHub Actions. macOS produces signed
-and notarized DMGs with Tauri updater artifacts. Windows produces signed NSIS
-installers and merges Windows updater metadata into the shared release.
+and notarized DMGs with Tauri updater artifacts. Windows produces NSIS
+installers, Authenticode-signs them when certificate secrets are configured, and
+merges Windows updater metadata into the shared release.
 
 Start with:
 

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -1,9 +1,10 @@
 # Releasing June for Windows
 
 June ships Windows builds as an NSIS installer. The production Windows release
-workflow builds from `main`, signs the app executable and installer with
-Authenticode, signs updater artifacts with the Tauri updater key, and attaches
-Windows assets to the existing `open-software-network/os-june-releases` release.
+workflow builds from `main`, signs updater artifacts with the Tauri updater key,
+signs the app executable and installer with Authenticode when certificate
+secrets are configured, and attaches Windows assets to the existing
+`open-software-network/os-june-releases` release.
 
 ## Windows support
 
@@ -25,9 +26,10 @@ Create or confirm these before cutting the first Windows release:
 - Release GitHub App installed on `os-june` and `os-june-releases` with
   `contents:write`, exposed as `RELEASE_APP_ID` and
   `RELEASE_APP_PRIVATE_KEY`.
-- Authenticode signing certificate exported as a password-protected PFX. Store
-  the base64-encoded PFX in `WINDOWS_CERTIFICATE` and its password in
-  `WINDOWS_CERTIFICATE_PASSWORD`.
+- Optional Authenticode signing certificate exported as a password-protected
+  PFX. Store the base64-encoded PFX in `WINDOWS_CERTIFICATE` and its password in
+  `WINDOWS_CERTIFICATE_PASSWORD`. If both are absent, the workflow publishes an
+  unsigned NSIS installer and records a warning in the run summary.
 - Optional `WINDOWS_SIGNING_TIMESTAMP_URL` if the default
   `http://timestamp.digicert.com` should be overridden.
 - Optional `WINDOWS_SIGNTOOL_PATH` if the runner cannot discover
@@ -39,8 +41,9 @@ Create or confirm these before cutting the first Windows release:
   `PRODUCTION_JUNE_API_URL`.
 
 Keep the Authenticode certificate separate from the Tauri updater key. The
-certificate establishes the Windows publisher signature. The updater key signs
-the update artifact that Tauri verifies before installation.
+certificate establishes the Windows publisher signature when configured. The
+updater key signs the update artifact that Tauri verifies before installation
+and is required for every Windows release.
 
 ## Cutting a production Windows release
 
@@ -62,8 +65,8 @@ GitHub Actions -> production-desktop-windows -> Run workflow -> version X.Y.Z
 The Windows workflow performs the release steps in order:
 
 1. Checks out `main`.
-2. Validates required Windows signing, updater, release, and production runtime
-   secrets.
+2. Validates required updater, release, and production runtime secrets, then
+   detects whether Authenticode signing is configured.
 3. Verifies `package.json`, `src-tauri/tauri.conf.json`, and
    `src-tauri/Cargo.toml` already match the requested version.
 4. Verifies release `vX.Y.Z` and its existing `latest.json` exist in
@@ -73,14 +76,15 @@ The Windows workflow performs the release steps in order:
    `scripts/bundle-hermes-runtime-windows.ps1`: the pinned hermes-agent
    checkout, a relocatable CPython, Python deps, prebuilt dashboard UI, and a
    relocatable `bin/hermes.exe` launcher.
-7. Authenticode-signs the bundled Hermes `.exe`, `.dll`, and `.pyd` binaries.
+7. Authenticode-signs the bundled Hermes `.exe`, `.dll`, and `.pyd` binaries
+   when certificate secrets are configured.
 8. Builds the Windows NSIS installer with production OS Accounts and June API
    configuration embedded as fallback runtime config.
 9. Signs the app executable and NSIS installer through
-   `scripts/windows-sign.ps1`.
-10. Verifies Authenticode status for the executable and installer, checks the
-    updater signature file exists, and inspects the NSIS payload, including the
-    bundled Hermes launcher and Python runtime.
+   `scripts/windows-sign.ps1` when certificate secrets are configured.
+10. Verifies Authenticode status for the executable and installer when signing
+    is configured, checks the updater signature file exists, and inspects the
+    NSIS payload, including the bundled Hermes launcher and Python runtime.
 11. Uploads the NSIS output as a workflow artifact.
 12. Uploads Windows release assets and merges `windows-x86_64` into
     `latest.json` without removing macOS updater entries or the generated
@@ -99,16 +103,18 @@ Start-Process -FilePath $installer -ArgumentList "/S" -Wait
 Start-Process "$env:LOCALAPPDATA\June\June.exe"
 ```
 
-Confirm the signature status is `Valid`, the publisher is Open Software Network,
-the app launches as June, the sign-in copy mentions recording and notes without
-dictation, and the bundled agent starts on a clean VM with no Python installed.
-Record from the microphone and generate a note against production June API
-before linking the installer publicly.
+If Authenticode signing was enabled, confirm the signature status is `Valid` and
+the publisher is Open Software Network. If signing was not enabled, expect
+Windows to report an unsigned installer and do not describe it as signed. In
+both cases, confirm the app launches as June, the sign-in copy mentions
+recording and notes without dictation, and the bundled agent starts on a clean VM
+with no Python installed. Record from the microphone and generate a note against
+production June API before linking the installer publicly.
 
 For updater validation after a second Windows release, install an older
 updater-capable Windows build, run **June -> Check for updates...**, confirm the
 prompt shows the new version, install, and verify the app exits for the Windows
 installer handoff and relaunches cleanly on the new version.
 
-If Authenticode validation, updater signature validation, sign-in, recording, or
-update installation fails, do not promote the Windows installer.
+If expected Authenticode validation, updater signature validation, sign-in,
+recording, or update installation fails, do not promote the Windows installer.


### PR DESCRIPTION
Closes JUN-154

## What changed
- Treat Windows Authenticode certificate secrets as an optional pair in `production-desktop-windows`.
- Skip certificate writing, bundled Hermes Authenticode signing, and Authenticode verification when the certificate pair is absent.
- Keep Tauri updater signing, release token, runtime config, NSIS payload verification, artifact upload, release asset upload, and `windows-x86_64` `latest.json` updates required.
- Update the Windows release runbook and README so unsigned Windows launches are documented accurately.

## Why
The latest `production-desktop-windows` run for v0.0.24 failed because `WINDOWS_CERTIFICATE` and `WINDOWS_CERTIFICATE_PASSWORD` are not configured. The latest release has no Windows assets and `latest.json` has only Darwin updater entries. The signing script already supports skipping Authenticode when certificate material is absent, but the workflow hard-failed before that path could run.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/production-desktop-windows.yml"); puts "workflow yaml ok"'`
- `actionlint .github/workflows/production-desktop-windows.yml`
- `pnpm exec prettier --check README.md docs/release-windows.md .github/workflows/production-desktop-windows.yml`
- `pnpm lint`

## Skipped checks and gaps
- `pnpm format` still fails on pre-existing unrelated formatting issues in `src/components/account/AccountGate.tsx`, `src/components/note-editor/NoteFailureBanner.tsx`, `src/test/agent-workspace.test.tsx`, and `src-tauri/tauri.conf.json`.
- Live app walkthrough skipped because this changes release automation and docs only.
- I did not run the production Windows workflow from this PR. After merge, run `production-desktop-windows` for version `0.0.24` to publish `June_x64-setup.exe` and merge the Windows updater metadata. If the Authenticode secrets are still absent, the installer will be unsigned but Tauri updater-signed.
