### PR TITLE
Apply 1.2x usage credit margin

### DIFF
--- a/docs/june-api-prd.md
+++ b/docs/june-api-prd.md
@@ -48,7 +48,7 @@ configured **credit price** for the chosen **upstream model**, and the
 existing "Top up credits" affordance in the Account settings becomes the only
 way to fund usage. Users see "Insufficient credits → Top up" instead of a
 generic provider error when they run dry. Usage credit prices are retail
-prices; June's current policy is a 1.25x multiplier over upstream cost.
+prices; June's current policy is a 1.2x multiplier over upstream cost.
 
 ## User Stories
 
@@ -134,7 +134,7 @@ prices; June's current policy is a 1.25x multiplier over upstream cost.
     swap or add a provider without changing the orchestration code.
 23. As a **June API maintainer**, I want a typed pricing table loaded from
     config, so that adding or repricing an upstream model is a config diff
-    not a code change. Usage prices include the chosen 1.25x retail
+    not a code change. Usage prices include the chosen 1.2x retail
     multiplier over upstream cost.
 24. As a **June API maintainer**, I want unknown models (no credit price)
     to be rejected at the API boundary with a clear error code, so that we
@@ -306,7 +306,7 @@ defaults + `config.toml` + env, no `std::env::var` calls outside):
 - `[upstreams.venice]` — `api_key` (env-only), `base_url`.
 - `[pricing]` — table keyed by `model_id`, each entry `{ unit: "seconds" |
   "tokens", credits_per_unit: u64 }`. Values are retail credit prices,
-  currently 1.25x upstream cost for usage-priced models. Loaded from
+  currently 1.2x upstream cost for usage-priced models. Loaded from
   `config.toml` baked into the image; `JUNE__PRICING__…` env overrides
   supported via figment for per-env tweaking.
 

--- a/docs/june-api-prd.md
+++ b/docs/june-api-prd.md
@@ -47,7 +47,8 @@ call is billed against the signed-in user's OS Accounts wallet at the
 configured **credit price** for the chosen **upstream model**, and the
 existing "Top up credits" affordance in the Account settings becomes the only
 way to fund usage. Users see "Insufficient credits → Top up" instead of a
-generic provider error when they run dry.
+generic provider error when they run dry. Usage credit prices are retail
+prices; June's current policy is a 1.25x multiplier over upstream cost.
 
 ## User Stories
 
@@ -133,7 +134,8 @@ generic provider error when they run dry.
     swap or add a provider without changing the orchestration code.
 23. As a **June API maintainer**, I want a typed pricing table loaded from
     config, so that adding or repricing an upstream model is a config diff
-    not a code change.
+    not a code change. Usage prices include the chosen 1.25x retail
+    multiplier over upstream cost.
 24. As a **June API maintainer**, I want unknown models (no credit price)
     to be rejected at the API boundary with a clear error code, so that we
     never silently charge $0 or absorb a margin we didn't choose.
@@ -303,9 +305,10 @@ defaults + `config.toml` + env, no `std::env::var` calls outside):
 - `[upstreams.openai]` — `api_key` (env-only), `base_url`.
 - `[upstreams.venice]` — `api_key` (env-only), `base_url`.
 - `[pricing]` — table keyed by `model_id`, each entry `{ unit: "seconds" |
-  "tokens", credits_per_unit: u64 }`. Loaded from `config.toml` baked
-  into the image; `JUNE__PRICING__…` env overrides supported via
-  figment for per-env tweaking.
+  "tokens", credits_per_unit: u64 }`. Values are retail credit prices,
+  currently 1.25x upstream cost for usage-priced models. Loaded from
+  `config.toml` baked into the image; `JUNE__PRICING__…` env overrides
+  supported via figment for per-env tweaking.
 
 June (Tauri client):
 

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -58,12 +58,12 @@ base_url = "https://api.openai.com/v1"
 [upstreams.venice]
 base_url = "https://api.venice.ai/api/v1"
 
-# Usage credit prices include June's 1.25x retail multiplier over upstream cost.
+# Usage credit prices include June's 1.2x retail multiplier over upstream cost.
 # OpenAI lists ASR prices per MINUTE of audio ($0.003/min mini, $0.006/min 4o);
-# these are the per-second conversions: $/min ÷ 60 × 1.25 × 1000 credits/$ × 1e6.
+# these are the per-second conversions: $/min ÷ 60 × 1.2 × 1000 credits/$ × 1e6.
 [pricing."gpt-4o-mini-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 62500
+credits_per_million_seconds = 60000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o mini transcribe"
@@ -75,7 +75,7 @@ capabilities = []
 
 [pricing."gpt-4o-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 125000
+credits_per_million_seconds = 120000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o transcribe"
@@ -87,7 +87,7 @@ capabilities = []
 
 [pricing."nvidia/parakeet-tdt-0.6b-v3"]
 unit = "seconds"
-credits_per_million_seconds = 125000
+credits_per_million_seconds = 120000
 provider = "venice"
 model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
@@ -98,8 +98,8 @@ privacy = "private"
 # DEFAULT_GENERATION_MODEL in the Tauri providers module.
 [pricing."zai-org-glm-5-2"]
 unit = "tokens"
-input_credits_per_million_tokens = 2188
-output_credits_per_million_tokens = 6875
+input_credits_per_million_tokens = 2100
+output_credits_per_million_tokens = 6600
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5.2"
@@ -115,8 +115,8 @@ capabilities = [
 
 [pricing."kimi-k2-6"]
 unit = "tokens"
-input_credits_per_million_tokens = 1063
-output_credits_per_million_tokens = 5825
+input_credits_per_million_tokens = 1020
+output_credits_per_million_tokens = 5592
 provider = "venice"
 model_type = "text"
 display_name = "Kimi K2.6"
@@ -135,8 +135,8 @@ capabilities = [
 
 [pricing."zai-org-glm-5-1"]
 unit = "tokens"
-input_credits_per_million_tokens = 2188
-output_credits_per_million_tokens = 6875
+input_credits_per_million_tokens = 2100
+output_credits_per_million_tokens = 6600
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5.1"
@@ -152,8 +152,8 @@ capabilities = [
 
 [pricing."zai-org-glm-5"]
 unit = "tokens"
-input_credits_per_million_tokens = 1250
-output_credits_per_million_tokens = 4000
+input_credits_per_million_tokens = 1200
+output_credits_per_million_tokens = 3840
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5"
@@ -163,8 +163,8 @@ capabilities = ["supportsFunctionCalling"]
 
 [pricing."nvidia-nemotron-3-nano-30b-a3b"]
 unit = "tokens"
-input_credits_per_million_tokens = 88
-output_credits_per_million_tokens = 375
+input_credits_per_million_tokens = 84
+output_credits_per_million_tokens = 360
 provider = "venice"
 model_type = "text"
 display_name = "Nemotron Nano 30B (dictation cleanup)"

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -58,9 +58,10 @@ base_url = "https://api.openai.com/v1"
 [upstreams.venice]
 base_url = "https://api.venice.ai/api/v1"
 
+# Usage credit prices include June's 1.25x retail multiplier over upstream cost.
 [pricing."gpt-4o-mini-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 1000000
+credits_per_million_seconds = 1250000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o mini transcribe"
@@ -72,7 +73,7 @@ capabilities = []
 
 [pricing."gpt-4o-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 2000000
+credits_per_million_seconds = 2500000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o transcribe"
@@ -84,7 +85,7 @@ capabilities = []
 
 [pricing."nvidia/parakeet-tdt-0.6b-v3"]
 unit = "seconds"
-credits_per_million_seconds = 100000
+credits_per_million_seconds = 125000
 provider = "venice"
 model_type = "asr"
 display_name = "Parakeet TDT 0.6B v3"
@@ -95,8 +96,8 @@ privacy = "private"
 # DEFAULT_GENERATION_MODEL in the Tauri providers module.
 [pricing."zai-org-glm-5-2"]
 unit = "tokens"
-input_credits_per_million_tokens = 1750
-output_credits_per_million_tokens = 5500
+input_credits_per_million_tokens = 2188
+output_credits_per_million_tokens = 6875
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5.2"
@@ -112,8 +113,8 @@ capabilities = [
 
 [pricing."kimi-k2-6"]
 unit = "tokens"
-input_credits_per_million_tokens = 850
-output_credits_per_million_tokens = 4660
+input_credits_per_million_tokens = 1063
+output_credits_per_million_tokens = 5825
 provider = "venice"
 model_type = "text"
 display_name = "Kimi K2.6"
@@ -132,8 +133,8 @@ capabilities = [
 
 [pricing."zai-org-glm-5-1"]
 unit = "tokens"
-input_credits_per_million_tokens = 1750
-output_credits_per_million_tokens = 5500
+input_credits_per_million_tokens = 2188
+output_credits_per_million_tokens = 6875
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5.1"
@@ -149,8 +150,8 @@ capabilities = [
 
 [pricing."zai-org-glm-5"]
 unit = "tokens"
-input_credits_per_million_tokens = 1000
-output_credits_per_million_tokens = 3200
+input_credits_per_million_tokens = 1250
+output_credits_per_million_tokens = 4000
 provider = "venice"
 model_type = "text"
 display_name = "GLM 5"
@@ -160,8 +161,8 @@ capabilities = ["supportsFunctionCalling"]
 
 [pricing."nvidia-nemotron-3-nano-30b-a3b"]
 unit = "tokens"
-input_credits_per_million_tokens = 70
-output_credits_per_million_tokens = 300
+input_credits_per_million_tokens = 88
+output_credits_per_million_tokens = 375
 provider = "venice"
 model_type = "text"
 display_name = "Nemotron Nano 30B (dictation cleanup)"

--- a/june-api/config.toml
+++ b/june-api/config.toml
@@ -59,9 +59,11 @@ base_url = "https://api.openai.com/v1"
 base_url = "https://api.venice.ai/api/v1"
 
 # Usage credit prices include June's 1.25x retail multiplier over upstream cost.
+# OpenAI lists ASR prices per MINUTE of audio ($0.003/min mini, $0.006/min 4o);
+# these are the per-second conversions: $/min ÷ 60 × 1.25 × 1000 credits/$ × 1e6.
 [pricing."gpt-4o-mini-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 1250000
+credits_per_million_seconds = 62500
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o mini transcribe"
@@ -73,7 +75,7 @@ capabilities = []
 
 [pricing."gpt-4o-transcribe"]
 unit = "seconds"
-credits_per_million_seconds = 2500000
+credits_per_million_seconds = 125000
 provider = "openai"
 model_type = "asr"
 display_name = "GPT-4o transcribe"

--- a/june-api/crates/api/src/handlers/models.rs
+++ b/june-api/crates/api/src/handlers/models.rs
@@ -127,7 +127,9 @@ mod tests {
     fn price_description_uses_june_credit_price_over_provider_display() {
         let model = ModelPriceConfig {
             unit: PriceUnit::Seconds,
-            credits_per_million_seconds: Some(1_250_000),
+            // gpt-4o-mini-transcribe's packaged price; also pins the display
+            // string default_pricing() carries for the same model.
+            credits_per_million_seconds: Some(62_500),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -141,6 +143,6 @@ mod tests {
             capabilities: Vec::new(),
         };
 
-        assert_eq!(price_description(&model), "$0.00125 per second audio");
+        assert_eq!(price_description(&model), "$0.000063 per second audio");
     }
 }

--- a/june-api/crates/api/src/handlers/models.rs
+++ b/june-api/crates/api/src/handlers/models.rs
@@ -80,16 +80,8 @@ fn to_dto(id: &str, model: &ModelPriceConfig) -> ModelDto {
 }
 
 fn price_description(model: &ModelPriceConfig) -> String {
-    if let Some(display) = model
-        .pricing
-        .as_ref()
-        .and_then(|pricing| pricing.get("display"))
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        return display.to_string();
-    }
+    // `pricing` may contain raw upstream metadata. The user-facing description
+    // must come from June's configured credit price, including margin.
     match model.unit {
         june_config::PriceUnit::Seconds => format!(
             "{} per second audio",
@@ -122,5 +114,33 @@ fn format_credits_as_usd_per_unit(credits: u64, units: u64) -> String {
     } else {
         let decimals = format!("{micro_usd:06}");
         format!("$0.{}", decimals.trim_end_matches('0'))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::price_description;
+    use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn price_description_uses_june_credit_price_over_provider_display() {
+        let model = ModelPriceConfig {
+            unit: PriceUnit::Seconds,
+            credits_per_million_seconds: Some(1_250_000),
+            input_credits_per_million_tokens: None,
+            output_credits_per_million_tokens: None,
+            provider: ModelProvider::Openai,
+            model_type: ModelType::Asr,
+            display_name: "ASR".to_string(),
+            description: None,
+            privacy: None,
+            pricing: Some(serde_json::json!({ "display": "$0.001/sec audio" })),
+            context_tokens: None,
+            traits: Vec::new(),
+            capabilities: Vec::new(),
+        };
+
+        assert_eq!(price_description(&model), "$0.00125 per second audio");
     }
 }

--- a/june-api/crates/api/src/handlers/models.rs
+++ b/june-api/crates/api/src/handlers/models.rs
@@ -129,7 +129,7 @@ mod tests {
             unit: PriceUnit::Seconds,
             // gpt-4o-mini-transcribe's packaged price; also pins the display
             // string default_pricing() carries for the same model.
-            credits_per_million_seconds: Some(62_500),
+            credits_per_million_seconds: Some(60_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -143,6 +143,6 @@ mod tests {
             capabilities: Vec::new(),
         };
 
-        assert_eq!(price_description(&model), "$0.000063 per second audio");
+        assert_eq!(price_description(&model), "$0.00006 per second audio");
     }
 }

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -418,7 +418,9 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         "gpt-4o-mini-transcribe".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
-            credits_per_million_seconds: Some(1_250_000),
+            // OpenAI lists ASR prices per MINUTE ($0.003/min for mini);
+            // converted per second with the 1.25x retail multiplier.
+            credits_per_million_seconds: Some(62_500),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -426,7 +428,9 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             display_name: "GPT-4o mini transcribe".to_string(),
             description: Some("Fast OpenAI speech-to-text model.".to_string()),
             privacy: Some("anonymized".to_string()),
-            pricing: Some(serde_json::json!({ "display": "$0.00125 per second audio" })),
+            // Matches what `models.rs::price_description` derives from the
+            // credit price above (raw metadata only — the API recomputes it).
+            pricing: Some(serde_json::json!({ "display": "$0.000063 per second audio" })),
             context_tokens: Some(16_000),
             traits: vec!["prompt".to_string()],
             capabilities: Vec::new(),
@@ -930,12 +934,21 @@ mod tests {
     fn packaged_config_toml_includes_usage_margin() {
         let config = packaged_config_toml();
 
+        // Per-second conversions of OpenAI's per-MINUTE ASR list prices
+        // ($0.003/min mini, $0.006/min 4o) with the 1.25x retail multiplier.
         assert_eq!(
             config
                 .pricing
                 .get("gpt-4o-mini-transcribe")
                 .and_then(|model| model.credits_per_million_seconds),
-            Some(1_250_000)
+            Some(62_500)
+        );
+        assert_eq!(
+            config
+                .pricing
+                .get("gpt-4o-transcribe")
+                .and_then(|model| model.credits_per_million_seconds),
+            Some(125_000)
         );
         assert_eq!(
             config

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -410,7 +410,7 @@ struct TextModelFallback {
 /// authoritative numbers and extends over this on every boot. Split out of
 /// `AppConfig::default` to keep that constructor under the line limit.
 ///
-/// Usage credit prices include June's 1.25x retail multiplier over upstream
+/// Usage credit prices include June's 1.2x retail multiplier over upstream
 /// cost. `$1 = 1000 credits`.
 fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     let mut pricing = BTreeMap::new();
@@ -419,8 +419,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
             // OpenAI lists ASR prices per MINUTE ($0.003/min for mini);
-            // converted per second with the 1.25x retail multiplier.
-            credits_per_million_seconds: Some(62_500),
+            // converted per second with the 1.2x retail multiplier.
+            credits_per_million_seconds: Some(60_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -430,7 +430,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             privacy: Some("anonymized".to_string()),
             // Matches what `models.rs::price_description` derives from the
             // credit price above (raw metadata only — the API recomputes it).
-            pricing: Some(serde_json::json!({ "display": "$0.000063 per second audio" })),
+            pricing: Some(serde_json::json!({ "display": "$0.00006 per second audio" })),
             context_tokens: Some(16_000),
             traits: vec!["prompt".to_string()],
             capabilities: Vec::new(),
@@ -440,7 +440,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         "nvidia/parakeet-tdt-0.6b-v3".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
-            credits_per_million_seconds: Some(125_000),
+            credits_per_million_seconds: Some(120_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Venice,
@@ -463,8 +463,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5-2",
             display_name: "GLM 5.2",
-            input_credits_per_million_tokens: 2_188,
-            output_credits_per_million_tokens: 6_875,
+            input_credits_per_million_tokens: 2_100,
+            output_credits_per_million_tokens: 6_600,
             context_tokens: 200_000,
             capabilities: &[
                 "supportsFunctionCalling",
@@ -477,8 +477,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "kimi-k2-6",
             display_name: "Kimi K2.6",
-            input_credits_per_million_tokens: 1_063,
-            output_credits_per_million_tokens: 5_825,
+            input_credits_per_million_tokens: 1_020,
+            output_credits_per_million_tokens: 5_592,
             context_tokens: 256_000,
             // Kimi K2.6 is natively multimodal (Venice `supportsVision`), so it
             // is the image-input fallback the frontend switches to when an image
@@ -494,8 +494,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5-1",
             display_name: "GLM 5.1",
-            input_credits_per_million_tokens: 2_188,
-            output_credits_per_million_tokens: 6_875,
+            input_credits_per_million_tokens: 2_100,
+            output_credits_per_million_tokens: 6_600,
             context_tokens: 200_000,
             capabilities: &[
                 "supportsFunctionCalling",
@@ -508,8 +508,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5",
             display_name: "GLM 5",
-            input_credits_per_million_tokens: 1_250,
-            output_credits_per_million_tokens: 4_000,
+            input_credits_per_million_tokens: 1_200,
+            output_credits_per_million_tokens: 3_840,
             context_tokens: 198_000,
             capabilities: &["supportsFunctionCalling"],
         },
@@ -935,41 +935,41 @@ mod tests {
         let config = packaged_config_toml();
 
         // Per-second conversions of OpenAI's per-MINUTE ASR list prices
-        // ($0.003/min mini, $0.006/min 4o) with the 1.25x retail multiplier.
+        // ($0.003/min mini, $0.006/min 4o) with the 1.2x retail multiplier.
         assert_eq!(
             config
                 .pricing
                 .get("gpt-4o-mini-transcribe")
                 .and_then(|model| model.credits_per_million_seconds),
-            Some(62_500)
+            Some(60_000)
         );
         assert_eq!(
             config
                 .pricing
                 .get("gpt-4o-transcribe")
                 .and_then(|model| model.credits_per_million_seconds),
-            Some(125_000)
+            Some(120_000)
         );
         assert_eq!(
             config
                 .pricing
                 .get("zai-org-glm-5-2")
                 .and_then(|model| model.input_credits_per_million_tokens),
-            Some(2_188)
+            Some(2_100)
         );
         assert_eq!(
             config
                 .pricing
                 .get("zai-org-glm-5-2")
                 .and_then(|model| model.output_credits_per_million_tokens),
-            Some(6_875)
+            Some(6_600)
         );
         assert_eq!(
             config
                 .pricing
                 .get("nvidia-nemotron-3-nano-30b-a3b")
                 .and_then(|model| model.input_credits_per_million_tokens),
-            Some(88)
+            Some(84)
         );
     }
 

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -31,7 +31,8 @@ pub struct AppConfig {
     /// into the served model pickers. A model absent here is rejected at the
     /// `/image/generate` boundary (`model_not_priced`), so the settings picker
     /// must only offer models listed here. `$1 = 1000 credits`; values are the
-    /// Venice per-image cost with margin (e.g. SD3.5 costs ~$0.01, charged 20).
+    /// Venice per-image cost with margin (e.g. SD3.5 costs about $0.01,
+    /// charged 20).
     #[serde(default = "default_image_pricing")]
     pub image_pricing: BTreeMap<String, u64>,
 }
@@ -408,13 +409,16 @@ struct TextModelFallback {
 /// reached at startup so metered charges still settle. The catalog carries the
 /// authoritative numbers and extends over this on every boot. Split out of
 /// `AppConfig::default` to keep that constructor under the line limit.
+///
+/// Usage credit prices include June's 1.25x retail multiplier over upstream
+/// cost. `$1 = 1000 credits`.
 fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
     let mut pricing = BTreeMap::new();
     pricing.insert(
         "gpt-4o-mini-transcribe".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
-            credits_per_million_seconds: Some(1_000_000),
+            credits_per_million_seconds: Some(1_250_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Openai,
@@ -422,7 +426,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             display_name: "GPT-4o mini transcribe".to_string(),
             description: Some("Fast OpenAI speech-to-text model.".to_string()),
             privacy: Some("anonymized".to_string()),
-            pricing: Some(serde_json::json!({ "display": "$0.001/sec audio" })),
+            pricing: Some(serde_json::json!({ "display": "$0.00125/sec audio" })),
             context_tokens: Some(16_000),
             traits: vec!["prompt".to_string()],
             capabilities: Vec::new(),
@@ -432,7 +436,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         "nvidia/parakeet-tdt-0.6b-v3".to_string(),
         ModelPriceConfig {
             unit: PriceUnit::Seconds,
-            credits_per_million_seconds: Some(100_000),
+            credits_per_million_seconds: Some(125_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
             provider: ModelProvider::Venice,
@@ -455,8 +459,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5-2",
             display_name: "GLM 5.2",
-            input_credits_per_million_tokens: 1_750,
-            output_credits_per_million_tokens: 5_500,
+            input_credits_per_million_tokens: 2_188,
+            output_credits_per_million_tokens: 6_875,
             context_tokens: 200_000,
             capabilities: &[
                 "supportsFunctionCalling",
@@ -469,8 +473,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "kimi-k2-6",
             display_name: "Kimi K2.6",
-            input_credits_per_million_tokens: 850,
-            output_credits_per_million_tokens: 4_660,
+            input_credits_per_million_tokens: 1_063,
+            output_credits_per_million_tokens: 5_825,
             context_tokens: 256_000,
             // Kimi K2.6 is natively multimodal (Venice `supportsVision`), so it
             // is the image-input fallback the frontend switches to when an image
@@ -486,8 +490,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5-1",
             display_name: "GLM 5.1",
-            input_credits_per_million_tokens: 1_750,
-            output_credits_per_million_tokens: 5_500,
+            input_credits_per_million_tokens: 2_188,
+            output_credits_per_million_tokens: 6_875,
             context_tokens: 200_000,
             capabilities: &[
                 "supportsFunctionCalling",
@@ -500,8 +504,8 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
         TextModelFallback {
             id: "zai-org-glm-5",
             display_name: "GLM 5",
-            input_credits_per_million_tokens: 1_000,
-            output_credits_per_million_tokens: 3_200,
+            input_credits_per_million_tokens: 1_250,
+            output_credits_per_million_tokens: 4_000,
             context_tokens: 198_000,
             capabilities: &["supportsFunctionCalling"],
         },
@@ -857,6 +861,19 @@ mod tests {
         config
     }
 
+    fn packaged_config_toml() -> AppConfig {
+        use figment::{
+            Figment,
+            providers::{Format, Serialized, Toml},
+        };
+        let toml_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config.toml");
+        Figment::new()
+            .merge(Serialized::defaults(AppConfig::default()))
+            .merge(Toml::file(toml_path))
+            .extract::<AppConfig>()
+            .unwrap_or_default()
+    }
+
     #[test]
     fn default_kimi_declares_vision_but_glm_does_not() {
         // Kimi K2.6 is the image-input fallback the app switches to, so it must
@@ -890,16 +907,7 @@ mod tests {
         // Docker image, so it is what `/models` serves when the live Venice
         // catalog is unreachable. It must agree that Kimi is a vision model, or
         // the image-attach fallback breaks in the packaged build (JUN-165).
-        use figment::{
-            Figment,
-            providers::{Format, Serialized, Toml},
-        };
-        let toml_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../config.toml");
-        let config = Figment::new()
-            .merge(Serialized::defaults(AppConfig::default()))
-            .merge(Toml::file(toml_path))
-            .extract::<AppConfig>()
-            .unwrap_or_default();
+        let config = packaged_config_toml();
         // A TOML-only model proves config.toml actually merged, so a failed
         // load can't make the vision assertion below pass on the default alone.
         assert!(
@@ -915,6 +923,40 @@ mod tests {
         assert!(
             kimi_declares_vision,
             "packaged config.toml must declare supportsVision for kimi-k2-6"
+        );
+    }
+
+    #[test]
+    fn packaged_config_toml_includes_usage_margin() {
+        let config = packaged_config_toml();
+
+        assert_eq!(
+            config
+                .pricing
+                .get("gpt-4o-mini-transcribe")
+                .and_then(|model| model.credits_per_million_seconds),
+            Some(1_250_000)
+        );
+        assert_eq!(
+            config
+                .pricing
+                .get("zai-org-glm-5-2")
+                .and_then(|model| model.input_credits_per_million_tokens),
+            Some(2_188)
+        );
+        assert_eq!(
+            config
+                .pricing
+                .get("zai-org-glm-5-2")
+                .and_then(|model| model.output_credits_per_million_tokens),
+            Some(6_875)
+        );
+        assert_eq!(
+            config
+                .pricing
+                .get("nvidia-nemotron-3-nano-30b-a3b")
+                .and_then(|model| model.input_credits_per_million_tokens),
+            Some(88)
         );
     }
 

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -426,7 +426,7 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
             display_name: "GPT-4o mini transcribe".to_string(),
             description: Some("Fast OpenAI speech-to-text model.".to_string()),
             privacy: Some("anonymized".to_string()),
-            pricing: Some(serde_json::json!({ "display": "$0.00125/sec audio" })),
+            pricing: Some(serde_json::json!({ "display": "$0.00125 per second audio" })),
             context_tokens: Some(16_000),
             traits: vec!["prompt".to_string()],
             capabilities: Vec::new(),

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -15,6 +15,8 @@ pub const PROVIDER_NAME: &str = "venice";
 
 const CREDITS_PER_USD: f64 = 1_000.0;
 const RATE_SCALE: f64 = 1_000_000.0;
+/// A 20% margin is a 1.25x retail price over upstream cost.
+const RETAIL_PRICE_MULTIPLIER: f64 = 1.25;
 
 /// Standing safety policy injected as the leading system message on every
 /// Venice chat completion — note generation, dictation cleanup, and agent
@@ -919,11 +921,11 @@ fn usd_at_path(value: &serde_json::Value, path: &[&str]) -> Option<f64> {
 }
 
 fn credits_per_million_units(usd_per_million_units: f64) -> Option<u64> {
-    ceil_positive_u64(usd_per_million_units * CREDITS_PER_USD)
+    ceil_positive_u64(usd_per_million_units * CREDITS_PER_USD * RETAIL_PRICE_MULTIPLIER)
 }
 
 fn credits_per_million_seconds(usd_per_second: f64) -> Option<u64> {
-    ceil_positive_u64(usd_per_second * CREDITS_PER_USD * RATE_SCALE)
+    ceil_positive_u64(usd_per_second * CREDITS_PER_USD * RATE_SCALE * RETAIL_PRICE_MULTIPLIER)
 }
 
 fn ceil_positive_u64(value: f64) -> Option<u64> {
@@ -1643,8 +1645,8 @@ mod tests {
             model.capabilities,
             vec!["nested.enabled", "supportsFunctionCalling"]
         );
-        assert_eq!(model.input_credits_per_million_tokens, Some(70));
-        assert_eq!(model.output_credits_per_million_tokens, Some(300));
+        assert_eq!(model.input_credits_per_million_tokens, Some(88));
+        assert_eq!(model.output_credits_per_million_tokens, Some(375));
         assert!(model.pricing.is_some());
     }
 
@@ -1670,6 +1672,6 @@ mod tests {
         let models = venice_priced_model_items(response, ModelType::Asr);
         let model = models.get("asr-model").expect("asr model");
 
-        assert_eq!(model.credits_per_million_seconds, Some(100_000));
+        assert_eq!(model.credits_per_million_seconds, Some(125_000));
     }
 }

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -15,8 +15,8 @@ pub const PROVIDER_NAME: &str = "venice";
 
 const CREDITS_PER_USD: f64 = 1_000.0;
 const RATE_SCALE: f64 = 1_000_000.0;
-/// A 20% margin is a 1.25x retail price over upstream cost.
-const RETAIL_PRICE_MULTIPLIER: f64 = 1.25;
+/// A 20% markup over upstream cost is a 1.2x retail price.
+const RETAIL_PRICE_MULTIPLIER: f64 = 1.2;
 
 /// Standing safety policy injected as the leading system message on every
 /// Venice chat completion — note generation, dictation cleanup, and agent
@@ -1645,8 +1645,8 @@ mod tests {
             model.capabilities,
             vec!["nested.enabled", "supportsFunctionCalling"]
         );
-        assert_eq!(model.input_credits_per_million_tokens, Some(88));
-        assert_eq!(model.output_credits_per_million_tokens, Some(375));
+        assert_eq!(model.input_credits_per_million_tokens, Some(84));
+        assert_eq!(model.output_credits_per_million_tokens, Some(360));
         assert!(model.pricing.is_some());
     }
 
@@ -1672,6 +1672,6 @@ mod tests {
         let models = venice_priced_model_items(response, ModelType::Asr);
         let model = models.get("asr-model").expect("asr model");
 
-        assert_eq!(model.credits_per_million_seconds, Some(125_000));
+        assert_eq!(model.credits_per_million_seconds, Some(120_000));
     }
 }

--- a/june-api/crates/services/src/dictate.rs
+++ b/june-api/crates/services/src/dictate.rs
@@ -61,8 +61,9 @@ impl DictateService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
-        // Flat-estimate mode — see the matching comment in note_transcribe.rs.
-        let estimate = Credits(self.flat_estimate_credits);
+        // Hold covers the already-known price, floored at the flat estimate —
+        // see the matching comment in note_transcribe.rs.
+        let estimate = Credits(actual.0.max(self.flat_estimate_credits));
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -524,6 +524,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_transcribe_hold_covers_actual_price_above_flat_estimate() {
+        // Audio priced above the flat estimate must raise the hold to the
+        // already-known price — otherwise the charge is clamped to the flat
+        // cap and the overage is silently unbilled.
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                1_000,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        let output = service
+            .transcribe(NoteTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                note_id: "note_pricey".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "pricey.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                preview: true,
+                provider_credentials: ProviderCredentials::default(),
+            })
+            .await
+            .expect("transcription succeeds");
+
+        // 2s (probed, ceiled) × 1_000 credits/sec = 2_000 > flat 1_024: the
+        // hold rises to the actual price and the charge settles unclamped.
+        assert_eq!(output.receipt.credits_charged.0, 2_000);
+        assert!(matches!(
+            os_accounts.events().first(),
+            Some(RecordedCall::Authorize {
+                estimate: 2_000,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
     async fn note_transcribe_preview_failure_still_settles_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -77,10 +77,11 @@ impl NoteTranscribeService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
-        // Flat-estimate mode: skip per-request estimation for the upfront
-        // authorize. The Hold is bigger than necessary; the actual charge
-        // below is what the user pays.
-        let estimate = Credits(self.flat_estimate_credits);
+        // The Hold must cover the already-known price: the charge below is
+        // clamped to the Hold's cap, so a flat-only estimate would silently
+        // underbill any audio priced above it. The flat value remains the
+        // floor, keeping short-audio holds exactly as before.
+        let estimate = Credits(actual.0.max(self.flat_estimate_credits));
         let prepared = PreparedNoteTranscription {
             params,
             format,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -656,8 +656,8 @@ mod tests {
             traits: Vec::new(),
             capabilities: Vec::new(),
             price_unit: "seconds".to_string(),
-            price_description: "$0.000063 per second audio".to_string(),
-            credits_per_million_seconds: Some(62_500),
+            price_description: "$0.00006 per second audio".to_string(),
+            credits_per_million_seconds: Some(60_000),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
         });
@@ -667,7 +667,7 @@ mod tests {
                 .get("display")
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_string)),
-            Some("$0.000063 per second audio".to_string())
+            Some("$0.00006 per second audio".to_string())
         );
     }
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -656,8 +656,8 @@ mod tests {
             traits: Vec::new(),
             capabilities: Vec::new(),
             price_unit: "seconds".to_string(),
-            price_description: "$0.00125 per second audio".to_string(),
-            credits_per_million_seconds: Some(1_250_000),
+            price_description: "$0.000063 per second audio".to_string(),
+            credits_per_million_seconds: Some(62_500),
             input_credits_per_million_tokens: None,
             output_credits_per_million_tokens: None,
         });
@@ -667,7 +667,7 @@ mod tests {
                 .get("display")
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_string)),
-            Some("$0.00125 per second audio".to_string())
+            Some("$0.000063 per second audio".to_string())
         );
     }
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -159,8 +159,10 @@ fn pricing_with_display(pricing: Option<serde_json::Value>, display: &str) -> se
     match pricing {
         Some(serde_json::Value::Object(mut map)) => {
             if !display.is_empty() {
-                map.entry("display".to_string())
-                    .or_insert_with(|| serde_json::Value::String(display.to_string()));
+                map.insert(
+                    "display".to_string(),
+                    serde_json::Value::String(display.to_string()),
+                );
             }
             serde_json::Value::Object(map)
         }
@@ -637,6 +639,35 @@ mod tests {
         assert_eq!(
             serde_json::to_value(response).unwrap()["mode"],
             serde_json::json!("transcription")
+        );
+    }
+
+    #[test]
+    fn api_model_conversion_prefers_retail_price_description_display() {
+        let model = VeniceModelDto::from(crate::june_api::ModelDto {
+            provider: "openai".to_string(),
+            id: "asr-model".to_string(),
+            name: "ASR model".to_string(),
+            model_type: "asr".to_string(),
+            description: None,
+            privacy: None,
+            pricing: Some(serde_json::json!({ "display": "$0.001/sec audio" })),
+            context_tokens: None,
+            traits: Vec::new(),
+            capabilities: Vec::new(),
+            price_unit: "seconds".to_string(),
+            price_description: "$0.00125 per second audio".to_string(),
+            credits_per_million_seconds: Some(1_250_000),
+            input_credits_per_million_tokens: None,
+            output_credits_per_million_tokens: None,
+        });
+
+        assert_eq!(
+            model.pricing.and_then(|pricing| pricing
+                .get("display")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)),
+            Some("$0.00125 per second audio".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

- Applies June's 1.2x retail multiplier to usage-priced model credit prices in the packaged June API config.
- Applies the same 1.2x multiplier when the live Venice model catalog converts upstream USD prices into OS Accounts credit prices.
- Makes model price display strings derive from June's retail credit price instead of raw upstream provider metadata.

## Root cause

N/A - pricing policy change.

## Validation

- `cargo fmt --all -- --check` from `june-api/`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`
- `cargo +1.95.0-aarch64-apple-darwin clippy --manifest-path june-api/Cargo.toml --all-targets --all-features --locked -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked providers::tests`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --locked -- -D warnings`
- `git diff --check`

- [x] Tested visually where it matters. Not applicable: backend pricing and model metadata display wiring only, no layout change.
- [x] Needs a June API (backend) deploy before it works end to end. The new charge prices and live catalog conversion take effect when June API is deployed; the desktop display adapter ships with the next app release.

## Out of scope

- Changing flat web-search, web-fetch, or image-generation prices, which already have separate flat pricing policy.
- Moving pricing policy into OS Accounts. OS Accounts continues to only hold and settle credits.

## Followups

- Consider making the usage margin an explicit June API config value if we expect to tune it frequently per environment.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. N/A, no workflow changes.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. N/A, none changed.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions. No app copy changed.
