### PR TITLE
Warn before oversized composer sends

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -763,6 +763,7 @@ type PreparedComposerSubmission = {
 };
 
 type ComposerInputSizeWarning = {
+  inputSignature: string;
   signature: string;
   estimatedTokens: number;
   contextLimit: number;
@@ -1223,10 +1224,11 @@ export function AgentWorkspace({
   // Confirmation that a submitted issue report reached the June team; shown
   // in the composer notice slot until dismissed by the next send.
   const [issueReportNotice, setIssueReportNotice] = useState<AgentWorkspaceNotice | null>(null);
-  const [composerSizeWarningSignature, setComposerSizeWarningSignature] = useState<string | null>(
+  const [composerSizeWarning, setComposerSizeWarning] = useState<ComposerInputSizeWarning | null>(
     null,
   );
   const composerSizeProceedSignatureRef = useRef<string | null>(null);
+  const composerSizeProceedInputSignatureRef = useRef<string | null>(null);
   // Honest result of the last model switch (feature 10): scoped to the session
   // it acted on so it survives background refreshes and disappears when the
   // user moves to another conversation. A null sessionId means it reports a
@@ -1880,22 +1882,18 @@ export function AgentWorkspace({
     composerHasPendingImage &&
     !!resolvedGenerationModel &&
     !modelSupportsImageInput(resolvedGenerationModel);
-  const composerInputSizeWarning = useMemo(
+  const composerInputSignature = useMemo(
     () =>
-      oversizedComposerInputWarning({
+      composerInputSignatureFor({
         message: draft.trim(),
         category,
         attachments,
         model: generationModel,
-        models: generationModels,
       }),
-    [attachments, category, draft, generationModel, generationModels],
+    [attachments, category, draft, generationModel],
   );
   const visibleComposerSizeWarning =
-    composerSizeWarningSignature &&
-    composerInputSizeWarning?.signature === composerSizeWarningSignature
-      ? composerInputSizeWarning
-      : null;
+    composerSizeWarning?.inputSignature === composerInputSignature ? composerSizeWarning : null;
   const selectedHermesMessages = useMemo(() => {
     if (!selectedHermesSessionId) return [];
     return [
@@ -2844,17 +2842,17 @@ export function AgentWorkspace({
   }, [attachments]);
 
   useEffect(() => {
-    const signature = composerInputSizeWarning?.signature ?? null;
-    if (composerSizeWarningSignature && composerSizeWarningSignature !== signature) {
-      setComposerSizeWarningSignature(null);
+    if (composerSizeWarning && composerSizeWarning.inputSignature !== composerInputSignature) {
+      setComposerSizeWarning(null);
     }
     if (
       composerSizeProceedSignatureRef.current &&
-      composerSizeProceedSignatureRef.current !== signature
+      composerSizeProceedInputSignatureRef.current !== composerInputSignature
     ) {
       composerSizeProceedSignatureRef.current = null;
+      composerSizeProceedInputSignatureRef.current = null;
     }
-  }, [composerInputSizeWarning?.signature, composerSizeWarningSignature]);
+  }, [composerInputSignature, composerSizeWarning]);
 
   useEffect(() => {
     let disposed = false;
@@ -3197,14 +3195,6 @@ export function AgentWorkspace({
     )
       return;
     if (message && (await handleBuiltinComposerSlashCommand(message))) return;
-    if (
-      composerInputSizeWarning &&
-      composerSizeProceedSignatureRef.current !== composerInputSizeWarning.signature
-    ) {
-      setComposerSizeWarningSignature(composerInputSizeWarning.signature);
-      composerEditorRef.current?.focus();
-      return;
-    }
     // June is mid-run: send the message straight into the loop via steer so
     // June picks it up after the current tool call (adds context without
     // interrupting — Escape or Stop interrupts instead). Plain-text follow-ups
@@ -3218,6 +3208,21 @@ export function AgentWorkspace({
       selectedHermesSessionId &&
       workingSessionIdsRef.current.has(selectedHermesSessionId)
     ) {
+      const steerSizeWarning = oversizedComposerInputWarning({
+        content: message,
+        inputSignature: composerInputSignature,
+        attachments: [],
+        model: generationModel,
+        models: generationModels,
+      });
+      if (
+        steerSizeWarning &&
+        composerSizeProceedSignatureRef.current !== steerSizeWarning.signature
+      ) {
+        setComposerSizeWarning(steerSizeWarning);
+        composerEditorRef.current?.focus();
+        return;
+      }
       const steerSessionId = selectedHermesSessionId;
       // Delivery guarantee. Hermes only injects a steer into the next tool
       // result and rejects the RPC during a no-tool phase, so the steer alone
@@ -3280,6 +3285,21 @@ export function AgentWorkspace({
       | undefined;
     try {
       const prepared = await prepareComposerSubmission(message, attachments);
+      const runtimeContent = reportCategory
+        ? categoryPrompt(reportCategory, prepared.runtimeContent)
+        : prepared.runtimeContent;
+      const sizeWarning = oversizedComposerInputWarning({
+        content: runtimeContent,
+        inputSignature: composerInputSignature,
+        attachments,
+        model: generationModel,
+        models: generationModels,
+      });
+      if (sizeWarning && composerSizeProceedSignatureRef.current !== sizeWarning.signature) {
+        setComposerSizeWarning(sizeWarning);
+        composerEditorRef.current?.focus();
+        return;
+      }
       const nextIssueReport: PendingIssueReport | undefined = reportCategory
         ? {
             category: reportCategory,
@@ -3322,18 +3342,12 @@ export function AgentWorkspace({
         };
       }
       setIssueReportNotice(null);
-      await submitHermesSession(
-        reportCategory
-          ? categoryPrompt(reportCategory, prepared.runtimeContent)
-          : prepared.runtimeContent,
-        undefined,
-        {
-          displayContent: prepared.displayContent,
-          titleContent: prepared.titleContent,
-          attachments,
-          ...(nextIssueReport ? { issueReport: nextIssueReport } : {}),
-        },
-      );
+      await submitHermesSession(runtimeContent, undefined, {
+        displayContent: prepared.displayContent,
+        titleContent: prepared.titleContent,
+        attachments,
+        ...(nextIssueReport ? { issueReport: nextIssueReport } : {}),
+      });
       if (reportFollowUpSessionId) {
         deferredFailedIssueReportDeliverySessionIdsRef.current.delete(reportFollowUpSessionId);
       }
@@ -3403,20 +3417,24 @@ export function AgentWorkspace({
   function proceedWithOversizeComposerInput() {
     if (!visibleComposerSizeWarning) return;
     composerSizeProceedSignatureRef.current = visibleComposerSizeWarning.signature;
-    setComposerSizeWarningSignature(null);
+    composerSizeProceedInputSignatureRef.current = visibleComposerSizeWarning.inputSignature;
+    setComposerSizeWarning(null);
     void submit();
   }
 
   function trimOversizeComposerInput() {
-    setComposerSizeWarningSignature(null);
+    setComposerSizeWarning(null);
+    composerSizeProceedSignatureRef.current = null;
+    composerSizeProceedInputSignatureRef.current = null;
     composerEditorRef.current?.focus();
   }
 
   function switchOversizeComposerModel() {
     const switchModel = visibleComposerSizeWarning?.switchModel;
     if (!switchModel) return;
-    setComposerSizeWarningSignature(null);
+    setComposerSizeWarning(null);
     composerSizeProceedSignatureRef.current = null;
+    composerSizeProceedInputSignatureRef.current = null;
     void handleSelectGenerationModel(switchModel.id);
   }
 
@@ -10883,15 +10901,35 @@ function artifactsFromFilesystemSnapshot(
   );
 }
 
-function oversizedComposerInputWarning({
+function composerInputSignatureFor({
   message,
   category,
   attachments,
   model,
-  models,
 }: {
   message: string;
   category: ReportCategory | null;
+  attachments: AgentAttachment[];
+  model?: VeniceModelDto;
+}) {
+  const attachmentSignature = composerAttachmentSignature(attachments);
+  return [
+    model?.id ?? "",
+    positiveContextTokens(model?.contextTokens) ?? "",
+    category ?? "",
+    composerInputHash(`${message}\n${attachmentSignature}`),
+  ].join(":");
+}
+
+function oversizedComposerInputWarning({
+  content,
+  inputSignature,
+  attachments,
+  model,
+  models,
+}: {
+  content: string;
+  inputSignature: string;
   attachments: AgentAttachment[];
   model?: VeniceModelDto;
   models: VeniceModelDto[];
@@ -10899,37 +10937,25 @@ function oversizedComposerInputWarning({
   const contextLimit = positiveContextTokens(model?.contextTokens);
   if (!contextLimit) return null;
 
-  const displayContent = promptWithAttachments(message, attachments);
-  const routedContent = category ? categoryPrompt(category, displayContent) : displayContent;
   const attachmentBytes = attachments.reduce(
     (total, attachment) => total + nonNegativeAttachmentSize(attachment.size),
     0,
   );
   const estimatedTokens = Math.ceil(
-    (routedContent.length + attachmentBytes) / COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN,
+    (content.length + attachmentBytes) / COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN,
   );
   if (estimatedTokens <= contextLimit) return null;
 
-  const attachmentSignature = attachments
-    .map((attachment) =>
-      [
-        attachment.id,
-        attachment.path,
-        attachment.name,
-        attachment.size ?? "",
-        attachment.attach.status,
-      ].join("|"),
-    )
-    .join("\n");
   const signature = [
+    inputSignature,
     model?.id ?? "",
     contextLimit,
-    category ?? "",
     estimatedTokens,
-    composerInputHash(`${routedContent}\n${attachmentSignature}`),
+    composerInputHash(content),
   ].join(":");
 
   return {
+    inputSignature,
     signature,
     estimatedTokens,
     contextLimit,
@@ -10941,6 +10967,20 @@ function oversizedComposerInputWarning({
       models,
     }),
   };
+}
+
+function composerAttachmentSignature(attachments: AgentAttachment[]) {
+  return attachments
+    .map((attachment) =>
+      [
+        attachment.id,
+        attachment.path,
+        attachment.name,
+        attachment.size ?? "",
+        attachment.attach.status,
+      ].join("|"),
+    )
+    .join("\n");
 }
 
 function positiveContextTokens(value?: number) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -3422,7 +3422,7 @@ export function AgentWorkspace({
     void submit();
   }
 
-  function trimOversizeComposerInput() {
+  function editOversizeComposerInput() {
     setComposerSizeWarning(null);
     composerSizeProceedSignatureRef.current = null;
     composerSizeProceedInputSignatureRef.current = null;
@@ -6173,9 +6173,9 @@ export function AgentWorkspace({
                 <button
                   type="button"
                   className="agent-composer-notice-button"
-                  onClick={trimOversizeComposerInput}
+                  onClick={editOversizeComposerInput}
                 >
-                  Trim input
+                  Edit message
                 </button>
                 {visibleComposerSizeWarning.switchModel ? (
                   <button
@@ -10937,12 +10937,14 @@ function oversizedComposerInputWarning({
   const contextLimit = positiveContextTokens(model?.contextTokens);
   if (!contextLimit) return null;
 
-  const attachmentBytes = attachments.reduce(
+  // The composer only has attachment metadata here. Treat file bytes as a
+  // conservative character proxy so large pending files still get a warning.
+  const attachmentCharacterProxy = attachments.reduce(
     (total, attachment) => total + nonNegativeAttachmentSize(attachment.size),
     0,
   );
   const estimatedTokens = Math.ceil(
-    (content.length + attachmentBytes) / COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN,
+    (content.length + attachmentCharacterProxy) / COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN,
   );
   if (estimatedTokens <= contextLimit) return null;
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -280,6 +280,7 @@ const AGENT_WORKSPACE_MAX_SESSION_RETRY_DELAY_MS =
 const QUEUED_STEER_RETRY_DELAY_MS = 300;
 const RESTORED_QUEUED_STEER_RECONCILE_DELAY_MS = 1000;
 const RESTORED_QUEUED_STEER_BUSY_RECONCILE_DELAY_MS = 3000;
+const COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN = 4;
 
 // What the user reads instead of the gateway's "session busy" rejection. No
 // action in the pill — the composer's send slot already shows stop while
@@ -761,6 +762,14 @@ type PreparedComposerSubmission = {
   typedMessage: string;
 };
 
+type ComposerInputSizeWarning = {
+  signature: string;
+  estimatedTokens: number;
+  contextLimit: number;
+  modelName: string;
+  switchModel?: VeniceModelDto;
+};
+
 type ComposerDraftSnapshot = {
   text: string;
   category: ReportCategory | null;
@@ -1214,6 +1223,10 @@ export function AgentWorkspace({
   // Confirmation that a submitted issue report reached the June team; shown
   // in the composer notice slot until dismissed by the next send.
   const [issueReportNotice, setIssueReportNotice] = useState<AgentWorkspaceNotice | null>(null);
+  const [composerSizeWarningSignature, setComposerSizeWarningSignature] = useState<string | null>(
+    null,
+  );
+  const composerSizeProceedSignatureRef = useRef<string | null>(null);
   // Honest result of the last model switch (feature 10): scoped to the session
   // it acted on so it survives background refreshes and disappears when the
   // user moves to another conversation. A null sessionId means it reports a
@@ -1867,6 +1880,22 @@ export function AgentWorkspace({
     composerHasPendingImage &&
     !!resolvedGenerationModel &&
     !modelSupportsImageInput(resolvedGenerationModel);
+  const composerInputSizeWarning = useMemo(
+    () =>
+      oversizedComposerInputWarning({
+        message: draft.trim(),
+        category,
+        attachments,
+        model: generationModel,
+        models: generationModels,
+      }),
+    [attachments, category, draft, generationModel, generationModels],
+  );
+  const visibleComposerSizeWarning =
+    composerSizeWarningSignature &&
+    composerInputSizeWarning?.signature === composerSizeWarningSignature
+      ? composerInputSizeWarning
+      : null;
   const selectedHermesMessages = useMemo(() => {
     if (!selectedHermesSessionId) return [];
     return [
@@ -2815,6 +2844,19 @@ export function AgentWorkspace({
   }, [attachments]);
 
   useEffect(() => {
+    const signature = composerInputSizeWarning?.signature ?? null;
+    if (composerSizeWarningSignature && composerSizeWarningSignature !== signature) {
+      setComposerSizeWarningSignature(null);
+    }
+    if (
+      composerSizeProceedSignatureRef.current &&
+      composerSizeProceedSignatureRef.current !== signature
+    ) {
+      composerSizeProceedSignatureRef.current = null;
+    }
+  }, [composerInputSizeWarning?.signature, composerSizeWarningSignature]);
+
+  useEffect(() => {
     let disposed = false;
     const unlisteners: Array<() => void> = [];
     const installListener = async (eventName: string) => {
@@ -3155,6 +3197,14 @@ export function AgentWorkspace({
     )
       return;
     if (message && (await handleBuiltinComposerSlashCommand(message))) return;
+    if (
+      composerInputSizeWarning &&
+      composerSizeProceedSignatureRef.current !== composerInputSizeWarning.signature
+    ) {
+      setComposerSizeWarningSignature(composerInputSizeWarning.signature);
+      composerEditorRef.current?.focus();
+      return;
+    }
     // June is mid-run: send the message straight into the loop via steer so
     // June picks it up after the current tool call (adds context without
     // interrupting — Escape or Stop interrupts instead). Plain-text follow-ups
@@ -3348,6 +3398,26 @@ export function AgentWorkspace({
       // is dropped and can land on the always-on-top agent HUD.
       window.requestAnimationFrame(() => composerEditorRef.current?.focus());
     }
+  }
+
+  function proceedWithOversizeComposerInput() {
+    if (!visibleComposerSizeWarning) return;
+    composerSizeProceedSignatureRef.current = visibleComposerSizeWarning.signature;
+    setComposerSizeWarningSignature(null);
+    void submit();
+  }
+
+  function trimOversizeComposerInput() {
+    setComposerSizeWarningSignature(null);
+    composerEditorRef.current?.focus();
+  }
+
+  function switchOversizeComposerModel() {
+    const switchModel = visibleComposerSizeWarning?.switchModel;
+    if (!switchModel) return;
+    setComposerSizeWarningSignature(null);
+    composerSizeProceedSignatureRef.current = null;
+    void handleSelectGenerationModel(switchModel.id);
   }
 
   function handleComposerDragOver(event: DragEvent<HTMLFormElement>) {
@@ -6058,6 +6128,47 @@ export function AgentWorkspace({
                   Switch to {preferredVisionModel.name}
                 </button>
               ) : null}
+            </div>
+          ) : null}
+          {visibleComposerSizeWarning ? (
+            <div className="agent-composer-size-warning" role="status">
+              <IconExclamationTriangle
+                size={14}
+                aria-hidden
+                className="agent-composer-size-warning-icon"
+              />
+              <span className="agent-composer-size-warning-text">
+                This message is about{" "}
+                {formatComposerTokenCount(visibleComposerSizeWarning.estimatedTokens)} tokens, over{" "}
+                {visibleComposerSizeWarning.modelName}'s{" "}
+                {formatComposerTokenCount(visibleComposerSizeWarning.contextLimit)} token context
+                window.
+              </span>
+              <span className="agent-composer-size-warning-actions">
+                <button
+                  type="button"
+                  className="agent-composer-notice-button"
+                  onClick={proceedWithOversizeComposerInput}
+                >
+                  Proceed
+                </button>
+                <button
+                  type="button"
+                  className="agent-composer-notice-button"
+                  onClick={trimOversizeComposerInput}
+                >
+                  Trim input
+                </button>
+                {visibleComposerSizeWarning.switchModel ? (
+                  <button
+                    type="button"
+                    className="agent-composer-notice-button"
+                    onClick={switchOversizeComposerModel}
+                  >
+                    Switch to {visibleComposerSizeWarning.switchModel.name}
+                  </button>
+                ) : null}
+              </span>
             </div>
           ) : null}
           <ComposerEditor
@@ -10770,6 +10881,115 @@ function artifactsFromFilesystemSnapshot(
   return (snapshot?.roots ?? []).flatMap((root) =>
     filesystemEntriesToArtifacts(root.entries, root.label),
   );
+}
+
+function oversizedComposerInputWarning({
+  message,
+  category,
+  attachments,
+  model,
+  models,
+}: {
+  message: string;
+  category: ReportCategory | null;
+  attachments: AgentAttachment[];
+  model?: VeniceModelDto;
+  models: VeniceModelDto[];
+}): ComposerInputSizeWarning | null {
+  const contextLimit = positiveContextTokens(model?.contextTokens);
+  if (!contextLimit) return null;
+
+  const displayContent = promptWithAttachments(message, attachments);
+  const routedContent = category ? categoryPrompt(category, displayContent) : displayContent;
+  const attachmentBytes = attachments.reduce(
+    (total, attachment) => total + nonNegativeAttachmentSize(attachment.size),
+    0,
+  );
+  const estimatedTokens = Math.ceil(
+    (routedContent.length + attachmentBytes) / COMPOSER_TOKEN_ESTIMATE_CHARS_PER_TOKEN,
+  );
+  if (estimatedTokens <= contextLimit) return null;
+
+  const attachmentSignature = attachments
+    .map((attachment) =>
+      [
+        attachment.id,
+        attachment.path,
+        attachment.name,
+        attachment.size ?? "",
+        attachment.attach.status,
+      ].join("|"),
+    )
+    .join("\n");
+  const signature = [
+    model?.id ?? "",
+    contextLimit,
+    category ?? "",
+    estimatedTokens,
+    composerInputHash(`${routedContent}\n${attachmentSignature}`),
+  ].join(":");
+
+  return {
+    signature,
+    estimatedTokens,
+    contextLimit,
+    modelName: model?.name?.trim() || "the selected model",
+    switchModel: largerContextModel({
+      currentModel: model,
+      estimatedTokens,
+      currentContextLimit: contextLimit,
+      models,
+    }),
+  };
+}
+
+function positiveContextTokens(value?: number) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function nonNegativeAttachmentSize(value?: number | null) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.ceil(value) : 0;
+}
+
+function largerContextModel({
+  currentModel,
+  estimatedTokens,
+  currentContextLimit,
+  models,
+}: {
+  currentModel?: VeniceModelDto;
+  estimatedTokens: number;
+  currentContextLimit: number;
+  models: VeniceModelDto[];
+}) {
+  const candidates = models
+    .filter((model) => model.id !== currentModel?.id)
+    .filter((model) => modelSupportsTools(model))
+    .map((model) => ({ model, contextTokens: positiveContextTokens(model.contextTokens) }))
+    .filter(
+      (item): item is { model: VeniceModelDto; contextTokens: number } =>
+        item.contextTokens !== undefined && item.contextTokens > currentContextLimit,
+    );
+  const sufficient = candidates
+    .filter((item) => item.contextTokens >= estimatedTokens)
+    .sort((a, b) => a.contextTokens - b.contextTokens);
+  if (sufficient.length) return sufficient[0].model;
+  return candidates.sort((a, b) => b.contextTokens - a.contextTokens)[0]?.model;
+}
+
+function composerInputHash(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function formatComposerTokenCount(value: number) {
+  return value.toLocaleString();
 }
 
 function promptWithAttachments(message: string, attachments: AgentAttachment[]): string {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4660,7 +4660,8 @@ input:focus-visible,
  * offer a one-tap switch to an image-capable model (the send-time fallback in
  * unsupportedImageInputPrompt still degrades gracefully if the user sends
  * anyway). */
-.agent-composer-image-warning {
+.agent-composer-image-warning,
+.agent-composer-size-warning {
   display: flex;
   align-items: center;
   gap: var(--sp-1);
@@ -4672,13 +4673,33 @@ input:focus-visible,
   font-size: var(--fs-sm);
 }
 
-.agent-composer-image-warning-icon {
+.agent-composer-size-warning {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.agent-composer-image-warning-icon,
+.agent-composer-size-warning-icon {
   flex: 0 0 auto;
   color: var(--muted-foreground);
 }
 
-.agent-composer-image-warning-text {
+.agent-composer-image-warning-text,
+.agent-composer-size-warning-text {
   min-width: 0;
+}
+
+.agent-composer-size-warning-text {
+  flex: 1 1 240px;
+}
+
+.agent-composer-size-warning-actions {
+  display: inline-flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--sp-1);
+  margin-left: auto;
 }
 
 .agent-composer-image-warning-action {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5405,6 +5405,60 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("estimates skill-expanded composer prompts before sending", async () => {
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "short-context",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "short-context",
+      models: [
+        {
+          provider: "venice",
+          id: "short-context",
+          name: "Short context",
+          modelType: "text",
+          privacy: "private",
+          contextTokens: 64,
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+      ],
+    });
+    mocks.hermesBridgeSkills.mockResolvedValue([
+      {
+        name: "large-skill",
+        description: "Adds a large instruction block.",
+        category: "Testing",
+        enabled: true,
+      },
+    ]);
+    mocks.getHermesBridgeSkill.mockResolvedValue({
+      name: "large-skill",
+      relativePath: "large-skill/SKILL.md",
+      content: `# Large skill\n\n${"Follow this instruction. ".repeat(80)}`,
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await screen.findByRole("button", { name: "Model: Short context" });
+    await user.type(screen.getByRole("textbox"), "/large-skill summarize");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(await screen.findByText(/This message is about/)).toHaveTextContent(
+      "over Short context's 64 token context window.",
+    );
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
+      false,
+    );
+  });
+
   it("counts pending attachment size in the oversize composer estimate", async () => {
     mocks.providerModelSettings.mockResolvedValue({
       settings: {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5332,7 +5332,7 @@ describe("AgentWorkspace", () => {
       "over Short context's 16 token context window.",
     );
     expect(screen.getByRole("button", { name: "Proceed" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Trim input" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit message" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Switch to Long context" })).toBeInTheDocument();
     expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
       false,

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5285,6 +5285,175 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("screenshot.png")).toBeInTheDocument();
   });
 
+  it("warns before sending composer text that exceeds the active model context", async () => {
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "short-context",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "short-context",
+      models: [
+        {
+          provider: "venice",
+          id: "short-context",
+          name: "Short context",
+          modelType: "text",
+          privacy: "private",
+          contextTokens: 16,
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+        {
+          provider: "venice",
+          id: "long-context",
+          name: "Long context",
+          modelType: "text",
+          privacy: "private",
+          contextTokens: 256,
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await screen.findByRole("button", { name: "Model: Short context" });
+    await user.type(screen.getByRole("textbox"), "a".repeat(100));
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(await screen.findByText(/This message is about/)).toHaveTextContent(
+      "over Short context's 16 token context window.",
+    );
+    expect(screen.getByRole("button", { name: "Proceed" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Trim input" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Switch to Long context" })).toBeInTheDocument();
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
+      false,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Proceed" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("switches to a larger-context model from the oversize composer warning", async () => {
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "short-context",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "short-context",
+      models: [
+        {
+          provider: "venice",
+          id: "short-context",
+          name: "Short context",
+          modelType: "text",
+          privacy: "private",
+          contextTokens: 16,
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+        {
+          provider: "venice",
+          id: "long-context",
+          name: "Long context",
+          modelType: "text",
+          privacy: "private",
+          contextTokens: 256,
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+
+    await screen.findByRole("button", { name: "Model: Short context" });
+    await user.type(screen.getByRole("textbox"), "a".repeat(100));
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+    await user.click(await screen.findByRole("button", { name: "Switch to Long context" }));
+
+    expect(await screen.findByRole("button", { name: "Model: Long context" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(/This message is about/)).not.toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
+        true,
+      ),
+    );
+  });
+
+  it("counts pending attachment size in the oversize composer estimate", async () => {
+    mocks.providerModelSettings.mockResolvedValue({
+      settings: {
+        transcriptionProvider: "venice",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "short-context",
+      },
+    });
+    mocks.listVeniceModels.mockResolvedValue({
+      mode: "generation",
+      modelType: "text",
+      selectedModel: "short-context",
+      models: [
+        {
+          provider: "venice",
+          id: "short-context",
+          name: "Short context",
+          modelType: "text",
+          privacy: "private",
+          contextTokens: 100,
+          traits: [],
+          capabilities: ["functionCalling"],
+        },
+      ],
+    });
+    const user = userEvent.setup();
+
+    render(<AgentWorkspace initialSession={existingSession} />);
+    await waitFor(() =>
+      expect(mocks.listen).toHaveBeenCalledWith("tauri://drag-drop", expect.any(Function)),
+    );
+
+    mocks.eventHandlers.get("tauri://drag-drop")?.({
+      payload: {
+        paths: ["/Users/alex/Desktop/large-notes.txt"],
+      },
+    });
+
+    expect(await screen.findByText("large-notes.txt")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    expect(await screen.findByText(/This message is about/)).toHaveTextContent(
+      "over Short context's 100 token context window.",
+    );
+    expect(mocks.gatewayRequest.mock.calls.some(([method]) => method === "prompt.submit")).toBe(
+      false,
+    );
+  });
+
   it("prefers the suggested vision model over the first eligible one (JUN-165)", async () => {
     // The banner action is a one-tap fix, and with several image-capable models
     // it prefers a curated suggested pick (Kimi K2.6) rather than the


### PR DESCRIPTION
## Summary

- Add a client-side composer size estimate using a 4 chars per token heuristic plus conservative pending attachment size proxy.
- Block oversized sends before Hermes requests are made, with actions to proceed, edit message, or switch to a larger-context model.
- Add focused AgentWorkspace coverage for text-only oversize sends, model switching, and attachment-size estimates.

Closes JUN-174

## Validation

- `pnpm test src/test/agent-workspace.test.tsx`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm run check` (passes with existing warning-level Biome diagnostics)
- Browser QA via Vite preview on `127.0.0.1:1422` with a temporary fake Tauri bridge:
  - Warning appeared before submit for a short-context model.
  - Proceed, Edit message, and Switch to Long context actions were visible.
  - Switching to Long context cleared the warning with no clipping or overlap.

## QA artifacts

- Raw video: `.tmp/qa-recordings/036742f7a629087570c6dda87ebfbedd.webm`
- Compressed video: `.tmp/qa-recordings/036742f7a629087570c6dda87ebfbedd.compressed.mp4`
- Screenshots:
  - `.tmp/qa-recordings/composer-size-warning-visible.png`
  - `.tmp/qa-recordings/composer-size-warning-switched.png`

Note: the browser QA preview intentionally did not run a real Hermes gateway, so the screenshot includes an expected fake-preview gateway banner unrelated to the size warning flow.