### PR TITLE
ci: direct version bump on promote + github slack app release notifications

### DIFF
--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -370,26 +370,39 @@ jobs:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
-          # promote's tree is the rc's pinned commit with the build version stamped
-          # in; discard that and branch from current main to record the bump there.
-          git fetch origin main
-          git reset --hard
-          git checkout -B main origin/main
-          # version:bump (not set-build-version) so main's monotonic X.Y.Z gate applies.
-          pnpm version:bump "$VERSION"
-          cargo update --workspace --manifest-path src-tauri/Cargo.toml
-          git add package.json pnpm-lock.yaml src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
-          if git diff --cached --quiet; then
-            echo "main is already at v$VERSION; skipping version commit."
-            exit 0
-          fi
           bot_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
-          git commit -m "release: v$VERSION"
-          # Plain push (never force main). A non-fast-forward here means main moved
-          # since the fetch above; rerun promote (the bump is deterministic).
-          git push origin HEAD:main
+
+          # This bump is the last step, after the stable release is already
+          # published. Its push can lose a race with an unrelated commit to main;
+          # rather than fail the whole promote (which would force a 30-60 min
+          # rebuild rerun), re-fetch and replay the deterministic bump onto the new
+          # tip, then fast-forward push again. promote's own tree (the rc's pinned
+          # commit with the build version stamped in) is discarded each attempt.
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            git reset --hard
+            git checkout -B main origin/main
+            current="$(node -e 'process.stdout.write(require("./package.json").version)')"
+            if [ "$current" = "$VERSION" ]; then
+              echo "main is already at v$VERSION; nothing to record."
+              exit 0
+            fi
+            # version:bump (not set-build-version) so main's monotonic X.Y.Z gate applies.
+            pnpm version:bump "$VERSION"
+            cargo update --workspace --manifest-path src-tauri/Cargo.toml
+            git add package.json pnpm-lock.yaml src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json
+            git commit -m "release: v$VERSION"
+            # Plain push (never force main); the App bypasses branch protection.
+            if git push origin HEAD:main; then
+              echo "Recorded release: v$VERSION on main."
+              exit 0
+            fi
+            echo "::warning::Push to main was rejected (it advanced); retrying ($attempt/5)."
+          done
+          echo "::error::Could not record release: v$VERSION on main after 5 attempts."
+          exit 1
 
       # Release announcements are handled by the org's GitHub Slack app
       # (`/github subscribe open-software-network/os-june-releases releases`),

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 concurrency:
   group: promote-desktop-release
@@ -360,14 +359,14 @@ jobs:
 
       # Record the released version on main so its version files advance and the
       # next changelog can find this release. Runs only after the stable release
-      # is published, so a build/notarize failure never leaves an orphan
-      # `release:` PR. The branch push authenticates as the release App (persisted
-      # at checkout); the PR uses GITHUB_TOKEN because the App may lack
-      # pull-request write. This is the version-bump duty inherited from the
-      # retired production-desktop-dmg.yml.
-      - name: Open release version PR
+      # is published, so a build/notarize failure never leaves main bumped without
+      # a matching release. The release App is on main's branch-protection bypass
+      # list, so it commits the bump straight to main (no PR to merge); the push
+      # authenticates as the App via the credentials persisted at checkout. This
+      # is the version-bump duty inherited from the retired production workflow.
+      - name: Record released version on main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
@@ -375,7 +374,7 @@ jobs:
           # in; discard that and branch from current main to record the bump there.
           git fetch origin main
           git reset --hard
-          git checkout -B "release/v$VERSION" origin/main
+          git checkout -B main origin/main
           # version:bump (not set-build-version) so main's monotonic X.Y.Z gate applies.
           pnpm version:bump "$VERSION"
           cargo update --workspace --manifest-path src-tauri/Cargo.toml
@@ -388,48 +387,14 @@ jobs:
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           git commit -m "release: v$VERSION"
-          git push --force-with-lease origin "HEAD:refs/heads/release/v$VERSION"
+          # Plain push (never force main). A non-fast-forward here means main moved
+          # since the fetch above; rerun promote (the bump is deterministic).
+          git push origin HEAD:main
 
-          body_file="$RUNNER_TEMP/release-pr-body.md"
-          cat > "$body_file" <<EOF
-          Bumps desktop release version files to v$VERSION.
-
-          The stable release was already published by promote-desktop. Merge to record the version on main.
-          EOF
-          pr_number="$(
-            gh pr list --repo open-software-network/os-june --base main \
-              --head "release/v$VERSION" --state open --json number --jq '.[0].number // empty'
-          )"
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" --repo open-software-network/os-june \
-              --title "release: v$VERSION" --body-file "$body_file"
-          else
-            gh pr create --repo open-software-network/os-june --base main \
-              --head "release/v$VERSION" --title "release: v$VERSION" --body-file "$body_file"
-          fi
-
-      - name: Notify Slack on promote
-        if: ${{ success() }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          set -euo pipefail
-          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-            echo "::warning::SLACK_WEBHOOK_URL is not configured; skipping Slack notification."
-            exit 0
-          fi
-          payload=$(cat <<EOF
-          {
-            "text": ":ship: *June v${VERSION} promoted to stable* (from ${RC_VERSION})"
-          }
-          EOF
-          )
-          curl -sS -f -X POST -H "Content-Type: application/json" \
-            --data "$payload" "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || {
-            echo "::warning::Slack notification failed."
-            exit 0
-          }
-
+      # Release announcements are handled by the org's GitHub Slack app
+      # (`/github subscribe open-software-network/os-june-releases releases`),
+      # which posts when the stable `vX.Y.Z` release is published. See
+      # docs/release-macos.md.
       - name: Summary
         run: |
           {

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -399,13 +399,13 @@ jobs:
           if gh release view rc --repo open-software-network/os-june-releases >/dev/null 2>&1; then
             gh release edit rc \
               --repo open-software-network/os-june-releases \
-              --title "June $VERSION (rc)" \
+              --title "June v$VERSION (rc)" \
               --prerelease \
               --notes-file "$notes_file"
           else
             gh release create rc \
               --repo open-software-network/os-june-releases \
-              --title "June $VERSION (rc)" \
+              --title "June v$VERSION (rc)" \
               --prerelease \
               --notes-file "$notes_file" \
               --target main

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -136,8 +136,10 @@ version-bump PR being merged first.
   `release: vX.Y.Z` directly (no PR to merge), advancing the version files so the
   next RC's Q9 gate and the next changelog anchor work. It runs only after the
   stable release is published, so a build failure never leaves `main` bumped
-  without a matching release. A non-fast-forward push (main moved since promote's
-  fetch) fails the step; rerun, since the bump is deterministic.
+  without a matching release. If the push loses a race with a concurrent commit
+  to `main`, promote re-fetches and replays the deterministic bump onto the new
+  tip (a few attempts) rather than failing after the release is already published
+  and forcing a full rebuild rerun.
 - **Release announcements are delegated to the GitHub Slack app.** Rather than a
   webhook step in the workflows, a channel subscribes with
   `/github subscribe open-software-network/os-june-releases releases`. This

--- a/docs/adr/0003-release-candidate-channel-and-promotion.md
+++ b/docs/adr/0003-release-candidate-channel-and-promotion.md
@@ -131,10 +131,18 @@ version-bump PR being merged first.
   older stable to users; recover from a bad stable by releasing forward.
 - **Promote does a second full macOS build + notarize.** Slower than re-tagging,
   in exchange for a clean stable version string from tested source.
-- **The version-bump PR is bookkeeping.** Merging `release: vX.Y.Z` advances
-  `main`'s version files so the next RC's Q9 gate and the next changelog anchor
-  work. Windows and the stable release no longer depend on it, so it can merge in
-  parallel.
+- **The version bump is bookkeeping, committed straight to `main`.** The release
+  bot is on `main`'s branch-protection bypass list, so promote commits
+  `release: vX.Y.Z` directly (no PR to merge), advancing the version files so the
+  next RC's Q9 gate and the next changelog anchor work. It runs only after the
+  stable release is published, so a build failure never leaves `main` bumped
+  without a matching release. A non-fast-forward push (main moved since promote's
+  fetch) fails the step; rerun, since the bump is deterministic.
+- **Release announcements are delegated to the GitHub Slack app.** Rather than a
+  webhook step in the workflows, a channel subscribes with
+  `/github subscribe open-software-network/os-june-releases releases`. This
+  covers stable (each is a freshly published `vX.Y.Z`); RC iterations reuse the
+  fixed `rc` tag and are edited in place, so they do not reliably post.
 - **Post-RC commits merged during an RC cycle are not in that release.** They ship
   in a later release built from a future RC. Because the changelog anchors on the
   latest `release: v...` first-parent commit, such commits can fall between two

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -98,14 +98,29 @@ ships the same source you tested with a clean version string. It then:
   recording the source commit (so the Windows build reuses the same tree);
 - generates the changelog (first-parent commits since the previous `release: v...`)
   and embeds it in both the GitHub release notes and `latest.json`;
-- opens a `release: vX.Y.Z` PR bumping the version files on `main`.
+- commits `release: vX.Y.Z` directly to `main` (the release bot is on the
+  branch-protection bypass list), advancing the version files so the next RC's
+  gate and the next changelog can anchor on it. No PR to merge.
 
-### 4. Merge the version PR
+### 4. Cut the Windows release
 
-Merge the `release: vX.Y.Z` PR so `main`'s version files advance and the next
-changelog can anchor on it. The Windows release does not depend on this merge
-(it rebuilds from the commit recorded in `stable-build.json`), so it can run in
-parallel.
+The version bump lands on `main` automatically, so there is nothing to merge.
+The Windows release rebuilds from the commit recorded in `stable-build.json`, so
+it does not depend on the bump and can run as soon as promote finishes (see
+`release-windows.md`).
+
+## Release notifications
+
+Stable releases are announced in Slack by the org's GitHub Slack app. Subscribe a
+channel once with:
+
+```text
+/github subscribe open-software-network/os-june-releases releases
+```
+
+It posts when a `vX.Y.Z` stable release is published. RC builds reuse the fixed
+`rc` release tag and are edited in place rather than re-published, so they do not
+reliably trigger a Slack post; watch the `rc` release page for candidates.
 
 The app polls:
 

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -51,11 +51,12 @@ GitHub Actions -> rc-desktop-release -> Run workflow (base-version X.Y.Z, rc-num
 GitHub Actions -> promote-desktop-release -> Run workflow (rc-version X.Y.Z-rc.N)
 ```
 
-Promote owns the clean semver `X.Y.Z`, the `release: vX.Y.Z` bump PR to `main`,
-the stable release creation, macOS assets, and initial `latest.json`. It also
-records the source commit in a `stable-build.json` asset on the `vX.Y.Z` release.
-The Windows workflow reads that commit and rebuilds the same tree, so it does NOT
-depend on the version PR being merged and can run as soon as promote finishes.
+Promote owns the clean semver `X.Y.Z`, the `release: vX.Y.Z` bump committed
+directly to `main` by the release bot, the stable release creation, macOS assets,
+and initial `latest.json`. It also records the source commit in a
+`stable-build.json` asset on the `vX.Y.Z` release. The Windows workflow reads that
+commit and rebuilds the same tree, so it does not depend on the bump and can run
+as soon as promote finishes.
 
 Once promote has published `vX.Y.Z`, run:
 


### PR DESCRIPTION
Follow-ups to the JUN-132 release-channel work (#529), on a fresh branch off main.

## Pillar 4: promote commits the version bump straight to `main`
The release bot is now on `main`'s branch-protection bypass list, so `promote-desktop.yml` commits `release: vX.Y.Z` directly to `main` instead of opening a `release/*` PR. Removes the PR create/edit block and the now-unused `pull-requests: write` permission. The bump still runs only after the stable release is published, and uses a plain push (never force) so a non-fast-forward just fails and can be rerun.

## Release notifications via the org GitHub Slack app
Chose the existing org GitHub Slack app over a custom webhook. Removed the custom `SLACK_WEBHOOK_URL` step from promote. Setup is a one-time `/github subscribe open-software-network/os-june-releases releases` in the target channel (documented in `docs/release-macos.md`).

Note: the app posts on stable (`vX.Y.Z`, freshly published each time) but not reliably on RC iterations, which reuse the fixed `rc` tag edited in place. This trade-off is documented.

## Docs
- `release-macos.md`: version bump auto-lands on `main` (no PR to merge); added a Release notifications section.
- `release-windows.md`: bump is committed directly, not via PR.
- `adr/0003`: updated the version-bump consequence and recorded the Slack-app decision.

Verified: actionlint clean on all three desktop workflows; no leftover `SLACK_WEBHOOK_URL` references.

https://claude.ai/code/session_01N7EjAZTbHeK9gf2JkQbZoD
