### PR TITLE
Match chat send arrow weight to the mic icon

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6461,7 +6461,7 @@ export function AgentWorkspace({
                       : "Start session"
                   }
                 >
-                  {submitting ? <Spinner /> : <IconArrowUp size={16} />}
+                  {submitting ? <Spinner /> : <IconArrowUp size={18} />}
                 </button>
               )}
             </div>


### PR DESCRIPTION
## Summary

- Bump the composer send button's `IconArrowUp` from `size={16}` to `size={18}` so it matches the adjacent `IconMicrophone`. Both are `central-icons` outlined glyphs, so aligning the size makes them read as a matched pair instead of looking like different icon weights.

## Validation

- Visual only, verified in-app: send arrow and mic now sit at the same size and stroke weight in the chat composer.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.