### PR TITLE
Add June community links

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -571,6 +571,14 @@ pub fn june_open_verify_page() -> Result<(), AppError> {
     crate::os_accounts::open_in_browser(&crate::june_api::verify_url())
 }
 
+const JUNE_COMMUNITY_URL: &str = "https://t.me/osjune";
+
+/// Opens the June Telegram community in the default browser.
+#[tauri::command]
+pub fn june_open_community_page() -> Result<(), AppError> {
+    crate::os_accounts::open_in_browser(JUNE_COMMUNITY_URL)
+}
+
 #[tauri::command]
 pub async fn open_privacy_settings(request: OpenPrivacySettingsRequest) -> Result<(), AppError> {
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -197,6 +197,7 @@ pub fn run() {
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,
             commands::june_open_verify_page,
+            commands::june_open_community_page,
             commands::start_recording,
             commands::pause_recording,
             commands::resume_recording,

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -130,7 +130,7 @@ export function SignInStep({
         ))}
       </ul>
       <p className="onboarding-community">
-        Meet other builders in the{" "}
+        Join us in the{" "}
         <button
           type="button"
           className="onboarding-community-link"

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -4,7 +4,11 @@ import { IconLock } from "central-icons/IconLock";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSparkle } from "central-icons/IconSparkle";
 import { isMacLikePlatform } from "../../../lib/platform";
-import { osAccountsCancelLogin, osAccountsLogin } from "../../../lib/tauri";
+import {
+  juneOpenCommunityPage,
+  osAccountsCancelLogin,
+  osAccountsLogin,
+} from "../../../lib/tauri";
 import type { AccountStatus } from "../../../lib/tauri";
 import { OsMark } from "../../account/AccountGate";
 import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
@@ -125,6 +129,17 @@ export function SignInStep({
           </li>
         ))}
       </ul>
+      <p className="onboarding-community">
+        Meet other builders in the{" "}
+        <button
+          type="button"
+          className="onboarding-community-link"
+          onClick={() => void juneOpenCommunityPage().catch(() => undefined)}
+        >
+          June community on Telegram
+        </button>
+        .
+      </p>
       {account.configured ? (
         <div className="welcome-providers">
           {busy ? (

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1258,7 +1258,7 @@ export function AppSettings({
                   <div className="settings-row-info">
                     <h3 className="settings-row-title">Community</h3>
                     <p className="settings-row-description">
-                      Join the June community on Telegram at{" "}
+                      Join us in the June community on Telegram at{" "}
                       {JUNE_COMMUNITY_URL.replace("https://", "")}.
                     </p>
                   </div>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -11,11 +11,13 @@ import { IconTelevision } from "central-icons/IconTelevision";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import {
+  JUNE_COMMUNITY_URL,
   dictationHelperCommand,
   dictationSettings,
   listVeniceModels,
   localAudioFileSrc,
   providerModelSettings,
+  juneOpenCommunityPage,
   juneOpenVerifyPage,
   setDictationLanguage,
   setDictationMicrophone,
@@ -1251,6 +1253,27 @@ export function AppSettings({
                     </div>
                   </div>
                 ) : null}
+
+                <div className="settings-row">
+                  <div className="settings-row-info">
+                    <h3 className="settings-row-title">Community</h3>
+                    <p className="settings-row-description">
+                      Join the June community on Telegram at{" "}
+                      {JUNE_COMMUNITY_URL.replace("https://", "")}.
+                    </p>
+                  </div>
+                  <div className="settings-row-control">
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      onClick={() =>
+                        void juneOpenCommunityPage().catch(() => undefined)
+                      }
+                    >
+                      Join community
+                    </button>
+                  </div>
+                </div>
 
                 <div className="settings-row">
                   <div className="settings-row-info">

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -649,11 +649,19 @@ export async function bootstrapApp() {
   return invoke<BootstrapResponse>("bootstrap_app");
 }
 
+export const JUNE_COMMUNITY_URL = "https://t.me/osjune";
+
 /** Opens the june-api /verify page (attestation, routing, retention) in
  * the default browser. Routed through Rust because the webview drops
  * target="_blank" anchors. */
 export async function juneOpenVerifyPage() {
   return invoke<void>("june_open_verify_page");
+}
+
+/** Opens the June community in the default browser. Routed through Rust for
+ * the same target="_blank" reliability reason as the verify page. */
+export async function juneOpenCommunityPage() {
+  return invoke<void>("june_open_community_page");
 }
 
 export async function createNote(folderId?: string) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -15156,6 +15156,7 @@ input:focus-visible,
  * shouldn't stretch with it — keep them in a centered, button-width column. */
 .welcome-card-intro .welcome-providers,
 .welcome-card-intro .welcome-status,
+.welcome-card-intro .onboarding-community,
 .welcome-card-intro .welcome-terms {
   width: 100%;
   max-width: 320px;
@@ -15409,6 +15410,34 @@ input:focus-visible,
   line-height: 1.5;
   color: var(--muted-foreground);
   text-wrap: pretty;
+}
+
+.onboarding-community {
+  margin: var(--sp-1) 0 0;
+  padding: var(--sp-3) var(--sp-4);
+  border: 1px solid color-mix(in oklch, var(--brand) 18%, var(--border));
+  border-radius: var(--r-lg);
+  background: color-mix(in oklch, var(--warm-soft) 34%, var(--card));
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  text-align: center;
+}
+
+.onboarding-community-link {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  font: inherit;
+  font-weight: 500;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.onboarding-community-link:hover {
+  color: var(--warm-strong);
 }
 
 .onboarding-skip {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -46,12 +46,14 @@ const mocks = vi.hoisted(() => ({
   createDictionaryEntry: vi.fn(),
   updateDictionaryEntry: vi.fn(),
   deleteDictionaryEntry: vi.fn(),
+  juneOpenCommunityPage: vi.fn(),
   juneOpenVerifyPage: vi.fn(),
   listen: vi.fn(),
   eventHandler: undefined as ((event: { payload: string }) => void) | undefined,
 }));
 
 vi.mock("../lib/tauri", () => ({
+  JUNE_COMMUNITY_URL: "https://t.me/osjune",
   dictationSettings: mocks.dictationSettings,
   dictationHelperCommand: mocks.dictationHelperCommand,
   localAudioFileSrc: mocks.localAudioFileSrc,
@@ -83,6 +85,7 @@ vi.mock("../lib/tauri", () => ({
   createDictionaryEntry: mocks.createDictionaryEntry,
   updateDictionaryEntry: mocks.updateDictionaryEntry,
   deleteDictionaryEntry: mocks.deleteDictionaryEntry,
+  juneOpenCommunityPage: mocks.juneOpenCommunityPage,
   juneOpenVerifyPage: mocks.juneOpenVerifyPage,
 }));
 
@@ -171,6 +174,7 @@ describe("AppSettings", () => {
       language,
     }));
     mocks.listDictionaryEntries.mockResolvedValue([]);
+    mocks.juneOpenCommunityPage.mockResolvedValue(undefined);
     mocks.juneOpenVerifyPage.mockResolvedValue(undefined);
     mocks.providerModelSettings.mockResolvedValue({
       settings: {
@@ -1816,6 +1820,30 @@ describe("AppSettings", () => {
       await screen.findByRole("button", { name: "Verify server" }),
     );
     expect(mocks.juneOpenVerifyPage).toHaveBeenCalledOnce();
+  });
+
+  it("opens the June community page from About through Rust", async () => {
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("tab", { name: "About" }));
+    expect(await screen.findByText("Community")).toBeInTheDocument();
+    expect(screen.getByText(/t\.me\/osjune/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Join community" }));
+
+    expect(mocks.juneOpenCommunityPage).toHaveBeenCalledOnce();
   });
 
   it("replays onboarding from About in dev builds", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   setDictationLanguage: vi.fn(),
   setDictationShortcut: vi.fn(),
   osAccountsLogin: vi.fn(),
+  juneOpenCommunityPage: vi.fn(),
   juneOpenVerifyPage: vi.fn(),
   osAccountsCancelLogin: vi.fn(),
   osAccountsOpenPortal: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock("../lib/tauri", () => ({
   setDictationLanguage: mocks.setDictationLanguage,
   setDictationShortcut: mocks.setDictationShortcut,
   osAccountsLogin: mocks.osAccountsLogin,
+  juneOpenCommunityPage: mocks.juneOpenCommunityPage,
   juneOpenVerifyPage: mocks.juneOpenVerifyPage,
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsOpenPortal: mocks.osAccountsOpenPortal,
@@ -142,6 +144,7 @@ describe("OnboardingFlow", () => {
     );
     mocks.openPrivacySettings.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
+    mocks.juneOpenCommunityPage.mockResolvedValue(undefined);
     mocks.osAccountsOpenPortal.mockResolvedValue(undefined);
     mocks.setDictationLanguage.mockResolvedValue(undefined);
     mocks.setDictationShortcut.mockResolvedValue(undefined);
@@ -418,6 +421,20 @@ describe("OnboardingFlow", () => {
 
     expect(mocks.osAccountsLogin).toHaveBeenCalledOnce();
     await waitFor(() => expect(onAccountChanged).toHaveBeenCalledWith(account));
+  });
+
+  it("opens the June community from the welcome step", async () => {
+    const user = userEvent.setup();
+    render(<OnboardingFlow {...flowProps({ account: signedOutAccount })} />);
+
+    await screen.findByRole("heading", { name: "Welcome to June" });
+    await user.click(
+      screen.getByRole("button", {
+        name: "June community on Telegram",
+      }),
+    );
+
+    expect(mocks.juneOpenCommunityPage).toHaveBeenCalledOnce();
   });
 
   it("shows Windows-accurate welcome copy", async () => {

--- a/src/test/tauri-contract.test.ts
+++ b/src/test/tauri-contract.test.ts
@@ -4,6 +4,7 @@ import {
   ensureHermesBridgeGateway,
   finishRecording,
   getNote,
+  juneOpenCommunityPage,
   recoverRecording,
   retryProcessing,
   startRecording,
@@ -86,5 +87,11 @@ describe("Tauri command contracts", () => {
     await ensureHermesBridgeGateway();
 
     expect(mocks.invoke).toHaveBeenCalledWith("ensure_hermes_bridge_gateway");
+  });
+
+  it("opens the June community through a dedicated command", async () => {
+    await juneOpenCommunityPage();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("june_open_community_page");
   });
 });


### PR DESCRIPTION
Closes JUN-149

## What changed
- Added a first-run welcome invite that opens the June Telegram community.
- Added a persistent Community row in Settings > About with the `t.me/osjune` link.
- Added a Rust-backed `june_open_community_page` command and frontend wrapper so the desktop app opens the link through the default browser.
- Unified the invite copy to "Join us in the June community on Telegram" across the onboarding welcome step and the Settings > About row.
- Covered onboarding, Settings, and Tauri wrapper behavior with focused tests.

## Why
New users should hear about the June community during their first sessions, and existing users need a durable place to find the link later.

## Validation
- `pnpm test -- src/test/onboarding.test.tsx src/test/app-settings.test.tsx src/test/tauri-contract.test.ts`
- `pnpm run lint`
- `pnpm exec prettier --check src/lib/tauri.ts src/components/onboarding/steps/SignInStep.tsx src/components/settings/AppSettings.tsx src/styles/app.css src/test/onboarding.test.tsx src/test/app-settings.test.tsx src/test/tauri-contract.test.ts`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`
- Copy update revalidated with `pnpm run lint` and `pnpm exec vitest run src/test/onboarding.test.tsx src/test/app-settings.test.tsx` (55 passed).

## Live QA
- PASS - Web-preview onboarding welcome shows "Join us in the June community on Telegram" and the link still invokes `june_open_community_page`.
- PASS - Web-preview Settings > About Community row shows "Join us in the June community on Telegram at t.me/osjune" and keeps the Join community button.
- QA video (os-platform), onboarding welcome + Settings > About with the updated copy: https://app.opensoftware.co/api/v1/files/fil_RaqLCPTtXSY0/download

## Gaps
- The in-app Browser backend was unavailable in this session, so live QA used headless Chrome via Playwright with a Tauri IPC shim.
- The external Telegram handoff was not opened during QA; the command invocation was intercepted to avoid leaving the app.
