### PR TITLE
Add agent evidence log

### DIFF
--- a/src/components/agent/AgentEvidenceLogSection.tsx
+++ b/src/components/agent/AgentEvidenceLogSection.tsx
@@ -1,0 +1,570 @@
+import { useMemo, useState } from "react";
+import { IconArrowInbox } from "central-icons/IconArrowInbox";
+import { IconBolt } from "central-icons/IconBolt";
+import { IconClock } from "central-icons/IconClock";
+import { IconConsole } from "central-icons/IconConsole";
+import { IconExclamationCircle } from "central-icons/IconExclamationCircle";
+import { IconEyeOpen } from "central-icons/IconEyeOpen";
+import { IconFileText } from "central-icons/IconFileText";
+import { IconHand5Finger } from "central-icons/IconHand5Finger";
+import { IconRobot } from "central-icons/IconRobot";
+import { toolActivityLabel } from "../../lib/agent-tool-labels";
+import type { AgentChatTurn } from "../../lib/agent-chat-runtime";
+import type { AgentArtifact } from "../../lib/hermes-artifact-store";
+import type { HermesTraceEntry } from "../../lib/hermes-trace-buffer";
+
+const EVIDENCE_ROWS_LIMIT = 50;
+
+export type AgentEvidenceLogRow = {
+  id: string;
+  timestamp?: string;
+  title: string;
+  detail?: string;
+  kind:
+    | "action"
+    | "tool"
+    | "computer"
+    | "file"
+    | "pending"
+    | "background"
+    | "error";
+};
+
+export function AgentEvidenceLogSection({
+  sessionId,
+  traceEntries,
+  turns,
+  artifacts,
+}: {
+  sessionId: string | undefined;
+  traceEntries: HermesTraceEntry[];
+  turns: AgentChatTurn[];
+  artifacts: AgentArtifact[];
+}) {
+  const rows = useMemo(
+    () => buildEvidenceLogRows({ traceEntries, turns, artifacts }),
+    [traceEntries, turns, artifacts],
+  );
+  const [copied, setCopied] = useState(false);
+
+  if (!sessionId) return null;
+
+  async function copyRows(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(rows, null, 2));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <section className="agent-evidence-section" aria-label="Evidence log">
+      <header className="agent-evidence-header">
+        <span className="agent-evidence-heading">
+          <IconEyeOpen size={14} ariaHidden />
+          <span className="agent-evidence-title">Evidence log</span>
+          <span className="agent-evidence-count" aria-hidden>
+            {rows.length}
+          </span>
+        </span>
+        <button
+          type="button"
+          className="agent-evidence-copy"
+          onClick={() => void copyRows()}
+          disabled={rows.length === 0}
+        >
+          <IconArrowInbox size={13} ariaHidden />
+          {copied ? "Copied" : "Copy log"}
+        </button>
+      </header>
+      {rows.length === 0 ? (
+        <p className="agent-evidence-empty">
+          No evidence recorded for this session yet.
+        </p>
+      ) : (
+        <ol className="agent-evidence-list">
+          {rows.map((row) => (
+            <EvidenceRow key={row.id} row={row} />
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+export function buildEvidenceLogRows({
+  traceEntries,
+  turns,
+  artifacts,
+}: {
+  traceEntries: HermesTraceEntry[];
+  turns: AgentChatTurn[];
+  artifacts: AgentArtifact[];
+}): AgentEvidenceLogRow[] {
+  const traceRows = traceEntries.flatMap(rowFromTraceEntry);
+  const turnRows = traceRows.length === 0 ? rowsFromTurns(turns) : [];
+  const artifactRows = artifacts.map(rowFromArtifact);
+  return [...traceRows, ...turnRows, ...artifactRows]
+    .sort(compareRows)
+    .slice(-EVIDENCE_ROWS_LIMIT);
+}
+
+function EvidenceRow({ row }: { row: AgentEvidenceLogRow }) {
+  return (
+    <li className="agent-evidence-row" data-kind={row.kind}>
+      <span className="agent-evidence-icon" data-kind={row.kind} aria-hidden>
+        {iconForKind(row.kind)}
+      </span>
+      <span className="agent-evidence-body">
+        <span className="agent-evidence-row-title">{row.title}</span>
+        {row.detail ? (
+          <span className="agent-evidence-row-detail">{row.detail}</span>
+        ) : null}
+      </span>
+      {row.timestamp ? (
+        <time className="agent-evidence-time" dateTime={row.timestamp}>
+          <IconClock size={11} ariaHidden />
+          {formatEvidenceTime(row.timestamp)}
+        </time>
+      ) : null}
+    </li>
+  );
+}
+
+function rowFromTraceEntry(entry: HermesTraceEntry): AgentEvidenceLogRow[] {
+  const payload = parsePayloadPreview(entry.payloadPreview);
+  if (entry.direction === "outbound") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: titleForOutboundMethod(entry.method),
+        detail: detailFromPayload(payload, entry.method),
+        kind: "action",
+      },
+    ];
+  }
+  if (entry.direction === "error") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: "Action failed",
+        detail: compactDetail(entry.message),
+        kind: "error",
+      },
+    ];
+  }
+  if (
+    entry.normalizedKind === "transcript" ||
+    entry.normalizedKind === "reasoning"
+  ) {
+    return [];
+  }
+  if (entry.normalizedKind === "tool") {
+    const rawName = firstString(payloadRecords(payload), [
+      "name",
+      "tool_name",
+      "tool",
+    ]);
+    const label = isComputerUse(rawName, payload, entry)
+      ? "Computer use"
+      : toolActivityLabel(rawName, payload);
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: toolTitle(label, toolPhase(entry.rawType)),
+        detail: detailFromPayload(payload),
+        kind: label === "Computer use" ? "computer" : "tool",
+      },
+    ];
+  }
+  if (entry.normalizedKind === "pending_action") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: titleForPendingAction(entry.rawType),
+        detail: detailFromPayload(payload),
+        kind: "pending",
+      },
+    ];
+  }
+  if (entry.normalizedKind === "background_activity") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: titleForBackgroundEvent(entry.rawType),
+        detail: detailFromPayload(payload),
+        kind: "background",
+      },
+    ];
+  }
+  if (entry.normalizedKind === "error") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: "Agent reported an error",
+        detail: detailFromPayload(payload),
+        kind: "error",
+      },
+    ];
+  }
+  if (entry.normalizedKind === "lifecycle") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: titleForLifecycle(entry.rawType),
+        detail: detailFromPayload(payload),
+        kind: "action",
+      },
+    ];
+  }
+  if (entry.normalizedKind === "unsupported") {
+    return [
+      {
+        id: `trace:${entry.id}`,
+        timestamp: entry.observedAt,
+        title: "Unrecognized agent event",
+        detail: compactDetail(entry.rawType),
+        kind: "error",
+      },
+    ];
+  }
+  return [];
+}
+
+function rowsFromTurns(turns: AgentChatTurn[]): AgentEvidenceLogRow[] {
+  const rows: AgentEvidenceLogRow[] = [];
+  for (const turn of turns) {
+    turn.parts.forEach((part, index) => {
+      if (part.type === "tool") {
+        rows.push({
+          id: `turn:${turn.id}:${index}`,
+          timestamp: turn.createdAt,
+          title: toolTitle(part.name, part.status),
+          detail: compactDetail(part.text),
+          kind: isComputerUse(part.name, part.text) ? "computer" : "tool",
+        });
+      } else if (part.type === "approval") {
+        rows.push({
+          id: `turn:${turn.id}:${index}`,
+          timestamp: turn.createdAt,
+          title: "Approval requested",
+          detail: compactDetail(part.description || part.command),
+          kind: "pending",
+        });
+      } else if (part.type === "clarify") {
+        rows.push({
+          id: `turn:${turn.id}:${index}`,
+          timestamp: turn.createdAt,
+          title: "Clarification requested",
+          detail: compactDetail(part.question),
+          kind: "pending",
+        });
+      } else if (part.type === "sudo") {
+        rows.push({
+          id: `turn:${turn.id}:${index}`,
+          timestamp: turn.createdAt,
+          title: "Privilege approval requested",
+          detail: compactDetail(part.reason || part.command),
+          kind: "pending",
+        });
+      } else if (part.type === "secret") {
+        rows.push({
+          id: `turn:${turn.id}:${index}`,
+          timestamp: turn.createdAt,
+          title: "Secret requested",
+          detail: compactDetail(part.keyName || part.reason),
+          kind: "pending",
+        });
+      } else if (part.type === "steering") {
+        rows.push({
+          id: `turn:${turn.id}:${index}`,
+          timestamp: turn.createdAt,
+          title: "Steering sent",
+          detail: compactDetail(part.text),
+          kind: "action",
+        });
+      }
+    });
+  }
+  return rows;
+}
+
+function rowFromArtifact(artifact: AgentArtifact): AgentEvidenceLogRow {
+  return {
+    id: `artifact:${artifact.id}`,
+    timestamp: new Date(artifact.createdAt).toISOString(),
+    title: `${artifactActionTitle(artifact.action)} ${artifact.displayName ?? artifact.path ?? "file"}`,
+    detail: compactDetail(artifact.path),
+    kind: "file",
+  };
+}
+
+function titleForOutboundMethod(method: string | undefined): string {
+  switch (method) {
+    case "prompt.submit":
+      return "Prompt sent";
+    case "session.create":
+      return "Session created";
+    case "session.resume":
+      return "Session resumed";
+    case "session.steer":
+      return "Steering sent";
+    case "session.interrupt":
+      return "Stop requested";
+    case "command.dispatch":
+      return "Command sent";
+    case "approval.respond":
+      return "Approval response sent";
+    case "clarify.respond":
+      return "Clarification response sent";
+    case "sudo.respond":
+      return "Privilege response sent";
+    case "secret.respond":
+      return "Secret response sent";
+    case "image.attach_bytes":
+      return "Image attached";
+    default:
+      return method ? `Called ${humanizeMethod(method)}` : "Action sent";
+  }
+}
+
+function titleForPendingAction(rawType: string | undefined): string {
+  switch (rawType) {
+    case "approval.request":
+      return "Approval requested";
+    case "clarify.request":
+      return "Clarification requested";
+    case "sudo.request":
+      return "Privilege approval requested";
+    case "secret.request":
+      return "Secret requested";
+    default:
+      return "User input requested";
+  }
+}
+
+function titleForBackgroundEvent(rawType: string | undefined): string {
+  const subtype = rawType?.startsWith("subagent.")
+    ? rawType.slice("subagent.".length)
+    : "";
+  switch (subtype) {
+    case "start":
+      return "Background subagent started";
+    case "tool":
+      return "Background subagent used a tool";
+    case "complete":
+      return "Background subagent completed";
+    case "error":
+      return "Background subagent failed";
+    case "blocked":
+      return "Background subagent blocked";
+    default:
+      return "Background work updated";
+  }
+}
+
+function titleForLifecycle(rawType: string | undefined): string {
+  switch (rawType) {
+    case "session.start":
+      return "Session started";
+    case "session.complete":
+    case "session.completed":
+      return "Session completed";
+    case "gateway.ready":
+      return "Gateway connected";
+    default:
+      return "Session status updated";
+  }
+}
+
+function toolTitle(label: string, phase: string | undefined): string {
+  const phrase = lowerFirst(stripTrailingPeriod(label));
+  switch (phase) {
+    case "start":
+    case "running":
+      return `Started ${phrase}`;
+    case "progress":
+      return `Updated ${phrase}`;
+    case "complete":
+      return `Completed ${phrase}`;
+    case "failed":
+      return `Failed ${phrase}`;
+    default:
+      return stripTrailingPeriod(label);
+  }
+}
+
+function toolPhase(rawType: string | undefined): string | undefined {
+  if (rawType === "tool.start") return "start";
+  if (rawType === "tool.progress") return "progress";
+  if (rawType === "tool.complete") return "complete";
+  return undefined;
+}
+
+function artifactActionTitle(action: AgentArtifact["action"]): string {
+  switch (action) {
+    case "created":
+      return "Created";
+    case "modified":
+      return "Modified";
+    case "read":
+      return "Read";
+    case "downloaded":
+      return "Downloaded";
+    case "failed":
+      return "Failed";
+    case "attached":
+      return "Attached";
+  }
+}
+
+function detailFromPayload(
+  payload: unknown,
+  fallback?: string,
+): string | undefined {
+  const records = payloadRecords(payload);
+  const value = firstString(records, [
+    "description",
+    "question",
+    "command",
+    "cmd",
+    "path",
+    "file_path",
+    "filename",
+    "url",
+    "query",
+    "q",
+    "goal",
+    "summary",
+    "tool_preview",
+    "text",
+    "output",
+    "message",
+    "status",
+  ]);
+  return compactDetail(value ?? fallback);
+}
+
+function parsePayloadPreview(preview: string | undefined): unknown {
+  if (!preview) return undefined;
+  try {
+    return JSON.parse(preview);
+  } catch {
+    return preview;
+  }
+}
+
+function payloadRecords(payload: unknown): Record<string, unknown>[] {
+  const root = objectRecord(payload);
+  if (!root) return [];
+  const records = [root];
+  for (const key of ["arguments", "args", "input", "parameters", "payload"]) {
+    const child = objectRecord(root[key]);
+    if (child) records.push(child);
+  }
+  return records;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function firstString(
+  records: Record<string, unknown>[],
+  keys: string[],
+): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) return value;
+    }
+  }
+  return undefined;
+}
+
+function compactDetail(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (!compact) return undefined;
+  return compact.length > 180 ? `${compact.slice(0, 177)}...` : compact;
+}
+
+function isComputerUse(
+  name: unknown,
+  payload?: unknown,
+  entry?: HermesTraceEntry,
+): boolean {
+  const haystack = [
+    typeof name === "string" ? name : "",
+    typeof payload === "string" ? payload : "",
+    entry?.rawType ?? "",
+    entry?.payloadKeys.join(" ") ?? "",
+    entry?.payloadPreview ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  return /\b(computer|screenshot|screen|display|mouse|cursor|click|keyboard|keypress|typed?|scroll|drag)\b/.test(
+    haystack,
+  );
+}
+
+function humanizeMethod(method: string): string {
+  return method.replace(/[._-]+/g, " ");
+}
+
+function stripTrailingPeriod(value: string): string {
+  return value.endsWith(".") ? value.slice(0, -1) : value;
+}
+
+function lowerFirst(value: string): string {
+  return value ? `${value.charAt(0).toLowerCase()}${value.slice(1)}` : value;
+}
+
+function compareRows(a: AgentEvidenceLogRow, b: AgentEvidenceLogRow): number {
+  return timestampValue(a.timestamp) - timestampValue(b.timestamp);
+}
+
+function timestampValue(value: string | undefined): number {
+  const parsed = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatEvidenceTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function iconForKind(kind: AgentEvidenceLogRow["kind"]): JSX.Element {
+  switch (kind) {
+    case "computer":
+      return <IconConsole size={14} />;
+    case "tool":
+      return <IconBolt size={14} />;
+    case "file":
+      return <IconFileText size={14} />;
+    case "pending":
+      return <IconHand5Finger size={14} />;
+    case "background":
+      return <IconRobot size={14} />;
+    case "error":
+      return <IconExclamationCircle size={14} />;
+    case "action":
+      return <IconEyeOpen size={14} />;
+  }
+}

--- a/src/components/agent/AgentEvidenceLogSection.tsx
+++ b/src/components/agent/AgentEvidenceLogSection.tsx
@@ -104,7 +104,10 @@ export function buildEvidenceLogRows({
   artifacts: AgentArtifact[];
 }): AgentEvidenceLogRow[] {
   const traceRows = traceEntries.flatMap(rowFromTraceEntry);
-  const turnRows = traceRows.length === 0 ? rowsFromTurns(turns) : [];
+  const traceKeys = new Set(traceRows.map(evidenceRowDedupeKey));
+  const turnRows = rowsFromTurns(turns).filter(
+    (row) => !traceKeys.has(evidenceRowDedupeKey(row)),
+  );
   const artifactRows = artifacts.map(rowFromArtifact);
   return [...traceRows, ...turnRows, ...artifactRows]
     .sort(compareRows)
@@ -176,7 +179,7 @@ function rowFromTraceEntry(entry: HermesTraceEntry): AgentEvidenceLogRow[] {
       {
         id: `trace:${entry.id}`,
         timestamp: entry.observedAt,
-        title: toolTitle(label, toolPhase(entry.rawType)),
+        title: toolTitle(label, toolPhase(entry.rawType, payload)),
         detail: detailFromPayload(payload),
         kind: label === "Computer use" ? "computer" : "tool",
       },
@@ -403,10 +406,15 @@ function toolTitle(label: string, phase: string | undefined): string {
   }
 }
 
-function toolPhase(rawType: string | undefined): string | undefined {
+function toolPhase(
+  rawType: string | undefined,
+  payload?: unknown,
+): string | undefined {
   if (rawType === "tool.start") return "start";
   if (rawType === "tool.progress") return "progress";
-  if (rawType === "tool.complete") return "complete";
+  if (rawType === "tool.complete") {
+    return payloadHasFailureSignal(payload) ? "failed" : "complete";
+  }
   return undefined;
 }
 
@@ -474,6 +482,25 @@ function payloadRecords(payload: unknown): Record<string, unknown>[] {
   return records;
 }
 
+function payloadHasFailureSignal(payload: unknown): boolean {
+  for (const record of payloadRecords(payload)) {
+    if (
+      record.error !== undefined &&
+      record.error !== null &&
+      record.error !== false
+    ) {
+      return true;
+    }
+    if (record.failed === true) return true;
+    const status =
+      typeof record.status === "string" ? record.status.toLowerCase() : "";
+    if (status === "error" || status === "failed" || status === "denied") {
+      return true;
+    }
+  }
+  return false;
+}
+
 function objectRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
@@ -534,6 +561,12 @@ function lowerFirst(value: string): string {
 
 function compareRows(a: AgentEvidenceLogRow, b: AgentEvidenceLogRow): number {
   return timestampValue(a.timestamp) - timestampValue(b.timestamp);
+}
+
+function evidenceRowDedupeKey(row: AgentEvidenceLogRow): string {
+  return [row.kind, row.title, row.detail ?? ""]
+    .map((value) => value.replace(/\s+/g, " ").trim().toLowerCase())
+    .join("\u0000");
 }
 
 function timestampValue(value: string | undefined): number {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -158,6 +158,7 @@ import {
   isHermesFeatureSupported,
   isSensitiveKey,
   type HermesMode,
+  type JuneHermesEvent,
 } from "../../lib/hermes-control-plane";
 import {
   attachImageToSession,
@@ -196,6 +197,7 @@ import {
   AgentActivityDrawer,
   AgentArtifactsSection,
 } from "./AgentActivityDrawer";
+import { AgentEvidenceLogSection } from "./AgentEvidenceLogSection";
 import { hermesTraceBuffer } from "../../lib/hermes-trace-buffer";
 import { UnsupportedEventNotice } from "./UnsupportedEventNotice";
 import { HermesTracePanel } from "./HermesTracePanel";
@@ -325,6 +327,32 @@ const SESSION_GONE_MESSAGE =
 
 function isSessionGoneError(message: string): boolean {
   return message.toLowerCase().includes("session not found");
+}
+
+function eventForStoredSession(
+  event: JuneHermesEvent,
+  sessionId: string,
+): JuneHermesEvent {
+  switch (event.kind) {
+    case "transcript":
+    case "reasoning":
+    case "tool":
+    case "pending_action":
+      return { ...event, sessionId };
+    case "background_activity":
+      return {
+        ...event,
+        sessionId,
+        activity: {
+          ...event.activity,
+          parentSessionId: sessionId,
+        },
+      };
+    case "lifecycle":
+    case "error":
+    case "unsupported":
+      return { ...event, sessionId };
+  }
 }
 
 // Dev-tools response gallery handle. Registered at module scope so
@@ -2174,13 +2202,9 @@ export function AgentWorkspace({
   // version re-derives the rows whenever any session's activity changes; the
   // drawer is one toggled, top-level surface that shows every session at once.
   //
-  // TEMPORARILY HIDDEN: the drawer's "open session" routes by the row's id,
-  // which is the ephemeral runtime session id, not the durable stored id, so it
-  // opens the wrong session (or none). Until that runtime->stored resolution is
-  // fixed, the entry-point toggle is gated off below. The whole feature (drawer,
-  // subagent watch, stop, artifacts timeline) stays mounted and tested; flip
-  // this flag back to true to restore it.
-  const ACTIVITY_DRAWER_ENABLED = false;
+  // The live event ingestion path stores drawer rows under durable June session
+  // ids, not ephemeral runtime ids, so opening a row targets a real session.
+  const ACTIVITY_DRAWER_ENABLED = true;
   const [activityDrawerOpen, setActivityDrawerOpen] = useState(false);
   const activityStoreVersion = useSyncExternalStore(
     hermesActivityStore.subscribe,
@@ -2196,7 +2220,7 @@ export function AgentWorkspace({
   // never-touched store as "loading" so the very first paint shows a spinner
   // copy rather than the empty state flashing before any event lands.
   const activityStatus: "loading" | "ready" =
-    activityStoreVersion === 0 ? "loading" : "ready";
+    activityStoreVersion === 0 && !hermesSessionsHydrated ? "loading" : "ready";
   // Open a session from a drawer row: clear new-session mode, switch panel +
   // selection.
   const openSessionFromDrawer = useCallback((sessionId: string) => {
@@ -2258,6 +2282,18 @@ export function AgentWorkspace({
         : [],
     // `artifactStoreVersion` is the change signal; the read returns live rows.
     [selectedHermesSessionId, artifactStoreVersion],
+  );
+  const traceStoreVersion = useSyncExternalStore(
+    hermesTraceBuffer.subscribe,
+    hermesTraceBuffer.getVersion,
+    hermesTraceBuffer.getVersion,
+  );
+  const evidenceTraceEntries = useMemo(
+    () =>
+      selectedHermesSessionId
+        ? hermesTraceBuffer.entriesFor(selectedHermesSessionId)
+        : [],
+    [selectedHermesSessionId, traceStoreVersion],
   );
 
   // Feature 15: the dev/debug raw-trace panel. Holds the session it was opened
@@ -4001,27 +4037,34 @@ export function AgentWorkspace({
       // classified to) into the bounded, sanitized trace buffer so the dev/debug
       // trace panel can reconstruct the session. recordInbound re-classifies and
       // sanitizes internally; nothing raw is retained.
-      hermesTraceBuffer.recordInbound(liveEvent);
-      if (classified.kind === "unsupported") {
+      hermesTraceBuffer.recordInbound(liveEvent, storedSessionId);
+      const storedSessionEvent = eventForStoredSession(
+        classified,
+        storedSessionId,
+      );
+      if (storedSessionEvent.kind === "unsupported") {
         // Feed the bounded per-session store so the user gets a recoverable
         // notice (when this is the active session) and developers get a
         // sanitized, issue-report-safe export. The payload is already sanitized
         // by the classifier; nothing raw is retained or logged.
-        unsupportedEventStore.record(classified);
+        unsupportedEventStore.record(storedSessionEvent);
         if (import.meta.env.DEV) {
           console.debug(
             "[hermes] unsupported event",
-            classified.rawType,
-            classified.sanitizedPayload,
+            storedSessionEvent.rawType,
+            storedSessionEvent.sanitizedPayload,
           );
         }
-      } else if (classified.kind === "pending_action") {
+      } else if (storedSessionEvent.kind === "pending_action") {
         // Feature 04: aggregate this blocker into the pending-action store
         // keyed by mode + session + request. The session's mode comes from its
         // recorded opt-in (sudo carries its own; the rest derive it here). A
         // fresh event for a known request also re-confirms a row that went
         // stale across a reconnect (see the store's reconcile logic).
-        pendingActionStore.record(classified, hermesModeFor(storedSessionId));
+        pendingActionStore.record(
+          storedSessionEvent,
+          hermesModeFor(storedSessionId),
+        );
       }
       // Feature 11: roll EVERY classified event into the global activity store
       // that backs the Agent activity drawer. The store is total and ignores
@@ -4029,14 +4072,20 @@ export function AgentWorkspace({
       // derives the session's phase (running/waiting/background/error/complete),
       // current tool, and subagent count from the normalized event — never from
       // the raw frame (raw JSON belongs to feature 15's trace panel).
-      hermesActivityStore.record(classified, hermesModeFor(storedSessionId));
+      hermesActivityStore.record(
+        storedSessionEvent,
+        hermesModeFor(storedSessionId),
+      );
       // Feature 14: extract any file/artifact reference this event carries into
       // the per-session artifact timeline behind the drawer's "Artifacts"
       // section. The store is total and only acts on `tool` completions that
       // name a known file/url field (conservative — never parses prose), so one
       // unconditional call is safe for every kind. Mode rides along so each
       // artifact can show its blast radius (sandboxed copy vs unrestricted path).
-      hermesArtifactStore.record(classified, hermesModeFor(storedSessionId));
+      hermesArtifactStore.record(
+        storedSessionEvent,
+        hermesModeFor(storedSessionId),
+      );
       const nextSessionEvents = [
         ...(liveEventsRef.current[storedSessionId] ?? []),
         liveEvent,
@@ -4890,6 +4939,29 @@ export function AgentWorkspace({
     }
   }
 
+  function resolvePendingRequestForKnownSessionIds(
+    requestId: string,
+    ...sessionIds: Array<string | undefined>
+  ) {
+    const ids = new Set<string>();
+    for (const sessionId of sessionIds) {
+      const trimmed = sessionId?.trim();
+      if (!trimmed) continue;
+      ids.add(trimmed);
+      for (const [storedId, runtimeId] of Object.entries(
+        runtimeSessionIdsRef.current,
+      )) {
+        if (storedId === trimmed || runtimeId === trimmed) {
+          ids.add(storedId);
+          ids.add(runtimeId);
+        }
+      }
+    }
+    for (const sessionId of ids) {
+      pendingActionStore.resolveRequest(sessionId, requestId);
+    }
+  }
+
   async function respondToApproval(
     liveEventKey: string,
     sessionId: string,
@@ -4913,7 +4985,11 @@ export function AgentWorkspace({
       });
       // Feature 04: the user just answered this approval — clear its global
       // "Needs you" row immediately (the response itself is the resolution).
-      pendingActionStore.resolveRequest(sessionId, requestId);
+      resolvePendingRequestForKnownSessionIds(
+        requestId,
+        liveEventKey,
+        sessionId,
+      );
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
@@ -4939,7 +5015,11 @@ export function AgentWorkspace({
         setLiveEvents(liveEventsRef.current);
         // The request can never be answered now — retire its card so neither the
         // sidebar count nor the inline prompt offers a dead-end "Respond".
-        pendingActionStore.resolveRequest(sessionId, requestId);
+        resolvePendingRequestForKnownSessionIds(
+          requestId,
+          liveEventKey,
+          sessionId,
+        );
         void loadHermesSessions();
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
@@ -4972,14 +5052,14 @@ export function AgentWorkspace({
         payload: { request_id: requestId, answer },
       });
       // Feature 04: the user answered the clarification — clear its pending record.
-      pendingActionStore.resolveRequest(liveEventKey, requestId);
+      resolvePendingRequestForKnownSessionIds(requestId, liveEventKey);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
       if (isSessionGoneError(message)) {
         // The runtime is gone, so this clarification can never be answered —
         // retire its card and say so plainly instead of leaking the raw 404.
-        pendingActionStore.resolveRequest(liveEventKey, requestId);
+        resolvePendingRequestForKnownSessionIds(requestId, liveEventKey);
         setError(SESSION_GONE_MESSAGE);
       } else {
         setError(message);
@@ -5023,14 +5103,22 @@ export function AgentWorkspace({
         payload: { request_id: requestId, granted: approved, mode },
       });
       // Feature 04: the user resolved the sudo prompt — clear its pending record.
-      pendingActionStore.resolveRequest(sessionId, requestId);
+      resolvePendingRequestForKnownSessionIds(
+        requestId,
+        liveEventKey,
+        sessionId,
+      );
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
       if (isSessionGoneError(message)) {
         // The runtime is gone, so this prompt can never be answered — retire
         // its card and say so plainly instead of leaking the raw 404.
-        pendingActionStore.resolveRequest(sessionId, requestId);
+        resolvePendingRequestForKnownSessionIds(
+          requestId,
+          liveEventKey,
+          sessionId,
+        );
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
         setError(message, { sessionId });
@@ -5068,14 +5156,22 @@ export function AgentWorkspace({
         payload: { request_id: requestId, provided: true },
       });
       // Feature 04: the user provided the secret — clear its pending record.
-      pendingActionStore.resolveRequest(sessionId, requestId);
+      resolvePendingRequestForKnownSessionIds(
+        requestId,
+        liveEventKey,
+        sessionId,
+      );
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
       if (isSessionGoneError(message)) {
         // The runtime is gone, so this secret prompt can never be answered —
         // retire its card and say so plainly instead of leaking the raw 404.
-        pendingActionStore.resolveRequest(sessionId, requestId);
+        resolvePendingRequestForKnownSessionIds(
+          requestId,
+          liveEventKey,
+          sessionId,
+        );
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
         setError(message, { sessionId });
@@ -6849,10 +6945,7 @@ export function AgentWorkspace({
           surface so it shows every session's live activity, not
           just the selected one. The toggle is hidden while the drawer is open
           (the drawer carries its own close control) and surfaces the count of
-          sessions currently doing work.
-          Gated by ACTIVITY_DRAWER_ENABLED (currently false): with no toggle the
-          drawer is unreachable, since nothing else flips activityDrawerOpen to
-          true. See the flag's note for the open-wrong-session bug it parks. */}
+          sessions currently doing work. */}
       {ACTIVITY_DRAWER_ENABLED && !activityDrawerOpen ? (
         <button
           type="button"
@@ -6883,10 +6976,18 @@ export function AgentWorkspace({
         onStopSubagent={stopHermesSubagent}
         onClose={() => setActivityDrawerOpen(false)}
         footer={
-          <AgentArtifactsSection
-            artifacts={timelineArtifacts}
-            onOpenArtifact={openTimelineArtifact}
-          />
+          <>
+            <AgentEvidenceLogSection
+              sessionId={selectedHermesSessionId}
+              traceEntries={evidenceTraceEntries}
+              turns={hermesTurns}
+              artifacts={timelineArtifacts}
+            />
+            <AgentArtifactsSection
+              artifacts={timelineArtifacts}
+              onOpenArtifact={openTimelineArtifact}
+            />
+          </>
         }
       />
       {!heroMode &&

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1999,6 +1999,9 @@ export function AgentWorkspace({
       hermesActivityStore.clearSession(sessionId);
       // Feature 14: likewise drop its artifact timeline.
       hermesArtifactStore.clearSession(sessionId);
+      // Feature 20: evidence rows are trace-backed, so deleted sessions must
+      // not leave stale audit rows in memory either.
+      hermesTraceBuffer.clearSession(sessionId);
       sessionGatewayUnlistenRef.current.get(sessionId)?.();
       liveEventsRef.current = omitRecordKey(liveEventsRef.current, sessionId);
       setLiveEvents(liveEventsRef.current);

--- a/src/lib/hermes-trace-buffer.ts
+++ b/src/lib/hermes-trace-buffer.ts
@@ -97,7 +97,7 @@ export type ErrorTraceInput = {
 
 export type HermesTraceBuffer = {
   /** Record one inbound raw frame, classifying it for the normalized column. */
-  recordInbound(frame: InboundTraceInput): void;
+  recordInbound(frame: InboundTraceInput, sessionIdOverride?: string): void;
   /** Record one outbound method call (params sanitized). */
   recordOutbound(call: OutboundTraceInput): void;
   /** Record one error/rejection. */
@@ -106,6 +106,8 @@ export type HermesTraceBuffer = {
   entriesFor(sessionId: string | undefined): HermesTraceEntry[];
   /** Session ids that currently have entries (real ids only, oldest-first). */
   sessionIds(): string[];
+  /** Drop one session's trace entirely. */
+  clearSession(sessionId: string | undefined): void;
   /** A secrets-free export bundle for one session. */
   exportSanitizedTrace(sessionId: string | undefined): SanitizedTraceBundle;
   /** Subscribe to changes (for `useSyncExternalStore`). Returns an unsubscribe. */
@@ -142,10 +144,15 @@ export function createHermesTraceBuffer(): HermesTraceBuffer {
     emit();
   }
 
-  function recordInbound(frame: InboundTraceInput): void {
+  function recordInbound(
+    frame: InboundTraceInput,
+    sessionIdOverride?: string,
+  ): void {
     const classified: JuneHermesEvent = classifyHermesEvent(frame);
     const sessionId =
-      nonEmpty(frame?.session_id) ?? nonEmpty(eventSession(classified));
+      nonEmpty(sessionIdOverride) ??
+      nonEmpty(frame?.session_id) ??
+      nonEmpty(eventSession(classified));
     const { payloadKeys, payloadPreview } = describePayload(frame?.payload);
     push(sessionId, {
       id: nextId++,
@@ -197,6 +204,11 @@ export function createHermesTraceBuffer(): HermesTraceBuffer {
     return [...bySession.keys()].filter((key) => key !== NO_SESSION_KEY);
   }
 
+  function clearSession(sessionId: string | undefined): void {
+    const key = sessionId ?? NO_SESSION_KEY;
+    if (bySession.delete(key)) emit();
+  }
+
   function exportSanitizedTrace(
     sessionId: string | undefined,
   ): SanitizedTraceBundle {
@@ -226,6 +238,7 @@ export function createHermesTraceBuffer(): HermesTraceBuffer {
     recordError,
     entriesFor,
     sessionIds,
+    clearSession,
     exportSanitizedTrace,
     subscribe,
     getVersion,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2958,6 +2958,27 @@ input:focus-visible,
   box-shadow: var(--shadow-lg);
 }
 
+@media (max-width: 560px) {
+  .agent-activity-toggle {
+    position: fixed;
+    top: calc(var(--card-top) + var(--detail-bar-h) + var(--sp-2));
+    right: var(--sp-3);
+    z-index: 102;
+  }
+
+  .agent-activity-drawer {
+    position: fixed;
+    top: calc(var(--card-top) + var(--detail-bar-h) + var(--sp-2));
+    left: var(--sp-3);
+    right: var(--sp-3);
+    z-index: 102;
+    width: auto;
+    max-height: calc(
+      100vh - var(--card-top) - var(--detail-bar-h) - var(--sp-5)
+    );
+  }
+}
+
 .agent-activity-drawer-header {
   display: flex;
   align-items: center;
@@ -3317,6 +3338,162 @@ input:focus-visible,
  * event reconciles the row. */
 .agent-activity-subagent-status[data-stopping="true"] {
   color: var(--muted-foreground);
+}
+
+/* ---- Feature 20: Evidence log ----
+ * A user-facing audit trail for the selected session. It reads from sanitized
+ * trace entries and existing chat/tool rows, not raw gateway payloads. */
+.agent-evidence-section {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.agent-evidence-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-3) var(--sp-4) var(--sp-1);
+}
+
+.agent-evidence-heading {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-width: 0;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--muted-foreground);
+}
+
+.agent-evidence-title {
+  flex: 1;
+}
+
+.agent-evidence-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 var(--sp-1);
+  border-radius: var(--r-pill);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-evidence-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.agent-evidence-copy:hover:not(:disabled) {
+  background: var(--accent);
+}
+
+.agent-evidence-copy:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.agent-evidence-empty {
+  margin: 0;
+  padding: var(--sp-2) var(--sp-4) var(--sp-3);
+  font-size: var(--fs-sm);
+  color: var(--muted-foreground);
+}
+
+.agent-evidence-list {
+  margin: 0;
+  padding: var(--sp-2);
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  overflow-y: auto;
+  max-height: 220px;
+}
+
+.agent-evidence-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+}
+
+.agent-evidence-row:hover {
+  background: var(--accent);
+  border-color: var(--border-subtle);
+}
+
+.agent-evidence-icon {
+  display: inline-flex;
+  margin-top: var(--sp-px);
+  color: var(--muted-foreground);
+}
+
+.agent-evidence-icon[data-kind="computer"] {
+  color: var(--primary);
+}
+
+.agent-evidence-icon[data-kind="file"] {
+  color: var(--success);
+}
+
+.agent-evidence-icon[data-kind="pending"] {
+  color: var(--warm-strong);
+}
+
+.agent-evidence-icon[data-kind="error"] {
+  color: var(--destructive);
+}
+
+.agent-evidence-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-px);
+}
+
+.agent-evidence-row-title {
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-evidence-row-detail {
+  font-size: var(--fs-xs);
+  color: var(--muted-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-evidence-time {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  color: var(--muted-foreground);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* ---- Feature 14: Artifacts (files touched) timeline ----

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -26,6 +26,7 @@ import {
 } from "../lib/model-privacy";
 import { HermesGatewayError } from "../lib/hermes-gateway";
 import { classifyHermesEvent } from "../lib/hermes-control-plane";
+import { hermesActivityStore } from "../lib/hermes-activity-store";
 import { hermesArtifactStore } from "../lib/hermes-artifact-store";
 import { hermesTraceBuffer } from "../lib/hermes-trace-buffer";
 import { pendingActionStore } from "../lib/hermes-pending-actions";
@@ -226,8 +227,15 @@ describe("AgentWorkspace", () => {
     // Feature 14: the artifact store is a process-wide singleton; drop the
     // session rows these tests touch so one test's artifacts don't leak into
     // the next.
-    for (const id of ["session-1", "session-2", "runtime-session-2"]) {
+    for (const id of [
+      "session-1",
+      "session-2",
+      "runtime-session-1",
+      "runtime-session-2",
+    ]) {
+      hermesActivityStore.clearSession(id);
       hermesArtifactStore.clearSession(id);
+      hermesTraceBuffer.clearSession(id);
     }
     window.sessionStorage.clear();
     window.localStorage.clear();
@@ -5196,12 +5204,7 @@ describe("AgentWorkspace", () => {
     ).not.toBeInTheDocument();
   });
 
-  // SKIPPED while the Agent activity drawer's entry point is hidden
-  // (ACTIVITY_DRAWER_ENABLED=false in AgentWorkspace, parking the open-wrong-
-  // session bug). These two reach feature 14's artifacts timeline THROUGH the
-  // drawer toggle, which no longer renders. The artifacts section itself stays
-  // covered by agent-artifacts-section.test.tsx; un-skip when the flag flips back.
-  it.skip("shows a tool-touched file in the activity drawer's artifacts timeline and opens it in the preview flow", async () => {
+  it("shows a tool-touched file in the activity drawer's artifacts timeline and opens it in the preview flow", async () => {
     const user = userEvent.setup();
     const reportPath =
       "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/timeline.md";
@@ -5241,9 +5244,7 @@ describe("AgentWorkspace", () => {
     );
   });
 
-  // SKIPPED: see the note above. Reaches the artifacts timeline through the
-  // hidden activity drawer toggle; un-skip when ACTIVITY_DRAWER_ENABLED is true.
-  it.skip("marks a failed file access as failed in the artifacts timeline", async () => {
+  it("marks a failed file access as failed in the artifacts timeline", async () => {
     const user = userEvent.setup();
     render(<AgentWorkspace />);
     await screen.findByRole("button", { name: "Show agent activity" });
@@ -5270,6 +5271,101 @@ describe("AgentWorkspace", () => {
     expect(within(row).getByText(/failed/i)).toBeInTheDocument();
     // An unrestricted session's real path is labeled as such.
     expect(within(row).getByText(/unrestricted/i)).toBeInTheDocument();
+  });
+
+  it("shows live agent actions in the selected session evidence log", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+    render(<AgentWorkspace />);
+    await user.type(await screen.findByRole("textbox"), "check the screen");
+    await user.click(screen.getByRole("button", { name: "Start session" }));
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "check the screen",
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.gatewayEventHandlers.size).toBeGreaterThan(0),
+    );
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "tool.start",
+          session_id: "runtime-session-2",
+          payload: {
+            name: "computer_use",
+            description: "Captured the current screen",
+          },
+        });
+      }
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Show agent activity" }),
+    );
+    const drawer = await screen.findByRole("region", {
+      name: "Agent activity",
+    });
+    expect(within(drawer).queryByText("runtime-session-2")).toBeNull();
+
+    const evidence = await within(drawer).findByRole("region", {
+      name: "Evidence log",
+    });
+    expect(
+      within(evidence).getByText("Started computer use"),
+    ).toBeInTheDocument();
+    expect(
+      within(evidence).getByText("Captured the current screen"),
+    ).toBeInTheDocument();
+    expect(
+      hermesTraceBuffer
+        .exportSanitizedTrace("session-2")
+        .entries.some((entry) => entry.rawType === "tool.start"),
+    ).toBe(true);
+    expect(
+      hermesTraceBuffer.exportSanitizedTrace("runtime-session-2").entries,
+    ).toHaveLength(0);
+  });
+
+  it("falls back to persisted tool rows in the evidence log for revisited sessions", async () => {
+    const user = userEvent.setup();
+    mocks.listHermesSessionMessages.mockResolvedValue([
+      {
+        id: "tool-msg-1",
+        role: "tool",
+        tool_call_id: "tc-screen",
+        tool_name: "computer_use",
+        content: "Captured browser window",
+        timestamp: "2026-06-04T12:01:00Z",
+      },
+    ]);
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-1"),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Show agent activity" }),
+    );
+    const drawer = await screen.findByRole("region", {
+      name: "Agent activity",
+    });
+    const evidence = await within(drawer).findByRole("region", {
+      name: "Evidence log",
+    });
+    expect(
+      within(evidence).getByText("Completed computer use"),
+    ).toBeInTheDocument();
+    expect(
+      within(evidence).getByText("Captured browser window"),
+    ).toBeInTheDocument();
   });
 
   it("lists every surfaced file behind the session bar files button", async () => {
@@ -5775,7 +5871,10 @@ describe("AgentWorkspace", () => {
     );
 
     await waitFor(() =>
-      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "qwen-vl"),
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "generation",
+        "qwen-vl",
+      ),
     );
     // The switch picks the image-capable model and keeps the dropped image.
     expect(screen.getByText("screenshot.png")).toBeInTheDocument();
@@ -5843,7 +5942,10 @@ describe("AgentWorkspace", () => {
     );
     // Lands on the first eligible vision model (Qwen VL), no picker dialog.
     await waitFor(() =>
-      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "qwen-vl"),
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "generation",
+        "qwen-vl",
+      ),
     );
     expect(
       screen.queryByRole("dialog", { name: "Choose text model" }),

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -3458,6 +3458,14 @@ describe("AgentWorkspace", () => {
         "session-1",
       ),
     );
+    hermesTraceBuffer.recordOutbound({
+      sessionId: "session-1",
+      method: "prompt.submit",
+      params: { session_id: "runtime-session-1", text: "old prompt" },
+    });
+    expect(
+      hermesTraceBuffer.exportSanitizedTrace("session-1").entries,
+    ).toHaveLength(1);
 
     act(() => {
       window.dispatchEvent(
@@ -3475,6 +3483,9 @@ describe("AgentWorkspace", () => {
     expect(
       window.localStorage.getItem("june.agent.unrestrictedSessions"),
     ).toBeNull();
+    expect(
+      hermesTraceBuffer.exportSanitizedTrace("session-1").entries,
+    ).toHaveLength(0);
   });
 
   it("keeps the blank composer after a New Session event during refresh", async () => {
@@ -5302,6 +5313,16 @@ describe("AgentWorkspace", () => {
             description: "Captured the current screen",
           },
         });
+        handler({
+          type: "tool.complete",
+          session_id: "runtime-session-2",
+          payload: {
+            name: "computer_use",
+            description: "Screen capture failed",
+            status: "error",
+            error: "permission denied",
+          },
+        });
       }
     });
 
@@ -5323,6 +5344,12 @@ describe("AgentWorkspace", () => {
       within(evidence).getByText("Captured the current screen"),
     ).toBeInTheDocument();
     expect(
+      within(evidence).getByText("Failed computer use"),
+    ).toBeInTheDocument();
+    expect(
+      within(evidence).getByText("Screen capture failed"),
+    ).toBeInTheDocument();
+    expect(
       hermesTraceBuffer
         .exportSanitizedTrace("session-2")
         .entries.some((entry) => entry.rawType === "tool.start"),
@@ -5332,7 +5359,7 @@ describe("AgentWorkspace", () => {
     ).toHaveLength(0);
   });
 
-  it("falls back to persisted tool rows in the evidence log for revisited sessions", async () => {
+  it("merges persisted tool rows with partial trace rows in the evidence log", async () => {
     const user = userEvent.setup();
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
@@ -5350,6 +5377,16 @@ describe("AgentWorkspace", () => {
     await waitFor(() =>
       expect(mocks.listHermesSessionMessages).toHaveBeenCalledWith("session-1"),
     );
+    act(() => {
+      hermesTraceBuffer.recordOutbound({
+        sessionId: "session-1",
+        method: "prompt.submit",
+        params: {
+          session_id: "runtime-session-1",
+          text: "check the browser",
+        },
+      });
+    });
 
     await user.click(
       screen.getByRole("button", { name: "Show agent activity" }),
@@ -5366,6 +5403,8 @@ describe("AgentWorkspace", () => {
     expect(
       within(evidence).getByText("Captured browser window"),
     ).toBeInTheDocument();
+    expect(within(evidence).getByText("Prompt sent")).toBeInTheDocument();
+    expect(within(evidence).getByText("check the browser")).toBeInTheDocument();
   });
 
   it("lists every surfaced file behind the session bar files button", async () => {


### PR DESCRIPTION
## Summary
- Add an Evidence log section to the Agent activity drawer that summarizes sanitized prompt, tool, computer-use, pending-action, lifecycle, error, and artifact rows.
- Re-enable the activity drawer by routing live event stores through durable stored session ids instead of ephemeral runtime ids.
- Cover live trace rows, persisted tool fallback rows, and the restored artifact drawer path in tests.

## Validation
- `pnpm exec prettier --check src/lib/hermes-trace-buffer.ts src/components/agent/AgentEvidenceLogSection.tsx src/components/agent/AgentWorkspace.tsx src/styles/app.css src/test/agent-workspace.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm exec vitest run src/test/hermes-trace-buffer.test.ts src/test/agent-workspace.test.tsx`
- `pnpm test`

## Live QA
- Vite preview on `http://127.0.0.1:1423/` with Chrome automation.
- Desktop drawer walkthrough showed `Prompt sent`, `Started computer use`, `Captured the current screen`, and `Copy log`.
- Narrow-width drawer walkthrough passed with the same rows visible and the drawer reachable.
- QA video (os-platform): https://app.opensoftware.co/api/v1/files/fil_6JnkYnA0VIBr/download
- Local artifacts: `.tmp/qa-artifacts/jun-130-evidence-log.png`, `.tmp/qa-artifacts/jun-130-evidence-log-narrow.png`, `.tmp/qa-artifacts/74bc38bef56eba16f6fd787001405881.webm`.
- Preview noise observed outside this flow: one 404 console entry and repeated `transformCallback` page errors while loading the app shell.

Closes JUN-130
