### PR TITLE
Skip June metering for BYOK Venice requests

### DIFF
--- a/june-api/crates/api/src/handlers/image.rs
+++ b/june-api/crates/api/src/handlers/image.rs
@@ -1,5 +1,9 @@
 use crate::{
-    auth::authenticated_user, envelope::ApiResponse, error::ApiError, state::ApiState, validation,
+    auth::{authenticated_user, provider_credentials},
+    envelope::ApiResponse,
+    error::ApiError,
+    state::ApiState,
+    validation,
 };
 use axum::{Json, extract::State, http::HeaderMap};
 use june_domain::GeneratedImage;
@@ -45,16 +49,18 @@ impl From<GeneratedImage> for ImageGenerateResponse {
     }
 }
 
-/// Generates an image from a text prompt via Venice. Metered: the service holds
-/// a wallet estimate, generates, then charges the model's flat per-image price
-/// (see `ImageService`). An unpriced model is rejected `model_not_priced`; an
-/// out-of-credits user gets 402 before Venice is called.
+/// Generates an image from a text prompt via Venice. Without a user Venice key,
+/// the service holds a wallet estimate, generates, then charges the model's
+/// flat per-image price (see `ImageService`). A user Venice key skips June
+/// credit metering. An unpriced model is rejected `model_not_priced`; an
+/// out-of-credits user without BYOK gets 402 before Venice is called.
 pub(crate) async fn generate(
     State(state): State<ApiState>,
     headers: HeaderMap,
     Json(request): Json<ImageGenerateRequest>,
 ) -> Result<Json<ApiResponse<ImageGenerateResponse>>, ApiError> {
     let user_id = authenticated_user(&state, &headers).await?;
+    let provider_credentials = provider_credentials(&headers)?;
 
     let prompt = request.prompt.trim().to_string();
     if prompt.is_empty() {
@@ -79,6 +85,7 @@ pub(crate) async fn generate(
             model,
             width,
             height,
+            provider_credentials,
         })
         .await?;
 

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -15,10 +15,10 @@ use june_domain::{
     WebFetcher, WebSearchRequest, WebSearchResult, WebSearchResults, WebSearcher,
 };
 use june_services::{
-    AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps, ImageService,
-    ImageServiceDeps, NOTE_GENERATE_PROMPT_VERSION, NoteGenerateService, NoteGenerateServiceDeps,
-    NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable, WebAugmentService,
-    WebAugmentServiceDeps,
+    AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps, ImageModelPrice,
+    ImageService, ImageServiceDeps, NOTE_GENERATE_PROMPT_VERSION, NoteGenerateService,
+    NoteGenerateServiceDeps, NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable,
+    WebAugmentService, WebAugmentServiceDeps,
 };
 use pretty_assertions::assert_eq;
 use std::{
@@ -628,7 +628,7 @@ fn test_state_with_sinks(
     let image = Arc::new(ImageService::new(ImageServiceDeps {
         os_accounts: os_accounts.clone(),
         generator: Arc::new(FakeImageGenerator),
-        pricing: BTreeMap::from([("venice-sd35".to_string(), 20_u64)]),
+        pricing: BTreeMap::from([("venice-sd35".to_string(), ImageModelPrice::venice(20))]),
         hold_ttl_seconds: 30,
     }));
 

--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -11,9 +11,10 @@ use june_providers::{
     VeniceModelCatalog, client_with_timeout, default_client, jwks_client,
 };
 use june_services::{
-    AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps, ImageService,
-    ImageServiceDeps, NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeService,
-    NoteTranscribeServiceDeps, PricingTable, WebAugmentService, WebAugmentServiceDeps,
+    AgentChatService, AgentChatServiceDeps, DictateService, DictateServiceDeps, ImageModelPrice,
+    ImageService, ImageServiceDeps, NoteGenerateService, NoteGenerateServiceDeps,
+    NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable, WebAugmentService,
+    WebAugmentServiceDeps,
 };
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Duration};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -165,7 +166,11 @@ fn build_router(
     let image = Arc::new(ImageService::new(ImageServiceDeps {
         os_accounts: os_accounts.clone(),
         generator: build_image_generator(upstream_http, &config.upstreams.venice),
-        pricing: config.image_pricing.clone(),
+        pricing: config
+            .image_pricing
+            .iter()
+            .map(|(model, credits)| (model.clone(), ImageModelPrice::venice(*credits)))
+            .collect(),
         hold_ttl_seconds: config.os_accounts.authorize_hold_ttl_image_secs,
     }));
     let dictate = Arc::new(DictateService::new(DictateServiceDeps {

--- a/june-api/crates/domain/src/lib.rs
+++ b/june-api/crates/domain/src/lib.rs
@@ -105,6 +105,15 @@ pub struct ProviderCredentials {
     pub venice_api_key: Option<String>,
 }
 
+impl ProviderCredentials {
+    pub fn has_venice_api_key(&self) -> bool {
+        self.venice_api_key
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty())
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Authorization {
@@ -203,16 +212,16 @@ pub struct AgentChatRequest {
     pub provider_credentials: ProviderCredentials,
 }
 
-/// What an image generator needs: a prompt, the model, and optional pixel
-/// dimensions. Deliberately carries no user id — image generation is not
-/// metered yet (subscription metering is a follow-up), so the provider sees
-/// only the inference inputs.
+/// What an image generator needs: a prompt, the model, optional pixel
+/// dimensions, and provider credentials. Deliberately carries no user id,
+/// so the provider sees only the inference inputs and the upstream key.
 #[derive(Clone, Debug)]
 pub struct ImageGenerationRequest {
     pub prompt: String,
     pub model: ModelId,
     pub width: Option<u32>,
     pub height: Option<u32>,
+    pub provider_credentials: ProviderCredentials,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/june-api/crates/providers/src/venice_image.rs
+++ b/june-api/crates/providers/src/venice_image.rs
@@ -3,16 +3,17 @@
 //! Mirrors the chat/augment providers — same Venice base URL and bearer
 //! credential, same bounded retry on transient upstream failures. The wire
 //! shapes are confined to this file: Venice returns the generated image(s) as
-//! base64 strings in an `images` array, and we surface the first one. Image
-//! generation is NOT metered yet (subscription metering is a follow-up), so
-//! there is no authorize/charge flow here — the API handler enforces auth and
-//! calls this directly.
+//! base64 strings in an `images` array, and we surface the first one. Billing
+//! lives in `ImageService`; this provider only chooses the configured key or a
+//! user-supplied Venice key for the upstream call.
 
 use crate::retry::{self, UpstreamAttemptError};
 use crate::venice::PROVIDER_NAME;
 use async_trait::async_trait;
 use june_config::UpstreamConfig;
-use june_domain::{DomainError, GeneratedImage, ImageGenerationRequest, ImageGenerator};
+use june_domain::{
+    DomainError, GeneratedImage, ImageGenerationRequest, ImageGenerator, ProviderCredentials,
+};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 
@@ -41,11 +42,12 @@ impl VeniceImageGenerator {
         &self,
         url: &str,
         body: &VeniceImageRequest<'_>,
+        api_key: &str,
     ) -> Result<VeniceImageResponse, UpstreamAttemptError> {
         let response = self
             .http
             .post(url)
-            .bearer_auth(&self.api_key)
+            .bearer_auth(api_key)
             .json(body)
             .send()
             .await
@@ -106,13 +108,13 @@ impl ImageGenerator for VeniceImageGenerator {
             height: request.height,
         };
         let url = format!("{}/image/generate", self.base_url);
+        let api_key = venice_api_key(&self.api_key, &request.provider_credentials);
         // Bounded retry on transient failures (connection reset, 429, 5xx),
-        // same as the chat and augment paths. Image generation does not meter
-        // the user's credits, so a replay never double-charges them; each retry
-        // costs at most one extra upstream generation if a completed response
-        // was lost, bounded by UPSTREAM_ATTEMPTS.
+        // same as the chat and augment paths. The service settles at most one
+        // June charge after this call returns; a retry can cost at most one
+        // extra upstream generation if a completed response was lost.
         for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-            let error = match self.generate_once(&url, &body).await {
+            let error = match self.generate_once(&url, &body, api_key).await {
                 Ok(parsed) => return image_from_response(parsed, &request.model.0),
                 Err(error) => error,
             };
@@ -125,6 +127,15 @@ impl ImageGenerator for VeniceImageGenerator {
         }
         Err(DomainError::UpstreamProvider)
     }
+}
+
+fn venice_api_key<'a>(configured: &'a str, credentials: &'a ProviderCredentials) -> &'a str {
+    credentials
+        .venice_api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(configured)
 }
 
 /// Maps a Venice image response to the domain type: the first non-empty base64
@@ -170,7 +181,9 @@ mod tests {
     use super::VeniceImageGenerator;
     use crate::http;
     use june_config::UpstreamConfig;
-    use june_domain::{DomainError, ImageGenerationRequest, ImageGenerator, ModelId};
+    use june_domain::{
+        DomainError, ImageGenerationRequest, ImageGenerator, ModelId, ProviderCredentials,
+    };
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use wiremock::{
@@ -194,6 +207,7 @@ mod tests {
             model: ModelId("venice-sd35".to_string()),
             width: Some(1024),
             height: Some(1024),
+            provider_credentials: ProviderCredentials::default(),
         }
     }
 
@@ -223,6 +237,30 @@ mod tests {
         assert_eq!(generated.mime_type, "image/png");
         assert_eq!(generated.model, "venice-sd35");
         assert_eq!(generated.provider, "venice");
+    }
+
+    #[tokio::test]
+    async fn image_generation_prefers_request_venice_api_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/image/generate"))
+            .and(header("authorization", "Bearer user_venice_key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "images": ["aGVsbG8="],
+            })))
+            .mount(&server)
+            .await;
+
+        let mut request = request("a red bicycle");
+        request.provider_credentials = ProviderCredentials {
+            venice_api_key: Some("user_venice_key".to_string()),
+        };
+        let generated = generator(&server)
+            .generate(request)
+            .await
+            .expect("generation should succeed");
+
+        assert_eq!(generated.image_base64, "aGVsbG8=");
     }
 
     #[tokio::test]

--- a/june-api/crates/services/src/agent_chat.rs
+++ b/june-api/crates/services/src/agent_chat.rs
@@ -1,8 +1,10 @@
 use crate::{
     charge_flow::{
         AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        zero_receipt,
     },
     error::ServiceError,
+    metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
     pricing::PricingTable,
     util::sha256_hex,
 };
@@ -42,6 +44,25 @@ impl AgentChatService {
     pub async fn complete(&self, params: AgentChatParams) -> Result<AgentChatOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        if uses_user_venice_key_for_model(
+            &self.pricing,
+            &params.model_id.0,
+            &params.provider_credentials,
+        ) {
+            let completion = self
+                .chat_completer
+                .complete(AgentChatRequest {
+                    body: params.body,
+                    model: params.model_id.clone(),
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await?;
+            log_skipped_user_venice_key(ActionSlug::AgentChat, &params.user_id, &params.model_id.0);
+            return Ok(AgentChatOutput {
+                completion,
+                receipt: zero_receipt(),
+            });
+        }
         let estimate = Credits(self.flat_estimate_credits);
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),

--- a/june-api/crates/services/src/charge_flow.rs
+++ b/june-api/crates/services/src/charge_flow.rs
@@ -102,6 +102,13 @@ pub(crate) fn clamp_to_cap(actual: Credits, cap: Credits) -> Credits {
     Credits(min(actual.0, cap.0))
 }
 
+pub(crate) fn zero_receipt() -> Receipt {
+    Receipt {
+        credits_charged: Credits(0),
+        idempotent_replay: false,
+    }
+}
+
 pub(crate) struct ChargeParams<'a> {
     pub os_accounts: &'a dyn OsAccountsClient,
     pub action_token: String,

--- a/june-api/crates/services/src/dictate.rs
+++ b/june-api/crates/services/src/dictate.rs
@@ -1,8 +1,10 @@
 use crate::{
     charge_flow::{
         AsyncChargeParams, AuthorizeParams, authorize_or_deny, clamp_to_cap, spawn_charge,
+        zero_receipt,
     },
     error::ServiceError,
+    metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
     pricing::PricingTable,
     prompts,
     util::ceil_seconds,
@@ -63,6 +65,33 @@ impl DictateService {
             .price_audio_seconds(&params.model_id.0, seconds)?;
         // Flat-estimate mode — see the matching comment in note_transcribe.rs.
         let estimate = Credits(self.flat_estimate_credits);
+        if uses_user_venice_key_for_model(
+            &self.pricing,
+            &params.model_id.0,
+            &params.provider_credentials,
+        ) {
+            let transcript = self
+                .transcriber
+                .transcribe(TranscriptionRequest {
+                    audio: params.audio,
+                    format: AudioFormat::from_filename(&params.filename),
+                    context: params.context,
+                    language: params.language,
+                    model: params.model_id.clone(),
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await
+                .map_err(ServiceError::from)?;
+            log_skipped_user_venice_key(
+                ActionSlug::DictateTranscribe,
+                &params.user_id,
+                &params.model_id.0,
+            );
+            return Ok(DictateTranscribeOutput {
+                transcript,
+                receipt: zero_receipt(),
+            });
+        }
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),
@@ -110,6 +139,32 @@ impl DictateService {
     ) -> Result<DictateCleanupOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        if uses_user_venice_key_for_model(
+            &self.pricing,
+            &params.model_id.0,
+            &params.provider_credentials,
+        ) {
+            let cleaned = self
+                .cleaner
+                .cleanup(CleanupRequest {
+                    text: params.text,
+                    dictionary_context: params.dictionary_context,
+                    style: params.style,
+                    model: params.model_id.clone(),
+                    system_prompt: prompts::DICTATE_CLEANUP.to_string(),
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await?;
+            log_skipped_user_venice_key(
+                ActionSlug::DictateCleanup,
+                &params.user_id,
+                &params.model_id.0,
+            );
+            return Ok(DictateCleanupOutput {
+                cleaned,
+                receipt: zero_receipt(),
+            });
+        }
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),

--- a/june-api/crates/services/src/image.rs
+++ b/june-api/crates/services/src/image.rs
@@ -1,13 +1,16 @@
 use crate::{
     charge_flow::{
         AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        zero_receipt,
     },
     error::ServiceError,
+    metering::{log_skipped_user_venice_key, uses_user_venice_key},
     util::sha256_hex,
 };
+use june_config::ModelProvider;
 use june_domain::{
     ActionSlug, Credits, GeneratedImage, ImageGenerationRequest, ImageGenerator, ModelId,
-    OsAccountsClient, Receipt, UserId,
+    OsAccountsClient, ProviderCredentials, Receipt, UserId,
 };
 use std::{
     collections::BTreeMap,
@@ -26,16 +29,31 @@ use std::{
 pub struct ImageServiceDeps {
     pub os_accounts: Arc<dyn OsAccountsClient>,
     pub generator: Arc<dyn ImageGenerator>,
-    /// Flat credits per image, keyed by model id. A model absent here is
-    /// rejected as `model_not_priced`.
-    pub pricing: BTreeMap<String, u64>,
+    /// Flat price and upstream provider per image model. A model absent here
+    /// is rejected as `model_not_priced`.
+    pub pricing: BTreeMap<String, ImageModelPrice>,
     pub hold_ttl_seconds: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ImageModelPrice {
+    pub credits: u64,
+    pub provider: ModelProvider,
+}
+
+impl ImageModelPrice {
+    pub fn venice(credits: u64) -> Self {
+        Self {
+            credits,
+            provider: ModelProvider::Venice,
+        }
+    }
 }
 
 pub struct ImageService {
     os_accounts: Arc<dyn OsAccountsClient>,
     generator: Arc<dyn ImageGenerator>,
-    pricing: BTreeMap<String, u64>,
+    pricing: BTreeMap<String, ImageModelPrice>,
     hold_ttl_seconds: u64,
     /// Per-process sequence that makes every generation settle under a UNIQUE
     /// charge key. Image generation is not idempotent — a repeat produces a new
@@ -57,7 +75,7 @@ impl ImageService {
 
     /// Look up a model's flat per-image price. `None` for an unpriced model.
     pub fn price(&self, model: &str) -> Option<u64> {
-        self.pricing.get(model).copied()
+        self.pricing.get(model).map(|price| price.credits)
     }
 
     pub async fn generate(
@@ -65,12 +83,31 @@ impl ImageService {
         params: ImageGenerateParams,
     ) -> Result<ImageGenerateOutput, ServiceError> {
         // Reject an unpriced model before touching the wallet or Venice.
-        let credits = self
+        let price = self
             .pricing
             .get(&params.model)
             .copied()
             .ok_or(ServiceError::ModelNotPriced)?;
-        let estimate = Credits(credits);
+        let estimate = Credits(price.credits);
+        if price.provider == ModelProvider::Venice
+            && uses_user_venice_key(&params.provider_credentials)
+        {
+            let image = self
+                .generator
+                .generate(ImageGenerationRequest {
+                    prompt: params.prompt.clone(),
+                    model: ModelId(params.model.clone()),
+                    width: params.width,
+                    height: params.height,
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await?;
+            log_skipped_user_venice_key(ActionSlug::ImageGenerate, &params.user_id, &params.model);
+            return Ok(ImageGenerateOutput {
+                image,
+                receipt: zero_receipt(),
+            });
+        }
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),
@@ -88,6 +125,7 @@ impl ImageService {
                 model: ModelId(params.model.clone()),
                 width: params.width,
                 height: params.height,
+                provider_credentials: params.provider_credentials.clone(),
             })
             .await?;
         let charge_credits = clamp_to_cap(estimate, authorization.cap_credits);
@@ -142,6 +180,7 @@ pub struct ImageGenerateParams {
     pub model: String,
     pub width: Option<u32>,
     pub height: Option<u32>,
+    pub provider_credentials: ProviderCredentials,
 }
 
 #[derive(Clone, Debug)]
@@ -152,11 +191,13 @@ pub struct ImageGenerateOutput {
 
 #[cfg(test)]
 mod tests {
-    use super::{ImageGenerateParams, ImageService, ImageServiceDeps};
+    use super::{ImageGenerateParams, ImageModelPrice, ImageService, ImageServiceDeps};
     use async_trait::async_trait;
+    use june_config::ModelProvider;
     use june_domain::{
         Authorization, AuthorizeRequest, ChargeRequest, DomainError, GeneratedImage,
-        ImageGenerationRequest, ImageGenerator, OsAccountsClient, Receipt, UserId,
+        ImageGenerationRequest, ImageGenerator, OsAccountsClient, ProviderCredentials, Receipt,
+        UserId,
     };
     use pretty_assertions::assert_eq;
     use std::{
@@ -261,7 +302,7 @@ mod tests {
         ImageService::new(ImageServiceDeps {
             os_accounts,
             generator,
-            pricing: BTreeMap::from([("venice-sd35".to_string(), 20_u64)]),
+            pricing: BTreeMap::from([("venice-sd35".to_string(), ImageModelPrice::venice(20))]),
             hold_ttl_seconds: 60,
         })
     }
@@ -273,6 +314,7 @@ mod tests {
             model: model.to_string(),
             width: None,
             height: None,
+            provider_credentials: ProviderCredentials::default(),
         }
     }
 
@@ -359,6 +401,53 @@ mod tests {
                 action: "image_generate".to_string(),
                 estimate: 20,
             }]
+        );
+    }
+
+    #[tokio::test]
+    async fn user_venice_key_generates_without_wallet_authorize_or_charge() {
+        let os_accounts = Arc::new(RecordingOsAccounts::new(true));
+        let mut params = params("venice-sd35");
+        params.provider_credentials = ProviderCredentials {
+            venice_api_key: Some("vc_user_key".to_string()),
+        };
+        let output = service(os_accounts.clone(), Arc::new(FixedGenerator))
+            .generate(params)
+            .await
+            .expect("generation succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert!(os_accounts.events().is_empty());
+    }
+
+    #[tokio::test]
+    async fn user_venice_key_does_not_skip_non_venice_image_model_metering() {
+        let os_accounts = Arc::new(RecordingOsAccounts::new(true));
+        let service = ImageService::new(ImageServiceDeps {
+            os_accounts: os_accounts.clone(),
+            generator: Arc::new(FixedGenerator),
+            pricing: BTreeMap::from([(
+                "openai-image".to_string(),
+                ImageModelPrice {
+                    credits: 20,
+                    provider: ModelProvider::Openai,
+                },
+            )]),
+            hold_ttl_seconds: 60,
+        });
+        let mut params = params("openai-image");
+        params.provider_credentials = ProviderCredentials {
+            venice_api_key: Some("vc_user_key".to_string()),
+        };
+        let output = service.generate(params).await.expect("generation succeeds");
+
+        assert_eq!(output.receipt.credits_charged.0, 20);
+        assert_eq!(
+            os_accounts.events()[0],
+            Call::Authorize {
+                action: "image_generate".to_string(),
+                estimate: 20,
+            }
         );
     }
 

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -5,6 +5,7 @@ mod charge_flow;
 mod dictate;
 mod error;
 mod image;
+mod metering;
 mod note_generate;
 mod note_transcribe;
 mod pricing;
@@ -18,7 +19,9 @@ pub use dictate::{
     DictateTranscribeOutput, DictateTranscribeParams,
 };
 pub use error::ServiceError;
-pub use image::{ImageGenerateOutput, ImageGenerateParams, ImageService, ImageServiceDeps};
+pub use image::{
+    ImageGenerateOutput, ImageGenerateParams, ImageModelPrice, ImageService, ImageServiceDeps,
+};
 pub use note_generate::{
     NOTE_GENERATE_PROMPT_VERSION, NoteGenerateOutput, NoteGenerateParams, NoteGenerateService,
     NoteGenerateServiceDeps,
@@ -35,16 +38,17 @@ pub use web_augment::{
 #[cfg(test)]
 mod tests {
     use super::{
-        DictateCleanupParams, DictateService, DictateServiceDeps, DictateTranscribeParams,
-        NOTE_GENERATE_PROMPT_VERSION, NoteGenerateParams, NoteGenerateService,
-        NoteGenerateServiceDeps, NoteTranscribeParams, NoteTranscribeService,
-        NoteTranscribeServiceDeps, PricingTable, ServiceError,
+        AgentChatParams, AgentChatService, AgentChatServiceDeps, DictateCleanupParams,
+        DictateService, DictateServiceDeps, DictateTranscribeParams, NOTE_GENERATE_PROMPT_VERSION,
+        NoteGenerateParams, NoteGenerateService, NoteGenerateServiceDeps, NoteTranscribeParams,
+        NoteTranscribeService, NoteTranscribeServiceDeps, PricingTable, ServiceError,
     };
     use async_trait::async_trait;
     use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
     use june_domain::{
-        AudioDurationProbe, Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner,
-        CleanupRequest, Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
+        AgentChatCompleter, AgentChatCompletion, AgentChatRequest, AudioDurationProbe,
+        Authorization, AuthorizeRequest, ChargeRequest, CleanedText, Cleaner, CleanupRequest,
+        Credits, DomainError, GeneratedNote, GenerationRequest, Generator, ModelId,
         OsAccountsClient, ProviderCredentials, Receipt, TokenUsage, Transcriber, Transcript,
         TranscriptionRequest, UserId,
     };
@@ -127,6 +131,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_generate_user_venice_key_skips_wallet_metering_for_venice_model() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = NoteGenerateService::new(NoteGenerateServiceDeps {
+            pricing: Arc::new(PricingTable::new(venice_models([(
+                "text-model",
+                PriceUnit::Tokens,
+                2,
+                ModelType::Text,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            generator: Arc::new(FixedGenerator),
+            hold_ttl_seconds: 300,
+            flat_estimate_credits: 8200,
+        });
+        let mut params = note_generate_params();
+        params.provider_credentials = user_venice_credentials();
+
+        let output = service
+            .generate(params)
+            .await
+            .expect("generate succeeds with user Venice key");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
+    async fn note_generate_user_venice_key_still_meters_non_venice_model() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = note_generate_service(os_accounts.clone());
+        let mut params = note_generate_params();
+        params.provider_credentials = user_venice_credentials();
+
+        let output = service
+            .generate(params)
+            .await
+            .expect("generate succeeds with non-Venice model");
+
+        assert_eq!(output.receipt.credits_charged.0, 30);
+        assert!(matches!(
+            os_accounts.events().first(),
+            Some(RecordedCall::Authorize { action, .. }) if action == "note_generate"
+        ));
+    }
+
+    #[tokio::test]
     async fn dictate_cleanup_uses_deterministic_idempotency_key_with_real_session() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = DictateService::new(DictateServiceDeps {
@@ -164,6 +214,56 @@ mod tests {
             .await
             .unwrap_or_default();
         assert_eq!(charge_call, "dictate_cleanup:usr_123:session_1:utt_2");
+    }
+
+    #[tokio::test]
+    async fn dictate_user_venice_key_skips_wallet_metering() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = DictateService::new(DictateServiceDeps {
+            pricing: Arc::new(PricingTable::new(venice_models([
+                ("audio-model", PriceUnit::Seconds, 2, ModelType::Asr),
+                ("text-model", PriceUnit::Tokens, 1, ModelType::Text),
+            ]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: Arc::new(FixedTranscriber),
+            cleaner: Arc::new(FixedCleaner),
+            duration_probe: Arc::new(FixedDurationProbe),
+            transcribe_hold_ttl_seconds: 30,
+            cleanup_hold_ttl_seconds: 30,
+            flat_estimate_credits: 1024,
+        });
+
+        let transcribe = service
+            .transcribe(DictateTranscribeParams {
+                user_id: UserId("usr_123".to_string()),
+                session_id: "session_1".to_string(),
+                utterance_id: "utt_1".to_string(),
+                audio: vec![1, 2, 3],
+                filename: "dictation.wav".to_string(),
+                context: None,
+                language: None,
+                model_id: ModelId("audio-model".to_string()),
+                provider_credentials: user_venice_credentials(),
+            })
+            .await
+            .expect("dictate transcription succeeds with user Venice key");
+        let cleanup = service
+            .cleanup(DictateCleanupParams {
+                user_id: UserId("usr_123".to_string()),
+                session_id: "session_1".to_string(),
+                utterance_id: "utt_1".to_string(),
+                text: "hello".to_string(),
+                dictionary_context: None,
+                style: "plain".to_string(),
+                model_id: ModelId("text-model".to_string()),
+                provider_credentials: user_venice_credentials(),
+            })
+            .await
+            .expect("dictate cleanup succeeds with user Venice key");
+
+        assert_eq!(transcribe.receipt.credits_charged.0, 0);
+        assert_eq!(cleanup.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
     }
 
     #[tokio::test]
@@ -524,6 +624,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn note_transcribe_user_venice_key_skips_wallet_metering_for_preview_and_final() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let transcriber = Arc::new(RecordingTranscriber::default());
+        let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
+            pricing: Arc::new(PricingTable::new(venice_models([(
+                "audio-model",
+                PriceUnit::Seconds,
+                2,
+                ModelType::Asr,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            transcriber: transcriber.clone(),
+            duration_probe: Arc::new(FixedDurationProbe),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+            preview_max_audio_seconds: 30,
+        });
+
+        for preview in [true, false] {
+            let output = service
+                .transcribe(NoteTranscribeParams {
+                    user_id: UserId("usr_123".to_string()),
+                    note_id: format!("note_{preview}"),
+                    audio: vec![1, 2, 3],
+                    filename: "recording.wav".to_string(),
+                    context: None,
+                    language: None,
+                    model_id: ModelId("audio-model".to_string()),
+                    preview,
+                    provider_credentials: user_venice_credentials(),
+                })
+                .await
+                .expect("transcription succeeds with user Venice key");
+            assert_eq!(output.receipt.credits_charged.0, 0);
+        }
+
+        assert_eq!(transcriber.call_count(), 2);
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
     async fn note_transcribe_preview_failure_still_settles_hold() {
         let os_accounts = Arc::new(RecordingOsAccounts::default());
         let service = NoteTranscribeService::new(NoteTranscribeServiceDeps {
@@ -796,6 +937,39 @@ mod tests {
         assert!(matches!(result, Err(ServiceError::AuthorizationDenied)));
     }
 
+    #[tokio::test]
+    async fn agent_chat_user_venice_key_skips_wallet_metering_for_venice_model() {
+        let os_accounts = Arc::new(RecordingOsAccounts::default());
+        let service = AgentChatService::new(AgentChatServiceDeps {
+            pricing: Arc::new(PricingTable::new(venice_models([(
+                "text-model",
+                PriceUnit::Tokens,
+                1,
+                ModelType::Text,
+            )]))),
+            os_accounts: os_accounts.clone(),
+            chat_completer: Arc::new(FixedAgentChatCompleter),
+            hold_ttl_seconds: 60,
+            flat_estimate_credits: 1024,
+        });
+
+        let output = service
+            .complete(AgentChatParams {
+                user_id: UserId("usr_123".to_string()),
+                model_id: ModelId("text-model".to_string()),
+                body: serde_json::json!({
+                    "model": "text-model",
+                    "messages": [{ "role": "user", "content": "hello" }],
+                }),
+                provider_credentials: user_venice_credentials(),
+            })
+            .await
+            .expect("agent chat succeeds with user Venice key");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
     async fn wait_for_charge_idempotency_key(os_accounts: &RecordingOsAccounts) -> Option<String> {
         let deadline = Instant::now() + Duration::from_secs(1);
         loop {
@@ -848,6 +1022,22 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    fn venice_models<const N: usize>(
+        values: [(&str, PriceUnit, u64, ModelType); N],
+    ) -> BTreeMap<String, ModelPriceConfig> {
+        let mut models = models(values);
+        for model in models.values_mut() {
+            model.provider = ModelProvider::Venice;
+        }
+        models
+    }
+
+    fn user_venice_credentials() -> ProviderCredentials {
+        ProviderCredentials {
+            venice_api_key: Some("vc_user_key".to_string()),
+        }
     }
 
     struct RecordingOsAccounts {
@@ -989,6 +1179,26 @@ mod tests {
                 usage: TokenUsage {
                     prompt_tokens: 5,
                     completion_tokens: 6,
+                },
+            })
+        }
+    }
+
+    struct FixedAgentChatCompleter;
+
+    #[async_trait]
+    impl AgentChatCompleter for FixedAgentChatCompleter {
+        async fn complete(
+            &self,
+            _request: AgentChatRequest,
+        ) -> Result<AgentChatCompletion, DomainError> {
+            Ok(AgentChatCompletion {
+                body: br#"{"id":"chatcmpl_test"}"#.to_vec(),
+                content_type: "application/json".to_string(),
+                provider: "test".to_string(),
+                usage: TokenUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 20,
                 },
             })
         }

--- a/june-api/crates/services/src/metering.rs
+++ b/june-api/crates/services/src/metering.rs
@@ -1,0 +1,23 @@
+use crate::pricing::PricingTable;
+use june_domain::{ActionSlug, ProviderCredentials, UserId};
+
+pub(crate) fn uses_user_venice_key_for_model(
+    pricing: &PricingTable,
+    model_id: &str,
+    provider_credentials: &ProviderCredentials,
+) -> bool {
+    provider_credentials.has_venice_api_key() && pricing.is_venice_model(model_id)
+}
+
+pub(crate) fn uses_user_venice_key(provider_credentials: &ProviderCredentials) -> bool {
+    provider_credentials.has_venice_api_key()
+}
+
+pub(crate) fn log_skipped_user_venice_key(action: ActionSlug, user_id: &UserId, model_id: &str) {
+    tracing::info!(
+        user_id = %user_id.0,
+        action = action.as_str(),
+        model = model_id,
+        "skipped June credit metering for user-provided Venice API key"
+    );
+}

--- a/june-api/crates/services/src/note_generate.rs
+++ b/june-api/crates/services/src/note_generate.rs
@@ -1,8 +1,10 @@
 use crate::{
     charge_flow::{
         AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        zero_receipt,
     },
     error::ServiceError,
+    metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
     pricing::PricingTable,
     prompts,
 };
@@ -47,6 +49,36 @@ impl NoteGenerateService {
     ) -> Result<NoteGenerateOutput, ServiceError> {
         self.pricing
             .ensure_model_kind(&params.model_id.0, ModelKind::Text)?;
+        if uses_user_venice_key_for_model(
+            &self.pricing,
+            &params.model_id.0,
+            &params.provider_credentials,
+        ) {
+            let generated = self
+                .generator
+                .generate(GenerationRequest {
+                    title: params.title,
+                    transcript: params.transcript,
+                    transcript_source_labels: params.transcript_source_labels,
+                    manual_notes: params.manual_notes,
+                    language: params.language,
+                    existing_generated_note: params.existing_generated_note,
+                    model: params.model_id.clone(),
+                    system_prompt: prompts::NOTE_GENERATE.to_string(),
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await?;
+            log_skipped_user_venice_key(
+                ActionSlug::NoteGenerate,
+                &params.user_id,
+                &params.model_id.0,
+            );
+            return Ok(NoteGenerateOutput {
+                generated,
+                receipt: zero_receipt(),
+                prompt_version: NOTE_GENERATE_PROMPT_VERSION.to_string(),
+            });
+        }
         // Flat-estimate mode — see note_transcribe.rs. The actual charge below
         // is still computed from real token usage; only the Hold size changes.
         let estimate = Credits(self.flat_estimate_credits);

--- a/june-api/crates/services/src/note_transcribe.rs
+++ b/june-api/crates/services/src/note_transcribe.rs
@@ -1,8 +1,10 @@
 use crate::{
     charge_flow::{
         AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        zero_receipt,
     },
     error::ServiceError,
+    metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
     pricing::PricingTable,
     util::{ceil_seconds, sha256_hex},
 };
@@ -88,10 +90,58 @@ impl NoteTranscribeService {
             actual,
             estimate,
         };
+        if uses_user_venice_key_for_model(
+            &self.pricing,
+            &prepared.params.model_id.0,
+            &prepared.params.provider_credentials,
+        ) {
+            return self.transcribe_with_user_venice_key(prepared).await;
+        }
         if prepared.params.preview {
             return self.transcribe_preview(prepared).await;
         }
         self.transcribe_charged(prepared).await
+    }
+
+    async fn transcribe_with_user_venice_key(
+        &self,
+        prepared: PreparedNoteTranscription,
+    ) -> Result<NoteTranscribeOutput, ServiceError> {
+        let PreparedNoteTranscription {
+            params,
+            format,
+            seconds,
+            actual: _,
+            estimate: _,
+        } = prepared;
+        if params.preview && seconds > self.preview_max_audio_seconds {
+            return Err(ServiceError::InvalidInput {
+                reason: format!(
+                    "live transcript preview chunks must be {} seconds or shorter",
+                    self.preview_max_audio_seconds
+                ),
+            });
+        }
+        let transcript = self
+            .transcriber
+            .transcribe(TranscriptionRequest {
+                audio: params.audio,
+                format,
+                context: params.context,
+                language: params.language,
+                model: params.model_id.clone(),
+                provider_credentials: params.provider_credentials.clone(),
+            })
+            .await?;
+        log_skipped_user_venice_key(
+            ActionSlug::NoteTranscribe,
+            &params.user_id,
+            &params.model_id.0,
+        );
+        Ok(NoteTranscribeOutput {
+            transcript,
+            receipt: zero_receipt(),
+        })
     }
 
     async fn transcribe_preview(

--- a/june-api/crates/services/src/pricing.rs
+++ b/june-api/crates/services/src/pricing.rs
@@ -1,4 +1,4 @@
-use june_config::{ModelPriceConfig, ModelType, PriceUnit};
+use june_config::{ModelPriceConfig, ModelProvider, ModelType, PriceUnit};
 use june_domain::{Credits, ModelKind, TokenUsage};
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -53,6 +53,12 @@ impl PricingTable {
 
     pub fn has_model(&self, model_id: &str) -> bool {
         self.models.contains_key(model_id)
+    }
+
+    pub fn is_venice_model(&self, model_id: &str) -> bool {
+        self.models
+            .get(model_id)
+            .is_some_and(|model| model.provider == ModelProvider::Venice)
     }
 
     pub fn ensure_model_kind(&self, model_id: &str, kind: ModelKind) -> Result<(), PricingError> {
@@ -300,5 +306,22 @@ mod tests {
         )]));
         assert!(table.has_model("known"));
         assert!(!table.has_model("unknown"));
+    }
+
+    #[test]
+    fn identifies_venice_models_from_pricing_metadata() {
+        let mut models = models([
+            ("openai-asr", PriceUnit::Seconds, 1, 0, ModelType::Asr),
+            ("venice-text", PriceUnit::Tokens, 1, 1, ModelType::Text),
+        ]);
+        models
+            .get_mut("venice-text")
+            .expect("model exists")
+            .provider = ModelProvider::Venice;
+        let table = PricingTable::new(models);
+
+        assert!(!table.is_venice_model("openai-asr"));
+        assert!(table.is_venice_model("venice-text"));
+        assert!(!table.is_venice_model("missing"));
     }
 }

--- a/june-api/crates/services/src/web_augment.rs
+++ b/june-api/crates/services/src/web_augment.rs
@@ -1,8 +1,10 @@
 use crate::{
     charge_flow::{
         AuthorizeParams, ChargeParams, authorize_or_deny, charge, clamp_to_cap, log_settled,
+        zero_receipt,
     },
     error::ServiceError,
+    metering::{log_skipped_user_venice_key, uses_user_venice_key},
     util::sha256_hex,
 };
 use june_domain::{
@@ -49,6 +51,22 @@ impl WebAugmentService {
 
     pub async fn search(&self, params: WebSearchParams) -> Result<WebSearchOutput, ServiceError> {
         let estimate = Credits(self.search_credits);
+        if uses_user_venice_key(&params.provider_credentials) {
+            let results = self
+                .searcher
+                .search(WebSearchRequest {
+                    query: params.query.clone(),
+                    limit: params.limit,
+                    provider: params.provider,
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await?;
+            log_skipped_user_venice_key(ActionSlug::WebSearch, &params.user_id, "web");
+            return Ok(WebSearchOutput {
+                results,
+                receipt: zero_receipt(),
+            });
+        }
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),
@@ -91,6 +109,20 @@ impl WebAugmentService {
 
     pub async fn fetch(&self, params: WebFetchParams) -> Result<WebFetchOutput, ServiceError> {
         let estimate = Credits(self.fetch_credits);
+        if uses_user_venice_key(&params.provider_credentials) {
+            let result = self
+                .fetcher
+                .fetch(WebFetchRequest {
+                    url: params.url.clone(),
+                    provider_credentials: params.provider_credentials.clone(),
+                })
+                .await?;
+            log_skipped_user_venice_key(ActionSlug::WebFetch, &params.user_id, "web");
+            return Ok(WebFetchOutput {
+                result,
+                receipt: zero_receipt(),
+            });
+        }
         let authorization = authorize_or_deny(AuthorizeParams {
             os_accounts: self.os_accounts.as_ref(),
             user_id: params.user_id.clone(),
@@ -344,6 +376,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn search_user_venice_key_skips_wallet_metering() {
+        let os_accounts = Arc::new(RecordingOsAccounts::new(true));
+        let output = service(os_accounts.clone(), Arc::new(FixedFetcher))
+            .search(WebSearchParams {
+                user_id: UserId("usr_1".to_string()),
+                request_id: "req_1".to_string(),
+                query: "rust async".to_string(),
+                limit: Some(5),
+                provider: WebSearchProvider::Brave,
+                provider_credentials: ProviderCredentials {
+                    venice_api_key: Some("vc_user_key".to_string()),
+                },
+            })
+            .await
+            .expect("search succeeds with user Venice key");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
+    }
+
+    #[tokio::test]
     async fn search_same_request_id_different_shape_uses_distinct_keys() {
         // Regression: the key must fold in limit/provider, not just query, so
         // reusing a request_id with a different search shape still settles as a
@@ -437,5 +490,24 @@ mod tests {
                 estimate: 25,
             }]
         );
+    }
+
+    #[tokio::test]
+    async fn fetch_user_venice_key_skips_wallet_metering() {
+        let os_accounts = Arc::new(RecordingOsAccounts::new(true));
+        let output = service(os_accounts.clone(), Arc::new(FixedFetcher))
+            .fetch(WebFetchParams {
+                user_id: UserId("usr_1".to_string()),
+                request_id: "req_1".to_string(),
+                url: "https://example.com".to_string(),
+                provider_credentials: ProviderCredentials {
+                    venice_api_key: Some("vc_user_key".to_string()),
+                },
+            })
+            .await
+            .expect("fetch succeeds with user Venice key");
+
+        assert_eq!(output.receipt.credits_charged.0, 0);
+        assert_eq!(os_accounts.events(), Vec::new());
     }
 }

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1781,7 +1781,8 @@ function VeniceApiKeyRow({
       <div className="settings-row-info">
         <h3 className="settings-row-title">Venice API key</h3>
         <p className="settings-row-description">
-          Use your own key for Venice models. Stored locally and sent only for Venice requests.
+          Use your own key for Venice models so June credits are not used. Stored locally and sent
+          only for Venice requests.
         </p>
         {configured ? (
           <p className="settings-row-description settings-row-substatus">Key saved.</p>


### PR DESCRIPTION
## Summary
- Skip OS Accounts authorize/charge when a request uses a user-provided Venice API key for Venice-backed note generation, transcription, dictation, agent chat, web augment, and image generation.
- Keep non-Venice model calls metered even if a Venice key header is present, including future non-Venice image models through provider-aware image pricing.
- Forward user Venice credentials through image generation and update the settings copy to clarify that June credits are not used for Venice BYOK.

## Validation
- cargo fmt --manifest-path june-api/Cargo.toml --all -- --check
- cargo clippy --manifest-path june-api/Cargo.toml --all-targets --all-features --locked -- -D warnings
- cargo test --manifest-path june-api/Cargo.toml -p june-services
- cargo test --manifest-path june-api/Cargo.toml -p june-providers venice_image
- cargo test --manifest-path june-api/Cargo.toml -p june-api --test http_boundary
- cargo test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1
- pnpm dlx @biomejs/biome@2.4.16 check . --diagnostic-level=error --max-diagnostics=200
- pnpm vitest run src/test/app-settings.test.tsx (using a temporary node_modules symlink from the main checkout because this worktree had no local install)
- git diff --check

Live walkthrough not run: this is a June API billing/provider-routing fix with a copy-only settings UI change, covered by service/provider/API tests.