### PR TITLE
Align free plan credit bar with the $2 starting grant

### DIFF
--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -18,7 +18,7 @@ import type { AccountStatus, SubscriptionPlan } from "../../lib/tauri";
 const FREE_PLAN_NAME = "Free plan";
 const PRO_PLAN_NAME = "Pro plan";
 const MAX_PLAN_NAME = "Max plan";
-const FREE_PLAN_CREDITS = 5000;
+const FREE_PLAN_CREDITS = 2000;
 
 type Props = {
   account: AccountStatus;

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -637,8 +637,8 @@ describe("AppSettings", () => {
         account={{
           ...signedInAccount,
           balance: {
-            credits: 4857,
-            usdMillis: 4857,
+            credits: 1943,
+            usdMillis: 1943,
           },
           subscription: {
             subscribed: false,


### PR DESCRIPTION
open-software-network/os-accounts#77 reduces the new-user starting grant default from $5 (5,000 credits) to $2 (2,000 credits, ADR-0021). June's AccountSettings keeps its own copy of that denominator (`FREE_PLAN_CREDITS`) to render the usage bar for unsubscribed accounts; left at 5,000, a brand-new user would see their untouched balance as 40% instead of 100%.

- `FREE_PLAN_CREDITS` 5000 -> 2000 in `src/components/account/AccountSettings.tsx`
- Updated the free-grant fallback fixture in `src/test/app-settings.test.tsx` (4,857/5,000 -> 1,943/2,000, still 97%) to mirror the os-accounts web test

Validation: `vitest run` on app-settings (49/49), account-gate, funding-gate, and onboarding suites, all green.

Should land with (or after) os-accounts#77. Found via Greptile review on that PR; June otherwise reads all account state from OS Accounts and has no other copy of the amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)