### PR TITLE
[codex] Request promo-code checkout sessions

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -550,8 +550,12 @@ pub async fn os_accounts_upgrade() -> Result<(), AppError> {
             "OS Accounts is not configured for this build.",
         ));
     }
-    let session: CheckoutSessionWire =
-        authed_post(&cfg, "/billing/subscription", serde_json::json!({})).await?;
+    let session: CheckoutSessionWire = authed_post(
+        &cfg,
+        "/billing/subscription",
+        subscription_checkout_request(),
+    )
+    .await?;
     let url = session.url.trim();
     if url.is_empty() {
         return Err(AppError::new(
@@ -560,6 +564,12 @@ pub async fn os_accounts_upgrade() -> Result<(), AppError> {
         ));
     }
     open_in_browser(url)
+}
+
+fn subscription_checkout_request() -> serde_json::Value {
+    serde_json::json!({
+        "allow_promotion_codes": true,
+    })
 }
 
 /// Opens the accounts portal in the default browser. The webview swallows
@@ -1479,5 +1489,13 @@ mod tests {
     fn oauth_scope_allows_checkout_and_credit_spend() {
         assert!(OAUTH_SCOPES.contains("billing:write"));
         assert!(OAUTH_SCOPES.contains("credits:spend"));
+    }
+
+    #[test]
+    fn subscription_checkout_request_allows_promotion_codes() {
+        assert_eq!(
+            subscription_checkout_request(),
+            serde_json::json!({ "allow_promotion_codes": true })
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Send `allow_promotion_codes: true` when June asks OS Accounts to create a subscription Checkout session.
- Add a focused Rust unit test for the subscription checkout request payload.

## Why
Stripe Checkout supports `allow_promotion_codes` on session creation for user-redeemable promotion codes. June does not create Stripe sessions directly; it asks OS Accounts for the subscription checkout URL, so this client request needs the companion server forwarding support in open-software-network/os-accounts#73.

Stripe reference: https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-allow_promotion_codes

## Validation
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked os_accounts`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --quiet`

## Gaps
- No live checkout walkthrough was run. It would require configured OS Accounts billing/auth and would open a real external Stripe Checkout session.
