### PR TITLE
Fix system source silently dropped from long or quiet meetings (JUN-178)

### DIFF
--- a/src-tauri/src/audio/turns.rs
+++ b/src-tauri/src/audio/turns.rs
@@ -10,10 +10,14 @@ const NORMALIZE_MAX_GAIN: f32 = 32.0;
 const TRANSCRIPTION_SAMPLE_RATE: u32 = 16_000;
 const TRANSCRIPTION_CHANNELS: u16 = 1;
 pub const MAX_TRANSCRIPTION_CHUNK_MS: i64 = 30 * 1000;
-/// Loudest-window RMS below which a track carries no transcribable speech.
-/// Deliberately conservative (≈ -38 dBFS) and matches the microphone lane's
-/// activity `min_rms`, so we only ever skip clearly-silent audio.
+/// Loudest-window RMS below which normalized audio carries no transcribable
+/// speech. Applied to already-gained audio (chunk-skip before API calls), so a
+/// track this quiet after up to 32x normalization is genuinely silent.
 const SILENCE_RMS_FLOOR: f32 = 0.012;
+/// Activity `min_rms` for the system lane's turn detection. The pre-transcription
+/// silence pre-filter must not drop below what detection can still find, so both
+/// derive from this one constant.
+pub const SYSTEM_DETECTION_MIN_RMS: f32 = 0.006;
 
 #[derive(Debug, Clone)]
 pub struct DetectionSource {
@@ -66,10 +70,24 @@ pub fn detect_turns(sources: &[DetectionSource]) -> Result<Vec<AudioTurn>, AppEr
 /// can't be read we return `false` so the audio is still attempted rather than
 /// silently dropped.
 pub fn source_is_effectively_silent(path: &Path) -> bool {
+    source_is_effectively_silent_with_floor(path, SILENCE_RMS_FLOOR)
+}
+
+/// Like [`source_is_effectively_silent`] but with a caller-supplied floor, so
+/// the pre-transcription drop can use the detector's floor while the normalized
+/// chunk-skip keeps the higher default.
+pub fn source_is_effectively_silent_with_floor(path: &Path, floor: f32) -> bool {
     match read_rms_windows(path) {
-        Ok(windows) => windows.iter().copied().fold(0.0_f32, f32::max) < SILENCE_RMS_FLOOR,
+        Ok(windows) => windows.iter().copied().fold(0.0_f32, f32::max) < floor,
         Err(_) => false,
     }
+}
+
+/// The loudest 30ms RMS window of a source, or `None` if it can't be read.
+pub fn source_max_rms(path: &Path) -> Option<f32> {
+    read_rms_windows(path)
+        .ok()
+        .map(|windows| windows.iter().copied().fold(0.0_f32, f32::max))
 }
 
 pub fn coalesce_turns_for_transcription(mut turns: Vec<AudioTurn>) -> Vec<AudioTurn> {
@@ -459,7 +477,7 @@ fn config_for_source(source: &str) -> SourceDetectionConfig {
             end_silence_ms: 2_000,
             min_turn_ms: 600,
             merge_gap_ms: 1_200,
-            min_rms: 0.006,
+            min_rms: SYSTEM_DETECTION_MIN_RMS,
             noise_multiplier: 3.0,
         }
     } else {
@@ -584,6 +602,46 @@ mod tests {
 
         assert!(source_is_effectively_silent(&silent));
         assert!(!source_is_effectively_silent(&audible));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn quiet_system_track_survives_detection_floor_but_is_silent_at_default_floor() {
+        let dir = std::env::temp_dir().join(format!("os-june-floor-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let quiet = dir.join("quiet-system.wav");
+        // Constant amplitude ~0.008 RMS: between the system detection floor
+        // (0.006) and the normalized-chunk silence floor (0.012).
+        let amplitude = (0.008 * i16::MAX as f32).round() as i16;
+        let samples = vec![amplitude; 16_000];
+        write_samples(&quiet, &samples);
+
+        let max_rms = source_max_rms(&quiet).unwrap();
+        assert!(
+            max_rms > SYSTEM_DETECTION_MIN_RMS && max_rms < SILENCE_RMS_FLOOR,
+            "expected RMS between floors, got {max_rms}"
+        );
+        assert!(!source_is_effectively_silent_with_floor(
+            &quiet,
+            SYSTEM_DETECTION_MIN_RMS
+        ));
+        assert!(source_is_effectively_silent(&quiet));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn truly_silent_track_is_dropped_at_detection_floor() {
+        let dir = std::env::temp_dir().join(format!("os-june-floor-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let silent = dir.join("silent-system.wav");
+        write_samples(&silent, &vec![0_i16; 16_000]);
+
+        assert!(source_is_effectively_silent_with_floor(
+            &silent,
+            SYSTEM_DETECTION_MIN_RMS
+        ));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -112,6 +112,15 @@ pub fn validate_audio_artifact(
     Ok(result)
 }
 
+/// Repair a stale WAV header in place, reading the on-disk size first. Callers
+/// that derive an expected duration from the header (recovery) must run this
+/// before reading duration, or a stale header makes a repaired capture look
+/// mismatched against itself.
+pub fn repair_stale_wav_header_in_place(path: &Path) -> Result<Option<String>, std::io::Error> {
+    let size = std::fs::metadata(path)?.len();
+    repair_stale_wav_header(path, size)
+}
+
 /// The RIFF/data chunk sizes AVAudioFile writes are only finalized on a clean
 /// close. When the system-audio helper is SIGKILLed mid-finalization the sizes
 /// stay stale (usually far smaller than the bytes actually on disk), so a header
@@ -135,6 +144,14 @@ fn repair_stale_wav_header(path: &Path, file_size: u64) -> Result<Option<String>
     if repaired_data_size == layout.declared_data_size as u64 {
         return Ok(None);
     }
+    // A self-consistent declared size (declared audio end lands at EOF, or the
+    // bytes there parse as a plausible trailing chunk header) is real, not
+    // stale: expanding it would fold trailing metadata into the audio length.
+    // Only the stale-small (declared end followed by non-chunk bytes) and
+    // truncated (declared end beyond EOF) mismatches get rewritten.
+    if declared_data_size_is_self_consistent(path, &layout, file_size)? {
+        return Ok(None);
+    }
     let Ok(repaired_data_size_u32) = u32::try_from(repaired_data_size) else {
         return Ok(None);
     };
@@ -153,6 +170,48 @@ fn repair_stale_wav_header(path: &Path, file_size: u64) -> Result<Option<String>
         "repaired stale WAV header: data size {} -> {} bytes",
         layout.declared_data_size, repaired_data_size
     )))
+}
+
+/// True when the declared `data` size is corroborated by the file layout: the
+/// declared audio end (plus a word-align pad byte if the size is odd) either
+/// lands exactly at EOF or is followed by bytes that parse as a plausible RIFF
+/// chunk header. Such a header is authoritative and must not be expanded.
+fn declared_data_size_is_self_consistent(
+    path: &Path,
+    layout: &WavLayout,
+    file_size: u64,
+) -> Result<bool, std::io::Error> {
+    let declared = layout.declared_data_size as u64;
+    let padded = declared + (declared & 1);
+    let declared_end = layout.data_payload_offset + padded;
+    if declared_end > file_size {
+        // Declared end runs past EOF: truncated/stale, let the caller shrink.
+        return Ok(false);
+    }
+    if declared_end == file_size {
+        return Ok(true);
+    }
+    // A trailing chunk needs at least an 8-byte header to be plausible.
+    if file_size - declared_end < 8 {
+        return Ok(false);
+    }
+    let mut file = File::open(path)?;
+    file.seek(SeekFrom::Start(declared_end))?;
+    let mut chunk_header = [0_u8; 8];
+    if file.read_exact(&mut chunk_header).is_err() {
+        return Ok(false);
+    }
+    let id_is_ascii = chunk_header[0..4]
+        .iter()
+        .all(|byte| byte.is_ascii_graphic() || *byte == b' ');
+    let chunk_size = u32::from_le_bytes([
+        chunk_header[4],
+        chunk_header[5],
+        chunk_header[6],
+        chunk_header[7],
+    ]) as u64;
+    let remaining = file_size - declared_end - 8;
+    Ok(id_is_ascii && chunk_size <= remaining)
 }
 
 struct WavLayout {
@@ -208,7 +267,11 @@ fn read_wav_layout(path: &Path) -> Result<Option<WavLayout>, std::io::Error> {
             channels = Some(u16::from_le_bytes([fmt[2], fmt[3]]));
             bits_per_sample = Some(u16::from_le_bytes([fmt[14], fmt[15]]));
         } else if &chunk_id == b"data" {
-            if format_tag != Some(1) || bits_per_sample != Some(16) {
+            // AVAudioFile can emit WAVE_FORMAT_EXTENSIBLE (0xFFFE) for 16-bit
+            // PCM; hound reads it as PCM, and the live-preview parser already
+            // accepts it. The extended fmt chunk is larger, but chunk skipping
+            // is size-based so the first 16 bytes still give channels/bits.
+            if !matches!(format_tag, Some(1) | Some(0xFFFE)) || bits_per_sample != Some(16) {
                 return Ok(None);
             }
             let (Some(channels), Some(bits_per_sample)) = (channels, bits_per_sample) else {
@@ -327,18 +390,19 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("os-june-repair-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("system.wav");
-        write_wav(&path, 3_600_000);
+        write_wav(&path, 10_000);
 
         // Simulate SIGKILL mid-finalization: RIFF + data chunk sizes claim only
-        // a few seconds while an hour of samples sit on disk.
+        // ~1s while 10s of samples sit on disk. Same code path as an hour-long
+        // capture, negligible I/O.
         let data_offset = data_size_field_offset(&path);
-        patch_le_u32(&path, 4, 32 + 5 * 16_000 * 2);
-        patch_le_u32(&path, data_offset, 5 * 16_000 * 2);
+        patch_le_u32(&path, 4, 32 + 16_000 * 2);
+        patch_le_u32(&path, data_offset, 16_000 * 2);
 
-        let result = validate_audio_artifact(&path, 3_600_000, AudioValidationConfig::default())
+        let result = validate_audio_artifact(&path, 10_000, AudioValidationConfig::default())
             .expect("validation should run");
 
-        assert_eq!(result.actual_duration_ms, 3_600_000);
+        assert_eq!(result.actual_duration_ms, 10_000);
         assert!(source_audio_passes_validation(
             RecordingSource::System,
             &result
@@ -371,6 +435,98 @@ mod tests {
             RecordingSource::System,
             &result
         ));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn leaves_correct_header_with_trailing_chunk_unrepaired() {
+        let dir = std::env::temp_dir().join(format!("os-june-repair-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("system.wav");
+        write_wav(&path, 2_000);
+
+        // Append a plausible trailing LIST chunk. The declared data size stays
+        // correct, so the repair must not fold these metadata bytes into audio.
+        let list_body = b"INFOISFT\x04\x00\x00\x00juna";
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(b"LIST").unwrap();
+        file.write_all(&(list_body.len() as u32).to_le_bytes())
+            .unwrap();
+        file.write_all(list_body).unwrap();
+        file.flush().unwrap();
+
+        let result = validate_audio_artifact(&path, 2_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert_eq!(result.actual_duration_ms, 2_000);
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("repaired stale WAV header")),
+            "correct header followed by a trailing chunk must not be repaired"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn repairs_extensible_format_stale_header() {
+        // Hand-built 16-bit PCM WAVE_FORMAT_EXTENSIBLE (0xFFFE) file: hound reads
+        // it as PCM and the repair must recognize its layout. Header claims ~0.5s
+        // while ~1s of samples are on disk.
+        let dir = std::env::temp_dir().join(format!("os-june-repair-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("extensible.wav");
+
+        let sample_rate: u32 = 16_000;
+        let channels: u16 = 1;
+        let bits: u16 = 16;
+        let block_align: u16 = channels * bits / 8;
+        let byte_rate: u32 = sample_rate * block_align as u32;
+        let true_samples: u32 = sample_rate; // ~1s
+        let true_data_size: u32 = true_samples * block_align as u32;
+
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&0_u32.to_le_bytes()); // riff size patched below
+        bytes.extend_from_slice(b"WAVE");
+        // fmt chunk, extensible = 40 bytes.
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&40_u32.to_le_bytes());
+        bytes.extend_from_slice(&0xFFFE_u16.to_le_bytes()); // WAVE_FORMAT_EXTENSIBLE
+        bytes.extend_from_slice(&channels.to_le_bytes());
+        bytes.extend_from_slice(&sample_rate.to_le_bytes());
+        bytes.extend_from_slice(&byte_rate.to_le_bytes());
+        bytes.extend_from_slice(&block_align.to_le_bytes());
+        bytes.extend_from_slice(&bits.to_le_bytes());
+        bytes.extend_from_slice(&22_u16.to_le_bytes()); // cbSize
+        bytes.extend_from_slice(&bits.to_le_bytes()); // valid bits per sample
+        bytes.extend_from_slice(&0_u32.to_le_bytes()); // channel mask
+                                                       // KSDATAFORMAT_SUBTYPE_PCM GUID.
+        bytes.extend_from_slice(&[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xAA, 0x00, 0x38,
+            0x9B, 0x71,
+        ]);
+        // data chunk with a stale-small declared size.
+        bytes.extend_from_slice(b"data");
+        let stale_data_size: u32 = true_data_size / 2;
+        bytes.extend_from_slice(&stale_data_size.to_le_bytes());
+        bytes.extend_from_slice(&vec![0_u8; true_data_size as usize]);
+        let riff_size = (bytes.len() - 8) as u32;
+        bytes[4..8].copy_from_slice(&riff_size.to_le_bytes());
+        std::fs::write(&path, &bytes).unwrap();
+
+        let result = validate_audio_artifact(&path, 1_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert!(result.readable_audio);
+        assert_eq!(result.actual_duration_ms, 1_000);
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("repaired stale WAV header")));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -1,7 +1,11 @@
 use crate::domain::types::{AudioValidationDto, RecordingSource};
 use hound::WavReader;
 use sha2::{Digest, Sha256};
-use std::{fs::File, io::Read, path::Path};
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    path::Path,
+};
 
 pub const MIN_RECORDING_MS: i64 = 1_000;
 const MIN_POSITIVE_DURATION_DRIFT_MS: i64 = 60_000;
@@ -59,6 +63,10 @@ pub fn validate_audio_artifact(
         return Ok(result);
     }
 
+    if let Ok(Some(note)) = repair_stale_wav_header(path, size) {
+        result.warnings.push(note);
+    }
+
     let Ok(mut reader) = WavReader::open(path) else {
         result
             .warnings
@@ -102,6 +110,126 @@ pub fn validate_audio_artifact(
     result.non_silent_signal = samples > 0;
 
     Ok(result)
+}
+
+/// The RIFF/data chunk sizes AVAudioFile writes are only finalized on a clean
+/// close. When the system-audio helper is SIGKILLed mid-finalization the sizes
+/// stay stale (usually far smaller than the bytes actually on disk), so a header
+/// alone can make an hour-long capture look like minutes. A genuinely truncated
+/// file leaves the opposite mismatch (a header claiming more than exists). In
+/// either case the byte length on disk is the truth for a plain PCM stream, so
+/// rewrite the size fields to match before duration is read.
+fn repair_stale_wav_header(path: &Path, file_size: u64) -> Result<Option<String>, std::io::Error> {
+    let Some(layout) = read_wav_layout(path)? else {
+        return Ok(None);
+    };
+    if file_size < layout.data_payload_offset {
+        return Ok(None);
+    }
+    let frame_bytes = layout.channels as u64 * (layout.bits_per_sample as u64 / 8);
+    if frame_bytes == 0 {
+        return Ok(None);
+    }
+    let available = file_size - layout.data_payload_offset;
+    let repaired_data_size = available - (available % frame_bytes);
+    if repaired_data_size == layout.declared_data_size as u64 {
+        return Ok(None);
+    }
+    let Ok(repaired_data_size_u32) = u32::try_from(repaired_data_size) else {
+        return Ok(None);
+    };
+    let Ok(riff_size_u32) = u32::try_from(file_size.saturating_sub(8)) else {
+        return Ok(None);
+    };
+
+    let mut file = OpenOptions::new().write(true).open(path)?;
+    file.seek(SeekFrom::Start(4))?;
+    file.write_all(&riff_size_u32.to_le_bytes())?;
+    file.seek(SeekFrom::Start(layout.data_size_field_offset))?;
+    file.write_all(&repaired_data_size_u32.to_le_bytes())?;
+    file.flush()?;
+
+    Ok(Some(format!(
+        "repaired stale WAV header: data size {} -> {} bytes",
+        layout.declared_data_size, repaired_data_size
+    )))
+}
+
+struct WavLayout {
+    channels: u16,
+    bits_per_sample: u16,
+    declared_data_size: u32,
+    data_size_field_offset: u64,
+    data_payload_offset: u64,
+}
+
+/// Walk the RIFF chunk list for a plain 16-bit PCM WAV (format tag 1). Returns
+/// `None` for anything else so non-PCM or malformed files fall through to the
+/// existing paths unchanged.
+fn read_wav_layout(path: &Path) -> Result<Option<WavLayout>, std::io::Error> {
+    let mut file = File::open(path)?;
+    let mut header = [0_u8; 12];
+    if file.read_exact(&mut header).is_err() {
+        return Ok(None);
+    }
+    if &header[0..4] != b"RIFF" || &header[8..12] != b"WAVE" {
+        return Ok(None);
+    }
+
+    let mut format_tag: Option<u16> = None;
+    let mut channels: Option<u16> = None;
+    let mut bits_per_sample: Option<u16> = None;
+    let mut offset: u64 = 12;
+    loop {
+        let mut chunk_header = [0_u8; 8];
+        if file.read_exact(&mut chunk_header).is_err() {
+            return Ok(None);
+        }
+        let chunk_id = [
+            chunk_header[0],
+            chunk_header[1],
+            chunk_header[2],
+            chunk_header[3],
+        ];
+        let chunk_size = u32::from_le_bytes([
+            chunk_header[4],
+            chunk_header[5],
+            chunk_header[6],
+            chunk_header[7],
+        ]);
+        let chunk_body_offset = offset + 8;
+
+        if &chunk_id == b"fmt " {
+            let mut fmt = [0_u8; 16];
+            if file.read_exact(&mut fmt).is_err() {
+                return Ok(None);
+            }
+            format_tag = Some(u16::from_le_bytes([fmt[0], fmt[1]]));
+            channels = Some(u16::from_le_bytes([fmt[2], fmt[3]]));
+            bits_per_sample = Some(u16::from_le_bytes([fmt[14], fmt[15]]));
+        } else if &chunk_id == b"data" {
+            if format_tag != Some(1) || bits_per_sample != Some(16) {
+                return Ok(None);
+            }
+            let (Some(channels), Some(bits_per_sample)) = (channels, bits_per_sample) else {
+                return Ok(None);
+            };
+            return Ok(Some(WavLayout {
+                channels,
+                bits_per_sample,
+                declared_data_size: chunk_size,
+                data_size_field_offset: offset + 4,
+                data_payload_offset: chunk_body_offset,
+            }));
+        }
+
+        // Chunks are word-aligned: an odd size is followed by a pad byte.
+        let advance = chunk_size as u64 + (chunk_size as u64 & 1);
+        offset = chunk_body_offset + advance;
+        if file.seek(SeekFrom::Start(offset)).is_err() {
+            return Ok(None);
+        }
+    }
 }
 
 pub fn validation_config_for_source(_source: RecordingSource) -> AudioValidationConfig {
@@ -157,4 +285,112 @@ pub fn checksum_file(path: &Path) -> Result<String, std::io::Error> {
         hasher.update(&buffer[..read]);
     }
     Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::{SampleFormat, WavSpec, WavWriter};
+
+    fn write_wav(path: &Path, duration_ms: i64) {
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(path, spec).unwrap();
+        let samples = ((16_000 * duration_ms) / 1000) as usize;
+        for index in 0..samples {
+            let sample = if index % 2 == 0 { 6_000 } else { -6_000 };
+            writer.write_sample(sample).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+
+    fn data_size_field_offset(path: &Path) -> u64 {
+        read_wav_layout(path)
+            .unwrap()
+            .unwrap()
+            .data_size_field_offset
+    }
+
+    fn patch_le_u32(path: &Path, offset: u64, value: u32) {
+        let mut file = OpenOptions::new().write(true).open(path).unwrap();
+        file.seek(SeekFrom::Start(offset)).unwrap();
+        file.write_all(&value.to_le_bytes()).unwrap();
+        file.flush().unwrap();
+    }
+
+    #[test]
+    fn repairs_stale_small_header_and_reports_true_duration() {
+        let dir = std::env::temp_dir().join(format!("os-june-repair-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("system.wav");
+        write_wav(&path, 3_600_000);
+
+        // Simulate SIGKILL mid-finalization: RIFF + data chunk sizes claim only
+        // a few seconds while an hour of samples sit on disk.
+        let data_offset = data_size_field_offset(&path);
+        patch_le_u32(&path, 4, 32 + 5 * 16_000 * 2);
+        patch_le_u32(&path, data_offset, 5 * 16_000 * 2);
+
+        let result = validate_audio_artifact(&path, 3_600_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert_eq!(result.actual_duration_ms, 3_600_000);
+        assert!(source_audio_passes_validation(
+            RecordingSource::System,
+            &result
+        ));
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("repaired stale WAV header")));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn repairs_oversized_header_to_on_disk_duration_and_still_fails_truncated() {
+        let dir = std::env::temp_dir().join(format!("os-june-repair-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("system.wav");
+        write_wav(&path, 2_000);
+
+        // Header claims an hour of data the file does not contain.
+        let data_offset = data_size_field_offset(&path);
+        patch_le_u32(&path, 4, 32 + 3_600 * 16_000 * 2);
+        patch_le_u32(&path, data_offset, 3_600 * 16_000 * 2);
+
+        let result = validate_audio_artifact(&path, 3_600_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert_eq!(result.actual_duration_ms, 2_000);
+        assert!(!source_audio_passes_validation(
+            RecordingSource::System,
+            &result
+        ));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn leaves_garbage_file_as_not_readable() {
+        let dir = std::env::temp_dir().join(format!("os-june-repair-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("garbage.bin");
+        std::fs::write(&path, b"not a wav file at all, just some bytes").unwrap();
+
+        let result = validate_audio_artifact(&path, 1_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert!(!result.readable_audio);
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("not readable WAV")));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1463,6 +1463,11 @@ fn recovery_validation_expected_duration_ms(path: &Path, stored_duration_ms: i64
     if stored_duration_ms > 1 {
         return stored_duration_ms;
     }
+    // Pending source rows persist expected_duration_ms = 0, so the expectation
+    // is derived from the WAV itself. Repair a stale header first — otherwise a
+    // SIGKILLed long capture yields a short expected duration that its own
+    // repaired (true) duration then fails as "stale long audio".
+    let _ = crate::audio::validation::repair_stale_wav_header_in_place(path);
     wav_duration_ms(path).unwrap_or_else(|| stored_duration_ms.max(1))
 }
 
@@ -1856,6 +1861,46 @@ mod tests {
         let (_dir, path) = write_one_second_flushed_wav();
 
         assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 1_000);
+    }
+
+    #[test]
+    fn recovered_wav_duration_repairs_stale_header_before_deriving() {
+        use std::io::{Seek, SeekFrom, Write};
+
+        // 10s of samples with a SIGKILL-stale header claiming ~1s. Without an
+        // up-front repair the expectation would be ~1s while validation's own
+        // repaired duration is 10s, failing the source as stale-long audio.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("partial.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&path, spec).expect("writer");
+        for _ in 0..160_000 {
+            writer.write_sample(0_i16).expect("sample");
+        }
+        writer.finalize().expect("finalize");
+
+        let stale_data_size: u32 = 16_000 * 2;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open");
+        // data chunk size field sits at byte 40 for a canonical 16-bit PCM WAV;
+        // RIFF size at byte 4.
+        file.seek(SeekFrom::Start(4)).expect("seek");
+        file.write_all(&(36 + stale_data_size).to_le_bytes())
+            .expect("write riff size");
+        file.seek(SeekFrom::Start(40)).expect("seek");
+        file.write_all(&stale_data_size.to_le_bytes())
+            .expect("write data size");
+        file.flush().expect("flush");
+        drop(file);
+
+        assert_eq!(recovery_validation_expected_duration_ms(&path, 0), 10_000);
     }
 
     #[test]

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -396,7 +396,27 @@ pub async fn process_saved_source_audio(
     let dictionary_context = build_dictionary_context(&dictionary_entries);
     let processing_started = Instant::now();
     let detection_started = Instant::now();
-    let sources = drop_silent_system_sources(sources);
+    let SilentSystemDropOutcome {
+        kept: sources,
+        dropped,
+    } = partition_silent_system_sources(sources);
+    for drop in &dropped {
+        repos
+            .add_source_checkpoint(
+                session_id,
+                Some(drop.artifact_id.as_str()),
+                Some(drop.source.as_str()),
+                "silent_source_dropped",
+                Some(
+                    serde_json::json!({
+                        "source": drop.source,
+                        "maxRms": drop.max_rms,
+                    })
+                    .to_string(),
+                ),
+            )
+            .await?;
+    }
     let turns = detect_turns(
         &sources
             .iter()
@@ -1457,33 +1477,70 @@ fn blocking_transcription_failure_summary(
     source_failure_summary(&blocking_failures)
 }
 
-/// Remove system-audio sources whose track is effectively silent, but only when
-/// another source remains to carry the recording. Keeping the last source — even
-/// a silent one — preserves the "no speech" failure for system-only captures.
+struct DroppedSource {
+    artifact_id: String,
+    source: String,
+    max_rms: f32,
+}
+
+struct SilentSystemDropOutcome {
+    kept: Vec<(String, String, PathBuf)>,
+    dropped: Vec<DroppedSource>,
+}
+
+#[cfg(test)]
 fn drop_silent_system_sources(
     sources: Vec<(String, String, PathBuf)>,
 ) -> Vec<(String, String, PathBuf)> {
+    partition_silent_system_sources(sources).kept
+}
+
+/// Remove system-audio sources whose track is effectively silent, but only when
+/// another source remains to carry the recording. Keeping the last source — even
+/// a silent one — preserves the "no speech" failure for system-only captures.
+///
+/// A system track is only dropped when it falls below what the system lane's
+/// turn detection could still find (`SYSTEM_DETECTION_MIN_RMS`). A higher floor
+/// would strand quiet-but-real tracks before the full-source fallback ever runs,
+/// transcribing mic-only.
+fn partition_silent_system_sources(
+    sources: Vec<(String, String, PathBuf)>,
+) -> SilentSystemDropOutcome {
     let has_other_source = sources
         .iter()
         .any(|(_, source, _)| source.as_str() != "system");
     if !has_other_source {
-        return sources;
+        return SilentSystemDropOutcome {
+            kept: sources,
+            dropped: Vec::new(),
+        };
     }
-    sources
-        .into_iter()
-        .filter(|(_, source, path)| {
-            let silent = source.as_str() == "system"
-                && crate::audio::turns::source_is_effectively_silent(path);
-            if silent {
-                tracing::info!(
-                    %source,
-                    path = %path.display(),
-                    "skipping silent system source — no transcribable audio"
-                );
-            }
-            !silent
-        })
-        .collect()
+    let mut kept = Vec::new();
+    let mut dropped = Vec::new();
+    for (artifact_id, source, path) in sources {
+        let silent = source.as_str() == "system"
+            && crate::audio::turns::source_is_effectively_silent_with_floor(
+                &path,
+                crate::audio::turns::SYSTEM_DETECTION_MIN_RMS,
+            );
+        if silent {
+            let max_rms = crate::audio::turns::source_max_rms(&path).unwrap_or(0.0);
+            tracing::info!(
+                %source,
+                path = %path.display(),
+                max_rms,
+                "skipping silent system source — no transcribable audio"
+            );
+            dropped.push(DroppedSource {
+                artifact_id,
+                source,
+                max_rms,
+            });
+        } else {
+            kept.push((artifact_id, source, path));
+        }
+    }
+    SilentSystemDropOutcome { kept, dropped }
 }
 
 fn add_full_source_turns_for_missing_sources(
@@ -2646,6 +2703,36 @@ mod tests {
         // System-only capture of silence must survive so its "no speech"
         // failure still reaches the user.
         assert_eq!(kept.len(), 1);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn keeps_quiet_system_source_between_detection_and_silence_floors() {
+        let dir =
+            std::env::temp_dir().join(format!("os-june-drop-silent-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mic_path = dir.join("microphone.wav");
+        let system_path = dir.join("system.wav");
+        write_test_wav(&mic_path, &[20_000, -18_000]);
+        // ~0.008 RMS: detectable by the system lane (min_rms 0.006) but under the
+        // 0.012 normalized-chunk silence floor. Must survive the pre-filter so the
+        // full-source fallback can still transcribe it.
+        let amplitude = (0.008 * i16::MAX as f32).round() as i16;
+        let quiet = vec![amplitude; 48_000];
+        write_test_wav(&system_path, &quiet);
+
+        let kept = drop_silent_system_sources(vec![
+            ("mic".to_string(), "microphone".to_string(), mic_path),
+            ("sys".to_string(), "system".to_string(), system_path.clone()),
+        ]);
+
+        assert_eq!(kept.len(), 2);
+        // The old 0.012 floor still judges it silent — the chunk-skip guard is
+        // intentionally left stricter than the pre-filter.
+        assert!(crate::audio::turns::source_is_effectively_silent(
+            &system_path
+        ));
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -1518,13 +1518,16 @@ fn partition_silent_system_sources(
     let mut kept = Vec::new();
     let mut dropped = Vec::new();
     for (artifact_id, source, path) in sources {
-        let silent = source.as_str() == "system"
-            && crate::audio::turns::source_is_effectively_silent_with_floor(
-                &path,
-                crate::audio::turns::SYSTEM_DETECTION_MIN_RMS,
-            );
+        // Decode once: `source_max_rms` is `None` when the file can't be read,
+        // which must mean "keep" (matching the old read-failure semantics).
+        let max_rms = if source.as_str() == "system" {
+            crate::audio::turns::source_max_rms(&path)
+        } else {
+            None
+        };
+        let silent = max_rms.is_some_and(|rms| rms < crate::audio::turns::SYSTEM_DETECTION_MIN_RMS);
         if silent {
-            let max_rms = crate::audio::turns::source_max_rms(&path).unwrap_or(0.0);
+            let max_rms = max_rms.unwrap_or(0.0);
             tracing::info!(
                 %source,
                 path = %path.display(),

--- a/src-tauri/tests/source_processing.rs
+++ b/src-tauri/tests/source_processing.rs
@@ -1,9 +1,20 @@
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+use os_june_lib::audio::turns::{
+    coalesce_turns_for_transcription, detect_turns, normalize_wav_for_transcription,
+    write_turn_wav, AudioTurn, DetectionSource,
+};
+use os_june_lib::audio::validation::{
+    source_audio_passes_validation, validate_audio_artifact, AudioValidationConfig,
+};
 use os_june_lib::domain::processing::{
     build_dictionary_context, build_transcription_context, coalesce_source_transcripts,
     labeled_transcript_from_sources, merge_transcription_context, valid_sources_for_processing,
     SourceTranscriptInput,
 };
-use os_june_lib::domain::types::DictionaryEntryDto;
+use os_june_lib::domain::types::{DictionaryEntryDto, RecordingSource};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
 
 #[test]
 fn labeled_transcript_keeps_microphone_and_system_sections() {
@@ -157,4 +168,181 @@ fn merges_dictionary_and_previous_transcription_context() {
 
     assert!(merged.contains("Custom dictionary terms"));
     assert!(merged.contains("Previous transcript context"));
+}
+
+/// Write a mono 16kHz 16-bit PCM WAV whose samples alternate `±amplitude`
+/// inside `[active_start_ms, active_end_ms)` and are silent elsewhere, so turn
+/// detection sees a clear active region against a silent floor.
+fn write_active_region_wav(
+    path: &Path,
+    amplitude: i16,
+    duration_ms: u32,
+    active_start_ms: u32,
+    active_end_ms: u32,
+) {
+    let spec = WavSpec {
+        channels: 1,
+        sample_rate: 16_000,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec).expect("wav writer");
+    let samples = (spec.sample_rate as f32 * (duration_ms as f32 / 1000.0)) as usize;
+    let active_start = (spec.sample_rate as f32 * (active_start_ms as f32 / 1000.0)) as usize;
+    let active_end = (spec.sample_rate as f32 * (active_end_ms as f32 / 1000.0)) as usize;
+    for i in 0..samples {
+        let sample = if i >= active_start && i < active_end {
+            if i % 2 == 0 {
+                amplitude
+            } else {
+                -amplitude
+            }
+        } else {
+            0
+        };
+        writer.write_sample(sample).expect("sample write");
+    }
+    writer.finalize().expect("wav finalize");
+}
+
+fn patch_le_u32(path: &Path, offset: u64, value: u32) {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open wav for header patch");
+    file.seek(SeekFrom::Start(offset))
+        .expect("seek header field");
+    file.write_all(&value.to_le_bytes())
+        .expect("write header field");
+    file.flush().expect("flush header field");
+}
+
+fn wav_duration_ms(path: &Path) -> i64 {
+    let reader = WavReader::open(path).expect("readable wav");
+    let sample_rate = reader.spec().sample_rate.max(1) as i64;
+    (reader.duration() as i64 * 1000) / sample_rate
+}
+
+/// End-to-end pin for the stale-header system-source path fixed in PR #570: a
+/// microphone WAV plus a system WAV whose RIFF/`data` header was left stale by a
+/// SIGKILLed capture helper (claims ~1s while ~10s of samples sit on disk) must
+/// survive validation and the turn pipeline as a real system lane instead of
+/// being silently dropped.
+///
+/// `process_saved_source_audio` transcribes via `default_turn_transcriber()`
+/// (a network call) with no injectable seam, and the full-source fallback
+/// (`add_full_source_turns_for_missing_sources`) is private, so this drives the
+/// deepest network-free depth: Gate 1 validation plus the real public turn
+/// pipeline (`detect_turns` -> `coalesce_turns_for_transcription` -> segment
+/// extraction/normalization), asserting the system lane reaches non-empty,
+/// transcription-ready audio.
+#[test]
+fn stale_header_system_source_survives_validation_and_turn_pipeline() {
+    let dir = tempdir().expect("tempdir");
+    let mic_path = dir.path().join("microphone.wav");
+    let system_path = dir.path().join("system.wav");
+
+    // Microphone: an audible burst framed by silence so detection finds a mic turn.
+    write_active_region_wav(&mic_path, 18_000, 4_000, 1_000, 3_000);
+    // System: ~10s with an audible speech-like region framed by silence.
+    write_active_region_wav(&system_path, 18_000, 10_000, 2_000, 8_000);
+
+    // Simulate SIGKILL mid-finalization: rewrite the RIFF size (offset 4) and the
+    // `data` chunk size (offset 40 for a canonical mono 16-bit PCM WAV) to claim
+    // only ~1s while 10s of samples remain on disk.
+    let one_second_data_bytes = 16_000 * 2;
+    patch_le_u32(&system_path, 4, 32 + one_second_data_bytes);
+    patch_le_u32(&system_path, 40, one_second_data_bytes);
+
+    // Gate 1 (load-bearing): before the header repair the stale WAV reads ~1s
+    // against an expected 10s and fails `is_not_truncated`, so the system source
+    // is dropped. `validate_audio_artifact` repairs the header first, so the
+    // system source now passes validation.
+    let system_validation =
+        validate_audio_artifact(&system_path, 10_000, AudioValidationConfig::default())
+            .expect("validation should run");
+    assert_eq!(
+        system_validation.actual_duration_ms, 10_000,
+        "stale header should be repaired to the true on-disk duration"
+    );
+    assert!(
+        source_audio_passes_validation(RecordingSource::System, &system_validation),
+        "repaired system source must pass validation (Gate 1)"
+    );
+
+    // Drive the real turn pipeline for the dual-source recording.
+    let sources: Vec<(String, String, PathBuf)> = vec![
+        (
+            "mic-artifact".to_string(),
+            "microphone".to_string(),
+            mic_path.clone(),
+        ),
+        (
+            "system-artifact".to_string(),
+            "system".to_string(),
+            system_path.clone(),
+        ),
+    ];
+    let detection_sources = sources
+        .iter()
+        .map(|(artifact_id, source, path)| DetectionSource {
+            artifact_id: artifact_id.clone(),
+            source: source.clone(),
+            path: path.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    let detected = detect_turns(&detection_sources).expect("turn detection should run");
+    // Mirror the private full-source fallback: any source without a detected turn
+    // gets a 0..0 sentinel turn covering the whole source recording.
+    let mut turns = detected;
+    for (artifact_id, source, path) in &sources {
+        let has_turn = turns
+            .iter()
+            .any(|turn| turn.artifact_id == *artifact_id && turn.source == *source);
+        if !has_turn {
+            turns.push(AudioTurn {
+                artifact_id: artifact_id.clone(),
+                source: source.clone(),
+                source_path: path.clone(),
+                start_ms: 0,
+                end_ms: 0,
+                turn_index: turns.len() as i64,
+            });
+        }
+    }
+    let turns = coalesce_turns_for_transcription(turns);
+
+    assert!(
+        turns.iter().any(|turn| turn.source == "microphone"),
+        "microphone lane must be present"
+    );
+    let system_turn = turns
+        .iter()
+        .find(|turn| turn.source == "system")
+        .expect("system lane must be present, not dropped");
+
+    // Extract the system turn exactly as the pipeline does, then normalize it into
+    // transcription-ready audio and assert it is a non-empty ~10s segment.
+    let segment_dir = dir.path().join("segments");
+    std::fs::create_dir_all(&segment_dir).expect("segment dir");
+    let covers_full_source = system_turn.end_ms <= system_turn.start_ms;
+    let raw_segment_path = if covers_full_source {
+        system_turn.source_path.clone()
+    } else {
+        let segment_path = segment_dir.join("system-turn.wav");
+        write_turn_wav(system_turn, &segment_path).expect("system turn extraction");
+        segment_path
+    };
+    let normalized_path = normalize_wav_for_transcription(
+        &raw_segment_path,
+        &segment_dir.join("system-turn-normalized.wav"),
+    )
+    .expect("system turn normalization");
+
+    let normalized_duration_ms = wav_duration_ms(&normalized_path);
+    assert!(
+        normalized_duration_ms >= 5_000,
+        "system lane should carry substantial (~10s) audio, got {normalized_duration_ms}ms"
+    );
 }


### PR DESCRIPTION
Closes JUN-178

Continuation of #569 (closed by a head-branch rename to link the platform issue — same commits, review history there: Greptile signed off 5/5 "safe to merge" on `c79631a6`).

## Summary

- Fixes hour-long meetings where both microphone.wav and system.wav exist on disk with full duration but only the microphone is transcribed (JUN-178: "system audio never gets brought into the conversation", 25-minute transcript gaps while the reporter was muted). Two upstream gates could discard the system source before the PR #563 full-source fallback ever ran.
- Gate 1: `validate_audio_artifact` now repairs stale WAV headers before reading duration, so validation judges the true recording, not a header the helper never finalized.
- Gate 2: the pre-transcription silence pre-filter now uses the same floor as system turn detection, so quiet-but-real system tracks are no longer dropped before the fallback.

## Root cause

- **Validation trusted stale WAV headers.** On a long/unhealthy capture the system-audio helper can be SIGKILLed mid-finalization (5s grace before kill). AVAudioFile only rewrites the RIFF/data chunk sizes on a clean close, so the header is left stale (smaller than the bytes actually on disk). hound's `reader.duration()` trusts that header, making an hour-long file read as minutes, which fails the `is_not_truncated` check and keeps the source out of `valid_sources` - processing proceeds mic-only. The file plays fine in tolerant players; only the header is wrong. Fix: parse the RIFF structure and, for plain or extensible 16-bit PCM, rewrite the RIFF and data size fields in place from the real byte length before duration is read; declared sizes corroborated by a valid trailing chunk are treated as authoritative and never expanded.
- **The silence pre-filter floor was stricter than the detection floor.** `drop_silent_system_sources` ran before turn detection (and before the #563 fallback) using `SILENCE_RMS_FLOOR = 0.012`, while system-source turn detection uses `min_rms = 0.006`. A system track whose loudest 30ms window sits between 0.006 and 0.012 was detectable speech to the detector but "effectively silent" to the pre-filter, so it was dropped before the fallback could cover it. Fix: derive both floors from one shared `SYSTEM_DETECTION_MIN_RMS` constant and use it for the pre-drop; the normalized-audio chunk-skip guard keeps the 0.012 floor.

## Review feedback already addressed (from #569)

- Drop path decodes each system WAV once (was twice) - Greptile.
- Header repair only expands to EOF when the declared end is not corroborated by a trailing RIFF chunk - Greptile.
- 1-hour (~110MB) test fixture shrunk to seconds - Greptile.
- Crash recovery repairs the stale header before deriving its expected duration, so the repair cannot make recovery worse - Codex, verified.
- Repair accepts WAVE_FORMAT_EXTENSIBLE 16-bit PCM, matching the live-preview parser - Codex, verified.

## Validation

- `cargo fmt` clean; `cargo clippy --all-targets` clean; full `cargo test` suite green (302 lib tests + all integration binaries, 0 failures).
- New tests: stale-small header repair, oversized-header truncation, trailing-chunk no-repair, extensible-format repair, recovery expectation repair, between-floors system source kept, truly-silent source dropped. Load-bearing tests verified to fail with the fix reverted.
- A `silent_source_dropped` session checkpoint (source + max RMS) now records any pre-filter drop for observability; a repaired header adds a non-fatal note to the validation warnings.
- Tested visually: N/A, backend-only (Rust audio processing, no UI change).
- Needs a June API (backend) deploy: no. Desktop-only change; no `/v1/*` contract touched.

## Out of scope

- The system-audio helper's stop budget (SIGTERM 5s grace before SIGKILL); this PR makes validation resilient to an unfinalized header rather than preventing it.
- The helper's realtime-thread I/O (root cause of glitchy capture, likely behind JUN-178's provider-rejected chunk at 9:28).
- The adaptive system detection threshold (only the pre-filter floor is aligned to it).
- The single provider-rejected mic chunk in JUN-178 ("could not process this audio") - separate failure mode, should be split into its own issue.

## Followups

- Give the helper a realistic stop budget or incremental header finalization so SIGKILL is survivable (prevention for Gate 1).
- Move capture-side work off the realtime IO thread (ring buffer + writer thread) - the actual glitchy-audio fix.
- Cap the adaptive detection threshold so dense speech cannot inflate its own noise floor.
- Note for #505: with this change, stale-header artifacts revalidate to their true duration, so its retry path can now recover them - JUN-178's original recording should be recoverable via Retry on a build with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
