### PR TITLE
Lead the billing card with the daily usage limit (JUN-183)

### DIFF
--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -91,6 +91,27 @@ struct BalanceWire {
     usd_millis: i64,
     #[serde(default)]
     usage_remaining_percent: Option<i64>,
+    /// Per-plan usage limits (os-accounts ADR-0022). Absent on accounts APIs
+    /// that predate them and when every window is uncapped.
+    #[serde(default)]
+    usage_limits: Option<UsageLimitsWire>,
+}
+
+#[derive(Deserialize)]
+struct UsageLimitsWire {
+    plan: String,
+    daily: Option<UsageWindowWire>,
+    weekly: Option<UsageWindowWire>,
+    monthly: Option<UsageWindowWire>,
+}
+
+#[derive(Deserialize)]
+struct UsageWindowWire {
+    limit_credits: i64,
+    used_credits: i64,
+    remaining_percent: i64,
+    /// RFC 3339; passed through as a string like the subscription dates.
+    resets_at: String,
 }
 
 #[derive(Deserialize)]
@@ -159,6 +180,31 @@ pub struct AccountBalance {
     pub usd_millis: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_remaining_percent: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_limits: Option<AccountUsageLimits>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountUsageLimits {
+    /// "free" for accounts without an active subscription, else the plan
+    /// slug ("pro", "max").
+    pub plan: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daily: Option<AccountUsageWindow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weekly: Option<AccountUsageWindow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monthly: Option<AccountUsageWindow>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountUsageWindow {
+    pub limit_credits: i64,
+    pub used_credits: i64,
+    pub remaining_percent: i64,
+    pub resets_at: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -243,6 +289,29 @@ impl From<BalanceWire> for AccountBalance {
             credits: w.credits,
             usd_millis: w.usd_millis,
             usage_remaining_percent: w.usage_remaining_percent,
+            usage_limits: w.usage_limits.map(Into::into),
+        }
+    }
+}
+
+impl From<UsageLimitsWire> for AccountUsageLimits {
+    fn from(w: UsageLimitsWire) -> Self {
+        Self {
+            plan: w.plan,
+            daily: w.daily.map(Into::into),
+            weekly: w.weekly.map(Into::into),
+            monthly: w.monthly.map(Into::into),
+        }
+    }
+}
+
+impl From<UsageWindowWire> for AccountUsageWindow {
+    fn from(w: UsageWindowWire) -> Self {
+        Self {
+            limit_credits: w.limit_credits,
+            used_credits: w.used_credits,
+            remaining_percent: w.remaining_percent,
+            resets_at: w.resets_at,
         }
     }
 }
@@ -358,6 +427,36 @@ fn normalize_local_dev_user_id(value: &str) -> String {
     }
 }
 
+/// Representative free-plan usage windows so the local-dev build exercises
+/// the usage limit UI without a live accounts API.
+fn local_dev_usage_limits() -> AccountUsageLimits {
+    let now = chrono::Utc::now();
+    let tomorrow = (now.date_naive() + chrono::Days::new(1))
+        .and_time(chrono::NaiveTime::MIN)
+        .and_utc();
+    AccountUsageLimits {
+        plan: "free".to_string(),
+        daily: Some(AccountUsageWindow {
+            limit_credits: 400,
+            used_credits: 120,
+            remaining_percent: 70,
+            resets_at: tomorrow.to_rfc3339(),
+        }),
+        weekly: Some(AccountUsageWindow {
+            limit_credits: 1_000,
+            used_credits: 320,
+            remaining_percent: 68,
+            resets_at: tomorrow.to_rfc3339(),
+        }),
+        monthly: Some(AccountUsageWindow {
+            limit_credits: 2_000,
+            used_credits: 480,
+            remaining_percent: 76,
+            resets_at: tomorrow.to_rfc3339(),
+        }),
+    }
+}
+
 fn local_dev_account_status() -> AccountStatus {
     AccountStatus {
         signed_in: true,
@@ -374,6 +473,7 @@ fn local_dev_account_status() -> AccountStatus {
             credits: 0,
             usd_millis: 0,
             usage_remaining_percent: Some(100),
+            usage_limits: Some(local_dev_usage_limits()),
         }),
         subscription: Some(AccountSubscription {
             subscribed: true,

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -13,7 +13,7 @@ import {
   osAccountsOpenPortal,
   osAccountsUpgrade,
 } from "../../lib/tauri";
-import type { AccountStatus, SubscriptionPlan } from "../../lib/tauri";
+import type { AccountStatus, AccountUsageWindow, SubscriptionPlan } from "../../lib/tauri";
 
 const FREE_PLAN_NAME = "Free plan";
 const PRO_PLAN_NAME = "Pro plan";
@@ -258,6 +258,18 @@ function BillingCard({
   const subscription = account.subscription;
   const liveSubscription = hasLiveSubscription(account);
   const usageRemainingPercent = usagePercentFromBalance(account.balance, subscription);
+  // Per-plan usage windows (os-accounts ADR-0022). When a daily cap exists it
+  // becomes the primary value users see; weekly and monthly stay one glance
+  // away as compact rows. Absent on older accounts APIs and uncapped plans,
+  // where the card keeps the original balance-based bar.
+  const usageLimits = account.balance?.usageLimits;
+  const dailyWindow = usageLimits?.daily;
+  const periodRows = (
+    [
+      ["Weekly", usageLimits?.weekly],
+      ["Monthly", usageLimits?.monthly],
+    ] as [string, AccountUsageWindow | undefined][]
+  ).filter((row): row is [string, AccountUsageWindow] => row[1] !== undefined);
   const billingRecovery =
     subscription?.subscribed === true &&
     typeof subscription.status === "string" &&
@@ -268,9 +280,14 @@ function BillingCard({
   // is a subset of this, kept to drive the "update billing" detail line.
   const onPaidPlan = subscription?.subscribed === true || liveSubscription;
   const canUpgrade = account.signedIn && !onPaidPlan;
+  const primaryPercent = dailyWindow
+    ? clampPercent(dailyWindow.remainingPercent)
+    : usageRemainingPercent;
+  const primaryLabel = dailyWindow ? "Daily usage remaining" : "Usage remaining";
+  const dailyResets = dailyWindow ? describeEnd("Resets", dailyWindow.resetsAt) : undefined;
   // Warm the meter toward "running low" so green never implies a near-empty
   // allowance. Only meaningful once we have a real signed-in reading.
-  const lowUsage = account.signedIn && usageRemainingPercent <= 15;
+  const lowUsage = account.signedIn && primaryPercent <= 15;
 
   // Legacy subscription rows predate plan tiers and carry no slug; they are
   // all Pro, so anything that isn't explicitly "max" reads as Pro.
@@ -322,9 +339,9 @@ function BillingCard({
 
       <div className="billing-usage">
         <div className="billing-usage-head">
-          <span className="billing-usage-label">Usage remaining</span>
+          <span className="billing-usage-label">{primaryLabel}</span>
           <span className="billing-usage-right">
-            <span className="billing-usage-value">{formatPercent(usageRemainingPercent)}</span>
+            <span className="billing-usage-value">{formatPercent(primaryPercent)}</span>
             <button
               type="button"
               className="icon-button"
@@ -344,18 +361,47 @@ function BillingCard({
         <div
           className={`usage-remaining-progress${lowUsage ? " is-low" : ""}`}
           role="progressbar"
-          aria-label="Usage remaining"
+          aria-label={primaryLabel}
           aria-valuemin={0}
           aria-valuemax={100}
-          aria-valuenow={usageRemainingPercent}
+          aria-valuenow={primaryPercent}
         >
           <div
             className="usage-remaining-progress-fill"
             style={{
-              transform: `scaleX(${usageRemainingPercent / 100})`,
+              transform: `scaleX(${primaryPercent / 100})`,
             }}
           />
         </div>
+        {dailyResets ? <p className="billing-usage-resets">{dailyResets}</p> : null}
+        {periodRows.length > 0 ? (
+          <div className="billing-usage-periods">
+            {periodRows.map(([label, usageWindow]) => {
+              const percent = clampPercent(usageWindow.remainingPercent);
+              return (
+                <div key={label} className="billing-usage-period">
+                  <span className="billing-usage-period-label">{label}</span>
+                  <div
+                    className={`usage-remaining-progress is-compact${
+                      account.signedIn && percent <= 15 ? " is-low" : ""
+                    }`}
+                    role="progressbar"
+                    aria-label={`${label} usage remaining`}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={percent}
+                  >
+                    <div
+                      className="usage-remaining-progress-fill"
+                      style={{ transform: `scaleX(${percent / 100})` }}
+                    />
+                  </div>
+                  <span className="billing-usage-period-value">{formatPercent(percent)}</span>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/lib/billing-demo.ts
+++ b/src/lib/billing-demo.ts
@@ -37,6 +37,34 @@ const DEMO_USER = {
 const DAY_MS = 24 * 60 * 60 * 1000;
 const RENEWS_AT = new Date(Date.now() + 24 * DAY_MS).toISOString();
 const TRIAL_ENDS_AT = new Date(Date.now() + 7 * DAY_MS).toISOString();
+const DAILY_RESETS_AT = new Date(Date.now() + 1 * DAY_MS).toISOString();
+const WEEKLY_RESETS_AT = new Date(Date.now() + 3 * DAY_MS).toISOString();
+const MONTHLY_RESETS_AT = new Date(Date.now() + 12 * DAY_MS).toISOString();
+
+/** Usage windows shaped like the os-accounts ADR-0022 ladder, scaled per
+ * fixture from used credits. */
+function demoUsageLimits(
+  plan: string,
+  caps: { daily: number; weekly: number; monthly: number },
+  used: { daily: number; weekly: number; monthly: number },
+) {
+  const window = (limitCredits: number, usedCredits: number, resetsAt: string) => ({
+    limitCredits,
+    usedCredits,
+    remainingPercent: Math.round(((limitCredits - usedCredits) / limitCredits) * 100),
+    resetsAt,
+  });
+  return {
+    plan,
+    daily: window(caps.daily, used.daily, DAILY_RESETS_AT),
+    weekly: window(caps.weekly, used.weekly, WEEKLY_RESETS_AT),
+    monthly: window(caps.monthly, used.monthly, MONTHLY_RESETS_AT),
+  };
+}
+
+const FREE_CAPS = { daily: 400, weekly: 1000, monthly: 2000 };
+const PRO_CAPS = { daily: 2000, weekly: 6000, monthly: 20000 };
+const MAX_CAPS = { daily: 10000, weekly: 30000, monthly: 100000 };
 
 // Ordered so the gallery reads from the default state outward to the edges.
 export const BILLING_DEMO_FIXTURES: Record<BillingDemoKey, BillingDemoFixture> = {
@@ -46,7 +74,12 @@ export const BILLING_DEMO_FIXTURES: Record<BillingDemoKey, BillingDemoFixture> =
       signedIn: true,
       configured: true,
       user: DEMO_USER,
-      balance: { credits: 3900, usdMillis: 3900, usageRemainingPercent: 78 },
+      balance: {
+        credits: 3900,
+        usdMillis: 3900,
+        usageRemainingPercent: 78,
+        usageLimits: demoUsageLimits("free", FREE_CAPS, { daily: 120, weekly: 320, monthly: 480 }),
+      },
       subscription: { subscribed: false },
     },
   },
@@ -56,7 +89,12 @@ export const BILLING_DEMO_FIXTURES: Record<BillingDemoKey, BillingDemoFixture> =
       signedIn: true,
       configured: true,
       user: DEMO_USER,
-      balance: { credits: 300, usdMillis: 300, usageRemainingPercent: 6 },
+      balance: {
+        credits: 300,
+        usdMillis: 300,
+        usageRemainingPercent: 6,
+        usageLimits: demoUsageLimits("free", FREE_CAPS, { daily: 380, weekly: 700, monthly: 1700 }),
+      },
       subscription: { subscribed: false },
     },
   },
@@ -70,6 +108,11 @@ export const BILLING_DEMO_FIXTURES: Record<BillingDemoKey, BillingDemoFixture> =
         credits: 12800,
         usdMillis: 12800,
         usageRemainingPercent: 64,
+        usageLimits: demoUsageLimits("pro", PRO_CAPS, {
+          daily: 720,
+          weekly: 2100,
+          monthly: 7200,
+        }),
       },
       subscription: {
         subscribed: true,
@@ -89,6 +132,11 @@ export const BILLING_DEMO_FIXTURES: Record<BillingDemoKey, BillingDemoFixture> =
         credits: 64000,
         usdMillis: 64000,
         usageRemainingPercent: 64,
+        usageLimits: demoUsageLimits("max", MAX_CAPS, {
+          daily: 3600,
+          weekly: 10800,
+          monthly: 36000,
+        }),
       },
       subscription: {
         subscribed: true,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1443,6 +1443,27 @@ export type AccountBalance = {
    * Optional while the app can still receive older accounts API payloads. */
   usageRemainingPercent?: number;
   usdMillis: number;
+  /** Per-plan usage limits (os-accounts ADR-0022). Absent on accounts APIs
+   * that predate them and when every window is uncapped. */
+  usageLimits?: AccountUsageLimits;
+};
+
+export type AccountUsageLimits = {
+  /** "free" for accounts without an active subscription, else the plan
+   * slug ("pro", "max"). */
+  plan: string;
+  daily?: AccountUsageWindow;
+  weekly?: AccountUsageWindow;
+  monthly?: AccountUsageWindow;
+};
+
+export type AccountUsageWindow = {
+  limitCredits: number;
+  usedCredits: number;
+  /** Rounded share of the window still spendable, 0 to 100. */
+  remainingPercent: number;
+  /** RFC 3339 instant the window resets (UTC calendar boundary). */
+  resetsAt: string;
 };
 
 export type SubscriptionPlan = "pro" | "max";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9873,7 +9873,7 @@ input:focus-visible,
 }
 
 .usage-remaining-progress.is-compact {
-  height: 4px;
+  height: var(--sp-1);
 }
 
 .billing-usage-period-value {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9845,6 +9845,45 @@ input:focus-visible,
   background: color-mix(in oklch, var(--destructive) 80%, var(--foreground));
 }
 
+/* Daily window reset note under the primary bar. */
+.billing-usage-resets {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+/* Weekly/monthly windows: one glance away, visually subordinate to the
+ * daily bar above. */
+.billing-usage-periods {
+  display: grid;
+  gap: var(--sp-2);
+  padding-top: var(--sp-2);
+}
+
+.billing-usage-period {
+  display: grid;
+  grid-template-columns: 3.5rem 1fr auto;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.billing-usage-period-label {
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+}
+
+.usage-remaining-progress.is-compact {
+  height: 4px;
+}
+
+.billing-usage-period-value {
+  min-width: 2.5rem;
+  color: var(--muted-foreground);
+  font-size: var(--fs-sm);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
 /* Dev-only __billingDemo("all") gallery: each plan variant stacked under a
  * monospace caption so states are easy to compare side by side. */
 .billing-demo-gallery {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -615,6 +615,59 @@ describe("AppSettings", () => {
     expect(screen.queryByText("Usage remaining")).not.toBeInTheDocument();
   });
 
+  it("keeps capped weekly windows visible when the daily window is uncapped", async () => {
+    // An operator can uncap daily while keeping weekly (limits are per-window
+    // kill switches). The gate still enforces the weekly cap, so the card must
+    // not hide it: legacy balance-based primary + compact rows for the capped
+    // windows.
+    const user = userEvent.setup();
+    const resetsAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          balance: {
+            credits: 1600,
+            usdMillis: 1600,
+            usageRemainingPercent: 80,
+            usageLimits: {
+              plan: "free",
+              weekly: {
+                limitCredits: 500,
+                usedCredits: 400,
+                remainingPercent: 20,
+                resetsAt,
+              },
+            },
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    // No daily window: the balance-based bar stays primary.
+    expect(screen.getByText("Usage remaining")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "Usage remaining" })).toHaveAttribute(
+      "aria-valuenow",
+      "80",
+    );
+    expect(screen.queryByText("Daily usage remaining")).not.toBeInTheDocument();
+    // The capped weekly window still shows.
+    expect(screen.getByRole("progressbar", { name: "Weekly usage remaining" })).toHaveAttribute(
+      "aria-valuenow",
+      "20",
+    );
+    expect(screen.queryByRole("progressbar", { name: "Monthly usage remaining" })).toBeNull();
+  });
+
   it("changes the accent color through the appearance picker", () => {
     vi.useFakeTimers();
     try {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -547,6 +547,74 @@ describe("AppSettings", () => {
     expect(screen.queryByText("$1.20")).not.toBeInTheDocument();
   });
 
+  it("leads with the daily usage limit and keeps weekly and monthly in view", async () => {
+    const user = userEvent.setup();
+    const resetsAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    render(
+      <AppSettings
+        account={{
+          ...signedInAccount,
+          balance: {
+            credits: 1600,
+            usdMillis: 1600,
+            usageRemainingPercent: 80,
+            usageLimits: {
+              plan: "free",
+              daily: {
+                limitCredits: 400,
+                usedCredits: 120,
+                remainingPercent: 70,
+                resetsAt,
+              },
+              weekly: {
+                limitCredits: 1000,
+                usedCredits: 320,
+                remainingPercent: 68,
+                resetsAt,
+              },
+              monthly: {
+                limitCredits: 2000,
+                usedCredits: 480,
+                remainingPercent: 76,
+                resetsAt,
+              },
+            },
+          },
+        }}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+
+    // Daily is the primary value; the balance-based 80% takes the back seat.
+    expect(screen.getByText("Daily usage remaining")).toBeInTheDocument();
+    expect(screen.getByText("70%")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar", { name: "Daily usage remaining" })).toHaveAttribute(
+      "aria-valuenow",
+      "70",
+    );
+    expect(screen.getByText(/^Resets /)).toBeInTheDocument();
+    // Weekly and monthly stay one glance away.
+    expect(screen.getByRole("progressbar", { name: "Weekly usage remaining" })).toHaveAttribute(
+      "aria-valuenow",
+      "68",
+    );
+    expect(screen.getByRole("progressbar", { name: "Monthly usage remaining" })).toHaveAttribute(
+      "aria-valuenow",
+      "76",
+    );
+    expect(screen.getByText("68%")).toBeInTheDocument();
+    expect(screen.getByText("76%")).toBeInTheDocument();
+    expect(screen.queryByText("Usage remaining")).not.toBeInTheDocument();
+  });
+
   it("changes the accent color through the appearance picker", () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
Part of JUN-183 ("Update plan usage limits, pricing credits, and usage limit UI"). Companion to open-software-network/os-accounts#78, which adds the per-plan daily/weekly/monthly usage limits (ADR-0022) this UI renders. Depends on that PR for real data; without it the card keeps today's behavior.

## What changed

- **Wire plumbing**: `GET /billing/balance`'s new `usage_limits` object (plan + per-window `limit_credits` / `used_credits` / `remaining_percent` / `resets_at`) flows through `BalanceWire` → `AccountBalance` in `src-tauri/src/os_accounts.rs` and the `AccountBalance` DTO in `src/lib/tauri.ts`. All fields optional, so older accounts APIs and uncapped plans change nothing.
- **Billing card** (`AccountSettings.tsx`): when a daily window exists it becomes the primary value — "Daily usage remaining" with the big percentage, the existing progress bar, and a "Resets July 3" note. Weekly and monthly sit directly below as compact labeled bars, one glance away. Without period data the card keeps the original balance-based "Usage remaining" bar.
- The low-usage warm color applies per window at 15% or less remaining.
- **Demo fixtures**: `__billingDemo` free/freeLow/pro/max variants carry ADR-0022-ladder windows (trial/pastDue intentionally keep the legacy shape to cover the fallback); the local-dev account status ships representative free-plan windows so `OS_JUNE_LOCAL_DEV=1` exercises the new UI.

## Why

The issue asks that the daily usage limit be the primary value users see, with weekly and monthly easy to find. Everything else in JUN-183 already shipped ($2 grant #577, Max plan #574, local models #536, Venice BYOK #541, 1.2x margin #564); the remaining backend half is os-accounts#78.

## Validation

- `pnpm typecheck`, `pnpm check --diagnostic-level=error` clean; full frontend suite green (127 files, 1903 tests) including a new test asserting daily-primary layout, weekly/monthly progressbars, the resets note, and the absence of the legacy label when windows exist.
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` green; `cargo check` clean.
- Existing usage-bar tests pass unchanged, covering the no-usage-limits fallback path.
- **Live walkthrough**: recorded the Vite preview's real Settings → Billing surface (Playwright, Tauri shim per the established QA recipe) walking the `__billingDemo("all")` gallery — Free/Pro/Max with daily-primary windows and reset dates, plus the legacy variants. Video upload to os-platform follows as a PR comment.

## Known gaps

- Real end-to-end data needs os-accounts#78 deployed; until then production payloads omit `usage_limits` and the card renders exactly as today (covered by existing tests).
- The funding gate is unchanged: a daily-cap `usage_limit_exceeded` denial currently surfaces through existing request-error paths. Distinct "resumes at ..." error copy in the recorder/chat flows is a sensible follow-up once the backend lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)