### PR TITLE
Windows and Linux feature parity: system audio, meeting detection, dictation, autostart

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -240,7 +240,8 @@ jobs:
             file \
             libxdo-dev \
             libssl-dev \
-            libdbus-1-dev
+            libdbus-1-dev \
+            libpulse-dev
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -412,6 +413,7 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libdbus-1-dev \
+            libpulse-dev \
             libfuse2
 
       - name: Install uv

--- a/.github/workflows/production-desktop-linux.yml
+++ b/.github/workflows/production-desktop-linux.yml
@@ -129,6 +129,7 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libdbus-1-dev \
+            libpulse-dev \
             libfuse2
 
       - name: Install uv

--- a/bun.lock
+++ b/bun.lock
@@ -5,28 +5,30 @@
     "": {
       "name": "os-notetaker",
       "dependencies": {
-        "@tauri-apps/api": "^2.9.0",
+        "@tauri-apps/api": "^2.11.1",
+        "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-notification": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
-        "@tiptap/extension-mention": "3.23.5",
-        "@tiptap/extension-placeholder": "^3.23.5",
-        "@tiptap/pm": "3.23.5",
-        "@tiptap/react": "^3.23.5",
-        "@tiptap/starter-kit": "^3.23.5",
-        "@tiptap/suggestion": "3.23.5",
+        "@tiptap/extension-mention": "3.27.1",
+        "@tiptap/extension-placeholder": "^3.27.1",
+        "@tiptap/pm": "3.27.1",
+        "@tiptap/react": "^3.27.1",
+        "@tiptap/starter-kit": "^3.27.1",
+        "@tiptap/suggestion": "3.27.1",
         "border-beam": "^1.2.0",
         "central-icons": "npm:@central-icons-react/round-outlined-radius-3-stroke-2@1.1.233",
         "central-icons-filled": "npm:@central-icons-react/round-filled-radius-3-stroke-2@1.1.241",
-        "framer-motion": "^12.39.0",
+        "framer-motion": "^12.40.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "unicode-animations": "^1.0.3",
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2.9.0",
+        "@biomejs/biome": "2.4.16",
+        "@tauri-apps/cli": "^2.11.3",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -36,7 +38,6 @@
         "@vitest/coverage-v8": "^2.1.8",
         "agentation": "^3.0.2",
         "jsdom": "^25.0.1",
-        "prettier": "^3.4.2",
         "typescript": "^5.6.3",
         "vite": "^6.0.3",
         "vitest": "^2.1.8",
@@ -91,6 +92,24 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "7.27.1", "@babel/helper-validator-identifier": "7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -228,31 +247,33 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
-    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.2", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.2", "@tauri-apps/cli-darwin-x64": "2.11.2", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2", "@tauri-apps/cli-linux-arm64-gnu": "2.11.2", "@tauri-apps/cli-linux-arm64-musl": "2.11.2", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-gnu": "2.11.2", "@tauri-apps/cli-linux-x64-musl": "2.11.2", "@tauri-apps/cli-win32-arm64-msvc": "2.11.2", "@tauri-apps/cli-win32-ia32-msvc": "2.11.2", "@tauri-apps/cli-win32-x64-msvc": "2.11.2" }, "bin": { "tauri": "tauri.js" } }, "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw=="],
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.4", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.4", "@tauri-apps/cli-darwin-x64": "2.11.4", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4", "@tauri-apps/cli-linux-arm64-gnu": "2.11.4", "@tauri-apps/cli-linux-arm64-musl": "2.11.4", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-musl": "2.11.4", "@tauri-apps/cli-win32-arm64-msvc": "2.11.4", "@tauri-apps/cli-win32-ia32-msvc": "2.11.4", "@tauri-apps/cli-win32-x64-msvc": "2.11.4" }, "bin": { "tauri": "tauri.js" } }, "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ=="],
 
-    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w=="],
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ=="],
 
-    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg=="],
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A=="],
 
-    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.2", "", { "os": "linux", "cpu": "arm" }, "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA=="],
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.4", "", { "os": "linux", "cpu": "arm" }, "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ=="],
 
-    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw=="],
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA=="],
 
-    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw=="],
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw=="],
 
-    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.2", "", { "os": "linux", "cpu": "none" }, "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ=="],
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.4", "", { "os": "linux", "cpu": "none" }, "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ=="],
 
-    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw=="],
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ=="],
 
-    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.2", "", { "os": "linux", "cpu": "x64" }, "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw=="],
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A=="],
 
-    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA=="],
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ=="],
 
-    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA=="],
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA=="],
 
-    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
+
+    "@tauri-apps/plugin-autostart": ["@tauri-apps/plugin-autostart@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w=="],
 
     "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
 
@@ -272,67 +293,67 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": "10.4.1" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
-    "@tiptap/core": ["@tiptap/core@3.23.5", "", { "peerDependencies": { "@tiptap/pm": "3.23.5" } }, "sha512-657Xqcgf1IYWLkAmRDJKNSGdoS1AHJEgK6zHWHFJERQGIqHnwC7Fz7nvWs/NQhQVBkclQd0ERRdTCZ3XwRc1+g=="],
+    "@tiptap/core": ["@tiptap/core@3.27.1", "", { "peerDependencies": { "@tiptap/pm": "3.27.1" } }, "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ=="],
 
-    "@tiptap/extension-blockquote": ["@tiptap/extension-blockquote@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-PBQRoGfSWfIY7HmGbS5PTHEBQl5nKbild5J5phPLFF+O3aOBQ0d49AC9cxbaou/6FRCtq6g4Uqse9rRTKJRM0w=="],
+    "@tiptap/extension-blockquote": ["@tiptap/extension-blockquote@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg=="],
 
-    "@tiptap/extension-bold": ["@tiptap/extension-bold@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-DZsDCCf53fA9HmsFzfUHl5jLOwDYf+XzfP+QJjJ4cK23SsxDirameTjgnwi4l1EgEPLWunMZQjU+wHmh7vvX6Q=="],
+    "@tiptap/extension-bold": ["@tiptap/extension-bold@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ=="],
 
-    "@tiptap/extension-bubble-menu": ["@tiptap/extension-bubble-menu@3.23.5", "", { "dependencies": { "@floating-ui/dom": "1.7.6" }, "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-otcGwyVO6OfxdDPnbooZxYGrb+6q5WYmS+g2V+XGGNRn5oJgyY5pW0dqELIUJ66dosIIXXPyw2XqBDpMMY2kyQ=="],
+    "@tiptap/extension-bubble-menu": ["@tiptap/extension-bubble-menu@3.27.1", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-j/j8Qp9Z5nViade2m7zjrO/CYH/Ca80Qj7aqo0eUaei6FZQ5izlF9o4XQU5EFMAutV6mwynsPUp8FVo5sCuYfw=="],
 
-    "@tiptap/extension-bullet-list": ["@tiptap/extension-bullet-list@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-o0bzZbFvOPhPX6+RAhIFPKMIN3jIenY6Ib3FJ6ZqxTdVcjuV2mIXUmJU0uV2BwKtz73GmKSRKRKia6KJ0ml8qA=="],
+    "@tiptap/extension-bullet-list": ["@tiptap/extension-bullet-list@3.27.1", "", { "peerDependencies": { "@tiptap/extension-list": "3.27.1" } }, "sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg=="],
 
-    "@tiptap/extension-code": ["@tiptap/extension-code@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-NOJUD2Z0hrtBWnovXiiH1XtOjEQePOfIG3bNJgXSs1bWxPVhqp6KjVd8mUJNra974hxbml3tC97sL9QqjpAWFg=="],
+    "@tiptap/extension-code": ["@tiptap/extension-code@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w=="],
 
-    "@tiptap/extension-code-block": ["@tiptap/extension-code-block@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-P2XH8WPM4UahavcWoQgAwNAKQCbF/JWi6ZqgsQmVBfAqQ3mf8gMxB7HnciMq1DlyI9EfjXoJH11yUqldF/6AaQ=="],
+    "@tiptap/extension-code-block": ["@tiptap/extension-code-block@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA=="],
 
-    "@tiptap/extension-document": ["@tiptap/extension-document@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-Y7uPjEM1xIK4Spcdk/kp/vZ/Az3cEaglTCk6uHrWvNFVglEoGehNb6IQbQFZW0wjE19YoMIiLBLtG6V9dqrpBw=="],
+    "@tiptap/extension-document": ["@tiptap/extension-document@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw=="],
 
-    "@tiptap/extension-dropcursor": ["@tiptap/extension-dropcursor@3.23.5", "", { "peerDependencies": { "@tiptap/extensions": "3.23.5" } }, "sha512-l72R798Q69D6f89Vp9xreoRnPcpK0LHPKLZIc6pvqBC2iOjx5wLKtW0uP1uqVWdQtvF5AUYBRNIGAQ5Gel9XEg=="],
+    "@tiptap/extension-dropcursor": ["@tiptap/extension-dropcursor@3.27.1", "", { "peerDependencies": { "@tiptap/extensions": "3.27.1" } }, "sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ=="],
 
-    "@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@3.23.5", "", { "peerDependencies": { "@floating-ui/dom": "1.7.6", "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-kP0bZKH/lxNogfvoIy/YJZ5gkty0OwqFVtQUwoc85vXYUfvy5Jh1VdO053tCE1iDzmvOITUpcb+MdWryP8dBxA=="],
+    "@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@3.27.1", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-BmJF1VqB7dSJkgAalrpVFj88WLhxKjcWPuWHOqf2ITrUU2832BhKLXKmxjWUy1gqV8PfNNVWtGfIERy7I0y0+Q=="],
 
-    "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.23.5", "", { "peerDependencies": { "@tiptap/extensions": "3.23.5" } }, "sha512-x9XlYG26TowX0Ly1w0ZV2D8qliyQy9fTmMY4suI6B/6o6m/sXHGTAJMmJqwP66sZKF6cMLU3HECumhtyQxPT2g=="],
+    "@tiptap/extension-gapcursor": ["@tiptap/extension-gapcursor@3.27.1", "", { "peerDependencies": { "@tiptap/extensions": "3.27.1" } }, "sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ=="],
 
-    "@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-j/BDBMOA1mA+RhCx622SRPBhpp2XWNFYz9asbg8T3yk8v9WI3Vjo6IDlfTp6fwsR2LGE7Pek3R0xDAjW6yVG3g=="],
+    "@tiptap/extension-hard-break": ["@tiptap/extension-hard-break@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ=="],
 
-    "@tiptap/extension-heading": ["@tiptap/extension-heading@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-tFI+iYk34geacVOGqYgyoC8siQjdGn605XaYSZcGRFF8NY+HrGlLkQi2QRRCeLaUhxoctONmWc8USn3H5U7wLQ=="],
+    "@tiptap/extension-heading": ["@tiptap/extension-heading@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg=="],
 
-    "@tiptap/extension-horizontal-rule": ["@tiptap/extension-horizontal-rule@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-9XkRYc4XE0stERZB3y8bsJd32Jw9UZfMwZXo1GLNYRHFr7dmhSGUj0IzgofqOVmLDcOMW6XcCk54TBYw6BCrWA=="],
+    "@tiptap/extension-horizontal-rule": ["@tiptap/extension-horizontal-rule@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg=="],
 
-    "@tiptap/extension-italic": ["@tiptap/extension-italic@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-XjRSPr6j4mz+8O5j5KNfxVb+1fGNt0wr+js6MLxxGdU7M+PoDPdVY6fARbmBazv4ERlZ5PNS9m35Vo5xDjDfrg=="],
+    "@tiptap/extension-italic": ["@tiptap/extension-italic@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA=="],
 
-    "@tiptap/extension-link": ["@tiptap/extension-link@3.23.5", "", { "dependencies": { "linkifyjs": "4.3.3" }, "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-FEI58NAPnauBbs4nw1dkgRyEhcWnure0vIlStfQoQGXxj3xSRvxKH2lOkz54fGzuzRJAoudyLU65HW6D7kc+8Q=="],
+    "@tiptap/extension-link": ["@tiptap/extension-link@3.27.1", "", { "dependencies": { "linkifyjs": "^4.3.3" }, "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g=="],
 
-    "@tiptap/extension-list": ["@tiptap/extension-list@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-nzZXpVwnyKwTj4TVyPyu1bCUFjJCsaXnhAthmvJDnX3RBtemNG9Ka07xGR2NIspzumSbQSMFtDxjmxv3W5dEtg=="],
+    "@tiptap/extension-list": ["@tiptap/extension-list@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ=="],
 
-    "@tiptap/extension-list-item": ["@tiptap/extension-list-item@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-l7Hb4rfNIkO6JrNJYkdXap6QYXCz4XeeFmI1bfQgEiwPGs+RAn/+0cOdg7q+6MmtZFac5uSXV0PftPk6A0GsEA=="],
+    "@tiptap/extension-list-item": ["@tiptap/extension-list-item@3.27.1", "", { "peerDependencies": { "@tiptap/extension-list": "3.27.1" } }, "sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA=="],
 
-    "@tiptap/extension-list-keymap": ["@tiptap/extension-list-keymap@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-Hz8jRA51VSiHezEkwqwaMYbTEYcR/5Aq3UgCgDlNPlE6k1OZrvRtV/4s3AOO0RRgzyVLKv7yv7KuOJN/OLGErw=="],
+    "@tiptap/extension-list-keymap": ["@tiptap/extension-list-keymap@3.27.1", "", { "peerDependencies": { "@tiptap/extension-list": "3.27.1" } }, "sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig=="],
 
-    "@tiptap/extension-mention": ["@tiptap/extension-mention@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5", "@tiptap/suggestion": "3.23.5" } }, "sha512-SI6cx7G5ZQXEcYmNb7OVzVmhbUdBM4IGH1MU68oB2V9Cbi2OdhXYmG04N37FzsSPDeFDNwCZM9BW6TWYh9xKRg=="],
+    "@tiptap/extension-mention": ["@tiptap/extension-mention@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1", "@tiptap/suggestion": "3.27.1" } }, "sha512-QfaKdl8PET01JvEFrIjMcOC1iYrBm2tsZEn07J1AaCqClW9iWcg/nCAdkdFhVir1fC54SLuaui43xslBawQRFg=="],
 
-    "@tiptap/extension-ordered-list": ["@tiptap/extension-ordered-list@3.23.5", "", { "peerDependencies": { "@tiptap/extension-list": "3.23.5" } }, "sha512-qQeU71ij0cAAD9bbGqot5T5bpR3dysgQ+W67quRs6VDyusU89EYaJHKn/qWU6a1XOEQ4sL+5GNw52FYQVHUxbA=="],
+    "@tiptap/extension-ordered-list": ["@tiptap/extension-ordered-list@3.27.1", "", { "peerDependencies": { "@tiptap/extension-list": "3.27.1" } }, "sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA=="],
 
-    "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-LtgMcR1rvWnZDtphFJ/LBltlC0+6HGA07k7vhy+U7P/zIg/V3Fb4RD6YDuAo0cPfBsLm8p1WYJV92WpAsGgtlg=="],
+    "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q=="],
 
-    "@tiptap/extension-placeholder": ["@tiptap/extension-placeholder@3.23.5", "", { "peerDependencies": { "@tiptap/extensions": "3.23.5" } }, "sha512-B2snUujc6fb/16p8jSQCN4+mto7RlHKLm8quBTUWXksY8D82u/cxjUdmRQ7ueq7vsbRsA+WoJTrKEjJ8RQOpjw=="],
+    "@tiptap/extension-placeholder": ["@tiptap/extension-placeholder@3.27.1", "", { "peerDependencies": { "@tiptap/extensions": "3.27.1" } }, "sha512-lhcNDcczQ75yJOSywCHb58Hmtg1aPL/2TdYmeLPxVrP048D7rRs133sfONcgyyw0AvhnfmPOkHLTv3QtKSowhw=="],
 
-    "@tiptap/extension-strike": ["@tiptap/extension-strike@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-PMB9lpQGOJGuRTIS9rBw8UZtHQwmsiJbWKjcBr5z20MluaJQ3ZCHFhDYG6ncIDRz+0ny4ZvoJ7cKGpI+NTvXMA=="],
+    "@tiptap/extension-strike": ["@tiptap/extension-strike@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q=="],
 
-    "@tiptap/extension-text": ["@tiptap/extension-text@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-GLa+AaA2NC5XYRZad/Qq/oH5Pa95s+uA17J7+RCkF8j1RNREUBkYQ5CD5MT8kT+D3DHgU8MRyYdTd28I46HBDQ=="],
+    "@tiptap/extension-text": ["@tiptap/extension-text@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg=="],
 
-    "@tiptap/extension-underline": ["@tiptap/extension-underline@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5" } }, "sha512-fyxthzE6CNCi9a9OVAwXs1sSyJ7jlrzT3aP2KhYLQCsJABHaPJgJA7k52/CRuKqCW3WbxU1ULH9LGuGtBbhEyw=="],
+    "@tiptap/extension-underline": ["@tiptap/extension-underline@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ=="],
 
-    "@tiptap/extensions": ["@tiptap/extensions@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-ROcdNPV+buzldEFKvD3o29P7H7zpAf2lnLfndO2LHSToWyHw4hlzVPCeAU8uAvhl/jyfeUoFLrBwxphMX/KG6A=="],
+    "@tiptap/extensions": ["@tiptap/extensions@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw=="],
 
-    "@tiptap/pm": ["@tiptap/pm@3.23.5", "", { "dependencies": { "prosemirror-changeset": "2.4.1", "prosemirror-commands": "1.7.1", "prosemirror-dropcursor": "1.8.2", "prosemirror-gapcursor": "1.4.1", "prosemirror-history": "1.5.0", "prosemirror-keymap": "1.2.3", "prosemirror-model": "1.25.7", "prosemirror-schema-list": "1.5.1", "prosemirror-state": "1.4.4", "prosemirror-tables": "1.8.5", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8" } }, "sha512-9tgLdpTvNN0/fLP4RcNzbyQ0qjg9J2ahaFbQzgV5uvd+QMy8Xkg2IqKKnOoJJUAV3FDjGq3Yx0WrV2BGro9pfw=="],
+    "@tiptap/pm": ["@tiptap/pm@3.27.1", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.7", "prosemirror-schema-list": "^1.5.0", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.0", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8" } }, "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw=="],
 
-    "@tiptap/react": ["@tiptap/react@3.23.5", "", { "dependencies": { "@types/use-sync-external-store": "0.0.6", "fast-equals": "5.4.0", "use-sync-external-store": "1.6.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "3.23.5", "@tiptap/extension-floating-menu": "3.23.5" }, "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5", "@types/react": "18.3.28", "@types/react-dom": "18.3.7", "react": "18.3.1", "react-dom": "18.3.1" } }, "sha512-aEdKfJxoa6tCEV4FrnBqMQoUPwGcTWLaDzmP4fL1gR7E40rYDTiYNKoF1Ob+UimUpguAP6Emv1WlJa5oyI8FSw=="],
+    "@tiptap/react": ["@tiptap/react@3.27.1", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.27.1", "@tiptap/extension-floating-menu": "^3.27.1" }, "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/Wn2fc9zMtX08MXYScDFsm4wJ8lzfhfPEdbtls7WCDlbtrop48PWlkHDBBJrywARfAQTB2mFs9KiFy9yrQm5Lg=="],
 
-    "@tiptap/starter-kit": ["@tiptap/starter-kit@3.23.5", "", { "dependencies": { "@tiptap/core": "3.23.5", "@tiptap/extension-blockquote": "3.23.5", "@tiptap/extension-bold": "3.23.5", "@tiptap/extension-bullet-list": "3.23.5", "@tiptap/extension-code": "3.23.5", "@tiptap/extension-code-block": "3.23.5", "@tiptap/extension-document": "3.23.5", "@tiptap/extension-dropcursor": "3.23.5", "@tiptap/extension-gapcursor": "3.23.5", "@tiptap/extension-hard-break": "3.23.5", "@tiptap/extension-heading": "3.23.5", "@tiptap/extension-horizontal-rule": "3.23.5", "@tiptap/extension-italic": "3.23.5", "@tiptap/extension-link": "3.23.5", "@tiptap/extension-list": "3.23.5", "@tiptap/extension-list-item": "3.23.5", "@tiptap/extension-list-keymap": "3.23.5", "@tiptap/extension-ordered-list": "3.23.5", "@tiptap/extension-paragraph": "3.23.5", "@tiptap/extension-strike": "3.23.5", "@tiptap/extension-text": "3.23.5", "@tiptap/extension-underline": "3.23.5", "@tiptap/extensions": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-ac0edQ1a1nYkNAzOgdqIBKGdrOlNQpPP9wGAG3Q9EgTq4+C4/EftJZZJmUn3KzaSOUv4cLEDo0z0jurJvZPkaw=="],
+    "@tiptap/starter-kit": ["@tiptap/starter-kit@3.27.1", "", { "dependencies": { "@tiptap/core": "^3.27.1", "@tiptap/extension-blockquote": "^3.27.1", "@tiptap/extension-bold": "^3.27.1", "@tiptap/extension-bullet-list": "^3.27.1", "@tiptap/extension-code": "^3.27.1", "@tiptap/extension-code-block": "^3.27.1", "@tiptap/extension-document": "^3.27.1", "@tiptap/extension-dropcursor": "^3.27.1", "@tiptap/extension-gapcursor": "^3.27.1", "@tiptap/extension-hard-break": "^3.27.1", "@tiptap/extension-heading": "^3.27.1", "@tiptap/extension-horizontal-rule": "^3.27.1", "@tiptap/extension-italic": "^3.27.1", "@tiptap/extension-link": "^3.27.1", "@tiptap/extension-list": "^3.27.1", "@tiptap/extension-list-item": "^3.27.1", "@tiptap/extension-list-keymap": "^3.27.1", "@tiptap/extension-ordered-list": "^3.27.1", "@tiptap/extension-paragraph": "^3.27.1", "@tiptap/extension-strike": "^3.27.1", "@tiptap/extension-text": "^3.27.1", "@tiptap/extension-underline": "^3.27.1", "@tiptap/extensions": "^3.27.1", "@tiptap/pm": "^3.27.1" } }, "sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow=="],
 
-    "@tiptap/suggestion": ["@tiptap/suggestion@3.23.5", "", { "peerDependencies": { "@tiptap/core": "3.23.5", "@tiptap/pm": "3.23.5" } }, "sha512-m5QoCs4IZqxTnDTJkNYm14Y3UFpJPZzUjS2APXpx9+wxaoo1q0SZ6fXardUgQET1wCJeUrsu73mvEnlK8mmuog=="],
+    "@tiptap/suggestion": ["@tiptap/suggestion@3.27.1", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
@@ -476,7 +497,7 @@
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "0.4.0", "combined-stream": "1.0.8", "es-set-tostringtag": "2.1.0", "hasown": "2.0.3", "mime-types": "2.1.35" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
-    "framer-motion": ["framer-motion@12.39.0", "", { "dependencies": { "motion-dom": "12.39.0", "motion-utils": "12.39.0", "tslib": "2.8.1" }, "optionalDependencies": { "react": "18.3.1", "react-dom": "18.3.1" } }, "sha512-+vnLfzrv0MzjLzNl+nvNvR7jdg3q4cxxjz/YvzfifHl0TREtL00cs1RoMTxs+1PzLiEqZGV6gYsBY0oEAYZ24w=="],
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -564,7 +585,7 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "motion-dom": ["motion-dom@12.39.0", "", { "dependencies": { "motion-utils": "12.39.0" } }, "sha512-Xn7aAcGDhco/JZTXOub64UmaYn73C6J1Po7Fk+8EvkJsNGTqfhon6UJY53vJKXW5v5Zl8HrYsVxv6oPXeGoGLQ=="],
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
 
     "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
@@ -596,8 +617,6 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "3.3.12", "picocolors": "1.1.1", "source-map-js": "1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
-
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "5.0.1", "ansi-styles": "5.2.0", "react-is": "17.0.2" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "prosemirror-changeset": ["prosemirror-changeset@2.4.1", "", { "dependencies": { "prosemirror-transform": "1.12.0" } }, "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw=="],
@@ -609,6 +628,8 @@
     "prosemirror-gapcursor": ["prosemirror-gapcursor@1.4.1", "", { "dependencies": { "prosemirror-keymap": "1.2.3", "prosemirror-model": "1.25.7", "prosemirror-state": "1.4.4", "prosemirror-view": "1.41.8" } }, "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw=="],
 
     "prosemirror-history": ["prosemirror-history@1.5.0", "", { "dependencies": { "prosemirror-state": "1.4.4", "prosemirror-transform": "1.12.0", "prosemirror-view": "1.41.8", "rope-sequence": "1.3.4" } }, "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg=="],
+
+    "prosemirror-inputrules": ["prosemirror-inputrules@1.5.1", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.0.0" } }, "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw=="],
 
     "prosemirror-keymap": ["prosemirror-keymap@1.2.3", "", { "dependencies": { "prosemirror-state": "1.4.4", "w3c-keyname": "2.2.8" } }, "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw=="],
 
@@ -745,6 +766,16 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@tauri-apps/plugin-deep-link/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-dialog/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-notification/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-process/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-updater/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-notification": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-autostart':
+        specifier: ^2.5.1
+        version: 2.5.1
       '@tauri-apps/plugin-deep-link':
         specifier: ^2.4.9
         version: 2.4.9
@@ -846,6 +849,9 @@ packages:
     resolution: {integrity: sha512-EElQe8z8uD7Pi5++tJ/UfEwWuK08rd3oCDYdeIbJAb6pZRrxlqmoF5gh5H5YvzmUPhS4IRCaLSsQhvWkrfK+GQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
@@ -2528,6 +2534,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.3
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.3
       '@tauri-apps/cli-win32-x64-msvc': 2.11.3
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-deep-link@2.4.9':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -265,6 +265,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,11 +978,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -982,7 +1013,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1130,7 +1161,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3061,6 +3092,7 @@ dependencies = [
  "sqlx-sqlite",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
@@ -3554,6 +3586,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4584,7 +4627,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4636,7 +4679,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4704,6 +4747,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4821,7 +4878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5351,7 +5408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6334,6 +6391,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6452,7 +6518,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2381,6 +2381,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "libpulse-binding"
+version = "2.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libpulse-sys",
+ "num-derive",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "libpulse-simple-binding"
+version = "2.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bebef0381c8e3e4b23cc24aaf36fab37472bece128de96f6a111efa464cfef"
+dependencies = [
+ "libpulse-binding",
+ "libpulse-simple-sys",
+ "libpulse-sys",
+]
+
+[[package]]
+name = "libpulse-simple-sys"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd96888fe37ad270d16abf5e82cccca1424871cf6afa2861824d2a52758eebc"
+dependencies = [
+ "libpulse-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libpulse-sys"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74371848b22e989f829cc1621d2ebd74960711557d8b45cfe740f60d0a05e61"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3096,8 @@ dependencies = [
  "dotenvy",
  "hound",
  "keyring",
+ "libpulse-binding",
+ "libpulse-simple-binding",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3074,6 +3074,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "window-vibrancy",
+ "windows 0.61.3",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -85,6 +85,14 @@ keyring = { version = "3", features = ["windows-native"] }
 # with a Secret Service has libdbus (it is the transport), so the AppImage
 # follows the standard exclude list and does not ship it.
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+# System-audio capture on Linux records the default sink's monitor source
+# through libpulse. These bindings dynamically link the system libpulse
+# (`libpulse.so.0` + `libpulse-simple.so.0`), which every PulseAudio and
+# PipeWire (via pipewire-pulse) desktop ships, so this works on both. Build
+# hosts need `libpulse-dev`; the AppImage relies on the runtime library from the
+# host (libpulse is on the linuxdeploy exclude list, so it is not bundled).
+libpulse-binding = "2.30"
+libpulse-simple-binding = "2.29"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,13 +78,19 @@ window-vibrancy = "0.6"
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
 # Meeting detection enumerates active WASAPI capture sessions (see
-# meeting_detection.rs). Keep the feature set minimal: WASAPI session APIs,
-# COM bootstrap, base handles, and pid -> executable name resolution.
+# meeting_detection.rs). Dictation (dictation/win.rs) adds the low-level
+# keyboard hook + message pump (WindowsAndMessaging), synthetic Ctrl+V and
+# key-state queries (Input_KeyboardAndMouse), and the clipboard round-trip
+# (DataExchange + Memory). Keep the feature set minimal.
 windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Media_Audio",
     "Win32_System_Com",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
     "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ sha2 = "0.10"
 sqlx = { package = "sqlx-core", version = "0.8", default-features = false, features = ["_rt-tokio", "chrono", "uuid"] }
 sqlx-sqlite = { version = "0.8", default-features = false, features = ["bundled", "chrono", "uuid"] }
 tauri = { version = "2.8.0", features = ["protocol-asset", "macos-private-api", "tray-icon", "image-png"] }
+tauri-plugin-autostart = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,6 +76,15 @@ window-vibrancy = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
+# Meeting detection enumerates active WASAPI capture sessions (see
+# meeting_detection.rs). Keep the feature set minimal: WASAPI session APIs,
+# COM bootstrap, base handles, and pid -> executable name resolution.
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Media_Audio",
+    "Win32_System_Com",
+    "Win32_System_Threading",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Secret Service is the only Linux keyring store that survives a reboot; the

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -9,6 +9,9 @@
     "deep-link:default",
     "notification:default",
     "dialog:allow-open",
-    "process:allow-restart"
+    "process:allow-restart",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -5,7 +5,7 @@ use crate::{
             start_live_transcript_preview, start_system_live_transcript_preview,
             LivePreviewController, LivePreviewSink, SystemLivePreviewController,
         },
-        system_macos::SystemAudioCapture,
+        SystemAudioCapture,
     },
     domain::types::{
         AppError, AudioLevelDto, RecordingSessionDto, RecordingSource, RecordingSourceMode,

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,7 +1,29 @@
 pub mod capture;
 pub mod live_preview;
 pub mod recovery;
-pub mod system_macos;
 pub mod turns;
 pub mod validation;
 pub mod waveform;
+
+// Per-platform system-audio backends. Each exposes the same `SystemAudioCapture`
+// type plus `system_audio_readiness` / `helper_permission_check`, re-exported
+// below under one path so `capture.rs` and `commands.rs` are platform agnostic.
+// A Linux backend slots in here the same way: add `mod system_linux;` gated on
+// `target_os = "linux"`, re-export it, and narrow the stub's `cfg`.
+#[cfg(target_os = "macos")]
+mod system_macos;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod system_stub;
+#[cfg(target_os = "windows")]
+mod system_windows;
+
+// Shared wall-clock alignment / level math for the non-macOS backends. Compiled
+// on every host so its cross-platform unit tests run under the macOS CI gate.
+mod system_timeline;
+
+#[cfg(target_os = "macos")]
+pub use system_macos::{helper_permission_check, system_audio_readiness, SystemAudioCapture};
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub use system_stub::{helper_permission_check, system_audio_readiness, SystemAudioCapture};
+#[cfg(target_os = "windows")]
+pub use system_windows::{helper_permission_check, system_audio_readiness, SystemAudioCapture};

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,7 +1,26 @@
 pub mod capture;
 pub mod live_preview;
 pub mod recovery;
-pub mod system_macos;
 pub mod turns;
 pub mod validation;
 pub mod waveform;
+
+// System-audio capture has a platform-specific backend. Each backend exposes the
+// same public surface (`SystemAudioCapture`, `system_audio_readiness`,
+// `helper_permission_check`) and is re-exported under the stable `system_macos`
+// path that `audio::capture` and `commands` already import, so the consumers
+// stay platform-agnostic and untouched. A parallel change adds a
+// `system_windows` backend the same way; the arms below stay independent so the
+// branches merge cleanly.
+#[cfg(target_os = "macos")]
+pub mod system_macos;
+
+#[cfg(target_os = "linux")]
+pub mod system_linux;
+#[cfg(target_os = "linux")]
+pub use system_linux as system_macos;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub mod system_unsupported;
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub use system_unsupported as system_macos;

--- a/src-tauri/src/audio/system_linux.rs
+++ b/src-tauri/src/audio/system_linux.rs
@@ -1,0 +1,683 @@
+//! Linux system-audio capture.
+//!
+//! June records what the meeting participants hear by capturing the default
+//! sink's *monitor* source through the PulseAudio client API. libpulse is the
+//! pragmatic universal choice: it links `libpulse.so.0` / `libpulse-simple.so.0`
+//! which every desktop ships, and it works natively on PipeWire desktops via
+//! the `pipewire-pulse` compatibility server as well as on legacy PulseAudio.
+//! Capturing a monitor source requires no OS-level permission, unlike the macOS
+//! process-tap path.
+//!
+//! The observable behavior mirrors the macOS helper
+//! (`native/mac-system-audio-recorder/main.swift`): the system track is
+//! wall-clock aligned with the separately recorded microphone track. A
+//! `timeline_offset` of silence is written at the start, and alignment is kept
+//! across pause/resume by filling any drift with silence (paused spans are
+//! excluded from the timeline, exactly like `writeTimelineSilenceIfNeeded`).
+//!
+//! The public surface matches `system_macos`:
+//! `SystemAudioCapture::{start, pause, resume, status, stop}`,
+//! `system_audio_readiness`, and `helper_permission_check`.
+
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use hound::{SampleFormat, WavSpec, WavWriter};
+use libpulse_binding::{
+    callbacks::ListResult,
+    context::{Context, FlagSet, State as ContextState},
+    mainloop::standard::{IterateResult, Mainloop},
+    operation::{Operation, State as OperationState},
+    sample::{Format, Spec},
+    stream::Direction,
+};
+use libpulse_simple_binding::Simple;
+use std::{
+    cell::RefCell,
+    collections::VecDeque,
+    fs::File,
+    io::BufWriter,
+    path::PathBuf,
+    rc::Rc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc, Mutex,
+    },
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+/// We request a fixed, universally supported capture spec and let PulseAudio /
+/// PipeWire resample from the sink's native format. Transcription resamples
+/// again downstream, and it only requires signed 16-bit PCM.
+const CAPTURE_SAMPLE_RATE: u32 = 48_000;
+const CAPTURE_CHANNELS: u8 = 2;
+/// 10 ms read granularity: small enough to keep `stop()` latency and the live
+/// meter responsive, large enough to avoid excessive syscalls.
+const READ_CHUNK_FRAMES: usize = (CAPTURE_SAMPLE_RATE as usize) / 100;
+/// Rolling window of recent per-chunk peaks, matching the microphone path.
+const RECENT_PEAKS_CAP: usize = 24;
+/// Only fill silence once drift exceeds ~80 ms, matching the macOS helper.
+const ALIGNMENT_TOLERANCE_SECS: f64 = 0.08;
+const CONNECT_BUDGET: Duration = Duration::from_secs(5);
+const OPERATION_BUDGET: Duration = Duration::from_secs(5);
+const START_TIMEOUT: Duration = Duration::from_secs(10);
+/// How often the WAV header is refreshed so the partial file stays readable.
+const FLUSH_INTERVAL: Duration = Duration::from_millis(500);
+/// Optional override to pin a specific PulseAudio source (e.g. a particular
+/// sink monitor). Handy when the default sink changes (Bluetooth switching) or
+/// for deterministic testing. When unset, the default sink monitor is used.
+const SOURCE_OVERRIDE_ENV: &str = "JUNE_SYSTEM_AUDIO_SOURCE";
+
+type WavFileWriter = WavWriter<BufWriter<File>>;
+
+#[derive(Debug, Clone)]
+struct MonitorSource {
+    name: String,
+}
+
+#[derive(Default)]
+struct CaptureStats {
+    peak: f32,
+    sum_square: f64,
+    samples: u64,
+    recent_peaks: VecDeque<f32>,
+    bytes_written: i64,
+    last_error: Option<String>,
+}
+
+struct Shared {
+    paused: AtomicBool,
+    stop: AtomicBool,
+    stats: Mutex<CaptureStats>,
+}
+
+pub struct SystemAudioCapture {
+    partial_path: PathBuf,
+    final_path: PathBuf,
+    shared: Arc<Shared>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SystemAudioCapture {
+    pub fn start(
+        partial_path: PathBuf,
+        final_path: PathBuf,
+        timeline_offset: Duration,
+    ) -> Result<Self, AppError> {
+        let monitor = probe_monitor_source()
+            .map_err(|message| AppError::new("system_audio_capture_unavailable", message))?;
+
+        if let Some(parent) = partial_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                AppError::new("system_audio_capture_unavailable", error.to_string())
+            })?;
+        }
+        let spec = WavSpec {
+            channels: CAPTURE_CHANNELS as u16,
+            sample_rate: CAPTURE_SAMPLE_RATE,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let writer = WavWriter::create(&partial_path, spec).map_err(|error| {
+            AppError::new("system_audio_capture_unavailable", error.to_string())
+        })?;
+
+        let shared = Arc::new(Shared {
+            paused: AtomicBool::new(false),
+            stop: AtomicBool::new(false),
+            stats: Mutex::new(CaptureStats::default()),
+        });
+        let thread_shared = Arc::clone(&shared);
+        let source_name = monitor.name.clone();
+        let (ready_tx, ready_rx) = mpsc::channel::<Result<(), AppError>>();
+
+        let handle = std::thread::Builder::new()
+            .name("june-system-audio".to_string())
+            .spawn(move || {
+                capture_loop(
+                    source_name,
+                    writer,
+                    thread_shared,
+                    timeline_offset,
+                    ready_tx,
+                );
+            })
+            .map_err(|error| {
+                AppError::new("system_audio_capture_unavailable", error.to_string())
+            })?;
+
+        // The capture thread opens the PulseAudio stream, then reports the
+        // outcome so `start()` can return the real error synchronously.
+        match ready_rx.recv_timeout(START_TIMEOUT) {
+            Ok(Ok(())) => Ok(Self {
+                partial_path,
+                final_path,
+                shared,
+                handle: Some(handle),
+            }),
+            Ok(Err(error)) => {
+                shared.stop.store(true, Ordering::Release);
+                let _ = handle.join();
+                let _ = std::fs::remove_file(&partial_path);
+                Err(error)
+            }
+            Err(_) => {
+                shared.stop.store(true, Ordering::Release);
+                let _ = handle.join();
+                let _ = std::fs::remove_file(&partial_path);
+                Err(AppError::new(
+                    "system_audio_capture_unavailable",
+                    format!(
+                        "Timed out opening the PulseAudio monitor source '{}'.",
+                        monitor.name
+                    ),
+                ))
+            }
+        }
+    }
+
+    pub fn pause(&mut self) {
+        self.shared.paused.store(true, Ordering::Release);
+    }
+
+    pub fn resume(&mut self) {
+        self.shared.paused.store(false, Ordering::Release);
+    }
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        let Ok(stats) = self.shared.stats.lock() else {
+            return (AudioLevelDto::default(), 0, None);
+        };
+        let rms = if stats.samples == 0 {
+            0.0
+        } else {
+            (stats.sum_square / stats.samples as f64).sqrt() as f32
+        };
+        let level = AudioLevelDto {
+            peak: stats.peak,
+            rms,
+            recent_peaks: stats.recent_peaks.iter().copied().collect(),
+        };
+        (level, stats.bytes_written, stats.last_error.clone())
+    }
+
+    pub fn stop(mut self) -> Result<PathBuf, AppError> {
+        self.shared.stop.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            // The thread finalizes the WAV (writes the real header sizes) before
+            // it exits, so the file is complete once the join returns.
+            let _ = handle.join();
+        }
+        if self.partial_path.exists() {
+            std::fs::rename(&self.partial_path, &self.final_path)
+                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        }
+        Ok(self.final_path.clone())
+    }
+}
+
+impl Drop for SystemAudioCapture {
+    fn drop(&mut self) {
+        // Guard against a capture being dropped without `stop()`: never leave the
+        // recording thread (and its PulseAudio stream) running in the background.
+        self.shared.stop.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Records the monitor source to `writer`, keeping the file wall-clock aligned.
+///
+/// Runs on a dedicated thread. It reports the outcome of opening the PulseAudio
+/// stream through `ready_tx`, then loops reading fixed-size chunks. It finalizes
+/// the WAV before returning so `stop()` only has to rename the file.
+fn capture_loop(
+    source_name: String,
+    mut writer: WavFileWriter,
+    shared: Arc<Shared>,
+    timeline_offset: Duration,
+    ready_tx: mpsc::Sender<Result<(), AppError>>,
+) {
+    let spec = Spec {
+        format: Format::S16le,
+        rate: CAPTURE_SAMPLE_RATE,
+        channels: CAPTURE_CHANNELS,
+    };
+    if !spec.is_valid() {
+        let _ = ready_tx.send(Err(AppError::new(
+            "system_audio_capture_unavailable",
+            "Invalid PulseAudio capture specification.",
+        )));
+        return;
+    }
+
+    let simple = match Simple::new(
+        None,
+        "June",
+        Direction::Record,
+        Some(source_name.as_str()),
+        "System audio",
+        &spec,
+        None,
+        None,
+    ) {
+        Ok(simple) => simple,
+        Err(error) => {
+            let _ = ready_tx.send(Err(AppError::new(
+                "system_audio_capture_unavailable",
+                format!("Could not open PulseAudio monitor source '{source_name}': {error}"),
+            )));
+            return;
+        }
+    };
+    let _ = ready_tx.send(Ok(()));
+    drop(ready_tx);
+
+    let channels = CAPTURE_CHANNELS as usize;
+    let bytes_per_frame = 2 * channels;
+    let mut buffer = vec![0u8; READ_CHUNK_FRAMES * bytes_per_frame];
+
+    // Discard whatever the server buffered between connecting the stream and the
+    // first read. Without this the loop would drain that pre-roll faster than
+    // real time and the track would run ahead of the wall clock (unlike the
+    // real-time macOS tap). After the flush, monitor delivery is real-time paced,
+    // so `origin` marks a clean timeline start.
+    let _ = simple.flush();
+
+    // Wall-clock alignment bookkeeping, mirroring the macOS helper:
+    // `active_elapsed = timeline_offset + since(origin) - paused_time`.
+    let origin = Instant::now();
+    let mut accumulated_paused = Duration::ZERO;
+    let mut pause_started: Option<Instant> = None;
+    let mut frames_written: u64 = 0;
+    // Periodically flush the WAV header so the partial file stays readable while
+    // recording: `audio::capture` streams the live transcript preview off
+    // `system.partial.wav`, and recovery snapshots read it too.
+    let mut last_flush = Instant::now();
+
+    loop {
+        if shared.stop.load(Ordering::Acquire) {
+            break;
+        }
+
+        let is_paused = shared.paused.load(Ordering::Acquire);
+        match (is_paused, pause_started) {
+            (true, None) => pause_started = Some(Instant::now()),
+            (false, Some(started)) => {
+                accumulated_paused += started.elapsed();
+                pause_started = None;
+            }
+            _ => {}
+        }
+
+        // Always drain the monitor source so the server-side buffer never
+        // overruns. Monitor sources deliver silence frames continuously, so this
+        // read returns roughly every chunk period even when nothing is playing.
+        if let Err(error) = simple.read(&mut buffer) {
+            record_error(&shared, format!("PulseAudio read failed: {error}"));
+            break;
+        }
+
+        if is_paused {
+            // Skip writing while paused. `accumulated_paused` grows so the paused
+            // span is excluded from the timeline, keeping alignment on resume.
+            continue;
+        }
+
+        let frames_in = READ_CHUNK_FRAMES as u64;
+        let active_elapsed = active_elapsed_secs(timeline_offset, origin, accumulated_paused, None);
+        match fill_alignment_silence(
+            &mut writer,
+            &shared,
+            active_elapsed,
+            frames_written,
+            frames_in,
+            channels,
+        ) {
+            Ok(filled) => frames_written += filled,
+            Err(error) => {
+                record_error(
+                    &shared,
+                    format!("Failed to write system audio silence: {error}"),
+                );
+                break;
+            }
+        }
+        if let Err(error) = write_chunk(&mut writer, &shared, &buffer) {
+            record_error(
+                &shared,
+                format!("Failed to write system audio samples: {error}"),
+            );
+            break;
+        }
+        frames_written += frames_in;
+
+        if last_flush.elapsed() >= FLUSH_INTERVAL {
+            let _ = writer.flush();
+            last_flush = Instant::now();
+        }
+    }
+
+    // Pad to the current active wall-clock like the macOS helper's
+    // `flushTimelineSilenceToNow()` on stop, so the track length reflects the
+    // full recording window.
+    let active_elapsed =
+        active_elapsed_secs(timeline_offset, origin, accumulated_paused, pause_started);
+    let _ = fill_alignment_silence(
+        &mut writer,
+        &shared,
+        active_elapsed,
+        frames_written,
+        0,
+        channels,
+    );
+
+    if let Err(error) = writer.finalize() {
+        record_error(
+            &shared,
+            format!("Failed to finalize system audio WAV: {error}"),
+        );
+    }
+}
+
+fn active_elapsed_secs(
+    timeline_offset: Duration,
+    origin: Instant,
+    accumulated_paused: Duration,
+    pause_started: Option<Instant>,
+) -> f64 {
+    let active_pause = pause_started
+        .map(|started| started.elapsed())
+        .unwrap_or_default();
+    (timeline_offset.as_secs_f64() + origin.elapsed().as_secs_f64())
+        - accumulated_paused.as_secs_f64()
+        - active_pause.as_secs_f64()
+}
+
+/// Writes leading/drift silence so the file tracks wall-clock time, returning the
+/// number of silence frames written. Mirrors `writeTimelineSilenceIfNeeded`:
+/// only fills once the gap exceeds the tolerance, then closes the whole gap.
+fn fill_alignment_silence(
+    writer: &mut WavFileWriter,
+    shared: &Arc<Shared>,
+    active_elapsed_secs: f64,
+    frames_written: u64,
+    incoming_frames: u64,
+    channels: usize,
+) -> Result<u64, String> {
+    let expected = (active_elapsed_secs * CAPTURE_SAMPLE_RATE as f64) as i64;
+    let tolerance = (CAPTURE_SAMPLE_RATE as f64 * ALIGNMENT_TOLERANCE_SECS) as i64;
+    let mut missing = expected - frames_written as i64 - incoming_frames as i64;
+    if missing <= tolerance {
+        return Ok(0);
+    }
+    let chunk_cap = (CAPTURE_SAMPLE_RATE / 2) as i64;
+    let mut filled: u64 = 0;
+    while missing > 0 {
+        let chunk = missing.min(chunk_cap);
+        for _ in 0..(chunk as usize * channels) {
+            writer
+                .write_sample(0i16)
+                .map_err(|error| error.to_string())?;
+        }
+        add_bytes(shared, chunk * (2 * channels) as i64);
+        filled += chunk as u64;
+        missing -= chunk;
+    }
+    Ok(filled)
+}
+
+/// Writes one chunk of interleaved S16LE samples and updates the live meter the
+/// same way the microphone path does (cumulative peak/rms plus a rolling window
+/// of recent per-chunk peaks).
+fn write_chunk(
+    writer: &mut WavFileWriter,
+    shared: &Arc<Shared>,
+    buffer: &[u8],
+) -> Result<(), String> {
+    let mut chunk_peak = 0.0_f32;
+    let mut sum_square = 0.0_f64;
+    let mut sample_count: u64 = 0;
+    for pair in buffer.chunks_exact(2) {
+        let sample = i16::from_le_bytes([pair[0], pair[1]]);
+        writer
+            .write_sample(sample)
+            .map_err(|error| error.to_string())?;
+        let normalized = (sample as f32 / i16::MAX as f32).abs();
+        chunk_peak = chunk_peak.max(normalized);
+        sum_square += (normalized as f64).powi(2);
+        sample_count += 1;
+    }
+    if let Ok(mut stats) = shared.stats.lock() {
+        stats.peak = stats.peak.max(chunk_peak);
+        stats.sum_square += sum_square;
+        stats.samples += sample_count;
+        stats.bytes_written += sample_count as i64 * 2;
+        if sample_count > 0 {
+            if stats.recent_peaks.len() == RECENT_PEAKS_CAP {
+                stats.recent_peaks.pop_front();
+            }
+            stats.recent_peaks.push_back(chunk_peak);
+        }
+    }
+    Ok(())
+}
+
+fn add_bytes(shared: &Arc<Shared>, bytes: i64) {
+    if let Ok(mut stats) = shared.stats.lock() {
+        stats.bytes_written += bytes;
+    }
+}
+
+fn record_error(shared: &Arc<Shared>, message: String) {
+    if let Ok(mut stats) = shared.stats.lock() {
+        stats.last_error = Some(message);
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    match probe_monitor_source() {
+        Ok(_) => SourceReadinessDto {
+            source: RecordingSource::System,
+            required: true,
+            ready: true,
+            // Capturing a sink monitor needs no OS-level permission on Linux.
+            permission_state: "granted".to_string(),
+            device_available: true,
+            capture_available: true,
+            recovery_action: None,
+            message: None,
+        },
+        Err(message) => SourceReadinessDto {
+            source: RecordingSource::System,
+            required: true,
+            ready: false,
+            device_available: false,
+            capture_available: false,
+            // There is still no OS permission to grant; the source is simply
+            // unavailable (no server, or no default sink monitor).
+            permission_state: "granted".to_string(),
+            recovery_action: None,
+            message: Some(message),
+        },
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    probe_monitor_source()
+        .map(|_| ())
+        .map_err(|message| AppError::new("system_audio_capture_unavailable", message))
+}
+
+/// Resolves the monitor source to record: the `JUNE_SYSTEM_AUDIO_SOURCE`
+/// override when set, otherwise the default sink's monitor via introspection.
+fn probe_monitor_source() -> Result<MonitorSource, String> {
+    if let Ok(name) = std::env::var(SOURCE_OVERRIDE_ENV) {
+        let name = name.trim().to_string();
+        if !name.is_empty() {
+            return Ok(MonitorSource { name });
+        }
+    }
+    resolve_default_monitor_source()
+}
+
+/// Connects to the audio server and resolves the default sink's monitor source
+/// name. Doubles as the readiness / permission probe: a clean success means a
+/// server is reachable and a default sink monitor exists.
+fn resolve_default_monitor_source() -> Result<MonitorSource, String> {
+    let mut mainloop =
+        Mainloop::new().ok_or_else(|| "Could not create a PulseAudio mainloop.".to_string())?;
+    let mut context = Context::new(&mainloop, "June system audio probe")
+        .ok_or_else(|| "Could not create a PulseAudio context.".to_string())?;
+    context
+        .connect(None, FlagSet::NOFLAGS, None)
+        .map_err(|error| format!("No PulseAudio or PipeWire audio server reachable: {error}"))?;
+
+    iterate_until(&mut mainloop, CONNECT_BUDGET, || {
+        match context.get_state() {
+            ContextState::Ready => Some(Ok(())),
+            ContextState::Failed | ContextState::Terminated => Some(Err(
+                "No PulseAudio or PipeWire audio server reachable.".to_string(),
+            )),
+            _ => None,
+        }
+    })?;
+
+    let default_sink: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    {
+        let sink = Rc::clone(&default_sink);
+        let op = context.introspect().get_server_info(move |info| {
+            if let Some(name) = info.default_sink_name.as_ref() {
+                *sink.borrow_mut() = Some(name.to_string());
+            }
+        });
+        wait_for_operation(&mut mainloop, &op, "read the default audio sink")?;
+    }
+    let sink_name = default_sink
+        .borrow_mut()
+        .take()
+        .ok_or_else(|| "No default audio output (sink) is configured.".to_string())?;
+
+    let monitor: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    {
+        let monitor = Rc::clone(&monitor);
+        let op = context
+            .introspect()
+            .get_sink_info_by_name(&sink_name, move |result| {
+                if let ListResult::Item(info) = result {
+                    if let Some(name) = info.monitor_source_name.as_ref() {
+                        *monitor.borrow_mut() = Some(name.to_string());
+                    }
+                }
+            });
+        wait_for_operation(&mut mainloop, &op, "read the sink monitor source")?;
+    }
+    // Every sink exposes a monitor source; fall back to the conventional name if
+    // the server did not report one explicitly.
+    let source_name = monitor
+        .borrow_mut()
+        .take()
+        .unwrap_or_else(|| format!("{sink_name}.monitor"));
+
+    context.disconnect();
+    Ok(MonitorSource { name: source_name })
+}
+
+/// Drives the mainloop non-blocking until `done` yields a result or the budget
+/// elapses. The short sleep keeps the probe from busy-spinning a CPU while it
+/// waits for the server.
+fn iterate_until<F>(mainloop: &mut Mainloop, budget: Duration, mut done: F) -> Result<(), String>
+where
+    F: FnMut() -> Option<Result<(), String>>,
+{
+    let started = Instant::now();
+    loop {
+        match mainloop.iterate(false) {
+            IterateResult::Quit(_) => {
+                return Err("The PulseAudio mainloop quit unexpectedly.".to_string())
+            }
+            IterateResult::Err(error) => return Err(format!("PulseAudio mainloop error: {error}")),
+            IterateResult::Success(_) => {}
+        }
+        if let Some(result) = done() {
+            return result;
+        }
+        if started.elapsed() >= budget {
+            return Err(
+                "Timed out talking to the PulseAudio or PipeWire audio server.".to_string(),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+fn wait_for_operation<T: ?Sized>(
+    mainloop: &mut Mainloop,
+    op: &Operation<T>,
+    what: &str,
+) -> Result<(), String> {
+    iterate_until(mainloop, OPERATION_BUDGET, || match op.get_state() {
+        OperationState::Done => Some(Ok(())),
+        OperationState::Cancelled => Some(Err(format!(
+            "The audio server cancelled the request to {what}."
+        ))),
+        OperationState::Running => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::WavReader;
+
+    // Functional capture test. Requires a running PulseAudio/PipeWire server with
+    // an audible default-sink monitor; the Docker harness sets that up and runs
+    // this with `cargo test -- --ignored`.
+    #[test]
+    #[ignore = "requires a running audio server with an audible monitor source"]
+    fn records_non_silent_int16_from_monitor() {
+        let dir = std::env::temp_dir().join(format!("june-sysaudio-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let partial = dir.join("system.partial.wav");
+        let final_path = dir.join("system.wav");
+        let _ = std::fs::remove_file(&partial);
+        let _ = std::fs::remove_file(&final_path);
+
+        let capture =
+            SystemAudioCapture::start(partial.clone(), final_path.clone(), Duration::ZERO)
+                .expect("system audio capture should start");
+        std::thread::sleep(Duration::from_secs(2));
+        let (level, bytes, last_error) = capture.status();
+        assert!(
+            last_error.is_none(),
+            "capture reported error: {last_error:?}"
+        );
+        assert!(bytes > 0, "expected bytes to be written during capture");
+
+        let out = capture.stop().expect("stop should finalize the WAV");
+        assert_eq!(out, final_path);
+
+        let mut reader = WavReader::open(&out).expect("output WAV should be readable");
+        let spec = reader.spec();
+        assert_eq!(spec.bits_per_sample, 16, "must be 16-bit PCM");
+        assert_eq!(
+            spec.sample_format,
+            SampleFormat::Int,
+            "must be signed int PCM"
+        );
+
+        let mut peak: i32 = 0;
+        let mut count: u64 = 0;
+        for sample in reader.samples::<i16>() {
+            let sample = sample.unwrap_or(0);
+            peak = peak.max((sample as i32).abs());
+            count += 1;
+        }
+        assert!(count > 0, "expected samples in the recording");
+        assert!(
+            peak > 200,
+            "expected non-silent int16 samples: peak={peak} count={count} bytes={bytes} meter_peak={}",
+            level.peak
+        );
+    }
+}

--- a/src-tauri/src/audio/system_linux.rs
+++ b/src-tauri/src/audio/system_linux.rs
@@ -19,6 +19,10 @@
 //! `SystemAudioCapture::{start, pause, resume, status, stop}`,
 //! `system_audio_readiness`, and `helper_permission_check`.
 
+use crate::audio::system_timeline::{
+    active_elapsed, expected_frames, max_silence_chunk_frames, silence_frames_to_fill,
+    tolerance_frames, LevelAccumulator,
+};
 use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
 use hound::{SampleFormat, WavSpec, WavWriter};
 use libpulse_binding::{
@@ -32,7 +36,6 @@ use libpulse_binding::{
 use libpulse_simple_binding::Simple;
 use std::{
     cell::RefCell,
-    collections::VecDeque,
     fs::File,
     io::BufWriter,
     path::PathBuf,
@@ -53,10 +56,6 @@ const CAPTURE_CHANNELS: u8 = 2;
 /// 10 ms read granularity: small enough to keep `stop()` latency and the live
 /// meter responsive, large enough to avoid excessive syscalls.
 const READ_CHUNK_FRAMES: usize = (CAPTURE_SAMPLE_RATE as usize) / 100;
-/// Rolling window of recent per-chunk peaks, matching the microphone path.
-const RECENT_PEAKS_CAP: usize = 24;
-/// Only fill silence once drift exceeds ~80 ms, matching the macOS helper.
-const ALIGNMENT_TOLERANCE_SECS: f64 = 0.08;
 const CONNECT_BUDGET: Duration = Duration::from_secs(5);
 const OPERATION_BUDGET: Duration = Duration::from_secs(5);
 const START_TIMEOUT: Duration = Duration::from_secs(10);
@@ -76,10 +75,9 @@ struct MonitorSource {
 
 #[derive(Default)]
 struct CaptureStats {
-    peak: f32,
-    sum_square: f64,
-    samples: u64,
-    recent_peaks: VecDeque<f32>,
+    /// Cumulative peak/rms plus the rolling per-chunk peak window, computed
+    /// exactly like the microphone path and the Windows backend.
+    level: LevelAccumulator,
     bytes_written: i64,
     last_error: Option<String>,
 }
@@ -187,17 +185,11 @@ impl SystemAudioCapture {
         let Ok(stats) = self.shared.stats.lock() else {
             return (AudioLevelDto::default(), 0, None);
         };
-        let rms = if stats.samples == 0 {
-            0.0
-        } else {
-            (stats.sum_square / stats.samples as f64).sqrt() as f32
-        };
-        let level = AudioLevelDto {
-            peak: stats.peak,
-            rms,
-            recent_peaks: stats.recent_peaks.iter().copied().collect(),
-        };
-        (level, stats.bytes_written, stats.last_error.clone())
+        (
+            stats.level.level(),
+            stats.bytes_written,
+            stats.last_error.clone(),
+        )
     }
 
     pub fn stop(mut self) -> Result<PathBuf, AppError> {
@@ -325,11 +317,14 @@ fn capture_loop(
         }
 
         let frames_in = READ_CHUNK_FRAMES as u64;
-        let active_elapsed = active_elapsed_secs(timeline_offset, origin, accumulated_paused, None);
+        // Not paused here (the loop `continue`s above while paused), so there is
+        // no in-progress pause to fold in: the paused offset is exactly the
+        // accumulated paused span.
+        let elapsed = active_elapsed(origin.elapsed(), timeline_offset, accumulated_paused);
         match fill_alignment_silence(
             &mut writer,
             &shared,
-            active_elapsed,
+            elapsed,
             frames_written,
             frames_in,
             channels,
@@ -360,17 +355,17 @@ fn capture_loop(
 
     // Pad to the current active wall-clock like the macOS helper's
     // `flushTimelineSilenceToNow()` on stop, so the track length reflects the
-    // full recording window.
-    let active_elapsed =
-        active_elapsed_secs(timeline_offset, origin, accumulated_paused, pause_started);
-    let _ = fill_alignment_silence(
-        &mut writer,
-        &shared,
-        active_elapsed,
-        frames_written,
-        0,
-        channels,
+    // full recording window. Fold in any in-progress pause so a recording
+    // stopped while paused pads only up to the last active instant.
+    let active_pause = pause_started
+        .map(|started| started.elapsed())
+        .unwrap_or_default();
+    let elapsed = active_elapsed(
+        origin.elapsed(),
+        timeline_offset,
+        accumulated_paused + active_pause,
     );
+    let _ = fill_alignment_silence(&mut writer, &shared, elapsed, frames_written, 0, channels);
 
     if let Err(error) = writer.finalize() {
         record_error(
@@ -380,38 +375,28 @@ fn capture_loop(
     }
 }
 
-fn active_elapsed_secs(
-    timeline_offset: Duration,
-    origin: Instant,
-    accumulated_paused: Duration,
-    pause_started: Option<Instant>,
-) -> f64 {
-    let active_pause = pause_started
-        .map(|started| started.elapsed())
-        .unwrap_or_default();
-    (timeline_offset.as_secs_f64() + origin.elapsed().as_secs_f64())
-        - accumulated_paused.as_secs_f64()
-        - active_pause.as_secs_f64()
-}
-
 /// Writes leading/drift silence so the file tracks wall-clock time, returning the
 /// number of silence frames written. Mirrors `writeTimelineSilenceIfNeeded`:
 /// only fills once the gap exceeds the tolerance, then closes the whole gap.
 fn fill_alignment_silence(
     writer: &mut WavFileWriter,
     shared: &Arc<Shared>,
-    active_elapsed_secs: f64,
+    elapsed: Duration,
     frames_written: u64,
     incoming_frames: u64,
     channels: usize,
 ) -> Result<u64, String> {
-    let expected = (active_elapsed_secs * CAPTURE_SAMPLE_RATE as f64) as i64;
-    let tolerance = (CAPTURE_SAMPLE_RATE as f64 * ALIGNMENT_TOLERANCE_SECS) as i64;
-    let mut missing = expected - frames_written as i64 - incoming_frames as i64;
-    if missing <= tolerance {
-        return Ok(0);
-    }
-    let chunk_cap = (CAPTURE_SAMPLE_RATE / 2) as i64;
+    let expected = expected_frames(elapsed, CAPTURE_SAMPLE_RATE);
+    let tolerance = tolerance_frames(CAPTURE_SAMPLE_RATE);
+    // Returns the whole gap once it exceeds the 80 ms tolerance, else 0 (so the
+    // loop below never runs and no silence is written).
+    let mut missing = silence_frames_to_fill(
+        expected,
+        frames_written as i64,
+        incoming_frames as i64,
+        tolerance,
+    );
+    let chunk_cap = max_silence_chunk_frames(CAPTURE_SAMPLE_RATE);
     let mut filled: u64 = 0;
     while missing > 0 {
         let chunk = missing.min(chunk_cap);
@@ -435,30 +420,23 @@ fn write_chunk(
     shared: &Arc<Shared>,
     buffer: &[u8],
 ) -> Result<(), String> {
-    let mut chunk_peak = 0.0_f32;
-    let mut sum_square = 0.0_f64;
-    let mut sample_count: u64 = 0;
     for pair in buffer.chunks_exact(2) {
         let sample = i16::from_le_bytes([pair[0], pair[1]]);
         writer
             .write_sample(sample)
             .map_err(|error| error.to_string())?;
-        let normalized = (sample as f32 / i16::MAX as f32).abs();
-        chunk_peak = chunk_peak.max(normalized);
-        sum_square += (normalized as f64).powi(2);
-        sample_count += 1;
     }
+    let sample_count = (buffer.len() / 2) as i64;
     if let Ok(mut stats) = shared.stats.lock() {
-        stats.peak = stats.peak.max(chunk_peak);
-        stats.sum_square += sum_square;
-        stats.samples += sample_count;
-        stats.bytes_written += sample_count as i64 * 2;
-        if sample_count > 0 {
-            if stats.recent_peaks.len() == RECENT_PEAKS_CAP {
-                stats.recent_peaks.pop_front();
-            }
-            stats.recent_peaks.push_back(chunk_peak);
-        }
+        // Fold this chunk into the shared level exactly like the microphone path
+        // and the Windows backend: `record_callback` takes signed normalized
+        // samples and applies `.abs()` internally.
+        stats.level.record_callback(
+            buffer
+                .chunks_exact(2)
+                .map(|pair| i16::from_le_bytes([pair[0], pair[1]]) as f32 / i16::MAX as f32),
+        );
+        stats.bytes_written += sample_count * 2;
     }
     Ok(())
 }

--- a/src-tauri/src/audio/system_stub.rs
+++ b/src-tauri/src/audio/system_stub.rs
@@ -1,0 +1,65 @@
+//! Fallback system-audio backend for platforms without a native implementation.
+//!
+//! macOS uses `system_macos`, Windows uses `system_windows`, and a Linux
+//! backend slots in the same way (its module would be gated in `audio::mod` and
+//! narrow this stub's `cfg` to `not(any(macos, windows, linux))`). Until then,
+//! any other OS reports system audio as unsupported and never constructs a
+//! capture. The API mirrors the real backends so `audio::capture` compiles
+//! unchanged.
+
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub struct SystemAudioCapture {
+    _never: std::convert::Infallible,
+}
+
+impl SystemAudioCapture {
+    pub fn start(
+        _partial_path: PathBuf,
+        _final_path: PathBuf,
+        _timeline_offset: Duration,
+    ) -> Result<Self, AppError> {
+        Err(AppError::new(
+            "system_audio_unavailable",
+            "System audio capture is not supported on this platform.",
+        ))
+    }
+
+    pub fn pause(&mut self) {
+        match self._never {}
+    }
+
+    pub fn resume(&mut self) {
+        match self._never {}
+    }
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        match self._never {}
+    }
+
+    pub fn stop(self) -> Result<PathBuf, AppError> {
+        match self._never {}
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    SourceReadinessDto {
+        source: RecordingSource::System,
+        required: true,
+        ready: false,
+        permission_state: "unsupported".to_string(),
+        device_available: false,
+        capture_available: false,
+        recovery_action: None,
+        message: Some("System audio capture is not supported on this platform.".to_string()),
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    Err(AppError::new(
+        "system_audio_unavailable",
+        "System audio capture is not supported on this platform.",
+    ))
+}

--- a/src-tauri/src/audio/system_timeline.rs
+++ b/src-tauri/src/audio/system_timeline.rs
@@ -1,0 +1,237 @@
+//! Wall-clock alignment and level math shared by the non-macOS system-audio
+//! backends. The macOS backend (`system_macos`) offloads this to the Swift
+//! helper's `writeTimelineSilenceIfNeeded` / `emitLevel`; the Windows backend
+//! (`system_windows`, and a Linux backend that slots in alongside it) drive a
+//! WASAPI/loopback stream from Rust and reproduce the same observable behavior
+//! here. Keeping the pure math in one place lets the unit tests run on any host
+//! (including the macOS CI host) instead of only on Windows.
+//!
+//! `allow(dead_code)` is scoped to this module because on a host whose backend
+//! does not consume these helpers (e.g. macOS) they are only referenced by the
+//! cross-platform tests below, which would otherwise trip `dead_code` in the
+//! non-test library build.
+#![allow(dead_code)]
+
+use crate::domain::types::AudioLevelDto;
+use std::{collections::VecDeque, time::Duration};
+
+/// Matches the microphone level window in `capture.rs` (`recent_peaks` keeps the
+/// most recent 24 per-callback peaks).
+pub(crate) const RECENT_PEAKS_CAP: usize = 24;
+
+/// Silence-fill tolerance in seconds. Mirrors the Swift helper's
+/// `toleranceFrames = format.sampleRate * 0.08`: gaps smaller than 80 ms are
+/// left for the next real buffer instead of being papered over with silence, so
+/// ordinary device jitter does not fragment the file.
+pub(crate) const SILENCE_TOLERANCE_SECS: f64 = 0.08;
+
+/// Upper bound on a single silence write, mirroring the Swift helper's
+/// `min(missingFrames, sampleRate / 2)` chunking so a long gap does not require
+/// one huge allocation.
+pub(crate) fn max_silence_chunk_frames(sample_rate: u32) -> i64 {
+    (sample_rate / 2).max(1) as i64
+}
+
+/// Number of per-channel frames of tolerance before silence is inserted.
+pub(crate) fn tolerance_frames(sample_rate: u32) -> i64 {
+    (sample_rate as f64 * SILENCE_TOLERANCE_SECS) as i64
+}
+
+/// Active (unpaused) elapsed time the output file should represent.
+///
+/// Mirrors the Swift helper, where `activeStartedAt = start - timelineOffset`
+/// and `activeElapsed = max(0, now - activeStartedAt - pausedOffset)`. Folding
+/// `timeline_offset` in here reproduces the helper's leading-silence alignment:
+/// at t=0 the expected timeline is already `timeline_offset` long, so the first
+/// thing written to the file is `timeline_offset` of silence, lining the system
+/// track up with a microphone track that began `timeline_offset` earlier.
+pub(crate) fn active_elapsed(
+    elapsed_since_start: Duration,
+    timeline_offset: Duration,
+    paused_offset: Duration,
+) -> Duration {
+    (elapsed_since_start + timeline_offset).saturating_sub(paused_offset)
+}
+
+/// Per-channel frame count the file should contain for a given active elapsed.
+pub(crate) fn expected_frames(active_elapsed: Duration, sample_rate: u32) -> i64 {
+    (active_elapsed.as_secs_f64() * sample_rate as f64) as i64
+}
+
+/// How many per-channel silence frames to insert before writing the next real
+/// buffer. Mirrors the Swift helper: fill the whole gap once it exceeds the
+/// tolerance, otherwise nothing. `incoming_frames` is the real buffer about to
+/// be written (0 for a silence-only tick or the trailing stop() flush).
+pub(crate) fn silence_frames_to_fill(
+    expected_frames: i64,
+    frames_written: i64,
+    incoming_frames: i64,
+    tolerance_frames: i64,
+) -> i64 {
+    let missing = expected_frames - frames_written - incoming_frames;
+    if missing > tolerance_frames {
+        missing
+    } else {
+        0
+    }
+}
+
+/// Running audio level, computed exactly like the microphone path in
+/// `capture.rs`: `peak` is the max absolute sample over the whole recording,
+/// `rms` is the root-mean-square over the whole recording, and `recent_peaks`
+/// is a sliding window of the most recent per-callback peaks.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LevelAccumulator {
+    peak: f32,
+    sum_square: f64,
+    samples: u64,
+    recent_peaks: VecDeque<f32>,
+}
+
+impl LevelAccumulator {
+    /// Fold one capture callback's worth of samples into the running level.
+    /// `samples` yields signed, normalized values in `[-1.0, 1.0]` (one item per
+    /// interleaved sample, all channels), matching `write_input_data`.
+    pub(crate) fn record_callback<I>(&mut self, samples: I)
+    where
+        I: IntoIterator<Item = f32>,
+    {
+        let mut callback_peak = 0.0_f32;
+        let mut saw_sample = false;
+        for sample in samples {
+            saw_sample = true;
+            let normalized = sample.abs();
+            callback_peak = callback_peak.max(normalized);
+            self.peak = self.peak.max(normalized);
+            self.sum_square += (normalized as f64).powi(2);
+            self.samples += 1;
+        }
+        if saw_sample {
+            if self.recent_peaks.len() == RECENT_PEAKS_CAP {
+                self.recent_peaks.pop_front();
+            }
+            self.recent_peaks.push_back(callback_peak);
+        }
+    }
+
+    pub(crate) fn level(&self) -> AudioLevelDto {
+        let rms = if self.samples == 0 {
+            0.0
+        } else {
+            (self.sum_square / self.samples as f64).sqrt() as f32
+        };
+        AudioLevelDto {
+            peak: self.peak,
+            rms,
+            recent_peaks: self.recent_peaks.iter().copied().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_silence_when_gap_within_tolerance() {
+        // 48 kHz, tolerance is 0.08 s = 3840 frames. A 1000-frame gap is left
+        // for the next real buffer.
+        let tol = tolerance_frames(48_000);
+        assert_eq!(tol, 3840);
+        assert_eq!(silence_frames_to_fill(1_000, 0, 0, tol), 0);
+        assert_eq!(silence_frames_to_fill(4_840, 1_000, 0, tol), 0);
+    }
+
+    #[test]
+    fn fills_whole_gap_once_past_tolerance() {
+        let tol = tolerance_frames(48_000);
+        // expected 48000, written 0, no incoming -> 48000 > 3840 -> fill 48000.
+        assert_eq!(silence_frames_to_fill(48_000, 0, 0, tol), 48_000);
+        // Incoming real frames count against the gap.
+        assert_eq!(silence_frames_to_fill(48_000, 0, 5_000, tol), 43_000);
+    }
+
+    #[test]
+    fn never_fills_when_already_ahead() {
+        let tol = tolerance_frames(48_000);
+        assert_eq!(silence_frames_to_fill(1_000, 5_000, 0, tol), 0);
+        assert_eq!(silence_frames_to_fill(1_000, 0, 5_000, tol), 0);
+    }
+
+    #[test]
+    fn timeline_offset_produces_leading_silence() {
+        // Half a second of offset, no elapsed time yet, no pause: the file
+        // should already owe ~0.5 s of silence.
+        let elapsed = active_elapsed(Duration::ZERO, Duration::from_millis(500), Duration::ZERO);
+        assert_eq!(elapsed, Duration::from_millis(500));
+        assert_eq!(expected_frames(elapsed, 48_000), 24_000);
+    }
+
+    #[test]
+    fn paused_time_is_excluded_not_filled() {
+        // 10 s of wall clock, 4 s of it paused: the file should represent 6 s,
+        // matching the microphone track which also drops paused audio. Paused
+        // time is therefore never written as silence.
+        let elapsed = active_elapsed(
+            Duration::from_secs(10),
+            Duration::ZERO,
+            Duration::from_secs(4),
+        );
+        assert_eq!(elapsed, Duration::from_secs(6));
+        assert_eq!(expected_frames(elapsed, 16_000), 96_000);
+    }
+
+    #[test]
+    fn paused_offset_larger_than_elapsed_clamps_to_zero() {
+        let elapsed = active_elapsed(
+            Duration::from_secs(1),
+            Duration::ZERO,
+            Duration::from_secs(5),
+        );
+        assert_eq!(elapsed, Duration::ZERO);
+        assert_eq!(expected_frames(elapsed, 48_000), 0);
+    }
+
+    #[test]
+    fn max_silence_chunk_is_half_a_second() {
+        assert_eq!(max_silence_chunk_frames(48_000), 24_000);
+        assert_eq!(max_silence_chunk_frames(0), 1);
+    }
+
+    #[test]
+    fn level_matches_microphone_windowing() {
+        let mut level = LevelAccumulator::default();
+        // Two callbacks; peaks 0.5 and 0.25.
+        level.record_callback([0.5_f32, -0.5, 0.1]);
+        level.record_callback([0.25_f32, -0.2]);
+        let dto = level.level();
+        assert_eq!(dto.peak, 0.5);
+        assert_eq!(dto.recent_peaks, vec![0.5, 0.25]);
+        // rms = sqrt((0.25+0.25+0.01+0.0625+0.04)/5)
+        let expected_rms = ((0.25_f64 + 0.25 + 0.01 + 0.0625 + 0.04) / 5.0).sqrt() as f32;
+        assert!((dto.rms - expected_rms).abs() < 1e-6);
+    }
+
+    #[test]
+    fn level_recent_peaks_window_caps_at_24() {
+        let mut level = LevelAccumulator::default();
+        for index in 0..30 {
+            level.record_callback([index as f32 / 100.0]);
+        }
+        let dto = level.level();
+        assert_eq!(dto.recent_peaks.len(), RECENT_PEAKS_CAP);
+        // Oldest six callbacks (0..6) have been evicted; window starts at 0.06.
+        assert!((dto.recent_peaks[0] - 0.06).abs() < 1e-6);
+        assert!((dto.recent_peaks[RECENT_PEAKS_CAP - 1] - 0.29).abs() < 1e-6);
+    }
+
+    #[test]
+    fn empty_callback_does_not_push_a_peak() {
+        let mut level = LevelAccumulator::default();
+        level.record_callback(std::iter::empty::<f32>());
+        let dto = level.level();
+        assert_eq!(dto.peak, 0.0);
+        assert_eq!(dto.rms, 0.0);
+        assert!(dto.recent_peaks.is_empty());
+    }
+}

--- a/src-tauri/src/audio/system_unsupported.rs
+++ b/src-tauri/src/audio/system_unsupported.rs
@@ -1,0 +1,63 @@
+//! Fallback system-audio backend for platforms without a dedicated
+//! implementation. It mirrors the previous `#[cfg(not(target_os = "macos"))]`
+//! behavior of `system_macos`: readiness reports the source as unsupported and
+//! every capture entry point fails cleanly instead of panicking. Real backends
+//! live in `system_macos` (macOS), `system_linux` (Linux) and, from a parallel
+//! change, `system_windows` (Windows).
+
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use std::{path::PathBuf, time::Duration};
+
+const UNSUPPORTED_MESSAGE: &str = "System audio capture is not supported on this platform.";
+
+pub struct SystemAudioCapture {
+    _private: (),
+}
+
+impl SystemAudioCapture {
+    pub fn start(
+        _partial_path: PathBuf,
+        _final_path: PathBuf,
+        _timeline_offset: Duration,
+    ) -> Result<Self, AppError> {
+        Err(AppError::new(
+            "system_audio_capture_unavailable",
+            UNSUPPORTED_MESSAGE,
+        ))
+    }
+
+    pub fn pause(&mut self) {}
+
+    pub fn resume(&mut self) {}
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        (AudioLevelDto::default(), 0, None)
+    }
+
+    pub fn stop(self) -> Result<PathBuf, AppError> {
+        Err(AppError::new(
+            "system_audio_capture_unavailable",
+            UNSUPPORTED_MESSAGE,
+        ))
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    SourceReadinessDto {
+        source: RecordingSource::System,
+        required: true,
+        ready: false,
+        permission_state: "unsupported".to_string(),
+        device_available: false,
+        capture_available: false,
+        recovery_action: None,
+        message: Some(UNSUPPORTED_MESSAGE.to_string()),
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    Err(AppError::new(
+        "system_audio_capture_unavailable",
+        UNSUPPORTED_MESSAGE,
+    ))
+}

--- a/src-tauri/src/audio/system_windows.rs
+++ b/src-tauri/src/audio/system_windows.rs
@@ -1,0 +1,542 @@
+//! Windows system-audio capture via WASAPI loopback.
+//!
+//! On Windows, building a cpal *input* stream on an *output* (render) device
+//! captures a loopback of everything that device is playing. cpal 0.15.3's
+//! WASAPI backend does this transparently: `Device::build_input_stream_raw`
+//! sets `AUDCLNT_STREAMFLAGS_LOOPBACK` whenever the device's data flow is
+//! `eRender` (see cpal `src/host/wasapi/device.rs`). No OS permission prompt is
+//! involved, which is why `system_audio_readiness()` reports `granted`.
+//!
+//! The public API mirrors `system_macos::SystemAudioCapture` exactly so
+//! `audio::capture` can consume either backend through the re-export in
+//! `audio::mod`. The observable file behavior also mirrors the macOS Swift
+//! helper:
+//!   * a 16-bit signed-int interleaved WAV at the device's native rate/channels,
+//!   * `timeline_offset` of leading silence so the system track lines up with a
+//!     microphone track that started `timeline_offset` earlier,
+//!   * wall-clock silence fill for gaps (mirroring `writeTimelineSilenceIfNeeded`),
+//!   * paused wall-clock excluded from the timeline rather than filled (see the
+//!     pause semantics note on `pause`).
+//!
+//! Design difference from macOS worth calling out: the macOS aggregate-device
+//! IOProc fires on the output device's clock even during silence, so the helper
+//! can fill gaps from inside its callback. WASAPI loopback delivers no packets
+//! while the endpoint is idle, so a callback-only design would stop advancing
+//! the timeline during silence. We therefore run a dedicated writer thread on a
+//! fixed tick that owns the WAV file and the wall clock: the cpal callback only
+//! buffers samples and updates the level meter, and the writer thread fills
+//! silence and appends real audio, keeping the file wall-clock aligned whether
+//! or not audio is currently playing.
+
+use crate::audio::system_timeline::{
+    active_elapsed, expected_frames, max_silence_chunk_frames, silence_frames_to_fill,
+    tolerance_frames, LevelAccumulator,
+};
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use hound::{SampleFormat, WavSpec, WavWriter};
+use std::{
+    fs::File,
+    io::BufWriter,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+/// How often the writer thread wakes to drain buffered audio and top up
+/// silence. Comfortably below the 80 ms silence tolerance so the file stays
+/// aligned without busy-waiting.
+const WRITER_TICK: Duration = Duration::from_millis(40);
+
+/// Shared between the cpal capture callback (producer) and the writer thread
+/// (consumer) plus `status()` (reader). Kept lock-light: the callback never
+/// touches the file, so it cannot block on disk I/O.
+#[derive(Default)]
+struct Shared {
+    /// Interleaved i16 samples captured but not yet written to the WAV.
+    pending: Vec<i16>,
+    level: LevelAccumulator,
+    /// WAV data bytes written so far (real audio + silence fill).
+    bytes_written: i64,
+    last_error: Option<String>,
+}
+
+/// Wall-clock pause bookkeeping, mirroring the Swift helper's
+/// `accumulatedPausedDuration` / `pausedAt`. Read by the writer thread to
+/// exclude paused time from the timeline.
+#[derive(Default)]
+struct PauseState {
+    paused: bool,
+    paused_at: Option<Instant>,
+    accumulated_paused: Duration,
+}
+
+impl PauseState {
+    /// Total paused time to subtract from elapsed wall clock right now,
+    /// including an in-progress pause.
+    fn paused_offset(&self) -> Duration {
+        let active = if self.paused {
+            self.paused_at.map(|at| at.elapsed()).unwrap_or_default()
+        } else {
+            Duration::ZERO
+        };
+        self.accumulated_paused + active
+    }
+}
+
+pub struct SystemAudioCapture {
+    // Dropping the stream stops the WASAPI loopback callback. `cpal::Stream` is
+    // `!Send`; this struct is only ever held inside `ActiveRecording`, which is
+    // force-`Send` (see `capture.rs`), exactly as the macOS backend relies on.
+    stream: Option<cpal::Stream>,
+    writer_handle: Option<JoinHandle<Result<(), String>>>,
+    shared: Arc<Mutex<Shared>>,
+    pause_state: Arc<Mutex<PauseState>>,
+    pause_flag: Arc<AtomicBool>,
+    stop_flag: Arc<AtomicBool>,
+    partial_path: PathBuf,
+    final_path: PathBuf,
+}
+
+impl SystemAudioCapture {
+    pub fn start(
+        partial_path: PathBuf,
+        final_path: PathBuf,
+        timeline_offset: Duration,
+    ) -> Result<Self, AppError> {
+        let host = cpal::default_host();
+        let device = host.default_output_device().ok_or_else(|| {
+            AppError::new(
+                "system_audio_unavailable",
+                "No audio output device is available to capture system audio.",
+            )
+        })?;
+        // Loopback capture reads the render device's mix format; an output
+        // device has no *input* config, so we derive the WAV spec and the
+        // callback sample type from the output (mix) config.
+        let supported = device.default_output_config().map_err(|error| {
+            AppError::new("system_audio_capture_unavailable", error.to_string())
+        })?;
+        let sample_format = supported.sample_format();
+        let sample_rate = supported.sample_rate().0;
+        let channels = supported.channels();
+        let stream_config: cpal::StreamConfig = supported.into();
+
+        let writer = WavWriter::create(
+            &partial_path,
+            WavSpec {
+                channels,
+                sample_rate,
+                bits_per_sample: 16,
+                sample_format: SampleFormat::Int,
+            },
+        )
+        .map_err(|error| AppError::new("system_audio_capture_unavailable", error.to_string()))?;
+
+        let shared = Arc::new(Mutex::new(Shared::default()));
+        let pause_state = Arc::new(Mutex::new(PauseState::default()));
+        let pause_flag = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::new(AtomicBool::new(false));
+
+        let stream = match build_loopback_stream(
+            &device,
+            &stream_config,
+            sample_format,
+            Arc::clone(&shared),
+            Arc::clone(&pause_flag),
+        ) {
+            Ok(stream) => stream,
+            Err(error) => {
+                // Building the stream failed; drop the writer and remove the
+                // half-created file so a failed start leaves nothing behind.
+                drop(writer);
+                let _ = std::fs::remove_file(&partial_path);
+                return Err(error);
+            }
+        };
+
+        // The writer thread owns the WAV file and the wall clock from here on.
+        let writer_handle = spawn_writer_thread(
+            writer,
+            channels,
+            sample_rate,
+            timeline_offset,
+            Arc::clone(&shared),
+            Arc::clone(&pause_state),
+            Arc::clone(&stop_flag),
+        );
+
+        if let Err(error) = stream.play() {
+            stop_flag.store(true, Ordering::Release);
+            let _ = writer_handle.join();
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(AppError::new(
+                "system_audio_capture_unavailable",
+                error.to_string(),
+            ));
+        }
+
+        Ok(Self {
+            stream: Some(stream),
+            writer_handle: Some(writer_handle),
+            shared,
+            pause_state,
+            pause_flag,
+            stop_flag,
+            partial_path,
+            final_path,
+        })
+    }
+
+    pub fn pause(&mut self) {
+        self.pause_flag.store(true, Ordering::Release);
+        if let Ok(mut state) = self.pause_state.lock() {
+            if !state.paused {
+                state.paused_at = Some(Instant::now());
+            }
+            state.paused = true;
+        }
+    }
+
+    pub fn resume(&mut self) {
+        self.pause_flag.store(false, Ordering::Release);
+        if let Ok(mut state) = self.pause_state.lock() {
+            if let Some(paused_at) = state.paused_at.take() {
+                state.accumulated_paused += paused_at.elapsed();
+            }
+            state.paused = false;
+        }
+    }
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        let Ok(shared) = self.shared.lock() else {
+            return (AudioLevelDto::default(), 0, None);
+        };
+        (
+            shared.level.level(),
+            shared.bytes_written,
+            shared.last_error.clone(),
+        )
+    }
+
+    pub fn stop(mut self) -> Result<PathBuf, AppError> {
+        // Stop the loopback callback first so no more samples arrive while the
+        // writer thread performs its final drain and trailing-silence flush.
+        drop(self.stream.take());
+        self.stop_flag.store(true, Ordering::Release);
+        if let Some(handle) = self.writer_handle.take() {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(message)) => {
+                    return Err(AppError::new("audio_finalization_failed", message));
+                }
+                Err(_) => {
+                    return Err(AppError::new(
+                        "audio_finalization_failed",
+                        "System audio writer thread panicked.",
+                    ));
+                }
+            }
+        }
+        if self.partial_path.exists() {
+            std::fs::rename(&self.partial_path, &self.final_path)
+                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        }
+        Ok(self.final_path.clone())
+    }
+}
+
+impl Drop for SystemAudioCapture {
+    fn drop(&mut self) {
+        // `stop()` consumes `self` and clears these; this only runs if a capture
+        // is dropped without `stop()` (e.g. a panic unwinds `start`). Make sure
+        // the loopback callback and writer thread do not outlive the struct.
+        drop(self.stream.take());
+        self.stop_flag.store(true, Ordering::Release);
+        if let Some(handle) = self.writer_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Build the WASAPI loopback input stream on the render `device`, converting
+/// whatever the mix format delivers into interleaved i16 for the writer thread
+/// while feeding a normalized copy into the level meter.
+fn build_loopback_stream(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    shared: Arc<Mutex<Shared>>,
+    pause_flag: Arc<AtomicBool>,
+) -> Result<cpal::Stream, AppError> {
+    let error_shared = Arc::clone(&shared);
+    let err_fn = move |error: cpal::StreamError| {
+        // Surface device invalidation / stream faults through status() rather
+        // than panicking. The capture keeps its file; the writer thread keeps
+        // filling silence so the timeline stays intact.
+        if let Ok(mut shared) = error_shared.lock() {
+            shared.last_error = Some(system_stream_error_message(&error));
+        }
+    };
+
+    let build = |device: &cpal::Device| -> Result<cpal::Stream, cpal::BuildStreamError> {
+        match sample_format {
+            cpal::SampleFormat::F32 => device.build_input_stream(
+                config,
+                move |data: &[f32], _| {
+                    ingest_samples(
+                        data.iter().map(|sample| sample.clamp(-1.0, 1.0)),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::I16 => device.build_input_stream(
+                config,
+                move |data: &[i16], _| {
+                    ingest_samples(
+                        data.iter().map(|sample| *sample as f32 / i16::MAX as f32),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::U16 => device.build_input_stream(
+                config,
+                move |data: &[u16], _| {
+                    ingest_samples(
+                        data.iter()
+                            .map(|sample| (*sample as f32 - 32768.0) / 32768.0),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            other => Err(cpal::BuildStreamError::BackendSpecific {
+                err: cpal::BackendSpecificError {
+                    description: format!(
+                        "Unsupported system audio loopback sample format {other:?}."
+                    ),
+                },
+            }),
+        }
+    };
+
+    build(device)
+        .map_err(|error| AppError::new("system_audio_capture_unavailable", error.to_string()))
+}
+
+/// Convert one callback's normalized samples to i16, buffer them for the writer
+/// thread and fold them into the level meter. Skips everything while paused so
+/// paused audio is dropped, matching the microphone path in `capture.rs`.
+fn ingest_samples<I>(samples: I, shared: &Arc<Mutex<Shared>>, pause_flag: &AtomicBool)
+where
+    I: Iterator<Item = f32>,
+{
+    if pause_flag.load(Ordering::Acquire) {
+        return;
+    }
+    let pcm: Vec<i16> = samples
+        .map(|sample| (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
+        .collect();
+    if pcm.is_empty() {
+        return;
+    }
+    let Ok(mut shared) = shared.lock() else {
+        return;
+    };
+    shared
+        .level
+        .record_callback(pcm.iter().map(|sample| *sample as f32 / i16::MAX as f32));
+    shared.pending.extend_from_slice(&pcm);
+}
+
+/// Spawn the thread that owns the WAV file and the wall clock. Returns a handle
+/// whose value is the finalize result (`Err` maps to `audio_finalization_failed`).
+fn spawn_writer_thread(
+    mut writer: WavWriter<BufWriter<File>>,
+    channels: u16,
+    sample_rate: u32,
+    timeline_offset: Duration,
+    shared: Arc<Mutex<Shared>>,
+    pause_state: Arc<Mutex<PauseState>>,
+    stop_flag: Arc<AtomicBool>,
+) -> JoinHandle<Result<(), String>> {
+    std::thread::spawn(move || {
+        let channels = channels.max(1) as i64;
+        let tolerance = tolerance_frames(sample_rate);
+        let chunk_cap = max_silence_chunk_frames(sample_rate);
+        let started = Instant::now();
+        // Per-channel frames written to the file (real audio + silence).
+        let mut frames_written: i64 = 0;
+
+        loop {
+            let stopping = stop_flag.load(Ordering::Acquire);
+            let pending = take_pending(&shared);
+            let paused_offset = pause_state
+                .lock()
+                .map(|state| state.paused_offset())
+                .unwrap_or_default();
+            let elapsed = active_elapsed(started.elapsed(), timeline_offset, paused_offset);
+            let expected = expected_frames(elapsed, sample_rate);
+
+            if let Err(message) = write_tick(
+                &mut writer,
+                &pending,
+                channels,
+                expected,
+                &mut frames_written,
+                tolerance,
+                chunk_cap,
+                &shared,
+            ) {
+                record_error(&shared, message);
+            }
+
+            if stopping {
+                // One trailing pass with no real audio flushes silence up to the
+                // stop instant, mirroring the helper's flushTimelineSilenceToNow.
+                let paused_offset = pause_state
+                    .lock()
+                    .map(|state| state.paused_offset())
+                    .unwrap_or_default();
+                let elapsed = active_elapsed(started.elapsed(), timeline_offset, paused_offset);
+                let expected = expected_frames(elapsed, sample_rate);
+                if let Err(message) = write_tick(
+                    &mut writer,
+                    &[],
+                    channels,
+                    expected,
+                    &mut frames_written,
+                    tolerance,
+                    chunk_cap,
+                    &shared,
+                ) {
+                    record_error(&shared, message);
+                }
+                break;
+            }
+
+            std::thread::sleep(WRITER_TICK);
+        }
+
+        writer.finalize().map_err(|error| error.to_string())
+    })
+}
+
+/// Take the buffered samples out of the shared state without holding the lock
+/// across the file write that follows.
+fn take_pending(shared: &Arc<Mutex<Shared>>) -> Vec<i16> {
+    match shared.lock() {
+        Ok(mut shared) => std::mem::take(&mut shared.pending),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Fill any missing silence, then append the real buffer, keeping the file
+/// aligned to `expected` per-channel frames. Updates `frames_written` and the
+/// shared byte counter. Mirrors `writeTimelineSilenceIfNeeded` followed by the
+/// real `audioFile.write`.
+#[allow(clippy::too_many_arguments)]
+fn write_tick(
+    writer: &mut WavWriter<BufWriter<File>>,
+    pending: &[i16],
+    channels: i64,
+    expected: i64,
+    frames_written: &mut i64,
+    tolerance: i64,
+    chunk_cap: i64,
+    shared: &Arc<Mutex<Shared>>,
+) -> Result<(), String> {
+    let incoming_frames = pending.len() as i64 / channels;
+    let mut silence_frames =
+        silence_frames_to_fill(expected, *frames_written, incoming_frames, tolerance);
+    let mut written_samples: i64 = 0;
+
+    while silence_frames > 0 {
+        let chunk = silence_frames.min(chunk_cap);
+        for _ in 0..(chunk * channels) {
+            writer
+                .write_sample(0i16)
+                .map_err(|error| error.to_string())?;
+        }
+        *frames_written += chunk;
+        written_samples += chunk * channels;
+        silence_frames -= chunk;
+    }
+
+    for sample in pending {
+        writer
+            .write_sample(*sample)
+            .map_err(|error| error.to_string())?;
+    }
+    *frames_written += incoming_frames;
+    written_samples += pending.len() as i64;
+
+    if written_samples > 0 {
+        if let Ok(mut shared) = shared.lock() {
+            shared.bytes_written += written_samples * 2;
+        }
+    }
+    Ok(())
+}
+
+fn record_error(shared: &Arc<Mutex<Shared>>, message: String) {
+    if let Ok(mut shared) = shared.lock() {
+        shared.last_error = Some(message);
+    }
+}
+
+fn system_stream_error_message(error: &cpal::StreamError) -> String {
+    match error {
+        cpal::StreamError::DeviceNotAvailable => {
+            "System audio output device became unavailable. Reconnect the output device and restart the recording to resume system audio."
+                .to_string()
+        }
+        cpal::StreamError::BackendSpecific { err } => {
+            format!("System audio capture error: {}", err.description)
+        }
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    let host = cpal::default_host();
+    let device_available = host.default_output_device().is_some();
+    SourceReadinessDto {
+        source: RecordingSource::System,
+        required: true,
+        ready: device_available,
+        // WASAPI loopback needs no OS permission, so the permission gate is
+        // always "granted"; the only thing that can block capture is the
+        // absence of an output device to loop back from.
+        permission_state: "granted".to_string(),
+        device_available,
+        capture_available: device_available,
+        // No recovery_action: there is no system-audio privacy pane to send the
+        // user to on Windows, so the frontend simply does not offer one.
+        recovery_action: None,
+        message: if device_available {
+            None
+        } else {
+            Some(
+                "No audio output device is available. Connect speakers or headphones to capture system audio."
+                    .to_string(),
+            )
+        },
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    // Loopback capture requires no permission grant on Windows.
+    Ok(())
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -585,10 +585,10 @@ pub fn get_platform_capabilities() -> PlatformCapabilities {
             target_os = "linux"
         )),
         meeting_detection: cfg!(any(target_os = "macos", target_os = "windows")),
-        // Dictation is macOS-only today. The Windows dictation backend is
-        // being implemented separately; it will add `target_os = "windows"`
-        // here when it lands.
-        dictation: cfg!(target_os = "macos"),
+        // macOS uses the Swift helper; Windows the in-process hook engine in
+        // dictation/win.rs. Linux is still unsupported (Wayland has no
+        // portable global-hotkey API).
+        dictation: cfg!(any(target_os = "macos", target_os = "windows")),
     }
 }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1079,11 +1079,11 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
         message: microphone_hint,
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
-        let mut system = crate::audio::system_macos::system_audio_readiness();
+        let mut system = crate::audio::system_audio_readiness();
         if should_probe_system_audio_permission(system.ready, is_capture_active()) {
             system = apply_system_audio_permission_probe_result(
                 system,
-                crate::audio::system_macos::helper_permission_check(),
+                crate::audio::helper_permission_check(),
             );
         }
         sources.push(system);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -562,6 +562,36 @@ pub async fn check_recording_source_readiness(
         .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))
 }
 
+/// What this build of June can actually do, decided at compile time. The
+/// frontend gates feature surfaces on these flags instead of sniffing the OS
+/// from the user agent, so newly ported backends light up their UI without
+/// frontend changes beyond flipping a `cfg` here.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PlatformCapabilities {
+    pub system_audio: bool,
+    pub meeting_detection: bool,
+    pub dictation: bool,
+}
+
+/// Static per-build capability report. Values mirror which platform modules
+/// are compiled in (see `audio/mod.rs` and `meeting_detection.rs`).
+#[tauri::command]
+pub fn get_platform_capabilities() -> PlatformCapabilities {
+    PlatformCapabilities {
+        system_audio: cfg!(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "linux"
+        )),
+        meeting_detection: cfg!(any(target_os = "macos", target_os = "windows")),
+        // Dictation is macOS-only today. The Windows dictation backend is
+        // being implemented separately; it will add `target_os = "windows"`
+        // here when it lands.
+        dictation: cfg!(target_os = "macos"),
+    }
+}
+
 /// Opens the june-api `/verify` page (enclave attestation, routing,
 /// retention) in the default browser. Must route through Rust: the webview
 /// installs no new-window handler, so `target="_blank"` anchors are silently

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1,3 +1,7 @@
+/// In-process Windows helper: hotkey hook, mic capture, paste. Speaks the
+/// same command/event protocol as the macOS Swift helper.
+#[cfg(target_os = "windows")]
+mod win;
 /// Pure chord-matching / key-mapping / command-parsing logic for the Windows
 /// helper. Host-independent so its unit tests run everywhere.
 #[cfg(any(target_os = "windows", test))]
@@ -14,11 +18,15 @@ use crate::june_api::{
 use crate::providers::{configured_transcription_provider, OPENAI_PROVIDER, VENICE_PROVIDER};
 use chrono::Utc;
 use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(not(target_os = "windows"))]
+use std::io::{BufRead, BufReader};
+#[cfg(not(target_os = "windows"))]
+use std::process::{Command, Stdio};
 use std::{
     fs,
-    io::{BufRead, BufReader, Write},
+    io::Write,
     path::PathBuf,
-    process::{Child, ChildStdin, Command, Stdio},
+    process::{Child, ChildStdin},
     sync::{Mutex, OnceLock},
     thread,
     time::{Duration, Instant},
@@ -609,6 +617,15 @@ pub fn setup(app: &mut tauri::App) {
         controller: Mutex::new(ShortcutActivationController::default()),
     });
 
+    // On Windows the helper is in-process (dictation/win.rs); there is no
+    // child process to spawn, and the same command/event protocol is served
+    // by the hook + capture threads started here.
+    #[cfg(target_os = "windows")]
+    let helper: Option<HelperProcess> = {
+        win::start(app.handle());
+        None
+    };
+    #[cfg(not(target_os = "windows"))]
     let helper = spawn_helper(app.handle()).ok();
     app.manage(HelperState {
         process: Mutex::new(helper),
@@ -616,15 +633,14 @@ pub fn setup(app: &mut tauri::App) {
 
     {
         let settings = app.state::<DictationSettingsState>();
-        let helper_state = app.state::<HelperState>();
         let settings = settings
             .settings
             .lock()
             .ok()
             .map(|settings| settings.clone());
         if let Some(settings) = settings {
-            let _ = apply_microphone_setting(&helper_state, &settings.microphone);
-            let _ = apply_shortcut_settings(&helper_state, &settings);
+            let _ = apply_microphone_setting(app.handle(), &settings.microphone);
+            let _ = apply_shortcut_settings(app.handle(), &settings);
         }
     }
 
@@ -674,11 +690,10 @@ pub async fn delete_dictation_history_item(app: AppHandle, id: String) -> Result
 }
 
 #[tauri::command]
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 pub fn set_dictation_shortcut(
     app: AppHandle,
     state: State<'_, DictationSettingsState>,
-    helper_state: State<'_, HelperState>,
     hotkey_status: State<'_, HotkeyStatus>,
     kind: DictationShortcutKind,
     shortcut: DictationShortcutInput,
@@ -699,7 +714,7 @@ pub fn set_dictation_shortcut(
 
     if current_shortcut == &shortcut {
         set_hotkey_status(&hotkey_status, hotkey_ready_event(&current_settings));
-        apply_shortcut_settings(&helper_state, &current_settings)?;
+        apply_shortcut_settings(&app, &current_settings)?;
         return Ok(current_settings);
     }
 
@@ -708,14 +723,14 @@ pub fn set_dictation_shortcut(
         DictationShortcutKind::Toggle => settings.toggle_shortcut = shortcut,
     })?;
     reset_shortcut_activation(&app);
-    apply_shortcut_settings(&helper_state, &settings)?;
+    apply_shortcut_settings(&app, &settings)?;
 
     set_hotkey_status(&hotkey_status, hotkey_ready_event(&settings));
     Ok(settings)
 }
 
 #[tauri::command]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub fn set_dictation_shortcut(
     kind: DictationShortcutKind,
     shortcut: DictationShortcutInput,
@@ -729,6 +744,7 @@ pub fn set_dictation_shortcut(
 
 #[tauri::command]
 pub fn set_dictation_microphone(
+    app: AppHandle,
     state: State<'_, DictationSettingsState>,
     helper_state: State<'_, HelperState>,
     id: Option<String>,
@@ -737,7 +753,9 @@ pub fn set_dictation_microphone(
     let settings = update_settings(&state, |settings| {
         settings.microphone = DictationMicrophoneSetting { id, name };
     })?;
-    #[cfg(not(target_os = "macos"))]
+    // Windows serves this in-process; only platforms that require the
+    // external helper (and lack it) skip the push.
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     if helper_state
         .process
         .lock()
@@ -746,8 +764,10 @@ pub fn set_dictation_microphone(
     {
         return Ok(settings);
     }
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    let _ = &helper_state;
 
-    apply_microphone_setting(&helper_state, &settings.microphone)?;
+    apply_microphone_setting(&app, &settings.microphone)?;
     Ok(settings)
 }
 
@@ -778,22 +798,30 @@ pub fn dictation_helper_command(
     state: State<'_, HelperState>,
     command: serde_json::Value,
 ) -> Result<(), AppError> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     if helper_command_resets_shortcut_activation(&command) {
         reset_shortcut_activation(&app);
     }
 
-    #[cfg(not(target_os = "macos"))]
-    if state
-        .process
-        .lock()
-        .map(|process| process.is_none())
-        .unwrap_or(true)
+    #[cfg(target_os = "windows")]
     {
-        return handle_missing_helper_command(&app, &command);
+        let _ = &state;
+        win::handle_command(&app, command)
     }
+    #[cfg(not(target_os = "windows"))]
+    {
+        #[cfg(not(target_os = "macos"))]
+        if state
+            .process
+            .lock()
+            .map(|process| process.is_none())
+            .unwrap_or(true)
+        {
+            return handle_missing_helper_command(&app, &command);
+        }
 
-    send_helper_command(&state, command)
+        send_helper_command(&state, command)
+    }
 }
 
 fn helper_command_resets_shortcut_activation(command: &serde_json::Value) -> bool {
@@ -1341,6 +1369,11 @@ fn spawn_hud_hover_thread(app: AppHandle) {
 }
 
 pub fn stop_helper(app: &AppHandle) {
+    // The Windows helper is in-process: stop its hook thread and reset any
+    // live recording instead of shutting down a child process.
+    #[cfg(target_os = "windows")]
+    win::stop();
+
     let state = app.state::<HelperState>();
     let Ok(mut guard) = state.process.lock() else {
         return;
@@ -1366,6 +1399,7 @@ pub(crate) fn dictation_helper_pid(app: &AppHandle) -> Option<u32> {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Result<(), AppError> {
     let mut guard = state
         .process
@@ -1390,7 +1424,7 @@ fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Resul
         .map_err(|error| AppError::new("dictation_helper_write_failed", error.to_string()))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn handle_missing_helper_command(
     app: &AppHandle,
     command: &serde_json::Value,
@@ -1430,7 +1464,7 @@ fn handle_missing_helper_command(
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn non_macos_permission_status_event() -> serde_json::Value {
     let (microphone, _) = crate::audio::capture::microphone_permission_state();
     serde_json::json!({
@@ -1442,12 +1476,31 @@ fn non_macos_permission_status_event() -> serde_json::Value {
     })
 }
 
+/// Deliver a helper command to whichever implementation owns the platform:
+/// the in-process Windows engine, or the external helper process elsewhere.
+fn dispatch_helper_command(app: &AppHandle, command: serde_json::Value) -> Result<(), AppError> {
+    #[cfg(target_os = "windows")]
+    {
+        win::handle_command(app, command)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let state = app.try_state::<HelperState>().ok_or_else(|| {
+            AppError::new(
+                "dictation_helper_unavailable",
+                "Dictation helper process is not running.",
+            )
+        })?;
+        send_helper_command(&state, command)
+    }
+}
+
 fn apply_microphone_setting(
-    helper_state: &HelperState,
+    app: &AppHandle,
     microphone: &DictationMicrophoneSetting,
 ) -> Result<(), AppError> {
-    send_helper_command(
-        helper_state,
+    dispatch_helper_command(
+        app,
         serde_json::json!({
             "type": "set_microphone",
             "id": microphone.id,
@@ -1457,12 +1510,12 @@ fn apply_microphone_setting(
 }
 
 fn apply_shortcut_setting(
-    helper_state: &HelperState,
+    app: &AppHandle,
     kind: DictationShortcutKind,
     shortcut: &DictationShortcutSetting,
 ) -> Result<(), AppError> {
-    send_helper_command(
-        helper_state,
+    dispatch_helper_command(
+        app,
         serde_json::json!({
             "type": "set_shortcut",
             "shortcut": {
@@ -1477,17 +1530,14 @@ fn apply_shortcut_setting(
     )
 }
 
-fn apply_shortcut_settings(
-    helper_state: &HelperState,
-    settings: &DictationSettings,
-) -> Result<(), AppError> {
+fn apply_shortcut_settings(app: &AppHandle, settings: &DictationSettings) -> Result<(), AppError> {
     apply_shortcut_setting(
-        helper_state,
+        app,
         DictationShortcutKind::PushToTalk,
         &settings.push_to_talk_shortcut,
     )?;
     apply_shortcut_setting(
-        helper_state,
+        app,
         DictationShortcutKind::Toggle,
         &settings.toggle_shortcut,
     )
@@ -1611,18 +1661,7 @@ fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_l
 }
 
 fn forward_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_label: &str) {
-    let Some(state) = app.try_state::<HelperState>() else {
-        emit_dictation_event_value(
-            app,
-            app_error_event(AppError::new(
-                "dictation_helper_unavailable",
-                "Dictation helper process is not running.",
-            )),
-        );
-        return;
-    };
-
-    if let Err(error) = send_helper_command(&state, command.helper_command(shortcut_label)) {
+    if let Err(error) = dispatch_helper_command(app, command.helper_command(shortcut_label)) {
         emit_dictation_event_value(app, app_error_event(error));
     }
 }
@@ -1757,6 +1796,7 @@ fn save_settings(
         .map_err(|error| AppError::new("dictation_settings_save_failed", error.to_string()))
 }
 
+#[cfg(not(target_os = "windows"))]
 fn helper_candidates(app: &AppHandle) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
@@ -1804,6 +1844,7 @@ fn helper_candidates(app: &AppHandle) -> Vec<PathBuf> {
     paths
 }
 
+#[cfg(not(target_os = "windows"))]
 fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
     let helper_path = helper_candidates(app)
         .into_iter()
@@ -1887,9 +1928,8 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
                     });
                 }
                 Err(error) => {
-                    let state = app.state::<HelperState>();
-                    let _ = send_helper_command(
-                        &state,
+                    let _ = dispatch_helper_command(
+                        app,
                         serde_json::json!({ "type": "discard_recording" }),
                     );
                     emit_dictation_event_value(app, app_error_event(error));
@@ -1914,16 +1954,15 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     // send_dictation_command can't tell start from stop) and for tokens that
     // expired between start and finish.
     if crate::os_accounts::access_token().await.is_err() {
-        let state = app.state::<HelperState>();
-        let _ = send_helper_command(&state, serde_json::json!({ "type": "discard_recording" }));
+        let _ = dispatch_helper_command(&app, serde_json::json!({ "type": "discard_recording" }));
         notify_dictation_not_signed_in(&app);
         return;
     }
     let provider = match dictation_transcription_provider(configured_transcription_provider()) {
         Ok(provider) => provider,
         Err(error) => {
-            let state = app.state::<HelperState>();
-            let _ = send_helper_command(&state, serde_json::json!({ "type": "discard_recording" }));
+            let _ =
+                dispatch_helper_command(&app, serde_json::json!({ "type": "discard_recording" }));
             emit_dictation_event_value(&app, app_error_event(error));
             return;
         }
@@ -1957,8 +1996,7 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     )
     .await;
     let outcome = outcome_from_transcription_result(result, recording.observed_audio_level, style);
-    let state = app.state::<HelperState>();
-    if let Err(error) = send_helper_command(&state, outcome.helper_command) {
+    if let Err(error) = dispatch_helper_command(&app, outcome.helper_command) {
         emit_dictation_event_value(&app, app_error_event(error));
         return;
     }
@@ -3134,12 +3172,12 @@ fn hotkey_ready_event(settings: &DictationSettings) -> serde_json::Value {
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn initial_hotkey_event(settings: &DictationSettings) -> serde_json::Value {
     hotkey_ready_event(settings)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn initial_hotkey_event(_settings: &DictationSettings) -> serde_json::Value {
     serde_json::json!({
         "type": "hotkey_trigger_unavailable",

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1,3 +1,8 @@
+/// Pure chord-matching / key-mapping / command-parsing logic for the Windows
+/// helper. Host-independent so its unit tests run everywhere.
+#[cfg(any(target_os = "windows", test))]
+mod win_chords;
+
 use crate::domain::{
     processing::{build_dictionary_context, merge_transcription_context},
     types::{AppError, ListDictationHistoryResponse},

--- a/src-tauri/src/dictation/win.rs
+++ b/src-tauri/src/dictation/win.rs
@@ -177,8 +177,13 @@ pub(crate) fn handle_command(_app: &AppHandle, command: Value) -> Result<(), App
             engine.emit(diagnostics_event());
         }
         HelperCommand::GetPermissionStatus => engine.emit(permission_status_event()),
+        // On macOS this triggers the one-time TCC prompt and is a no-op once
+        // decided, so App.tsx also sends it on every app open as a status
+        // refresh. Windows has no prompt to trigger; auto-opening the
+        // Settings app here would pop it on every launch, so just report the
+        // current status (the Manage buttons open Settings through the
+        // open_privacy_settings command instead).
         HelperCommand::RequestMicrophonePermission => {
-            open_microphone_privacy_settings();
             engine.emit(permission_status_event());
         }
         HelperCommand::RequestAccessibilityPermission => engine.emit(permission_status_event()),
@@ -317,15 +322,6 @@ fn diagnostics_event() -> Value {
             "autoDetectRawMeter": "disabled",
         },
     })
-}
-
-fn open_microphone_privacy_settings() {
-    use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    let _ = std::process::Command::new("cmd")
-        .args(["/C", "start", "ms-settings:privacy-microphone"])
-        .creation_flags(CREATE_NO_WINDOW)
-        .spawn();
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/dictation/win.rs
+++ b/src-tauri/src/dictation/win.rs
@@ -1,0 +1,1223 @@
+//! In-process Windows dictation "helper".
+//!
+//! On macOS an out-of-process Swift helper owns the global hotkey, the
+//! microphone capture, and the paste, talking to Rust over stdin/stdout
+//! JSON lines. On Windows this module satisfies the exact same command and
+//! event protocol in-process, so the existing Rust plumbing (shortcut
+//! activation controller, transcription, HUD) and the frontend work
+//! unchanged:
+//!
+//! - Commands arrive through [`handle_command`] (the same JSON shapes the
+//!   Swift helper reads from stdin).
+//! - Events leave through an mpsc channel whose consumer feeds them into
+//!   `dictation::handle_helper_event_line`, exactly like the helper's
+//!   stdout reader thread does on macOS.
+//!
+//! Threads:
+//! - A hook thread installs a WH_KEYBOARD_LL hook and pumps messages.
+//!   RegisterHotKey is not enough here: push-to-talk needs the key-up edge
+//!   and the settings UI's capture mode needs raw chord observation. The
+//!   hook callback only runs the pure chord matcher (dictation/win_chords)
+//!   and forwards resulting events to the dispatcher, so it returns fast.
+//! - A dispatcher thread turns engine events into `handle_helper_event_line`
+//!   calls (which may do real work: transcription spawns, HUD updates).
+//! - A capture thread owns the cpal input stream and the recording state
+//!   machine (dictation + mic test), mirroring the Swift
+//!   `DictationController` semantics and event vocabulary.
+//! - Short-lived timer threads implement the hold-threshold and capture
+//!   debounce, checking a generation token so stale timers are inert.
+//!
+//! Paste uses raw Win32 clipboard APIs (CF_UNICODETEXT save, set, restore)
+//! plus SendInput Ctrl+V; `arboard` would pull a sizable dependency tree for
+//! what is ~80 lines of Win32 here.
+
+use super::win_chords::{
+    self, parse_helper_command, parse_shortcut, Action, ChordMatcher, HelperCommand, Mods,
+    ShortcutParseError,
+};
+use crate::domain::types::AppError;
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use serde_json::{json, Value};
+use std::{
+    fs,
+    io::BufWriter,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        mpsc, Arc, Mutex, OnceLock,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+use tauri::AppHandle;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE, HGLOBAL, LPARAM, LRESULT, WPARAM};
+use windows::Win32::System::DataExchange::{
+    CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
+};
+use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+use windows::Win32::System::Threading::{
+    GetCurrentThreadId, OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+    PROCESS_QUERY_LIMITED_INFORMATION,
+};
+use windows::Win32::UI::Input::KeyboardAndMouse::{
+    GetAsyncKeyState, SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_KEYUP,
+    VIRTUAL_KEY, VK_CONTROL, VK_LWIN, VK_MENU, VK_RWIN, VK_SHIFT, VK_V,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
+    PostThreadMessageW, SetWindowsHookExW, TranslateMessage, UnhookWindowsHookEx, KBDLLHOOKSTRUCT,
+    LLKHF_INJECTED, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_QUIT, WM_SYSKEYDOWN, WM_SYSKEYUP,
+};
+
+const CF_UNICODETEXT: u32 = 13;
+/// Delay between claiming the clipboard and posting Ctrl+V (matches the
+/// Swift helper's 0.18s activation settle).
+const PASTE_KEYSTROKE_DELAY: Duration = Duration::from_millis(180);
+/// The clipboard is restored this long after the paste started (matches the
+/// Swift helper's 0.7s restore).
+const CLIPBOARD_RESTORE_DELAY: Duration = Duration::from_millis(700);
+/// Level events are coalesced to this cadence, like the Swift helper's
+/// selected-device recorder.
+const LEVEL_EMIT_INTERVAL: Duration = Duration::from_millis(40);
+/// Extra capture time appended to a mic test (Swift's
+/// `micTestCapturePaddingSeconds`).
+const MIC_TEST_PADDING: Duration = Duration::from_millis(350);
+
+static ENGINE: OnceLock<Engine> = OnceLock::new();
+
+struct Engine {
+    events: mpsc::Sender<Value>,
+    capture: mpsc::Sender<CaptureCmd>,
+    matcher: Mutex<ChordMatcher>,
+    hook_thread_id: AtomicU32,
+}
+
+impl Engine {
+    fn emit(&self, event: Value) {
+        let _ = self.events.send(event);
+    }
+}
+
+fn engine() -> Option<&'static Engine> {
+    ENGINE.get()
+}
+
+/// Start the in-process helper: dispatcher, capture, and hook threads.
+/// Idempotent; called once from `dictation::setup`.
+pub(crate) fn start(app: &AppHandle) {
+    let (event_tx, event_rx) = mpsc::channel::<Value>();
+    let (capture_tx, capture_rx) = mpsc::channel::<CaptureCmd>();
+
+    let engine = Engine {
+        events: event_tx.clone(),
+        capture: capture_tx,
+        matcher: Mutex::new(ChordMatcher::default()),
+        hook_thread_id: AtomicU32::new(0),
+    };
+    if ENGINE.set(engine).is_err() {
+        return;
+    }
+
+    let dispatch_app = app.clone();
+    thread::Builder::new()
+        .name("dictation-win-events".into())
+        .spawn(move || {
+            for event in event_rx {
+                super::handle_helper_event_line(&dispatch_app, event.to_string());
+            }
+        })
+        .ok();
+
+    let capture_events = event_tx.clone();
+    thread::Builder::new()
+        .name("dictation-win-capture".into())
+        .spawn(move || capture_thread(capture_rx, capture_events))
+        .ok();
+
+    thread::Builder::new()
+        .name("dictation-win-hook".into())
+        .spawn(hook_thread)
+        .ok();
+
+    if let Some(engine) = ENGINE.get() {
+        engine.emit(json!({ "type": "ready", "payload": {} }));
+        engine.emit(diagnostics_event());
+    }
+}
+
+/// Stop the hook thread and reset any live recording. Called on app exit.
+pub(crate) fn stop() {
+    if let Some(engine) = engine() {
+        let thread_id = engine.hook_thread_id.load(Ordering::SeqCst);
+        if thread_id != 0 {
+            unsafe {
+                let _ = PostThreadMessageW(thread_id, WM_QUIT, WPARAM(0), LPARAM(0));
+            }
+        }
+        let _ = engine.capture.send(CaptureCmd::Reset);
+    }
+}
+
+/// Route one helper command (the same JSON the Swift helper accepts on
+/// stdin) to the in-process implementation.
+pub(crate) fn handle_command(_app: &AppHandle, command: Value) -> Result<(), AppError> {
+    let Some(engine) = engine() else {
+        return Err(AppError::new(
+            "dictation_helper_unavailable",
+            "Dictation engine is not running.",
+        ));
+    };
+
+    match parse_helper_command(&command) {
+        HelperCommand::Ping => {
+            engine.emit(json!({ "type": "pong", "payload": {} }));
+            engine.emit(diagnostics_event());
+        }
+        HelperCommand::GetPermissionStatus => engine.emit(permission_status_event()),
+        HelperCommand::RequestMicrophonePermission => {
+            open_microphone_privacy_settings();
+            engine.emit(permission_status_event());
+        }
+        HelperCommand::RequestAccessibilityPermission => engine.emit(permission_status_event()),
+        HelperCommand::ListMicrophones => send_capture(engine, CaptureCmd::ListMicrophones),
+        HelperCommand::StartListening => send_capture(
+            engine,
+            CaptureCmd::Start {
+                purpose: Purpose::Dictation,
+                duration: None,
+            },
+        ),
+        HelperCommand::StopAndPaste => send_capture(engine, CaptureCmd::Stop),
+        HelperCommand::StartMicTest { duration_seconds } => send_capture(
+            engine,
+            CaptureCmd::Start {
+                purpose: Purpose::MicTest,
+                duration: Some(Duration::from_secs_f64(duration_seconds.clamp(1.0, 15.0))),
+            },
+        ),
+        HelperCommand::DiscardMicTest => send_capture(engine, CaptureCmd::DiscardMicTest),
+        HelperCommand::SetMicrophone { id, name } => {
+            send_capture(engine, CaptureCmd::SetMicrophone { id, name })
+        }
+        HelperCommand::SetShortcut { shortcut } => handle_set_shortcut(engine, shortcut),
+        HelperCommand::StartShortcutCapture => {
+            if let Ok(mut matcher) = engine.matcher.lock() {
+                matcher.start_capture();
+            }
+            engine.emit(json!({ "type": "shortcut_capture_started", "payload": {} }));
+        }
+        HelperCommand::CancelShortcutCapture => {
+            if let Ok(mut matcher) = engine.matcher.lock() {
+                matcher.cancel_capture();
+            }
+            engine.emit(json!({ "type": "shortcut_capture_cancelled", "payload": {} }));
+        }
+        HelperCommand::ToggleListening { shortcut } => {
+            send_capture(engine, CaptureCmd::Toggle { shortcut })
+        }
+        HelperCommand::PasteText { text } => send_capture(engine, CaptureCmd::Paste { text }),
+        HelperCommand::DiscardRecording => send_capture(engine, CaptureCmd::Discard),
+        HelperCommand::Shutdown => {
+            send_capture(engine, CaptureCmd::Reset);
+            engine.emit(json!({ "type": "shutdown_ack", "payload": {} }));
+        }
+        HelperCommand::Unknown => {
+            engine.emit(error_event("unknown_command", "Unknown helper command."))
+        }
+    }
+    Ok(())
+}
+
+fn send_capture(engine: &Engine, command: CaptureCmd) {
+    let _ = engine.capture.send(command);
+}
+
+fn handle_set_shortcut(engine: &Engine, shortcut: Option<Value>) {
+    let Some(payload) = shortcut else {
+        engine.emit(error_event(
+            "invalid_shortcut",
+            "Shortcut configuration was invalid.",
+        ));
+        return;
+    };
+    match parse_shortcut(&payload) {
+        Ok((kind, shortcut)) => {
+            if let Ok(mut matcher) = engine.matcher.lock() {
+                matcher.set_shortcut(kind, shortcut);
+            }
+        }
+        Err(ShortcutParseError::Invalid) => {
+            engine.emit(error_event(
+                "invalid_shortcut",
+                "Shortcut configuration was invalid.",
+            ));
+        }
+        Err(ShortcutParseError::FunctionUnsupported { label }) => {
+            clear_kind_for_payload(engine, &payload);
+            engine.emit(json!({
+                "type": "fn_monitor_unavailable",
+                "payload": {
+                    "message": format!(
+                        "The shortcut {label} uses the Fn key, which Windows cannot monitor. Pick a different shortcut in Settings."
+                    ),
+                },
+            }));
+        }
+        Err(ShortcutParseError::Unmappable { label }) => {
+            clear_kind_for_payload(engine, &payload);
+            engine.emit(json!({
+                "type": "fn_monitor_unavailable",
+                "payload": {
+                    "message": format!("Could not register the shortcut {label}."),
+                },
+            }));
+        }
+    }
+}
+
+/// A chord that cannot be monitored must also stop matching its kind's
+/// previous chord, mirroring the Swift helper's full hot key re-registration.
+fn clear_kind_for_payload(engine: &Engine, payload: &Value) {
+    let kind = match payload.get("kind").and_then(Value::as_str) {
+        Some("push_to_talk") => super::DictationShortcutKind::PushToTalk,
+        Some("toggle") => super::DictationShortcutKind::Toggle,
+        _ => return,
+    };
+    if let Ok(mut matcher) = engine.matcher.lock() {
+        matcher.clear_shortcut(kind);
+    }
+}
+
+fn error_event(code: &str, message: &str) -> Value {
+    json!({ "type": "error", "payload": { "code": code, "message": message } })
+}
+
+fn permission_status_event() -> Value {
+    let (microphone, _) = crate::audio::capture::microphone_permission_state();
+    json!({
+        "type": "permission_status",
+        "payload": {
+            "microphone": microphone,
+            "accessibility": "granted",
+        },
+    })
+}
+
+fn diagnostics_event() -> Value {
+    let (microphone, _) = crate::audio::capture::microphone_permission_state();
+    json!({
+        "type": "dictation_diagnostics",
+        "payload": {
+            "bundleIdentifier": "in-process-windows",
+            "microphone": microphone,
+            "accessibility": "granted",
+            "autoDetectRawMeter": "disabled",
+        },
+    })
+}
+
+fn open_microphone_privacy_settings() {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let _ = std::process::Command::new("cmd")
+        .args(["/C", "start", "ms-settings:privacy-microphone"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn();
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard hook
+// ---------------------------------------------------------------------------
+
+fn hook_thread() {
+    let Some(engine) = engine() else {
+        return;
+    };
+    engine
+        .hook_thread_id
+        .store(unsafe { GetCurrentThreadId() }, Ordering::SeqCst);
+
+    let hook = unsafe { SetWindowsHookExW(WH_KEYBOARD_LL, Some(keyboard_hook), None, 0) };
+    let hook = match hook {
+        Ok(hook) => hook,
+        Err(error) => {
+            engine.emit(json!({
+                "type": "fn_monitor_unavailable",
+                "payload": {
+                    "message": format!("Could not monitor global shortcut key events: {error}"),
+                },
+            }));
+            return;
+        }
+    };
+
+    let mut message = MSG::default();
+    // GetMessageW returns 0 on WM_QUIT and -1 on error; both end the pump.
+    while unsafe { GetMessageW(&mut message, None, 0, 0) }.0 > 0 {
+        unsafe {
+            let _ = TranslateMessage(&message);
+            DispatchMessageW(&message);
+        }
+    }
+
+    unsafe {
+        let _ = UnhookWindowsHookEx(hook);
+    }
+}
+
+unsafe extern "system" fn keyboard_hook(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    if code < 0 {
+        return CallNextHookEx(None, code, wparam, lparam);
+    }
+    let info = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
+    // Skip injected events: our own SendInput Ctrl+V must never re-enter the
+    // chord matcher.
+    if info.flags.0 & LLKHF_INJECTED.0 != 0 {
+        return CallNextHookEx(None, code, wparam, lparam);
+    }
+    let down = matches!(wparam.0 as u32, WM_KEYDOWN | WM_SYSKEYDOWN);
+    let up = matches!(wparam.0 as u32, WM_KEYUP | WM_SYSKEYUP);
+    if !down && !up {
+        return CallNextHookEx(None, code, wparam, lparam);
+    }
+
+    let Some(engine) = engine() else {
+        return CallNextHookEx(None, code, wparam, lparam);
+    };
+    let actions = engine
+        .matcher
+        .lock()
+        .map(|mut matcher| matcher.key_event(info.vkCode, down, Instant::now()))
+        .unwrap_or_default();
+    if run_matcher_actions(engine, actions) {
+        return LRESULT(1);
+    }
+    CallNextHookEx(None, code, wparam, lparam)
+}
+
+/// Perform the side effects of matcher actions; returns whether the hook
+/// should swallow the key event.
+fn run_matcher_actions(engine: &'static Engine, actions: Vec<Action>) -> bool {
+    let mut swallow = false;
+    for action in actions {
+        match action {
+            Action::Emit { kind, label, down } => emit_shortcut_edge(engine, kind, &label, down),
+            Action::SwallowKey => swallow = true,
+            Action::SchedulePushStart { token } => {
+                thread::spawn(move || {
+                    thread::sleep(win_chords::HOLD_THRESHOLD);
+                    let actions = engine
+                        .matcher
+                        .lock()
+                        .map(|mut matcher| matcher.fire_pending_push(token))
+                        .unwrap_or_default();
+                    run_matcher_actions(engine, actions);
+                });
+            }
+            Action::ScheduleCaptureCommit { token } => {
+                thread::spawn(move || {
+                    thread::sleep(win_chords::CAPTURE_DEBOUNCE);
+                    let captured = engine
+                        .matcher
+                        .lock()
+                        .ok()
+                        .and_then(|mut matcher| matcher.fire_capture_commit(token));
+                    if let Some(mods) = captured {
+                        emit_captured_modifier_shortcut(engine, mods);
+                    }
+                });
+            }
+        }
+    }
+    swallow
+}
+
+fn emit_shortcut_edge(
+    engine: &Engine,
+    kind: super::DictationShortcutKind,
+    label: &str,
+    down: bool,
+) {
+    let kind = match kind {
+        super::DictationShortcutKind::PushToTalk => "push_to_talk",
+        super::DictationShortcutKind::Toggle => "toggle",
+    };
+    engine.emit(json!({
+        "type": if down { "shortcut_key_down" } else { "shortcut_key_up" },
+        "payload": { "kind": kind, "shortcut": label },
+    }));
+}
+
+fn emit_captured_modifier_shortcut(engine: &Engine, mods: Mods) {
+    let label = mods.label_parts().join("+");
+    engine.emit(json!({
+        "type": "shortcut_captured",
+        "payload": {
+            "shortcut": {
+                "keyCode": 0,
+                "code": "Modifiers",
+                "label": label,
+                "pressCount": 1,
+                "modifiers": {
+                    "command": mods.command,
+                    "control": mods.control,
+                    "option": mods.option,
+                    "shift": mods.shift,
+                    "function": false,
+                },
+            },
+        },
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Microphone capture
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Purpose {
+    Dictation,
+    MicTest,
+}
+
+#[derive(Debug)]
+enum CaptureCmd {
+    Start {
+        purpose: Purpose,
+        duration: Option<Duration>,
+    },
+    Stop,
+    Toggle {
+        shortcut: String,
+    },
+    Discard,
+    DiscardMicTest,
+    SetMicrophone {
+        id: Option<String>,
+        name: Option<String>,
+    },
+    ListMicrophones,
+    Paste {
+        text: String,
+    },
+    Reset,
+}
+
+type SharedWavWriter = Arc<Mutex<Option<hound::WavWriter<BufWriter<fs::File>>>>>;
+
+struct ActiveRecording {
+    stream: cpal::Stream,
+    writer: SharedWavWriter,
+    path: PathBuf,
+    purpose: Purpose,
+    started_at: Instant,
+    /// f32 bits of the loudest observed level, shared with the stream
+    /// callback.
+    max_level: Arc<AtomicU32>,
+    /// Mic tests stop themselves at this deadline.
+    deadline: Option<Instant>,
+}
+
+struct CaptureState {
+    events: mpsc::Sender<Value>,
+    preferred_id: Option<String>,
+    preferred_name: Option<String>,
+    recording: Option<ActiveRecording>,
+    /// A finalized dictation take waiting for paste_text / discard_recording.
+    finalized_path: Option<PathBuf>,
+    mic_test_sample: Option<PathBuf>,
+}
+
+impl CaptureState {
+    fn emit(&self, event: Value) {
+        let _ = self.events.send(event);
+    }
+
+    fn listening(&self) -> bool {
+        self.recording.is_some() || self.finalized_path.is_some()
+    }
+}
+
+fn capture_thread(rx: mpsc::Receiver<CaptureCmd>, events: mpsc::Sender<Value>) {
+    let mut state = CaptureState {
+        events,
+        preferred_id: None,
+        preferred_name: None,
+        recording: None,
+        finalized_path: None,
+        mic_test_sample: None,
+    };
+
+    loop {
+        let deadline = state
+            .recording
+            .as_ref()
+            .and_then(|recording| recording.deadline);
+        let command = match deadline {
+            Some(deadline) => {
+                let timeout = deadline.saturating_duration_since(Instant::now());
+                match rx.recv_timeout(timeout) {
+                    Ok(command) => Some(command),
+                    Err(mpsc::RecvTimeoutError::Timeout) => None,
+                    Err(mpsc::RecvTimeoutError::Disconnected) => return,
+                }
+            }
+            None => match rx.recv() {
+                Ok(command) => Some(command),
+                Err(_) => return,
+            },
+        };
+
+        let Some(command) = command else {
+            // Mic test deadline reached.
+            finalize_recording(&mut state);
+            continue;
+        };
+
+        match command {
+            CaptureCmd::Start { purpose, duration } => {
+                start_recording(&mut state, purpose, duration)
+            }
+            CaptureCmd::Stop => stop_dictation(&mut state),
+            CaptureCmd::Toggle { shortcut } => {
+                if state.listening() {
+                    state.emit(json!({
+                        "type": "hotkey_trigger",
+                        "payload": { "action": "stop", "shortcut": shortcut },
+                    }));
+                    stop_dictation(&mut state);
+                } else {
+                    state.emit(json!({
+                        "type": "hotkey_trigger",
+                        "payload": { "action": "start", "shortcut": shortcut },
+                    }));
+                    start_recording(&mut state, Purpose::Dictation, None);
+                }
+            }
+            CaptureCmd::Discard => discard_recording(&mut state),
+            CaptureCmd::DiscardMicTest => {
+                if state
+                    .recording
+                    .as_ref()
+                    .is_some_and(|recording| recording.purpose == Purpose::MicTest)
+                {
+                    reset_recording(&mut state, false);
+                }
+                cleanup_mic_test_sample(&mut state);
+            }
+            CaptureCmd::SetMicrophone { id, name } => {
+                state.preferred_id = id.filter(|id| !id.is_empty());
+                state.preferred_name = name.filter(|name| !name.is_empty());
+                let selected_id = state.preferred_id.clone().unwrap_or_default();
+                let selected_name = state
+                    .preferred_name
+                    .clone()
+                    .unwrap_or_else(|| "Auto-detect".to_string());
+                state.emit(json!({
+                    "type": "microphone_selected",
+                    "payload": { "id": selected_id, "name": selected_name },
+                }));
+                emit_microphone_devices(&state);
+            }
+            CaptureCmd::ListMicrophones => emit_microphone_devices(&state),
+            CaptureCmd::Paste { text } => paste_transcript(&mut state, text),
+            CaptureCmd::Reset => reset_recording(&mut state, false),
+        }
+    }
+}
+
+fn emit_microphone_devices(state: &CaptureState) {
+    let host = cpal::default_host();
+    let devices: Vec<Value> = host
+        .input_devices()
+        .map(|devices| {
+            devices
+                .filter_map(|device| device.name().ok())
+                .map(|name| json!({ "id": name.clone(), "name": name }))
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut payload = json!({
+        "devices": devices,
+        "selectedID": state.preferred_id.clone().unwrap_or_default(),
+    });
+    if let Some(name) = host
+        .default_input_device()
+        .and_then(|device| device.name().ok())
+    {
+        payload["defaultDevice"] = json!({ "id": name.clone(), "name": name });
+    }
+    state.emit(json!({ "type": "microphone_devices", "payload": payload }));
+}
+
+fn recording_error_event(purpose: Purpose, code: &str, message: &str) -> Value {
+    let event_type = match purpose {
+        Purpose::Dictation => "error",
+        Purpose::MicTest => "mic_test_error",
+    };
+    json!({ "type": event_type, "payload": { "code": code, "message": message } })
+}
+
+fn start_recording(state: &mut CaptureState, purpose: Purpose, duration: Option<Duration>) {
+    if state.listening() {
+        state.emit(match purpose {
+            Purpose::Dictation => recording_error_event(
+                Purpose::Dictation,
+                "already_listening",
+                "Dictation is already listening.",
+            ),
+            Purpose::MicTest => recording_error_event(
+                Purpose::MicTest,
+                "already_listening",
+                "Audio capture is already running.",
+            ),
+        });
+        return;
+    }
+    cleanup_mic_test_sample(state);
+
+    let host = cpal::default_host();
+    let pinned = state.preferred_id.is_some() || state.preferred_name.is_some();
+    let device = pinned
+        .then(|| {
+            host.input_devices().ok().and_then(|mut devices| {
+                devices.find(|device| {
+                    device.name().is_ok_and(|name| {
+                        state.preferred_id.as_deref() == Some(name.as_str())
+                            || state.preferred_name.as_deref() == Some(name.as_str())
+                    })
+                })
+            })
+        })
+        .flatten()
+        .or_else(|| host.default_input_device());
+    let Some(device) = device else {
+        state.emit(recording_error_event(
+            purpose,
+            "microphone_permission_missing",
+            "Microphone permission is required.",
+        ));
+        state.emit(permission_status_event());
+        return;
+    };
+    let microphone_label = if pinned {
+        device.name().unwrap_or_else(|_| "Auto-detect".to_string())
+    } else {
+        "Auto-detect".to_string()
+    };
+
+    let config = match device.default_input_config() {
+        Ok(config) => config,
+        Err(error) => {
+            state.emit(recording_error_event(
+                purpose,
+                "audio_start_failed",
+                &error.to_string(),
+            ));
+            return;
+        }
+    };
+
+    let path = std::env::temp_dir().join(format!("os-june-dictation-{}.wav", uuid::Uuid::new_v4()));
+    let spec = hound::WavSpec {
+        channels: config.channels(),
+        sample_rate: config.sample_rate().0,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let writer = match hound::WavWriter::create(&path, spec) {
+        Ok(writer) => writer,
+        Err(error) => {
+            state.emit(recording_error_event(
+                purpose,
+                "audio_start_failed",
+                &error.to_string(),
+            ));
+            return;
+        }
+    };
+    let writer: SharedWavWriter = Arc::new(Mutex::new(Some(writer)));
+    let max_level = Arc::new(AtomicU32::new(0f32.to_bits()));
+
+    let mut meter = LevelMeter {
+        events: state.events.clone(),
+        purpose,
+        max_level: Arc::clone(&max_level),
+        pending: 0.0,
+        last_emit: Instant::now(),
+    };
+    let callback_writer = Arc::clone(&writer);
+    let err_fn = |error| tracing::warn!(%error, "dictation input stream error");
+    let stream = match config.sample_format() {
+        cpal::SampleFormat::F32 => device.build_input_stream(
+            &config.clone().into(),
+            move |data: &[f32], _| {
+                write_chunk(data.iter().copied(), &callback_writer, &mut meter);
+            },
+            err_fn,
+            None,
+        ),
+        cpal::SampleFormat::I16 => device.build_input_stream(
+            &config.clone().into(),
+            move |data: &[i16], _| {
+                write_chunk(
+                    data.iter().map(|sample| *sample as f32 / i16::MAX as f32),
+                    &callback_writer,
+                    &mut meter,
+                );
+            },
+            err_fn,
+            None,
+        ),
+        cpal::SampleFormat::U16 => device.build_input_stream(
+            &config.clone().into(),
+            move |data: &[u16], _| {
+                write_chunk(
+                    data.iter()
+                        .map(|sample| (*sample as f32 - 32768.0) / 32768.0),
+                    &callback_writer,
+                    &mut meter,
+                );
+            },
+            err_fn,
+            None,
+        ),
+        _ => {
+            let _ = fs::remove_file(&path);
+            state.emit(recording_error_event(
+                purpose,
+                "audio_start_failed",
+                "Unsupported microphone sample format.",
+            ));
+            return;
+        }
+    };
+    let stream = match stream {
+        Ok(stream) => stream,
+        Err(error) => {
+            let _ = fs::remove_file(&path);
+            state.emit(recording_error_event(
+                purpose,
+                "audio_start_failed",
+                &error.to_string(),
+            ));
+            return;
+        }
+    };
+    if let Err(error) = stream.play() {
+        let _ = fs::remove_file(&path);
+        state.emit(recording_error_event(
+            purpose,
+            "audio_start_failed",
+            &error.to_string(),
+        ));
+        return;
+    }
+
+    let now = Instant::now();
+    let deadline = duration.map(|duration| now + duration + MIC_TEST_PADDING);
+    state.recording = Some(ActiveRecording {
+        stream,
+        writer,
+        path,
+        purpose,
+        started_at: now,
+        max_level,
+        deadline,
+    });
+
+    match purpose {
+        Purpose::Dictation => state.emit(json!({
+            "type": "listening_started",
+            "payload": {
+                "recognitionMode": "venice_recording",
+                "microphone": microphone_label,
+            },
+        })),
+        Purpose::MicTest => state.emit(json!({
+            "type": "mic_test_started",
+            "payload": {
+                "durationMs": duration.unwrap_or(Duration::from_secs(5)).as_millis() as u64,
+                "microphone": microphone_label,
+            },
+        })),
+    }
+}
+
+fn stop_dictation(state: &mut CaptureState) {
+    let is_dictation = state
+        .recording
+        .as_ref()
+        .is_some_and(|recording| recording.purpose == Purpose::Dictation);
+    if !is_dictation {
+        state.emit(error_event("not_listening", "Dictation is not listening."));
+        return;
+    }
+    state.emit(json!({ "type": "finalizing_transcript", "payload": {} }));
+    finalize_recording(state);
+}
+
+/// Stop the stream, close the WAV, and emit recording_ready / mic_test_ready.
+fn finalize_recording(state: &mut CaptureState) {
+    let Some(recording) = state.recording.take() else {
+        return;
+    };
+    let ActiveRecording {
+        stream,
+        writer,
+        path,
+        purpose,
+        started_at,
+        max_level,
+        ..
+    } = recording;
+    drop(stream);
+    let finalize_result = writer
+        .lock()
+        .ok()
+        .and_then(|mut writer| writer.take())
+        .map(hound::WavWriter::finalize);
+
+    let observed = f32::from_bits(max_level.load(Ordering::Relaxed));
+    let wrote_audio = matches!(finalize_result, Some(Ok(())))
+        && fs::metadata(&path)
+            .map(|meta| meta.len() > 44)
+            .unwrap_or(false);
+    if !wrote_audio {
+        let _ = fs::remove_file(&path);
+        state.emit(recording_error_event(
+            purpose,
+            "missing_recording",
+            "No recorded audio was available to transcribe.",
+        ));
+        return;
+    }
+
+    match purpose {
+        Purpose::Dictation => {
+            state.emit(json!({
+                "type": "recording_ready",
+                "payload": {
+                    "path": path.to_string_lossy(),
+                    "observedAudioLevel": format!("{observed:.4}"),
+                },
+            }));
+            state.finalized_path = Some(path);
+        }
+        Purpose::MicTest => {
+            let duration_ms = started_at.elapsed().as_millis() as u64;
+            state.emit(json!({
+                "type": "mic_test_ready",
+                "payload": {
+                    "path": path.to_string_lossy(),
+                    "durationMs": duration_ms,
+                    "observedAudioLevel": format!("{observed:.4}"),
+                },
+            }));
+            state.mic_test_sample = Some(path);
+        }
+    }
+}
+
+fn discard_recording(state: &mut CaptureState) {
+    let was_listening = state.recording.is_some();
+    reset_recording(state, false);
+    if was_listening {
+        state.emit(json!({ "type": "recording_discarded", "payload": {} }));
+    }
+}
+
+fn paste_transcript(state: &mut CaptureState, text: String) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        state.emit(error_event(
+            "empty_transcript",
+            "No transcript text was available to paste.",
+        ));
+        reset_recording(state, false);
+        return;
+    }
+    // Trailing space so consecutive dictations don't run together, matching
+    // the Swift helper's dictationPasteText.
+    let text = format!("{trimmed} ");
+    state.emit(json!({
+        "type": "final_transcript",
+        "payload": { "text": text },
+    }));
+    let events = state.events.clone();
+    thread::Builder::new()
+        .name("dictation-win-paste".into())
+        .spawn(move || paste_worker(text, events))
+        .ok();
+    reset_recording(state, false);
+}
+
+fn reset_recording(state: &mut CaptureState, keep_recording_file: bool) {
+    if let Some(recording) = state.recording.take() {
+        drop(recording.stream);
+        if let Ok(mut writer) = recording.writer.lock() {
+            if let Some(writer) = writer.take() {
+                let _ = writer.finalize();
+            }
+        }
+        if !keep_recording_file {
+            let _ = fs::remove_file(&recording.path);
+        }
+    }
+    if let Some(path) = state.finalized_path.take() {
+        let _ = fs::remove_file(path);
+    }
+}
+
+fn cleanup_mic_test_sample(state: &mut CaptureState) {
+    if let Some(path) = state.mic_test_sample.take() {
+        let _ = fs::remove_file(path);
+    }
+}
+
+struct LevelMeter {
+    events: mpsc::Sender<Value>,
+    purpose: Purpose,
+    max_level: Arc<AtomicU32>,
+    pending: f32,
+    last_emit: Instant,
+}
+
+impl LevelMeter {
+    /// Level formula and coalescing mirror the Swift helper: per chunk,
+    /// `min(1, peak * 0.8 + rms * 0.2)`, emitted at most every 40ms with the
+    /// max held across skipped chunks so transients still register.
+    fn observe(&mut self, peak: f32, rms: f32) {
+        let level = (peak * 0.8 + rms * 0.2).min(1.0);
+        let previous = f32::from_bits(self.max_level.load(Ordering::Relaxed));
+        if level > previous {
+            self.max_level.store(level.to_bits(), Ordering::Relaxed);
+        }
+        self.pending = self.pending.max(level);
+        let now = Instant::now();
+        if now.duration_since(self.last_emit) < LEVEL_EMIT_INTERVAL {
+            return;
+        }
+        self.last_emit = now;
+        let coalesced = self.pending;
+        self.pending = 0.0;
+        let event_type = match self.purpose {
+            Purpose::Dictation => "audio_level",
+            Purpose::MicTest => "mic_test_level",
+        };
+        let _ = self.events.send(json!({
+            "type": event_type,
+            "payload": { "level": format!("{coalesced:.4}") },
+        }));
+    }
+}
+
+fn write_chunk<I>(samples: I, writer: &SharedWavWriter, meter: &mut LevelMeter)
+where
+    I: Iterator<Item = f32>,
+{
+    let mut guard = match writer.lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+    let Some(writer) = guard.as_mut() else {
+        return;
+    };
+    let mut peak = 0f32;
+    let mut sum_squares = 0f64;
+    let mut count = 0u32;
+    for sample in samples {
+        let clamped = sample.clamp(-1.0, 1.0);
+        peak = peak.max(clamped.abs());
+        sum_squares += f64::from(clamped) * f64::from(clamped);
+        count += 1;
+        let _ = writer.write_sample((clamped * i16::MAX as f32) as i16);
+    }
+    drop(guard);
+    if count > 0 {
+        let rms = (sum_squares / f64::from(count)).sqrt() as f32;
+        meter.observe(peak, rms);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Paste (clipboard + SendInput)
+// ---------------------------------------------------------------------------
+
+fn paste_worker(text: String, events: mpsc::Sender<Value>) {
+    let emit = |event: Value| {
+        let _ = events.send(event);
+    };
+
+    // CF_UNICODETEXT round-trip only: non-text clipboard content (images,
+    // files) cannot be snapshotted this way, so in that case the transcript
+    // is left on the clipboard instead of destroying the content.
+    let snapshot = read_clipboard_text();
+    if let Err(message) = set_clipboard_text(&text) {
+        emit(error_event(
+            "pasteboard_write_failed",
+            &format!("Could not write transcript to the clipboard: {message}"),
+        ));
+        return;
+    }
+
+    emit(json!({
+        "type": "paste_target",
+        "payload": {
+            "app": foreground_app_name(),
+            "activated": "granted",
+        },
+    }));
+
+    thread::sleep(PASTE_KEYSTROKE_DELAY);
+    send_ctrl_v();
+    emit(json!({ "type": "paste_completed", "payload": {} }));
+
+    thread::sleep(CLIPBOARD_RESTORE_DELAY.saturating_sub(PASTE_KEYSTROKE_DELAY));
+    if read_clipboard_text().as_deref() == Some(text.as_str()) {
+        if let Some(previous) = snapshot {
+            let _ = set_clipboard_text(&previous);
+        }
+    }
+}
+
+/// Open the clipboard, retrying briefly: another app can hold it.
+fn open_clipboard_with_retry() -> bool {
+    for _ in 0..10 {
+        if unsafe { OpenClipboard(None) }.is_ok() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(15));
+    }
+    false
+}
+
+fn read_clipboard_text() -> Option<String> {
+    if !open_clipboard_with_retry() {
+        return None;
+    }
+    let text = unsafe {
+        GetClipboardData(CF_UNICODETEXT).ok().and_then(|handle| {
+            let hglobal = HGLOBAL(handle.0);
+            let pointer = GlobalLock(hglobal) as *const u16;
+            if pointer.is_null() {
+                return None;
+            }
+            let mut length = 0usize;
+            while *pointer.add(length) != 0 {
+                length += 1;
+            }
+            let slice = std::slice::from_raw_parts(pointer, length);
+            let text = String::from_utf16_lossy(slice);
+            let _ = GlobalUnlock(hglobal);
+            Some(text)
+        })
+    };
+    unsafe {
+        let _ = CloseClipboard();
+    }
+    text
+}
+
+fn set_clipboard_text(text: &str) -> Result<(), String> {
+    let wide: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+    if !open_clipboard_with_retry() {
+        return Err("clipboard is busy".to_string());
+    }
+    let result = unsafe {
+        (|| -> Result<(), String> {
+            EmptyClipboard().map_err(|error| error.to_string())?;
+            let hglobal =
+                GlobalAlloc(GMEM_MOVEABLE, wide.len() * 2).map_err(|error| error.to_string())?;
+            let pointer = GlobalLock(hglobal) as *mut u16;
+            if pointer.is_null() {
+                return Err("could not lock clipboard memory".to_string());
+            }
+            std::ptr::copy_nonoverlapping(wide.as_ptr(), pointer, wide.len());
+            let _ = GlobalUnlock(hglobal);
+            // On success the system owns the allocation.
+            SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hglobal.0)))
+                .map_err(|error| error.to_string())?;
+            Ok(())
+        })()
+    };
+    unsafe {
+        let _ = CloseClipboard();
+    }
+    result
+}
+
+fn keyboard_input(vk: VIRTUAL_KEY, up: bool) -> INPUT {
+    INPUT {
+        r#type: INPUT_KEYBOARD,
+        Anonymous: INPUT_0 {
+            ki: KEYBDINPUT {
+                wVk: vk,
+                wScan: 0,
+                dwFlags: if up {
+                    KEYEVENTF_KEYUP
+                } else {
+                    Default::default()
+                },
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
+    }
+}
+
+/// Synthesize Ctrl+V. Any physically held Shift/Alt/Win is released first so
+/// a not-yet-lifted shortcut chord cannot turn the paste into Ctrl+Alt+V.
+fn send_ctrl_v() {
+    let mut inputs: Vec<INPUT> = Vec::with_capacity(8);
+    unsafe {
+        for vk in [VK_SHIFT, VK_MENU, VK_LWIN, VK_RWIN] {
+            if (GetAsyncKeyState(vk.0 as i32) as u16) & 0x8000 != 0 {
+                inputs.push(keyboard_input(vk, true));
+            }
+        }
+    }
+    inputs.push(keyboard_input(VK_CONTROL, false));
+    inputs.push(keyboard_input(VK_V, false));
+    inputs.push(keyboard_input(VK_V, true));
+    inputs.push(keyboard_input(VK_CONTROL, true));
+    unsafe {
+        SendInput(&inputs, std::mem::size_of::<INPUT>() as i32);
+    }
+}
+
+fn foreground_app_name() -> String {
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if hwnd.is_invalid() {
+            return "unknown".to_string();
+        }
+        let mut pid = 0u32;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        if pid == 0 {
+            return "unknown".to_string();
+        }
+        let Ok(process) = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) else {
+            return "unknown".to_string();
+        };
+        let mut buffer = [0u16; 1024];
+        let mut length = buffer.len() as u32;
+        let name = QueryFullProcessImageNameW(
+            process,
+            PROCESS_NAME_WIN32,
+            windows::core::PWSTR(buffer.as_mut_ptr()),
+            &mut length,
+        )
+        .ok()
+        .and_then(|_| {
+            let path = String::from_utf16_lossy(&buffer[..length as usize]);
+            std::path::Path::new(&path)
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+        let _ = CloseHandle(process);
+        name
+    }
+}

--- a/src-tauri/src/dictation/win.rs
+++ b/src-tauri/src/dictation/win.rs
@@ -51,7 +51,9 @@ use std::{
 };
 use tauri::AppHandle;
 
-use windows::Win32::Foundation::{CloseHandle, HANDLE, HGLOBAL, LPARAM, LRESULT, WPARAM};
+use windows::Win32::Foundation::{
+    CloseHandle, GlobalFree, HANDLE, HGLOBAL, LPARAM, LRESULT, WPARAM,
+};
 use windows::Win32::System::DataExchange::{
     CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
 };
@@ -1132,13 +1134,17 @@ fn set_clipboard_text(text: &str) -> Result<(), String> {
                 GlobalAlloc(GMEM_MOVEABLE, wide.len() * 2).map_err(|error| error.to_string())?;
             let pointer = GlobalLock(hglobal) as *mut u16;
             if pointer.is_null() {
+                let _ = GlobalFree(Some(hglobal));
                 return Err("could not lock clipboard memory".to_string());
             }
             std::ptr::copy_nonoverlapping(wide.as_ptr(), pointer, wide.len());
             let _ = GlobalUnlock(hglobal);
-            // On success the system owns the allocation.
-            SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hglobal.0)))
-                .map_err(|error| error.to_string())?;
+            // Only a successful SetClipboardData hands the allocation to the
+            // system; on failure it is still ours to free.
+            if let Err(error) = SetClipboardData(CF_UNICODETEXT, Some(HANDLE(hglobal.0))) {
+                let _ = GlobalFree(Some(hglobal));
+                return Err(error.to_string());
+            }
             Ok(())
         })()
     };

--- a/src-tauri/src/dictation/win_chords.rs
+++ b/src-tauri/src/dictation/win_chords.rs
@@ -1,0 +1,1271 @@
+//! Pure, host-testable logic for the in-process Windows dictation helper.
+//!
+//! This module mirrors the Swift helper's `ShortcutKeyMonitor` state machine
+//! (native/mac-dictation-helper/main.swift) on top of Windows virtual-key
+//! events instead of NSEvent/Carbon:
+//!
+//! - Key chords (e.g. Ctrl+Opt+D) match on the trigger key's virtual key with
+//!   an exact modifier state, and produce `shortcut_key_down`/`up` edges that
+//!   the existing Rust `ShortcutActivationController` consumes unchanged.
+//! - Modifier-only chords (code == "Modifiers") match on the exact modifier
+//!   set, with the press edge gated on the changed key belonging to the set,
+//!   like the Swift `handleFlagsChanged` path.
+//! - Double-press toggles (pressCount == 2) and the shared-trigger hold
+//!   threshold (a single-press push sharing its chord with a toggle) are
+//!   ported from the Swift monitor with the same timing constants.
+//!
+//! Mapping choice: settings store both a macOS `keyCode` and a W3C UI Events
+//! `code` string ("KeyD"). We ignore the macOS keyCode and map `code` to a
+//! Windows virtual key so settings roam across platforms. VKs (not scancodes)
+//! are used deliberately: the shortcut label says "Ctrl+Opt+D", and matching
+//! VK 'D' keeps that label truthful on every keyboard layout, whereas the
+//! scancode at the US-D position types a different character on non-QWERTY
+//! layouts. Punctuation codes use the US-layout OEM VKs (documented
+//! limitation for exotic layouts). "Fn" is not observable on Windows, so
+//! Fn-based shortcuts report `fn_monitor_unavailable`, matching the Swift
+//! helper's handling of unregistrable chords.
+//!
+//! Everything here is pure (no Win32 calls) so the chord matcher, key map,
+//! and command parsing unit-test on any host.
+
+use super::DictationShortcutKind;
+use std::time::{Duration, Instant};
+
+/// A push shorter than this on a shared trigger is (or arms) the toggle;
+/// only a hold is the push. Mirrors the Swift monitor's `holdThreshold`.
+pub(crate) const HOLD_THRESHOLD: Duration = Duration::from_millis(160);
+/// Two taps of a pressCount == 2 toggle must land within this window.
+/// Mirrors the Swift monitor's `doublePressWindow`.
+pub(crate) const DOUBLE_PRESS_WINDOW: Duration = Duration::from_millis(340);
+/// A modifier-only chord held stable for this long during shortcut capture
+/// commits as the captured shortcut. Mirrors the Swift capture debounce.
+pub(crate) const CAPTURE_DEBOUNCE: Duration = Duration::from_millis(180);
+
+// Modifier virtual keys (winuser.h). Generic VKs are included alongside the
+// left/right variants; the low-level hook reports the specific keys, but the
+// generic codes cost nothing to accept.
+const VK_SHIFT: u32 = 0x10;
+const VK_CONTROL: u32 = 0x11;
+const VK_MENU: u32 = 0x12;
+const VK_LWIN: u32 = 0x5B;
+const VK_RWIN: u32 = 0x5C;
+const VK_LSHIFT: u32 = 0xA0;
+const VK_RSHIFT: u32 = 0xA1;
+const VK_LCONTROL: u32 = 0xA2;
+const VK_RCONTROL: u32 = 0xA3;
+const VK_LMENU: u32 = 0xA4;
+const VK_RMENU: u32 = 0xA5;
+
+/// Map a W3C UI Events `code` string to a Windows virtual key.
+pub(crate) fn vk_for_code(code: &str) -> Option<u32> {
+    if let Some(letter) = code.strip_prefix("Key").filter(|rest| rest.len() == 1) {
+        let ch = letter.chars().next()?;
+        if ch.is_ascii_uppercase() {
+            return Some(ch as u32); // 'A'..'Z' == VK_A..VK_Z
+        }
+        return None;
+    }
+    if let Some(digit) = code.strip_prefix("Digit").filter(|rest| rest.len() == 1) {
+        let ch = digit.chars().next()?;
+        if ch.is_ascii_digit() {
+            return Some(ch as u32); // '0'..'9' == VK_0..VK_9
+        }
+        return None;
+    }
+    if let Some(number) = code.strip_prefix('F').filter(|rest| {
+        !rest.is_empty() && rest.len() <= 2 && rest.chars().all(|ch| ch.is_ascii_digit())
+    }) {
+        let index: u32 = number.parse().ok()?;
+        if (1..=24).contains(&index) {
+            return Some(0x70 + index - 1); // VK_F1..VK_F24
+        }
+        return None;
+    }
+    Some(match code {
+        "Space" => 0x20,
+        "Enter" => 0x0D,
+        "Tab" => 0x09,
+        "Backspace" => 0x08,
+        "Escape" => 0x1B,
+        "Minus" => 0xBD,        // VK_OEM_MINUS
+        "Equal" => 0xBB,        // VK_OEM_PLUS
+        "BracketLeft" => 0xDB,  // VK_OEM_4
+        "BracketRight" => 0xDD, // VK_OEM_6
+        "Backslash" => 0xDC,    // VK_OEM_5
+        "Semicolon" => 0xBA,    // VK_OEM_1
+        "Quote" => 0xDE,        // VK_OEM_7
+        "Comma" => 0xBC,        // VK_OEM_COMMA
+        "Period" => 0xBE,       // VK_OEM_PERIOD
+        "Slash" => 0xBF,        // VK_OEM_2
+        "Backquote" => 0xC0,    // VK_OEM_3
+        "ArrowLeft" => 0x25,
+        "ArrowUp" => 0x26,
+        "ArrowRight" => 0x27,
+        "ArrowDown" => 0x28,
+        _ => return None,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ModifierKey {
+    Command,
+    Control,
+    Option,
+    Shift,
+}
+
+/// The modifier a virtual key contributes, if any. The macOS "command"
+/// modifier maps to the Windows key and "option" to Alt.
+pub(crate) fn modifier_key_for_vk(vk: u32) -> Option<ModifierKey> {
+    match vk {
+        VK_SHIFT | VK_LSHIFT | VK_RSHIFT => Some(ModifierKey::Shift),
+        VK_CONTROL | VK_LCONTROL | VK_RCONTROL => Some(ModifierKey::Control),
+        VK_MENU | VK_LMENU | VK_RMENU => Some(ModifierKey::Option),
+        VK_LWIN | VK_RWIN => Some(ModifierKey::Command),
+        _ => None,
+    }
+}
+
+/// Modifier state of a chord. `function` is intentionally absent: Windows
+/// keyboards handle Fn in firmware and it never reaches the OS input stream.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Mods {
+    pub command: bool,
+    pub control: bool,
+    pub option: bool,
+    pub shift: bool,
+}
+
+impl Mods {
+    pub fn count(self) -> usize {
+        [self.command, self.control, self.option, self.shift]
+            .into_iter()
+            .filter(|enabled| *enabled)
+            .count()
+    }
+
+    pub fn has_any(self) -> bool {
+        self.count() > 0
+    }
+
+    fn set(&mut self, key: ModifierKey, down: bool) {
+        match key {
+            ModifierKey::Command => self.command = down,
+            ModifierKey::Control => self.control = down,
+            ModifierKey::Option => self.option = down,
+            ModifierKey::Shift => self.shift = down,
+        }
+    }
+
+    fn contains_key(self, key: ModifierKey) -> bool {
+        match key {
+            ModifierKey::Command => self.command,
+            ModifierKey::Control => self.control,
+            ModifierKey::Option => self.option,
+            ModifierKey::Shift => self.shift,
+        }
+    }
+
+    /// Label parts using the same names the Swift helper emits, so captured
+    /// modifier-only shortcuts round-trip through the shared settings
+    /// normalizer (which regenerates labels in this vocabulary).
+    pub fn label_parts(self) -> Vec<&'static str> {
+        [
+            (self.command, "Cmd"),
+            (self.control, "Ctrl"),
+            (self.option, "Opt"),
+            (self.shift, "Shift"),
+        ]
+        .into_iter()
+        .filter_map(|(enabled, label)| enabled.then_some(label))
+        .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Trigger {
+    Key(u32),
+    ModifierOnly,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WinShortcut {
+    pub trigger: Trigger,
+    pub mods: Mods,
+    pub label: String,
+    pub press_count: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Identity {
+    trigger: Trigger,
+    mods: Mods,
+}
+
+impl Identity {
+    fn of(shortcut: &WinShortcut) -> Self {
+        Self {
+            trigger: shortcut.trigger,
+            mods: shortcut.mods,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum Action {
+    /// Emit a shortcut_key_down / shortcut_key_up event.
+    Emit {
+        kind: DictationShortcutKind,
+        label: String,
+        down: bool,
+    },
+    /// Return 1 from the hook: consume the trigger key system-wide, like a
+    /// registered Carbon hot key does on macOS.
+    SwallowKey,
+    /// Call `fire_pending_push(token)` after [`HOLD_THRESHOLD`].
+    SchedulePushStart { token: u64 },
+    /// Call `fire_capture_commit(token)` after [`CAPTURE_DEBOUNCE`].
+    ScheduleCaptureCommit { token: u64 },
+}
+
+/// Chord matcher fed raw key transitions from the WH_KEYBOARD_LL hook.
+#[derive(Debug, Default)]
+pub(crate) struct ChordMatcher {
+    push_to_talk: Option<WinShortcut>,
+    toggle: Option<WinShortcut>,
+    modifiers: Mods,
+    active: Option<Identity>,
+    active_push: Option<Identity>,
+    pending_push: Option<(u64, Identity)>,
+    last_tap: Option<(Identity, Instant)>,
+    capturing: bool,
+    pending_capture: Option<(u64, Mods)>,
+    swallowed_vk: Option<u32>,
+    next_token: u64,
+}
+
+impl ChordMatcher {
+    pub fn set_shortcut(&mut self, kind: DictationShortcutKind, shortcut: WinShortcut) {
+        match kind {
+            DictationShortcutKind::PushToTalk => self.push_to_talk = Some(shortcut),
+            DictationShortcutKind::Toggle => self.toggle = Some(shortcut),
+        }
+        self.reset_transient();
+    }
+
+    /// Drop a kind's chord entirely (its configured shortcut cannot be
+    /// monitored on Windows, e.g. Fn-based). Mirrors the Swift helper
+    /// skipping registration for such chords.
+    pub fn clear_shortcut(&mut self, kind: DictationShortcutKind) {
+        match kind {
+            DictationShortcutKind::PushToTalk => self.push_to_talk = None,
+            DictationShortcutKind::Toggle => self.toggle = None,
+        }
+        self.reset_transient();
+    }
+
+    pub fn start_capture(&mut self) {
+        self.reset_transient();
+        self.capturing = true;
+    }
+
+    pub fn cancel_capture(&mut self) {
+        self.capturing = false;
+        self.pending_capture = None;
+    }
+
+    fn reset_transient(&mut self) {
+        self.active = None;
+        self.active_push = None;
+        self.pending_push = None;
+        self.last_tap = None;
+        self.pending_capture = None;
+    }
+
+    fn take_token(&mut self) -> u64 {
+        self.next_token += 1;
+        self.next_token
+    }
+
+    /// Feed one raw key transition. `down` covers WM_KEYDOWN/WM_SYSKEYDOWN.
+    pub fn key_event(&mut self, vk: u32, down: bool, now: Instant) -> Vec<Action> {
+        let mut actions = Vec::new();
+
+        if let Some(modifier) = modifier_key_for_vk(vk) {
+            let was_down = self.modifiers.contains_key(modifier);
+            self.modifiers.set(modifier, down);
+            let current = self.modifiers;
+            if down == was_down {
+                // Auto-repeat of a held modifier: no edge.
+                return actions;
+            }
+
+            if self.capturing {
+                self.handle_capture(current, &mut actions);
+                return actions;
+            }
+
+            // Any modifier change away from an active chord's exact set ends
+            // the press. It only counts as a physical release (arming the
+            // double-press detector) when the changed key belongs to the
+            // chord, mirroring the Swift handleFlagsChanged gating.
+            if let Some(active) = self.active {
+                if active.mods != current {
+                    let physical = active.mods.contains_key(modifier);
+                    self.physical_up(active, physical, now, &mut actions);
+                }
+            }
+
+            // Modifier-only press edge: exact match, and the changed key must
+            // be part of the chord (an arrow key's phantom flags or a foreign
+            // modifier release must not read as a fresh press).
+            if let Some(identity) = self.matching_modifier_only(current) {
+                if identity.mods.contains_key(modifier) && down {
+                    self.physical_down(identity, now, &mut actions);
+                }
+            }
+            return actions;
+        }
+
+        if self.capturing {
+            // Key chords are captured by the focused settings webview (DOM),
+            // exactly as on macOS. Don't match or swallow while capturing.
+            return actions;
+        }
+
+        if down {
+            if let Some(identity) = self.matching_key_identity(vk) {
+                self.swallowed_vk = Some(vk);
+                actions.push(Action::SwallowKey);
+                self.physical_down(identity, now, &mut actions);
+            }
+        } else {
+            if self.swallowed_vk == Some(vk) {
+                self.swallowed_vk = None;
+                actions.push(Action::SwallowKey);
+            }
+            if let Some(active) = self.active {
+                if active.trigger == Trigger::Key(vk) {
+                    self.physical_up(active, true, now, &mut actions);
+                }
+            }
+        }
+        actions
+    }
+
+    /// The hold threshold elapsed for a scheduled ambiguous push start.
+    pub fn fire_pending_push(&mut self, token: u64) -> Vec<Action> {
+        let mut actions = Vec::new();
+        let Some((pending_token, identity)) = self.pending_push else {
+            return actions;
+        };
+        if pending_token != token || self.active != Some(identity) {
+            return actions;
+        }
+        self.pending_push = None;
+        if let Some((kind, shortcut)) =
+            self.matches(identity).into_iter().find(|(kind, shortcut)| {
+                *kind == DictationShortcutKind::PushToTalk && shortcut.press_count == 1
+            })
+        {
+            self.active_push = Some(identity);
+            actions.push(Action::Emit {
+                kind,
+                label: shortcut.label,
+                down: true,
+            });
+        }
+        actions
+    }
+
+    /// The capture debounce elapsed; commit the held modifier-only chord.
+    pub fn fire_capture_commit(&mut self, token: u64) -> Option<Mods> {
+        if !self.capturing {
+            return None;
+        }
+        let (pending_token, mods) = self.pending_capture?;
+        if pending_token != token {
+            return None;
+        }
+        self.capturing = false;
+        self.pending_capture = None;
+        Some(mods)
+    }
+
+    fn handle_capture(&mut self, current: Mods, actions: &mut Vec<Action>) {
+        // Only combos of two or more modifiers are supported modifier-only
+        // shortcuts (bare Fn, the macOS single-modifier case, does not exist
+        // on Windows).
+        if current.count() >= 2 {
+            if self
+                .pending_capture
+                .is_some_and(|(_, pending)| pending == current)
+            {
+                return;
+            }
+            let token = self.take_token();
+            self.pending_capture = Some((token, current));
+            actions.push(Action::ScheduleCaptureCommit { token });
+        } else {
+            self.pending_capture = None;
+        }
+    }
+
+    fn matching_key_identity(&self, vk: u32) -> Option<Identity> {
+        let current = self.modifiers;
+        self.entries()
+            .into_iter()
+            .find(|(_, shortcut)| shortcut.trigger == Trigger::Key(vk) && shortcut.mods == current)
+            .map(|(_, shortcut)| Identity::of(&shortcut))
+    }
+
+    fn matching_modifier_only(&self, current: Mods) -> Option<Identity> {
+        self.entries()
+            .into_iter()
+            .find(|(_, shortcut)| {
+                shortcut.trigger == Trigger::ModifierOnly && shortcut.mods == current
+            })
+            .map(|(_, shortcut)| Identity::of(&shortcut))
+    }
+
+    fn entries(&self) -> Vec<(DictationShortcutKind, WinShortcut)> {
+        let mut entries = Vec::with_capacity(2);
+        if let Some(shortcut) = &self.push_to_talk {
+            entries.push((DictationShortcutKind::PushToTalk, shortcut.clone()));
+        }
+        if let Some(shortcut) = &self.toggle {
+            entries.push((DictationShortcutKind::Toggle, shortcut.clone()));
+        }
+        entries
+    }
+
+    fn matches(&self, identity: Identity) -> Vec<(DictationShortcutKind, WinShortcut)> {
+        self.entries()
+            .into_iter()
+            .filter(|(_, shortcut)| Identity::of(shortcut) == identity)
+            .collect()
+    }
+
+    fn physical_down(&mut self, identity: Identity, now: Instant, actions: &mut Vec<Action>) {
+        if self.active == Some(identity) {
+            return;
+        }
+        self.active = Some(identity);
+
+        let matches = self.matches(identity);
+        if let Some((_, shortcut)) = matches.iter().find(|(kind, shortcut)| {
+            *kind == DictationShortcutKind::Toggle && shortcut.press_count == 2
+        }) {
+            let double_tapped = self.last_tap.is_some_and(|(tap_identity, tapped_at)| {
+                tap_identity == identity && now.duration_since(tapped_at) <= DOUBLE_PRESS_WINDOW
+            });
+            if double_tapped {
+                self.last_tap = None;
+                self.pending_push = None;
+                actions.push(Action::Emit {
+                    kind: DictationShortcutKind::Toggle,
+                    label: shortcut.label.clone(),
+                    down: true,
+                });
+                return;
+            }
+        }
+
+        if let Some((_, shortcut)) = matches.iter().find(|(kind, shortcut)| {
+            *kind == DictationShortcutKind::Toggle && shortcut.press_count == 1
+        }) {
+            actions.push(Action::Emit {
+                kind: DictationShortcutKind::Toggle,
+                label: shortcut.label.clone(),
+                down: true,
+            });
+        }
+
+        if let Some((_, shortcut)) = matches.iter().find(|(kind, shortcut)| {
+            *kind == DictationShortcutKind::PushToTalk && shortcut.press_count == 1
+        }) {
+            let shares_toggle = matches
+                .iter()
+                .any(|(kind, _)| *kind == DictationShortcutKind::Toggle);
+            if shares_toggle {
+                // A toggle shares this trigger, so a fresh press is
+                // ambiguous: a tap is (or arms) the toggle, only a hold is
+                // the push. The hold threshold tells them apart.
+                let token = self.take_token();
+                self.pending_push = Some((token, identity));
+                actions.push(Action::SchedulePushStart { token });
+            } else {
+                self.pending_push = None;
+                self.active_push = Some(identity);
+                actions.push(Action::Emit {
+                    kind: DictationShortcutKind::PushToTalk,
+                    label: shortcut.label.clone(),
+                    down: true,
+                });
+            }
+        }
+    }
+
+    fn physical_up(
+        &mut self,
+        identity: Identity,
+        is_physical_release: bool,
+        now: Instant,
+        actions: &mut Vec<Action>,
+    ) {
+        if self.active != Some(identity) {
+            return;
+        }
+        self.active = None;
+
+        if self.active_push == Some(identity) {
+            self.active_push = None;
+            if let Some((kind, shortcut)) = self
+                .matches(identity)
+                .into_iter()
+                .find(|(kind, _)| *kind == DictationShortcutKind::PushToTalk)
+            {
+                actions.push(Action::Emit {
+                    kind,
+                    label: shortcut.label,
+                    down: false,
+                });
+                return;
+            }
+        }
+
+        self.pending_push = None;
+
+        if is_physical_release
+            && self.matches(identity).iter().any(|(kind, shortcut)| {
+                *kind == DictationShortcutKind::Toggle && shortcut.press_count == 2
+            })
+        {
+            self.last_tap = Some((identity, now));
+        }
+    }
+}
+
+/// Mirror of the Swift helper's `MonitoredShortcut.displayLabel`: a
+/// double-press shortcut renders as "label+label" unless already doubled.
+pub(crate) fn display_label(label: &str, press_count: u8) -> String {
+    if press_count != 2 {
+        return label.to_string();
+    }
+    let parts: Vec<&str> = label.split('+').collect();
+    if !parts.is_empty() && parts.len() % 2 == 0 {
+        let half = parts.len() / 2;
+        if parts[..half] == parts[half..] {
+            return label.to_string();
+        }
+    }
+    format!("{label}+{label}")
+}
+
+/// The helper command vocabulary (the JSON lines the Swift helper accepts on
+/// stdin, routed in-process on Windows).
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum HelperCommand {
+    Ping,
+    GetPermissionStatus,
+    RequestMicrophonePermission,
+    RequestAccessibilityPermission,
+    ListMicrophones,
+    StartListening,
+    StopAndPaste,
+    StartMicTest {
+        duration_seconds: f64,
+    },
+    DiscardMicTest,
+    SetMicrophone {
+        id: Option<String>,
+        name: Option<String>,
+    },
+    SetShortcut {
+        shortcut: Option<serde_json::Value>,
+    },
+    StartShortcutCapture,
+    CancelShortcutCapture,
+    ToggleListening {
+        shortcut: String,
+    },
+    PasteText {
+        text: String,
+    },
+    DiscardRecording,
+    Shutdown,
+    Unknown,
+}
+
+pub(crate) fn parse_helper_command(command: &serde_json::Value) -> HelperCommand {
+    let command_type = command
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    match command_type {
+        "ping" => HelperCommand::Ping,
+        "get_permission_status" => HelperCommand::GetPermissionStatus,
+        "request_microphone_permission" => HelperCommand::RequestMicrophonePermission,
+        "request_accessibility_permission" => HelperCommand::RequestAccessibilityPermission,
+        "list_microphones" => HelperCommand::ListMicrophones,
+        "start_listening" => HelperCommand::StartListening,
+        "stop_and_paste" => HelperCommand::StopAndPaste,
+        "start_mic_test" => HelperCommand::StartMicTest {
+            duration_seconds: command
+                .get("durationSeconds")
+                .and_then(serde_json::Value::as_f64)
+                .unwrap_or(5.0),
+        },
+        "discard_mic_test" => HelperCommand::DiscardMicTest,
+        "set_microphone" => HelperCommand::SetMicrophone {
+            id: command
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            name: command
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+        },
+        "set_shortcut" => HelperCommand::SetShortcut {
+            shortcut: command.get("shortcut").cloned(),
+        },
+        "start_shortcut_capture" => HelperCommand::StartShortcutCapture,
+        "cancel_shortcut_capture" => HelperCommand::CancelShortcutCapture,
+        "toggle_listening" => HelperCommand::ToggleListening {
+            shortcut: command
+                .get("shortcut")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("hotkey")
+                .to_string(),
+        },
+        "paste_text" => HelperCommand::PasteText {
+            text: command
+                .get("text")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        },
+        "discard_recording" => HelperCommand::DiscardRecording,
+        "shutdown" => HelperCommand::Shutdown,
+        _ => HelperCommand::Unknown,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ShortcutParseError {
+    /// The payload is malformed; the Swift helper answers `invalid_shortcut`.
+    Invalid,
+    /// The chord relies on the Fn key, which Windows cannot observe.
+    FunctionUnsupported { label: String },
+    /// The `code` string has no Windows virtual key mapping.
+    Unmappable { label: String },
+}
+
+/// Parse a `set_shortcut` payload into a monitorable Windows chord.
+pub(crate) fn parse_shortcut(
+    payload: &serde_json::Value,
+) -> Result<(DictationShortcutKind, WinShortcut), ShortcutParseError> {
+    let code = payload
+        .get("code")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let label = payload
+        .get("label")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let kind = match payload.get("kind").and_then(serde_json::Value::as_str) {
+        Some("push_to_talk") => DictationShortcutKind::PushToTalk,
+        Some("toggle") => DictationShortcutKind::Toggle,
+        _ => return Err(ShortcutParseError::Invalid),
+    };
+    if code.is_empty() || label.is_empty() {
+        return Err(ShortcutParseError::Invalid);
+    }
+
+    let raw_press_count = payload
+        .get("pressCount")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(1);
+    let press_count = if raw_press_count == 2 { 2 } else { 1 };
+
+    let modifiers = payload.get("modifiers");
+    let modifier = |name: &str| {
+        modifiers
+            .and_then(|modifiers| modifiers.get(name))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+    };
+    let mods = Mods {
+        command: modifier("command"),
+        control: modifier("control"),
+        option: modifier("option"),
+        shift: modifier("shift"),
+    };
+    let function = modifier("function");
+
+    if function || code.eq_ignore_ascii_case("Fn") {
+        return Err(ShortcutParseError::FunctionUnsupported { label });
+    }
+
+    let key_code = payload
+        .get("keyCode")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let trigger = if key_code == 0 && code.eq_ignore_ascii_case("Modifiers") {
+        if mods.count() < 2 {
+            return Err(ShortcutParseError::Invalid);
+        }
+        Trigger::ModifierOnly
+    } else {
+        let vk = vk_for_code(&code).ok_or_else(|| ShortcutParseError::Unmappable {
+            label: label.clone(),
+        })?;
+        if !mods.has_any() {
+            return Err(ShortcutParseError::Invalid);
+        }
+        Trigger::Key(vk)
+    };
+
+    Ok((
+        kind,
+        WinShortcut {
+            trigger,
+            mods,
+            label: display_label(&label, press_count),
+            press_count,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctrl_alt(vk: u32, label: &str) -> WinShortcut {
+        WinShortcut {
+            trigger: Trigger::Key(vk),
+            mods: Mods {
+                control: true,
+                option: true,
+                ..Mods::default()
+            },
+            label: label.to_string(),
+            press_count: 1,
+        }
+    }
+
+    fn press_chord(matcher: &mut ChordMatcher, now: Instant) -> Vec<Action> {
+        let mut actions = Vec::new();
+        actions.extend(matcher.key_event(VK_LCONTROL, true, now));
+        actions.extend(matcher.key_event(VK_LMENU, true, now));
+        actions.extend(matcher.key_event(0x44, true, now)); // 'D'
+        actions
+    }
+
+    #[test]
+    fn maps_w3c_codes_to_virtual_keys() {
+        assert_eq!(vk_for_code("KeyD"), Some(0x44));
+        assert_eq!(vk_for_code("KeyA"), Some(0x41));
+        assert_eq!(vk_for_code("Digit1"), Some(0x31));
+        assert_eq!(vk_for_code("Digit0"), Some(0x30));
+        assert_eq!(vk_for_code("Space"), Some(0x20));
+        assert_eq!(vk_for_code("Comma"), Some(0xBC));
+        assert_eq!(vk_for_code("F1"), Some(0x70));
+        assert_eq!(vk_for_code("F12"), Some(0x7B));
+        assert_eq!(vk_for_code("ArrowUp"), Some(0x26));
+        assert_eq!(vk_for_code("Fn"), None);
+        assert_eq!(vk_for_code("Modifiers"), None);
+        assert_eq!(vk_for_code(""), None);
+        assert_eq!(vk_for_code("F25"), None);
+    }
+
+    #[test]
+    fn key_chord_push_emits_down_and_up_and_swallows_trigger() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            ctrl_alt(0x44, "Ctrl+Opt+D"),
+        );
+
+        let now = Instant::now();
+        let actions = press_chord(&mut matcher, now);
+        assert_eq!(
+            actions,
+            vec![
+                Action::SwallowKey,
+                Action::Emit {
+                    kind: DictationShortcutKind::PushToTalk,
+                    label: "Ctrl+Opt+D".to_string(),
+                    down: true,
+                },
+            ]
+        );
+
+        let actions = matcher.key_event(0x44, false, now + Duration::from_millis(400));
+        assert_eq!(
+            actions,
+            vec![
+                Action::SwallowKey,
+                Action::Emit {
+                    kind: DictationShortcutKind::PushToTalk,
+                    label: "Ctrl+Opt+D".to_string(),
+                    down: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn releasing_a_chord_modifier_ends_the_push() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            ctrl_alt(0x44, "Ctrl+Opt+D"),
+        );
+        let now = Instant::now();
+        press_chord(&mut matcher, now);
+
+        let actions = matcher.key_event(VK_LCONTROL, false, now + Duration::from_millis(300));
+        assert_eq!(
+            actions,
+            vec![Action::Emit {
+                kind: DictationShortcutKind::PushToTalk,
+                label: "Ctrl+Opt+D".to_string(),
+                down: false,
+            }]
+        );
+        // The still-swallowed trigger key's release stays consumed.
+        let actions = matcher.key_event(0x44, false, now + Duration::from_millis(320));
+        assert_eq!(actions, vec![Action::SwallowKey]);
+    }
+
+    #[test]
+    fn wrong_modifiers_do_not_match_or_swallow() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            ctrl_alt(0x44, "Ctrl+Opt+D"),
+        );
+        let now = Instant::now();
+        matcher.key_event(VK_LCONTROL, true, now);
+        assert!(matcher.key_event(0x44, true, now).is_empty());
+        assert!(matcher.key_event(0x44, false, now).is_empty());
+    }
+
+    #[test]
+    fn single_press_toggle_emits_down_only() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(DictationShortcutKind::Toggle, ctrl_alt(0x54, "Ctrl+Opt+T"));
+        let now = Instant::now();
+
+        let mut actions = Vec::new();
+        actions.extend(matcher.key_event(VK_LCONTROL, true, now));
+        actions.extend(matcher.key_event(VK_LMENU, true, now));
+        actions.extend(matcher.key_event(0x54, true, now));
+        assert_eq!(
+            actions,
+            vec![
+                Action::SwallowKey,
+                Action::Emit {
+                    kind: DictationShortcutKind::Toggle,
+                    label: "Ctrl+Opt+T".to_string(),
+                    down: true,
+                },
+            ]
+        );
+        // Toggle releases emit no edge (only the swallow of the trigger).
+        let actions = matcher.key_event(0x54, false, now + Duration::from_millis(50));
+        assert_eq!(actions, vec![Action::SwallowKey]);
+    }
+
+    #[test]
+    fn double_press_toggle_fires_on_second_tap_within_window() {
+        let mut matcher = ChordMatcher::default();
+        let mut shortcut = ctrl_alt(0x54, "Ctrl+Opt+T+Ctrl+Opt+T");
+        shortcut.press_count = 2;
+        matcher.set_shortcut(DictationShortcutKind::Toggle, shortcut);
+
+        let now = Instant::now();
+        matcher.key_event(VK_LCONTROL, true, now);
+        matcher.key_event(VK_LMENU, true, now);
+        // First tap: no edge.
+        let actions = matcher.key_event(0x54, true, now);
+        assert_eq!(actions, vec![Action::SwallowKey]);
+        matcher.key_event(0x54, false, now + Duration::from_millis(60));
+
+        // Second tap inside the window: toggle fires.
+        let actions = matcher.key_event(0x54, true, now + Duration::from_millis(200));
+        assert_eq!(
+            actions,
+            vec![
+                Action::SwallowKey,
+                Action::Emit {
+                    kind: DictationShortcutKind::Toggle,
+                    label: "Ctrl+Opt+T+Ctrl+Opt+T".to_string(),
+                    down: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn double_press_toggle_expires_outside_window() {
+        let mut matcher = ChordMatcher::default();
+        let mut shortcut = ctrl_alt(0x54, "Ctrl+Opt+T");
+        shortcut.press_count = 2;
+        matcher.set_shortcut(DictationShortcutKind::Toggle, shortcut);
+
+        let now = Instant::now();
+        matcher.key_event(VK_LCONTROL, true, now);
+        matcher.key_event(VK_LMENU, true, now);
+        matcher.key_event(0x54, true, now);
+        matcher.key_event(0x54, false, now + Duration::from_millis(60));
+
+        let late = now + Duration::from_millis(600);
+        let actions = matcher.key_event(0x54, true, late);
+        assert_eq!(actions, vec![Action::SwallowKey]);
+    }
+
+    #[test]
+    fn shared_trigger_hold_becomes_push_and_tap_arms_toggle() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            ctrl_alt(0x44, "Ctrl+Opt+D"),
+        );
+        let mut toggle = ctrl_alt(0x44, "Ctrl+Opt+D+Ctrl+Opt+D");
+        toggle.press_count = 2;
+        matcher.set_shortcut(DictationShortcutKind::Toggle, toggle);
+
+        // Hold: pending push scheduled, then fires after the threshold.
+        let now = Instant::now();
+        let actions = press_chord(&mut matcher, now);
+        let token = actions
+            .iter()
+            .find_map(|action| match action {
+                Action::SchedulePushStart { token } => Some(*token),
+                _ => None,
+            })
+            .expect("ambiguous press should schedule a pending push");
+        let actions = matcher.fire_pending_push(token);
+        assert_eq!(
+            actions,
+            vec![Action::Emit {
+                kind: DictationShortcutKind::PushToTalk,
+                label: "Ctrl+Opt+D".to_string(),
+                down: true,
+            }]
+        );
+        let actions = matcher.key_event(0x44, false, now + Duration::from_millis(500));
+        assert!(actions.contains(&Action::Emit {
+            kind: DictationShortcutKind::PushToTalk,
+            label: "Ctrl+Opt+D".to_string(),
+            down: false,
+        }));
+
+        // Quick tap-tap: the stale pending push never fires, the second tap
+        // toggles.
+        let now = now + Duration::from_secs(2);
+        let actions = press_chord(&mut matcher, now);
+        let token = actions
+            .iter()
+            .find_map(|action| match action {
+                Action::SchedulePushStart { token } => Some(*token),
+                _ => None,
+            })
+            .expect("second ambiguous press should schedule a pending push");
+        matcher.key_event(0x44, false, now + Duration::from_millis(50));
+        assert!(matcher.fire_pending_push(token).is_empty());
+        let actions = matcher.key_event(0x44, true, now + Duration::from_millis(150));
+        assert!(actions.contains(&Action::Emit {
+            kind: DictationShortcutKind::Toggle,
+            label: "Ctrl+Opt+D+Ctrl+Opt+D".to_string(),
+            down: true,
+        }));
+    }
+
+    #[test]
+    fn modifier_only_chord_edges() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            WinShortcut {
+                trigger: Trigger::ModifierOnly,
+                mods: Mods {
+                    control: true,
+                    option: true,
+                    ..Mods::default()
+                },
+                label: "Ctrl+Opt".to_string(),
+                press_count: 1,
+            },
+        );
+
+        let now = Instant::now();
+        assert!(matcher.key_event(VK_LCONTROL, true, now).is_empty());
+        let actions = matcher.key_event(VK_LMENU, true, now);
+        assert_eq!(
+            actions,
+            vec![Action::Emit {
+                kind: DictationShortcutKind::PushToTalk,
+                label: "Ctrl+Opt".to_string(),
+                down: true,
+            }]
+        );
+
+        // A foreign modifier interrupting the chord ends the press.
+        let actions = matcher.key_event(VK_LSHIFT, true, now + Duration::from_millis(300));
+        assert_eq!(
+            actions,
+            vec![Action::Emit {
+                kind: DictationShortcutKind::PushToTalk,
+                label: "Ctrl+Opt".to_string(),
+                down: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn modifier_only_release_ends_the_press() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            WinShortcut {
+                trigger: Trigger::ModifierOnly,
+                mods: Mods {
+                    control: true,
+                    option: true,
+                    ..Mods::default()
+                },
+                label: "Ctrl+Opt".to_string(),
+                press_count: 1,
+            },
+        );
+        let now = Instant::now();
+        matcher.key_event(VK_LCONTROL, true, now);
+        matcher.key_event(VK_LMENU, true, now);
+        let actions = matcher.key_event(VK_LMENU, false, now + Duration::from_millis(400));
+        assert_eq!(
+            actions,
+            vec![Action::Emit {
+                kind: DictationShortcutKind::PushToTalk,
+                label: "Ctrl+Opt".to_string(),
+                down: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn capture_commits_a_stable_modifier_combo() {
+        let mut matcher = ChordMatcher::default();
+        matcher.start_capture();
+        let now = Instant::now();
+        assert!(matcher.key_event(VK_LCONTROL, true, now).is_empty());
+        let actions = matcher.key_event(VK_LSHIFT, true, now);
+        let token = actions
+            .iter()
+            .find_map(|action| match action {
+                Action::ScheduleCaptureCommit { token } => Some(*token),
+                _ => None,
+            })
+            .expect("two held modifiers should schedule a capture commit");
+        let mods = matcher.fire_capture_commit(token).expect("capture commits");
+        assert_eq!(
+            mods,
+            Mods {
+                control: true,
+                shift: true,
+                ..Mods::default()
+            }
+        );
+        assert_eq!(mods.label_parts(), vec!["Ctrl", "Shift"]);
+    }
+
+    #[test]
+    fn capture_cancels_when_combo_drops_below_two_modifiers() {
+        let mut matcher = ChordMatcher::default();
+        matcher.start_capture();
+        let now = Instant::now();
+        matcher.key_event(VK_LCONTROL, true, now);
+        let actions = matcher.key_event(VK_LSHIFT, true, now);
+        let token = actions
+            .iter()
+            .find_map(|action| match action {
+                Action::ScheduleCaptureCommit { token } => Some(*token),
+                _ => None,
+            })
+            .expect("commit scheduled");
+        matcher.key_event(VK_LSHIFT, false, now + Duration::from_millis(50));
+        assert_eq!(matcher.fire_capture_commit(token), None);
+
+        matcher.cancel_capture();
+        assert_eq!(matcher.fire_capture_commit(token), None);
+    }
+
+    #[test]
+    fn capture_ignores_key_chords_for_the_dom() {
+        let mut matcher = ChordMatcher::default();
+        matcher.set_shortcut(
+            DictationShortcutKind::PushToTalk,
+            ctrl_alt(0x44, "Ctrl+Opt+D"),
+        );
+        matcher.start_capture();
+        let now = Instant::now();
+        matcher.key_event(VK_LCONTROL, true, now);
+        matcher.key_event(VK_LMENU, true, now);
+        // The user's current chord must reach the DOM unswallowed and
+        // unmatched while capturing (the held modifier pair may still
+        // schedule a modifier-only capture, which typing the key does not
+        // commit).
+        assert!(matcher.key_event(0x44, true, now).is_empty());
+        assert!(matcher.key_event(0x44, false, now).is_empty());
+    }
+
+    #[test]
+    fn parses_helper_commands() {
+        assert_eq!(
+            parse_helper_command(&json!({"type": "start_listening"})),
+            HelperCommand::StartListening
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "stop_and_paste"})),
+            HelperCommand::StopAndPaste
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "toggle_listening", "shortcut": "Ctrl+Opt+T"})),
+            HelperCommand::ToggleListening {
+                shortcut: "Ctrl+Opt+T".to_string()
+            }
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "toggle_listening"})),
+            HelperCommand::ToggleListening {
+                shortcut: "hotkey".to_string()
+            }
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "paste_text", "text": "hello"})),
+            HelperCommand::PasteText {
+                text: "hello".to_string()
+            }
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "start_mic_test", "durationSeconds": 3})),
+            HelperCommand::StartMicTest {
+                duration_seconds: 3.0
+            }
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "start_mic_test"})),
+            HelperCommand::StartMicTest {
+                duration_seconds: 5.0
+            }
+        );
+        assert_eq!(
+            parse_helper_command(
+                &json!({"type": "set_microphone", "id": "mic-1", "name": "USB Mic"})
+            ),
+            HelperCommand::SetMicrophone {
+                id: Some("mic-1".to_string()),
+                name: Some("USB Mic".to_string()),
+            }
+        );
+        assert_eq!(
+            parse_helper_command(&json!({"type": "made_up"})),
+            HelperCommand::Unknown
+        );
+        assert_eq!(parse_helper_command(&json!({})), HelperCommand::Unknown);
+    }
+
+    #[test]
+    fn parses_key_chord_shortcut() {
+        let (kind, shortcut) = parse_shortcut(&json!({
+            "keyCode": 2,
+            "code": "KeyD",
+            "label": "Ctrl+Opt+D",
+            "kind": "push_to_talk",
+            "pressCount": 1,
+            "modifiers": {"command": false, "control": true, "option": true, "shift": false, "function": false},
+        }))
+        .expect("chord should parse");
+        assert_eq!(kind, DictationShortcutKind::PushToTalk);
+        assert_eq!(shortcut.trigger, Trigger::Key(0x44));
+        assert_eq!(
+            shortcut.mods,
+            Mods {
+                control: true,
+                option: true,
+                ..Mods::default()
+            }
+        );
+        assert_eq!(shortcut.label, "Ctrl+Opt+D");
+        assert_eq!(shortcut.press_count, 1);
+    }
+
+    #[test]
+    fn parses_modifier_only_and_double_press_shortcuts() {
+        let (kind, shortcut) = parse_shortcut(&json!({
+            "keyCode": 0,
+            "code": "Modifiers",
+            "label": "Ctrl+Shift",
+            "kind": "toggle",
+            "pressCount": 2,
+            "modifiers": {"command": false, "control": true, "option": false, "shift": true, "function": false},
+        }))
+        .expect("modifier-only chord should parse");
+        assert_eq!(kind, DictationShortcutKind::Toggle);
+        assert_eq!(shortcut.trigger, Trigger::ModifierOnly);
+        assert_eq!(shortcut.press_count, 2);
+        assert_eq!(shortcut.label, "Ctrl+Shift+Ctrl+Shift");
+    }
+
+    #[test]
+    fn rejects_fn_and_unmappable_shortcuts() {
+        assert_eq!(
+            parse_shortcut(&json!({
+                "keyCode": 0,
+                "code": "Fn",
+                "label": "Fn",
+                "kind": "push_to_talk",
+                "pressCount": 1,
+                "modifiers": {"function": true},
+            })),
+            Err(ShortcutParseError::FunctionUnsupported {
+                label: "Fn".to_string()
+            })
+        );
+        assert_eq!(
+            parse_shortcut(&json!({
+                "keyCode": 99,
+                "code": "NumpadEnter",
+                "label": "Ctrl+NumpadEnter",
+                "kind": "toggle",
+                "pressCount": 1,
+                "modifiers": {"control": true},
+            })),
+            Err(ShortcutParseError::Unmappable {
+                label: "Ctrl+NumpadEnter".to_string()
+            })
+        );
+        assert_eq!(
+            parse_shortcut(&json!({"kind": "toggle"})),
+            Err(ShortcutParseError::Invalid)
+        );
+    }
+
+    #[test]
+    fn doubles_display_labels_once() {
+        assert_eq!(display_label("Ctrl+Opt+T", 1), "Ctrl+Opt+T");
+        assert_eq!(display_label("Ctrl+Opt+T", 2), "Ctrl+Opt+T+Ctrl+Opt+T");
+        assert_eq!(
+            display_label("Ctrl+Opt+T+Ctrl+Opt+T", 2),
+            "Ctrl+Opt+T+Ctrl+Opt+T"
+        );
+    }
+}

--- a/src-tauri/src/dictation/win_chords.rs
+++ b/src-tauri/src/dictation/win_chords.rs
@@ -33,12 +33,14 @@ use std::time::{Duration, Instant};
 
 /// A push shorter than this on a shared trigger is (or arms) the toggle;
 /// only a hold is the push. Mirrors the Swift monitor's `holdThreshold`.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) const HOLD_THRESHOLD: Duration = Duration::from_millis(160);
 /// Two taps of a pressCount == 2 toggle must land within this window.
 /// Mirrors the Swift monitor's `doublePressWindow`.
 pub(crate) const DOUBLE_PRESS_WINDOW: Duration = Duration::from_millis(340);
 /// A modifier-only chord held stable for this long during shortcut capture
 /// commits as the captured shortcut. Mirrors the Swift capture debounce.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) const CAPTURE_DEBOUNCE: Duration = Duration::from_millis(180);
 
 // Modifier virtual keys (winuser.h). Generic VKs are included alongside the
@@ -256,6 +258,7 @@ impl ChordMatcher {
     /// Drop a kind's chord entirely (its configured shortcut cannot be
     /// monitored on Windows, e.g. Fn-based). Mirrors the Swift helper
     /// skipping registration for such chords.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     pub fn clear_shortcut(&mut self, kind: DictationShortcutKind) {
         match kind {
             DictationShortcutKind::PushToTalk => self.push_to_talk = None,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -218,6 +218,7 @@ pub fn run() {
             hermes_bridge::set_hermes_agent_cli_access,
             hermes_bridge::open_hermes_tui_debug,
             commands::get_microphone_permission_state,
+            commands::get_platform_capabilities,
             commands::check_recording_source_readiness,
             commands::open_privacy_settings,
             commands::june_open_verify_page,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,15 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // Launch at login. Order-independent, so it follows the updater. The
+        // plugin manages the platform launch entry: Login Items on macOS, the
+        // Run registry key on Windows, and ~/.config/autostart on Linux. Plain
+        // start with no launch args: June has no hidden-start / tray-only mode
+        // to honor, so there is nothing to signal with an `--autostart` flag.
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None::<Vec<&str>>,
+        ))
         .on_menu_event(|app, event| {
             if event.id().as_ref() == CHECK_FOR_UPDATES_MENU_ID {
                 let _ = app.emit(CHECK_FOR_UPDATES_EVENT, ());

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::thread;
 use std::{collections::BTreeSet, time::Duration};
 use tauri::{AppHandle, Emitter};
@@ -8,6 +8,7 @@ const CLEAR_AFTER_INACTIVE_POLLS: u8 = 2;
 const HEARTBEAT_EVERY_ACTIVE_POLLS: u8 = 5;
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const MEETING_DETECTION_EVENT_NAME: &str = "meeting-detection-event";
+#[cfg(not(target_os = "windows"))]
 const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] = &[
     "company.thebrowser.Browser",
     "com.google.Chrome",
@@ -18,10 +19,10 @@ const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] = &[
 ];
 
 pub fn setup(app: &mut tauri::App) {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     spawn_monitor(app.handle().clone());
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let _ = app;
 }
 
@@ -130,12 +131,37 @@ pub(crate) fn active_allowed_external_processes(
         .collect()
 }
 
-fn is_allowed_microphone_app(bundle_id: &str) -> bool {
+// The allow-list and friendly-label lookups are keyed on a platform-specific
+// identifier: a bundle id on macOS, an executable name on Windows. Both paths
+// feed the same `MicrophoneInputProcess` shape and the same shared filtering,
+// so the dispatchers below keep their original names and signatures.
+
+fn is_allowed_microphone_app(identifier: &str) -> bool {
+    #[cfg(target_os = "windows")]
+    let allowed = is_allowed_windows_microphone_app(identifier);
+    #[cfg(not(target_os = "windows"))]
+    let allowed = is_allowed_macos_microphone_app(identifier);
+    allowed
+}
+
+fn app_label_from_bundle_id(identifier: &str) -> String {
+    #[cfg(target_os = "windows")]
+    let label = windows_app_label_from_executable(identifier);
+    #[cfg(not(target_os = "windows"))]
+    let label = macos_app_label_from_bundle_id(identifier);
+    label
+}
+
+// ---- macOS bundle-id matching --------------------------------------------
+
+#[cfg(not(target_os = "windows"))]
+fn is_allowed_macos_microphone_app(bundle_id: &str) -> bool {
     ALLOWED_MIC_APP_BUNDLE_PREFIXES
         .iter()
         .any(|prefix| bundle_id_matches_prefix(bundle_id, prefix))
 }
 
+#[cfg(not(target_os = "windows"))]
 fn bundle_id_matches_prefix(bundle_id: &str, prefix: &str) -> bool {
     let bundle_id = bundle_id.trim().to_ascii_lowercase();
     let prefix = prefix.trim().to_ascii_lowercase();
@@ -145,7 +171,8 @@ fn bundle_id_matches_prefix(bundle_id: &str, prefix: &str) -> bool {
             .is_some_and(|suffix| suffix.starts_with('.'))
 }
 
-fn app_label_from_bundle_id(bundle_id: &str) -> String {
+#[cfg(not(target_os = "windows"))]
+fn macos_app_label_from_bundle_id(bundle_id: &str) -> String {
     if bundle_id_matches_prefix(bundle_id, "company.thebrowser.Browser") {
         return "Arc".to_string();
     }
@@ -170,7 +197,58 @@ fn app_label_from_bundle_id(bundle_id: &str) -> String {
         .to_string()
 }
 
-#[cfg(target_os = "macos")]
+// ---- Windows executable-name matching ------------------------------------
+
+/// Allow-list of Windows meeting apps keyed on lowercase executable names,
+/// mapped to the same friendly labels the macOS bundle-id path produces.
+/// June's own future WASAPI capture helper is excluded by pid (`owned_pids`),
+/// not by name, so it does not belong here.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const ALLOWED_WINDOWS_MIC_APPS: &[(&str, &str)] = &[
+    ("ms-teams.exe", "Teams"),
+    ("teams.exe", "Teams"),
+    ("zoom.exe", "Zoom"),
+    ("chrome.exe", "Chrome"),
+    ("msedge.exe", "Edge"),
+    ("arc.exe", "Arc"),
+    ("firefox.exe", "Firefox"),
+    ("brave.exe", "Brave"),
+];
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn is_allowed_windows_microphone_app(executable: &str) -> bool {
+    let executable = executable.trim().to_ascii_lowercase();
+    ALLOWED_WINDOWS_MIC_APPS
+        .iter()
+        .any(|(name, _)| *name == executable)
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn windows_app_label_from_executable(executable: &str) -> String {
+    let executable = executable.trim();
+    let lowercased = executable.to_ascii_lowercase();
+    if let Some((_, label)) = ALLOWED_WINDOWS_MIC_APPS
+        .iter()
+        .find(|(name, _)| *name == lowercased)
+    {
+        return (*label).to_string();
+    }
+    // Unlisted apps are dropped by the allow-list, so this label only surfaces
+    // defensively. Strip a trailing ".exe" (case-insensitively) so it reads as
+    // an app name rather than a file.
+    let stem = if lowercased.ends_with(".exe") {
+        &executable[..executable.len() - ".exe".len()]
+    } else {
+        executable
+    };
+    if stem.is_empty() {
+        executable.to_string()
+    } else {
+        stem.to_string()
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn spawn_monitor(app: AppHandle) {
     thread::spawn(move || {
         let mut state = MeetingDetectionState::default();
@@ -210,10 +288,20 @@ fn spawn_monitor(app: AppHandle) {
 }
 
 fn owned_pids(app: &AppHandle) -> BTreeSet<u32> {
+    // Only the macOS branch mutates `pids` today; keep `mut` warning-free where
+    // no helper pid is inserted.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut pids = BTreeSet::from([std::process::id()]);
+    // macOS spawns a dictation helper that also holds the microphone; exclude
+    // it so June's own capture never looks like an external meeting. Windows
+    // has no such helper yet, so its owned set is just this process. When a
+    // Windows capture helper lands, insert its pid here under a windows cfg.
+    #[cfg(target_os = "macos")]
     if let Some(helper_pid) = crate::dictation::dictation_helper_pid(app) {
         pids.insert(helper_pid);
     }
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
     pids
 }
 
@@ -282,7 +370,10 @@ fn emit_detection_event(
 #[cfg(target_os = "macos")]
 pub(crate) use macos::active_input_processes;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+pub(crate) use windows::active_input_processes;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub(crate) fn active_input_processes() -> Result<Vec<MicrophoneInputProcess>, ProbeError> {
     Ok(Vec::new())
 }
@@ -301,9 +392,11 @@ impl ProbeError {
 
 impl std::fmt::Display for ProbeError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `status` carries an OSStatus on macOS and an HRESULT on Windows;
+        // both are 32-bit and read fine as a signed decimal in the log line.
         write!(
             formatter,
-            "{} failed with OSStatus {}",
+            "{} failed with status {}",
             self.operation, self.status
         )
     }
@@ -601,6 +694,159 @@ mod macos {
     }
 }
 
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::{MicrophoneInputProcess, ProbeError};
+    use std::cell::Cell;
+    use std::collections::BTreeSet;
+
+    use ::windows::core::Interface;
+    use ::windows::Win32::Foundation::CloseHandle;
+    use ::windows::Win32::Media::Audio::{
+        eCapture, AudioSessionStateActive, IAudioSessionControl2, IAudioSessionManager2,
+        IMMDeviceEnumerator, MMDeviceEnumerator, DEVICE_STATE_ACTIVE,
+    };
+    use ::windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_MULTITHREADED,
+    };
+    use ::windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    thread_local! {
+        // COM must be initialised once per thread before any WASAPI call. The
+        // monitor owns a single long-lived polling thread, so we join the MTA on
+        // the first probe and never uninitialise (the thread outlives the app).
+        static COM_READY: Cell<bool> = const { Cell::new(false) };
+    }
+
+    fn ensure_com_initialized() {
+        COM_READY.with(|ready| {
+            if ready.get() {
+                return;
+            }
+            // SAFETY: CoInitializeEx with a null reserved pointer is the
+            // documented way to join an apartment. If the thread were already an
+            // STA this returns RPC_E_CHANGED_MODE; we proceed regardless because
+            // COM stays usable in whichever mode won and the objects below are
+            // apartment-neutral. The polling thread is fresh, so MTA wins.
+            unsafe {
+                let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+            }
+            ready.set(true);
+        });
+    }
+
+    pub(crate) fn active_input_processes() -> Result<Vec<MicrophoneInputProcess>, ProbeError> {
+        ensure_com_initialized();
+
+        // Dedupe pids across endpoints: one app capturing from a headset mic and
+        // a webcam mic shows up as two sessions on two endpoints, but is one app.
+        let mut pids: BTreeSet<u32> = BTreeSet::new();
+
+        // SAFETY: every interface below comes from a checked COM call and lives
+        // only within this scope; the `windows` crate ref-counts the pointers.
+        unsafe {
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                    .map_err(|error| probe(error, "create device enumerator"))?;
+
+            // Enumerate ALL active capture endpoints, not just the default: a
+            // meeting app may bind to any microphone the machine exposes.
+            let endpoints = enumerator
+                .EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE)
+                .map_err(|error| probe(error, "enumerate capture endpoints"))?;
+            let endpoint_count = endpoints
+                .GetCount()
+                .map_err(|error| probe(error, "count capture endpoints"))?;
+
+            for endpoint_index in 0..endpoint_count {
+                let Ok(device) = endpoints.Item(endpoint_index) else {
+                    continue;
+                };
+                let Ok(session_manager) =
+                    device.Activate::<IAudioSessionManager2>(CLSCTX_ALL, None)
+                else {
+                    continue;
+                };
+                let Ok(sessions) = session_manager.GetSessionEnumerator() else {
+                    continue;
+                };
+                let session_count = sessions.GetCount().unwrap_or(0);
+                for session_index in 0..session_count {
+                    let Ok(control) = sessions.GetSession(session_index) else {
+                        continue;
+                    };
+                    let Ok(control) = control.cast::<IAudioSessionControl2>() else {
+                        continue;
+                    };
+                    // Only sessions still actively capturing count. Sessions can
+                    // linger Active briefly after capture stops, and idle apps
+                    // keep Inactive sessions open; both would be false positives,
+                    // so require exactly AudioSessionStateActive.
+                    if !matches!(control.GetState(), Ok(state) if state == AudioSessionStateActive)
+                    {
+                        continue;
+                    }
+                    let Ok(pid) = control.GetProcessId() else {
+                        continue;
+                    };
+                    // pid 0 is the shared system-sounds pseudo-session; skip it.
+                    if pid != 0 {
+                        pids.insert(pid);
+                    }
+                }
+            }
+        }
+
+        let mut processes = Vec::new();
+        for pid in pids {
+            if let Some(executable) = process_executable_name(pid) {
+                if let Some(process) = MicrophoneInputProcess::new(pid, executable) {
+                    processes.push(process);
+                }
+            }
+        }
+        processes.sort_by_key(|process| process.pid);
+        Ok(processes)
+    }
+
+    fn probe(error: ::windows::core::Error, operation: &'static str) -> ProbeError {
+        ProbeError::new(operation, error.code().0)
+    }
+
+    /// Resolve a pid to its executable file name (e.g. `Zoom.exe`). Uses the
+    /// limited-information access right so it succeeds across sessions and
+    /// elevation levels where full query access would be denied.
+    fn process_executable_name(pid: u32) -> Option<String> {
+        // SAFETY: the process handle is closed on every return path, and
+        // QueryFullProcessImageNameW writes into `buffer` and reports the
+        // character count it produced back through `size`.
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+            let mut buffer = [0u16; 260];
+            let mut size = buffer.len() as u32;
+            let query = QueryFullProcessImageNameW(
+                handle,
+                PROCESS_NAME_WIN32,
+                ::windows::core::PWSTR(buffer.as_mut_ptr()),
+                &mut size,
+            );
+            let _ = CloseHandle(handle);
+            query.ok()?;
+
+            let full_path = String::from_utf16_lossy(&buffer[..size as usize]);
+            let file_name = full_path
+                .rsplit(['\\', '/'])
+                .next()
+                .unwrap_or(&full_path)
+                .trim();
+            (!file_name.is_empty()).then(|| file_name.to_string())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -717,6 +963,48 @@ mod tests {
             input_process(53, "com.apple.WebKit.WebContent"),
         ])
         .is_empty());
+    }
+
+    #[test]
+    fn windows_allow_list_matches_meeting_executables_case_insensitively() {
+        for (executable, label) in [
+            ("Zoom.exe", "Zoom"),
+            ("zoom.exe", "Zoom"),
+            ("ms-teams.exe", "Teams"),
+            ("Teams.exe", "Teams"),
+            ("chrome.exe", "Chrome"),
+            ("MSEDGE.EXE", "Edge"),
+            ("Arc.exe", "Arc"),
+            ("firefox.exe", "Firefox"),
+            ("brave.exe", "Brave"),
+        ] {
+            assert!(
+                is_allowed_windows_microphone_app(executable),
+                "{executable} should be allowed"
+            );
+            assert_eq!(windows_app_label_from_executable(executable), label);
+        }
+    }
+
+    #[test]
+    fn windows_allow_list_rejects_unlisted_executables() {
+        for executable in ["notepad.exe", "explorer.exe", "obs64.exe", ""] {
+            assert!(
+                !is_allowed_windows_microphone_app(executable),
+                "{executable} should not be allowed"
+            );
+        }
+        // Unlisted apps still get a sensible fallback label with the ".exe" tail
+        // stripped, even though the allow-list drops them before it is shown.
+        assert_eq!(windows_app_label_from_executable("notepad.exe"), "notepad");
+        assert_eq!(windows_app_label_from_executable("weird"), "weird");
+        assert_eq!(windows_app_label_from_executable(".exe"), ".exe");
+    }
+
+    #[test]
+    fn windows_allow_list_ignores_surrounding_whitespace() {
+        assert!(is_allowed_windows_microphone_app("  Zoom.exe  "));
+        assert_eq!(windows_app_label_from_executable("  Zoom.exe  "), "Zoom");
     }
 
     #[test]

--- a/src-tauri/tests/source_readiness.rs
+++ b/src-tauri/tests/source_readiness.rs
@@ -1,4 +1,4 @@
-use os_june_lib::{audio::system_macos::system_audio_readiness, domain::types::RecordingSource};
+use os_june_lib::{audio::system_audio_readiness, domain::types::RecordingSource};
 
 #[test]
 fn system_audio_readiness_reports_system_source() {

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -33,7 +33,7 @@ import {
 } from "../../lib/tauri";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
-import { isMacLikePlatform } from "../../lib/platform";
+import { usePlatformCapabilities } from "../../lib/capabilities";
 
 const NO_DICTATIONS: DictationHistoryItemDto[] = [];
 
@@ -88,7 +88,9 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
   const [dictionaryCount, setDictionaryCount] = useState<number | null>(null);
   const [hintDismissed, setHintDismissed] = useState(readHintDismissed);
   const [pendingDelete, setPendingDelete] = useState<DictationHistoryItemDto | null>(null);
-  const dictationAvailable = isMacLikePlatform();
+  // Backend-reported capability: flips on automatically when a platform's
+  // dictation backend ships, instead of tracking an OS allowlist here.
+  const dictationAvailable = usePlatformCapabilities().dictation;
 
   const loadHistory = useCallback(async () => {
     try {
@@ -241,7 +243,9 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
           label={dictationAvailable ? "Start dictating" : "Dictation unavailable"}
           icon={<IconMicrophoneSparkleFilled size={28} />}
           title={
-            dictationAvailable ? "Start dictating anywhere" : "Dictation is only supported on macOS"
+            dictationAvailable
+              ? "Start dictating anywhere"
+              : "Dictation is not available on this platform yet"
           }
           description={
             dictationAvailable

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -27,7 +27,7 @@ import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
-import { isMacLikePlatform } from "../../lib/platform";
+import { usePlatformCapabilities } from "../../lib/capabilities";
 import {
   isInvalidJuneResponseMessage,
   NoteFailureBanner,
@@ -144,6 +144,7 @@ export function NoteEditor({
   onNavigateToFolder,
   onTabChange,
 }: NoteEditorProps) {
+  const capabilities = usePlatformCapabilities();
   const content = note.editedContent ?? note.generatedContent ?? "";
   const activeTab = note.activeTab ?? "notes";
   const sourceTranscripts = orderedVisibleSourceTranscripts(note);
@@ -192,7 +193,10 @@ export function NoteEditor({
   const systemDenied =
     systemSource?.permissionState === "denied" || systemSource?.permissionState === "restricted";
   const systemUnsupported = systemSource?.permissionState === "unsupported";
-  const showRecordingOptions = isMacLikePlatform();
+  // Backend-reported capability, not a UA sniff: the toggle shows wherever
+  // this build can capture system audio (macOS, Windows, Linux), and the
+  // live readiness probe above drives its enabled/denied/unsupported state.
+  const showRecordingOptions = capabilities.systemAudio;
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.
   const micDenied = microphoneBlocked;
@@ -482,7 +486,11 @@ export function NoteEditor({
                   <div className="record-options-panel-inner">
                     {systemUnsupported ? (
                       <p className="record-options-unsupported">
-                        System audio requires macOS 14.2 or later.
+                        {/* The backend readiness probe knows why capture is
+                            unavailable on this exact platform; only fall back
+                            to generic copy when it sent no message. */}
+                        {systemSource?.message ??
+                          "System audio capture is not available on this device."}
                       </p>
                     ) : (
                       <div className="record-options-row" data-locked={systemDenied || undefined}>

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,9 +1,13 @@
 import { IconChevronLeftSmall } from "central-icons/IconChevronLeftSmall";
 import { useEffect, useMemo, useState } from "react";
+import { cachedPlatformCapabilities, platformCapabilities } from "../../lib/capabilities";
 import { onboardingResumeStep, setOnboardingResumeStep } from "../../lib/onboarding";
-import { isMacLikePlatform } from "../../lib/platform";
 import { dictationSettings, setDictationShortcut } from "../../lib/tauri";
-import type { AccountStatus, DictationShortcutSetting } from "../../lib/tauri";
+import type {
+  AccountStatus,
+  DictationShortcutSetting,
+  PlatformCapabilities,
+} from "../../lib/tauri";
 import { PermissionsStep } from "./steps/PermissionSteps";
 import { DictationPracticeStep } from "./steps/PracticeStep";
 import { SignInStep } from "./steps/SignInStep";
@@ -39,8 +43,8 @@ function isFactoryDefaultShortcut(shortcut: DictationShortcutSetting) {
   );
 }
 
-const MAC_STEPS: StepId[] = ["sign-in", "permissions", "dictation-practice"];
-const NON_MAC_STEPS: StepId[] = ["sign-in", "permissions"];
+const DICTATION_STEPS: StepId[] = ["sign-in", "permissions", "dictation-practice"];
+const BASE_STEPS: StepId[] = ["sign-in", "permissions"];
 
 type Props = {
   account: AccountStatus;
@@ -68,8 +72,39 @@ function browserOnboardingDemoStep(): StepId | null {
     : null;
 }
 
-export function OnboardingFlow({ account, onAccountChanged, onComplete }: Props) {
-  const steps = useMemo(() => (isMacLikePlatform() ? MAC_STEPS : NON_MAC_STEPS), []);
+export function OnboardingFlow(props: Props) {
+  // The steps array must be fixed before the wizard mounts: capabilities
+  // landing mid-flow would add or drop steps under the user's feet. Resolve
+  // the backend answer first (one fast IPC read, usually already cached),
+  // then hand the settled value to the step machine.
+  const [capabilities, setCapabilities] = useState(cachedPlatformCapabilities);
+  useEffect(() => {
+    if (capabilities) return;
+    let active = true;
+    void platformCapabilities().then((resolved) => {
+      if (active) setCapabilities(resolved);
+    });
+    return () => {
+      active = false;
+    };
+  }, [capabilities]);
+
+  if (!capabilities) {
+    return <div className="onboarding-screen" />;
+  }
+  return <OnboardingSteps capabilities={capabilities} {...props} />;
+}
+
+function OnboardingSteps({
+  capabilities,
+  account,
+  onAccountChanged,
+  onComplete,
+}: Props & { capabilities: PlatformCapabilities }) {
+  const steps = useMemo(
+    () => (capabilities.dictation ? DICTATION_STEPS : BASE_STEPS),
+    [capabilities.dictation],
+  );
   const supportsDictationPractice = steps.includes("dictation-practice");
   const [stepIndex, setStepIndex] = useState(() => {
     const initial = initialStepIndex(steps);
@@ -178,6 +213,7 @@ export function OnboardingFlow({ account, onAccountChanged, onComplete }: Props)
           <PermissionsStep
             statuses={permissionStatuses}
             systemAudioStatus={systemAudio.status}
+            capabilities={capabilities}
             onAllowSystemAudio={systemAudio.probe}
             onContinue={goNext}
           />

--- a/src/components/onboarding/steps/PermissionSteps.tsx
+++ b/src/components/onboarding/steps/PermissionSteps.tsx
@@ -5,6 +5,7 @@ import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconTextIndicator } from "central-icons/IconTextIndicator";
 import { IconVolumeFull } from "central-icons/IconVolumeFull";
 import { dictationHelperCommand, openPrivacySettings } from "../../../lib/tauri";
+import type { PlatformCapabilities } from "../../../lib/tauri";
 import { isMacLikePlatform } from "../../../lib/platform";
 import { StepActions, StepCard } from "../StepChrome";
 import {
@@ -60,11 +61,15 @@ function PermissionRow({
 export function PermissionsStep({
   statuses,
   systemAudioStatus,
+  capabilities,
   onAllowSystemAudio,
   onContinue,
 }: {
   statuses: PermissionStatuses;
   systemAudioStatus: SystemAudioStatus;
+  /** Backend-reported build capabilities; drives which permission rows this
+   * platform gets at all. */
+  capabilities: PlatformCapabilities;
   /** Re-runs the capture-helper probe; fires the TCC prompt while the
    * permission is still undetermined. */
   onAllowSystemAudio: () => void;
@@ -80,7 +85,12 @@ export function PermissionsStep({
   // explains itself and stays out of the Continue gate.
   const systemAudioUnsupported = systemAudioStatus === "unsupported";
   const showPermissionRows = statuses.checked || showUnknownStatuses;
-  const macLikePlatform = isMacLikePlatform();
+  const showSystemAudio = capabilities.systemAudio;
+  // Accessibility is a macOS TCC concept (dictated text is pasted through
+  // the AX APIs). Deliberately platform-sniffed rather than keyed on
+  // capabilities.dictation: Windows dictation, when it ships, must not grow
+  // an accessibility row.
+  const showAccessibility = isMacLikePlatform();
 
   // Fire the native TCC prompt as soon as the screen shows — the user just
   // read why we're asking, so the dialog lands in context. No-op when
@@ -119,9 +129,11 @@ export function PermissionsStep({
     <StepCard
       title="Let June listen and type"
       subtitle={
-        macLikePlatform
+        showAccessibility
           ? "Dictation and meeting notes need three macOS permissions."
-          : "Dictation and meeting notes need microphone access."
+          : showSystemAudio
+            ? "Meeting notes need microphone and system audio access."
+            : "Meeting notes need microphone access."
       }
       wide
     >
@@ -150,40 +162,40 @@ export function PermissionsStep({
               : undefined
           }
         />
-        {macLikePlatform ? (
-          <>
-            <PermissionRow
-              icon={<IconTextIndicator size={15} />}
-              granted={showPermissionRows && accessibilityGranted}
-              title="Accessibility"
-              detail="Types your words at your cursor, in any app."
-              onAllow={showPermissionRows ? openAccessibilitySettings : undefined}
-            />
-            <PermissionRow
-              icon={<IconVolumeFull size={15} />}
-              granted={showPermissionRows && systemAudioGranted}
-              probing={showPermissionRows && systemAudioStatus === "probing"}
-              title="System audio"
-              detail={
-                systemAudioDenied
-                  ? "Turned off in System Settings. Flip the toggle and June will notice."
-                  : systemAudioUnsupported
-                    ? "Needs macOS 14.2 or later."
-                    : systemAudioStatus === "probing"
-                      ? "Waiting for macOS. Approve the prompt when it appears."
-                      : "Hears your calls and meetings, only while you record."
-              }
-              onAllow={
-                showPermissionRows
-                  ? systemAudioDenied
-                    ? () => void openPrivacySettings("systemAudio")
-                    : systemAudioStatus === "unknown"
-                      ? onAllowSystemAudio
-                      : undefined
-                  : undefined
-              }
-            />
-          </>
+        {showAccessibility ? (
+          <PermissionRow
+            icon={<IconTextIndicator size={15} />}
+            granted={showPermissionRows && accessibilityGranted}
+            title="Accessibility"
+            detail="Types your words at your cursor, in any app."
+            onAllow={showPermissionRows ? openAccessibilitySettings : undefined}
+          />
+        ) : null}
+        {showSystemAudio ? (
+          <PermissionRow
+            icon={<IconVolumeFull size={15} />}
+            granted={showPermissionRows && systemAudioGranted}
+            probing={showPermissionRows && systemAudioStatus === "probing"}
+            title="System audio"
+            detail={
+              systemAudioDenied
+                ? "Turned off in System Settings. Flip the toggle and June will notice."
+                : systemAudioUnsupported
+                  ? "Needs macOS 14.2 or later."
+                  : systemAudioStatus === "probing"
+                    ? "Waiting for your system. Approve the prompt if one appears."
+                    : "Hears your calls and meetings, only while you record."
+            }
+            onAllow={
+              showPermissionRows
+                ? systemAudioDenied
+                  ? () => void openPrivacySettings("systemAudio")
+                  : systemAudioStatus === "unknown"
+                    ? onAllowSystemAudio
+                    : undefined
+                : undefined
+            }
+          />
         ) : null}
       </ul>
       <StepActions
@@ -191,8 +203,8 @@ export function PermissionsStep({
         continueDisabled={
           !showPermissionRows ||
           !micGranted ||
-          (macLikePlatform &&
-            (!accessibilityGranted || !(systemAudioGranted || systemAudioUnsupported)))
+          (showAccessibility && !accessibilityGranted) ||
+          (showSystemAudio && !(systemAudioGranted || systemAudioUnsupported))
         }
         onSkip={onContinue}
       />

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -73,6 +73,7 @@ import {
   setReleaseChannel,
   type ReleaseChannel,
 } from "../../lib/updater";
+import { usePlatformCapabilities } from "../../lib/capabilities";
 import { isMacLikePlatform } from "../../lib/platform";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
@@ -349,6 +350,9 @@ export function AppSettings({
   const settingsTabs = account.localDev
     ? SETTINGS_TABS.filter((tab) => tab.id !== "billing")
     : SETTINGS_TABS;
+  const capabilities = usePlatformCapabilities();
+  // Still needed for the mic test below: it runs through the macOS dictation
+  // helper binary, which is about the host OS, not a reported capability.
   const macLikePlatform = isMacLikePlatform();
   const setActiveTab = (tab: SettingsTab) => {
     if (controlled) {
@@ -366,7 +370,10 @@ export function AppSettings({
   );
   const systemState = systemReadiness?.permissionState;
   const systemDenied = systemState === "denied" || systemState === "restricted";
-  const systemUnavailable = !macLikePlatform || systemState === "unsupported";
+  // Capability says whether this build can capture system audio at all;
+  // "unsupported" from the live readiness probe covers a capable build on an
+  // OS that cannot deliver it (e.g. macOS older than 14.2).
+  const systemUnavailable = !capabilities.systemAudio || systemState === "unsupported";
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;
@@ -1093,7 +1100,7 @@ export function AppSettings({
             </h2>
             <div className="settings-card">
               <div className="settings-rows">
-                {macLikePlatform ? (
+                {capabilities.dictation ? (
                   <>
                     <ShortcutRow
                       title="Push to talk"
@@ -1128,7 +1135,7 @@ export function AppSettings({
                     <div className="settings-row-info">
                       <h3 className="settings-row-title">Dictation shortcuts unavailable</h3>
                       <p className="settings-row-description">
-                        Global dictation shortcuts are only supported on macOS.
+                        Dictation is not available on this platform yet.
                       </p>
                     </div>
                   </div>
@@ -1646,16 +1653,24 @@ function PermissionsSettingsSection({
   onEnableAccessibility?: () => void;
   onEnableSystemAudio: () => void;
 }) {
-  const macLikePlatform = isMacLikePlatform();
+  const capabilities = usePlatformCapabilities();
+  // Accessibility is a macOS TCC concept (June pastes dictated text through
+  // the AX APIs), so the row stays platform-sniffed on purpose: keying it on
+  // capabilities.dictation would wrongly grow an accessibility row on
+  // Windows once dictation ships there.
+  const showAccessibility = isMacLikePlatform();
+  const showSystemAudio = capabilities.systemAudio;
   return (
     <section className="settings-group" aria-labelledby="permissions-heading">
       <h2 id="permissions-heading" className="settings-group-heading">
         System permissions
       </h2>
       <p className="settings-group-description">
-        {macLikePlatform
+        {showAccessibility
           ? "macOS access used for recording audio, pasting dictation, and capturing system sound."
-          : "Access used for recording audio."}
+          : showSystemAudio
+            ? "Access used for recording audio and capturing system sound."
+            : "Access used for recording audio."}
       </p>
       <div className="settings-card">
         <div className="settings-rows">
@@ -1668,22 +1683,22 @@ function PermissionsSettingsSection({
             onManage={onEnableMicrophone}
           />
 
-          {macLikePlatform ? (
-            <>
-              <PermissionRow
-                title="Accessibility"
-                description="Paste dictated text into the active app."
-                status={permissionStatus(accessibilityPermissionStatus)}
-                onManage={onEnableAccessibility}
-              />
+          {showAccessibility ? (
+            <PermissionRow
+              title="Accessibility"
+              description="Paste dictated text into the active app."
+              status={permissionStatus(accessibilityPermissionStatus)}
+              onManage={onEnableAccessibility}
+            />
+          ) : null}
 
-              <PermissionRow
-                title="System audio"
-                description="Record audio from other apps when system audio is enabled."
-                status={sourcePermissionStatus(systemReadiness)}
-                onManage={onEnableSystemAudio}
-              />
-            </>
+          {showSystemAudio ? (
+            <PermissionRow
+              title="System audio"
+              description="Record audio from other apps when system audio is enabled."
+              status={sourcePermissionStatus(systemReadiness)}
+              onManage={onEnableSystemAudio}
+            />
           ) : null}
         </div>
       </div>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -351,9 +351,6 @@ export function AppSettings({
     ? SETTINGS_TABS.filter((tab) => tab.id !== "billing")
     : SETTINGS_TABS;
   const capabilities = usePlatformCapabilities();
-  // Still needed for the mic test below: it runs through the macOS dictation
-  // helper binary, which is about the host OS, not a reported capability.
-  const macLikePlatform = isMacLikePlatform();
   const setActiveTab = (tab: SettingsTab) => {
     if (controlled) {
       onTabChange?.(tab);
@@ -1276,7 +1273,7 @@ export function AppSettings({
                   </div>
                 </div>
 
-                {macLikePlatform ? (
+                {capabilities.dictation ? (
                   <MicTestControl
                     state={micTestState}
                     level={micTestLevel}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1,4 +1,9 @@
 import { listen } from "@tauri-apps/api/event";
+import {
+  disable as disableAutostart,
+  enable as enableAutostart,
+  isEnabled as isAutostartEnabled,
+} from "@tauri-apps/plugin-autostart";
 import { IconCheckmark1Small } from "central-icons/IconCheckmark1Small";
 import { IconChevronDownSmall } from "central-icons/IconChevronDownSmall";
 import { IconCircleCheck } from "central-icons/IconCircleCheck";
@@ -317,6 +322,8 @@ export function AppSettings({
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [brand, setBrand] = useState<BrandId>(() => getStoredBrand());
   const [releaseChannel, setReleaseChannelValue] = useState<ReleaseChannel>("stable");
+  const [launchAtLogin, setLaunchAtLogin] = useState(false);
+  const [launchAtLoginBusy, setLaunchAtLoginBusy] = useState(false);
   // Set only when a leave-rc switch turns up an installable stable, so the
   // bespoke in-context confirm below the toggle can name the exact version.
   const [reconcileVersion, setReconcileVersion] = useState<string>();
@@ -381,6 +388,38 @@ export function AppSettings({
       active = false;
     };
   }, [updaterAvailable]);
+
+  // Reflect the real launch-at-login state (macOS Login Items, the Windows Run
+  // key, or a Linux ~/.config/autostart entry) once on mount. A read failure
+  // leaves the toggle off rather than surfacing an error.
+  useEffect(() => {
+    let active = true;
+    void isAutostartEnabled()
+      .then((enabled) => {
+        if (active) setLaunchAtLogin(enabled);
+      })
+      .catch(() => undefined);
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handleLaunchAtLoginChange = (next: boolean) => {
+    // Optimistic flip so the switch feels instant, then persist. If writing the
+    // platform launch entry fails, re-read the real state so the toggle never
+    // lies about whether June actually launches at login.
+    setLaunchAtLogin(next);
+    setLaunchAtLoginBusy(true);
+    void (next ? enableAutostart() : disableAutostart())
+      .catch(() => {
+        void isAutostartEnabled()
+          .then((enabled) => setLaunchAtLogin(enabled))
+          .catch(() => setLaunchAtLogin(!next));
+      })
+      .finally(() => {
+        setLaunchAtLoginBusy(false);
+      });
+  };
 
   const handleReleaseChannelChange = (next: ReleaseChannel) => {
     setReleaseChannelValue(next);
@@ -998,6 +1037,32 @@ export function AppSettings({
                           setBrand(id);
                           setStoredBrand(id);
                         }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className="settings-group" aria-labelledby="startup-heading">
+              <h2 id="startup-heading" className="settings-group-heading">
+                Startup
+              </h2>
+              <div className="settings-card">
+                <div className="settings-rows">
+                  <div className="settings-row">
+                    <div className="settings-row-info">
+                      <h3 className="settings-row-title">Launch at login</h3>
+                      <p className="settings-row-description">
+                        Open June automatically when you sign in to your computer.
+                      </p>
+                    </div>
+                    <div className="settings-row-control">
+                      <Switch
+                        checked={launchAtLogin}
+                        disabled={launchAtLoginBusy}
+                        aria-label="Launch June at login"
+                        onCheckedChange={handleLaunchAtLoginChange}
                       />
                     </div>
                   </div>

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -15,10 +15,11 @@ let pending: Promise<PlatformCapabilities> | undefined;
  */
 export function fallbackPlatformCapabilities(): PlatformCapabilities {
   const mac = isMacLikePlatform();
+  const windows = isWindowsLikePlatform();
   return {
     systemAudio: true,
-    meetingDetection: mac || isWindowsLikePlatform(),
-    dictation: mac,
+    meetingDetection: mac || windows,
+    dictation: mac || windows,
   };
 }
 

--- a/src/lib/capabilities.ts
+++ b/src/lib/capabilities.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { isMacLikePlatform, isWindowsLikePlatform } from "./platform";
+import { getPlatformCapabilities, type PlatformCapabilities } from "./tauri";
+
+// Capabilities are static per build, so the first successful backend answer
+// is cached for the lifetime of the app and every later read is synchronous.
+let cached: PlatformCapabilities | undefined;
+let pending: Promise<PlatformCapabilities> | undefined;
+
+/**
+ * Best-guess capabilities from a user-agent sniff, used only until the
+ * backend answers (and in browser previews, where there is no backend).
+ * Kept in sync with `get_platform_capabilities` in
+ * `src-tauri/src/commands.rs` so the reconcile is a no-op on real builds.
+ */
+export function fallbackPlatformCapabilities(): PlatformCapabilities {
+  const mac = isMacLikePlatform();
+  return {
+    systemAudio: true,
+    meetingDetection: mac || isWindowsLikePlatform(),
+    dictation: mac,
+  };
+}
+
+/** The backend-reported capabilities when they have already been fetched;
+ * undefined before the first successful read. */
+export function cachedPlatformCapabilities(): PlatformCapabilities | undefined {
+  return cached;
+}
+
+/**
+ * Resolves the backend-reported capabilities, sharing one in-flight IPC call
+ * and caching the answer forever (the values are compile-time constants on
+ * the Rust side). An IPC failure resolves to the sniffed fallback but is not
+ * cached, so a later call can still pick up the real backend verdict.
+ */
+export function platformCapabilities(): Promise<PlatformCapabilities> {
+  if (cached) return Promise.resolve(cached);
+  if (!pending) {
+    // Wrapped in a resolved-promise chain so a synchronous throw from invoke
+    // (e.g. no Tauri runtime) lands in the catch instead of escaping.
+    pending = Promise.resolve()
+      .then(() => getPlatformCapabilities())
+      .then((capabilities) => {
+        cached = capabilities;
+        return capabilities;
+      })
+      .catch(() => {
+        pending = undefined;
+        return fallbackPlatformCapabilities();
+      });
+  }
+  return pending;
+}
+
+/**
+ * The running build's capabilities for render-time gating. Starts from the
+ * cached backend answer when available, otherwise from the sniffed fallback
+ * (so the first paint matches the eventual answer on every shipping
+ * platform and nothing flashes), then reconciles once the IPC read lands.
+ */
+export function usePlatformCapabilities(): PlatformCapabilities {
+  const [capabilities, setCapabilities] = useState(() => cached ?? fallbackPlatformCapabilities());
+  useEffect(() => {
+    let active = true;
+    void platformCapabilities().then((next) => {
+      if (!active) return;
+      // Skip the state write when the fallback already matched, so settled
+      // surfaces do not re-render.
+      setCapabilities((prev) =>
+        prev.systemAudio === next.systemAudio &&
+        prev.meetingDetection === next.meetingDetection &&
+        prev.dictation === next.dictation
+          ? prev
+          : next,
+      );
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+  return capabilities;
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -7,6 +7,12 @@ export function isMacLikePlatform() {
   return true;
 }
 
+export function isWindowsLikePlatform() {
+  const platform =
+    typeof navigator === "undefined" ? "" : `${navigator.platform} ${navigator.userAgent}`;
+  return /Windows|Win32|Win64/i.test(platform);
+}
+
 export function primaryShortcutLabel(key: string) {
   // No space after the ⌘ glyph (it reads tight), but keep one after the
   // "Ctrl" word so Windows labels don't run together as "CtrlN".

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1360,6 +1360,20 @@ export async function checkRecordingSourceReadiness(sourceMode: RecordingSourceM
   });
 }
 
+/** What this build of June can actually do, reported by the backend at
+ * compile time. The UI gates feature surfaces on these flags instead of
+ * sniffing the OS from the user agent. Static for the lifetime of the app;
+ * see `src/lib/capabilities.ts` for the cached accessor and hook. */
+export type PlatformCapabilities = {
+  systemAudio: boolean;
+  meetingDetection: boolean;
+  dictation: boolean;
+};
+
+export async function getPlatformCapabilities() {
+  return invoke<PlatformCapabilities>("get_platform_capabilities");
+}
+
 export async function openPrivacySettings(pane: "microphone" | "accessibility" | "systemAudio") {
   return invoke<void>("open_privacy_settings", { request: { pane } });
 }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1149,7 +1149,7 @@ describe("AppSettings", () => {
     expect(onEnableSystemAudio).toHaveBeenCalledTimes(1);
   });
 
-  it("only lists microphone permissions on Windows", async () => {
+  it("lists microphone and system audio permissions but no accessibility on Windows", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
@@ -1201,10 +1201,14 @@ describe("AppSettings", () => {
         />,
       );
 
-      expect(screen.getByText("Access used for recording audio.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Access used for recording audio and capturing system sound."),
+      ).toBeInTheDocument();
       expect(screen.getByText("Microphone")).toBeInTheDocument();
       expect(screen.queryByText("Accessibility")).not.toBeInTheDocument();
-      expect(screen.queryByText("System audio")).not.toBeInTheDocument();
+      // Windows captures system audio now (WASAPI loopback), so its
+      // permission row is listed alongside the microphone.
+      expect(screen.getByText("System audio")).toBeInTheDocument();
 
       const microphoneRow = screen.getByText("Microphone").closest(".settings-row");
       expect(microphoneRow).not.toBeNull();
@@ -1214,16 +1218,27 @@ describe("AppSettings", () => {
         }),
       );
 
+      const systemAudioRow = screen.getByText("System audio").closest(".settings-row");
+      expect(systemAudioRow).not.toBeNull();
+      await userEvent.click(
+        within(systemAudioRow as HTMLElement).getByRole("button", {
+          name: "Manage System audio permission",
+        }),
+      );
+
       expect(onEnableMicrophone).toHaveBeenCalledTimes(1);
       expect(onEnableAccessibility).not.toHaveBeenCalled();
-      expect(onEnableSystemAudio).not.toHaveBeenCalled();
+      expect(onEnableSystemAudio).toHaveBeenCalledTimes(1);
 
       await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
+      // The system audio toggle keys on the capability plus live readiness,
+      // not the OS; the mic test stays macOS-only (it runs through the
+      // dictation helper binary).
       expect(
-        screen.queryByRole("switch", {
+        screen.getByRole("switch", {
           name: "Capture system audio for notes",
         }),
-      ).not.toBeInTheDocument();
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", {
           name: "Start test",
@@ -1232,6 +1247,9 @@ describe("AppSettings", () => {
 
       await userEvent.click(screen.getByRole("tab", { name: "Shortcuts" }));
       expect(screen.getByText("Dictation shortcuts unavailable")).toBeInTheDocument();
+      expect(
+        screen.getByText("Dictation is not available on this platform yet."),
+      ).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
     } finally {
       restoreNavigator();

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1232,25 +1232,22 @@ describe("AppSettings", () => {
 
       await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
       // The system audio toggle keys on the capability plus live readiness,
-      // not the OS; the mic test stays macOS-only (it runs through the
-      // dictation helper binary).
+      // not the OS. The mic test and shortcut rows follow the dictation
+      // capability, which Windows now reports through its in-process engine.
       expect(
         screen.getByRole("switch", {
           name: "Capture system audio for notes",
         }),
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole("button", {
+        screen.getByRole("button", {
           name: "Start test",
         }),
-      ).not.toBeInTheDocument();
+      ).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole("tab", { name: "Shortcuts" }));
-      expect(screen.getByText("Dictation shortcuts unavailable")).toBeInTheDocument();
-      expect(
-        screen.getByText("Dictation is not available on this platform yet."),
-      ).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+      expect(await screen.findByText("Push to talk")).toBeInTheDocument();
+      expect(screen.queryByText("Dictation shortcuts unavailable")).toBeNull();
     } finally {
       restoreNavigator();
     }

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -121,10 +121,10 @@ describe("DictationHistoryView", () => {
     await waitFor(() => expect(mocks.writeText).toHaveBeenCalledWith("Send the follow up. "));
   });
 
-  it("does not advertise shortcut dictation on Windows", async () => {
+  it("does not advertise shortcut dictation on Linux", async () => {
     const restoreNavigator = stubNavigatorPlatform(
-      "Win32",
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+      "Linux x86_64",
+      "Mozilla/5.0 (X11; Linux x86_64)",
     );
     try {
       mocks.listDictationHistory.mockResolvedValue({

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -134,7 +134,9 @@ describe("DictationHistoryView", () => {
 
       render(<DictationHistoryView />);
 
-      expect(await screen.findByText("Dictation is only supported on macOS")).toBeInTheDocument();
+      expect(
+        await screen.findByText("Dictation is not available on this platform yet"),
+      ).toBeInTheDocument();
       expect(
         screen.getByText("Meeting notes still work with microphone recording on this device."),
       ).toBeInTheDocument();

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -661,7 +661,10 @@ describe("NoteEditor", () => {
     expect(onEnableSystemAudio).toHaveBeenCalledOnce();
   });
 
-  it("hides system audio recording options on Windows", () => {
+  it("shows system audio recording options on Windows", async () => {
+    // System audio capture is a build capability now (WASAPI loopback on
+    // Windows), so the recording options toggle is no longer mac-gated.
+    const user = userEvent.setup();
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
@@ -673,7 +676,7 @@ describe("NoteEditor", () => {
           note={note()}
           sourceReadiness={{
             sourceMode: "microphonePlusSystem",
-            ready: false,
+            ready: true,
             checkedAt: now,
             sources: [
               {
@@ -687,10 +690,10 @@ describe("NoteEditor", () => {
               {
                 source: "system",
                 required: true,
-                ready: false,
-                permissionState: "unsupported",
-                deviceAvailable: false,
-                captureAvailable: false,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
               },
             ],
           }}
@@ -698,14 +701,86 @@ describe("NoteEditor", () => {
       );
 
       expect(screen.getByRole("button", { name: "Record" })).toBeEnabled();
-      expect(screen.queryByRole("button", { name: "Recording options" })).not.toBeInTheDocument();
-      expect(screen.queryByText("Capture system audio")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText("System audio requires macOS 14.2 or later."),
-      ).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Recording options" }));
+      expect(screen.getByRole("switch", { name: "Capture system audio" })).toBeEnabled();
     } finally {
       restoreNavigator();
     }
+  });
+
+  it("surfaces the backend readiness message when system audio is unsupported", async () => {
+    const user = userEvent.setup();
+    render(
+      <NoteEditor
+        {...props}
+        note={note()}
+        sourceReadiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: false,
+          checkedAt: now,
+          sources: [
+            {
+              source: "microphone",
+              required: true,
+              ready: true,
+              permissionState: "granted",
+              deviceAvailable: true,
+              captureAvailable: true,
+            },
+            {
+              source: "system",
+              required: true,
+              ready: false,
+              permissionState: "unsupported",
+              deviceAvailable: false,
+              captureAvailable: false,
+              message:
+                "System audio capture requires macOS 14.2 or later. Use microphone-only recording on this Mac.",
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Recording options" }));
+    // The unsupported copy comes from the backend readiness probe, which
+    // knows the platform-accurate reason; no hardcoded macOS wording.
+    expect(
+      screen.getByText(
+        "System audio capture requires macOS 14.2 or later. Use microphone-only recording on this Mac.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("switch", { name: "Capture system audio" })).not.toBeInTheDocument();
+  });
+
+  it("falls back to generic copy when unsupported readiness carries no message", async () => {
+    const user = userEvent.setup();
+    render(
+      <NoteEditor
+        {...props}
+        note={note()}
+        sourceReadiness={{
+          sourceMode: "microphonePlusSystem",
+          ready: false,
+          checkedAt: now,
+          sources: [
+            {
+              source: "system",
+              required: true,
+              ready: false,
+              permissionState: "unsupported",
+              deviceAvailable: false,
+              captureAvailable: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Recording options" }));
+    expect(
+      screen.getByText("System audio capture is not available on this device."),
+    ).toBeInTheDocument();
   });
 
   it("surfaces a dismissible consent reminder after the recorder settles", async () => {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -518,8 +518,8 @@ describe("OnboardingFlow", () => {
 
   it("asks for microphone and system audio but not accessibility on Windows", async () => {
     // Windows now captures system audio (WASAPI loopback), so its permission
-    // row shows; accessibility stays macOS-only and dictation practice is
-    // skipped until the Windows dictation backend ships.
+    // row shows; accessibility stays macOS-only. Dictation practice follows
+    // the dictation capability, which Windows reports too.
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
@@ -546,8 +546,10 @@ describe("OnboardingFlow", () => {
       await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
       await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
-      await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
-      expect(screen.queryByRole("heading", { name: "Talk to June" })).not.toBeInTheDocument();
+      // Windows has dictation, so the practice step follows the permissions
+      // screen instead of completing the flow.
+      expect(await screen.findByRole("heading", { name: "Talk to June" })).toBeInTheDocument();
+      expect(onComplete).not.toHaveBeenCalled();
     } finally {
       restoreNavigator();
     }

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -516,7 +516,10 @@ describe("OnboardingFlow", () => {
     );
   });
 
-  it("only requires microphone access on Windows", async () => {
+  it("asks for microphone and system audio but not accessibility on Windows", async () => {
+    // Windows now captures system audio (WASAPI loopback), so its permission
+    // row shows; accessibility stays macOS-only and dictation practice is
+    // skipped until the Windows dictation backend ships.
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
@@ -525,10 +528,10 @@ describe("OnboardingFlow", () => {
       const onComplete = await renderFlow();
 
       expect(
-        screen.getByText("Dictation and meeting notes need microphone access."),
+        screen.getByText("Meeting notes need microphone and system audio access."),
       ).toBeInTheDocument();
       expect(screen.queryByText("Accessibility")).not.toBeInTheDocument();
-      expect(screen.queryByText("System audio")).not.toBeInTheDocument();
+      expect(screen.getByText("System audio")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
 
       emitDictationEvent?.({
@@ -538,6 +541,8 @@ describe("OnboardingFlow", () => {
         }),
       });
 
+      // The mocked readiness probe reports system audio granted, so the mic
+      // grant is all that was missing.
       await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled());
       await userEvent.click(screen.getByRole("button", { name: "Continue" }));
 

--- a/src/test/platform-capabilities.test.tsx
+++ b/src/test/platform-capabilities.test.tsx
@@ -71,7 +71,7 @@ describe("platformCapabilities", () => {
     await expect(platformCapabilities()).resolves.toEqual({
       systemAudio: true,
       meetingDetection: true,
-      dictation: false,
+      dictation: true,
     });
     // A failure is not cached, so the next read retries the backend.
     expect(cachedPlatformCapabilities()).toBeUndefined();

--- a/src/test/platform-capabilities.test.tsx
+++ b/src/test/platform-capabilities.test.tsx
@@ -1,0 +1,152 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PlatformCapabilities } from "../lib/tauri";
+
+const mocks = vi.hoisted(() => ({
+  getPlatformCapabilities: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", () => ({
+  getPlatformCapabilities: mocks.getPlatformCapabilities,
+}));
+
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+}
+
+const windowsBuild: PlatformCapabilities = {
+  systemAudio: true,
+  meetingDetection: true,
+  dictation: false,
+};
+
+// The module caches the backend answer for the lifetime of the app, so each
+// test gets a fresh copy via resetModules + dynamic import.
+async function loadModule() {
+  vi.resetModules();
+  return import("../lib/capabilities");
+}
+
+describe("platformCapabilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves the backend answer and caches it across calls", async () => {
+    mocks.getPlatformCapabilities.mockResolvedValue(windowsBuild);
+    const { platformCapabilities, cachedPlatformCapabilities } = await loadModule();
+
+    expect(cachedPlatformCapabilities()).toBeUndefined();
+    await expect(platformCapabilities()).resolves.toEqual(windowsBuild);
+    await expect(platformCapabilities()).resolves.toEqual(windowsBuild);
+
+    // Capabilities are static per build: one IPC read, then the cache.
+    expect(mocks.getPlatformCapabilities).toHaveBeenCalledTimes(1);
+    expect(cachedPlatformCapabilities()).toEqual(windowsBuild);
+  });
+
+  it("shares one in-flight IPC call between concurrent readers", async () => {
+    mocks.getPlatformCapabilities.mockResolvedValue(windowsBuild);
+    const { platformCapabilities } = await loadModule();
+
+    const [first, second] = await Promise.all([platformCapabilities(), platformCapabilities()]);
+
+    expect(first).toEqual(windowsBuild);
+    expect(second).toEqual(windowsBuild);
+    expect(mocks.getPlatformCapabilities).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the platform sniff on IPC failure without caching it", async () => {
+    stubNavigatorPlatform("Win32", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    mocks.getPlatformCapabilities.mockRejectedValue(new Error("no backend"));
+    const { platformCapabilities, cachedPlatformCapabilities } = await loadModule();
+
+    await expect(platformCapabilities()).resolves.toEqual({
+      systemAudio: true,
+      meetingDetection: true,
+      dictation: false,
+    });
+    // A failure is not cached, so the next read retries the backend.
+    expect(cachedPlatformCapabilities()).toBeUndefined();
+
+    mocks.getPlatformCapabilities.mockResolvedValue(windowsBuild);
+    await expect(platformCapabilities()).resolves.toEqual(windowsBuild);
+    expect(mocks.getPlatformCapabilities).toHaveBeenCalledTimes(2);
+    expect(cachedPlatformCapabilities()).toEqual(windowsBuild);
+  });
+
+  it("sniffs a mac-shaped fallback on macOS", async () => {
+    // setup.ts pins the navigator to macOS.
+    const { fallbackPlatformCapabilities } = await loadModule();
+
+    expect(fallbackPlatformCapabilities()).toEqual({
+      systemAudio: true,
+      meetingDetection: true,
+      dictation: true,
+    });
+  });
+
+  it("sniffs a linux-shaped fallback elsewhere", async () => {
+    stubNavigatorPlatform("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)");
+    const { fallbackPlatformCapabilities } = await loadModule();
+
+    expect(fallbackPlatformCapabilities()).toEqual({
+      systemAudio: true,
+      meetingDetection: false,
+      dictation: false,
+    });
+  });
+});
+
+describe("usePlatformCapabilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts from the sniffed fallback and reconciles to the backend answer", async () => {
+    // macOS-shaped navigator (from setup.ts) but a build that reports no
+    // dictation: the hook must settle on the backend's verdict.
+    mocks.getPlatformCapabilities.mockResolvedValue({
+      systemAudio: true,
+      meetingDetection: true,
+      dictation: false,
+    });
+    const { usePlatformCapabilities } = await loadModule();
+
+    const { result } = renderHook(() => usePlatformCapabilities());
+
+    // First render: the sniffed fallback (mac implies dictation).
+    expect(result.current.dictation).toBe(true);
+    await waitFor(() => expect(result.current.dictation).toBe(false));
+    expect(result.current.systemAudio).toBe(true);
+  });
+
+  it("keeps the fallback when the backend is unreachable", async () => {
+    mocks.getPlatformCapabilities.mockRejectedValue(new Error("no backend"));
+    const { usePlatformCapabilities, fallbackPlatformCapabilities } = await loadModule();
+
+    const { result } = renderHook(() => usePlatformCapabilities());
+
+    await waitFor(() => expect(mocks.getPlatformCapabilities).toHaveBeenCalled());
+    expect(result.current).toEqual(fallbackPlatformCapabilities());
+  });
+
+  it("serves the cached backend answer synchronously on later mounts", async () => {
+    mocks.getPlatformCapabilities.mockResolvedValue(windowsBuild);
+    const { usePlatformCapabilities, platformCapabilities } = await loadModule();
+    await platformCapabilities();
+
+    const { result } = renderHook(() => usePlatformCapabilities());
+
+    // No flash: the first render already carries the backend answer.
+    expect(result.current).toEqual(windowsBuild);
+    expect(mocks.getPlatformCapabilities).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

Closes the feature gap between macOS and the Windows/Linux builds shipped by #568 (this PR stacks on that branch). Implemented by parallel agent workstreams, integrated and cross-validated.

**System audio capture everywhere**
- Windows: WASAPI loopback via cpal (input stream on the render device). A dedicated writer thread owns the wall clock, so the track stays aligned even when WASAPI delivers no packets during silence.
- Linux: PulseAudio monitor-source capture via libpulse (works on PipeWire desktops through pipewire-pulse). `JUNE_SYSTEM_AUDIO_SOURCE` env override for pinning a source.
- Both fulfill the exact `SystemAudioCapture` contract (16-bit PCM WAV, timeline-offset alignment, pause excluded from the timeline like macOS, level telemetry, same error codes). `audio/mod.rs` now cfg-selects per-platform backends behind one re-exported surface; shared timeline math is host-testable (`system_timeline.rs`).
- No OS permission exists for loopback/monitor capture on either platform; readiness reports granted when a device/server is present.

**Meeting detection on Windows**
- WASAPI audio-session enumeration across all capture endpoints (`IAudioSessionManager2`), strictly Active sessions, pid dedupe, exe-name allow-list (Teams, Zoom, Chrome, Edge, Arc, Firefox, Brave). The shared state machine, event payloads, and meeting HUD are unchanged.

**Dictation on Windows**
- In-process engine replacing the macOS Swift helper's role: WH_KEYBOARD_LL hook thread for push-to-talk and toggle chords (double-press and hold-disambiguation ported from the Swift monitor; chords matched via W3C `code` strings so settings roam), cpal mic capture, clipboard-save + Ctrl+V SendInput paste with clipboard restore. Speaks the identical stdin-command/stdout-event protocol, so the existing Rust transcription pipeline and frontend work untouched.
- Linux dictation is intentionally deferred: Wayland has no portable global-hotkey API; shipping X11-only would break for the majority. Documented in the capability comment.

**Capability-based frontend gating**
- New `get_platform_capabilities` command (`systemAudio` / `meetingDetection` / `dictation`, compile-time cfg). The UI now gates feature surfaces on backend capabilities instead of UA sniffing, with a sniffed fallback kept in sync so nothing flashes. Onboarding resolves capabilities before building its step machine. Accessibility rows stay macOS-only (TCC concept).

**Autostart (all three platforms)**
- tauri-plugin-autostart + "Launch at login" toggle in settings (Login Items / Run key / ~/.config/autostart).

## Validation

- macOS: 385 Rust tests, `cargo fmt`, `clippy --all-targets -D warnings` all green; frontend 1883 tests across 127 files green
- Windows: full crate type-checks via mingw cross-target (`x86_64-pc-windows-gnu`); chord matcher, label mapping, and timeline math covered by host-runnable unit tests
- Linux: full crate compiles in Docker (bookworm + libpulse); **functional capture test**: a 440Hz sine played into a PulseAudio null sink was recorded through the real capture module at the expected amplitude (48kHz stereo int16, peak 0.60), with readiness reporting granted and the partial WAV readable mid-recording
- Windows NSIS + Linux AppImage/deb bundle CI jobs dispatched on this branch (all green: https://github.com/open-software-network/os-june/actions/runs/28562280478)

**Needs real-hardware verification** (no Windows/Linux hosts available here): live WASAPI loopback and hook behavior under real input, SendInput paste into Win32/UWP apps, session enumeration with a live Zoom/Teams call, and PipeWire capture on a physical desktop. Type-level and protocol-level correctness are CI-proven; runtime behavior needs the clean-VM pass from the release runbooks.

## Known limitations
- Windows clipboard restore is text-only after paste; non-text clipboard content is not restored
- System-audio capture binds the output device selected at start; mid-recording default-device switches record an error rather than following (macOS rebuilds its tap)
- Meeting detection misses apps using exclusive-mode/kernel-streaming capture (not the case for mainstream meeting apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

