### PR TITLE
ci: bump Homebrew tap cask on production release

### DIFF
--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -45,7 +45,9 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: open-software-network
-          repositories: os-june,os-june-releases
+          # homebrew-tap: the tap cask bump below pushes as this same release
+          # App, so the App must be installed on that repo too.
+          repositories: os-june,os-june-releases,homebrew-tap
 
       # Read the rc build manifest first (no checkout needed) to learn which
       # version + source commit to promote, then check that commit out below.
@@ -370,6 +372,54 @@ jobs:
             "$stable_build_json" \
             --repo open-software-network/os-june-releases \
             --clobber
+
+      # Keep the org tap cask (open-software-network/homebrew-tap, Casks/june.rb)
+      # pointing at the stable DMG published above; a stale tap ships users an
+      # old build, so any failure here must fail the promote loudly. Only the
+      # org tap is maintained here; the homebrew/homebrew-cask entry is bumped
+      # by BrewTestBot once that submission lands.
+      - name: Bump Homebrew tap cask
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          dmg="$RUNNER_TEMP/stable-release-assets/June_universal.dmg"
+          sha="$(shasum -a 256 "$dmg" | awk '{print $1}')"
+
+          tap_dir="$RUNNER_TEMP/homebrew-tap"
+          rm -rf "$tap_dir"
+          git clone --depth 1 \
+            "https://x-access-token:${TOKEN}@github.com/open-software-network/homebrew-tap.git" \
+            "$tap_dir"
+          cask="$tap_dir/Casks/june.rb"
+
+          # Parse before rewriting so a cask that drifted from the expected
+          # two-space `version`/`sha256` lines fails here instead of being
+          # silently left stale by a non-matching sed.
+          current_version="$(sed -n 's/^  version "\(.*\)"$/\1/p' "$cask")"
+          current_sha="$(sed -n 's/^  sha256 "\(.*\)"$/\1/p' "$cask")"
+          if [ -z "$current_version" ] || [ -z "$current_sha" ]; then
+            echo "::error::Casks/june.rb is missing the expected version/sha256 lines."
+            exit 1
+          fi
+          # Idempotent on rerun: a promote retried after the tap push already
+          # landed must not fail the whole workflow.
+          if [ "$current_version" = "$VERSION" ] && [ "$current_sha" = "$sha" ]; then
+            echo "Tap cask already at v$VERSION with matching sha256; nothing to bump."
+            exit 0
+          fi
+
+          sed -i '' \
+            -e "s/^  version \".*\"\$/  version \"$VERSION\"/" \
+            -e "s/^  sha256 \".*\"\$/  sha256 \"$sha\"/" \
+            "$cask"
+          grep -Fqx "  version \"$VERSION\"" "$cask"
+          grep -Fqx "  sha256 \"$sha\"" "$cask"
+
+          git -C "$tap_dir" config user.name "github-actions[bot]"
+          git -C "$tap_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$tap_dir" commit -am "june v$VERSION"
+          git -C "$tap_dir" push origin HEAD:main
 
       # Record the released version on main so its version files advance and the
       # next changelog can find this release. Runs only after the stable release

--- a/.github/workflows/promote-desktop.yml
+++ b/.github/workflows/promote-desktop.yml
@@ -418,7 +418,8 @@ jobs:
 
           git -C "$tap_dir" config user.name "github-actions[bot]"
           git -C "$tap_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C "$tap_dir" commit -am "june v$VERSION"
+          git -C "$tap_dir" add "$cask"
+          git -C "$tap_dir" commit -m "june v$VERSION"
           git -C "$tap_dir" push origin HEAD:main
 
       # Record the released version on main so its version files advance and the

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ in-app. It is free to start.
 - [Download for macOS](https://opensoftware.co/download/mac)
 - [All releases and changelog source](https://github.com/open-software-network/os-june-releases)
 
+If you use Homebrew, this is the recommended way to install:
+
+```sh
+brew install --cask open-software-network/tap/june
+```
+
 Windows builds cover the app shell, sign-in, microphone recording, notes, and
 the bundled agent runtime, but not global dictation paste, system audio
 capture, or the macOS sandbox. macOS is the primary target.


### PR DESCRIPTION
## What this does

- Adds a "Bump Homebrew tap cask" step to `promote-desktop.yml` (the workflow that publishes stable macOS releases; the old `production-desktop-dmg.yml` was retired in #529, so the step lives where the stable DMG is now published). After "Notarize, verify, and publish stable release assets" and before "Record released version on main", it:
  - computes the sha256 of the published `June_universal.dmg`
  - shallow-clones `open-software-network/homebrew-tap` with the release App token
  - rewrites the `version` and `sha256` lines in `Casks/june.rb`, verifying both lines exist beforehand and both rewrites landed afterwards (fails loudly otherwise, so a stale tap is visible)
  - commits as `github-actions[bot]` with message `june v$VERSION` and pushes directly to the tap's `main`
  - is idempotent: a rerun where the cask already holds this version and sha logs and exits 0
- Adds `homebrew-tap` to the release App token's `repositories:` list.
- Documents the Homebrew install path in the README Download section (`brew install --cask open-software-network/tap/june`), keeping the direct DMG link.

## Manual prerequisite

The release GitHub App (the one behind `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) must be installed on `open-software-network/homebrew-tap` with contents write access, or the token mint will fail. This is a one-time org admin action.

## Scope note

This step maintains only the org tap. The in-flight homebrew/homebrew-cask submission is handled separately; once accepted, BrewTestBot autobumps that one.

## Validation

- `actionlint` passes on the workflow.
- The cask rewrite was dry-run locally against a fresh clone of the real `Casks/june.rb`: bump rewrites both lines correctly, rerun with the same version+sha exits 0 with a log line, same version with a different sha rewrites the sha, and a cask missing the expected two-space lines fails before any write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)