### PR TITLE
Sign out of OS Accounts with June

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -194,6 +194,13 @@ pub struct AccountStatus {
     pub portal_url: Option<String>,
 }
 
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountsLogoutRequest {
+    #[serde(default)]
+    pub clear_browser_session: bool,
+}
+
 fn is_false(value: &bool) -> bool {
     !*value
 }
@@ -520,7 +527,7 @@ pub fn os_accounts_cancel_login(flow: tauri::State<'_, LoginFlow>) -> Result<(),
 }
 
 #[tauri::command]
-pub async fn os_accounts_logout() -> Result<(), AppError> {
+pub async fn os_accounts_logout(request: Option<AccountsLogoutRequest>) -> Result<(), AppError> {
     if local_dev_enabled() {
         set_cached_signed_in(true);
         return Ok(());
@@ -535,7 +542,28 @@ pub async fn os_accounts_logout() -> Result<(), AppError> {
     }
     clear_tokens().await;
     set_cached_signed_in(false);
+    if request
+        .map(|request| request.clear_browser_session)
+        .unwrap_or(false)
+    {
+        let _ = open_accounts_browser_logout(&cfg);
+    }
     Ok(())
+}
+
+fn open_accounts_browser_logout(cfg: &Config) -> Result<(), AppError> {
+    let Some(url) = accounts_browser_logout_url(cfg) else {
+        return Ok(());
+    };
+    open_in_browser(&url)
+}
+
+fn accounts_browser_logout_url(cfg: &Config) -> Option<String> {
+    let accounts_url = cfg.accounts_url.trim().trim_end_matches('/');
+    if accounts_url.is_empty() {
+        return None;
+    }
+    Some(format!("{accounts_url}/login?signed-out=1"))
 }
 
 #[tauri::command]
@@ -1497,5 +1525,32 @@ mod tests {
             subscription_checkout_request(),
             serde_json::json!({ "allow_promotion_codes": true })
         );
+    }
+
+    #[test]
+    fn browser_logout_url_points_at_signed_out_login() {
+        let cfg = Config {
+            accounts_url: "https://accounts.opensoftware.co/".to_string(),
+            api_url: "https://api.accounts.opensoftware.co".to_string(),
+            client_id: "ocl_test".to_string(),
+            loopback_port: DEFAULT_LOOPBACK_PORT,
+        };
+
+        assert_eq!(
+            accounts_browser_logout_url(&cfg).as_deref(),
+            Some("https://accounts.opensoftware.co/login?signed-out=1")
+        );
+    }
+
+    #[test]
+    fn browser_logout_url_is_absent_without_accounts_origin() {
+        let cfg = Config {
+            accounts_url: "   ".to_string(),
+            api_url: "https://api.accounts.opensoftware.co".to_string(),
+            client_id: "ocl_test".to_string(),
+            loopback_port: DEFAULT_LOOPBACK_PORT,
+        };
+
+        assert_eq!(accounts_browser_logout_url(&cfg), None);
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -953,7 +953,7 @@ export function App() {
   // shouldBlockOnSignIn back on, so the app falls through to the AccountGate.
   async function handleSignOut() {
     try {
-      await osAccountsLogout();
+      await osAccountsLogout({ clearBrowserSession: true });
       handleAccountChanged({ signedIn: false, configured: account.configured });
     } catch (err) {
       setError(messageFromError(err));

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -81,7 +81,7 @@ export function AccountSettingsSection({ account, loading, onAccountChanged }: P
   async function handleSignOut() {
     setBusy(true);
     try {
-      await osAccountsLogout();
+      await osAccountsLogout({ clearBrowserSession: true });
       onAccountChanged({ signedIn: false, configured: account.configured });
       setAccountStatus("Signed out.");
     } catch (error) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1484,8 +1484,14 @@ export async function osAccountsCancelLogin() {
   return invoke<void>("os_accounts_cancel_login");
 }
 
-export async function osAccountsLogout() {
-  return invoke<void>("os_accounts_logout");
+export type AccountsLogoutOptions = {
+  clearBrowserSession?: boolean;
+};
+
+export async function osAccountsLogout(options: AccountsLogoutOptions = {}) {
+  return invoke<void>("os_accounts_logout", {
+    request: { clearBrowserSession: options.clearBrowserSession ?? false },
+  });
 }
 
 export async function osAccountsUpgrade() {

--- a/src/test/account-status.test.tsx
+++ b/src/test/account-status.test.tsx
@@ -33,6 +33,7 @@ describe("useAccountStatus", () => {
     render(<StatusProbe forceLogoutOnMount />);
 
     await screen.findByText("Signed out");
+    expect(mocks.osAccountsLogout).toHaveBeenCalledWith();
     await waitFor(() => expect(calls).toEqual(["logout", "status"]));
   });
 });

--- a/src/test/account-status.test.tsx
+++ b/src/test/account-status.test.tsx
@@ -33,7 +33,7 @@ describe("useAccountStatus", () => {
     render(<StatusProbe forceLogoutOnMount />);
 
     await screen.findByText("Signed out");
-    expect(mocks.osAccountsLogout).toHaveBeenCalledWith();
+    expect(mocks.osAccountsLogout.mock.calls[0]?.[0]?.clearBrowserSession).not.toBe(true);
     await waitFor(() => expect(calls).toEqual(["logout", "status"]));
   });
 });

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -634,7 +634,7 @@ describe("AppSettings", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Sign out" }));
-    expect(mocks.osAccountsLogout).toHaveBeenCalledOnce();
+    expect(mocks.osAccountsLogout).toHaveBeenCalledWith({ clearBrowserSession: true });
     expect(signedOut).toHaveBeenCalledWith({
       signedIn: false,
       configured: signedInAccount.configured,

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -380,6 +380,20 @@ describe("App shortcuts", () => {
     }
   });
 
+  it("clears the OS Accounts browser session from sidebar sign-out", async () => {
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await user.click(screen.getByRole("button", { name: "alex@example.com, account menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Sign out" }));
+
+    expect(mocks.osAccountsLogout).toHaveBeenCalledWith({ clearBrowserSession: true });
+    expect(await screen.findByRole("heading", { name: "Welcome to June" })).toBeInTheDocument();
+  });
+
   it("starts a new session with Command-N", async () => {
     const onNewSession = vi.fn();
     window.addEventListener(AGENT_NEW_SESSION_EVENT, onNewSession);


### PR DESCRIPTION
Closes JUN-166

## What changed
- Added an optional `clearBrowserSession` request to the OS Accounts logout command.
- User-initiated sign-out paths now request browser-session clearing, which opens the OS Accounts portal at `/login?signed-out=1` after June revokes and clears its local token state.
- Internal forced logout paths remain local-only so onboarding replay and startup cleanup do not unexpectedly open a browser tab.
- Added Rust and frontend tests for the logout handoff and local-only forced logout behavior.

## Why
Signing out of June revoked June's stored OS Accounts refresh token but left the OS Accounts portal session in the system browser. The next sign-in could reuse that browser session instead of requiring the user to sign in again.

## Validation
- `pnpm run check` passed with existing Biome warning diagnostics.
- `pnpm test` passed: 126 files, 1856 passed, 2 skipped.
- `pnpm build` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` passed.
- `cargo test --manifest-path src-tauri/Cargo.toml os_accounts` passed.

## Live walkthrough
- BLOCKED: a full live OS Accounts browser-session sign-out walkthrough requires a real logged-in OS Accounts browser session and would mutate private account/session state. No credentials or account-session use was authorized in this run.
- Supplemental evidence: the public portal bundle was inspected and `/login?signed-out=1` is the portal route that triggers its Privy logout path; the generated handoff URL is covered by Rust tests.

## Known gaps
- No recorded live QA video for the external browser handoff because the live-account walkthrough was blocked.
