### PR TITLE
Show email before handle in sidebar account label

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1989,6 +1989,7 @@ function SidebarIdentity({
 function accountDisplayName(account: AccountStatus) {
   return (
     account.user?.displayName?.trim() ||
+    account.user?.email?.trim() ||
     account.user?.handle?.trim() ||
     "Account"
   );

--- a/src/test/folders-workspace.test.tsx
+++ b/src/test/folders-workspace.test.tsx
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FoldersWorkspace } from "../components/folders/FoldersWorkspace";
 import { Sidebar } from "../components/sidebar/Sidebar";
 import { NOTE_DND_MIME } from "../lib/dnd";
-import type { FolderDto, NoteListItemDto } from "../lib/tauri";
+import type { AccountStatus, FolderDto, NoteListItemDto } from "../lib/tauri";
 
 const mocks = vi.hoisted(() => ({
   osAccountsReferralSummary: vi.fn(),
@@ -273,6 +273,67 @@ describe("Sidebar primary navigation", () => {
     await user.click(identityButton);
     await user.click(screen.getByRole("menuitem", { name: "Settings" }));
     expect(onChangeView).toHaveBeenCalledWith("settings");
+  });
+
+  it("shows account name, then email, then handle in the sidebar footer", () => {
+    const renderSidebar = (account: AccountStatus) =>
+      render(
+        <Sidebar
+          notes={notes}
+          activeView="notes"
+          account={account}
+          onChangeView={vi.fn()}
+          onSelectNote={vi.fn()}
+          onDeleteNote={vi.fn()}
+          onOpenMoveDialog={vi.fn()}
+          onRemoveNoteFromFolder={vi.fn()}
+          onNewAgentSession={vi.fn()}
+          onSelectAgentSession={vi.fn()}
+        />,
+      );
+
+    const { unmount: unmountNamed } = renderSidebar({
+      signedIn: true,
+      configured: true,
+      user: {
+        id: "usr_123",
+        handle: "alex",
+        email: "alex@example.com",
+        displayName: "Alex",
+      },
+    });
+    expect(
+      screen.getByRole("button", { name: "Alex, account menu" }),
+    ).toBeInTheDocument();
+    unmountNamed();
+
+    const { unmount: unmountEmail } = renderSidebar({
+      signedIn: true,
+      configured: true,
+      user: {
+        id: "usr_123",
+        handle: "alex",
+        email: "alex@example.com",
+        displayName: " ",
+      },
+    });
+    expect(
+      screen.getByRole("button", { name: "alex@example.com, account menu" }),
+    ).toBeInTheDocument();
+    unmountEmail();
+
+    renderSidebar({
+      signedIn: true,
+      configured: true,
+      user: {
+        id: "usr_123",
+        handle: "alex",
+        email: " ",
+      },
+    });
+    expect(
+      screen.getByRole("button", { name: "alex, account menu" }),
+    ).toBeInTheDocument();
   });
 
   it("opens dictation history from the primary nav", async () => {


### PR DESCRIPTION
## What changed
- Updated the sidebar account identity label to prefer the account display name, then email, then handle.
- Added sidebar tests covering all three fallback levels, including blank display name and blank email cases.

## Why
- The sidebar footer could show an opaque handle such as `user-3a660b57` even when the account email is available. The account name should remain first, but email is a better fallback than handle.

## Validation
- `pnpm test -- src/test/folders-workspace.test.tsx`
- `pnpm run lint`
- `pnpm run build`
- `pnpm exec prettier --check src/components/sidebar/Sidebar.tsx src/test/folders-workspace.test.tsx`
- `git diff --check`

## Live agent walkthrough
- PASS: Served a temporary Vite QA harness at `http://127.0.0.1:1422/.tmp/qa-sidebar-account.html` rendering the real `Sidebar` with `displayName: ""`, `email: "alex@example.com"`, and `handle: "alex-handle"`.
- PASS: Headless Chrome found the visible account menu button named `alex@example.com, account menu`; visible label text was `alex@example.com`.
- PASS: No browser console errors on the clean QA pass.
- Artifacts, local only: `.tmp/qa-screenshots/sidebar-account-email.png`, `.tmp/qa-recordings/page@8f034a771ee0a415def1f3d3656e8b99.webm`, `.tmp/qa-recordings/page@8f034a771ee0a415def1f3d3656e8b99.compressed.mp4`.

## Known gaps
- `pnpm run format` still fails repo-wide on pre-existing unrelated files: `src/components/account/AccountGate.tsx`, `src/components/brand/JuneWordmark.tsx`, `src/components/note-editor/NoteFailureBanner.tsx`, `src/components/settings/AgentSettingsSection.tsx`, `src/test/agent-workspace.test.tsx`, `src/test/external-dirs.test.tsx`, and `src-tauri/tauri.conf.json`. The touched files pass Prettier.
- QA video was not uploaded publicly because public PR artifact sharing was not explicitly authorized.