### PR TITLE
fix: gate dictation paste on accessibility trust (JUN-181)

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1839,6 +1839,24 @@ enum PasteboardInserter {
             return
         }
 
+        // The synthetic Cmd+V below is a CGEvent keystroke, which macOS
+        // silently drops unless this helper holds Accessibility trust. That
+        // trust is commonly invalidated when an app update changes the
+        // helper's signature. Without this gate we'd post the keystroke into
+        // the void, emit paste_completed anyway, then restore the clipboard —
+        // so the transcript would vanish and the paste would look successful
+        // while nothing landed. When untrusted, leave the transcript on the
+        // clipboard for a manual paste, tell the user, and refresh the
+        // permission state so the in-app Accessibility banner appears.
+        guard AXIsProcessTrusted() else {
+            emit("permission_status", permissionPayload())
+            emit("error", [
+                "code": "accessibility_permission_missing",
+                "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
+            ])
+            return
+        }
+
         let targetActivated = FocusTargetController.shared.activateLastExternalApp()
         emit("paste_target", [
             "app": FocusTargetController.shared.targetDescription(),

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -4111,6 +4111,24 @@ mod tests {
     }
 
     #[test]
+    fn accessibility_permission_missing_error_is_visible() {
+        // The dictation helper emits this when Accessibility trust is missing,
+        // so the synthetic Cmd+V paste can't fire. The transcript is left on
+        // the clipboard and the user must be told: it must render as a real
+        // HUD error, never be swallowed as a "nothing recorded" silent case.
+        let mut event = serde_json::json!({
+            "type": "error",
+            "payload": {
+                "code": "accessibility_permission_missing",
+                "message": "June couldn't paste automatically. Your transcript is on the clipboard, so you can paste it with Cmd+V.",
+            }
+        });
+        assert!(!is_silent_transcription_error(&event));
+        annotate_silent_error(&mut event);
+        assert_eq!(event["payload"]["silent"], false);
+    }
+
+    #[test]
     fn dictation_event_log_redacts_transcript_text() {
         let event = serde_json::json!({
             "type": "final_transcript",


### PR DESCRIPTION
## Summary

Fixes dictations that reported "failed" to the user even though the transcript was in dictation history: the auto-paste silently dropped the text.

The macOS dictation helper delivered the transcript by writing the clipboard and posting a synthetic Cmd+V (`CGEvent`). That keystroke was never gated on Accessibility trust. When the helper is not trusted (macOS commonly invalidates the helper's Accessibility grant after an update changes its signature), macOS silently drops the keystroke, yet the helper emitted `paste_completed` anyway and then restored the previous clipboard 0.7s later, so the transcript vanished and the UX still looked successful.

Now the paste is gated on `AXIsProcessTrusted()`. When the helper is untrusted it:

- leaves the transcript on the clipboard (no clobber-and-restore) so the user can paste it manually with Cmd+V,
- emits an `error` event with code `accessibility_permission_missing` (rendered in the dictation HUD), whose copy tells the user the text is on the clipboard,
- emits a `permission_status` refresh so the existing in-app Accessibility banner appears (the banner's "Enable" button already routes to `request_accessibility_permission`),
- does not emit `paste_completed` and does not schedule the clipboard restore.

No frontend changes were needed: the helper `error` and `permission_status` events already flow through `emit_dictation_event_value` to the HUD and to `App.tsx`, which already maps a `missing` accessibility status to the actionable banner.

`Closes JUN-181`

## Root cause

Three compounding defects in the paste path (`src-tauri/native/mac-dictation-helper/main.swift`, `PasteboardInserter.paste`):

1. The synthetic Cmd+V was posted via `CGEvent` with no `AXIsProcessTrusted()` check. Without Accessibility trust macOS silently discards the event, so nothing pastes.
2. `paste_completed` was emitted unconditionally right after posting the keystroke, so the HUD showed success even when the keystroke was dropped.
3. The clipboard clobber-and-restore ran regardless, wiping the transcript off the clipboard 0.7s later, so there was nothing left to paste manually either.

History-write and text delivery are decoupled in `dictation.rs` (the transcript is persisted to history regardless of paste outcome), which is why the transcript still appeared in history while the user saw a failed/empty paste.

## Validation

- `swiftc` compile of the helper with the same frameworks the build uses (Foundation, AppKit, AVFoundation, Carbon, CoreMedia, CoreGraphics), single native arch: builds clean.
- `cargo test --manifest-path src-tauri/Cargo.toml --locked` (dictation module): 58 passed, incl. a new test `accessibility_permission_missing_error_is_visible` asserting the emitted error is classified as a visible HUD error, never swallowed as a silent "nothing recorded" case.
- `pnpm exec vitest run` on `dictation-events.test.ts`, `app-permissions.test.ts` (7 passed) and `hud-meeting.test.ts` (31 passed). `app-permissions` proves `isAccessibilityBlocked("missing") === true`, i.e. the `permission_status` refresh drives the banner.
- `cargo fmt --check` and `cargo clippy --all-targets --locked` on `src-tauri`: clean.

Live walkthrough / screenshot: intentionally skipped. Triggering the new branch live requires either recording real microphone audio or revoking system Accessibility, neither of which is authorized here. The diff adds no frontend code — the HUD error pill and the Accessibility banner are pre-existing surfaces exercised by every dictation error — and there is no fake-IPC preview entry for the separate HUD Tauri window, so a screenshot would require building a HUD IPC harness from scratch that dwarfs this two-line gate. The deterministic tests above cover the two novel behaviors: the emitted error renders as a visible HUD error, and the permission refresh drives the banner.

- [ ] Tested visually where it matters (see justification above).
- [ ] Needs a June API (backend) deploy before it works end to end. Not needed; desktop-only change.

## Out of scope

- Auto-respawn of a dead dictation helper — that is a different mechanism (a helper process that has died vs a live helper that survives but lacks Accessibility trust), diagnosed separately as JUN-168. This PR fixes only the surviving-but-untrusted case.
- Proactive Accessibility polling (surfacing the banner before the user attempts a paste). The banner still appears on the first failed paste and on app focus via the existing permission refresh.
- Decoupling of history-write from paste success in `dictation.rs` is left as-is; leaving the transcript in history is desirable, and this PR makes the paste failure visible and recoverable.

## Followups

- Proactive Accessibility trust polling so the banner can appear before the first failed paste attempt.
- JUN-168: auto-respawn / health-check of a dead dictation helper.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs. N/A (no workflow changes).
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. Touches the dictation helper's paste path (native macOS Accessibility usage); flagged for owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. N/A.
- [x] User-facing copy follows the repo UI conventions (sentence case, no en/em dashes in the error message).
