### PR TITLE
Add active session report action regressions

### DIFF
--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -215,13 +215,13 @@ describe("AgentWorkspace", () => {
     // Feature 14: the artifact store is a process-wide singleton; drop the
     // session rows these tests touch so one test's artifacts don't leak into
     // the next.
-    for (const id of ["session-1", "session-2", "runtime-session-2"]) {
+    for (const id of ["session-1", "session-2", "runtime-session-1", "runtime-session-2"]) {
       hermesArtifactStore.clearSession(id);
     }
     // Feature 04: the pending-action store is the same kind of process-wide
     // singleton. Clear these tests' session ids so a prior test's "Needs you"
     // rows (now keyed by the durable stored id) don't leak into the next.
-    for (const id of ["session-1", "session-2", "runtime-session-2"]) {
+    for (const id of ["session-1", "session-2", "runtime-session-1", "runtime-session-2"]) {
       pendingActionStore.resolveSession(id);
     }
     window.sessionStorage.clear();

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -720,7 +720,9 @@ describe("AgentWorkspace", () => {
     expect(screen.getByRole("button", { name: "Start session" })).toBeDisabled();
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
 
-    act(() => resolveSubmit?.());
+    await act(async () => {
+      resolveSubmit?.();
+    });
   });
 
   it("wraps a submitted issue report for June and waits for explicit send", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -686,6 +686,43 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
   });
 
+  it("seeds a report chip while the current session is still running", async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (() => void) | undefined;
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      if (method === "prompt.submit") {
+        return new Promise((resolve) => {
+          resolveSubmit = () => resolve({});
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox"), "keep working");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    expect(await screen.findByRole("button", { name: "Stop June" })).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_NEW_SESSION_EVENT, {
+          detail: { category: "feedback" },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Feedback")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start session" })).toBeDisabled();
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
+
+    act(() => resolveSubmit?.());
+  });
+
   it("wraps a submitted issue report for June and waits for explicit send", async () => {
     const user = userEvent.setup();
     window.sessionStorage.setItem(

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -398,6 +398,49 @@ describe("App shortcuts", () => {
     }
   });
 
+  it("opens a report draft from the account menu while a session is active", async () => {
+    const user = userEvent.setup();
+    const activeSession = {
+      id: "session-1",
+      title: "Existing session",
+      preview: "Existing session preview",
+      last_active: now,
+    };
+
+    render(<App />);
+
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AGENT_SESSIONS_CHANGED_EVENT, {
+          detail: {
+            sessions: [activeSession],
+            selectedSessionId: undefined,
+            workingSessionIds: [],
+            waitingSessionIds: [],
+          },
+        }),
+      );
+    });
+
+    for (const [menuItem, chipLabel] of [
+      ["Report a bug", "Bug report"],
+      ["Send feedback", "Feedback"],
+      ["Request a feature", "Feature request"],
+    ] as const) {
+      await user.click(await screen.findByRole("button", { name: "Existing session" }));
+      expect(await screen.findByRole("button", { name: "Send message" })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /account menu/i }));
+      await user.click(screen.getByRole("menuitem", { name: menuItem }));
+
+      expect(await screen.findByText(chipLabel)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Start session" })).toBeDisabled();
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
+    }
+  });
+
   it("keeps a newly started chat attached to its tab before sessions hydrate", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "MacIntel",


### PR DESCRIPTION
Closes JUN-173

## Summary
- Add app-level coverage that Report a bug, Send feedback, and Request a feature from the account menu open a fresh tagged report draft when a session is already selected.
- Add AgentWorkspace coverage that the same report-seeding event works while the current session is still running and the Stop June control is active.

## Why
JUN-173 reports the report/feedback/feature request buttons as unresponsive during an active session. Current main already routes those actions correctly, so this PR locks the behavior down with regressions around the reported paths.

## Validation
- `pnpm test src/test/app-shortcut.test.tsx`
- `pnpm test src/test/agent-workspace.test.tsx`
- `pnpm run check` (exit 0; existing Biome warnings outside this change remain)
- `pnpm run typecheck`
- `git diff --check`

## Live walkthrough
Skipped: this is test-only coverage with no user-facing code change.