### PR TITLE
Speed up macOS desktop release builds

### DIFF
--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -225,8 +225,6 @@ jobs:
         with:
           path: .tauri-hermes/hermes
           key: hermes-bundle-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/bundle-hermes-runtime.sh', 'src-tauri/src/hermes_bridge.rs') }}
-          restore-keys: |
-            hermes-bundle-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Bundle Hermes runtime into app resources
         env:

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -13,6 +13,14 @@ on:
         description: "RC version to promote (e.g. 0.0.25-rc.1). Must match the version the rc release currently holds."
         required: true
         type: string
+      macos-runner:
+        description: "Runner for the signed macOS build"
+        required: true
+        default: "mac-studio"
+        type: choice
+        options:
+          - mac-studio
+          - github-hosted
 
 permissions:
   contents: write
@@ -27,7 +35,7 @@ env:
 jobs:
   promote:
     name: Promote rc macOS app to stable
-    runs-on: macos-latest
+    runs-on: ${{ fromJSON(inputs.macos-runner == 'mac-studio' && '["self-hosted","macOS","ARM64","desktop-release"]' || '["macos-latest"]') }}
     environment: production
     steps:
       - name: Mint release token (GitHub App)
@@ -211,6 +219,14 @@ jobs:
           security list-keychains -d user -s "$keychain" \
             $(security list-keychains -d user | tr -d '"')
           rm -f "$cert"
+
+      - name: Cache bundled Hermes runtime
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .tauri-hermes/hermes
+          key: hermes-bundle-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/bundle-hermes-runtime.sh', 'src-tauri/src/hermes_bridge.rs') }}
+          restore-keys: |
+            hermes-bundle-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Bundle Hermes runtime into app resources
         env:

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -18,6 +18,14 @@ on:
         required: true
         default: "1"
         type: string
+      macos-runner:
+        description: "Runner for the signed macOS build"
+        required: true
+        default: "mac-studio"
+        type: choice
+        options:
+          - mac-studio
+          - github-hosted
 
 permissions:
   contents: write
@@ -32,7 +40,7 @@ env:
 jobs:
   release:
     name: Release rc macOS app
-    runs-on: macos-latest
+    runs-on: ${{ fromJSON(inputs.macos-runner == 'mac-studio' && '["self-hosted","macOS","ARM64","desktop-release"]' || '["macos-latest"]') }}
     environment: production
     steps:
       # Same release App identity as production: it publishes to os-june-releases.
@@ -272,6 +280,14 @@ jobs:
           security list-keychains -d user -s "$keychain" \
             $(security list-keychains -d user | tr -d '"')
           rm -f "$cert"
+
+      - name: Cache bundled Hermes runtime
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .tauri-hermes/hermes
+          key: hermes-bundle-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/bundle-hermes-runtime.sh', 'src-tauri/src/hermes_bridge.rs') }}
+          restore-keys: |
+            hermes-bundle-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Bundle Hermes runtime into app resources
         env:

--- a/.github/workflows/rc-desktop-dmg.yml
+++ b/.github/workflows/rc-desktop-dmg.yml
@@ -286,8 +286,6 @@ jobs:
         with:
           path: .tauri-hermes/hermes
           key: hermes-bundle-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/bundle-hermes-runtime.sh', 'src-tauri/src/hermes_bridge.rs') }}
-          restore-keys: |
-            hermes-bundle-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Bundle Hermes runtime into app resources
         env:

--- a/docs/desktop-release-runner.md
+++ b/docs/desktop-release-runner.md
@@ -1,0 +1,71 @@
+# Desktop release runner
+
+Use a dedicated Mac Studio self-hosted GitHub Actions runner for signed macOS
+desktop releases. The release workflows target this runner when
+`macos-runner = mac-studio`.
+
+## Required labels
+
+Register the runner for the `open-software-network/os-june` repo with these
+labels:
+
+```text
+self-hosted
+macOS
+ARM64
+desktop-release
+```
+
+`self-hosted`, `macOS`, and `ARM64` are added by GitHub for an Apple Silicon
+macOS runner. Add `desktop-release` as the custom label. Keep this label unique
+to the trusted Mac Studio so production signing secrets cannot run on a generic
+self-hosted machine.
+
+## One-time setup
+
+1. In GitHub, open `open-software-network/os-june` -> Settings -> Actions ->
+   Runners -> New self-hosted runner.
+2. Choose `macOS` and `ARM64`, then install the runner under a dedicated
+   directory such as `~/actions-runner/os-june-desktop-release`.
+3. Configure it with the `desktop-release` label.
+4. Install it as a launchd service so it survives restarts:
+
+```sh
+./svc.sh install
+./svc.sh start
+```
+
+The workflow installs Node and pnpm through GitHub Actions, but the host still
+needs the Apple and Rust build toolchain:
+
+```sh
+xcode-select --install
+brew install uv
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+```
+
+After setup, confirm the expected tools are available to the runner user:
+
+```sh
+xcode-select -p
+xcrun notarytool --version
+rustc --version
+cargo --version
+uv --version
+```
+
+## Release use
+
+The macOS release workflows expose `macos-runner`:
+
+- `mac-studio` uses `["self-hosted","macOS","ARM64","desktop-release"]`.
+- `github-hosted` uses `macos-latest` as the fallback.
+
+Use `mac-studio` for normal RC and promote runs. Use `github-hosted` only if the
+Mac Studio runner is offline or being maintained.
+
+The workflows cache `.tauri-hermes/hermes` by runner OS, runner architecture,
+Hermes pin, and bundling script. On a cache hit, `scripts/bundle-hermes-runtime.sh`
+reuses the restored runtime, re-signs every Mach-O file with the current
+Developer ID identity, and runs the relocation self-test before the app build.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ feature specs). Full index: [spec/index.md](../spec/index.md).
 ## Release & ops runbooks
 
 - [release-macos.md](release-macos.md) / [release-windows.md](release-windows.md) — the release runbooks
+- [desktop-release-runner.md](desktop-release-runner.md) — Mac Studio self-hosted runner setup for signed desktop releases
 - [reproducible-builds.md](reproducible-builds.md) — June API source → TEE trust chain (Phase A shipped)
 - [github-security-readiness.md](github-security-readiness.md) — pre-public repo hardening checklist
 - [settings-focus-runbook.md](settings-focus-runbook.md) — transient: settings tabs hidden while admin surfaces stabilize

--- a/docs/release-macos.md
+++ b/docs/release-macos.md
@@ -36,6 +36,9 @@ Create or confirm these before cutting the first updater release:
 - Production runtime secrets: `PRODUCTION_OS_ACCOUNTS_URL`,
   `PRODUCTION_OS_ACCOUNTS_API_URL`, `PRODUCTION_OS_ACCOUNTS_CLIENT_ID`, and
   `PRODUCTION_JUNE_API_URL`.
+- Optional fast release runner: a dedicated self-hosted Mac Studio runner with
+  the `desktop-release` label. See
+  [desktop-release-runner.md](desktop-release-runner.md).
 
 The updater keypair is separate from the Apple Developer ID certificate. The
 public key is embedded in `src-tauri/tauri.conf.json`; the private key must live
@@ -64,6 +67,7 @@ in-app updater, then promote it to stable. There is no direct stable-build path.
 GitHub Actions -> rc-desktop-release -> Run workflow
   base-version = X.Y.Z   (the version you are heading toward)
   rc-number    = 1        (2, 3, ... for later candidates)
+  macos-runner = mac-studio
 ```
 
 `rc-desktop-release` builds a signed + notarized `universal-apple-darwin` app at
@@ -83,6 +87,7 @@ higher `rc-number` until it is good.
 ```text
 GitHub Actions -> promote-desktop-release -> Run workflow
   rc-version = X.Y.Z-rc.N   (required; must match the current rc release exactly)
+  macos-runner = mac-studio
 ```
 
 `rc-version` is required and must equal the version the `rc` release currently

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -69,6 +69,7 @@ run_self_test() {
   log "self-test: running the launcher from a relocated copy"
   local selftest_root selftest test_home version_output
   selftest_root="$(mktemp -d)"
+  trap 'rm -rf "$selftest_root"' EXIT
   selftest="$selftest_root/re located"
   mkdir -p "$selftest"
   cp -R "$out" "$selftest/hermes"
@@ -83,6 +84,7 @@ run_self_test() {
   "$selftest/hermes/python/current/bin/python3.11" -c "import hermes_cli.main" \
     || die "self-test failed: bare interpreter cannot import hermes_cli (pth broken)"
   rm -rf "$selftest_root"
+  trap - EXIT
 }
 
 print_bundle_size() {

--- a/scripts/bundle-hermes-runtime.sh
+++ b/scripts/bundle-hermes-runtime.sh
@@ -41,6 +41,63 @@ bridge_rs="$root/src-tauri/src/hermes_bridge.rs"
 log() { printf '\033[1;34m[bundle-hermes]\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31m[bundle-hermes]\033[0m %s\n' "$*" >&2; exit 1; }
 
+ensure_no_symlinks() {
+  local leftover_links
+  leftover_links="$(find "$out" -type l | head -5)"
+  [ -z "$leftover_links" ] || die "bundle still contains symlinks:
+$leftover_links"
+}
+
+sign_macho_files() {
+  if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
+    log "signing Mach-O files as: $APPLE_SIGNING_IDENTITY"
+    local signed=0
+    while IFS= read -r -d '' candidate; do
+      if file -b "$candidate" | grep -q 'Mach-O'; then
+        codesign --force --timestamp --options runtime \
+          --sign "$APPLE_SIGNING_IDENTITY" "$candidate"
+        signed=$((signed + 1))
+      fi
+    done < <(find "$out" -type f \( -name '*.so' -o -name '*.dylib' -o -perm -u+x \) -print0)
+    log "signed $signed Mach-O files"
+  else
+    log "APPLE_SIGNING_IDENTITY not set; skipping codesign (dev bundle)"
+  fi
+}
+
+run_self_test() {
+  log "self-test: running the launcher from a relocated copy"
+  local selftest_root selftest test_home version_output
+  selftest_root="$(mktemp -d)"
+  selftest="$selftest_root/re located"
+  mkdir -p "$selftest"
+  cp -R "$out" "$selftest/hermes"
+  test_home="$selftest_root/hermes-home"
+  mkdir -p "$test_home"
+  version_output="$(HERMES_HOME="$test_home" "$selftest/hermes/bin/hermes" --version)" \
+    || die "self-test failed: bundled hermes --version"
+  case "$version_output" in
+    *"$selftest/hermes/hermes-agent"*) ;;
+    *) die "self-test failed: hermes resolved the wrong project root: $version_output" ;;
+  esac
+  "$selftest/hermes/python/current/bin/python3.11" -c "import hermes_cli.main" \
+    || die "self-test failed: bare interpreter cannot import hermes_cli (pth broken)"
+  rm -rf "$selftest_root"
+}
+
+print_bundle_size() {
+  du -sh "$out" | awk '{print "[bundle-hermes] bundle size: " $1}'
+}
+
+bundle_is_reusable() {
+  [ -f "$out/PIN" ] || return 1
+  [ "$(cat "$out/PIN")" = "$commit" ] || return 1
+  [ -x "$out/bin/hermes" ] || return 1
+  [ -x "$out/python/current/bin/python3.11" ] || return 1
+  [ -d "$out/hermes-agent" ] || return 1
+  [ -f "$out/hermes-agent/hermes_cli/web_dist/index.html" ] || return 1
+}
+
 # Builds that skip this script still compile: build.rs creates a placeholder
 # at the resources mapping (`ensure_bundled_hermes_dir`), and the app falls
 # back to the managed on-device install when no launcher is present.
@@ -65,8 +122,21 @@ tarball_url="$(pin HERMES_SOURCE_TARBALL_URL)"
 [ -n "$tarball_url" ] || die "could not read HERMES_SOURCE_TARBALL_URL from $bridge_rs"
 log "pin: $commit"
 
-# ---- uv ----------------------------------------------------------------------
 work="$out_parent/work"
+if bundle_is_reusable; then
+  log "using cached Hermes bundle for pin: $commit"
+  ensure_no_symlinks
+  # Always sign restored binaries with the currently imported Developer ID cert.
+  sign_macho_files
+  run_self_test
+  print_bundle_size
+  log "done: $out"
+  exit 0
+elif [ -e "$out" ]; then
+  log "cached Hermes bundle is missing required files or has a stale pin; rebuilding"
+fi
+
+# ---- uv ----------------------------------------------------------------------
 rm -rf "$out" "$work"
 mkdir -p "$work"
 # No curl-pipe-sh here, deliberately: this script runs in release CI after the
@@ -216,8 +286,7 @@ log "precompiling bytecode (checked-hash)"
 
 # No symlinks may survive anywhere in the bundle (Tauri bundler limitation,
 # see above) — fail loudly here instead of opaquely at app-bundling time.
-leftover_links="$(find "$out" -type l | head -5)"
-[ -z "$leftover_links" ] || die "bundle still contains symlinks:\n$leftover_links"
+ensure_no_symlinks
 
 # ---- launcher -----------------------------------------------------------------
 mkdir -p "$out/bin"
@@ -237,20 +306,7 @@ chmod +x "$out/bin/hermes"
 # Notarization rejects any unsigned Mach-O inside the app. Sign every binary
 # (interpreter, dylibs, extension modules) with the hardened runtime; the
 # outer app signature then seals the rest of the tree as resources.
-if [ -n "${APPLE_SIGNING_IDENTITY:-}" ]; then
-  log "signing Mach-O files as: $APPLE_SIGNING_IDENTITY"
-  signed=0
-  while IFS= read -r -d '' candidate; do
-    if file -b "$candidate" | grep -q 'Mach-O'; then
-      codesign --force --timestamp --options runtime \
-        --sign "$APPLE_SIGNING_IDENTITY" "$candidate"
-      signed=$((signed + 1))
-    fi
-  done < <(find "$out" -type f \( -name '*.so' -o -name '*.dylib' -o -perm -u+x \) -print0)
-  log "signed $signed Mach-O files"
-else
-  log "APPLE_SIGNING_IDENTITY not set; skipping codesign (dev bundle)"
-fi
+sign_macho_files
 
 # Stamp the bundle with its source pin. build.rs compares this against the
 # pins in hermes_bridge.rs and evicts a stale bundle (built before a pin
@@ -258,23 +314,8 @@ fi
 printf '%s\n' "$commit" > "$out/PIN"
 
 # ---- self-test: prove relocatability from a moved path with a space -----------
-log "self-test: running the launcher from a relocated copy"
-selftest_root="$(mktemp -d)"
-trap 'rm -rf "$selftest_root"' EXIT
-selftest="$selftest_root/re located"
-mkdir -p "$selftest"
-cp -R "$out" "$selftest/hermes"
-test_home="$selftest_root/hermes-home"
-mkdir -p "$test_home"
-version_output="$(HERMES_HOME="$test_home" "$selftest/hermes/bin/hermes" --version)" \
-  || die "self-test failed: bundled hermes --version"
-case "$version_output" in
-  *"$selftest/hermes/hermes-agent"*) ;;
-  *) die "self-test failed: hermes resolved the wrong project root: $version_output" ;;
-esac
-"$selftest/hermes/python/current/bin/python3.11" -c "import hermes_cli.main" \
-  || die "self-test failed: bare interpreter cannot import hermes_cli (pth broken)"
+run_self_test
 
 rm -rf "$work"
-du -sh "$out" | awk '{print "[bundle-hermes] bundle size: " $1}'
+print_bundle_size
 log "done: $out"


### PR DESCRIPTION
## Summary

- Add a `macos-runner` input to the RC and promote macOS release workflows, defaulting to the Mac Studio self-hosted runner labels with a GitHub-hosted fallback.
- Restore a pinned `.tauri-hermes/hermes` cache before bundling in both signed macOS release workflows.
- Teach `scripts/bundle-hermes-runtime.sh` to reuse a matching cached Hermes bundle, re-sign Mach-O files with the current Developer ID identity, and run the relocation self-test before the app build.
- Document the Mac Studio runner labels, host setup, service setup, fallback behavior, and cache behavior.

## Validation

- `bash -n scripts/bundle-hermes-runtime.sh`
- `actionlint .github/workflows/rc-desktop-dmg.yml .github/workflows/promote-desktop.yml`
- `pnpm check` (exits 0; repo has existing Biome warnings outside this change)
- `pnpm typecheck`
- Synthetic cache-hit smoke test for `scripts/bundle-hermes-runtime.sh`
- `pnpm test` (126 files, 1856 passed, 2 skipped)
- `git diff --check`

## Notes

This keeps the release-safe behavior intact: restored Hermes runtimes are accepted only when the `PIN` matches the Rust source pin and the required runtime files exist, and they are still signed with the currently imported certificate before notarization.
