### PR TITLE
Prompt feedback from app errors

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -59,6 +59,10 @@ import {
   type TabNav,
 } from "./tabs/tabs";
 import { BreadcrumbBar } from "../components/ui/BreadcrumbBar";
+import {
+  ErrorBanner,
+  ErrorFeedbackNudge,
+} from "../components/ui/ErrorFeedbackNudge";
 import { IconNoteText } from "central-icons/IconNoteText";
 import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconProjects } from "central-icons/IconProjects";
@@ -116,6 +120,10 @@ import {
 } from "../lib/agent-events";
 import { notifyAgentSessionStatus } from "../lib/agent-notifications";
 import { messageFromError } from "../lib/errors";
+import {
+  ERROR_FEEDBACK_REQUESTED_EVENT,
+  errorFeedbackCategoryFromDetail,
+} from "../lib/error-feedback";
 import { parseDictationHelperEvent } from "../lib/dictation-events";
 import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
 import { upsertLiveTranscriptEvent } from "../lib/live-transcript-preview";
@@ -2128,6 +2136,27 @@ export function App() {
     }, 0);
   }
 
+  useEffect(() => {
+    function handleErrorFeedbackRequested(event: Event) {
+      const category =
+        event instanceof CustomEvent
+          ? errorFeedbackCategoryFromDetail(event.detail)
+          : "bug";
+      handleReportIssue(category);
+    }
+
+    window.addEventListener(
+      ERROR_FEEDBACK_REQUESTED_EVENT,
+      handleErrorFeedbackRequested,
+    );
+    return () => {
+      window.removeEventListener(
+        ERROR_FEEDBACK_REQUESTED_EVENT,
+        handleErrorFeedbackRequested,
+      );
+    };
+  });
+
   // "New session" from inside a project: same fresh-chat handshake, but the
   // session gets filed into the project once Hermes hands back its id.
   function handleNewAgentSessionInProject(folderId: string) {
@@ -2896,7 +2925,7 @@ export function App() {
               noteDetailScrollerActive ? "true" : undefined
             }
           >
-            {error ? <p className="error-banner">{error}</p> : null}
+            {error ? <ErrorBanner>{error}</ErrorBanner> : null}
             <div className="workspace">
               {activeView === "settings" ? (
                 <AppSettings
@@ -3587,6 +3616,7 @@ function UpdateStatusCard({
           ) : null}
         </div>
       ) : null}
+      {failed ? <ErrorFeedbackNudge className="update-error-feedback" /> : null}
     </aside>
   );
 }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -73,6 +73,7 @@ import { BackButton } from "../ui/BackButton";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
+import { ErrorFeedbackNudge, SettingsRowError } from "../ui/ErrorFeedbackNudge";
 import { HoverTip } from "../ui/HoverTip";
 import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
@@ -8295,7 +8296,7 @@ function SkillEditorPanel({
             </div>
           </div>
         </header>
-        {error ? <p className="settings-row-error">{error}</p> : null}
+        {error ? <SettingsRowError>{error}</SettingsRowError> : null}
         {loading ? (
           <div className="agent-loading">
             <Spinner />
@@ -8626,7 +8627,8 @@ function MessagingPlatformDetail({
         </header>
         {platform.errorMessage || platform.error_message ? (
           <div className="agent-platform-error">
-            {platform.errorMessage ?? platform.error_message}
+            <span>{platform.errorMessage ?? platform.error_message}</span>
+            <ErrorFeedbackNudge className="agent-platform-error-feedback" />
           </div>
         ) : null}
         {docsUrl ? (
@@ -9530,7 +9532,15 @@ export function SessionCompactDialog({
             className="agent-compact-error"
             tone="destructive"
             role="alert"
-            body={errorMessage ?? "Couldn't compact context. Please try again."}
+            body={
+              <>
+                <span>
+                  {errorMessage ??
+                    "Couldn't compact context. Please try again."}
+                </span>
+                <ErrorFeedbackNudge className="agent-inline-error-feedback" />
+              </>
+            }
           />
         ) : (
           <>
@@ -9593,7 +9603,10 @@ function AgentErrorBanner({
 }) {
   return (
     <div className="error-banner agent-error-banner" role="alert">
-      <p>{message}</p>
+      <div className="agent-error-banner-copy">
+        <p>{message}</p>
+        <ErrorFeedbackNudge className="agent-inline-error-feedback" />
+      </div>
       <div className="agent-error-banner-actions">
         {onRetry ? (
           <button type="button" onClick={onRetry}>

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -22,6 +22,7 @@ import {
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Dialog } from "../ui/Dialog";
 import { EmptyState } from "../ui/EmptyState";
+import { ErrorBanner } from "../ui/ErrorFeedbackNudge";
 import { KeycapShortcut } from "../shortcuts/KeycapShortcut";
 import {
   deleteDictationHistoryItem,
@@ -244,7 +245,7 @@ export function DictationHistoryView({
         </div>
       ) : null}
 
-      {error ? <p className="error-banner">{error}</p> : null}
+      {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
       {loading ? (
         <div className="folders-empty">

--- a/src/components/note-editor/NoteFailureBanner.tsx
+++ b/src/components/note-editor/NoteFailureBanner.tsx
@@ -1,6 +1,7 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { useState } from "react";
 import { isInsufficientCreditsMessage } from "../../lib/errors";
+import { ErrorFeedbackNudge } from "../ui/ErrorFeedbackNudge";
 
 export type FailureKind = "balance_low" | "generic";
 
@@ -44,7 +45,8 @@ function friendlyFailureSegment(message: string) {
   } else if (isInvalidJuneResponseMessage(body)) {
     friendly = "The processing service returned an invalid response.";
   } else if (normalized.includes("metering_provider_failed")) {
-    friendly = "Billing is temporarily unavailable. Please try again in a moment.";
+    friendly =
+      "Billing is temporarily unavailable. Please try again in a moment.";
   } else if (normalized.includes("upstream_provider_failed")) {
     friendly = "The transcription provider could not process this audio.";
   }
@@ -95,16 +97,19 @@ export function NoteFailureBanner({
 
   return (
     <aside className="note-failure-banner" role="alert" data-kind={kind}>
-      <p className="note-failure-message">
-        {isBalanceIssue
-          ? audioPreserved
-            ? `Your balance ran out. Your recording is saved locally, so ${topUpAction} and retry.`
-            : `Your balance is too low. ${topUpLabel} to continue.`
-          : (displayMessage ?? "June couldn't finish processing this note.")}
-        {!isBalanceIssue && audioPreserved
-          ? " Your recording is saved locally, so you can retry."
-          : null}
-      </p>
+      <div className="note-failure-copy">
+        <p className="note-failure-message">
+          {isBalanceIssue
+            ? audioPreserved
+              ? `Your balance ran out. Your recording is saved locally, so ${topUpAction} and retry.`
+              : `Your balance is too low. ${topUpLabel} to continue.`
+            : (displayMessage ?? "June couldn't finish processing this note.")}
+          {!isBalanceIssue && audioPreserved
+            ? " Your recording is saved locally, so you can retry."
+            : null}
+        </p>
+        <ErrorFeedbackNudge className="note-failure-feedback" />
+      </div>
       <div className="note-failure-actions">
         {isBalanceIssue ? (
           <button

--- a/src/components/routines/RoutineCreate.tsx
+++ b/src/components/routines/RoutineCreate.tsx
@@ -5,6 +5,7 @@ import {
   type ScheduleDraft,
 } from "../../lib/routine-schedule";
 import { BreadcrumbBar } from "../ui/BreadcrumbBar";
+import { ErrorBanner } from "../ui/ErrorFeedbackNudge";
 import { GrowingTextarea } from "./GrowingTextarea";
 import { RoutineModePicker } from "./RoutineModePicker";
 import { SchedulePicker } from "./SchedulePicker";
@@ -89,7 +90,7 @@ export function RoutineCreate({
           onChange={(event) => setName(event.currentTarget.value)}
         />
 
-        {error ? <p className="error-banner">{error}</p> : null}
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
         <div className="routine-detail-body">
           <section

--- a/src/components/routines/RoutineDetail.tsx
+++ b/src/components/routines/RoutineDetail.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../lib/routine-schedule";
 import type { HermesSessionInfo } from "../../lib/tauri";
 import { BreadcrumbBar } from "../ui/BreadcrumbBar";
+import { ErrorBanner } from "../ui/ErrorFeedbackNudge";
 import { HoverTip } from "../ui/HoverTip";
 import { Switch } from "../ui/Switch";
 import { userFacingFailureMessage } from "../note-editor/NoteFailureBanner";
@@ -284,7 +285,7 @@ export function RoutineDetail({
           ) : null}
         </div>
 
-        {error ? <p className="error-banner">{error}</p> : null}
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
         {failure ? (
           <div className="routine-detail-failure" role="status">
             <strong>Last run failed.</strong> {failure}

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -39,6 +39,7 @@ import {
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
 import type { HermesSessionInfo } from "../../lib/tauri";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
+import { ErrorBanner } from "../ui/ErrorFeedbackNudge";
 import { HoverTip } from "../ui/HoverTip";
 import { RoutineCreate, type RoutineCreateInput } from "./RoutineCreate";
 import { RoutineDetail } from "./RoutineDetail";
@@ -441,7 +442,7 @@ export function RoutinesView({
         </div>
       ) : null}
 
-      {error ? <p className="error-banner">{error}</p> : null}
+      {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
       {loading ? (
         <div className="folders-empty">

--- a/src/components/settings/AgentSettingsSection.tsx
+++ b/src/components/settings/AgentSettingsSection.tsx
@@ -35,6 +35,7 @@ import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS,
 } from "../../lib/hermes-messaging";
+import { SettingsRowError } from "../ui/ErrorFeedbackNudge";
 import { Switch } from "../ui/Switch";
 
 type AgentSettingsPanel = "skills" | "messaging" | "files";
@@ -386,7 +387,7 @@ export function AgentSettingsSection() {
             Files
           </button>
         </div>
-        {error ? <p className="settings-row-error">{error}</p> : null}
+        {error ? <SettingsRowError>{error}</SettingsRowError> : null}
         {panel === "skills" ? (
           <SkillsToolsPanel
             loading={loading}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../lib/tauri";
 import { LANGUAGE_OPTIONS, languageLabel } from "../../lib/dictation-languages";
 import { replayOnboarding } from "../../lib/onboarding";
+import { SettingsRowError } from "../ui/ErrorFeedbackNudge";
 import type {
   AccountStatus,
   DictationHelperEvent,
@@ -1571,7 +1572,7 @@ function ShortcutRow({
       <div className="settings-row-info">
         <h3 className="settings-row-title">{title}</h3>
         <p className="settings-row-description">{description}</p>
-        {error ? <p className="settings-row-error">{error}</p> : null}
+        {error ? <SettingsRowError>{error}</SettingsRowError> : null}
       </div>
       <div className="settings-row-control">
         <KeycapShortcut label={shortcut.label} capturing={capturing} />

--- a/src/components/settings/DictionarySettingsSection.tsx
+++ b/src/components/settings/DictionarySettingsSection.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../lib/tauri";
 import type { DictionaryEntryDto } from "../../lib/tauri";
 import { Dialog, DialogField } from "../ui/Dialog";
+import { SettingsRowError } from "../ui/ErrorFeedbackNudge";
 
 type Draft = {
   phrase: string;
@@ -165,7 +166,7 @@ export function DictionarySettingsSection() {
           </div>
         )}
       </div>
-      {error ? <p className="settings-row-error">{error}</p> : null}
+      {error ? <SettingsRowError>{error}</SettingsRowError> : null}
 
       <DictionaryEntryDialog
         open={dialogOpen}

--- a/src/components/settings/InstalledSkillsSection.tsx
+++ b/src/components/settings/InstalledSkillsSection.tsx
@@ -21,6 +21,7 @@ import {
   type HermesSkillInfo,
   type InstalledSkillsState,
 } from "../../lib/hermes-admin";
+import { ErrorFeedbackNudge, SettingsRowError } from "../ui/ErrorFeedbackNudge";
 import { Switch } from "../ui/Switch";
 
 /** Sentinel for the "all categories" filter chip. */
@@ -174,10 +175,10 @@ export function InstalledSkillsView({
         ) : null}
 
         {state.error && hasSkills ? (
-          <p className="settings-row-error installed-skills-inline-error">
+          <SettingsRowError className="installed-skills-inline-error">
             <IconExclamationCircle size={14} ariaHidden />
             {state.error}
-          </p>
+          </SettingsRowError>
         ) : null}
 
         <div className="installed-skills-body">
@@ -498,6 +499,7 @@ function ErrorState({
       </span>
       <p className="installed-skills-empty-title">Couldn't load skills</p>
       <p className="installed-skills-empty-description">{message}</p>
+      <ErrorFeedbackNudge className="installed-skills-error-feedback" />
       {retryable ? (
         <button
           type="button"

--- a/src/components/settings/MicTestControl.tsx
+++ b/src/components/settings/MicTestControl.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { SettingsRowError } from "../ui/ErrorFeedbackNudge";
 
 export type MicTestState = "idle" | "recording" | "ready" | "error";
 
@@ -34,7 +35,7 @@ export function MicTestControl({
       <div className="settings-row-info">
         <h3 className="settings-row-title">Mic test</h3>
         <p className="settings-row-description">{micTestDescription(state)}</p>
-        {error ? <p className="settings-row-error">{error}</p> : null}
+        {error ? <SettingsRowError>{error}</SettingsRowError> : null}
       </div>
       <div className="settings-row-control settings-mic-test-control">
         {state === "recording" ? (

--- a/src/components/settings/StyleSettingsSection.tsx
+++ b/src/components/settings/StyleSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { dictationSettings, setDictationStyle } from "../../lib/tauri";
 import type { DictationStyle } from "../../lib/tauri";
+import { SettingsRowError } from "../ui/ErrorFeedbackNudge";
 import { SegmentedControl } from "../ui/SegmentedControl";
 
 const STYLE_OPTIONS = [
@@ -71,7 +72,7 @@ export function StyleSettingsSection() {
             <div className="settings-row-info">
               <h3 className="settings-row-title">Output style</h3>
               <p className="settings-row-description">{current.description}</p>
-              {error ? <p className="settings-row-error">{error}</p> : null}
+              {error ? <SettingsRowError>{error}</SettingsRowError> : null}
             </div>
             <div className="settings-row-control">
               <SegmentedControl

--- a/src/components/ui/ErrorFeedbackNudge.tsx
+++ b/src/components/ui/ErrorFeedbackNudge.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+import { requestErrorFeedback } from "../../lib/error-feedback";
+
+export const ERROR_FEEDBACK_NUDGE_TEXT =
+  "Please send feedback if this looks like a bug. Your sessions stay private, and the team cannot view them, so your report is needed.";
+
+type ErrorFeedbackNudgeProps = {
+  className?: string;
+  actionLabel?: ReactNode;
+};
+
+export function ErrorFeedbackNudge({
+  className,
+  actionLabel = "Send feedback",
+}: ErrorFeedbackNudgeProps) {
+  const classes = ["error-feedback-nudge", className].filter(Boolean).join(" ");
+
+  return (
+    <span className={classes}>
+      <span>{ERROR_FEEDBACK_NUDGE_TEXT}</span>
+      <button type="button" onClick={() => requestErrorFeedback()}>
+        {actionLabel}
+      </button>
+    </span>
+  );
+}
+
+type ErrorBannerProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function ErrorBanner({ children, className }: ErrorBannerProps) {
+  const classes = ["error-banner", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={classes} role="alert">
+      <p className="error-banner-message">{children}</p>
+      <ErrorFeedbackNudge />
+    </div>
+  );
+}
+
+type SettingsRowErrorProps = {
+  children: ReactNode;
+  className?: string;
+  id?: string;
+};
+
+export function SettingsRowError({
+  children,
+  className,
+  id,
+}: SettingsRowErrorProps) {
+  const classes = ["settings-row-error", className].filter(Boolean).join(" ");
+
+  return (
+    <p id={id} className={classes}>
+      <span className="settings-row-error-message">{children}</span>
+      <ErrorFeedbackNudge className="settings-error-feedback" />
+    </p>
+  );
+}

--- a/src/lib/error-feedback.ts
+++ b/src/lib/error-feedback.ts
@@ -1,0 +1,38 @@
+export type ErrorFeedbackCategory = "bug" | "feedback" | "feature";
+
+export type ErrorFeedbackRequestedDetail = {
+  category: ErrorFeedbackCategory;
+};
+
+export const ERROR_FEEDBACK_REQUESTED_EVENT = "june:error-feedback-requested";
+
+export function requestErrorFeedback(category: ErrorFeedbackCategory = "bug") {
+  window.dispatchEvent(
+    new CustomEvent<ErrorFeedbackRequestedDetail>(
+      ERROR_FEEDBACK_REQUESTED_EVENT,
+      { detail: { category } },
+    ),
+  );
+}
+
+export function errorFeedbackCategoryFromDetail(
+  detail: unknown,
+): ErrorFeedbackCategory {
+  if (
+    detail &&
+    typeof detail === "object" &&
+    "category" in detail &&
+    isErrorFeedbackCategory((detail as { category: unknown }).category)
+  ) {
+    return (detail as { category: ErrorFeedbackCategory }).category;
+  }
+  return "bug";
+}
+
+function isErrorFeedbackCategory(
+  category: unknown,
+): category is ErrorFeedbackCategory {
+  return (
+    category === "bug" || category === "feedback" || category === "feature"
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1193,6 +1193,8 @@ input:focus-visible,
 }
 
 .agent-platform-error {
+  display: grid;
+  gap: var(--sp-2);
   margin-top: var(--sp-4);
   border: 1px solid color-mix(in srgb, var(--destructive) 45%, transparent);
   border-radius: var(--r-sm);
@@ -1200,6 +1202,10 @@ input:focus-visible,
   background: color-mix(in srgb, var(--destructive) 10%, transparent);
   color: var(--destructive);
   font-size: var(--fs-sm);
+}
+
+.agent-platform-error-feedback {
+  margin-top: 0;
 }
 
 .agent-platform-docs {
@@ -8995,6 +9001,41 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
+.error-banner-message {
+  margin: 0;
+}
+
+.error-feedback-nudge {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp-1) var(--sp-2);
+  margin-top: var(--sp-2);
+  color: color-mix(in oklch, currentColor 76%, var(--muted-foreground));
+  font-size: var(--fs-sm);
+  line-height: 1.4;
+}
+
+.error-feedback-nudge button {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 var(--sp-1);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.error-feedback-nudge button:hover {
+  background: color-mix(in oklch, currentColor 10%, transparent);
+}
+
 /* Agent variant: actions on the right, and breathing room below the sticky
  * session bar instead of sitting on its bottom edge. */
 .agent-main > .agent-error-banner {
@@ -9057,9 +9098,19 @@ input:focus-visible,
   gap: var(--sp-4);
 }
 
-.agent-error-banner p {
+.agent-error-banner-copy {
+  display: grid;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
+.agent-error-banner-copy p {
   margin: 0;
   min-width: 0;
+}
+
+.agent-inline-error-feedback {
+  margin-top: 0;
 }
 
 .agent-error-banner-actions {
@@ -9160,6 +9211,11 @@ input:focus-visible,
   color: var(--muted-foreground);
 }
 
+.agent-compact-error .inline-notice-body {
+  display: grid;
+  gap: var(--sp-2);
+}
+
 .inline-notice-actions {
   display: inline-flex;
   align-items: center;
@@ -9184,12 +9240,23 @@ input:focus-visible,
   border-radius: var(--r-md);
 }
 
+.note-failure-copy {
+  display: grid;
+  gap: var(--sp-2);
+  min-width: 0;
+}
+
 .note-failure-message {
   margin: 0;
   min-width: 0;
   color: var(--muted-foreground);
   font-size: var(--fs-md);
   line-height: 1.45;
+}
+
+.note-failure-feedback {
+  margin-top: 0;
+  color: var(--muted-foreground);
 }
 
 .note-failure-actions {
@@ -9325,7 +9392,21 @@ input:focus-visible,
 }
 
 .settings-row-error {
+  display: grid;
+  gap: var(--sp-1);
   color: var(--destructive);
+}
+
+.settings-row-error-message {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-width: 0;
+}
+
+.settings-error-feedback {
+  margin-top: 0;
+  color: var(--muted-foreground);
 }
 
 .settings-row-action {
@@ -9904,8 +9985,7 @@ input:focus-visible,
 }
 
 .installed-skills-inline-error {
-  display: flex;
-  align-items: center;
+  display: grid;
   gap: var(--sp-2);
   margin: 0;
   padding: var(--sp-3) var(--sp-5);
@@ -10189,6 +10269,12 @@ input:focus-visible,
   color: var(--muted-foreground);
   font-size: var(--fs-sm);
   line-height: 1.5;
+}
+
+.installed-skills-error-feedback {
+  justify-content: center;
+  max-width: 420px;
+  color: var(--muted-foreground);
 }
 
 .installed-skills-retry {
@@ -14699,6 +14785,11 @@ input:focus-visible,
   color: var(--muted-foreground);
   font-size: var(--fs-xs);
   line-height: 1;
+}
+
+.update-error-feedback {
+  margin-top: calc(var(--sp-1) * -1);
+  color: var(--muted-foreground);
 }
 
 @keyframes update-popover-in {

--- a/src/test/error-feedback-nudge.test.tsx
+++ b/src/test/error-feedback-nudge.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ErrorBanner } from "../components/ui/ErrorFeedbackNudge";
+import {
+  ERROR_FEEDBACK_REQUESTED_EVENT,
+  type ErrorFeedbackRequestedDetail,
+} from "../lib/error-feedback";
+
+describe("Error feedback nudge", () => {
+  it("reminds users that sessions are private and requests feedback", async () => {
+    const user = userEvent.setup();
+    const requests: ErrorFeedbackRequestedDetail[] = [];
+    const onRequest = (event: Event) => {
+      requests.push(
+        (event as CustomEvent<ErrorFeedbackRequestedDetail>).detail,
+      );
+    };
+    window.addEventListener(ERROR_FEEDBACK_REQUESTED_EVENT, onRequest);
+
+    try {
+      render(<ErrorBanner>Could not load routines.</ErrorBanner>);
+
+      expect(screen.getByText("Could not load routines.")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Your sessions stay private/i),
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Send feedback" }));
+
+      expect(requests).toEqual([{ category: "bug" }]);
+    } finally {
+      window.removeEventListener(ERROR_FEEDBACK_REQUESTED_EVENT, onRequest);
+    }
+  });
+});


### PR DESCRIPTION
Closes JUN-162

## What changed

- Added a shared error feedback nudge that reminds users their sessions are private and asks them to send feedback when an app error looks like a bug.
- Routed the nudge's `Send feedback` action through the existing issue-report composer flow.
- Applied the nudge to existing visible error surfaces across app shell, agent, notes, routines, dictation, settings, installed skills, and failed update status UI.
- Added focused coverage for the new feedback nudge event.

## Why

Visible app errors previously stopped at the local message. Since the June team cannot view private sessions, users need an explicit reminder that their report is needed to understand and fix bugs.

## Validation

- `pnpm run lint`
- `pnpm test -- error-feedback-nudge note-failure-banner dictation-history routines-view app-settings agent-workspace`
- `pnpm test`
- `pnpm build`
- Live QA against the real app bundle (Vite dev preview, isolated worktree on a sandbox port). The dev preview auto-skips the OS Accounts sign-in gate but still opens the first-run onboarding wizard, whose first step is the "OpenSoftware sign-in is not configured" screen. That screen is what the earlier QA recording was stuck on. Skipping the completed-onboarding flag renders the real app shell, so QA could verify the feature in context: a representative error surfaced both the shared app-shell error banner and the agent error banner with the privacy reminder and `Send feedback` action rendering without clipping, and clicking `Send feedback` switched to the agent view with the "Bug report" chip seeded in the composer.

## Live QA evidence

- QA video (os-platform): https://app.opensoftware.co/api/v1/files/fil_NPpmg1i1s4WS/download
  - Shows the real app shell, the error banner plus feedback nudge on two surfaces, and `Send feedback` opening the issue-report composer with the seeded bug-report chip.

## Known gaps

- QA ran in the Vite dev web preview with the Tauri backend stubbed, so command-backed side effects (real report submission, account, billing) are not exercised live. The agent workspace test suite covers the issue-report composer and submission flow.
