### PR TITLE
fix: image fallback prefers Kimi over first vision model (JUN-165)

### DIFF
--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -119,7 +119,16 @@ model_type = "text"
 display_name = "Kimi K2.6"
 privacy = "private"
 context_tokens = 256000
-capabilities = ["supportsFunctionCalling"]
+# Kimi K2.6 is natively multimodal (Venice supportsVision); it is the
+# image-input fallback the app switches to. Keep in sync with the kimi-k2-6
+# entry in default_pricing() (crates/config/src/lib.rs) so the fallback still
+# resolves to a vision model when the live Venice catalog is unreachable and
+# this packaged config is what /models serves.
+capabilities = [
+  "supportsFunctionCalling",
+  "supportsVision",
+  "supportsMultipleImages",
+]
 
 [pricing."zai-org-glm-5-1"]
 unit = "tokens"

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -457,7 +457,16 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             input_credits_per_million_tokens: 850,
             output_credits_per_million_tokens: 4_660,
             context_tokens: 256_000,
-            capabilities: &["supportsFunctionCalling"],
+            // Kimi K2.6 is natively multimodal (Venice `supportsVision`), so it
+            // is the image-input fallback the frontend switches to when an image
+            // is attached to a non-vision model. Declare vision here too so that
+            // fallback still resolves when the live Venice catalog can't be
+            // reached at boot and only these built-in defaults are available.
+            capabilities: &[
+                "supportsFunctionCalling",
+                "supportsVision",
+                "supportsMultipleImages",
+            ],
         },
         TextModelFallback {
             id: "zai-org-glm-5-1",
@@ -797,6 +806,33 @@ mod tests {
         config.upstreams.openai.api_key = "sk-test".to_string();
         config.upstreams.venice.api_key = "venice-test".to_string();
         config
+    }
+
+    #[test]
+    fn default_kimi_declares_vision_but_glm_does_not() {
+        // Kimi K2.6 is the image-input fallback the app switches to, so it must
+        // read as vision-capable even from these built-in defaults, before the
+        // live Venice catalog loads (JUN-165). The non-vision GLM defaults must
+        // not claim vision, or the fallback could land on one of them.
+        let config = AppConfig::default();
+        let declares_vision = |id: &str| {
+            config
+                .pricing
+                .get(id)
+                .is_some_and(|model| model.capabilities.iter().any(|c| c == "supportsVision"))
+        };
+        assert!(
+            declares_vision("kimi-k2-6"),
+            "kimi-k2-6 default capabilities should declare supportsVision"
+        );
+        assert!(
+            config.pricing.contains_key("zai-org-glm-5-2"),
+            "zai-org-glm-5-2 should be present in default pricing"
+        );
+        assert!(
+            !declares_vision("zai-org-glm-5-2"),
+            "GLM 5.2 default must not claim vision"
+        );
     }
 
     #[test]

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -836,6 +836,40 @@ mod tests {
     }
 
     #[test]
+    fn packaged_config_toml_keeps_kimi_vision_in_sync() {
+        // config.toml overrides default_pricing() via Figment and ships in the
+        // Docker image, so it is what `/models` serves when the live Venice
+        // catalog is unreachable. It must agree that Kimi is a vision model, or
+        // the image-attach fallback breaks in the packaged build (JUN-165).
+        use figment::{
+            Figment,
+            providers::{Format, Serialized, Toml},
+        };
+        let toml_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config.toml");
+        let config = Figment::new()
+            .merge(Serialized::defaults(AppConfig::default()))
+            .merge(Toml::file(toml_path))
+            .extract::<AppConfig>()
+            .unwrap_or_default();
+        // A TOML-only model proves config.toml actually merged, so a failed
+        // load can't make the vision assertion below pass on the default alone.
+        assert!(
+            config
+                .pricing
+                .contains_key("nvidia-nemotron-3-nano-30b-a3b"),
+            "packaged config.toml did not merge"
+        );
+        let kimi_declares_vision = config
+            .pricing
+            .get("kimi-k2-6")
+            .is_some_and(|model| model.capabilities.iter().any(|c| c == "supportsVision"));
+        assert!(
+            kimi_declares_vision,
+            "packaged config.toml must declare supportsVision for kimi-k2-6"
+        );
+    }
+
+    #[test]
     fn config_debug_redacts_secrets() {
         let mut config = AppConfig::default();
         config.os_accounts.app_api_key = "app_api_key_secret_value".to_string();

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -209,7 +209,10 @@ import {
   type ProviderModelSettingsChangedDetail,
 } from "../../lib/model-privacy";
 import { resolveModelSwitchOutcome } from "../../lib/hermes-model-switch";
-import { suggestedModelsForMode } from "../../lib/suggested-models";
+import {
+  preferredVisionFallbackModel,
+  suggestedModelsForMode,
+} from "../../lib/suggested-models";
 import {
   contextLabel,
   modelOptions,
@@ -2012,14 +2015,11 @@ export function AgentWorkspace({
   const generationPrivacyBadge = generationModel
     ? modelPrivacyBadge(generationModel)
     : undefined;
-  // The agent can only switch to a model that reads images AND runs tools —
-  // a vision model without function calling would brick the agent the same way
-  // modelSupportsTools guards the picker, so it can't be an escape hatch here.
-  const visionModelOptions = useMemo(
-    () =>
-      generationModels.filter(
-        (model) => modelSupportsImageInput(model) && modelSupportsTools(model),
-      ),
+  // The model the image-attach banner offers to switch to: a vision + tool
+  // capable model, preferring a curated suggested pick (Kimi K2.6) over the
+  // alphabetically-first vision model. See preferredVisionFallbackModel.
+  const preferredVisionModel = useMemo(
+    () => preferredVisionFallbackModel(generationModels),
     [generationModels],
   );
   // Mirror the send-time fallback trigger (pendingImageAttachments +
@@ -6311,23 +6311,23 @@ export function AgentWorkspace({
                 {resolvedGenerationModel?.name ?? "This model"} can't read
                 images.
               </span>
-              {visionModelOptions.length ? (
+              {preferredVisionModel ? (
                 <button
                   type="button"
                   className="agent-composer-notice-button agent-composer-image-warning-action"
                   onClick={() =>
-                    // Switch straight to the first image-capable model. The
+                    // Switch straight to the preferred image-capable model. The
                     // label promises a one-tap fix, and the generic model picker
                     // isn't vision-scoped — opening it for the multi-candidate
                     // case would drop the user into an unfiltered list that
-                    // doesn't surface the eligible models. visionModelOptions is
-                    // pre-filtered to image + tool support;
-                    // handleSelectGenerationModel routes the global default vs
-                    // per-chat override.
-                    void handleSelectGenerationModel(visionModelOptions[0].id)
+                    // doesn't surface the eligible models. preferredVisionModel
+                    // is pre-filtered to image + tool support and prefers a
+                    // suggested pick; handleSelectGenerationModel routes the
+                    // global default vs per-chat override.
+                    void handleSelectGenerationModel(preferredVisionModel.id)
                   }
                 >
-                  Switch to a vision model
+                  Switch to {preferredVisionModel.name}
                 </button>
               ) : null}
             </div>

--- a/src/lib/model-privacy.ts
+++ b/src/lib/model-privacy.ts
@@ -62,21 +62,23 @@ export function modelSupportsTools(
   });
 }
 
+/** Whether the model can read image input (vision). Mirrors
+ * `modelSupportsTools`: key off the authoritative capability flag on
+ * `capabilities` only, never `traits`. Venice's backend emits a capability
+ * string only when its boolean is true (`collect_capability_names` in
+ * june-api), so `capabilities` reliably lists genuine vision support. `traits`
+ * is descriptive/marketing text (e.g. "multimodal") that conflates image
+ * OUTPUT with image INPUT — matching it would let the image-attach fallback
+ * switch to a model that can't actually read the image. The capability name
+ * comes from Venice's catalog (`supportsVision`); match defensively on the
+ * normalized name so a rename to snake_case keeps working. */
 export function modelSupportsImageInput(
-  model: Partial<Pick<VeniceModelDto, "capabilities" | "traits">>,
+  model: Partial<Pick<VeniceModelDto, "capabilities">>,
 ) {
-  return [...(model.capabilities ?? []), ...(model.traits ?? [])].some(
-    (capability) => {
-      const normalized = capability.toLowerCase().replace(/[^a-z]/g, "");
-      return (
-        normalized.includes("supportsvision") ||
-        normalized.includes("vision") ||
-        normalized.includes("imageinput") ||
-        normalized.includes("imageunderstanding") ||
-        normalized.includes("multimodal")
-      );
-    },
-  );
+  return (model.capabilities ?? []).some((capability) => {
+    const normalized = capability.toLowerCase().replace(/[^a-z]/g, "");
+    return normalized.includes("supportsvision");
+  });
 }
 
 // Strongest claim wins: E2EE models are also private, but "encrypted into the

--- a/src/lib/suggested-models.ts
+++ b/src/lib/suggested-models.ts
@@ -1,3 +1,4 @@
+import { modelSupportsImageInput, modelSupportsTools } from "./model-privacy";
 import type { ProviderModelMode, VeniceModelDto } from "./tauri";
 
 export type SuggestedModel = {
@@ -64,6 +65,32 @@ export const SUGGESTED_MODELS: Record<ProviderModelMode, SuggestedModel[]> = {
     },
   ],
 };
+
+/**
+ * The model June switches to when the user attaches an image while a
+ * non-vision model is active. The switch must land on a model that can both
+ * read images AND run tools — a vision model without function calling would
+ * brick the agent the same way the model picker guards against — so we filter
+ * on both capabilities. Among the eligible models we prefer a curated
+ * suggested pick (Kimi K2.6 is the suggested vision model), so the one-tap fix
+ * lands on a sensible default instead of the alphabetically-first vision model
+ * (which is otherwise arbitrary — the catalog sorts by display name). If no
+ * suggested model is eligible we fall back to the first eligible catalog model
+ * so a suggested-list change can never leave the fallback empty. The target is
+ * derived entirely from live catalog capabilities: no model id is hardcoded,
+ * so a retired model can never become the fallback.
+ */
+export function preferredVisionFallbackModel(
+  models: VeniceModelDto[],
+): VeniceModelDto | undefined {
+  const eligible = models.filter(
+    (model) => modelSupportsImageInput(model) && modelSupportsTools(model),
+  );
+  const suggested = SUGGESTED_MODELS.generation
+    .map((pick) => eligible.find((model) => model.id === pick.id))
+    .find((model): model is VeniceModelDto => model !== undefined);
+  return suggested ?? eligible[0];
+}
 
 /** The curated picks that are actually present in the live catalog, in
  * curated order, with their recommendation reasons attached. */

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5779,21 +5779,24 @@ describe("AgentWorkspace", () => {
       await screen.findByText("GLM 5.2 can't read images."),
     ).toBeInTheDocument();
 
-    await user.click(
-      screen.getByRole("button", { name: "Switch to a vision model" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Switch to Qwen VL" }));
 
     await waitFor(() =>
-      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "qwen-vl"),
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "generation",
+        "qwen-vl",
+      ),
     );
     // The switch picks the image-capable model and keeps the dropped image.
     expect(screen.getByText("screenshot.png")).toBeInTheDocument();
   });
 
-  it("switches to the first eligible vision model when several qualify", async () => {
-    // The banner action is a one-tap fix: with several image-capable models it
-    // switches straight to the first eligible one rather than opening the
-    // generic (non-vision-scoped) picker.
+  it("prefers the suggested vision model over the first eligible one (JUN-165)", async () => {
+    // The banner action is a one-tap fix, and with several image-capable models
+    // it prefers a curated suggested pick (Kimi K2.6) rather than the
+    // alphabetically-first vision model — otherwise it lands on an arbitrary
+    // model like Claude Fable 5. Qwen VL is listed first here to prove the
+    // preference overrides list order; no non-vision-scoped picker is opened.
     mocks.listAgentTasks.mockResolvedValue({ items: [] });
     mocks.listHermesSessions.mockResolvedValue([]);
     mocks.listVeniceModels.mockResolvedValue({
@@ -5821,8 +5824,8 @@ describe("AgentWorkspace", () => {
         },
         {
           provider: "venice",
-          id: "gpt-vision",
-          name: "GPT Vision",
+          id: "kimi-k2-6",
+          name: "Kimi K2.6",
           modelType: "text",
           privacy: "private",
           traits: [],
@@ -5848,11 +5851,15 @@ describe("AgentWorkspace", () => {
     });
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
     await user.click(
-      screen.getByRole("button", { name: "Switch to a vision model" }),
+      screen.getByRole("button", { name: "Switch to Kimi K2.6" }),
     );
-    // Lands on the first eligible vision model (Qwen VL), no picker dialog.
+    // Lands on the suggested vision model (Kimi), not first-listed Qwen VL, and
+    // no picker dialog opens.
     await waitFor(() =>
-      expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "qwen-vl"),
+      expect(mocks.setVeniceModel).toHaveBeenCalledWith(
+        "generation",
+        "kimi-k2-6",
+      ),
     );
     expect(
       screen.queryByRole("dialog", { name: "Choose text model" }),
@@ -5937,7 +5944,7 @@ describe("AgentWorkspace", () => {
 
     expect(await screen.findByText("screenshot.png")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Switch to a vision model" }),
+      screen.queryByRole("button", { name: /^Switch to / }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/test/model-privacy.test.ts
+++ b/src/test/model-privacy.test.ts
@@ -4,7 +4,14 @@ import {
   E2EE_MODEL_DESCRIPTION,
   PRIVATE_MODEL_DESCRIPTION,
   modelPrivacyBadge,
+  modelSupportsImageInput,
 } from "../lib/model-privacy";
+import type { VeniceModelDto } from "../lib/tauri";
+
+// Excess-property checks would reject a `traits` field on the narrowed
+// capabilities-only param, so route test shapes through a Partial helper.
+const model = (partial: Partial<VeniceModelDto>): Partial<VeniceModelDto> =>
+  partial;
 
 describe("model privacy labels", () => {
   it("uses e2ee mode over private — the stronger claim wins", () => {
@@ -58,5 +65,61 @@ describe("model privacy labels", () => {
     expect(modelPrivacyBadge({ privacy: "OpenAI", traits: ["prompt"] })).toBe(
       undefined,
     );
+  });
+});
+
+describe("model image input support", () => {
+  it("is true when the authoritative supportsVision capability is present", () => {
+    expect(modelSupportsImageInput({ capabilities: ["supportsVision"] })).toBe(
+      true,
+    );
+  });
+
+  it("recognizes a real vision model (Fable/Kimi shape: vision + tools)", () => {
+    expect(
+      modelSupportsImageInput({
+        capabilities: [
+          "supportsFunctionCalling",
+          "supportsVision",
+          "supportsMultipleImages",
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores descriptive traits — a 'multimodal' trait is not vision (JUN-165)", () => {
+    // Marketing/descriptive traits conflate image OUTPUT with image INPUT, so
+    // they must never make a non-vision model look vision-capable, or the
+    // image-attach fallback would switch to a model that can't read the image.
+    expect(
+      modelSupportsImageInput(
+        model({
+          capabilities: ["supportsFunctionCalling"],
+          traits: ["multimodal"],
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      modelSupportsImageInput(
+        model({ capabilities: [], traits: ["multimodal", "uncensored"] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for a non-vision model (GLM 5.2 shape: tools, no vision)", () => {
+    expect(
+      modelSupportsImageInput({
+        capabilities: [
+          "supportsFunctionCalling",
+          "supportsReasoning",
+          "supportsWebSearch",
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is false when no capabilities are reported", () => {
+    expect(modelSupportsImageInput({})).toBe(false);
+    expect(modelSupportsImageInput({ capabilities: [] })).toBe(false);
   });
 });

--- a/src/test/suggested-models.test.ts
+++ b/src/test/suggested-models.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { preferredVisionFallbackModel } from "../lib/suggested-models";
+import type { VeniceModelDto } from "../lib/tauri";
+
+const model = (
+  id: string,
+  name: string,
+  capabilities: string[],
+): VeniceModelDto => ({
+  provider: "venice",
+  id,
+  name,
+  modelType: "text",
+  traits: [],
+  capabilities,
+});
+
+const VISION_TOOLS = ["supportsFunctionCalling", "supportsVision"];
+// The catalog sorts by display name, so the alphabetically-first vision model
+// ("Claude Fable 5") is what a naive `[0]` fallback would pick — the JUN-165
+// bug. These fixtures put Fable first to prove the preference overrides order.
+const fable = model("claude-fable-5", "Claude Fable 5", VISION_TOOLS);
+const kimi = model("kimi-k2-6", "Kimi K2.6", VISION_TOOLS); // suggested pick
+const glm52 = model("zai-org-glm-5-2", "GLM 5.2", ["supportsFunctionCalling"]);
+
+describe("preferredVisionFallbackModel", () => {
+  it("prefers the suggested vision model (Kimi) over the first vision model", () => {
+    const chosen = preferredVisionFallbackModel([fable, kimi, glm52]);
+    expect(chosen?.id).toBe("kimi-k2-6");
+  });
+
+  it("never returns a non-vision model, even a suggested one (GLM 5.2)", () => {
+    // GLM 5.2 is the first suggested id but is non-vision; it must be skipped.
+    const chosen = preferredVisionFallbackModel([glm52, fable]);
+    expect(chosen?.id).toBe("claude-fable-5");
+  });
+
+  it("falls back to the first eligible model when none are suggested", () => {
+    const qwen = model("qwen3-5-9b", "Qwen 3.5 9B", VISION_TOOLS);
+    const chosen = preferredVisionFallbackModel([fable, qwen]);
+    expect(chosen?.id).toBe("claude-fable-5");
+  });
+
+  it("requires tool support: a vision model without tools is not eligible", () => {
+    // A vision model that can't run tools would brick the agent, so the
+    // suggested Kimi entry here (vision only, no tools) must be skipped.
+    const kimiNoTools = model("kimi-k2-6", "Kimi K2.6", ["supportsVision"]);
+    const chosen = preferredVisionFallbackModel([kimiNoTools, fable]);
+    expect(chosen?.id).toBe("claude-fable-5");
+  });
+
+  it("returns undefined when no model can read images", () => {
+    const glm51 = model("zai-org-glm-5-1", "GLM 5.1", [
+      "supportsFunctionCalling",
+    ]);
+    expect(preferredVisionFallbackModel([glm52, glm51])).toBeUndefined();
+    expect(preferredVisionFallbackModel([])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes **JUN-165** (os-platform). Attaching an image while a non-vision model (e.g. GLM 5.2) is active offered a "switch to a vision model" button that landed on **Claude Fable 5** instead of a sensible default.

## Root cause (corrected against the live catalog)

The original diagnosis assumed Fable 5 was non-vision and slipped into the candidate set via a loose `multimodal`/`vision` **trait** match. Dumping the **live Venice catalog** (148 models) disproved that premise:

- `claude-fable-5` genuinely reports `supportsVision: true` (empty traits) — it is a real vision model.
- **No** model in the catalog carries a `multimodal`/`vision` *trait* while lacking `supportsVision`, so the trait-only false positive the diagnosis described does not exist.
- The real cause: the fallback was `visionModelOptions[0]`, and the catalog sorts by display name (`providers/mod.rs:250`), so the first vision model is alphabetically "Claude Fable 5" — an arbitrary, poor default. Not a capability bug; a selection-quality bug.

## Changes

- **`preferredVisionFallbackModel`** (`src/lib/suggested-models.ts`): the image-attach banner now switches to the first *suggested* vision + tools model (→ **Kimi K2.6**, June's curated best-alternate) instead of the alphabetically-first one. Falls back to the first eligible catalog model if none are suggested. No hardcoded model id — derived entirely from live capabilities, so a retired model can never become the fallback.
- **`modelSupportsImageInput`** (`src/lib/model-privacy.ts`): tightened to key only off the authoritative `supportsVision` capability (dropped the `traits` scan and the loose `vision`/`multimodal`/`imageunderstanding` substrings), mirroring `modelSupportsTools`. No behavior change on today's catalog; defensive against a future marketing `multimodal` trait making a non-vision model look vision-capable.
- **Built-in default capabilities** (`june-api/crates/config/src/lib.rs`): `kimi-k2-6` now declares `supportsVision` + `supportsMultipleImages`, so the fallback still resolves to Kimi when the live Venice catalog can't be reached at boot and only these defaults are available.
- Banner button now names the target ("Switch to Kimi K2.6") instead of the generic "Switch to a vision model".

## Validation

- `pnpm run lint` (tsc --noEmit): PASS
- Targeted vitest (`model-privacy`, `suggested-models`): PASS — 15 tests, incl. a regression that a `multimodal` trait is not vision and that the fallback prefers Kimi over the first vision model
- Prettier `--check`: PASS
- `cargo +1.95.0 test -p june-config`: PASS — 15 tests, incl. new `default_kimi_declares_vision_but_glm_does_not`
- `cargo +1.95.0 clippy -p june-config --all-targets -- -D warnings` + `fmt --check`: PASS
- Live walkthrough of the attach-image -> banner -> switch flow: see PR comment (added after CI kicks off).

## Notes / out of scope

- GLM 5.2 stays correctly non-vision (Venice `supportsVision:false`); detection unchanged.
- Live catalog confirms the genuine vision models June ships (Kimi K2.6, GLM 5V Turbo, Qwen 3.5 9B, Mistral Small, plus the Claude/Gemini/GPT/Grok families) all carry `supportsVision:true`.
- Commit is unsigned (1Password SSH agent unavailable for GPG signing at commit time).

https://claude.ai/code/session_017waEignbBbeai3J1MpamLL
