### PR TITLE
Make dictation permission banner dismissible

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -429,6 +429,8 @@ export function App() {
     useState<RecordingSourceReadinessDto>();
   const [checkingSourceReadiness, setCheckingSourceReadiness] = useState(false);
   const [accessibilityStatus, setAccessibilityStatus] = useState<string>();
+  const [accessibilityBannerDismissed, setAccessibilityBannerDismissed] =
+    useState(false);
   const [systemAudioRefreshRequest, setSystemAudioRefreshRequest] = useState(0);
   const [microphoneStatus, setMicrophoneStatus] = useState<string>();
   const [readyUpdate, setReadyUpdate] =
@@ -1606,6 +1608,10 @@ export function App() {
   }, []);
 
   const accessibilityBlocked = isAccessibilityBlocked(accessibilityStatus);
+  useEffect(() => {
+    if (!accessibilityBlocked) setAccessibilityBannerDismissed(false);
+  }, [accessibilityBlocked]);
+
   // The Rust readiness check probes mic via cpal, which doesn't reflect
   // TCC denial. Trust the dictation helper's AVCaptureDevice status
   // instead — that's the authoritative macOS API for the mic privacy
@@ -2882,8 +2888,9 @@ export function App() {
           onDragRegionPointerDown={handleTitlebarPointerDown}
         />
         <section className="main-panel">
-          {accessibilityBlocked ? (
+          {accessibilityBlocked && !accessibilityBannerDismissed ? (
             <PermissionBanner
+              onDismiss={() => setAccessibilityBannerDismissed(true)}
               onEnableAccessibility={handleEnableAccessibility}
             />
           ) : null}

--- a/src/components/permissions/PermissionBanner.tsx
+++ b/src/components/permissions/PermissionBanner.tsx
@@ -1,8 +1,11 @@
+import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconLock } from "central-icons/IconLock";
 
 export function PermissionBanner({
+  onDismiss,
   onEnableAccessibility,
 }: {
+  onDismiss: () => void;
   onEnableAccessibility: () => void;
 }) {
   return (
@@ -26,6 +29,15 @@ export function PermissionBanner({
           onClick={onEnableAccessibility}
         >
           Grant access
+        </button>
+        <button
+          type="button"
+          className="permission-banner-dismiss"
+          aria-label="Dismiss accessibility reminder"
+          title="Dismiss"
+          onClick={onDismiss}
+        >
+          <IconCrossSmall size={14} aria-hidden />
         </button>
       </div>
     </section>

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8985,6 +8985,27 @@ input:focus-visible,
   flex-shrink: 0;
 }
 
+.permission-banner-dismiss {
+  display: inline-grid;
+  place-items: center;
+  width: var(--control-xs);
+  height: var(--control-xs);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.permission-banner-dismiss:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
 .error-banner {
   margin: 0 0 var(--sp-5);
   padding: var(--sp-3) var(--sp-4);

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -828,6 +828,65 @@ describe("App shortcuts", () => {
     );
   });
 
+  it("lets users dismiss the Accessibility reminder while access is missing", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() =>
+      expect(mocks.listeners.has("dictation-event")).toBe(true),
+    );
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+    });
+
+    const message =
+      "Dictation can't paste into other apps until you grant accessibility access.";
+    expect(await screen.findByText(message)).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Dismiss accessibility reminder",
+      }),
+    );
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+    });
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "granted" },
+        }),
+      });
+    });
+    await act(async () => {
+      mocks.listeners.get("dictation-event")?.({
+        payload: JSON.stringify({
+          type: "permission_status",
+          payload: { microphone: "granted", accessibility: "missing" },
+        }),
+      });
+    });
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
   it("polls system audio readiness after opening the macOS permission pane", async () => {
     const user = userEvent.setup();
     const restoreNavigator = stubNavigatorPlatform(


### PR DESCRIPTION
Closes JUN-163

## What changed
- Added a dismiss action to the Accessibility permission banner shown when dictation cannot paste into other apps.
- Kept the dismissal local to the current app run and reset it when Accessibility becomes granted, so a later missing-permission state shows the reminder again.
- Added regression coverage for dismissing the banner, repeated missing-permission updates, and a granted-to-missing reset.

## Why
The dictation permission reminder could stay pinned over the app with only a "Grant access" action. Users can now clear the reminder without granting Accessibility immediately, while the Settings permission controls remain available.

## Validation
- PASS `pnpm test src/test/app-shortcut.test.tsx`
- PASS `pnpm run lint`
- PASS `pnpm exec prettier --check src/app/App.tsx src/components/permissions/PermissionBanner.tsx src/styles/app.css src/test/app-shortcut.test.tsx`
- PASS `git diff --check`
- NOTE `pnpm run format` still reports pre-existing formatting drift in unrelated files: `src/components/account/AccountGate.tsx`, `src/components/note-editor/NoteFailureBanner.tsx`, `src/test/agent-workspace.test.tsx`, and `src-tauri/tauri.conf.json`.

## Live QA
- PASS background Chrome web preview at `http://127.0.0.1:1421/` with a Tauri IPC/event shim: emitted missing Accessibility status, verified the banner appeared with "Grant access" and dismiss controls, clicked dismiss, verified repeated missing status did not bring it back, then verified granted-to-missing status showed it again.
- Screenshots: `.tmp/qa-recordings/20260630-200826-jun-163-before-dismiss.png`, `.tmp/qa-recordings/20260630-200826-jun-163-after-dismiss.png`, `.tmp/qa-recordings/20260630-200826-jun-163-reset-visible.png`
- Local compressed QA video: `.tmp/qa-recordings/20260630-201014-jun-163-clean-video/page@7d18004251b995650566fb7ad3245c87.compressed.mp4`
- QA video (os-platform): https://app.opensoftware.co/api/v1/files/fil_xBuFbnZ2ObAV/download

## Known gaps
- Native macOS Accessibility prompts were not triggered. The walkthrough used the same `permission_status` event shape from the dictation helper and avoided changing real OS privacy settings.

