### PR TITLE
Fix partial meeting notes after long turn transcription failures

### DIFF
--- a/src-tauri/src/audio/turns.rs
+++ b/src-tauri/src/audio/turns.rs
@@ -9,7 +9,7 @@ const NORMALIZE_MIN_GAIN: f32 = 1.25;
 const NORMALIZE_MAX_GAIN: f32 = 32.0;
 const TRANSCRIPTION_SAMPLE_RATE: u32 = 16_000;
 const TRANSCRIPTION_CHANNELS: u16 = 1;
-const MAX_TRANSCRIPTION_CHUNK_MS: i64 = 8 * 60 * 1000;
+pub const MAX_TRANSCRIPTION_CHUNK_MS: i64 = 30 * 1000;
 /// Loudest-window RMS below which a track carries no transcribable speech.
 /// Deliberately conservative (≈ -38 dBFS) and matches the microphone lane's
 /// activity `min_rms`, so we only ever skip clearly-silent audio.
@@ -83,8 +83,13 @@ pub fn coalesce_turns_for_transcription(mut turns: Vec<AudioTurn>) -> Vec<AudioT
     for turn in turns {
         if let Some(last) = coalesced.last_mut() {
             let gap_ms = turn.start_ms - last.end_ms;
-            if last.source == turn.source && gap_ms <= TRANSCRIPTION_COHERENCE_GAP_MS {
-                last.end_ms = last.end_ms.max(turn.end_ms);
+            let merged_end_ms = last.end_ms.max(turn.end_ms);
+            let merged_duration_ms = merged_end_ms - last.start_ms;
+            if last.source == turn.source
+                && gap_ms <= TRANSCRIPTION_COHERENCE_GAP_MS
+                && merged_duration_ms <= MAX_TRANSCRIPTION_CHUNK_MS
+            {
+                last.end_ms = merged_end_ms;
                 continue;
             }
         }

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -578,19 +578,14 @@ pub async fn process_saved_source_audio(
     let has_valid_transcript = !transcription_outcome.candidates.is_empty();
     let visible_failures =
         visible_transcription_failures(&transcription_outcome.failures, has_valid_transcript);
+    // `visible_failures` is already filtered by `should_record_source_failure`,
+    // so every entry here is one we persist.
     for failure in &visible_failures {
         let warning = failure
             .input
             .warning
             .as_deref()
             .unwrap_or("Source did not produce a usable transcript.");
-        if !should_record_source_failure(
-            failure.input.source.as_str(),
-            warning,
-            has_valid_transcript,
-        ) {
-            continue;
-        }
         let persistence_started = Instant::now();
         repos
             .upsert_failed_source_turn_transcript(
@@ -884,7 +879,7 @@ async fn transcribe_prepared_audio(
             request.base_context.as_deref(),
             build_transcription_context(&previous).as_deref(),
         );
-        let transcript = transcribe_with_transient_retries(
+        let transcript = match transcribe_with_transient_retries(
             &transcriber,
             TranscriptionRequest {
                 provider: request.provider.clone(),
@@ -896,7 +891,16 @@ async fn transcribe_prepared_audio(
                 preview: false,
             },
         )
-        .await?;
+        .await
+        {
+            Ok(transcript) => transcript,
+            // A no-speech chunk is a silent segment, not a turn failure: fixed-size
+            // splitting routinely leaves a quiet trailing chunk. Skip it so the
+            // speech already transcribed from this turn's earlier chunks survives.
+            // Aborting here would discard that text and silently drop the turn.
+            Err(error) if is_no_speech_error(&error) => continue,
+            Err(error) => return Err(error),
+        };
         if language.is_none() {
             language = transcript.language.clone();
         }
@@ -917,10 +921,10 @@ async fn transcribe_prepared_audio(
     }
 
     if text_parts.is_empty() {
-        return Err(AppError::new(
-            "transcription_empty",
-            "Transcription provider returned empty text for every audio chunk.",
-        ));
+        // Every chunk was silent. Report it as a no-speech turn — exactly like a
+        // single silent turn — so it stays a non-blocking failure rather than a
+        // generic error that would fail the whole note.
+        return Err(AppError::new("no_speech", "no_speech"));
     }
     Ok(TranscriptionProviderResult {
         text: text_parts.join("\n"),
@@ -1507,6 +1511,13 @@ fn should_record_source_failure(source: &str, warning: &str, has_valid_transcrip
 fn is_no_speech_message(message: &str) -> bool {
     let normalized = message.trim().to_ascii_lowercase();
     normalized == "no_speech" || normalized.contains("no speech detected")
+}
+
+/// Whether a transcription error is a no-speech condition rather than a real
+/// failure. The backend surfaces an empty (silent) segment as a 400 with a
+/// `no_speech` reason, so it arrives on either the error code or message.
+fn is_no_speech_error(error: &AppError) -> bool {
+    is_no_speech_message(&error.code) || is_no_speech_message(&error.message)
 }
 
 fn user_facing_transcription_failure_message(code: &str, message: &str) -> String {
@@ -2263,6 +2274,126 @@ mod tests {
             writer.write_sample(*sample).unwrap();
         }
         writer.finalize().unwrap();
+    }
+
+    fn write_mono_wav(path: &std::path::Path, sample_rate: u32, sample_count: usize) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).unwrap();
+        for index in 0..sample_count {
+            // Content is irrelevant: the mock transcriber keys on the chunk
+            // operation id, not the audio. A non-zero ramp keeps it a signal.
+            writer.write_sample((index % 100) as i16 - 50).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    #[test]
+    fn is_no_speech_error_detects_no_speech_conditions() {
+        assert!(is_no_speech_error(&AppError::new("no_speech", "no_speech")));
+        assert!(is_no_speech_error(&AppError::new(
+            "june_request_failed",
+            "no_speech"
+        )));
+        assert!(!is_no_speech_error(&AppError::new(
+            "june_api_response_invalid",
+            "The processing service returned an invalid response."
+        )));
+    }
+
+    #[tokio::test]
+    async fn multi_chunk_turn_keeps_earlier_text_when_trailing_chunk_has_no_speech() {
+        // A 31s turn splits into a 30s chunk-0 and a ~1s chunk-1. The trailing
+        // chunk returns no-speech; the turn must still succeed with chunk-0's
+        // text instead of aborting and discarding it.
+        let dir =
+            std::env::temp_dir().join(format!("os-june-chunk-nospeech-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let audio_path = dir.join("turn.wav");
+        write_mono_wav(&audio_path, 16_000, 16_000 * 31);
+
+        let transcriber = Arc::new(move |request: TranscriptionRequest| {
+            Box::pin(async move {
+                if request.operation_id().ends_with("-chunk-0") {
+                    Ok(TranscriptionProviderResult {
+                        text: "first chunk speech".to_string(),
+                        language: Some("en".to_string()),
+                        provider: "test".to_string(),
+                    })
+                } else {
+                    Err(AppError::new("no_speech", "no_speech"))
+                }
+            }) as TranscriptionFuture
+        }) as TurnTranscriber;
+
+        let result = transcribe_prepared_audio(
+            transcriber,
+            TranscribePreparedAudioRequest {
+                provider: "test".to_string(),
+                audio_path,
+                temp_dir: dir.clone(),
+                chunk_stem: "turn-0".to_string(),
+                title: "Meeting".to_string(),
+                base_context: None,
+                operation_id: "turn-0".to_string(),
+                source: "microphone".to_string(),
+                start_ms: Some(0),
+                end_ms: Some(31_000),
+                turn_index: Some(0),
+            },
+        )
+        .await
+        .expect("a trailing no-speech chunk must not fail the whole turn");
+
+        assert_eq!(result.text, "first chunk speech");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn multi_chunk_turn_reports_no_speech_when_every_chunk_is_silent() {
+        // When no chunk has speech, the turn must fail as a no-speech condition
+        // so it stays non-blocking — not a generic error that fails the note.
+        let dir =
+            std::env::temp_dir().join(format!("os-june-chunk-allsilent-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let audio_path = dir.join("turn.wav");
+        write_mono_wav(&audio_path, 16_000, 16_000 * 31);
+
+        let transcriber = Arc::new(move |_request: TranscriptionRequest| {
+            Box::pin(async move { Err(AppError::new("no_speech", "no_speech")) })
+                as TranscriptionFuture
+        }) as TurnTranscriber;
+
+        let error = transcribe_prepared_audio(
+            transcriber,
+            TranscribePreparedAudioRequest {
+                provider: "test".to_string(),
+                audio_path,
+                temp_dir: dir.clone(),
+                chunk_stem: "turn-0".to_string(),
+                title: "Meeting".to_string(),
+                base_context: None,
+                operation_id: "turn-0".to_string(),
+                source: "microphone".to_string(),
+                start_ms: Some(0),
+                end_ms: Some(31_000),
+                turn_index: Some(0),
+            },
+        )
+        .await
+        .expect_err("an all-silent turn must fail");
+
+        assert!(
+            is_no_speech_error(&error),
+            "all-silent turn must stay a non-blocking no-speech failure, got code={} message={}",
+            error.code,
+            error.message
+        );
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -576,7 +576,9 @@ pub async fn process_saved_source_audio(
     let _ = std::fs::remove_dir_all(&segment_dir);
 
     let has_valid_transcript = !transcription_outcome.candidates.is_empty();
-    for failure in &transcription_outcome.failures {
+    let visible_failures =
+        visible_transcription_failures(&transcription_outcome.failures, has_valid_transcript);
+    for failure in &visible_failures {
         let warning = failure
             .input
             .warning
@@ -644,6 +646,19 @@ pub async fn process_saved_source_audio(
             )
             .await?;
         return Err(AppError::new("transcription_failed", failure_message));
+    }
+    if let Some(failure_message) = blocking_transcription_failure_summary(&visible_failures) {
+        repos
+            .set_note_status(
+                note_id,
+                ProcessingStatus::Failed,
+                Some(failure_message.clone()),
+            )
+            .await?;
+        return Err(AppError::new(
+            "transcription_partially_failed",
+            failure_message,
+        ));
     }
     let labeled_transcript = labeled_transcript_from_sources(&valid_sources);
     repos
@@ -1408,6 +1423,46 @@ fn source_failure_summary(failures: &[FailedTranscriptCandidate]) -> Option<Stri
     )
 }
 
+fn visible_transcription_failures(
+    failures: &[FailedTranscriptCandidate],
+    has_valid_transcript: bool,
+) -> Vec<FailedTranscriptCandidate> {
+    failures
+        .iter()
+        .filter(|failure| {
+            let warning = failure
+                .input
+                .warning
+                .as_deref()
+                .unwrap_or("Source did not produce a usable transcript.");
+            should_record_source_failure(
+                failure.input.source.as_str(),
+                warning,
+                has_valid_transcript,
+            )
+        })
+        .cloned()
+        .collect()
+}
+
+fn blocking_transcription_failure_summary(
+    failures: &[FailedTranscriptCandidate],
+) -> Option<String> {
+    let blocking_failures = failures
+        .iter()
+        .filter(|failure| {
+            let warning = failure
+                .input
+                .warning
+                .as_deref()
+                .unwrap_or("Source did not produce a usable transcript.");
+            !is_no_speech_message(warning)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    source_failure_summary(&blocking_failures)
+}
+
 /// Remove system-audio sources whose track is effectively silent, but only when
 /// another source remains to carry the recording. Keeping the last source — even
 /// a silent one — preserves the "no speech" failure for system-only captures.
@@ -2156,6 +2211,38 @@ mod tests {
     }
 
     #[test]
+    fn no_speech_failures_do_not_block_partial_note_generation() {
+        let visible = visible_transcription_failures(
+            &[failed_candidate(
+                "microphone",
+                "No speech detected. Try speaking louder or moving closer to the microphone.",
+                2,
+            )],
+            true,
+        );
+
+        assert_eq!(visible.len(), 1);
+        assert!(blocking_transcription_failure_summary(&visible).is_none());
+    }
+
+    #[test]
+    fn invalid_turn_failures_block_partial_note_generation() {
+        let visible = visible_transcription_failures(
+            &[failed_candidate(
+                "microphone",
+                "The processing service returned an invalid response.",
+                5,
+            )],
+            true,
+        );
+
+        assert_eq!(
+            blocking_transcription_failure_summary(&visible).as_deref(),
+            Some("Microphone: The processing service returned an invalid response.")
+        );
+    }
+
+    #[test]
     fn never_drops_microphone_failures() {
         assert!(should_record_source_failure(
             "microphone",
@@ -2269,6 +2356,21 @@ mod tests {
             source_path: PathBuf::from(source_path),
             covers_full_source: false,
             ..test_job(path, source, turn_index)
+        }
+    }
+
+    fn failed_candidate(source: &str, warning: &str, turn_index: i64) -> FailedTranscriptCandidate {
+        FailedTranscriptCandidate {
+            artifact_id: format!("{source}-artifact"),
+            input: SourceTranscriptInput {
+                source: source.to_string(),
+                text: String::new(),
+                valid: false,
+                warning: Some(warning.to_string()),
+                start_ms: Some(turn_index * 1_000),
+                end_ms: Some(turn_index * 1_000 + 500),
+                turn_index: Some(turn_index),
+            },
         }
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -875,6 +875,14 @@ async fn transcribe_prepared_audio(
     let mut language = None;
     let mut provider_name = request.provider.clone();
     for (index, audio_path) in audio_paths.into_iter().enumerate() {
+        // Skip clearly-silent chunks before any API call. Fixed-size splitting of
+        // a long (or fully silent) source leaves quiet boundary chunks, and each
+        // request authorizes a credit hold that a no-speech response never
+        // settles — so sending every silent chunk of a silent source would strand
+        // holds until TTL and can trip `authorization_denied` on later work.
+        if crate::audio::turns::source_is_effectively_silent(&audio_path) {
+            continue;
+        }
         let context = merge_transcription_context(
             request.base_context.as_deref(),
             build_transcription_context(&previous).as_deref(),
@@ -894,10 +902,9 @@ async fn transcribe_prepared_audio(
         .await
         {
             Ok(transcript) => transcript,
-            // A no-speech chunk is a silent segment, not a turn failure: fixed-size
-            // splitting routinely leaves a quiet trailing chunk. Skip it so the
-            // speech already transcribed from this turn's earlier chunks survives.
-            // Aborting here would discard that text and silently drop the turn.
+            // Backstop for a chunk the local silence check judged audible but the
+            // provider still reports as no-speech: skip it so earlier chunks' text
+            // survives, rather than aborting and dropping the whole turn.
             Err(error) if is_no_speech_error(&error) => continue,
             Err(error) => return Err(error),
         };
@@ -2276,7 +2283,15 @@ mod tests {
         writer.finalize().unwrap();
     }
 
-    fn write_mono_wav(path: &std::path::Path, sample_rate: u32, sample_count: usize) {
+    /// Loud tone, above the silence floor, so every chunk survives the local
+    /// silence prefilter and reaches the (mock) transcriber.
+    fn write_loud_wav(path: &std::path::Path, sample_rate: u32, sample_count: usize) {
+        write_segmented_wav(path, sample_rate, &[(sample_count, 20_000)]);
+    }
+
+    /// Writes consecutive `(frame_count, amplitude)` segments. Amplitude `0`
+    /// yields a silent span; a large amplitude yields an audible tone.
+    fn write_segmented_wav(path: &std::path::Path, sample_rate: u32, segments: &[(usize, i16)]) {
         let spec = hound::WavSpec {
             channels: 1,
             sample_rate,
@@ -2284,10 +2299,15 @@ mod tests {
             sample_format: hound::SampleFormat::Int,
         };
         let mut writer = hound::WavWriter::create(path, spec).unwrap();
-        for index in 0..sample_count {
-            // Content is irrelevant: the mock transcriber keys on the chunk
-            // operation id, not the audio. A non-zero ramp keeps it a signal.
-            writer.write_sample((index % 100) as i16 - 50).unwrap();
+        for (count, amplitude) in segments {
+            for index in 0..*count {
+                let sample = if index % 2 == 0 {
+                    *amplitude
+                } else {
+                    -*amplitude
+                };
+                writer.write_sample(sample).unwrap();
+            }
         }
         writer.finalize().unwrap();
     }
@@ -2314,7 +2334,7 @@ mod tests {
             std::env::temp_dir().join(format!("os-june-chunk-nospeech-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
         let audio_path = dir.join("turn.wav");
-        write_mono_wav(&audio_path, 16_000, 16_000 * 31);
+        write_loud_wav(&audio_path, 16_000, 16_000 * 31);
 
         let transcriber = Arc::new(move |request: TranscriptionRequest| {
             Box::pin(async move {
@@ -2361,7 +2381,7 @@ mod tests {
             std::env::temp_dir().join(format!("os-june-chunk-allsilent-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
         let audio_path = dir.join("turn.wav");
-        write_mono_wav(&audio_path, 16_000, 16_000 * 31);
+        write_loud_wav(&audio_path, 16_000, 16_000 * 31);
 
         let transcriber = Arc::new(move |_request: TranscriptionRequest| {
             Box::pin(async move { Err(AppError::new("no_speech", "no_speech")) })
@@ -2393,6 +2413,66 @@ mod tests {
             error.code,
             error.message
         );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn silent_chunks_are_skipped_before_reaching_the_transcriber() {
+        // 62s: loud 0-30s, silent 30-60s, loud 60-62s -> chunks 0 and 2 audible,
+        // chunk 1 silent. The silent chunk must never reach the API (no credit
+        // hold), while both audible chunks are transcribed.
+        let dir =
+            std::env::temp_dir().join(format!("os-june-chunk-silentskip-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let audio_path = dir.join("turn.wav");
+        write_segmented_wav(
+            &audio_path,
+            16_000,
+            &[
+                (16_000 * 30, 20_000),
+                (16_000 * 30, 0),
+                (16_000 * 2, 20_000),
+            ],
+        );
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let transcriber = {
+            let calls = Arc::clone(&calls);
+            Arc::new(move |_request: TranscriptionRequest| {
+                let calls = Arc::clone(&calls);
+                Box::pin(async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(TranscriptionProviderResult {
+                        text: format!("chunk text {n}"),
+                        language: None,
+                        provider: "test".to_string(),
+                    })
+                }) as TranscriptionFuture
+            }) as TurnTranscriber
+        };
+
+        let result = transcribe_prepared_audio(
+            transcriber,
+            TranscribePreparedAudioRequest {
+                provider: "test".to_string(),
+                audio_path,
+                temp_dir: dir.clone(),
+                chunk_stem: "turn-0".to_string(),
+                title: "Meeting".to_string(),
+                base_context: None,
+                operation_id: "turn-0".to_string(),
+                source: "microphone".to_string(),
+                start_ms: Some(0),
+                end_ms: Some(62_000),
+                turn_index: Some(0),
+            },
+        )
+        .await
+        .expect("audible chunks should transcribe");
+
+        // Only the two audible chunks reach the API; the silent middle is skipped.
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(result.text, "chunk text 0\nchunk text 1");
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src-tauri/tests/turn_detection.rs
+++ b/src-tauri/tests/turn_detection.rs
@@ -1,6 +1,7 @@
 use hound::{SampleFormat, WavSpec, WavWriter};
 use os_june_lib::audio::turns::{
-    coalesce_turns_for_transcription, detect_turns, AudioTurn, DetectionSource,
+    coalesce_turns_for_transcription, detect_turns, split_wav_for_transcription, AudioTurn,
+    DetectionSource, MAX_TRANSCRIPTION_CHUNK_MS,
 };
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
@@ -109,6 +110,25 @@ fn coalesces_adjacent_same_source_turns_before_transcription() {
 }
 
 #[test]
+fn does_not_coalesce_turns_past_transcription_chunk_cap() {
+    let turns = coalesce_turns_for_transcription(vec![
+        turn("microphone", 0, MAX_TRANSCRIPTION_CHUNK_MS - 1_000, 0),
+        turn(
+            "microphone",
+            MAX_TRANSCRIPTION_CHUNK_MS,
+            MAX_TRANSCRIPTION_CHUNK_MS + 5_000,
+            1,
+        ),
+    ]);
+
+    assert_eq!(turns.len(), 2);
+    assert_eq!(turns[0].start_ms, 0);
+    assert_eq!(turns[0].end_ms, MAX_TRANSCRIPTION_CHUNK_MS - 1_000);
+    assert_eq!(turns[1].start_ms, MAX_TRANSCRIPTION_CHUNK_MS);
+    assert_eq!(turns[1].turn_index, 1);
+}
+
+#[test]
 fn keeps_same_source_turns_separate_when_another_source_intervenes() {
     let turns = coalesce_turns_for_transcription(vec![
         turn("microphone", 1_000, 4_000, 0),
@@ -123,6 +143,32 @@ fn keeps_same_source_turns_separate_when_another_source_intervenes() {
             .collect::<Vec<_>>(),
         vec!["microphone", "system", "microphone"]
     );
+}
+
+#[test]
+fn splits_prepared_wav_into_provider_safe_chunks() {
+    let dir = tempdir().expect("tempdir");
+    let input = dir.path().join("long.wav");
+    let chunks_dir = dir.path().join("chunks");
+    write_pattern_wav(
+        &input,
+        &[
+            (MAX_TRANSCRIPTION_CHUNK_MS as u32, 8_000),
+            (MAX_TRANSCRIPTION_CHUNK_MS as u32, 7_000),
+            (5_000, 6_000),
+        ],
+    );
+
+    let chunks =
+        split_wav_for_transcription(&input, &chunks_dir, "turn").expect("wav should split");
+
+    assert_eq!(chunks.len(), 3);
+    for chunk in chunks.iter().take(2) {
+        let reader = hound::WavReader::open(chunk).expect("chunk reader");
+        assert_eq!(reader.duration(), MAX_TRANSCRIPTION_CHUNK_MS as u32);
+    }
+    let tail = hound::WavReader::open(chunks.last().expect("tail chunk")).expect("tail reader");
+    assert_eq!(tail.duration(), 5_000);
 }
 
 fn turn(source: &str, start_ms: i64, end_ms: i64, turn_index: i64) -> AudioTurn {


### PR DESCRIPTION
## What changed
- Cap prepared transcription chunks at 30 seconds and export the cap for tests.
- Prevent same-source turn coalescing from creating transcription jobs longer than the provider-safe cap.
- Stop marking notes ready when some visible transcription turns fail with blocking provider/service errors; no-speech failures can still be non-blocking when another source produced a usable transcript.
- Add regression coverage for turn coalescing, chunk splitting, and partial-failure handling.

## Root cause
The July 1 meeting source audio was not only two minutes long: the raw microphone and system WAVs were intact at roughly 23:24. The failure was downstream in transcription.

The app detected 48 turns, but long same-source turns were sent to ASR as very large requests. Several persisted failed turns were above 30 seconds, and the successful turns were all at or below roughly 31 seconds in the affected recording. The pipeline then generated a note from the successful subset instead of treating the visible failed turns as blocking. That made the generated note feel like it only covered the first couple minutes even though the source WAVs existed.

This patch makes the app split prepared WAVs into 30-second chunks, prevents coalescing from re-creating overlong jobs, and fails the note instead of producing a misleading partial note when real transcription failures remain.

## Additional audio diagnosis
I also checked the exported `combined.m4a` and the two raw source WAVs. The combined export is a mono AAC mix, so the microphone/system lanes cannot be independently shifted after export. The raw files are not perfectly timeline-locked:

- Microphone WAV: 1403.509333s
- System WAV: 1403.956792s
- System tail is about 447ms longer than microphone.
- Downsampled correlation showed shared activity around +350ms early in the meeting, then mostly with microphone roughly 350-450ms earlier than system later in the meeting.

That can create audible doubling/echo in a combined listen-back file and may contribute to duplicate or slightly misordered transcript snippets. It was not the primary cause of the missing note coverage: the failed transcript jobs line up with overlong chunks. Fixing capture-time alignment between CPAL microphone capture and the macOS system-audio helper should be handled as a separate live-audio change.

## Tested visually
Not applicable. This is a Rust recording/transcription pipeline change with no UI surface change.

## Backend / June API deploy
No. This changes desktop-side WAV preparation and local processing behavior; it does not require a June API deploy or contract change.

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --test turn_detection`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked domain::processing`
- `pnpm test:rust`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`

## Out of scope
- Capture-time synchronization between microphone and system audio lanes.
- Reprocessing/recovery UX for already-recorded meetings.
- Backend/provider diagnostics that preserve HTTP status/body classes for failed ASR requests.
- Provider-specific dynamic chunk limits.
- A new UI state for partial transcript failures.

## Follow-ups
- Add persisted diagnostics for normalized chunk duration, chunk count, and provider response class.
- Add a recovery/reprocess action so existing source WAVs can regenerate notes after this fix.
- Investigate microphone/system capture alignment using a live test recording and either shared timeline metadata or explicit helper offset compensation.
