### PR TITLE
Move local model config under More options in Settings -> Models

### DIFF
--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -874,6 +874,9 @@ export function AppSettings({
     const baseUrl = providerSettings.localGeneration.baseUrl.trim();
     if (!isLoopbackUrl(baseUrl)) {
       setLocalEnableConfirm(true);
+      // The confirm affordance lives in the Local model section behind "More
+      // options"; reveal it so the status message's instruction is reachable.
+      setShowMoreModelOptions(true);
       setStatus(
         "This endpoint is not on this machine. Requests will leave your device. Confirm in the Local model section to enable it.",
       );
@@ -1022,6 +1025,15 @@ export function AppSettings({
   const pickerValue = pickerMode ? modelValueForMode(pickerMode) : "";
   const localDraftBaseUrl = localGenerationDraft.baseUrl.trim();
   const localNonLoopback = localDraftBaseUrl.length > 0 && !isLoopbackUrl(localDraftBaseUrl);
+
+  // Advanced model settings (the Venice key and the local model) sit behind a
+  // collapsed "More options" disclosure. Auto-expand it when a local model is
+  // already enabled so the active toggle and endpoint config are never hidden
+  // behind the disclosure. It only ever expands: a manual collapse, or a later
+  // disable, is left as the user set it.
+  useEffect(() => {
+    if (localModelEnabled) setShowMoreModelOptions(true);
+  }, [localModelEnabled]);
 
   useEffect(() => {
     if (micOpen) updateMicrophonePopoverPlacement();
@@ -1489,7 +1501,7 @@ export function AppSettings({
                     type="button"
                     className="settings-row settings-more-options-trigger"
                     aria-expanded={showMoreModelOptions}
-                    aria-controls="models-more-options"
+                    aria-controls="models-more-options local-model-section"
                     onClick={() => setShowMoreModelOptions((open) => !open)}
                   >
                     <span className="settings-row-info">
@@ -1516,141 +1528,147 @@ export function AppSettings({
               </div>
             </section>
 
-            <section className="settings-group" aria-labelledby="local-model-heading">
-              <h2 id="local-model-heading" className="settings-group-heading">
-                Local model
-              </h2>
-              <p className="settings-group-description">
-                Advanced text generation through your own OpenAI-compatible endpoint.
-              </p>
-              <div className="settings-card">
-                <div className="settings-rows">
-                  <div className="settings-row">
-                    <div className="settings-row-info">
-                      <h3 className="settings-row-title">Use local model</h3>
-                      <p className="settings-row-description">
-                        Generated notes and agent responses use your local text model while
-                        transcription stays on the selected speech-to-text model.
-                      </p>
-                    </div>
-                    <div className="settings-row-control">
-                      <Switch
-                        checked={localModelEnabled}
-                        aria-label="Use local text model"
-                        onCheckedChange={handleLocalToggle}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="settings-row settings-row-stack">
-                    <div className="settings-row-info">
-                      <h3 className="settings-row-title">Endpoint</h3>
-                      <p className="settings-row-description">
-                        OpenAI-compatible base URL, model id, and an optional API key.
-                      </p>
-                    </div>
-                    <div className="settings-row-control settings-local-model-fields">
-                      <label className="settings-field">
-                        <span>Base URL</span>
-                        <input
-                          value={localGenerationDraft.baseUrl}
-                          onChange={(event) => {
-                            const baseUrl = event.currentTarget.value;
-                            setLocalGenerationDraft((draft) => ({
-                              ...draft,
-                              baseUrl,
-                            }));
-                            // A base-URL edit invalidates a pending remote
-                            // confirm.
-                            setLocalEnableConfirm(false);
-                          }}
-                          placeholder="http://localhost:11434/v1"
-                          autoCapitalize="none"
-                          autoCorrect="off"
-                          spellCheck={false}
-                        />
-                      </label>
-                      <label className="settings-field">
-                        <span>Model ID</span>
-                        <input
-                          value={localGenerationDraft.modelId}
-                          onChange={(event) => {
-                            const modelId = event.currentTarget.value;
-                            setLocalGenerationDraft((draft) => ({
-                              ...draft,
-                              modelId,
-                            }));
-                          }}
-                          placeholder="llama3.1:8b"
-                          list="local-generation-models"
-                          autoCapitalize="none"
-                          autoCorrect="off"
-                          spellCheck={false}
-                        />
-                        <datalist id="local-generation-models">
-                          {localProbeModels.map((id) => (
-                            <option key={id} value={id} />
-                          ))}
-                        </datalist>
-                      </label>
-                      <label className="settings-field">
-                        <span>API key</span>
-                        <input
-                          type="password"
-                          value={localGenerationDraft.apiKey}
-                          onChange={(event) => {
-                            const apiKey = event.currentTarget.value;
-                            setLocalGenerationDraft((draft) => ({
-                              ...draft,
-                              apiKey,
-                            }));
-                          }}
-                          placeholder="Optional"
-                          autoCapitalize="none"
-                          autoCorrect="off"
-                          spellCheck={false}
-                        />
-                      </label>
-                      {localNonLoopback ? (
-                        <p className="settings-local-model-warning" role="note">
-                          This endpoint is not on this machine. Requests will leave your device.
+            {showMoreModelOptions ? (
+              <section
+                id="local-model-section"
+                className="settings-group"
+                aria-labelledby="local-model-heading"
+              >
+                <h2 id="local-model-heading" className="settings-group-heading">
+                  Local model
+                </h2>
+                <p className="settings-group-description">
+                  Advanced text generation through your own OpenAI-compatible endpoint.
+                </p>
+                <div className="settings-card">
+                  <div className="settings-rows">
+                    <div className="settings-row">
+                      <div className="settings-row-info">
+                        <h3 className="settings-row-title">Use local model</h3>
+                        <p className="settings-row-description">
+                          Generated notes and agent responses use your local text model while
+                          transcription stays on the selected speech-to-text model.
                         </p>
-                      ) : null}
-                      <div className="settings-local-model-actions">
-                        <button
-                          type="button"
-                          className="btn btn-secondary"
-                          onClick={() => void testLocalConnection()}
-                        >
-                          Test connection
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-secondary"
-                          onClick={() => void handleSaveLocalModel()}
-                        >
-                          Save local model
-                        </button>
                       </div>
-                      {localEnableConfirm ? (
-                        <div className="settings-local-model-confirm" role="alert">
-                          <p className="settings-row-error">
+                      <div className="settings-row-control">
+                        <Switch
+                          checked={localModelEnabled}
+                          aria-label="Use local text model"
+                          onCheckedChange={handleLocalToggle}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="settings-row settings-row-stack">
+                      <div className="settings-row-info">
+                        <h3 className="settings-row-title">Endpoint</h3>
+                        <p className="settings-row-description">
+                          OpenAI-compatible base URL, model id, and an optional API key.
+                        </p>
+                      </div>
+                      <div className="settings-row-control settings-local-model-fields">
+                        <label className="settings-field">
+                          <span>Base URL</span>
+                          <input
+                            value={localGenerationDraft.baseUrl}
+                            onChange={(event) => {
+                              const baseUrl = event.currentTarget.value;
+                              setLocalGenerationDraft((draft) => ({
+                                ...draft,
+                                baseUrl,
+                              }));
+                              // A base-URL edit invalidates a pending remote
+                              // confirm.
+                              setLocalEnableConfirm(false);
+                            }}
+                            placeholder="http://localhost:11434/v1"
+                            autoCapitalize="none"
+                            autoCorrect="off"
+                            spellCheck={false}
+                          />
+                        </label>
+                        <label className="settings-field">
+                          <span>Model ID</span>
+                          <input
+                            value={localGenerationDraft.modelId}
+                            onChange={(event) => {
+                              const modelId = event.currentTarget.value;
+                              setLocalGenerationDraft((draft) => ({
+                                ...draft,
+                                modelId,
+                              }));
+                            }}
+                            placeholder="llama3.1:8b"
+                            list="local-generation-models"
+                            autoCapitalize="none"
+                            autoCorrect="off"
+                            spellCheck={false}
+                          />
+                          <datalist id="local-generation-models">
+                            {localProbeModels.map((id) => (
+                              <option key={id} value={id} />
+                            ))}
+                          </datalist>
+                        </label>
+                        <label className="settings-field">
+                          <span>API key</span>
+                          <input
+                            type="password"
+                            value={localGenerationDraft.apiKey}
+                            onChange={(event) => {
+                              const apiKey = event.currentTarget.value;
+                              setLocalGenerationDraft((draft) => ({
+                                ...draft,
+                                apiKey,
+                              }));
+                            }}
+                            placeholder="Optional"
+                            autoCapitalize="none"
+                            autoCorrect="off"
+                            spellCheck={false}
+                          />
+                        </label>
+                        {localNonLoopback ? (
+                          <p className="settings-local-model-warning" role="note">
                             This endpoint is not on this machine. Requests will leave your device.
                           </p>
+                        ) : null}
+                        <div className="settings-local-model-actions">
                           <button
                             type="button"
                             className="btn btn-secondary"
-                            onClick={() => void enableLocalGeneration()}
+                            onClick={() => void testLocalConnection()}
                           >
-                            Enable anyway
+                            Test connection
+                          </button>
+                          <button
+                            type="button"
+                            className="btn btn-secondary"
+                            onClick={() => void handleSaveLocalModel()}
+                          >
+                            Save local model
                           </button>
                         </div>
-                      ) : null}
+                        {localEnableConfirm ? (
+                          <div className="settings-local-model-confirm" role="alert">
+                            <p className="settings-row-error">
+                              This endpoint is not on this machine. Requests will leave your device.
+                            </p>
+                            <button
+                              type="button"
+                              className="btn btn-secondary"
+                              onClick={() => void enableLocalGeneration()}
+                            >
+                              Enable anyway
+                            </button>
+                          </div>
+                        ) : null}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </section>
+              </section>
+            ) : null}
 
             {IMAGE_GENERATION_ENABLED ? (
               <section className="settings-group" aria-labelledby="image-generation-heading">

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1731,6 +1731,86 @@ describe("AppSettings", () => {
     }
   });
 
+  it("keeps the local model config collapsed behind More options until expanded", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+
+    // The primary pickers are visible, but the local model config is hidden
+    // behind a collapsed "More options" disclosure by default.
+    const trigger = await screen.findByRole("button", { name: /More options/ });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("switch", { name: "Use local text model" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Base URL")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(await screen.findByRole("switch", { name: "Use local text model" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Base URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Model ID")).toBeInTheDocument();
+  });
+
+  it("auto-expands More options when a local model is already enabled", async () => {
+    localState = {
+      baseUrl: "http://localhost:11434/v1",
+      modelId: "llama3.1:8b",
+      apiKey: "",
+      enabled: true,
+    };
+    mocks.providerModelSettings.mockResolvedValueOnce({
+      settings: {
+        transcriptionProvider: "venice",
+        generationProvider: "local",
+        transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+        generationModel: "llama3.1:8b",
+        remoteGenerationModel: "zai-org-glm-5-2",
+        localGeneration: {
+          baseUrl: "http://localhost:11434/v1",
+          modelId: "llama3.1:8b",
+          apiKey: "",
+        },
+      },
+    });
+    const user = userEvent.setup();
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+
+    // An active local model must never be hidden: the disclosure opens itself so
+    // the enabled toggle and endpoint config stay reachable.
+    expect(await screen.findByRole("switch", { name: "Use local text model" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /More options/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
   it("saves the draft then enables a local text model", async () => {
     const user = userEvent.setup();
     const modelChanged = vi.fn();
@@ -1751,7 +1831,9 @@ describe("AppSettings", () => {
       );
 
       await user.click(await screen.findByRole("tab", { name: "Models" }));
-      await user.type(screen.getByLabelText("Base URL"), "http://localhost:11434/v1");
+      // The local model config lives behind the "More options" disclosure.
+      await user.click(await screen.findByRole("button", { name: /More options/ }));
+      await user.type(await screen.findByLabelText("Base URL"), "http://localhost:11434/v1");
       await user.type(screen.getByLabelText("Model ID"), "llama3.1:8b");
       await user.type(screen.getByLabelText("API key"), "sk-test");
       await user.click(screen.getByRole("switch", { name: "Use local text model" }));
@@ -2067,7 +2149,9 @@ describe("AppSettings", () => {
     );
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
-    await user.type(screen.getByLabelText("Base URL"), "http://localhost:11434/v1");
+    // The local model config lives behind the "More options" disclosure.
+    await user.click(await screen.findByRole("button", { name: /More options/ }));
+    await user.type(await screen.findByLabelText("Base URL"), "http://localhost:11434/v1");
     await user.click(screen.getByRole("button", { name: "Test connection" }));
 
     expect(mocks.probeLocalGenerationEndpoint).toHaveBeenCalledWith({
@@ -2099,7 +2183,9 @@ describe("AppSettings", () => {
     );
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
-    await user.type(screen.getByLabelText("Base URL"), "https://models.example.com/v1");
+    // The local model config lives behind the "More options" disclosure.
+    await user.click(await screen.findByRole("button", { name: /More options/ }));
+    await user.type(await screen.findByLabelText("Base URL"), "https://models.example.com/v1");
     await user.type(screen.getByLabelText("Model ID"), "llama3.1:8b");
 
     // A remote endpoint surfaces an inline warning up front.


### PR DESCRIPTION
## What

The Models settings tab now shows only the primary model pickers by default. The full local model configuration (enable toggle, endpoint, model id, API key, test connection, remote-endpoint confirm) moved inside the existing "More options" (Advanced model settings) disclosure, alongside the Venice API key it already held.

Judgment calls:
- "More options" auto-expands when a local model is already enabled, so an active setting is never hidden. It only ever expands; a manual collapse stays collapsed.
- Selecting a remote local endpoint from the model picker also expands it, so the "confirm in the Local model section" status message points at something visible.
- Draft endpoint state lives in the parent component, so collapsing never discards in-progress edits.

## Why

Local model configuration is an advanced, uncommon setting; surfacing it as a first-class section crowded the Models tab. Requested placement: under More options (advanced model settings).

## Validation

- `pnpm typecheck` clean; `pnpm test` 127 files / 1902 passed (3 existing local-model tests updated to expand the disclosure first; 2 new tests: collapsed by default + auto-expand when enabled); `pnpm check` (Biome) identical warning count to main, no errors
- Live walkthrough video to follow as a PR comment

## Known gaps

- None known; picker behavior (including the synthetic local option) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)