### PR TITLE
fix(june-api): detect dictation language server-side (JUN-180)

### DIFF
--- a/june-api/Cargo.lock
+++ b/june-api/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +564,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -803,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -953,6 +976,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "whatlang",
 ]
 
 [[package]]
@@ -2241,6 +2265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whatlang"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e8f38b596e2a359b755342473520a99421e43658548c79489ee221b728c107"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/june-api/Cargo.toml
+++ b/june-api/Cargo.toml
@@ -40,6 +40,10 @@ tower-http = { version = "0.6", features = ["trace", "timeout", "limit", "cors"]
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = "2"
+# Pure-Rust, offline trigram language detector used to fill in the transcript
+# language server-side (Venice ASR never returns one). No network or model
+# downloads, so it is safe to run inside the TEE.
+whatlang = "0.18"
 zeroize = { version = "1", features = ["derive"] }
 
 pretty_assertions = "1"

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -265,6 +265,74 @@ async fn integration_note_transcribe_rejects_unsupported_audio() -> Result<(), B
 }
 
 #[tokio::test]
+async fn integration_dictate_fills_language_when_provider_returns_none()
+-> Result<(), Box<dyn Error>> {
+    // Venice ASR never returns a detected language, so the provider yields
+    // `None` and the service must fill it in from the transcript text (JUN-180).
+    let state = test_state_with_sinks_and_transcriber(
+        Arc::new(RecordingIssueReportSink::default()),
+        test_attestation(),
+        Arc::new(LanguagelessTranscriber),
+    );
+    let response = match router(state)
+        .oneshot(multipart_request(
+            "/v1/dictate",
+            multipart_body([
+                text_part("model", "asr-model"),
+                text_part("sessionId", "session-1"),
+                text_part("utteranceId", "utterance-1"),
+                file_part("audio", "dictation.wav", valid_wav()),
+            ]),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["language"], "en");
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_dictate_prefers_requested_language_over_detection()
+-> Result<(), Box<dyn Error>> {
+    // When the user configured a dictation language, that explicit choice must
+    // reach enrichment and win over text detection (JUN-180 P2). The transcript
+    // text is English, but the request asks for Polish.
+    let state = test_state_with_sinks_and_transcriber(
+        Arc::new(RecordingIssueReportSink::default()),
+        test_attestation(),
+        Arc::new(LanguagelessTranscriber),
+    );
+    let response = match router(state)
+        .oneshot(multipart_request(
+            "/v1/dictate",
+            multipart_body([
+                text_part("model", "asr-model"),
+                text_part("sessionId", "session-1"),
+                text_part("utteranceId", "utterance-1"),
+                text_part("language", "pl"),
+                file_part("audio", "dictation.wav", valid_wav()),
+            ]),
+        )?)
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => match error {},
+    };
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["language"], "pl");
+    Ok(())
+}
+
+#[tokio::test]
 async fn integration_dictate_cleanup_returns_enveloped_response() -> Result<(), Box<dyn Error>> {
     let response = send(json_request(
         "/v1/dictate/cleanup",
@@ -618,9 +686,16 @@ fn test_state_with_sinks(
     issue_reports: Arc<dyn IssueReportSink>,
     attestation: AttestationInfo,
 ) -> ApiState {
+    test_state_with_sinks_and_transcriber(issue_reports, attestation, Arc::new(FakeTranscriber))
+}
+
+fn test_state_with_sinks_and_transcriber(
+    issue_reports: Arc<dyn IssueReportSink>,
+    attestation: AttestationInfo,
+    transcriber: Arc<dyn Transcriber>,
+) -> ApiState {
     let pricing = Arc::new(PricingTable::new(models()));
     let os_accounts = Arc::new(FakeOsAccounts);
-    let transcriber = Arc::new(FakeTranscriber);
     let generator = Arc::new(FakeGenerator);
     let cleaner = Arc::new(FakeCleaner);
     let duration_probe = Arc::new(FakeDurationProbe);
@@ -947,6 +1022,22 @@ impl Transcriber for FakeTranscriber {
         Ok(Transcript {
             text: "Transcribed audio".to_string(),
             language: request.language,
+            provider: "fake-transcriber".to_string(),
+        })
+    }
+}
+
+/// Mirrors Venice ASR: returns a real transcript but never a detected language,
+/// so the service layer must fill it in from the text.
+struct LanguagelessTranscriber;
+
+#[async_trait]
+impl Transcriber for LanguagelessTranscriber {
+    async fn transcribe(&self, _request: TranscriptionRequest) -> Result<Transcript, DomainError> {
+        Ok(Transcript {
+            text: "Let us schedule a call for next week to discuss the project roadmap and the budget."
+                .to_string(),
+            language: None,
             provider: "fake-transcriber".to_string(),
         })
     }

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -165,6 +165,10 @@ impl VeniceTranscriber {
             })?;
         let form = Form::new()
             .text("model", model_id.clone())
+            // Venice ASR accepts only `response_format` `json` | `text`
+            // (`verbose_json` is rejected with a 400) and never returns a
+            // `language`, so detected language is filled in server-side after
+            // transcription — do not switch this to `verbose_json`.
             .text("response_format", "json")
             .part("file", audio_part);
         let response = self

--- a/june-api/crates/services/Cargo.toml
+++ b/june-api/crates/services/Cargo.toml
@@ -19,6 +19,7 @@ sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+whatlang.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true

--- a/june-api/crates/services/src/dictate.rs
+++ b/june-api/crates/services/src/dictate.rs
@@ -4,6 +4,7 @@ use crate::{
         zero_receipt,
     },
     error::ServiceError,
+    language::fill_missing_language,
     metering::{log_skipped_user_venice_key, uses_user_venice_key_for_model},
     pricing::PricingTable,
     prompts,
@@ -63,6 +64,9 @@ impl DictateService {
         let actual = self
             .pricing
             .price_audio_seconds(&params.model_id.0, seconds)?;
+        // Captured before `params.language` is moved into the request below, so
+        // enrichment can fall back to the user-configured language.
+        let requested_language = params.language.clone();
         if uses_user_venice_key_for_model(
             &self.pricing,
             &params.model_id.0,
@@ -80,6 +84,7 @@ impl DictateService {
                 })
                 .await
                 .map_err(ServiceError::from)?;
+            let transcript = fill_missing_language(transcript, requested_language.as_deref());
             log_skipped_user_venice_key(
                 ActionSlug::DictateTranscribe,
                 &params.user_id,
@@ -113,6 +118,7 @@ impl DictateService {
             })
             .await
             .map_err(ServiceError::from)?;
+        let transcript = fill_missing_language(transcript, requested_language.as_deref());
         let charge_credits = clamp_to_cap(actual, authorization.cap_credits);
         let idempotency_key = format!(
             "dictate_transcribe:{}:{}:{}",

--- a/june-api/crates/services/src/language.rs
+++ b/june-api/crates/services/src/language.rs
@@ -1,0 +1,292 @@
+//! Best-effort language detection for transcripts.
+//!
+//! Venice ASR only ever returns `{"text"}` (no detected language), so the
+//! `language` on a [`Transcript`] comes back `None` for every dictation. Rather
+//! than leave the field empty, we detect the language from the transcribed text
+//! server-side with `whatlang` — a small, offline, pure-Rust trigram detector
+//! that needs no network or model downloads (safe inside the TEE).
+//!
+//! A missing badge is better than a wrong one, so detection only fills the field
+//! when the text is long enough to be worth trusting AND `whatlang` reports the
+//! guess as reliable. A language the provider itself supplied always wins over
+//! detection.
+
+use june_domain::Transcript;
+use whatlang::Lang;
+
+/// Below this many characters, trigram detection is too noisy to trust (short
+/// dictations like "yes" or "on my way" would get a confident but wrong guess),
+/// so we leave the language unset instead.
+const MIN_CHARS_FOR_DETECTION: usize = 20;
+
+/// Fill in `transcript.language` when the provider did not supply one, in
+/// priority order:
+///
+/// 1. Provider-supplied language (authoritative — left as-is).
+/// 2. `requested`: the language the user explicitly configured in the desktop
+///    dictation picker (a validated two-letter code). Trusted ahead of
+///    detection, since it is a deliberate user choice and covers short or
+///    ambiguous utterances that detection would miss.
+/// 3. Text detection.
+pub(crate) fn fill_missing_language(
+    mut transcript: Transcript,
+    requested: Option<&str>,
+) -> Transcript {
+    if transcript.language.is_none() {
+        transcript.language =
+            normalize_requested(requested).or_else(|| detect_iso639_1(&transcript.text));
+    }
+    transcript
+}
+
+/// The desktop dictation-language picker sends a validated two-letter ISO 639-1
+/// code, or an empty string for "Auto-detect". `/v1/dictate` only length-checks
+/// the field, though, so accept it only when it has the two-letter ISO 639-1
+/// shape — an empty string, a locale tag like `en-US`, or free text falls
+/// through to detection rather than becoming a bogus badge.
+fn normalize_requested(requested: Option<&str>) -> Option<String> {
+    let code = requested?.trim();
+    if code.len() == 2 && code.bytes().all(|byte| byte.is_ascii_alphabetic()) {
+        Some(code.to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+/// Detect the language of `text` and return its lowercase ISO 639-1 code
+/// (`"en"`, `"pl"`, `"fr"`), or `None` when the text is too short, the guess is
+/// unreliable, or the language has no ISO 639-1 code.
+fn detect_iso639_1(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.chars().count() < MIN_CHARS_FOR_DETECTION {
+        return None;
+    }
+    let info = whatlang::detect(trimmed)?;
+    if !info.is_reliable() {
+        return None;
+    }
+    Some(iso639_1(info.lang()).to_owned())
+}
+
+/// Map a `whatlang` language (ISO 639-3) to its ISO 639-1 two-letter code.
+/// `whatlang::Lang::code()` only exposes 639-3, but the dictation-history badge
+/// renders 639-1, so we translate here. The match is total over `whatlang`'s
+/// fixed language set (pinned to 0.18.x, which cannot add variants).
+fn iso639_1(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Epo => "eo",
+        Lang::Eng => "en",
+        Lang::Rus => "ru",
+        Lang::Cmn => "zh",
+        Lang::Spa => "es",
+        Lang::Por => "pt",
+        Lang::Ita => "it",
+        Lang::Ben => "bn",
+        Lang::Fra => "fr",
+        Lang::Deu => "de",
+        Lang::Ukr => "uk",
+        Lang::Kat => "ka",
+        Lang::Ara => "ar",
+        Lang::Hin => "hi",
+        Lang::Jpn => "ja",
+        Lang::Heb => "he",
+        Lang::Yid => "yi",
+        Lang::Pol => "pl",
+        Lang::Amh => "am",
+        Lang::Jav => "jv",
+        Lang::Kor => "ko",
+        Lang::Nob => "nb",
+        Lang::Dan => "da",
+        Lang::Swe => "sv",
+        Lang::Fin => "fi",
+        Lang::Tur => "tr",
+        Lang::Nld => "nl",
+        Lang::Hun => "hu",
+        Lang::Ces => "cs",
+        Lang::Ell => "el",
+        Lang::Bul => "bg",
+        Lang::Bel => "be",
+        Lang::Mar => "mr",
+        Lang::Kan => "kn",
+        Lang::Ron => "ro",
+        Lang::Slv => "sl",
+        Lang::Hrv => "hr",
+        Lang::Srp => "sr",
+        Lang::Mkd => "mk",
+        Lang::Lit => "lt",
+        Lang::Lav => "lv",
+        Lang::Est => "et",
+        Lang::Tam => "ta",
+        Lang::Vie => "vi",
+        Lang::Urd => "ur",
+        Lang::Tha => "th",
+        Lang::Guj => "gu",
+        Lang::Uzb => "uz",
+        Lang::Pan => "pa",
+        Lang::Aze => "az",
+        Lang::Ind => "id",
+        Lang::Tel => "te",
+        Lang::Pes => "fa",
+        Lang::Mal => "ml",
+        Lang::Ori => "or",
+        Lang::Mya => "my",
+        Lang::Nep => "ne",
+        Lang::Sin => "si",
+        Lang::Khm => "km",
+        Lang::Tuk => "tk",
+        Lang::Aka => "ak",
+        Lang::Zul => "zu",
+        Lang::Sna => "sn",
+        Lang::Afr => "af",
+        Lang::Lat => "la",
+        Lang::Slk => "sk",
+        Lang::Cat => "ca",
+        Lang::Tgl => "tl",
+        Lang::Hye => "hy",
+        Lang::Cym => "cy",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_iso639_1, fill_missing_language};
+    use june_domain::Transcript;
+    use pretty_assertions::assert_eq;
+
+    fn transcript(text: &str, language: Option<&str>) -> Transcript {
+        Transcript {
+            text: text.to_string(),
+            language: language.map(str::to_string),
+            provider: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn detects_english() {
+        assert_eq!(
+            detect_iso639_1(
+                "Let us schedule a call for next week to discuss the project roadmap and the budget."
+            ),
+            Some("en".to_string())
+        );
+    }
+
+    #[test]
+    fn detects_polish() {
+        assert_eq!(
+            detect_iso639_1(
+                "Dzień dobry, chciałbym umówić się na spotkanie w przyszłym tygodniu rano."
+            ),
+            Some("pl".to_string())
+        );
+    }
+
+    #[test]
+    fn detects_french() {
+        assert_eq!(
+            detect_iso639_1(
+                "Bonjour, je voudrais organiser une réunion la semaine prochaine avec l'équipe."
+            ),
+            Some("fr".to_string())
+        );
+    }
+
+    #[test]
+    fn short_or_gibberish_text_is_not_detected() {
+        // Below the length floor: a confident-but-wrong guess is worse than none.
+        assert_eq!(detect_iso639_1("ok thanks"), None);
+        assert_eq!(detect_iso639_1(""), None);
+        assert_eq!(detect_iso639_1("   \n  "), None);
+    }
+
+    #[test]
+    fn provider_supplied_language_wins_over_everything() {
+        // The text is plainly English and a language is requested, but a
+        // provider-supplied code is authoritative and must not be overwritten.
+        let enriched = fill_missing_language(
+            transcript(
+                "Let us schedule a call for next week to discuss the project roadmap and the budget.",
+                Some("ja"),
+            ),
+            Some("de"),
+        );
+        assert_eq!(enriched.language, Some("ja".to_string()));
+    }
+
+    #[test]
+    fn requested_language_wins_over_detection() {
+        // A deliberate user choice is trusted ahead of trigram detection.
+        let enriched = fill_missing_language(
+            transcript(
+                "Let us schedule a call for next week to discuss the project roadmap and the budget.",
+                None,
+            ),
+            Some("de"),
+        );
+        assert_eq!(enriched.language, Some("de".to_string()));
+    }
+
+    #[test]
+    fn requested_language_fills_when_detection_would_fail() {
+        // "sí" is too short to detect, but the user configured Spanish.
+        let enriched = fill_missing_language(transcript("sí", None), Some("es"));
+        assert_eq!(enriched.language, Some("es".to_string()));
+    }
+
+    #[test]
+    fn empty_requested_language_is_auto_detect_and_falls_through() {
+        // "" is the picker's "Auto-detect" sentinel: detection still runs.
+        let enriched = fill_missing_language(
+            transcript(
+                "Let us schedule a call for next week to discuss the project roadmap and the budget.",
+                None,
+            ),
+            Some(""),
+        );
+        assert_eq!(enriched.language, Some("en".to_string()));
+    }
+
+    #[test]
+    fn malformed_requested_language_is_rejected_and_falls_through() {
+        let english =
+            "Let us schedule a call for next week to discuss the project roadmap and the budget.";
+        // Locale tags and free text are not the two-letter shape: fall through
+        // to detection rather than badge the raw string.
+        assert_eq!(
+            fill_missing_language(transcript(english, None), Some("en-US")).language,
+            Some("en".to_string())
+        );
+        assert_eq!(
+            fill_missing_language(transcript(english, None), Some("auto")).language,
+            Some("en".to_string())
+        );
+        // Rejected requested value AND text too short to detect -> stays None.
+        assert_eq!(
+            fill_missing_language(transcript("sí", None), Some("english")).language,
+            None
+        );
+        // A valid two-letter code is normalized to lowercase.
+        assert_eq!(
+            fill_missing_language(transcript("sí", None), Some("PL")).language,
+            Some("pl".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_language_is_filled_from_text() {
+        let enriched = fill_missing_language(
+            transcript(
+                "Let us schedule a call for next week to discuss the project roadmap and the budget.",
+                None,
+            ),
+            None,
+        );
+        assert_eq!(enriched.language, Some("en".to_string()));
+    }
+
+    #[test]
+    fn missing_language_stays_none_for_trivial_text() {
+        let enriched = fill_missing_language(transcript("ok", None), None);
+        assert_eq!(enriched.language, None);
+    }
+}

--- a/june-api/crates/services/src/lib.rs
+++ b/june-api/crates/services/src/lib.rs
@@ -5,6 +5,7 @@ mod charge_flow;
 mod dictate;
 mod error;
 mod image;
+mod language;
 mod metering;
 mod note_generate;
 mod note_transcribe;


### PR DESCRIPTION
## Summary

Every dictation-history entry showed `language: null`. This detects the language
from the transcribed text server-side (in the dictate service) and fills the
`language` field when the provider does not supply one, so the dictation-history
badge renders instead of staying blank.

The first version of this PR tried `response_format: "verbose_json"` on the Venice
ASR request. Automated review (Codex) flagged that as a P1, and a live check
against Venice confirmed it: Venice rejects `verbose_json` and never returns a
language at all. That approach was reverted; this is the replacement.

Closes JUN-180

## Root cause

`june-api` requested `response_format: "json"` from Venice ASR, which returns a
body of only `{"text"}` — no `language`. So `TranscriptionWireResponse.language`
deserialized to `None`, and null propagated end to end through the (already
correct) downstream wiring into `DictationHistoryView.tsx`.

There is no upstream fix available. Verified live against `api.venice.ai` with the
dev key on `nvidia/parakeet-tdt-0.6b-v3`:

- `response_format=json` -> HTTP 200, body `{"text": ...}` only.
- `response_format=verbose_json` -> HTTP 400, `Invalid enum value. Expected 'json' | 'text', received 'verbose_json'`.

Venice's transcription contract simply does not carry a detected language. So the
language is now derived from the transcript text on the server instead.

Why the tests stayed green before: the API-boundary suite's `FakeTranscriber`
echoed the request's `language` back, so it never exercised the real
provider-returns-`None` case. This PR adds a fake that returns `None`, plus unit
coverage for the detector.

## What changed

- `crates/services/src/language.rs` (new): `whatlang`-based detection. `whatlang`
  is a small, offline, pure-Rust trigram detector (no network, no model
  downloads), so it is safe inside the TEE. It maps `whatlang`'s ISO 639-3 output
  to the ISO 639-1 code the badge renders.
- `crates/services/src/dictate.rs`: after the provider call (both the metered and
  user-Venice-key paths), fill `transcript.language` when the provider left it
  empty, in priority order: **provider-supplied > user-configured request language
  > text detection**. The desktop dictation picker sends a validated two-letter
  code when the user picked one (empty string = "Auto-detect"); that explicit
  choice is trusted ahead of detection, so short/ambiguous utterances like
  `hola` still get the known language instead of a blank badge.
- Detection is deliberately conservative: it fills the field only when the text
  clears a length floor (`MIN_CHARS_FOR_DETECTION = 20` chars) AND `whatlang`
  reports the guess as reliable (`Info::is_reliable()`). Otherwise the field stays
  `None`. A missing badge beats a wrong badge.
- `crates/providers/src/venice.rs`: reverted to `response_format: "json"` with a
  comment recording the live 400 finding so nobody re-tries `verbose_json`.

## Backward compatibility

No wire-shape change. `language` is already an optional field on the dictate
response (`DictateTranscribeResponse.language: Option<String>`); this only changes
how often it is populated. Older app versions keep working unchanged.

## Validation

- `cargo +1.95.0-aarch64-apple-darwin test --manifest-path june-api/Cargo.toml --all-targets --all-features --locked` — 233 tests pass, 0 failures.
- New unit tests: English -> `en`, Polish -> `pl`, French -> `fr`, short/gibberish -> `None`, provider-supplied language wins, trivial text stays `None`.
- New HTTP-boundary test: a transcriber returning `language: None` yields a response whose `data.language` is the detected code (`en`).
- `cargo fmt --check` clean; `cargo clippy --all-targets --all-features --locked` clean.
- No live app walkthrough: backend-only change with no user-visible surface reachable without a June API deploy. `DictationHistoryView.tsx` is unchanged and already renders the badge when `language` is truthy.
- Note: commits on this branch are unsigned — local commit signing was temporarily unavailable while this was built. Squash-merge, or re-sign before merge, per repo policy.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [x] Needs a June API (backend) deploy before it works end to end. Zero effect until June API deploys; the existing `DictationHistoryView` badge surfaces the value once the backend ships. No frontend change in this PR.

## Known tradeoff (by design)

Trigram detection is conservative for short or ambiguous Latin-script text.
English in particular shares trigrams with other languages, so a short English
utterance can be judged unreliable and left `None` (verified: a distinctive
multi-clause English sentence detects at full confidence; a borderline one is
dropped rather than mislabelled). Morphologically distinctive languages (Polish,
etc.) and non-Latin scripts detect readily. This is a strict improvement over the
all-`null` status quo with no risk of a wrong badge, not a claim of full coverage.

## Out of scope

- The OpenAI ASR path (`openai.rs`) also requests `json`. Left as-is here; the
  dictate service enrichment covers whichever provider returns `None`.
- Note transcription (`note_transcribe.rs`) is not enriched in this PR; JUN-180 is
  about dictation history. The detector is reusable if we want the same there.
- Tuning `MIN_CHARS_FOR_DETECTION` or the reliability policy (e.g. a confidence
  floor to raise English recall) is deferred; the current setting favours
  precision.

## Followups

- Optionally enrich `note_transcribe.rs` with the same detector.
- Optionally revisit the precision/recall tradeoff for English if the conservative
  default leaves too many entries unlabelled in practice.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (None. New dependency `whatlang` is offline/pure-Rust with no network or model downloads; only transitive dep is `hashbrown`.)
- [ ] Workflow action references are pinned to full-length commit SHAs. (n/a — no workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (n/a)
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (n/a — none touched; only transcript language enrichment.)
- [x] User-facing copy follows the repo UI conventions. (n/a — no copy changes.)

https://claude.ai/code/session_016jdLY1DsSVVAhJKCG8nZmS
