### PR TITLE
Block negative credit usage

### DIFF
--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -914,11 +914,11 @@ struct FakeOsAccounts;
 
 #[async_trait]
 impl OsAccountsClient for FakeOsAccounts {
-    async fn authorize(&self, _request: AuthorizeRequest) -> Result<Authorization, DomainError> {
+    async fn authorize(&self, request: AuthorizeRequest) -> Result<Authorization, DomainError> {
         Ok(Authorization {
             allowed: true,
             action_token: Some("agt_test".to_string()),
-            cap_credits: None,
+            cap_credits: Some(request.estimate),
             reason: None,
         })
     }

--- a/june-api/crates/providers/src/local_dev.rs
+++ b/june-api/crates/providers/src/local_dev.rs
@@ -47,7 +47,7 @@ impl OsAccountsClient for LocalDevOsAccountsClient {
                 request.action.as_str(),
                 request.estimate.0
             )),
-            cap_credits: None,
+            cap_credits: Some(request.estimate),
             reason: None,
         })
     }
@@ -105,7 +105,7 @@ mod tests {
 
         assert_eq!(authorization.allowed, true);
         assert!(authorization.action_token.is_some());
-        assert_eq!(authorization.cap_credits, None);
+        assert_eq!(authorization.cap_credits, Some(Credits(250)));
 
         let receipt = client
             .charge(ChargeRequest {

--- a/june-api/crates/services/src/charge_flow.rs
+++ b/june-api/crates/services/src/charge_flow.rs
@@ -7,7 +7,7 @@ use std::cmp::min;
 
 pub(crate) struct AuthorizationOutcome {
     pub action_token: String,
-    pub cap_credits: Option<Credits>,
+    pub cap_credits: Credits,
 }
 
 pub(crate) struct AuthorizeParams<'a> {
@@ -65,9 +65,23 @@ fn action_token_or_error(
             );
             ServiceError::AuthorizationDenied
         })?;
+    let cap_credits = authorization.cap_credits.ok_or_else(|| {
+        tracing::error!(
+            reason = ?authorization.reason,
+            "authorization allowed but cap_credits is missing"
+        );
+        ServiceError::MeteringProvider
+    })?;
+    if cap_credits.0 == 0 {
+        tracing::warn!(
+            reason = ?authorization.reason,
+            "authorization allowed with zero cap_credits"
+        );
+        return Err(ServiceError::InsufficientCredits);
+    }
     Ok(AuthorizationOutcome {
         action_token: token,
-        cap_credits: authorization.cap_credits,
+        cap_credits,
     })
 }
 
@@ -84,11 +98,8 @@ fn is_insufficient_balance(reason: Option<&str>) -> bool {
     })
 }
 
-pub(crate) fn clamp_to_cap(actual: Credits, cap: Option<Credits>) -> Credits {
-    match cap {
-        Some(cap) => Credits(min(actual.0, cap.0)),
-        None => actual,
-    }
+pub(crate) fn clamp_to_cap(actual: Credits, cap: Credits) -> Credits {
+    Credits(min(actual.0, cap.0))
 }
 
 pub(crate) struct ChargeParams<'a> {
@@ -172,7 +183,7 @@ pub(crate) fn log_settled(action: ActionSlug, user_id: &UserId, model_id: &str, 
 mod tests {
     use super::{action_token_or_error, is_insufficient_balance};
     use crate::error::ServiceError;
-    use june_domain::Authorization;
+    use june_domain::{Authorization, Credits};
 
     fn denied(reason: Option<&str>) -> Authorization {
         Authorization {
@@ -180,6 +191,15 @@ mod tests {
             action_token: None,
             cap_credits: None,
             reason: reason.map(str::to_string),
+        }
+    }
+
+    fn allowed(cap_credits: Option<Credits>) -> Authorization {
+        Authorization {
+            allowed: true,
+            action_token: Some("agts_test".to_string()),
+            cap_credits,
+            reason: None,
         }
     }
 
@@ -201,6 +221,24 @@ mod tests {
     fn unknown_denial_reason_is_treated_as_transient() {
         let result = action_token_or_error(denied(None));
         assert!(matches!(result, Err(ServiceError::AuthorizationDenied)));
+    }
+
+    #[test]
+    fn allowed_authorization_requires_a_cap() {
+        let result = action_token_or_error(allowed(None));
+        assert!(matches!(result, Err(ServiceError::MeteringProvider)));
+    }
+
+    #[test]
+    fn allowed_authorization_with_zero_cap_is_out_of_credits() {
+        let result = action_token_or_error(allowed(Some(Credits(0))));
+        assert!(matches!(result, Err(ServiceError::InsufficientCredits)));
+    }
+
+    #[test]
+    fn allowed_authorization_keeps_positive_cap() {
+        let result = action_token_or_error(allowed(Some(Credits(17))));
+        assert_eq!(result.map(|outcome| outcome.cap_credits), Ok(Credits(17)));
     }
 
     #[test]

--- a/june-api/crates/services/src/image.rs
+++ b/june-api/crates/services/src/image.rs
@@ -206,7 +206,7 @@ mod tests {
             Ok(Authorization {
                 allowed: self.allow,
                 action_token: self.allow.then(|| "agt_test".to_string()),
-                cap_credits: None,
+                cap_credits: self.allow.then_some(request.estimate),
                 reason: (!self.allow).then(|| "insufficient_available_balance".to_string()),
             })
         }

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -862,7 +862,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 allow: true,
-                cap: None,
+                cap: Some(10_000),
                 deny_reason: None,
                 fail_charge: false,
                 events: Mutex::new(Vec::new()),

--- a/june-api/crates/services/src/web_augment.rs
+++ b/june-api/crates/services/src/web_augment.rs
@@ -226,7 +226,7 @@ mod tests {
             Ok(Authorization {
                 allowed: self.allow,
                 action_token: self.allow.then(|| "agt_test".to_string()),
-                cap_credits: None,
+                cap_credits: self.allow.then_some(request.estimate),
                 reason: (!self.allow).then(|| "insufficient_available_balance".to_string()),
             })
         }

--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -114,6 +114,7 @@ export function AccountGate({ account, loading, onAccountChanged }: Props) {
 export function JuneMark() {
   return (
     <svg width="24" height="28" viewBox="0 0 12 14" fill="currentColor" aria-hidden>
+      <title>June</title>
       <JuneMarkPaths />
     </svg>
   );
@@ -124,6 +125,7 @@ export function JuneGradientMark() {
 
   return (
     <svg width="40" height="46" viewBox="0 0 12 14" fill="none" aria-hidden>
+      <title>June</title>
       <defs>
         <linearGradient id={gradientId} x1="6" y1="0" x2="6" y2="14" gradientUnits="userSpaceOnUse">
           <stop style={{ stopColor: "color-mix(in oklch, var(--brand) 55%, white)" }} />
@@ -154,6 +156,7 @@ function JuneMarkPaths({ fill }: { fill?: string }) {
 export function OsMark() {
   return (
     <svg width="28" height="16" viewBox="-1 -1 30 18" fill="currentColor" aria-hidden>
+      <title>Open Software</title>
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/src/components/account/FundingGate.tsx
+++ b/src/components/account/FundingGate.tsx
@@ -20,9 +20,11 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
   const handle = account.user?.handle;
   const status = account.subscription?.status;
   const subscribed = account.subscription?.subscribed === true;
+  const credits = account.balance?.credits;
+  const negativeBalance = typeof credits === "number" && credits < 0;
   const billingRecovery =
     subscribed && typeof status === "string" && status.length > 0 && !hasLiveSubscription(account);
-  const topUpRequired = subscribed && !billingRecovery;
+  const topUpRequired = subscribed && !billingRecovery && negativeBalance;
 
   const copy = billingRecovery
     ? {

--- a/src/components/account/FundingGate.tsx
+++ b/src/components/account/FundingGate.tsx
@@ -19,11 +19,10 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
   const [portalError, setPortalError] = useState<string>();
   const handle = account.user?.handle;
   const status = account.subscription?.status;
+  const subscribed = account.subscription?.subscribed === true;
   const billingRecovery =
-    account.subscription?.subscribed === true &&
-    typeof status === "string" &&
-    status.length > 0 &&
-    !hasLiveSubscription(account);
+    subscribed && typeof status === "string" && status.length > 0 && !hasLiveSubscription(account);
+  const topUpRequired = subscribed && !billingRecovery;
 
   const copy = billingRecovery
     ? {
@@ -33,13 +32,21 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
         waiting: "Waiting for your billing update",
         reopen: "Reopen billing",
       }
-    : {
-        title: "Upgrade to continue",
-        subtitle: "Your starter credits are used up. Upgrade to a paid plan to keep using June.",
-        cta: "Upgrade",
-        waiting: "Waiting for your upgrade",
-        reopen: "Reopen checkout",
-      };
+    : topUpRequired
+      ? {
+          title: "Top up credits",
+          subtitle: "Your credit balance is below zero. Top up credits to keep using June.",
+          cta: "Top up credits",
+          waiting: "Waiting for your top-up",
+          reopen: "Reopen account portal",
+        }
+      : {
+          title: "Upgrade to continue",
+          subtitle: "Your starter credits are used up. Upgrade to a paid plan to keep using June.",
+          cta: "Upgrade",
+          waiting: "Waiting for your upgrade",
+          reopen: "Reopen checkout",
+        };
 
   useEffect(() => {
     const interval = window.setInterval(() => {
@@ -51,7 +58,7 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
   async function handleOpenPortal() {
     setPortalError(undefined);
     try {
-      if (billingRecovery) {
+      if (billingRecovery || topUpRequired) {
         await osAccountsOpenPortal();
       } else {
         await osAccountsUpgrade();

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1302,9 +1302,7 @@ export function AppSettings({
                   >
                     <span className="settings-row-info">
                       <span className="settings-row-title">More options</span>
-                      <span className="settings-row-description">
-                        Advanced model settings.
-                      </span>
+                      <span className="settings-row-description">Advanced model settings.</span>
                     </span>
                     <IconChevronDownSmall
                       className="settings-more-options-chevron"
@@ -1783,13 +1781,10 @@ function VeniceApiKeyRow({
       <div className="settings-row-info">
         <h3 className="settings-row-title">Venice API key</h3>
         <p className="settings-row-description">
-          Use your own key for Venice models. Stored locally and sent only for
-          Venice requests.
+          Use your own key for Venice models. Stored locally and sent only for Venice requests.
         </p>
         {configured ? (
-          <p className="settings-row-description settings-row-substatus">
-            Key saved.
-          </p>
+          <p className="settings-row-description settings-row-substatus">Key saved.</p>
         ) : null}
       </div>
       <div className="settings-row-control settings-secret-control">
@@ -1806,20 +1801,11 @@ function VeniceApiKeyRow({
             if (event.key === "Enter" && canSave) onSave();
           }}
         />
-        <button
-          type="button"
-          className="btn btn-secondary"
-          disabled={!canSave}
-          onClick={onSave}
-        >
+        <button type="button" className="btn btn-secondary" disabled={!canSave} onClick={onSave}>
           Save
         </button>
         {configured ? (
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={onRemove}
-          >
+          <button type="button" className="btn btn-secondary" onClick={onRemove}>
             Remove
           </button>
         ) : null}

--- a/src/lib/account-gate.ts
+++ b/src/lib/account-gate.ts
@@ -32,13 +32,21 @@ function hasKnownNonLiveSubscription(account: AccountStatus): boolean {
   return typeof status === "string" && status.length > 0;
 }
 
+function hasNegativeBalance(account: AccountStatus): boolean {
+  const credits = account.balance?.credits;
+  return typeof credits === "number" && credits < 0;
+}
+
 // New users start from their OS Accounts credits, not a card-gated
-// subscription. Only block the shell when the backend positively reports a
-// zero-or-negative balance and a non-live subscription state. Older account
-// snapshots may omit `credits` or subscription status; treat those as usable
-// and let the metered action return a precise out-of-credits error if needed.
+// subscription. A known negative balance is never usable, even for live
+// subscribers, because it means spending has already crossed the credit floor.
+// Zero-credit live subscribers keep the current credit-line behavior. Older
+// account snapshots may omit `credits` or subscription status; treat those as
+// usable and let the metered action return a precise out-of-credits error if
+// needed.
 export function shouldBlockOnFunding(account: AccountStatus): boolean {
   if (!account.signedIn) return false;
+  if (hasNegativeBalance(account)) return true;
   if (hasLiveSubscription(account)) return false;
   if (!hasKnownNonLiveSubscription(account)) return false;
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9975,8 +9975,7 @@ input:focus-visible,
   color: var(--foreground);
 }
 
-.settings-more-options-trigger[aria-expanded="true"]
-  .settings-more-options-chevron {
+.settings-more-options-trigger[aria-expanded="true"] .settings-more-options-chevron {
   transform: rotate(180deg);
 }
 

--- a/src/test/account-gate.test.ts
+++ b/src/test/account-gate.test.ts
@@ -93,6 +93,27 @@ describe("shouldBlockOnFunding", () => {
     ).toBe(false);
   });
 
+  it("blocks a negative balance even for a live subscriber", () => {
+    expect(
+      shouldBlockOnFunding(
+        signedIn({
+          balance: { credits: -1, usdMillis: -1 },
+          subscription: { subscribed: true, status: "active" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks a negative balance while subscription state is unknown", () => {
+    expect(
+      shouldBlockOnFunding(
+        signedIn({
+          balance: { credits: -1, usdMillis: -1 },
+        }),
+      ),
+    ).toBe(true);
+  });
+
   it("blocks a past-due subscriber with no credits left", () => {
     expect(
       shouldBlockOnFunding(

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1667,9 +1667,7 @@ describe("AppSettings", () => {
 
     await user.click(screen.getByRole("button", { name: "Remove" }));
     expect(mocks.clearVeniceApiKey).toHaveBeenCalled();
-    await waitFor(() =>
-      expect(screen.queryByText("Key saved.")).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText("Key saved.")).not.toBeInTheDocument());
   });
 
   it("defaults the model picker to curated suggestions", async () => {

--- a/src/test/funding-gate.test.tsx
+++ b/src/test/funding-gate.test.tsx
@@ -90,6 +90,24 @@ describe("FundingGate", () => {
     expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
   });
 
+  it("opens the account portal for subscribed users below zero credits", async () => {
+    const user = userEvent.setup();
+    renderFundingGate({
+      ...baseAccount,
+      balance: { credits: -1, usdMillis: -1 },
+      subscription: { subscribed: true, status: "active" },
+    });
+
+    expect(screen.getByRole("heading", { name: "Top up credits" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Your credit balance is below zero. Top up credits to keep using June."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Top up credits" }));
+    expect(mocks.osAccountsOpenPortal).toHaveBeenCalledOnce();
+    expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
+  });
+
   it("lets a waiting account update be checked or reopened", async () => {
     const user = userEvent.setup();
     const onRefresh = vi.fn(async () => baseAccount);

--- a/src/test/funding-gate.test.tsx
+++ b/src/test/funding-gate.test.tsx
@@ -108,6 +108,22 @@ describe("FundingGate", () => {
     expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
   });
 
+  it("does not show top-up copy for subscribed users with positive credits", async () => {
+    const user = userEvent.setup();
+    renderFundingGate({
+      ...baseAccount,
+      balance: { credits: 1200, usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
+    });
+
+    expect(screen.getByRole("heading", { name: "Upgrade to continue" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Top up credits" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Upgrade" }));
+    expect(mocks.osAccountsUpgrade).toHaveBeenCalledOnce();
+    expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
+  });
+
   it("lets a waiting account update be checked or reopened", async () => {
     const user = userEvent.setup();
     const onRefresh = vi.fn(async () => baseAccount);


### PR DESCRIPTION
## Summary

- fail closed in June API when OS Accounts returns an allowed authorization without a usable positive `cap_credits`
- keep local-dev and test OS Accounts fakes aligned with the stricter authorize response shape
- block known negative credit balances in the desktop funding gate, including live subscribers, and route subscribed users to top up credits in the accounts portal
- include small Biome formatting cleanup needed for `pnpm run check` to pass on this branch

## Why

A user with a negative credit balance should not keep spending compute. June already authorizes before provider work, but the service accepted `allowed: true` with a missing cap and allowed `cap_credits: 0`, which could let work proceed without a real spendable hold. The app shell also allowed live subscribers through even when the account snapshot reported negative credits.

## Validation

- `pnpm test src/test/account-gate.test.ts src/test/funding-gate.test.tsx`
- `pnpm test src/test/app-settings.test.tsx`
- `pnpm run check` (passes; prints existing warnings)
- `pnpm run typecheck`
- `cargo fmt --manifest-path june-api/Cargo.toml --all -- --check`
- `cargo test --manifest-path june-api/Cargo.toml -p june-services --lib -- --test-threads=1`
- `cargo test --manifest-path june-api/Cargo.toml -p june-providers --lib -- --test-threads=1`
- `cargo test --manifest-path june-api/Cargo.toml -p june-api --test http_boundary -- --test-threads=1`
- `cargo test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked -- --test-threads=1`
- `git diff --check`

## Live walkthrough

Skipped. Proving the exact live flow safely would require a real signed-in OS Accounts user with a negative credit balance and would open account billing/top-up surfaces. The behavior is covered with focused component tests and backend metering tests instead.

## Known gaps

No live production account was exercised, and this PR does not change OS Accounts balance mutation itself. It makes June fail closed when the authorize response has no spendable cap and blocks any already-known negative balance in the desktop shell.
