### PR TITLE
fix: dedupe Hermes 5xx wire string, friendly retryable banner (JUN-167)

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -2086,6 +2086,18 @@ pub async fn ensure_hermes_bridge_session(
     }
 }
 
+/// Builds the error message for a non-2xx Hermes REST response. Interpolates
+/// the numeric status rather than `reqwest::StatusCode`, whose `Display`
+/// already renders the reason phrase ("500 Internal Server Error"); against a
+/// bare-500 body (also "Internal Server Error") that duplicated the phrase and
+/// surfaced raw in the chat error banner (JUN-167). The `Hermes API returned
+/// <status>: ` prefix is a load-bearing contract: `hermes_api_status` matches
+/// it to swallow idempotent 404/405/409s, and the desktop admin transport
+/// (`rust-transport.ts`) parses it back into status + body.
+fn hermes_api_error_message(status: u16, body: &str) -> String {
+    format!("Hermes API returned {status}: {body}")
+}
+
 fn hermes_api_status(error: &AppError, status_code: u16) -> bool {
     error.code == "hermes_bridge_api_failed"
         && error
@@ -4788,7 +4800,7 @@ async fn hermes_connection_json(
     if !status.is_success() {
         return Err(AppError::new(
             "hermes_bridge_api_failed",
-            format!("Hermes API returned {status}: {text}"),
+            hermes_api_error_message(status.as_u16(), &text),
         ));
     }
     if text.trim().is_empty() {
@@ -6705,6 +6717,30 @@ mod tests {
             sandboxed: true,
             full_mode: false,
         }
+    }
+
+    #[test]
+    fn hermes_api_error_message_uses_numeric_status() {
+        // `reqwest::StatusCode` Display renders "500 Internal Server Error", and
+        // a bare 500 body is also "Internal Server Error"; interpolating the
+        // StatusCode duplicated the phrase and leaked raw to the user (JUN-167).
+        // The numeric status keeps the message to a single reason phrase.
+        assert_eq!(
+            hermes_api_error_message(500, "Internal Server Error"),
+            "Hermes API returned 500: Internal Server Error",
+        );
+    }
+
+    #[test]
+    fn hermes_api_status_still_matches_numeric_message() {
+        // The dedup must not break the idempotency swallow, which keys on the
+        // `Hermes API returned <status>` prefix (405/409 on unchanged updates).
+        let err = AppError::new(
+            "hermes_bridge_api_failed",
+            hermes_api_error_message(404, "Not Found"),
+        );
+        assert!(hermes_api_status(&err, 404));
+        assert!(!hermes_api_status(&err, 500));
     }
 
     #[test]

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -217,7 +217,11 @@ import {
   pricingLabel,
   selectedModel as selectedModelOption,
 } from "../settings/ModelPickerDialog";
-import { isHermesSessionsStartupRequestError, messageFromError } from "../../lib/errors";
+import {
+  isHermesServerError,
+  isHermesSessionsStartupRequestError,
+  messageFromError,
+} from "../../lib/errors";
 import { withTimeout } from "../../lib/async-timeout";
 import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
@@ -314,6 +318,22 @@ const SESSION_GONE_MESSAGE = "This session has ended, so the request can no long
 
 function isSessionGoneError(message: string): boolean {
   return message.toLowerCase().includes("session not found");
+}
+
+// A Hermes REST 5xx (`Hermes API returned 5xx: …`) is a transient server-side
+// fault, so session-load handlers show this friendly line instead of the raw
+// wire string — which read as a doubled "500 Internal Server Error: Internal
+// Server Error" before the bridge deduped it (JUN-167). Mirrors the admin
+// path's copy; the banner's own "Try again" button provides the retry, so the
+// message stays a plain description. `visibleErrorRetryable` keys off this
+// constant to offer that retry.
+const HERMES_SERVER_ERROR_MESSAGE = "Hermes ran into a problem with that request.";
+
+// Picks the banner text for a caught session-command error: a transient Hermes
+// 5xx becomes the friendly retryable line; anything else passes through raw.
+function describeAgentError(err: unknown): string {
+  const message = messageFromError(err);
+  return isHermesServerError(message) ? HERMES_SERVER_ERROR_MESSAGE : message;
 }
 
 // Dev-tools response gallery handle. Registered at module scope so
@@ -2134,6 +2154,13 @@ export function AgentWorkspace({
   const heroMode =
     !gallerySections && (newSessionMode || (!selectedHermesSessionId && !selectedTask));
   const visibleError = visibleAgentWorkspaceError(errorState, selectedHermesSessionId);
+  // The banner offers "Try again" for failures a reconnect-and-reload can clear:
+  // our own gateway/bridge connection errors, and a transient Hermes 5xx
+  // (HERMES_SERVER_ERROR_MESSAGE, JUN-167). retryGatewayConnection re-runs the
+  // session-management loads that produced either.
+  const visibleErrorRetryable =
+    visibleError != null &&
+    (GATEWAY_CONNECTION_ERROR.test(visibleError) || visibleError === HERMES_SERVER_ERROR_MESSAGE);
   const visibleIssueReportNotice =
     issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
       ? issueReportNotice.message
@@ -2506,7 +2533,7 @@ export function AgentWorkspace({
           keepLoading = true;
           return "transient-startup-error";
         }
-        setError(messageFromError(err));
+        setError(describeAgentError(err));
         return "failed";
       } finally {
         if (!keepLoading) {
@@ -3022,7 +3049,7 @@ export function AgentWorkspace({
         // working-gated poll re-loads once it resolves — so don't flash it as
         // an error banner (JUN-116).
         if (isSessionGoneError(message)) return;
-        setError(message, { sessionId: selectedHermesSessionId });
+        setError(describeAgentError(err), { sessionId: selectedHermesSessionId });
       });
     return () => {
       cancelled = true;
@@ -3050,7 +3077,7 @@ export function AgentWorkspace({
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) setError(messageFromError(err));
+        if (!cancelled) setError(describeAgentError(err));
       });
     return () => {
       cancelled = true;
@@ -3072,7 +3099,7 @@ export function AgentWorkspace({
         if (cancelled) return;
         setBridge(status);
       } catch (err) {
-        if (!cancelled) setError(messageFromError(err));
+        if (!cancelled) setError(describeAgentError(err));
       }
     })();
     return () => {
@@ -4804,8 +4831,18 @@ export function AgentWorkspace({
     try {
       await ensureHermesGateway();
       await loadHermesSessions();
+      // Re-run the selected session's transcript load too: a friendly Hermes
+      // 5xx banner (JUN-167) can originate from that message fetch, and
+      // reconnecting alone would clear the banner without reloading the
+      // messages — the load effect is keyed on the session id, which does not
+      // change on retry, so it would not re-fire. refreshHermesSession handles
+      // its own errors (re-showing the friendly banner if the 5xx persists).
+      const sessionId = selectedHermesSessionIdRef.current;
+      if (sessionId && !isProvisionalHermesSessionId(sessionId)) {
+        await refreshHermesSession(sessionId);
+      }
     } catch (err) {
-      setError(messageFromError(err));
+      setError(describeAgentError(err));
     }
   }
 
@@ -5040,7 +5077,7 @@ export function AgentWorkspace({
       // "Session not found" 404 resolves on the next poll, so don't surface
       // it as an error banner (JUN-116).
       if (isSessionGoneError(message)) return;
-      setError(message, { sessionId });
+      setError(describeAgentError(err), { sessionId });
     }
   }
 
@@ -7144,11 +7181,7 @@ export function AgentWorkspace({
           {visibleError ? (
             <AgentErrorBanner
               message={visibleError}
-              onRetry={
-                GATEWAY_CONNECTION_ERROR.test(visibleError)
-                  ? () => void retryGatewayConnection()
-                  : undefined
-              }
+              onRetry={visibleErrorRetryable ? () => void retryGatewayConnection() : undefined}
               onDismiss={() => setError(null)}
             />
           ) : null}
@@ -7206,11 +7239,7 @@ export function AgentWorkspace({
               ) : visibleError ? (
                 <AgentErrorBanner
                   message={visibleError}
-                  onRetry={
-                    GATEWAY_CONNECTION_ERROR.test(visibleError)
-                      ? () => void retryGatewayConnection()
-                      : undefined
-                  }
+                  onRetry={visibleErrorRetryable ? () => void retryGatewayConnection() : undefined}
                   onDismiss={() => setError(null)}
                 />
               ) : null}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -321,13 +321,13 @@ function isSessionGoneError(message: string): boolean {
 }
 
 // A Hermes REST 5xx (`Hermes API returned 5xx: …`) is a transient server-side
-// fault, so session-load handlers show this friendly line instead of the raw
+// fault, so session-load handlers show this June-branded line instead of the raw
 // wire string — which read as a doubled "500 Internal Server Error: Internal
-// Server Error" before the bridge deduped it (JUN-167). Mirrors the admin
-// path's copy; the banner's own "Try again" button provides the retry, so the
-// message stays a plain description. `visibleErrorRetryable` keys off this
+// Server Error" before the bridge deduped it (JUN-167). The banner's own
+// "Try again" button provides the retry, so the message stays a plain
+// description. `visibleErrorRetryable` keys off this
 // constant to offer that retry.
-const HERMES_SERVER_ERROR_MESSAGE = "Hermes ran into a problem with that request.";
+const HERMES_SERVER_ERROR_MESSAGE = "June ran into a problem with that request.";
 
 // Picks the banner text for a caught session-command error: a transient Hermes
 // 5xx becomes the friendly retryable line; anything else passes through raw.

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -736,16 +736,44 @@ type PendingIssueReport = {
   diagnosisStartedAt?: string;
 };
 
+function hermesServerErrorIssueReport(err: unknown): PendingIssueReport | undefined {
+  const rawMessage = messageFromError(err).trim();
+  if (!isHermesServerError(rawMessage)) return undefined;
+  return {
+    category: "bug",
+    description: [
+      "June hit a Hermes server error while loading this agent session.",
+      "",
+      "Raw error:",
+      rawMessage,
+    ].join("\n"),
+    followUps: [],
+    attachmentNames: [],
+    attachmentPaths: [],
+  };
+}
+
+function reportableAgentErrorOptions(
+  err: unknown,
+  options: AgentWorkspaceErrorOptions = {},
+): AgentWorkspaceErrorOptions {
+  const issueReport = hermesServerErrorIssueReport(err);
+  if (!issueReport) return options;
+  return { ...options, issueReport };
+}
+
 type HermesToolEventPhase = "start" | "progress" | "complete";
 
 type AgentWorkspaceError = {
   message: string;
   /** Null means the error belongs to the no-session workspace surface. */
   sessionId: string | null;
+  issueReport?: PendingIssueReport;
 };
 
 type AgentWorkspaceErrorOptions = {
   sessionId?: string | null;
+  issueReport?: PendingIssueReport;
 };
 
 type AgentWorkspaceNotice = {
@@ -1345,6 +1373,7 @@ export function AgentWorkspace({
   // Confirmation that a submitted issue report reached the June team; shown
   // in the composer notice slot until dismissed by the next send.
   const [issueReportNotice, setIssueReportNotice] = useState<AgentWorkspaceNotice | null>(null);
+  const [submittingErrorIssueReport, setSubmittingErrorIssueReport] = useState(false);
   const [composerSizeWarning, setComposerSizeWarning] = useState<ComposerInputSizeWarning | null>(
     null,
   );
@@ -1422,13 +1451,17 @@ export function AgentWorkspace({
         setErrorState(null);
         return;
       }
-      setErrorState({
+      const next: AgentWorkspaceError = {
         message,
         sessionId:
           options.sessionId === undefined
             ? (selectedHermesSessionIdRef.current ?? null)
             : options.sessionId,
-      });
+      };
+      if (options.issueReport) {
+        next.issueReport = options.issueReport;
+      }
+      setErrorState(next);
     },
     [],
   );
@@ -2153,7 +2186,8 @@ export function AgentWorkspace({
   // because the composer auto-grow effect below needs it as a dependency.
   const heroMode =
     !gallerySections && (newSessionMode || (!selectedHermesSessionId && !selectedTask));
-  const visibleError = visibleAgentWorkspaceError(errorState, selectedHermesSessionId);
+  const visibleErrorState = visibleAgentWorkspaceError(errorState, selectedHermesSessionId);
+  const visibleError = visibleErrorState?.message ?? null;
   // The banner offers "Try again" for failures a reconnect-and-reload can clear:
   // our own gateway/bridge connection errors, and a transient Hermes 5xx
   // (HERMES_SERVER_ERROR_MESSAGE, JUN-167). retryGatewayConnection re-runs the
@@ -2533,7 +2567,7 @@ export function AgentWorkspace({
           keepLoading = true;
           return "transient-startup-error";
         }
-        setError(describeAgentError(err));
+        setError(describeAgentError(err), reportableAgentErrorOptions(err));
         return "failed";
       } finally {
         if (!keepLoading) {
@@ -3049,7 +3083,10 @@ export function AgentWorkspace({
         // working-gated poll re-loads once it resolves — so don't flash it as
         // an error banner (JUN-116).
         if (isSessionGoneError(message)) return;
-        setError(describeAgentError(err), { sessionId: selectedHermesSessionId });
+        setError(
+          describeAgentError(err),
+          reportableAgentErrorOptions(err, { sessionId: selectedHermesSessionId }),
+        );
       });
     return () => {
       cancelled = true;
@@ -3077,7 +3114,7 @@ export function AgentWorkspace({
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) setError(describeAgentError(err));
+        if (!cancelled) setError(describeAgentError(err), reportableAgentErrorOptions(err));
       });
     return () => {
       cancelled = true;
@@ -3099,7 +3136,7 @@ export function AgentWorkspace({
         if (cancelled) return;
         setBridge(status);
       } catch (err) {
-        if (!cancelled) setError(describeAgentError(err));
+        if (!cancelled) setError(describeAgentError(err), reportableAgentErrorOptions(err));
       }
     })();
     return () => {
@@ -3964,6 +4001,41 @@ export function AgentWorkspace({
       if (result) {
         dispatchIssueReportDeliverySettled({ sessionId, report, result });
       }
+    }
+  }
+
+  async function sendErrorIssueReport(error: AgentWorkspaceError) {
+    const report = error.issueReport;
+    if (!report || submittingErrorIssueReport) return;
+    const sessionId = error.sessionId ?? selectedHermesSessionIdRef.current;
+    setSubmittingErrorIssueReport(true);
+    try {
+      await submitIssueReport({
+        category: report.category,
+        description: issueReportDescription(report),
+        agentDiagnosis: undefined,
+        attachmentNames: report.attachmentNames,
+        attachmentPaths: report.attachmentPaths,
+        ...(sessionId ? { sessionId } : {}),
+      });
+      if (sessionId) {
+        clearErrorForSession(sessionId);
+        if (selectedHermesSessionIdRef.current === sessionId) {
+          setIssueReportNotice({
+            message: "Your report was sent to the June team. Thank you for helping improve June.",
+            sessionId,
+          });
+        }
+      } else {
+        setError(null);
+      }
+    } catch (err) {
+      setError(`The issue report could not be sent. ${messageFromError(err)}`, {
+        sessionId: sessionId ?? null,
+        issueReport: report,
+      });
+    } finally {
+      setSubmittingErrorIssueReport(false);
     }
   }
 
@@ -4842,7 +4914,7 @@ export function AgentWorkspace({
         await refreshHermesSession(sessionId);
       }
     } catch (err) {
-      setError(describeAgentError(err));
+      setError(describeAgentError(err), reportableAgentErrorOptions(err));
     }
   }
 
@@ -5077,7 +5149,7 @@ export function AgentWorkspace({
       // "Session not found" 404 resolves on the next poll, so don't surface
       // it as an error banner (JUN-116).
       if (isSessionGoneError(message)) return;
-      setError(describeAgentError(err), { sessionId });
+      setError(describeAgentError(err), reportableAgentErrorOptions(err, { sessionId }));
     }
   }
 
@@ -7182,6 +7254,12 @@ export function AgentWorkspace({
             <AgentErrorBanner
               message={visibleError}
               onRetry={visibleErrorRetryable ? () => void retryGatewayConnection() : undefined}
+              onReportBug={
+                visibleErrorState?.issueReport
+                  ? () => void sendErrorIssueReport(visibleErrorState)
+                  : undefined
+              }
+              reportBugSubmitting={submittingErrorIssueReport}
               onDismiss={() => setError(null)}
             />
           ) : null}
@@ -7240,6 +7318,12 @@ export function AgentWorkspace({
                 <AgentErrorBanner
                   message={visibleError}
                   onRetry={visibleErrorRetryable ? () => void retryGatewayConnection() : undefined}
+                  onReportBug={
+                    visibleErrorState?.issueReport
+                      ? () => void sendErrorIssueReport(visibleErrorState)
+                      : undefined
+                  }
+                  reportBugSubmitting={submittingErrorIssueReport}
                   onDismiss={() => setError(null)}
                 />
               ) : null}
@@ -9652,11 +9736,15 @@ function CompactSuccess({ result }: { result: CompressSessionResult | null }) {
 function AgentErrorBanner({
   message,
   onDismiss,
+  onReportBug,
   onRetry,
+  reportBugSubmitting = false,
 }: {
   message: string;
   onDismiss: () => void;
+  onReportBug?: () => void;
   onRetry?: () => void;
+  reportBugSubmitting?: boolean;
 }) {
   return (
     <div className="error-banner agent-error-banner" role="alert">
@@ -9665,6 +9753,11 @@ function AgentErrorBanner({
         {onRetry ? (
           <button type="button" onClick={onRetry}>
             Try again
+          </button>
+        ) : null}
+        {onReportBug ? (
+          <button type="button" onClick={onReportBug} disabled={reportBugSubmitting}>
+            {reportBugSubmitting ? "Sending" : "Send bug report"}
           </button>
         ) : null}
         <button type="button" aria-label="Dismiss" onClick={onDismiss}>
@@ -9701,8 +9794,8 @@ function visibleAgentWorkspaceError(
   selectedSessionId: string | undefined,
 ) {
   if (!error) return null;
-  if (!error.sessionId) return selectedSessionId ? null : error.message;
-  return error.sessionId === selectedSessionId ? error.message : null;
+  if (!error.sessionId) return selectedSessionId ? null : error;
+  return error.sessionId === selectedSessionId ? error : null;
 }
 
 // The raw billing failure ("Error: Error code: 402 - …") never reaches the

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -778,7 +778,7 @@ type AgentWorkspaceErrorOptions = {
 
 type AgentWorkspaceNotice = {
   message: string;
-  sessionId: string;
+  sessionId: string | null;
 };
 
 type AgentDeleteSessionDetail = {
@@ -921,6 +921,8 @@ const REVIEWABLE_ISSUE_REPORTS_STORAGE_KEY = "june:agent:reviewable-issue-report
 const ISSUE_REPORT_DELIVERY_SETTLED_EVENT = "june-agent-issue-report-delivery-settled";
 const ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT =
   "june-agent-issue-report-follow-up-submit-failed";
+const ISSUE_REPORT_SENT_MESSAGE =
+  "Your report was sent to the June team. Thank you for helping improve June.";
 const ISSUE_REPORT_DIAGNOSIS_REFRESH_TIMEOUT_MS = 1500;
 const ISSUE_REPORT_DIAGNOSIS_BOUNDARY_SKEW_MS = 1500;
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
@@ -2196,7 +2198,7 @@ export function AgentWorkspace({
     visibleError != null &&
     (GATEWAY_CONNECTION_ERROR.test(visibleError) || visibleError === HERMES_SERVER_ERROR_MESSAGE);
   const visibleIssueReportNotice =
-    issueReportNotice && issueReportNotice.sessionId === selectedHermesSessionId
+    issueReportNotice && issueReportNotice.sessionId === (selectedHermesSessionId ?? null)
       ? issueReportNotice.message
       : null;
   // The model-switch notice (feature 10) shows on the session it acted on; a
@@ -3968,7 +3970,7 @@ export function AgentWorkspace({
       clearErrorForSession(sessionId);
       if (selectedHermesSessionIdRef.current === sessionId) {
         setIssueReportNotice({
-          message: "Your report was sent to the June team. Thank you for helping improve June.",
+          message: ISSUE_REPORT_SENT_MESSAGE,
           sessionId,
         });
       }
@@ -4022,12 +4024,16 @@ export function AgentWorkspace({
         clearErrorForSession(sessionId);
         if (selectedHermesSessionIdRef.current === sessionId) {
           setIssueReportNotice({
-            message: "Your report was sent to the June team. Thank you for helping improve June.",
+            message: ISSUE_REPORT_SENT_MESSAGE,
             sessionId,
           });
         }
       } else {
         setError(null);
+        setIssueReportNotice({
+          message: ISSUE_REPORT_SENT_MESSAGE,
+          sessionId: null,
+        });
       }
     } catch (err) {
       setError(`The issue report could not be sent. ${messageFromError(err)}`, {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -37,6 +37,18 @@ export function isInsufficientCreditsMessage(message?: string) {
   );
 }
 
+/** Whether a Tauri error is a Hermes REST 5xx. The desktop bridge's session
+ * commands surface a non-2xx response as `Hermes API returned <status>: <body>`
+ * (see `hermes_bridge.rs`); a 5xx is a transient server-side fault worth a
+ * retry, unlike a 4xx (the caller's request) or a bridge-down connection error.
+ * String matching mirrors the other classifiers here — the wire string carries
+ * no structured code today. The `\b` after the status keeps the match anchored
+ * to the three-digit code regardless of the trailing `:` or reason phrase. */
+export function isHermesServerError(message?: string) {
+  if (!message) return false;
+  return /Hermes API returned 5\d\d\b/.test(message);
+}
+
 /** Whether an error message means the request outgrew the model's context (or
  * the agent request-size limit) — a hard size failure the user must act on
  * (trim the input, attach a smaller file, start a fresh session), NOT something

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9172,6 +9172,15 @@ input:focus-visible,
   background: color-mix(in oklch, var(--destructive) 12%, transparent);
 }
 
+.agent-error-banner-actions button:disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.agent-error-banner-actions button:disabled:hover {
+  background: transparent;
+}
+
 /* Out-of-credits card in the transcript: no title, just the tone-colored
  * wallet glyph flowing inline with one sentence. The base notice lays its
  * pieces out as wrapping flex items, so long text drops wholesale onto its

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6810,6 +6810,59 @@ describe("AgentWorkspace", () => {
     expect(screen.queryByText("Hermes gateway is not connected.")).toBeNull();
   });
 
+  it("shows friendly, retryable copy for a Hermes 5xx from a session command (JUN-167)", async () => {
+    const user = userEvent.setup();
+    // A bare 500 reaches the bridge as `Hermes API returned 500: Internal
+    // Server Error` (deduped from the doubled StatusCode Display) — the raw
+    // string the user saw in the chat banner before this fix.
+    mocks.listHermesSessionMessages.mockRejectedValue(
+      new Error("Hermes API returned 500: Internal Server Error"),
+    );
+
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    // The banner shows the friendly line, never the raw wire error.
+    expect(
+      await screen.findByText("Hermes ran into a problem with that request."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Hermes API returned 500/)).toBeNull();
+    // A 5xx is a transient server fault, so the banner offers a retry (unlike a
+    // one-off 4xx, which only offers dismiss).
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText("Hermes ran into a problem with that request.")).toBeNull();
+  });
+
+  it("re-fetches the transcript when Try again is clicked on a Hermes 5xx banner (JUN-167)", async () => {
+    const user = userEvent.setup();
+    mocks.listHermesSessionMessages.mockRejectedValue(
+      new Error("Hermes API returned 500: Internal Server Error"),
+    );
+
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Hermes ran into a problem with that request."),
+    ).toBeInTheDocument();
+
+    const callsBeforeRetry = mocks.listHermesSessionMessages.mock.calls.length;
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    // The retry actually re-runs the failed transcript load — not just a
+    // reconnect that clears the banner and leaves the messages unfetched.
+    await waitFor(() =>
+      expect(mocks.listHermesSessionMessages.mock.calls.length).toBeGreaterThan(callsBeforeRetry),
+    );
+    // The 500 persists, so the friendly banner returns rather than leaving a
+    // silently-empty transcript; the raw wire string never appears.
+    expect(
+      await screen.findByText("Hermes ran into a problem with that request."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Hermes API returned 500/)).toBeNull();
+  });
+
   it("renders an out-of-credits notice with an upgrade action instead of the raw 402 error", async () => {
     const user = userEvent.setup();
     mocks.osAccountsUpgrade.mockResolvedValue(undefined);

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6865,6 +6865,32 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText(/Your report was sent to the June team/)).toBeInTheDocument();
   });
 
+  it("confirms a no-session Hermes 5xx bug report after sending (JUN-167)", async () => {
+    const user = userEvent.setup();
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    mocks.listHermesSessions.mockRejectedValue(
+      new Error("Hermes API returned 500: Internal Server Error"),
+    );
+
+    render(<AgentWorkspace />);
+    expect(
+      await screen.findByText("June ran into a problem with that request."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Send bug report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: expect.stringContaining("Hermes API returned 500: Internal Server Error"),
+        agentDiagnosis: undefined,
+        attachmentNames: [],
+        attachmentPaths: [],
+      }),
+    );
+    expect(await screen.findByText(/Your report was sent to the June team/)).toBeInTheDocument();
+  });
+
   it("re-fetches the transcript when Try again is clicked on a Hermes 5xx banner (JUN-167)", async () => {
     const user = userEvent.setup();
     mocks.listHermesSessionMessages.mockRejectedValue(

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6825,7 +6825,7 @@ describe("AgentWorkspace", () => {
 
     // The banner shows the friendly line, never the raw wire error.
     expect(
-      await screen.findByText("Hermes ran into a problem with that request."),
+      await screen.findByText("June ran into a problem with that request."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Hermes API returned 500/)).toBeNull();
     // A 5xx is a transient server fault, so the banner offers a retry (unlike a
@@ -6834,7 +6834,7 @@ describe("AgentWorkspace", () => {
     expect(screen.getByRole("button", { name: "Send bug report" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Dismiss" }));
-    expect(screen.queryByText("Hermes ran into a problem with that request.")).toBeNull();
+    expect(screen.queryByText("June ran into a problem with that request.")).toBeNull();
   });
 
   it("sends the raw Hermes 5xx as a bug report from the error banner (JUN-167)", async () => {
@@ -6847,7 +6847,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
     expect(await screen.findByText("Existing session")).toBeInTheDocument();
     expect(
-      await screen.findByText("Hermes ran into a problem with that request."),
+      await screen.findByText("June ran into a problem with that request."),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Send bug report" }));
@@ -6874,7 +6874,7 @@ describe("AgentWorkspace", () => {
     render(<AgentWorkspace />);
     expect(await screen.findByText("Existing session")).toBeInTheDocument();
     expect(
-      await screen.findByText("Hermes ran into a problem with that request."),
+      await screen.findByText("June ran into a problem with that request."),
     ).toBeInTheDocument();
 
     const callsBeforeRetry = mocks.listHermesSessionMessages.mock.calls.length;
@@ -6888,7 +6888,7 @@ describe("AgentWorkspace", () => {
     // The 500 persists, so the friendly banner returns rather than leaving a
     // silently-empty transcript; the raw wire string never appears.
     expect(
-      await screen.findByText("Hermes ran into a problem with that request."),
+      await screen.findByText("June ran into a problem with that request."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Hermes API returned 500/)).toBeNull();
   });

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6805,6 +6805,7 @@ describe("AgentWorkspace", () => {
     // Connection-shaped failures are the retryable ones — reconnecting can fix
     // them, unlike one-off action failures which only offer dismiss.
     expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send bug report" })).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(screen.queryByText("Hermes gateway is not connected.")).toBeNull();
@@ -6828,11 +6829,40 @@ describe("AgentWorkspace", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/Hermes API returned 500/)).toBeNull();
     // A 5xx is a transient server fault, so the banner offers a retry (unlike a
-    // one-off 4xx, which only offers dismiss).
+    // one-off 4xx, which only offers dismiss), plus direct bug reporting.
     expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send bug report" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(screen.queryByText("Hermes ran into a problem with that request.")).toBeNull();
+  });
+
+  it("sends the raw Hermes 5xx as a bug report from the error banner (JUN-167)", async () => {
+    const user = userEvent.setup();
+    mocks.submitIssueReport.mockResolvedValue({ received: true });
+    mocks.listHermesSessionMessages.mockRejectedValue(
+      new Error("Hermes API returned 500: Internal Server Error"),
+    );
+
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Hermes ran into a problem with that request."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Send bug report" }));
+
+    await waitFor(() =>
+      expect(mocks.submitIssueReport).toHaveBeenCalledWith({
+        category: "bug",
+        description: expect.stringContaining("Hermes API returned 500: Internal Server Error"),
+        agentDiagnosis: undefined,
+        attachmentNames: [],
+        attachmentPaths: [],
+        sessionId: "session-1",
+      }),
+    );
+    expect(await screen.findByText(/Your report was sent to the June team/)).toBeInTheDocument();
   });
 
   it("re-fetches the transcript when Try again is clicked on a Hermes 5xx banner (JUN-167)", async () => {


### PR DESCRIPTION
## Summary

Fixes the raw, duplicated error the user saw in the agent chat banner:
`Hermes API returned 500 Internal Server Error: Internal Server Error`, with no
friendly copy and no retry.

- **Deduped the wire string (Rust).** `hermes_connection_json` now interpolates
  the numeric status (`status.as_u16()`) instead of the `reqwest::StatusCode`,
  whose `Display` already renders the reason phrase. The message is now
  `Hermes API returned 500: Internal Server Error`. Extracted a small
  `hermes_api_error_message` helper as a test seam and documented the
  `Hermes API returned <status>: ` prefix as the load-bearing contract both
  consumers depend on.
- **Friendly, retryable banner (frontend).** Added `isHermesServerError`
  (`/Hermes API returned 5\d\d\b/`) in `src/lib/errors.ts`, mirroring the
  existing string-match classifiers. The four session-load `setError` sites in
  `AgentWorkspace` now map a Hermes 5xx to `HERMES_SERVER_ERROR_MESSAGE`
  ("Hermes ran into a problem with that request."), and the error banner offers
  **Try again** for it (via `retryGatewayConnection`, which re-runs the failed
  session-management loads). Mirrors the existing 404 -> `SESSION_GONE_MESSAGE`
  precedent and the admin path's 5xx copy/retry tone.

**Review feedback addressed (Codex P2):** the new "Try again" now re-runs the
selected session's transcript load (`retryGatewayConnection` calls
`refreshHermesSession` after reconnecting), instead of just reconnecting and
clearing the banner while leaving the messages unfetched. `refreshHermesSession`'s
own 5xx `setError` was made consistent (`describeAgentError`) so a persistent 500
re-shows the friendly banner rather than the raw string; a new test asserts the
retry re-fetches and the friendly banner returns. Greptile: 5/5, safe to merge.

`Closes JUN-167`

## Root cause

Two compounding causes:

1. **Duplicated text.** `hermes_bridge.rs` built the message with
   `format!("Hermes API returned {status}: {text}")` where `{status}` is a
   `reqwest::StatusCode` (its `Display` is `500 Internal Server Error`) and
   `{text}` is the response body, which for a bare upstream 500 is also
   `Internal Server Error` — so the reason phrase appeared twice.
2. **Raw, un-retryable surfacing.** That string reached the REST
   session-management commands (`hermes_api_json` -> `hermes_connection_json`)
   and was surfaced verbatim via `messageFromError` -> `setError` with no
   known-error mapping, and the banner's "Try again" was gated on
   `/hermes (gateway|bridge)/i`, which this string never matched — so it was
   dismiss-only.

## Validation

- `pnpm check` — exit 0 (only pre-existing retrofit warnings on untouched lines).
- `pnpm typecheck` — exit 0.
- `pnpm test src/test/agent-workspace.test.tsx` — 160 passed / 2 skipped,
  including the new JUN-167 test (friendly copy + Try again, raw string absent).
- `pnpm test src/test/hermes-admin-rust-transport.test.ts` — 6 passed (the
  transport parser handles both the old and deduped wire formats).
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 327 passed,
  including the 2 new Rust tests (`hermes_api_error_message_uses_numeric_status`,
  `hermes_api_status_still_matches_numeric_message` — the latter guards the
  404/405/409 idempotency swallow that keys on the same prefix).
- `cargo fmt --check` + `cargo clippy --lib` — clean.

- [x] Tested visually where it matters. Captured a real before/after of the
  banner by mounting the actual `AgentWorkspace` in a headless-Chromium Vite
  preview (dev-only fake-IPC bridge; the session-message REST command throws the
  500) and screenshotting:
  - **Before** (pristine frontend, pre-dedup string): banner reads
    `Hermes API returned 500 Internal Server Error: Internal Server Error`, with
    only a dismiss (X), no retry.
  - **After** (this PR): banner reads `Hermes ran into a problem with that
    request.` with a **Try again** button and a dismiss.

  Before/after screenshots are attached as a PR comment.
- [ ] Needs a June API (backend) deploy. No — desktop-only (Rust bridge +
  React). The June API is not touched.

## Out of scope

- Structured error bodies from the Hermes runtime (a real `{code,message}` over
  the wire would let the frontend stop string-matching entirely).
- Automatic retry/backoff — this only adds the manual "Try again" affordance.
- 5xx handling on the pending-action respond handlers (approval/sudo/secret);
  those already terminate on their 404 `SESSION_GONE` case. Left untouched.

## Followups

- Consider a shared, typed Hermes error envelope so `isHermesServerError`,
  `isSessionGoneError`, `isInsufficientCreditsMessage`, and the admin
  transport's `parseHermesHttpError` can key on a code instead of message text.

## Assumptions (AFK build, no clarifying answers)

- Reused the admin path's exact copy ("Hermes ran into a problem with that
  request.") rather than the brief's literal "...request. Try again." string,
  because the banner already renders a **Try again** button — a trailing
  "Try again." in the sentence would double the CTA. Flagging for reviewer taste.
