### PR TITLE
feat: play back and trim a recording before transcription

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -463,15 +463,29 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
 /// later consumes it via [`take_pending_recording`].
 pub fn stage_finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
     let finished = finish_capture(session_id)?;
-    if let Ok(mut pending) = PENDING_RECORDINGS.lock() {
-        pending.insert(finished.session_id.clone(), finished.clone());
-    }
+    // Recover from a poisoned lock rather than dropping `finished`. finish_capture
+    // has already consumed ACTIVE_RECORDING, so this staged clone is the only
+    // remaining handle to the finalized recording. Skipping the insert (or
+    // propagating an error, which drops `finished`) would strand the captured
+    // audio: `finish_recording`'s fallback would re-run finish_capture against an
+    // already-consumed session and fail.
+    pending_recordings().insert(finished.session_id.clone(), finished.clone());
     Ok(finished)
 }
 
 /// Remove a staged recording awaiting trim review, if one exists for the session.
 pub fn take_pending_recording(session_id: &str) -> Option<FinishedRecording> {
-    PENDING_RECORDINGS.lock().ok()?.remove(session_id)
+    pending_recordings().remove(session_id)
+}
+
+/// Lock the pending-recordings store, recovering from a poisoned lock. The store
+/// only maps session ids to finalized recordings, so a panic elsewhere cannot
+/// leave it in a state that makes recovery unsafe. Recovering keeps a staged
+/// recording reachable even after such a panic, so captured audio is never lost.
+fn pending_recordings() -> std::sync::MutexGuard<'static, HashMap<String, FinishedRecording>> {
+    PENDING_RECORDINGS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, AppError> {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -15,7 +15,7 @@ use crate::{
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use hound::{SampleFormat, WavSpec, WavWriter};
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     fs::File,
     io::BufWriter,
     path::PathBuf,
@@ -33,6 +33,14 @@ const RECOVERY_SNAPSHOT_INTERVAL_MS: i64 = 500;
 static ACTIVE_RECORDING: LazyLock<Mutex<Option<ActiveRecording>>> =
     LazyLock::new(|| Mutex::new(None));
 
+// Recordings whose capture has been finalized (WAVs written to disk) but whose
+// transcription has been deferred while the user reviews/trims them in the stop
+// modal. Keyed by session id; consumed by `finish_recording` once the user
+// confirms. Capture is single-instance, so this holds at most one entry in
+// practice, but a map keeps `take` cheap and unambiguous.
+static PENDING_RECORDINGS: LazyLock<Mutex<HashMap<String, FinishedRecording>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 pub struct StartedRecording {
     pub session_id: String,
     pub note_id: String,
@@ -44,6 +52,7 @@ pub struct StartedRecording {
     pub status: RecordingStatusDto,
 }
 
+#[derive(Clone)]
 pub struct FinishedRecording {
     pub session_id: String,
     pub note_id: String,
@@ -60,6 +69,7 @@ pub struct StartedSource {
     pub final_path: PathBuf,
 }
 
+#[derive(Clone)]
 pub struct FinishedSource {
     pub source: RecordingSource,
     pub final_path: PathBuf,
@@ -445,6 +455,23 @@ pub fn finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
         ));
     }
     finalize_recording(recording)
+}
+
+/// Stop and finalize capture like [`finish_capture`], but stash the result so
+/// the user can review and optionally trim it before transcription begins. The
+/// returned recording is cloned into the pending store; [`finish_recording`]
+/// later consumes it via [`take_pending_recording`].
+pub fn stage_finish_capture(session_id: &str) -> Result<FinishedRecording, AppError> {
+    let finished = finish_capture(session_id)?;
+    if let Ok(mut pending) = PENDING_RECORDINGS.lock() {
+        pending.insert(finished.session_id.clone(), finished.clone());
+    }
+    Ok(finished)
+}
+
+/// Remove a staged recording awaiting trim review, if one exists for the session.
+pub fn take_pending_recording(session_id: &str) -> Option<FinishedRecording> {
+    PENDING_RECORDINGS.lock().ok()?.remove(session_id)
 }
 
 fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, AppError> {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -482,10 +482,14 @@ pub fn take_pending_recording(session_id: &str) -> Option<FinishedRecording> {
 /// only maps session ids to finalized recordings, so a panic elsewhere cannot
 /// leave it in a state that makes recovery unsafe. Recovering keeps a staged
 /// recording reachable even after such a panic, so captured audio is never lost.
+/// The recovery is logged rather than silent: a poisoned lock means a thread
+/// panicked while holding it, which is worth surfacing even though it is not
+/// fatal here.
 fn pending_recordings() -> std::sync::MutexGuard<'static, HashMap<String, FinishedRecording>> {
-    PENDING_RECORDINGS
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
+    PENDING_RECORDINGS.lock().unwrap_or_else(|poisoned| {
+        eprintln!("pending-recordings lock was poisoned; recovering to avoid losing staged audio");
+        poisoned.into_inner()
+    })
 }
 
 fn finalize_recording(recording: ActiveRecording) -> Result<FinishedRecording, AppError> {

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -2,6 +2,7 @@ pub mod capture;
 pub mod live_preview;
 pub mod recovery;
 pub mod system_macos;
+pub mod trim;
 pub mod turns;
 pub mod validation;
 pub mod waveform;

--- a/src-tauri/src/audio/trim.rs
+++ b/src-tauri/src/audio/trim.rs
@@ -1,0 +1,193 @@
+use crate::audio::capture::FinishedSource;
+use crate::domain::types::AppError;
+use hound::{SampleFormat, WavReader, WavWriter};
+use std::path::Path;
+
+/// Downsampled amplitude envelope used to render the trim modal's waveform.
+/// `peaks` are normalized 0.0..=1.0 maxima, one per equal-width time bucket
+/// across `duration_ms`. Multi-source recordings (microphone + system) are
+/// merged onto a single shared wall-clock timeline so the picture matches what
+/// the user heard.
+pub struct WaveformPreview {
+    pub duration_ms: i64,
+    pub peaks: Vec<f32>,
+}
+
+/// Build the preview envelope from the finalized source WAVs. Sources keep their
+/// wall-clock alignment, so every source is bucketed against the longest one's
+/// timeline and merged by taking the louder of the two at each bucket.
+pub fn waveform_preview(
+    sources: &[FinishedSource],
+    buckets: usize,
+) -> Result<WaveformPreview, AppError> {
+    let buckets = buckets.max(1);
+    let mut timeline_ms = 0_i64;
+    for source in sources {
+        timeline_ms = timeline_ms.max(wav_duration_ms(&source.final_path)?);
+    }
+    let mut peaks = vec![0.0_f32; buckets];
+    if timeline_ms > 0 {
+        for source in sources {
+            accumulate_peaks(&source.final_path, timeline_ms, &mut peaks)?;
+        }
+    }
+    Ok(WaveformPreview {
+        duration_ms: timeline_ms,
+        peaks,
+    })
+}
+
+/// Rewrite a 16-bit PCM WAV in place so it only contains the `[start_ms, end_ms]`
+/// window, returning the trimmed duration in milliseconds. The new audio is
+/// written to a sibling temp file first and then renamed over the original so a
+/// failure mid-write never corrupts the source artifact.
+pub fn trim_source_wav(path: &Path, start_ms: i64, end_ms: i64) -> Result<i64, AppError> {
+    let mut reader = WavReader::open(path)
+        .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+    let spec = reader.spec();
+    if spec.sample_format != SampleFormat::Int || spec.bits_per_sample != 16 {
+        return Err(AppError::new(
+            "audio_trim_failed",
+            "Only 16-bit PCM WAV trimming is supported.",
+        ));
+    }
+    let channels = spec.channels.max(1) as usize;
+    let sample_rate = spec.sample_rate.max(1) as i64;
+    let total_frames = reader.duration() as i64;
+    let start_frame = ((start_ms.max(0) * sample_rate) / 1000).clamp(0, total_frames);
+    let end_frame = ((end_ms.max(0) * sample_rate) / 1000).clamp(start_frame, total_frames);
+    let frame_count = (end_frame - start_frame) as usize;
+    let sample_count = frame_count.saturating_mul(channels);
+
+    let start_frame_u32 = u32::try_from(start_frame)
+        .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+    reader
+        .seek(start_frame_u32)
+        .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+
+    let temp_path = path.with_extension("trim.wav");
+    let mut writer = WavWriter::create(&temp_path, spec)
+        .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+    for sample in reader.samples::<i16>().take(sample_count) {
+        writer
+            .write_sample(sample.unwrap_or(0))
+            .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+    }
+    writer
+        .finalize()
+        .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+    drop(reader);
+    std::fs::rename(&temp_path, path)
+        .map_err(|error| AppError::new("audio_trim_failed", error.to_string()))?;
+
+    Ok((frame_count as i64 * 1000) / sample_rate)
+}
+
+fn wav_duration_ms(path: &Path) -> Result<i64, AppError> {
+    let reader = WavReader::open(path)
+        .map_err(|error| AppError::new("audio_waveform_failed", error.to_string()))?;
+    let sample_rate = reader.spec().sample_rate.max(1) as i64;
+    let frames = reader.duration() as i64;
+    Ok((frames * 1000) / sample_rate)
+}
+
+fn accumulate_peaks(path: &Path, timeline_ms: i64, peaks: &mut [f32]) -> Result<(), AppError> {
+    let buckets = peaks.len().max(1);
+    let mut reader = WavReader::open(path)
+        .map_err(|error| AppError::new("audio_waveform_failed", error.to_string()))?;
+    let spec = reader.spec();
+    let channels = spec.channels.max(1) as usize;
+    let sample_rate = spec.sample_rate.max(1) as i64;
+    // Frames spanning the *shared* timeline, so bucket index maps to absolute
+    // wall-clock time even when sources differ in sample rate or length.
+    let timeline_frames = ((timeline_ms * sample_rate) / 1000).max(1);
+
+    let mut frame_index: i64 = 0;
+    let mut channel: usize = 0;
+    let mut frame_peak = 0.0_f32;
+    for sample in reader.samples::<i16>() {
+        let sample = sample.unwrap_or(0);
+        let normalized = (sample as f32 / i16::MAX as f32).abs();
+        frame_peak = frame_peak.max(normalized);
+        channel += 1;
+        if channel >= channels {
+            let bucket = ((frame_index * buckets as i64) / timeline_frames) as usize;
+            if let Some(slot) = peaks.get_mut(bucket.min(buckets - 1)) {
+                *slot = slot.max(frame_peak);
+            }
+            channel = 0;
+            frame_peak = 0.0;
+            frame_index += 1;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::WavSpec;
+
+    fn write_wav(path: &Path, sample_rate: u32, channels: u16, samples: &[i16]) {
+        let spec = WavSpec {
+            channels,
+            sample_rate,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        for sample in samples {
+            writer.write_sample(*sample).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn read_samples(path: &Path) -> Vec<i16> {
+        WavReader::open(path)
+            .unwrap()
+            .samples::<i16>()
+            .map(|sample| sample.unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn trims_to_the_selected_window() {
+        let dir = std::env::temp_dir().join(format!("june-trim-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("microphone.wav");
+        // 1000 mono frames at 1kHz == 1000ms; ramp so we can spot the window.
+        let samples: Vec<i16> = (0..1000).map(|i| i as i16).collect();
+        write_wav(&path, 1000, 1, &samples);
+
+        let duration = trim_source_wav(&path, 200, 700).unwrap();
+        assert_eq!(duration, 500);
+        let trimmed = read_samples(&path);
+        assert_eq!(trimmed.len(), 500);
+        assert_eq!(trimmed.first().copied(), Some(200));
+        assert_eq!(trimmed.last().copied(), Some(699));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn waveform_preview_buckets_match_timeline() {
+        let dir = std::env::temp_dir().join(format!("june-wave-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("microphone.wav");
+        // First half loud, second half silent.
+        let mut samples = vec![i16::MAX; 500];
+        samples.resize(1000, 0);
+        write_wav(&path, 1000, 1, &samples);
+
+        let source = FinishedSource {
+            source: crate::domain::types::RecordingSource::Microphone,
+            final_path: path.clone(),
+            elapsed_ms: 1000,
+        };
+        let preview = waveform_preview(std::slice::from_ref(&source), 10).unwrap();
+        assert_eq!(preview.duration_ms, 1000);
+        assert_eq!(preview.peaks.len(), 10);
+        assert!(preview.peaks[0] > 0.9, "loud first half");
+        assert!(preview.peaks[9] < 0.1, "silent second half");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src-tauri/src/audio/trim.rs
+++ b/src-tauri/src/audio/trim.rs
@@ -54,9 +54,18 @@ pub fn trim_source_wav(path: &Path, start_ms: i64, end_ms: i64) -> Result<i64, A
     let channels = spec.channels.max(1) as usize;
     let sample_rate = spec.sample_rate.max(1) as i64;
     let total_frames = reader.duration() as i64;
-    let start_frame = ((start_ms.max(0) * sample_rate) / 1000).clamp(0, total_frames);
-    let end_frame = ((end_ms.max(0) * sample_rate) / 1000).clamp(start_frame, total_frames);
+    // saturating_mul so a garbage-large ms value clamps to the clip instead of
+    // overflowing i64 (which panics under debug overflow-checks).
+    let start_frame = (start_ms.max(0).saturating_mul(sample_rate) / 1000).clamp(0, total_frames);
+    let end_frame =
+        (end_ms.max(0).saturating_mul(sample_rate) / 1000).clamp(start_frame, total_frames);
     let frame_count = (end_frame - start_frame) as usize;
+    if frame_count == 0 {
+        // Degenerate window (start == end, or a start past this source's end, as
+        // can happen when one source is shorter than the shared timeline). Leave
+        // the file untouched rather than writing an empty WAV over it.
+        return Ok((total_frames * 1000) / sample_rate);
+    }
     let sample_count = frame_count.saturating_mul(channels);
 
     let start_frame_u32 = u32::try_from(start_frame)
@@ -107,7 +116,7 @@ fn accumulate_peaks(path: &Path, timeline_ms: i64, peaks: &mut [f32]) -> Result<
     let mut frame_peak = 0.0_f32;
     for sample in reader.samples::<i16>() {
         let sample = sample.unwrap_or(0);
-        let normalized = (sample as f32 / i16::MAX as f32).abs();
+        let normalized = crate::audio::waveform::normalize_peak(sample);
         frame_peak = frame_peak.max(normalized);
         channel += 1;
         if channel >= channels {
@@ -165,6 +174,22 @@ mod tests {
         assert_eq!(trimmed.len(), 500);
         assert_eq!(trimmed.first().copied(), Some(200));
         assert_eq!(trimmed.last().copied(), Some(699));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn degenerate_window_leaves_the_source_untouched() {
+        let dir = std::env::temp_dir().join(format!("june-trim0-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("microphone.wav");
+        let samples: Vec<i16> = (0..1000).map(|i| i as i16).collect();
+        write_wav(&path, 1000, 1, &samples);
+
+        // A start at/after the source end yields a zero-frame window: keep the
+        // full clip rather than writing an empty WAV over it.
+        let duration = trim_source_wav(&path, 1000, 1000).unwrap();
+        assert_eq!(duration, 1000);
+        assert_eq!(read_samples(&path).len(), 1000);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -817,7 +817,7 @@ pub async fn finish_recording(
         None => finish_capture(&request.session_id)?,
     };
     if let Some(trim) = request.trim {
-        apply_trim(&mut finished, trim)?;
+        apply_trim(&mut finished, trim);
     }
     finish_recording_session(&repos, finished, finalization_started).await
 }
@@ -825,26 +825,36 @@ pub async fn finish_recording(
 /// Rewrite every source WAV to the selected `[start_ms, end_ms]` window and
 /// update the recording's elapsed timings so validation compares against the
 /// trimmed duration. A no-op (or inverted) range leaves the audio untouched.
+///
+/// Best-effort by design: `finish_recording` has already consumed the staged
+/// recording by the time this runs, so a propagated error would strand the
+/// captured audio. If a source fails to trim, keep it untrimmed and still
+/// finalize it — `trim_source_wav` writes via a temp file + rename, so a failure
+/// leaves the original intact.
 fn apply_trim(
     finished: &mut crate::audio::capture::FinishedRecording,
     trim: crate::domain::types::TrimRange,
-) -> Result<(), AppError> {
+) {
     let start_ms = trim.start_ms.max(0);
     let end_ms = trim.end_ms.max(start_ms);
     let trims_start = start_ms > 0;
     let trims_end = end_ms < finished.elapsed_ms;
     if !trims_start && !trims_end {
-        return Ok(());
+        return;
     }
     let mut max_duration = 0;
     for source in &mut finished.sources {
-        let duration = trim_source_wav(&source.final_path, start_ms, end_ms)?;
-        source.elapsed_ms = duration;
-        max_duration = max_duration.max(duration);
+        match trim_source_wav(&source.final_path, start_ms, end_ms) {
+            Ok(duration) => source.elapsed_ms = duration,
+            Err(error) => eprintln!(
+                "trim failed for {:?}, keeping the full source: {}",
+                source.source, error.message
+            ),
+        }
+        max_duration = max_duration.max(source.elapsed_ms);
     }
     finished.elapsed_ms = max_duration;
     finished.recording.elapsed_ms = max_duration;
-    Ok(())
 }
 
 async fn finish_active_capture_before_start(repos: &Repositories) -> Result<(), AppError> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,10 +3,11 @@ use crate::{
     audio::{
         capture::{
             capture_status_for_recovery, finish_active_capture, finish_capture, is_capture_active,
-            microphone_permission_state, pause_capture, resume_capture, start_capture,
-            CaptureRecoverySnapshot,
+            microphone_permission_state, pause_capture, resume_capture, stage_finish_capture,
+            start_capture, take_pending_recording, CaptureRecoverySnapshot,
         },
         recovery::scan_recoverable_recordings,
+        trim::{trim_source_wav, waveform_preview},
         validation::{
             checksum_file, source_audio_passes_validation, validate_audio_artifact,
             validation_config_for_source, AudioValidationConfig,
@@ -26,16 +27,17 @@ use crate::{
             CreateDictionaryEntryRequest, CreateFolderRequest, CreateNoteRequest,
             DeleteDictionaryEntryRequest, DeleteFolderRequest, DeleteNoteRequest,
             DeleteNotesRequest, DictionaryEntryDto, ExplainAgentApprovalRequest,
-            ExplainAgentApprovalResponse, FinishRecordingResponse, GetAgentTaskRequest,
-            GetNoteRequest, ListNotesRequest, ListNotesResponse, MicrophonePermissionResponse,
-            NoteDto, OpenPrivacySettingsRequest, ProcessingStatus, RecordingSessionDto,
-            RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto, RecordingStatusDto,
-            RemoveNoteFromFolderRequest, RemoveSessionFromFolderRequest, RenameFolderRequest,
-            RetryProcessingRequest, SaveAgentAssistantMessageRequest,
-            SaveAgentHermesSessionRequest, SendAgentMessageRequest, SessionFolderDto,
-            SessionRequest, SourceReadinessDto, StartRecordingRequest, SubmitIssueReportRequest,
-            SubmitIssueReportResponse, SuggestAgentSessionTitleRequest,
-            SuggestAgentSessionTitleResponse, UpdateDictionaryEntryRequest, UpdateNoteRequest,
+            ExplainAgentApprovalResponse, FinishRecordingRequest, FinishRecordingResponse,
+            GetAgentTaskRequest, GetNoteRequest, ListNotesRequest, ListNotesResponse,
+            MicrophonePermissionResponse, NoteDto, OpenPrivacySettingsRequest, ProcessingStatus,
+            RecordingSessionDto, RecordingSource, RecordingSourceMode, RecordingSourceReadinessDto,
+            RecordingStatusDto, RecordingTrimPreviewDto, RemoveNoteFromFolderRequest,
+            RemoveSessionFromFolderRequest, RenameFolderRequest, RetryProcessingRequest,
+            SaveAgentAssistantMessageRequest, SaveAgentHermesSessionRequest,
+            SendAgentMessageRequest, SessionFolderDto, SessionRequest, SourceReadinessDto,
+            StartRecordingRequest, SubmitIssueReportRequest, SubmitIssueReportResponse,
+            SuggestAgentSessionTitleRequest, SuggestAgentSessionTitleResponse,
+            UpdateDictionaryEntryRequest, UpdateNoteRequest,
         },
     },
 };
@@ -770,15 +772,70 @@ async fn persist_recording_recovery_snapshot(
     Ok(())
 }
 
+/// Stop capture and finalize the WAVs, then return a downsampled waveform so the
+/// frontend can open the trim modal. The finished recording is held in the
+/// pending store until `finish_recording` consumes it. Transcription does not
+/// start here — that waits for the user's trim decision.
+#[tauri::command]
+pub async fn prepare_recording_trim(
+    _app: AppHandle,
+    request: SessionRequest,
+) -> Result<RecordingTrimPreviewDto, AppError> {
+    // ~240 buckets gives a dense-enough envelope for clips of any length while
+    // staying tiny to serialize; the frontend scales it to the modal width.
+    const PREVIEW_BUCKETS: usize = 240;
+    let finished = stage_finish_capture(&request.session_id)?;
+    let preview = waveform_preview(&finished.sources, PREVIEW_BUCKETS)?;
+    Ok(RecordingTrimPreviewDto {
+        session_id: finished.session_id.clone(),
+        duration_ms: preview.duration_ms,
+        peaks: preview.peaks,
+        source_mode: finished.source_mode,
+    })
+}
+
 #[tauri::command]
 pub async fn finish_recording(
     app: AppHandle,
-    request: SessionRequest,
+    request: FinishRecordingRequest,
 ) -> Result<FinishRecordingResponse, AppError> {
     let repos = repositories(&app).await?;
     let finalization_started = Instant::now();
-    let finished = finish_capture(&request.session_id)?;
+    // Prefer a recording staged by `prepare_recording_trim`; fall back to
+    // stopping capture directly so a plain stop (no trim modal) still works.
+    let mut finished = match take_pending_recording(&request.session_id) {
+        Some(finished) => finished,
+        None => finish_capture(&request.session_id)?,
+    };
+    if let Some(trim) = request.trim {
+        apply_trim(&mut finished, trim)?;
+    }
     finish_recording_session(&repos, finished, finalization_started).await
+}
+
+/// Rewrite every source WAV to the selected `[start_ms, end_ms]` window and
+/// update the recording's elapsed timings so validation compares against the
+/// trimmed duration. A no-op (or inverted) range leaves the audio untouched.
+fn apply_trim(
+    finished: &mut crate::audio::capture::FinishedRecording,
+    trim: crate::domain::types::TrimRange,
+) -> Result<(), AppError> {
+    let start_ms = trim.start_ms.max(0);
+    let end_ms = trim.end_ms.max(start_ms);
+    let trims_start = start_ms > 0;
+    let trims_end = end_ms < finished.elapsed_ms;
+    if !trims_start && !trims_end {
+        return Ok(());
+    }
+    let mut max_duration = 0;
+    for source in &mut finished.sources {
+        let duration = trim_source_wav(&source.final_path, start_ms, end_ms)?;
+        source.elapsed_ms = duration;
+        max_duration = max_duration.max(duration);
+    }
+    finished.elapsed_ms = max_duration;
+    finished.recording.elapsed_ms = max_duration;
+    Ok(())
 }
 
 async fn finish_active_capture_before_start(repos: &Repositories) -> Result<(), AppError> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -36,7 +36,7 @@ use crate::{
             SaveAgentAssistantMessageRequest, SaveAgentHermesSessionRequest,
             SendAgentMessageRequest, SessionFolderDto, SessionRequest, SourceReadinessDto,
             StartRecordingRequest, SubmitIssueReportRequest, SubmitIssueReportResponse,
-            SuggestAgentSessionTitleRequest, SuggestAgentSessionTitleResponse,
+            SuggestAgentSessionTitleRequest, SuggestAgentSessionTitleResponse, TrimSourceDto,
             UpdateDictionaryEntryRequest, UpdateNoteRequest,
         },
     },
@@ -786,11 +786,20 @@ pub async fn prepare_recording_trim(
     const PREVIEW_BUCKETS: usize = 240;
     let finished = stage_finish_capture(&request.session_id)?;
     let preview = waveform_preview(&finished.sources, PREVIEW_BUCKETS)?;
+    let sources = finished
+        .sources
+        .iter()
+        .map(|source| TrimSourceDto {
+            source: source.source,
+            path: source.final_path.to_string_lossy().into_owned(),
+        })
+        .collect();
     Ok(RecordingTrimPreviewDto {
         session_id: finished.session_id.clone(),
         duration_ms: preview.duration_ms,
         peaks: preview.peaks,
         source_mode: finished.source_mode,
+        sources,
     })
 }
 

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -275,8 +275,18 @@ pub struct FinishRecordingRequest {
     pub trim: Option<TrimRange>,
 }
 
+/// A finalized source WAV the trim modal can play back through the Tauri asset
+/// protocol while the user reviews the clip before transcription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrimSourceDto {
+    pub source: RecordingSource,
+    pub path: String,
+}
+
 /// Downsampled waveform returned when the user stops a recording, so the trim
 /// modal can draw the clip and place its handles before transcription runs.
+/// `sources` carries the on-disk WAV paths so the modal can play the audio back.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecordingTrimPreviewDto {
@@ -284,6 +294,7 @@ pub struct RecordingTrimPreviewDto {
     pub duration_ms: i64,
     pub peaks: Vec<f32>,
     pub source_mode: RecordingSourceMode,
+    pub sources: Vec<TrimSourceDto>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -256,6 +256,36 @@ pub struct SessionRequest {
     pub session_id: String,
 }
 
+/// A start/end window (in milliseconds from the recording start) selected in the
+/// stop-and-trim modal. Applied to every source before transcription.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrimRange {
+    pub start_ms: i64,
+    pub end_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinishRecordingRequest {
+    pub session_id: String,
+    /// Present when the user trimmed the recording in the stop modal. Absent
+    /// keeps the full recording (the legacy one-click stop behavior).
+    #[serde(default)]
+    pub trim: Option<TrimRange>,
+}
+
+/// Downsampled waveform returned when the user stops a recording, so the trim
+/// modal can draw the clip and place its handles before transcription runs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingTrimPreviewDto {
+    pub session_id: String,
+    pub duration_ms: i64,
+    pub peaks: Vec<f32>,
+    pub source_mode: RecordingSourceMode,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FinishRecordingResponse {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -218,6 +218,7 @@ pub fn run() {
             commands::resume_recording,
             commands::get_recording_status,
             set_recording_presence_bounds,
+            commands::prepare_recording_trim,
             commands::finish_recording,
             commands::retry_processing,
             commands::recover_recording,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -349,9 +349,17 @@ fn setup_recordings_asset_scope(app: &tauri::App) {
     let Ok(paths) = crate::app_paths::AppPaths::from_data_dir(data_dir) else {
         return;
     };
+    // Canonicalize so the scope matches the paths Tauri resolves when serving:
+    // it canonicalizes an asset path before the scope check (as
+    // `contained_recording_file` does), so a symlinked data dir would otherwise
+    // block playback. Fall back to the raw path if canonicalization fails.
+    let recordings_dir = paths
+        .recordings_dir
+        .canonicalize()
+        .unwrap_or(paths.recordings_dir);
     if let Err(error) = app
         .asset_protocol_scope()
-        .allow_directory(&paths.recordings_dir, true)
+        .allow_directory(&recordings_dir, true)
     {
         eprintln!("failed to allow recordings dir for asset protocol: {error}");
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -279,6 +279,7 @@ pub fn run() {
             hermes_bridge::start_on_app_start(app);
             meeting_hud::setup(app);
             os_accounts::setup_deep_link(app);
+            setup_recordings_asset_scope(app);
             #[cfg(target_os = "macos")]
             setup_main_window_lifecycle(app);
             Ok(())
@@ -333,6 +334,26 @@ mod tests {
         assert!(should_emit_close_tab_event(Some(true)));
         assert!(!should_emit_close_tab_event(Some(false)));
         assert!(!should_emit_close_tab_event(None));
+    }
+}
+
+/// Let the trim modal's `<audio>` playback read finalized recording WAVs through
+/// the Tauri asset protocol. Allowing the whole recordings directory at runtime
+/// covers both the dev (`-dev`) and prod data dirs without a brittle static glob
+/// in `tauri.conf.json`, and mirrors how `AppPaths::contained_recording_file`
+/// already treats everything under `recordings/` as ours.
+fn setup_recordings_asset_scope(app: &tauri::App) {
+    let Ok(data_dir) = crate::app_paths::app_data_dir(app.handle()) else {
+        return;
+    };
+    let Ok(paths) = crate::app_paths::AppPaths::from_data_dir(data_dir) else {
+        return;
+    };
+    if let Err(error) = app
+        .asset_protocol_scope()
+        .allow_directory(&paths.recordings_dir, true)
+    {
+        eprintln!("failed to allow recordings dir for asset protocol: {error}");
     }
 }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -422,9 +422,7 @@ export function App() {
   const recordingInactivityTrackerRef = useRef<RecordingInactivityTracker>({});
   const [recordingInactivityPrompt, setRecordingInactivityPrompt] =
     useState<RecordingInactivityPrompt | null>(null);
-  const [recordingInactivityNow, setRecordingInactivityNow] = useState(() =>
-    Date.now(),
-  );
+  const [recordingInactivityNow, setRecordingInactivityNow] = useState(() => Date.now());
   // The stop-and-trim modal. Set when the user presses Done; carries the
   // finalized recording's waveform so they can trim before transcription.
   const [trimSession, setTrimSession] = useState<{
@@ -2387,10 +2385,7 @@ export function App() {
       // the recording — finalize the full take immediately. The backend staged
       // it before previewing, so this still goes through the normal pipeline.
       setTrimSession(null);
-      if (
-        !owningNoteId ||
-        !(await applyNoteScopedProcessingFailure(owningNoteId, err))
-      ) {
+      if (!owningNoteId || !(await applyNoteScopedProcessingFailure(owningNoteId, err))) {
         await finalizeRecording(sessionId, owningNoteId, null);
       }
     } finally {
@@ -2403,9 +2398,7 @@ export function App() {
   async function handleConfirmTrim(trim: TrimRangeDto | null) {
     const session = trimSession;
     if (!session || session.finalizing) return;
-    setTrimSession((current) =>
-      current ? { ...current, finalizing: true } : current,
-    );
+    setTrimSession((current) => (current ? { ...current, finalizing: true } : current));
     await finalizeRecording(session.sessionId, session.noteId, trim);
     setTrimSession(null);
   }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,6 +28,7 @@ import { MoveNoteToFolderDialog } from "../components/folders/MoveNoteToFolderDi
 import { MoveSessionToProjectDialog } from "../components/folders/MoveSessionToProjectDialog";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import { GlobalRecorderPill } from "../components/recorder/GlobalRecorderPill";
+import { TrimRecordingDialog } from "../components/recorder/TrimRecordingDialog";
 import type { GlobalRecorderDemoApi } from "../lib/global-recorder-demo";
 import type { UpdateCardDemoApi } from "../lib/update-card-demo";
 import { NotesList, type NotesListHandle } from "../components/notes-list/NotesList";
@@ -59,6 +60,7 @@ import {
   getRecordingStatus,
   getNote,
   LIVE_TRANSCRIPT_EVENT,
+  prepareRecordingTrim,
   listNotes,
   listSessionFolders,
   openPrivacySettings,
@@ -125,6 +127,8 @@ import type {
   FolderDto,
   NoteDto,
   RecordingStatusDto,
+  RecordingTrimPreviewDto,
+  TrimRangeDto,
   AccountStatus,
   HermesSessionInfo,
 } from "../lib/tauri";
@@ -418,7 +422,25 @@ export function App() {
   const recordingInactivityTrackerRef = useRef<RecordingInactivityTracker>({});
   const [recordingInactivityPrompt, setRecordingInactivityPrompt] =
     useState<RecordingInactivityPrompt | null>(null);
-  const [recordingInactivityNow, setRecordingInactivityNow] = useState(() => Date.now());
+  const [recordingInactivityNow, setRecordingInactivityNow] = useState(() =>
+    Date.now(),
+  );
+  // The stop-and-trim modal. Set when the user presses Done; carries the
+  // finalized recording's waveform so they can trim before transcription.
+  const [trimSession, setTrimSession] = useState<{
+    sessionId: string;
+    noteId?: string;
+    preview?: RecordingTrimPreviewDto;
+    preparing: boolean;
+    finalizing: boolean;
+  } | null>(null);
+  // Ref mirror so the recording-start guard can see an open trim modal without
+  // re-creating its useCallback. Starting a new take while a recording is staged
+  // for trim would strand the staged audio, so we block it.
+  const trimSessionActiveRef = useRef(false);
+  useEffect(() => {
+    trimSessionActiveRef.current = trimSession !== null;
+  }, [trimSession]);
   const recordingStartInFlightRef = useRef(false);
   const [liveTranscriptEvents, setLiveTranscriptEvents] = useState<LiveTranscriptEventDto[]>([]);
   useEffect(() => {
@@ -492,6 +514,9 @@ export function App() {
   }, []);
   // Sessions with a finishRecording call in flight; guards stop double-clicks.
   const finishingSessionsRef = useRef<Set<string>>(new Set());
+  // Sessions whose stop press is being staged for the trim modal; a synchronous
+  // guard against a double-click firing the prepare step twice.
+  const stoppingSessionsRef = useRef<Set<string>>(new Set());
   // A dev build without the OS Accounts env vars (fresh workspace, no .env)
   // can never complete sign-in, so the account gates would be dead
   // ends — skip them and let account-dependent features surface their own
@@ -2174,6 +2199,7 @@ export function App() {
       const startAlreadyClaimed = options.startAlreadyClaimed ?? false;
       if (
         recordingStatusRef.current ||
+        trimSessionActiveRef.current ||
         (!startAlreadyClaimed && recordingStartInFlightRef.current)
       ) {
         if (startAlreadyClaimed) {
@@ -2318,28 +2344,87 @@ export function App() {
     };
   }, [appBlocked, bootstrapped, handleStartMeetingDetectedRecording]);
 
+  // Pressing Done stops capture and opens the trim modal: the shell collapses
+  // immediately, then the finalized waveform loads so the user can cut silence
+  // or off-topic audio from either end before anything is transcribed.
   async function handleFinishRecording(sessionId: string) {
-    // The recorder bar stays mounted (and clickable) for the duration of its
-    // exit animation after the first stop click, so a fast double-click would
-    // fire finishRecording twice — the second call fails with a scary
-    // "recording not found" error. Gate per session until the call settles.
-    if (finishingSessionsRef.current.has(sessionId)) return;
-    finishingSessionsRef.current.add(sessionId);
-    // Collapse the shell back to idle the instant stop is pressed so it
-    // never lingers wide while the (potentially long) transcribe +
-    // generate pipeline runs. Processing is queued per note, so the record
-    // button stays available — you can stack another take while this one
-    // finishes — and the body shimmer ("Transcribing audio…" → "Generating
-    // notes…") plus a queued count tell the user work is still in flight.
+    // The recorder bar stays mounted (and clickable) during its exit animation,
+    // so a fast double-click could open the flow twice before `trimSession`
+    // re-renders. Guard synchronously on a ref; the trim session and finalize
+    // guards cover the slower paths.
+    if (
+      stoppingSessionsRef.current.has(sessionId) ||
+      trimSession ||
+      finishingSessionsRef.current.has(sessionId)
+    ) {
+      return;
+    }
+    stoppingSessionsRef.current.add(sessionId);
+    // Collapse the shell back to idle the instant stop is pressed so it never
+    // lingers wide while the trim modal (and the transcribe + generate pipeline
+    // behind it) runs. The owning note isn't necessarily the selected one — the
+    // user may have browsed elsewhere while recording — so capture it now.
     const owningNoteId = recordingNoteIdRef.current;
     dispatch({ type: "recordingStatusCleared" });
     setLiveTranscriptEvents([]);
     setRecordingNote(undefined);
     playRecordingSound("stop");
+    setTrimSession({
+      sessionId,
+      noteId: owningNoteId,
+      preparing: true,
+      finalizing: false,
+    });
+    try {
+      const preview = await prepareRecordingTrim(sessionId);
+      setTrimSession((current) =>
+        current && current.sessionId === sessionId
+          ? { ...current, preview, preparing: false }
+          : current,
+      );
+    } catch (err) {
+      // The waveform couldn't be built (e.g. a zero-length clip). Never strand
+      // the recording — finalize the full take immediately. The backend staged
+      // it before previewing, so this still goes through the normal pipeline.
+      setTrimSession(null);
+      if (
+        !owningNoteId ||
+        !(await applyNoteScopedProcessingFailure(owningNoteId, err))
+      ) {
+        await finalizeRecording(sessionId, owningNoteId, null);
+      }
+    } finally {
+      // The modal (or its fallback) now owns this session; the Done button is
+      // gone, so the re-entry guard can release.
+      stoppingSessionsRef.current.delete(sessionId);
+    }
+  }
+
+  async function handleConfirmTrim(trim: TrimRangeDto | null) {
+    const session = trimSession;
+    if (!session || session.finalizing) return;
+    setTrimSession((current) =>
+      current ? { ...current, finalizing: true } : current,
+    );
+    await finalizeRecording(session.sessionId, session.noteId, trim);
+    setTrimSession(null);
+  }
+
+  // Apply the optional trim, kick off transcription, and report progress on the
+  // owning note. Processing is queued per note, so the record button stays
+  // available — you can stack another take while this one finishes — and the
+  // body shimmer ("Transcribing audio…" → "Generating notes…") plus a queued
+  // count tell the user work is still in flight.
+  async function finalizeRecording(
+    sessionId: string,
+    owningNoteId: string | undefined,
+    trim: TrimRangeDto | null,
+  ) {
+    if (finishingSessionsRef.current.has(sessionId)) return;
+    finishingSessionsRef.current.add(sessionId);
     // Optimistically flip the note that owns this recording to transcribing.
-    // The selected note isn't necessarily that note — the user may have
-    // browsed elsewhere while recording — and stamping the wrong note as
-    // transcribing would lock its record button and shimmer forever.
+    // Stamping the wrong note would lock its record button and shimmer forever,
+    // so only do it when the selected note is the owning one.
     if (selectedNote && selectedNote.id === owningNoteId) {
       dispatch({
         type: "noteProcessingUpdated",
@@ -2347,7 +2432,7 @@ export function App() {
       });
     }
     try {
-      const result = await finishRecording(sessionId);
+      const result = await finishRecording(sessionId, trim ?? undefined);
       dispatch({ type: "noteProcessingUpdated", note: result.note });
     } catch (err) {
       if (!owningNoteId || !(await applyNoteScopedProcessingFailure(owningNoteId, err))) {
@@ -3200,6 +3285,13 @@ export function App() {
           </p>
         </div>
       </Dialog>
+      <TrimRecordingDialog
+        open={trimSession !== null}
+        preview={trimSession?.preview}
+        preparing={trimSession?.preparing ?? false}
+        busy={trimSession?.finalizing ?? false}
+        onConfirm={(trim) => void handleConfirmTrim(trim)}
+      />
       <MoveNoteToFolderDialog
         open={moveDialogNoteIds !== null}
         onClose={() => setMoveDialogNoteIds(null)}

--- a/src/components/recorder/TrimRecordingDialog.tsx
+++ b/src/components/recorder/TrimRecordingDialog.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { RecordingTrimPreviewDto, TrimRangeDto } from "../../lib/tauri";
+import { Dialog } from "../ui/Dialog";
+import { Spinner } from "../ui/Spinner";
+import { formatElapsed } from "./RecorderBar";
+
+type TrimRecordingDialogProps = {
+  open: boolean;
+  /** The waveform + duration, once `prepare_recording_trim` resolves. */
+  preview?: RecordingTrimPreviewDto;
+  /** True while the preview is still being computed in the backend. */
+  preparing: boolean;
+  /** True while the finalize (trim + transcribe) call is in flight. */
+  busy: boolean;
+  /**
+   * Finalize the recording. `null` keeps the full clip; a range trims to it.
+   * Dismissing the dialog (Esc / close button) finalizes the full clip so a
+   * stopped recording is never left unprocessed.
+   */
+  onConfirm: (trim: TrimRangeDto | null) => void;
+};
+
+// Don't let the selection collapse to nothing — keep at least a sliver of audio
+// so a fumbled drag can't produce an empty recording.
+const MIN_SELECTION_MS = 500;
+// A bound within this distance of the clip edge counts as "not trimmed" on that
+// side, so a near-but-not-exact handle still sends the full clip.
+const EDGE_EPSILON_MS = 60;
+
+type Edge = "start" | "end";
+
+export function TrimRecordingDialog({
+  open,
+  preview,
+  preparing,
+  busy,
+  onConfirm,
+}: TrimRecordingDialogProps) {
+  const duration = preview?.durationMs ?? 0;
+  const [startMs, setStartMs] = useState(0);
+  const [endMs, setEndMs] = useState(0);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef<Edge | null>(null);
+
+  // Reset the handles to span the whole clip whenever a new preview arrives.
+  useEffect(() => {
+    if (!preview) return;
+    setStartMs(0);
+    setEndMs(preview.durationMs);
+  }, [preview]);
+
+  const clampStart = useCallback(
+    (value: number) => Math.min(Math.max(0, value), endMs - MIN_SELECTION_MS),
+    [endMs],
+  );
+  const clampEnd = useCallback(
+    (value: number) =>
+      Math.max(Math.min(duration, value), startMs + MIN_SELECTION_MS),
+    [duration, startMs],
+  );
+
+  const msFromClientX = useCallback(
+    (clientX: number) => {
+      const track = trackRef.current;
+      if (!track || duration <= 0) return 0;
+      const rect = track.getBoundingClientRect();
+      const fraction = (clientX - rect.left) / rect.width;
+      return Math.round(Math.min(1, Math.max(0, fraction)) * duration);
+    },
+    [duration],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    function onMove(event: PointerEvent) {
+      const edge = draggingRef.current;
+      if (!edge) return;
+      const value = msFromClientX(event.clientX);
+      if (edge === "start") setStartMs(clampStart(value));
+      else setEndMs(clampEnd(value));
+    }
+    function onUp() {
+      draggingRef.current = null;
+    }
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, [open, msFromClientX, clampStart, clampEnd]);
+
+  function beginDrag(edge: Edge, event: React.PointerEvent) {
+    if (busy) return;
+    event.preventDefault();
+    draggingRef.current = edge;
+  }
+
+  function nudge(edge: Edge, deltaMs: number) {
+    if (edge === "start") setStartMs((value) => clampStart(value + deltaMs));
+    else setEndMs((value) => clampEnd(value + deltaMs));
+  }
+
+  function onHandleKeyDown(edge: Edge, event: React.KeyboardEvent) {
+    // ~1% of the clip per press (min 250ms), Shift for a coarser jump.
+    const step = Math.max(250, Math.round(duration / 100));
+    const coarse = event.shiftKey ? step * 5 : step;
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      nudge(edge, -coarse);
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      nudge(edge, coarse);
+    }
+  }
+
+  const trimmed =
+    startMs > EDGE_EPSILON_MS || endMs < duration - EDGE_EPSILON_MS;
+  const selectedMs = Math.max(0, endMs - startMs);
+
+  const startPct = duration > 0 ? (startMs / duration) * 100 : 0;
+  const endPct = duration > 0 ? (endMs / duration) * 100 : 100;
+
+  const peaks = preview?.peaks ?? [];
+  const bars = useMemo(
+    () =>
+      peaks.map((peak, index) => {
+        const position = peaks.length > 1 ? index / (peaks.length - 1) : 0;
+        const ms = position * duration;
+        const inside = ms >= startMs && ms <= endMs;
+        // Floor the height so silent stretches still read as a faint baseline.
+        const height = Math.max(0.06, Math.min(1, peak));
+        return { height, inside, key: index };
+      }),
+    [peaks, duration, startMs, endMs],
+  );
+
+  function handleClose() {
+    if (preparing || busy) return;
+    onConfirm(null);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title="Trim recording"
+      description="Drag the handles to cut silence or off-topic audio from the start or end before it's transcribed."
+      width={640}
+      className="trim-recording-dialog"
+      disableBackdropClose
+      footer={
+        <>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={() => onConfirm(null)}
+            disabled={busy}
+          >
+            Use full recording
+          </button>
+          <button
+            type="button"
+            className="primary-action primary-solid"
+            onClick={() =>
+              onConfirm(
+                trimmed
+                  ? { startMs: Math.round(startMs), endMs: Math.round(endMs) }
+                  : null,
+              )
+            }
+            disabled={busy || preparing || duration <= 0}
+          >
+            {busy
+              ? "Saving…"
+              : trimmed
+                ? "Trim and transcribe"
+                : "Save and transcribe"}
+          </button>
+        </>
+      }
+    >
+      {preparing || !preview ? (
+        <div className="trim-loading">
+          <Spinner />
+          <p>Preparing waveform…</p>
+        </div>
+      ) : (
+        <div className="trim-body">
+          <div
+            className="trim-track"
+            ref={trackRef}
+            data-busy={busy ? "true" : undefined}
+          >
+            <div className="trim-waveform" aria-hidden="true">
+              {bars.map((bar) => (
+                <span
+                  key={bar.key}
+                  className={`trim-bar${bar.inside ? "" : " trim-bar-muted"}`}
+                  style={{ height: `${bar.height * 100}%` }}
+                />
+              ))}
+            </div>
+            <div
+              className="trim-shade trim-shade-start"
+              style={{ width: `${startPct}%` }}
+              aria-hidden="true"
+            />
+            <div
+              className="trim-shade trim-shade-end"
+              style={{ width: `${100 - endPct}%` }}
+              aria-hidden="true"
+            />
+            <button
+              type="button"
+              className="trim-handle trim-handle-start"
+              style={{ left: `${startPct}%` }}
+              onPointerDown={(event) => beginDrag("start", event)}
+              onKeyDown={(event) => onHandleKeyDown("start", event)}
+              role="slider"
+              aria-label="Trim start"
+              aria-valuemin={0}
+              aria-valuemax={Math.round(duration)}
+              aria-valuenow={Math.round(startMs)}
+              aria-valuetext={formatElapsed(startMs)}
+              disabled={busy}
+            />
+            <button
+              type="button"
+              className="trim-handle trim-handle-end"
+              style={{ left: `${endPct}%` }}
+              onPointerDown={(event) => beginDrag("end", event)}
+              onKeyDown={(event) => onHandleKeyDown("end", event)}
+              role="slider"
+              aria-label="Trim end"
+              aria-valuemin={0}
+              aria-valuemax={Math.round(duration)}
+              aria-valuenow={Math.round(endMs)}
+              aria-valuetext={formatElapsed(endMs)}
+              disabled={busy}
+            />
+          </div>
+          <div className="trim-readout">
+            <span className="trim-time">{formatElapsed(startMs)}</span>
+            <span className="trim-duration">
+              {trimmed
+                ? `Keeping ${formatElapsed(selectedMs)} of ${formatElapsed(duration)}`
+                : `Full recording, ${formatElapsed(duration)}`}
+            </span>
+            <span className="trim-time">{formatElapsed(endMs)}</span>
+          </div>
+        </div>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/recorder/TrimRecordingDialog.tsx
+++ b/src/components/recorder/TrimRecordingDialog.tsx
@@ -1,5 +1,11 @@
+import { IconPause } from "central-icons-filled/IconPause";
+import { IconPlay } from "central-icons-filled/IconPlay";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { RecordingTrimPreviewDto, TrimRangeDto } from "../../lib/tauri";
+import {
+  localAudioFileSrc,
+  type RecordingTrimPreviewDto,
+  type TrimRangeDto,
+} from "../../lib/tauri";
 import { Dialog } from "../ui/Dialog";
 import { Spinner } from "../ui/Spinner";
 import { formatElapsed } from "./RecorderBar";
@@ -39,23 +45,105 @@ export function TrimRecordingDialog({
   const duration = preview?.durationMs ?? 0;
   const [startMs, setStartMs] = useState(0);
   const [endMs, setEndMs] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [playheadMs, setPlayheadMs] = useState(0);
   const trackRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef<Edge | null>(null);
+  const scrubbingRef = useRef(false);
+  // Mic + system are captured to separate WAVs aligned on the same wall clock,
+  // so we play them together (the browser mixes their output) to reproduce what
+  // the user heard. Element 0 is the "clock" that drives the playhead.
+  const audioEls = useRef<(HTMLAudioElement | null)[]>([]);
+  const sources = useMemo(() => preview?.sources ?? [], [preview]);
 
   // Reset the handles to span the whole clip whenever a new preview arrives.
   useEffect(() => {
     if (!preview) return;
     setStartMs(0);
     setEndMs(preview.durationMs);
+    setPlayheadMs(0);
+    setPlaying(false);
   }, [preview]);
+
+  const forEachAudio = useCallback((fn: (el: HTMLAudioElement) => void) => {
+    for (const el of audioEls.current) {
+      if (el) fn(el);
+    }
+  }, []);
+
+  const pausePlayback = useCallback(() => {
+    forEachAudio((el) => el.pause());
+    setPlaying(false);
+  }, [forEachAudio]);
+
+  const seekMs = useCallback(
+    (ms: number) => {
+      const clamped = Math.min(Math.max(0, ms), duration);
+      forEachAudio((el) => {
+        // Guard: jsdom and unloaded media can throw on currentTime assignment.
+        try {
+          el.currentTime = clamped / 1000;
+        } catch {
+          /* ignore */
+        }
+      });
+      setPlayheadMs(clamped);
+    },
+    [duration, forEachAudio],
+  );
+
+  // Stop playback whenever the dialog closes or the finalize spinner takes over.
+  useEffect(() => {
+    if (!open || busy) pausePlayback();
+  }, [open, busy, pausePlayback]);
+
+  const togglePlay = useCallback(() => {
+    if (busy || duration <= 0 || sources.length === 0) return;
+    if (playing) {
+      pausePlayback();
+      return;
+    }
+    // Auditioning the kept region: start at the head unless it's outside the
+    // selection, in which case begin at the start handle.
+    if (playheadMs < startMs || playheadMs >= endMs) {
+      seekMs(startMs);
+    }
+    forEachAudio((el) => {
+      void el.play?.()?.catch(() => {
+        /* autoplay/format errors shouldn't wedge the modal */
+      });
+    });
+    setPlaying(true);
+  }, [
+    busy,
+    duration,
+    sources.length,
+    playing,
+    playheadMs,
+    startMs,
+    endMs,
+    seekMs,
+    pausePlayback,
+    forEachAudio,
+  ]);
+
+  function handleTimeUpdate(event: React.SyntheticEvent<HTMLAudioElement>) {
+    const ms = event.currentTarget.currentTime * 1000;
+    // Stop at the end handle so playback previews exactly the kept audio.
+    if (playing && ms >= endMs) {
+      pausePlayback();
+      seekMs(endMs);
+      return;
+    }
+    setPlayheadMs(ms);
+  }
 
   const clampStart = useCallback(
     (value: number) => Math.min(Math.max(0, value), endMs - MIN_SELECTION_MS),
     [endMs],
   );
   const clampEnd = useCallback(
-    (value: number) =>
-      Math.max(Math.min(duration, value), startMs + MIN_SELECTION_MS),
+    (value: number) => Math.max(Math.min(duration, value), startMs + MIN_SELECTION_MS),
     [duration, startMs],
   );
 
@@ -74,13 +162,17 @@ export function TrimRecordingDialog({
     if (!open) return;
     function onMove(event: PointerEvent) {
       const edge = draggingRef.current;
-      if (!edge) return;
-      const value = msFromClientX(event.clientX);
-      if (edge === "start") setStartMs(clampStart(value));
-      else setEndMs(clampEnd(value));
+      if (edge) {
+        const value = msFromClientX(event.clientX);
+        if (edge === "start") setStartMs(clampStart(value));
+        else setEndMs(clampEnd(value));
+      } else if (scrubbingRef.current) {
+        seekMs(msFromClientX(event.clientX));
+      }
     }
     function onUp() {
       draggingRef.current = null;
+      scrubbingRef.current = false;
     }
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
@@ -88,12 +180,21 @@ export function TrimRecordingDialog({
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
     };
-  }, [open, msFromClientX, clampStart, clampEnd]);
+  }, [open, msFromClientX, clampStart, clampEnd, seekMs]);
 
   function beginDrag(edge: Edge, event: React.PointerEvent) {
     if (busy) return;
     event.preventDefault();
     draggingRef.current = edge;
+  }
+
+  // Click or drag anywhere on the track (but not on a handle) moves the playhead
+  // so the user can scrub to a spot and hear it.
+  function beginScrub(event: React.PointerEvent) {
+    if (busy || duration <= 0) return;
+    if ((event.target as HTMLElement).closest(".trim-handle")) return;
+    scrubbingRef.current = true;
+    seekMs(msFromClientX(event.clientX));
   }
 
   function nudge(edge: Edge, deltaMs: number) {
@@ -114,12 +215,12 @@ export function TrimRecordingDialog({
     }
   }
 
-  const trimmed =
-    startMs > EDGE_EPSILON_MS || endMs < duration - EDGE_EPSILON_MS;
+  const trimmed = startMs > EDGE_EPSILON_MS || endMs < duration - EDGE_EPSILON_MS;
   const selectedMs = Math.max(0, endMs - startMs);
 
   const startPct = duration > 0 ? (startMs / duration) * 100 : 0;
   const endPct = duration > 0 ? (endMs / duration) * 100 : 100;
+  const playheadPct = duration > 0 ? Math.min(100, Math.max(0, (playheadMs / duration) * 100)) : 0;
 
   const peaks = preview?.peaks ?? [];
   const bars = useMemo(
@@ -145,7 +246,7 @@ export function TrimRecordingDialog({
       open={open}
       onClose={handleClose}
       title="Trim recording"
-      description="Drag the handles to cut silence or off-topic audio from the start or end before it's transcribed."
+      description="Play it back and drag the handles to cut silence or off-topic audio from the start or end before it's transcribed."
       width={640}
       className="trim-recording-dialog"
       disableBackdropClose
@@ -163,19 +264,11 @@ export function TrimRecordingDialog({
             type="button"
             className="primary-action primary-solid"
             onClick={() =>
-              onConfirm(
-                trimmed
-                  ? { startMs: Math.round(startMs), endMs: Math.round(endMs) }
-                  : null,
-              )
+              onConfirm(trimmed ? { startMs: Math.round(startMs), endMs: Math.round(endMs) } : null)
             }
             disabled={busy || preparing || duration <= 0}
           >
-            {busy
-              ? "Saving…"
-              : trimmed
-                ? "Trim and transcribe"
-                : "Save and transcribe"}
+            {busy ? "Saving…" : trimmed ? "Trim and transcribe" : "Save and transcribe"}
           </button>
         </>
       }
@@ -187,10 +280,23 @@ export function TrimRecordingDialog({
         </div>
       ) : (
         <div className="trim-body">
+          {sources.map((source, index) => (
+            <audio
+              key={source.path}
+              ref={(el) => {
+                audioEls.current[index] = el;
+              }}
+              src={localAudioFileSrc(source.path)}
+              preload="auto"
+              onTimeUpdate={index === 0 ? handleTimeUpdate : undefined}
+              onEnded={index === 0 ? pausePlayback : undefined}
+            />
+          ))}
           <div
             className="trim-track"
             ref={trackRef}
             data-busy={busy ? "true" : undefined}
+            onPointerDown={beginScrub}
           >
             <div className="trim-waveform" aria-hidden="true">
               {bars.map((bar) => (
@@ -211,6 +317,7 @@ export function TrimRecordingDialog({
               style={{ width: `${100 - endPct}%` }}
               aria-hidden="true"
             />
+            <div className="trim-playhead" style={{ left: `${playheadPct}%` }} aria-hidden="true" />
             <button
               type="button"
               className="trim-handle trim-handle-start"
@@ -239,6 +346,19 @@ export function TrimRecordingDialog({
               aria-valuetext={formatElapsed(endMs)}
               disabled={busy}
             />
+          </div>
+          <div className="trim-transport">
+            <button
+              type="button"
+              className="trim-play"
+              onClick={togglePlay}
+              disabled={busy || duration <= 0 || sources.length === 0}
+              aria-label={playing ? "Pause" : "Play"}
+              aria-pressed={playing}
+            >
+              {playing ? <IconPause size={18} /> : <IconPlay size={18} />}
+            </button>
+            <span className="trim-playhead-time">{formatElapsed(playheadMs)}</span>
           </div>
           <div className="trim-readout">
             <span className="trim-time">{formatElapsed(startMs)}</span>

--- a/src/components/recorder/TrimRecordingDialog.tsx
+++ b/src/components/recorder/TrimRecordingDialog.tsx
@@ -52,7 +52,8 @@ export function TrimRecordingDialog({
   const scrubbingRef = useRef(false);
   // Mic + system are captured to separate WAVs aligned on the same wall clock,
   // so we play them together (the browser mixes their output) to reproduce what
-  // the user heard. Element 0 is the "clock" that drives the playhead.
+  // the user heard. The playhead follows the furthest-along element (see
+  // handleTimeUpdate) so an early-ending source doesn't freeze it.
   const audioEls = useRef<(HTMLAudioElement | null)[]>([]);
   const sources = useMemo(() => preview?.sources ?? [], [preview]);
 
@@ -127,8 +128,13 @@ export function TrimRecordingDialog({
     forEachAudio,
   ]);
 
-  function handleTimeUpdate(event: React.SyntheticEvent<HTMLAudioElement>) {
-    const ms = event.currentTarget.currentTime * 1000;
+  function handleTimeUpdate() {
+    // Don't fight an active scrub: seekMs already set the playhead there.
+    if (scrubbingRef.current) return;
+    // Drive the playhead from the furthest-along source. Sources can differ in
+    // length (mic vs system) and `duration` is their max, so keying off a single
+    // (possibly shorter) element would freeze the playhead before endMs.
+    const ms = Math.max(0, ...audioEls.current.map((el) => el?.currentTime ?? 0)) * 1000;
     // Stop at the end handle so playback previews exactly the kept audio.
     if (playing && ms >= endMs) {
       pausePlayback();
@@ -138,12 +144,25 @@ export function TrimRecordingDialog({
     setPlayheadMs(ms);
   }
 
+  // Natural end: only stop once every source has finished, so the longer source
+  // isn't cut off when a shorter one ends first.
+  function handleEnded() {
+    if (audioEls.current.every((el) => !el || el.ended || el.paused)) {
+      pausePlayback();
+      seekMs(endMs);
+    }
+  }
+
+  // Clamp the min-selection offsets to [0, duration] too, so a clip shorter than
+  // MIN_SELECTION_MS can't invert the bounds into a negative start or an end past
+  // the clip (the handles just stop moving instead).
   const clampStart = useCallback(
-    (value: number) => Math.min(Math.max(0, value), endMs - MIN_SELECTION_MS),
+    (value: number) => Math.min(Math.max(0, value), Math.max(0, endMs - MIN_SELECTION_MS)),
     [endMs],
   );
   const clampEnd = useCallback(
-    (value: number) => Math.max(Math.min(duration, value), startMs + MIN_SELECTION_MS),
+    (value: number) =>
+      Math.max(Math.min(duration, value), Math.min(duration, startMs + MIN_SELECTION_MS)),
     [duration, startMs],
   );
 
@@ -256,7 +275,7 @@ export function TrimRecordingDialog({
             type="button"
             className="primary-action"
             onClick={() => onConfirm(null)}
-            disabled={busy}
+            disabled={busy || preparing}
           >
             Use full recording
           </button>
@@ -288,8 +307,8 @@ export function TrimRecordingDialog({
               }}
               src={localAudioFileSrc(source.path)}
               preload="auto"
-              onTimeUpdate={index === 0 ? handleTimeUpdate : undefined}
-              onEnded={index === 0 ? pausePlayback : undefined}
+              onTimeUpdate={handleTimeUpdate}
+              onEnded={handleEnded}
             />
           ))}
           <div

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -266,12 +266,20 @@ export type TrimRangeDto = {
   endMs: number;
 };
 
+export type TrimSourceDto = {
+  source: RecordingSource;
+  /** Absolute path to the finalized source WAV, for asset-protocol playback. */
+  path: string;
+};
+
 export type RecordingTrimPreviewDto = {
   sessionId: string;
   durationMs: number;
   /** Normalized 0..1 amplitude maxima, one per equal-width time bucket. */
   peaks: number[];
   sourceMode?: RecordingSourceMode;
+  /** Source WAVs to play back while reviewing the clip in the trim modal. */
+  sources: TrimSourceDto[];
 };
 
 export type RecordingPresenceBoundsDto = {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -261,6 +261,19 @@ export type RecordingStatusDto = {
   warnings?: SourceWarningDto[];
 };
 
+export type TrimRangeDto = {
+  startMs: number;
+  endMs: number;
+};
+
+export type RecordingTrimPreviewDto = {
+  sessionId: string;
+  durationMs: number;
+  /** Normalized 0..1 amplitude maxima, one per equal-width time bucket. */
+  peaks: number[];
+  sourceMode?: RecordingSourceMode;
+};
+
 export type RecordingPresenceBoundsDto = {
   x: number;
   y: number;
@@ -1399,9 +1412,15 @@ export async function setRecordingPresenceBounds(
   });
 }
 
-export async function finishRecording(sessionId: string) {
-  return invoke<FinishRecordingResponse>("finish_recording", {
+export async function prepareRecordingTrim(sessionId: string) {
+  return invoke<RecordingTrimPreviewDto>("prepare_recording_trim", {
     request: { sessionId },
+  });
+}
+
+export async function finishRecording(sessionId: string, trim?: TrimRangeDto) {
+  return invoke<FinishRecordingResponse>("finish_recording", {
+    request: trim ? { sessionId, trim } : { sessionId },
   });
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17580,6 +17580,61 @@ input:focus-visible,
   color: var(--foreground);
 }
 
+/* Playback head sweeping the waveform. Above the shades and handles so it stays
+ * visible over the trimmed-away regions. */
+.trim-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 3;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--foreground);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--card) 70%, transparent);
+  pointer-events: none;
+}
+
+.trim-transport {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.trim-play {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  cursor: pointer;
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.trim-play:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--primary) 92%, var(--foreground));
+}
+
+.trim-play:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--ring-focus);
+}
+
+.trim-play:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.trim-playhead-time {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Referral dialog — a 50/50 split. The left is a terracotta hero (brand
  * gradient + the app's fractal-noise grain, the same recipe as
  * .dictation-hint) that carries the offer; the right is the borderless

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17446,6 +17446,140 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
+/* Trim recording modal — waveform of the finalized clip with two draggable
+ * handles. The selected window keeps full-opacity brand bars; the trimmed
+ * ends dim under a scrim so the cut is obvious at a glance. */
+.trim-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp-3);
+  min-height: 140px;
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+}
+
+.trim-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.trim-track {
+  position: relative;
+  height: 132px;
+  padding: 0 var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--muted);
+  overflow: hidden;
+  touch-action: none;
+}
+
+.trim-track[data-busy="true"] {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.trim-waveform {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  width: 100%;
+  height: 100%;
+}
+
+.trim-bar {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 2px;
+  border-radius: var(--r-pill);
+  background: var(--brand);
+  transition: background-color var(--t-fast) var(--ease-out);
+}
+
+.trim-bar-muted {
+  background: color-mix(in oklch, var(--muted-foreground) 45%, transparent);
+}
+
+/* Dim the trimmed-away regions. Sit above the bars but below the handles. */
+.trim-shade {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  background: color-mix(in oklch, var(--card) 62%, transparent);
+  pointer-events: none;
+}
+
+.trim-shade-start {
+  left: 0;
+}
+
+.trim-shade-end {
+  right: 0;
+}
+
+.trim-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 2;
+  width: 14px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  transform: translateX(-50%);
+  background: transparent;
+  cursor: ew-resize;
+  touch-action: none;
+}
+
+/* The visible grip: a rounded brand pill centered in the hit area. */
+.trim-handle::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 64%;
+  transform: translate(-50%, -50%);
+  border-radius: var(--r-pill);
+  background: var(--brand);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--card) 70%, transparent);
+}
+
+.trim-handle:hover::before {
+  background: color-mix(in oklch, var(--brand) 86%, var(--foreground));
+}
+
+.trim-handle:focus-visible {
+  outline: none;
+}
+
+.trim-handle:focus-visible::before {
+  box-shadow: 0 0 0 3px var(--ring-focus);
+}
+
+.trim-handle:disabled {
+  cursor: default;
+}
+
+.trim-readout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.trim-readout .trim-duration {
+  color: var(--foreground);
+}
+
 /* Referral dialog — a 50/50 split. The left is a terracotta hero (brand
  * gradient + the app's fractal-noise grain, the same recipe as
  * .dictation-hint) that carries the offer; the right is the borderless

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -81,6 +81,7 @@ vi.mock("../lib/tauri", () => ({
   pauseRecording: mocks.pauseRecording,
   resumeRecording: mocks.resumeRecording,
   getRecordingStatus: mocks.getRecordingStatus,
+  prepareRecordingTrim: vi.fn(),
   finishRecording: mocks.finishRecording,
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -81,7 +81,14 @@ vi.mock("../lib/tauri", () => ({
   pauseRecording: mocks.pauseRecording,
   resumeRecording: mocks.resumeRecording,
   getRecordingStatus: mocks.getRecordingStatus,
-  prepareRecordingTrim: vi.fn(),
+  // Resolve a preview so a stopped recording's trim modal leaves the loading
+  // spinner (otherwise its confirm/finish actions stay disabled).
+  prepareRecordingTrim: vi.fn().mockResolvedValue({
+    sessionId: "rec-1",
+    durationMs: 1000,
+    peaks: [0.2, 0.8, 0.4],
+    sourceMode: "microphoneOnly",
+  }),
   finishRecording: mocks.finishRecording,
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   resumeRecording: vi.fn(),
   getRecordingStatus: vi.fn(),
   setRecordingPresenceBounds: vi.fn(),
+  prepareRecordingTrim: vi.fn(),
   finishRecording: vi.fn(),
   retryProcessing: vi.fn(),
   recoverRecording: vi.fn(),
@@ -94,6 +95,7 @@ vi.mock("../lib/tauri", () => ({
   resumeRecording: mocks.resumeRecording,
   getRecordingStatus: mocks.getRecordingStatus,
   setRecordingPresenceBounds: mocks.setRecordingPresenceBounds,
+  prepareRecordingTrim: mocks.prepareRecordingTrim,
   finishRecording: mocks.finishRecording,
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,
@@ -213,6 +215,14 @@ describe("notes recording reliability", () => {
       startDragging: vi.fn().mockResolvedValue(undefined),
     });
     mocks.bootstrapApp.mockResolvedValue(payload);
+    // Stopping a recording opens the trim modal, which needs a waveform preview
+    // before its confirm buttons render.
+    mocks.prepareRecordingTrim.mockResolvedValue({
+      sessionId: "rec-1",
+      durationMs: 1000,
+      peaks: [0.2, 0.8, 0.4],
+      sourceMode: "microphoneOnly",
+    });
     // The meeting-detected start path creates a fresh note to record into; this
     // suite asserts recording lands on note-1, so the fresh note IS note-1.
     mocks.createNote.mockResolvedValue(first);
@@ -331,7 +341,13 @@ describe("notes recording reliability", () => {
     await userEvent.click(indicator);
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
     await userEvent.click(await screen.findByRole("button", { name: "Done" }));
-    await waitFor(() => expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1"));
+    // Done opens the trim modal; finalize the full clip to transcribe.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Use full recording" }),
+    );
+    await waitFor(() =>
+      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1", undefined),
+    );
 
     // note-2 must not pick up note-1's optimistic "transcribing" lock.
     mocks.getNote.mockClear();
@@ -668,7 +684,13 @@ describe("notes recording reliability", () => {
     // note-1 is "ready" (terminal); stacking another take must still flip it
     // back to transcribing so the shimmer shows and polling resumes.
     await userEvent.click(screen.getByRole("button", { name: "Done" }));
-    await waitFor(() => expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1"));
+    // Done opens the trim modal; finalize the full clip to transcribe.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Use full recording" }),
+    );
+    await waitFor(() =>
+      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1", undefined),
+    );
 
     await waitFor(() => expect(screen.getByText(/Transcribing audio/)).toBeInTheDocument());
   });

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -342,12 +342,8 @@ describe("notes recording reliability", () => {
     await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
     await userEvent.click(await screen.findByRole("button", { name: "Done" }));
     // Done opens the trim modal; finalize the full clip to transcribe.
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Use full recording" }),
-    );
-    await waitFor(() =>
-      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1", undefined),
-    );
+    await userEvent.click(await screen.findByRole("button", { name: "Use full recording" }));
+    await waitFor(() => expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1", undefined));
 
     // note-2 must not pick up note-1's optimistic "transcribing" lock.
     mocks.getNote.mockClear();
@@ -685,12 +681,8 @@ describe("notes recording reliability", () => {
     // back to transcribing so the shimmer shows and polling resumes.
     await userEvent.click(screen.getByRole("button", { name: "Done" }));
     // Done opens the trim modal; finalize the full clip to transcribe.
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Use full recording" }),
-    );
-    await waitFor(() =>
-      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1", undefined),
-    );
+    await userEvent.click(await screen.findByRole("button", { name: "Use full recording" }));
+    await waitFor(() => expect(mocks.finishRecording).toHaveBeenCalledWith("rec-1", undefined));
 
     await waitFor(() => expect(screen.getByText(/Transcribing audio/)).toBeInTheDocument());
   });

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -164,6 +164,7 @@ vi.mock("../lib/tauri", () => ({
   pauseRecording: mocks.pauseRecording,
   resumeRecording: mocks.resumeRecording,
   getRecordingStatus: mocks.getRecordingStatus,
+  prepareRecordingTrim: vi.fn(),
   finishRecording: mocks.finishRecording,
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -164,7 +164,14 @@ vi.mock("../lib/tauri", () => ({
   pauseRecording: mocks.pauseRecording,
   resumeRecording: mocks.resumeRecording,
   getRecordingStatus: mocks.getRecordingStatus,
-  prepareRecordingTrim: vi.fn(),
+  // Resolve a preview so a stopped recording's trim modal leaves the loading
+  // spinner (otherwise its confirm/finish actions stay disabled).
+  prepareRecordingTrim: vi.fn().mockResolvedValue({
+    sessionId: "rec-1",
+    durationMs: 1000,
+    peaks: [0.2, 0.8, 0.4],
+    sourceMode: "microphoneOnly",
+  }),
   finishRecording: mocks.finishRecording,
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,

--- a/src/test/trim-recording-dialog.test.tsx
+++ b/src/test/trim-recording-dialog.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TrimRecordingDialog } from "../components/recorder/TrimRecordingDialog";
+import type { RecordingTrimPreviewDto } from "../lib/tauri";
+
+const preview: RecordingTrimPreviewDto = {
+  sessionId: "rec-1",
+  durationMs: 60_000,
+  peaks: [0.1, 0.5, 0.9, 0.4, 0.2],
+  sourceMode: "microphoneOnly",
+};
+
+describe("TrimRecordingDialog", () => {
+  it("shows a loading state until the waveform preview arrives", () => {
+    render(
+      <TrimRecordingDialog
+        open
+        preview={undefined}
+        preparing
+        busy={false}
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Preparing waveform…")).toBeInTheDocument();
+  });
+
+  it("finalizes the full recording with no trim by default", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <TrimRecordingDialog
+        open
+        preview={preview}
+        preparing={false}
+        busy={false}
+        onConfirm={onConfirm}
+      />,
+    );
+    // Untrimmed, the primary action keeps the whole clip.
+    expect(screen.getByText(/Full recording, 01:00/)).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Save and transcribe" }),
+    );
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+
+  it("trims from the start with the keyboard and confirms a range", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <TrimRecordingDialog
+        open
+        preview={preview}
+        preparing={false}
+        busy={false}
+        onConfirm={onConfirm}
+      />,
+    );
+    // Step is max(250, duration/100) == 600ms for a 60s clip.
+    fireEvent.keyDown(screen.getByRole("slider", { name: "Trim start" }), {
+      key: "ArrowRight",
+    });
+    expect(screen.getByText(/Keeping 00:59 of 01:00/)).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Trim and transcribe" }),
+    );
+    expect(onConfirm).toHaveBeenCalledWith({ startMs: 600, endMs: 60_000 });
+  });
+
+  it("lets the user keep the full recording explicitly", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <TrimRecordingDialog
+        open
+        preview={preview}
+        preparing={false}
+        busy={false}
+        onConfirm={onConfirm}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Use full recording" }),
+    );
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+
+  it("disables the confirm actions while finalizing", () => {
+    render(
+      <TrimRecordingDialog
+        open
+        preview={preview}
+        preparing={false}
+        busy
+        onConfirm={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
+  });
+});

--- a/src/test/trim-recording-dialog.test.tsx
+++ b/src/test/trim-recording-dialog.test.tsx
@@ -1,26 +1,34 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { TrimRecordingDialog } from "../components/recorder/TrimRecordingDialog";
 import type { RecordingTrimPreviewDto } from "../lib/tauri";
+
+// The dialog turns source paths into playable URLs via `convertFileSrc`, which
+// needs the Tauri runtime — stub it so playback wiring can be exercised in jsdom.
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: (path: string) => `asset://localhost/${encodeURIComponent(path)}`,
+  invoke: vi.fn(),
+}));
 
 const preview: RecordingTrimPreviewDto = {
   sessionId: "rec-1",
   durationMs: 60_000,
   peaks: [0.1, 0.5, 0.9, 0.4, 0.2],
   sourceMode: "microphoneOnly",
+  sources: [{ source: "microphone", path: "/tmp/rec-1/microphone.wav" }],
 };
+
+// jsdom doesn't implement media playback; stub play/pause so the transport works.
+beforeAll(() => {
+  window.HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve());
+  window.HTMLMediaElement.prototype.pause = vi.fn();
+});
 
 describe("TrimRecordingDialog", () => {
   it("shows a loading state until the waveform preview arrives", () => {
     render(
-      <TrimRecordingDialog
-        open
-        preview={undefined}
-        preparing
-        busy={false}
-        onConfirm={vi.fn()}
-      />,
+      <TrimRecordingDialog open preview={undefined} preparing busy={false} onConfirm={vi.fn()} />,
     );
     expect(screen.getByText("Preparing waveform…")).toBeInTheDocument();
   });
@@ -38,9 +46,7 @@ describe("TrimRecordingDialog", () => {
     );
     // Untrimmed, the primary action keeps the whole clip.
     expect(screen.getByText(/Full recording, 01:00/)).toBeInTheDocument();
-    await userEvent.click(
-      screen.getByRole("button", { name: "Save and transcribe" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Save and transcribe" }));
     expect(onConfirm).toHaveBeenCalledWith(null);
   });
 
@@ -60,10 +66,24 @@ describe("TrimRecordingDialog", () => {
       key: "ArrowRight",
     });
     expect(screen.getByText(/Keeping 00:59 of 01:00/)).toBeInTheDocument();
-    await userEvent.click(
-      screen.getByRole("button", { name: "Trim and transcribe" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Trim and transcribe" }));
     expect(onConfirm).toHaveBeenCalledWith({ startMs: 600, endMs: 60_000 });
+  });
+
+  it("plays the recording back and toggles to pause", async () => {
+    render(
+      <TrimRecordingDialog
+        open
+        preview={preview}
+        preparing={false}
+        busy={false}
+        onConfirm={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Play" }));
+    expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    await userEvent.click(await screen.findByRole("button", { name: "Pause" }));
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
   });
 
   it("lets the user keep the full recording explicitly", async () => {
@@ -77,21 +97,13 @@ describe("TrimRecordingDialog", () => {
         onConfirm={onConfirm}
       />,
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Use full recording" }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Use full recording" }));
     expect(onConfirm).toHaveBeenCalledWith(null);
   });
 
   it("disables the confirm actions while finalizing", () => {
     render(
-      <TrimRecordingDialog
-        open
-        preview={preview}
-        preparing={false}
-        busy
-        onConfirm={vi.fn()}
-      />,
+      <TrimRecordingDialog open preview={preview} preparing={false} busy onConfirm={vi.fn()} />,
     );
     expect(screen.getByRole("button", { name: "Saving…" })).toBeDisabled();
   });


### PR DESCRIPTION
## Summary

- Stopping a recording now opens a trim modal showing the clip's waveform with
  draggable start/end handles, so silence or off-topic audio can be cut from
  either end before transcription and note generation run. Dismissing the modal
  (Esc / close / "Use full recording") finalizes the full clip, so a stopped
  recording is never left unprocessed.
- The modal plays the recording back with a play/pause control and a scrubbable
  playhead over the waveform. Microphone and system sources play together (the
  browser mixes their output) so you hear what was captured; playback auditions
  exactly the kept region (starts at the start handle, stops at the end handle).
- Backend splits stop into stage/finalize phases so transcription is deferred
  until the trim decision: `prepare_recording_trim` finalizes the WAVs, stashes
  the recording, and returns a downsampled waveform plus the source paths;
  `finish_recording` applies the trim (rewriting each 16-bit PCM WAV to the
  selected window) and then runs the existing transcription pipeline.
- Security-sensitive: adds the app recordings directory to the Tauri
  asset-protocol scope at runtime (in the setup hook) so the modal's `<audio>`
  can read local WAVs. This covers both the dev (`-dev`) and prod data dirs
  without a static glob, and mirrors how `AppPaths::contained_recording_file`
  already treats everything under `recordings/` as ours.

## Validation

- `pnpm typecheck` (tsc --noEmit): clean.
- `pnpm check` (Biome): exit 0 (no errors; only the repo's pre-existing
  warnings).
- `pnpm test` (vitest): trim dialog suite (incl. playback) and the app
  trim-path suites pass.
- `pnpm test:rust` (`cargo test`): passes, including new `trim.rs` unit tests
  (`trims_to_the_selected_window`, `waveform_preview_buckets_match_timeline`).
- `cargo fmt --check` and `cargo clippy --all-targets`: clean for the changed
  files.
- Rebased onto `main` at v0.0.25 (conflicts in `App.tsx` and one app test
  resolved; branch reformatted to Biome).

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- Live record -> play back -> scrub -> trim -> transcribe verified end-to-end on a configured, signed-in build. Recording available on request. -->
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- No: desktop-only change; uses the current June API unchanged. -->

## Out of scope

- No audio re-encoding or format conversion: trimming rewrites the existing
  16-bit PCM WAVs in place; non-PCM sources are left untouched.
- No waveform zoom or multi-region selection; a single start/end window only.

## Followups

- A staged-but-never-confirmed recording (e.g. app crash with the modal open)
  leaves an orphaned entry in the in-memory pending store; the WAVs remain on
  disk. Acceptable for v1 since a normal dismiss always finalizes.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- N/A: no workflow changes -->
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- asset-protocol scope change flagged in summary for owner review -->
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- N/A -->
- [x] User-facing copy follows the repo UI conventions.
