### PR TITLE
Fix Meeting notes delete fallback

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2088,6 +2088,16 @@ export function App() {
     }
   }
 
+  function handleEmptyNotesAfterDelete() {
+    const currentView = activeViewRef.current;
+    if (currentView === "meetings" || currentView === "notes" || currentView === "all-notes") {
+      setActiveView("notes");
+    }
+    setOriginFolderId(undefined);
+    setOriginAllNotes(false);
+    setFolderReturnTarget(undefined);
+  }
+
   async function handleDeleteNote(noteId: string) {
     if (state.recordingStatus) {
       setError("Stop the current recording before deleting a note.");
@@ -2103,9 +2113,7 @@ export function App() {
         const note = await getNote(nextNoteId);
         dispatch({ type: "noteLoaded", note });
       } else {
-        setActiveView("settings");
-        setOriginFolderId(undefined);
-        setFolderReturnTarget(undefined);
+        handleEmptyNotesAfterDelete();
       }
     } catch (err) {
       setError(messageFromError(err));
@@ -2127,9 +2135,7 @@ export function App() {
         const note = await getNote(nextNoteId);
         dispatch({ type: "noteLoaded", note });
       } else {
-        setActiveView("settings");
-        setOriginFolderId(undefined);
-        setFolderReturnTarget(undefined);
+        handleEmptyNotesAfterDelete();
       }
     } catch (err) {
       setError(messageFromError(err));
@@ -2273,7 +2279,7 @@ export function App() {
         const restored = await getNote(restoreNoteId);
         dispatch({ type: "noteLoaded", note: restored });
       } else {
-        setActiveView("settings");
+        handleEmptyNotesAfterDelete();
       }
     } catch (err) {
       setError(messageFromError(err));

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   listNotes: vi.fn(),
   getNote: vi.fn(),
   deleteNote: vi.fn(),
+  deleteNotes: vi.fn(),
   updateNote: vi.fn(),
   checkRecordingSourceReadiness: vi.fn(),
   openPrivacySettings: vi.fn(),
@@ -86,6 +87,7 @@ vi.mock("../lib/tauri", () => ({
   listNotes: mocks.listNotes,
   getNote: mocks.getNote,
   deleteNote: mocks.deleteNote,
+  deleteNotes: mocks.deleteNotes,
   updateNote: mocks.updateNote,
   checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
   openPrivacySettings: mocks.openPrivacySettings,
@@ -217,6 +219,7 @@ describe("notes recording reliability", () => {
     // suite asserts recording lands on note-1, so the fresh note IS note-1.
     mocks.createNote.mockResolvedValue(first);
     mocks.deleteNote.mockResolvedValue(undefined);
+    mocks.deleteNotes.mockResolvedValue(undefined);
     mocks.listNotes.mockResolvedValue({ items: [first, second] });
     mocks.getNote.mockImplementation(async (noteId: string) =>
       noteId === "note-2" ? second : first,
@@ -307,6 +310,49 @@ describe("notes recording reliability", () => {
       expect(mocks.startRecording).toHaveBeenCalledWith("note-1", "microphonePlusSystem");
     });
   }
+
+  it("stays on meeting notes after deleting the last note", async () => {
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [first],
+      activeRecoveries: [],
+      providerConfigured: true,
+    });
+    mocks.listNotes.mockResolvedValue({ items: [] });
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("button", { name: "Actions for First note" }));
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete note" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete note" }));
+
+    await waitFor(() => expect(mocks.deleteNote).toHaveBeenCalledWith("note-1"));
+    expect(
+      screen.getByRole("button", { name: "Meeting notes", current: "page" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Capture your first meeting" })).toBeInTheDocument();
+  });
+
+  it("stays on meeting notes after bulk deleting every note", async () => {
+    mocks.listNotes.mockResolvedValue({ items: [] });
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select First note" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Select Second note" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete notes" }));
+
+    await waitFor(() => expect(mocks.deleteNotes).toHaveBeenCalledWith(["note-1", "note-2"]));
+    expect(
+      screen.getByRole("button", { name: "Meeting notes", current: "page" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Capture your first meeting" })).toBeInTheDocument();
+  });
 
   it("does not mark a different note transcribing when finishing a recording started elsewhere", async () => {
     mocks.finishRecording.mockResolvedValue({


### PR DESCRIPTION
Closes JUN-175

## Summary
- Keep note-related views on Meeting notes when deleting leaves no notes, instead of routing to Settings.
- Apply the same empty-notes fallback to single delete, bulk delete, and failed meeting-start cleanup.
- Add App-level regressions for deleting the last note and bulk deleting every note.

## Why
JUN-175 reports that deleting the latest Meeting notes entry sends the user to Settings. The empty-list branch in the delete handlers explicitly called `setActiveView("settings")`, so the user lost the Meeting notes context after a successful delete.

## Validation
- `pnpm exec vitest run src/test/app-notes-reliability.test.tsx`
- `pnpm test`
- `pnpm build`
- `pnpm exec biome check src/app/App.tsx src/test/app-notes-reliability.test.tsx` exited 0, with existing App warnings still reported
- `git diff --check`

## Skipped or blocked
- `pnpm run check` is blocked by pre-existing repo-wide Biome diagnostics outside this change. First reported error: `scripts/hermes-smoke.ts:515` prefers a template literal; Biome also reports existing warnings in unrelated files.
- Live native QA was not run because reproducing the bug would delete real local Meeting notes. The added App regression tests drive the visible delete dialog path with mocked Tauri data and assert the empty Meeting notes page remains current.

## Known gaps
- This PR does not change how the next note is selected when notes remain. It only fixes the empty-list redirect to Settings.
