### PR TITLE
fix: keep transcription retries to safe failure classes (JUN-177)

### DIFF
--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -982,7 +982,16 @@ fn is_retryable_transcription_error(error: &AppError) -> bool {
             && (message == "authorization_denied"
                 || message == "timeout"
                 || message.contains("connection")
-                || message.contains("error sending request")))
+                || message.contains("error sending request")
+                // June API collapses a transient upstream (Venice ASR gateway,
+                // 502) or metering-provider outage (OS Accounts billing, 503)
+                // into a `june_request_failed` envelope carrying these messages.
+                // Both are transient service-dependency failures a short retry
+                // can clear — the same class as the `authorization_denied`
+                // concurrency-cap denial above — so route them through the
+                // bounded retry instead of failing the whole note on one blip.
+                || message.contains("upstream_provider_failed")
+                || message.contains("metering_provider_failed")))
 }
 
 fn transient_retry_delay(operation_id: &str, attempt: usize, error: &AppError) -> Duration {
@@ -2134,93 +2143,130 @@ mod tests {
 
     #[tokio::test]
     async fn transient_invalid_turn_response_retries_before_failing() {
-        let attempts = Arc::new(AtomicUsize::new(0));
-        let transcriber = {
-            let attempts = Arc::clone(&attempts);
-            Arc::new(move |request: TranscriptionRequest| {
+        // Every transient class June API can surface on one flaky attempt must
+        // recover on retry rather than fail the whole note: an invalid/empty
+        // envelope, a Venice ASR gateway failure (`upstream_provider_failed`,
+        // 502), and a metering-provider outage (`metering_provider_failed`,
+        // 503). See JUN-177 for the last two.
+        let transient_errors = [
+            AppError::new(
+                "june_api_response_invalid",
+                "The processing service returned an invalid response.",
+            ),
+            AppError::new("june_request_failed", "upstream_provider_failed"),
+            AppError::new("june_request_failed", "metering_provider_failed"),
+        ];
+
+        for transient_error in transient_errors {
+            let attempts = Arc::new(AtomicUsize::new(0));
+            let transcriber = {
                 let attempts = Arc::clone(&attempts);
-                Box::pin(async move {
-                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
-                        return Err(AppError::new(
-                            "june_api_response_invalid",
-                            "The processing service returned an invalid response.",
-                        ));
-                    }
-                    Ok(TranscriptionProviderResult {
-                        text: request.audio_path.to_string_lossy().to_string(),
-                        language: None,
-                        provider: "test".to_string(),
-                    })
-                }) as TranscriptionFuture
-            }) as TurnTranscriber
-        };
+                Arc::new(move |request: TranscriptionRequest| {
+                    let attempts = Arc::clone(&attempts);
+                    let transient_error = transient_error.clone();
+                    Box::pin(async move {
+                        if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                            return Err(transient_error);
+                        }
+                        Ok(TranscriptionProviderResult {
+                            text: request.audio_path.to_string_lossy().to_string(),
+                            language: None,
+                            provider: "test".to_string(),
+                        })
+                    }) as TranscriptionFuture
+                }) as TurnTranscriber
+            };
 
-        let outcome = transcribe_turn_jobs_by_source_lane(
-            vec![test_job("m0", "microphone", 0)],
-            crate::providers::OPENAI_PROVIDER.to_string(),
-            "Meeting".to_string(),
-            None,
-            transcriber,
-        )
-        .await
-        .expect("transient invalid response should be retried");
+            let outcome = transcribe_turn_jobs_by_source_lane(
+                vec![test_job("m0", "microphone", 0)],
+                crate::providers::OPENAI_PROVIDER.to_string(),
+                "Meeting".to_string(),
+                None,
+                transcriber,
+            )
+            .await
+            .expect("transient response should be retried");
 
-        assert_eq!(attempts.load(Ordering::SeqCst), 2);
-        assert_eq!(outcome.failures.len(), 0);
-        assert_eq!(outcome.candidates.len(), 1);
-        assert_eq!(outcome.candidates[0].input.text, "m0");
+            assert_eq!(attempts.load(Ordering::SeqCst), 2);
+            assert_eq!(outcome.failures.len(), 0);
+            assert_eq!(outcome.candidates.len(), 1);
+            assert_eq!(outcome.candidates[0].input.text, "m0");
+        }
     }
 
     #[tokio::test]
     async fn exhausted_invalid_tail_turn_stays_visible_as_failure() {
-        let tail_attempts = Arc::new(AtomicUsize::new(0));
-        let transcriber = {
-            let tail_attempts = Arc::clone(&tail_attempts);
-            Arc::new(move |request: TranscriptionRequest| {
+        // When every retry of a turn is exhausted it stays a visible per-turn
+        // failure without dropping earlier successful turns — for each transient
+        // class, including the JUN-177 Venice gateway (502) and metering-provider
+        // (503) outages. The surfaced warning is user-facing copy, never the raw
+        // provider code.
+        let cases = [
+            (
+                AppError::new(
+                    "june_api_response_invalid",
+                    "The processing service returned an invalid response.",
+                ),
+                "The processing service returned an invalid response.",
+            ),
+            (
+                AppError::new("june_request_failed", "upstream_provider_failed"),
+                "The transcription provider could not process this audio.",
+            ),
+            (
+                AppError::new("june_request_failed", "metering_provider_failed"),
+                "Billing is temporarily unavailable. Please try again in a moment.",
+            ),
+        ];
+
+        for (tail_error, expected_warning) in cases {
+            let tail_attempts = Arc::new(AtomicUsize::new(0));
+            let transcriber = {
                 let tail_attempts = Arc::clone(&tail_attempts);
-                Box::pin(async move {
-                    if request.audio_path == std::path::Path::new("tail") {
-                        tail_attempts.fetch_add(1, Ordering::SeqCst);
-                        return Err(AppError::new(
-                            "june_api_response_invalid",
-                            "The processing service returned an invalid response.",
-                        ));
-                    }
-                    Ok(TranscriptionProviderResult {
-                        text: request.audio_path.to_string_lossy().to_string(),
-                        language: None,
-                        provider: "test".to_string(),
-                    })
-                }) as TranscriptionFuture
-            }) as TurnTranscriber
-        };
+                Arc::new(move |request: TranscriptionRequest| {
+                    let tail_attempts = Arc::clone(&tail_attempts);
+                    let tail_error = tail_error.clone();
+                    Box::pin(async move {
+                        if request.audio_path == std::path::Path::new("tail") {
+                            tail_attempts.fetch_add(1, Ordering::SeqCst);
+                            return Err(tail_error);
+                        }
+                        Ok(TranscriptionProviderResult {
+                            text: request.audio_path.to_string_lossy().to_string(),
+                            language: None,
+                            provider: "test".to_string(),
+                        })
+                    }) as TranscriptionFuture
+                }) as TurnTranscriber
+            };
 
-        let outcome = transcribe_turn_jobs_by_source_lane(
-            vec![
-                test_job("intro", "microphone", 0),
-                test_job("tail", "microphone", 1),
-            ],
-            crate::providers::OPENAI_PROVIDER.to_string(),
-            "Meeting".to_string(),
-            None,
-            transcriber,
-        )
-        .await
-        .expect("source lanes should complete despite a failed tail turn");
+            let outcome = transcribe_turn_jobs_by_source_lane(
+                vec![
+                    test_job("intro", "microphone", 0),
+                    test_job("tail", "microphone", 1),
+                ],
+                crate::providers::OPENAI_PROVIDER.to_string(),
+                "Meeting".to_string(),
+                None,
+                transcriber,
+            )
+            .await
+            .expect("source lanes should complete despite a failed tail turn");
 
-        assert_eq!(
-            tail_attempts.load(Ordering::SeqCst),
-            TRANSIENT_TRANSCRIPTION_ATTEMPTS
-        );
-        assert_eq!(outcome.candidates.len(), 1);
-        assert_eq!(outcome.failures.len(), 1);
-        assert_eq!(outcome.candidates[0].input.text, "intro");
-        assert_eq!(outcome.failures[0].input.source, "microphone");
-        assert_eq!(outcome.failures[0].input.turn_index, Some(1));
-        assert_eq!(
-            outcome.failures[0].input.warning.as_deref(),
-            Some("The processing service returned an invalid response.")
-        );
+            assert_eq!(
+                tail_attempts.load(Ordering::SeqCst),
+                TRANSIENT_TRANSCRIPTION_ATTEMPTS
+            );
+            assert_eq!(outcome.candidates.len(), 1);
+            assert_eq!(outcome.failures.len(), 1);
+            assert_eq!(outcome.candidates[0].input.text, "intro");
+            assert_eq!(outcome.failures[0].input.source, "microphone");
+            assert_eq!(outcome.failures[0].input.turn_index, Some(1));
+            assert_eq!(
+                outcome.failures[0].input.warning.as_deref(),
+                Some(expected_warning)
+            );
+        }
     }
 
     #[test]
@@ -2247,6 +2293,17 @@ mod tests {
         assert!(!is_retryable_transcription_error(&AppError::new(
             "june_request_failed",
             "operation timed out"
+        )));
+        // JUN-177: a transient Venice ASR gateway failure (502) and a
+        // metering-provider outage (503) both arrive as a `june_request_failed`
+        // envelope; both are transient and must retry, not fail the whole note.
+        assert!(is_retryable_transcription_error(&AppError::new(
+            "june_request_failed",
+            "upstream_provider_failed"
+        )));
+        assert!(is_retryable_transcription_error(&AppError::new(
+            "june_request_failed",
+            "metering_provider_failed"
         )));
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -982,11 +982,7 @@ fn is_retryable_transcription_error(error: &AppError) -> bool {
             && (message == "authorization_denied"
                 || message == "timeout"
                 || message.contains("connection")
-                || message.contains("error sending request")
-                // June API surfaces transient upstream ASR gateway failures
-                // (502) through this envelope before any charge can settle, so
-                // the bounded retry can safely replay the note-transcribe call.
-                || message.contains("upstream_provider_failed")))
+                || message.contains("error sending request")))
 }
 
 fn transient_retry_delay(operation_id: &str, attempt: usize, error: &AppError) -> Duration {
@@ -2138,16 +2134,15 @@ mod tests {
 
     #[tokio::test]
     async fn transient_invalid_turn_response_retries_before_failing() {
-        // Every transient class June API can surface before ASR charges settle
+        // Every transient class June API can surface without a provider result
         // must recover on retry rather than fail the whole note: an
-        // invalid/empty envelope and a Venice ASR gateway failure
-        // (`upstream_provider_failed`, 502). See JUN-177 for the latter.
+        // invalid/empty envelope and explicit transient request failures.
         let transient_errors = [
             AppError::new(
                 "june_api_response_invalid",
                 "The processing service returned an invalid response.",
             ),
-            AppError::new("june_request_failed", "upstream_provider_failed"),
+            AppError::new("june_request_failed", "authorization_denied"),
         ];
 
         for transient_error in transient_errors {
@@ -2190,7 +2185,7 @@ mod tests {
     #[tokio::test]
     async fn exhausted_invalid_tail_turn_stays_visible_as_failure() {
         // When a turn fails after the allowed attempt budget, or fails with a
-        // non-retryable post-ASR metering error, it stays a visible per-turn
+        // non-retryable provider/metering error, it stays a visible per-turn
         // failure without dropping earlier successful turns. The surfaced
         // warning is user-facing copy, never the raw provider code.
         let cases = [
@@ -2205,7 +2200,7 @@ mod tests {
             (
                 AppError::new("june_request_failed", "upstream_provider_failed"),
                 "The transcription provider could not process this audio.",
-                TRANSIENT_TRANSCRIPTION_ATTEMPTS,
+                1,
             ),
             (
                 AppError::new("june_request_failed", "metering_provider_failed"),
@@ -2286,10 +2281,10 @@ mod tests {
             "june_request_failed",
             "operation timed out"
         )));
-        // JUN-177: a transient Venice ASR gateway failure (502) arrives as a
-        // `june_request_failed` envelope before any charge can settle, so it
-        // must retry instead of failing the whole note.
-        assert!(is_retryable_transcription_error(&AppError::new(
+        // `upstream_provider_failed` is not precise enough for desktop retry:
+        // June API uses the same envelope for transient 5xxs and deterministic
+        // provider 4xxs after taking a Hold.
+        assert!(!is_retryable_transcription_error(&AppError::new(
             "june_request_failed",
             "upstream_provider_failed"
         )));

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -983,15 +983,10 @@ fn is_retryable_transcription_error(error: &AppError) -> bool {
                 || message == "timeout"
                 || message.contains("connection")
                 || message.contains("error sending request")
-                // June API collapses a transient upstream (Venice ASR gateway,
-                // 502) or metering-provider outage (OS Accounts billing, 503)
-                // into a `june_request_failed` envelope carrying these messages.
-                // Both are transient service-dependency failures a short retry
-                // can clear — the same class as the `authorization_denied`
-                // concurrency-cap denial above — so route them through the
-                // bounded retry instead of failing the whole note on one blip.
-                || message.contains("upstream_provider_failed")
-                || message.contains("metering_provider_failed")))
+                // June API surfaces transient upstream ASR gateway failures
+                // (502) through this envelope before any charge can settle, so
+                // the bounded retry can safely replay the note-transcribe call.
+                || message.contains("upstream_provider_failed")))
 }
 
 fn transient_retry_delay(operation_id: &str, attempt: usize, error: &AppError) -> Duration {
@@ -2143,18 +2138,16 @@ mod tests {
 
     #[tokio::test]
     async fn transient_invalid_turn_response_retries_before_failing() {
-        // Every transient class June API can surface on one flaky attempt must
-        // recover on retry rather than fail the whole note: an invalid/empty
-        // envelope, a Venice ASR gateway failure (`upstream_provider_failed`,
-        // 502), and a metering-provider outage (`metering_provider_failed`,
-        // 503). See JUN-177 for the last two.
+        // Every transient class June API can surface before ASR charges settle
+        // must recover on retry rather than fail the whole note: an
+        // invalid/empty envelope and a Venice ASR gateway failure
+        // (`upstream_provider_failed`, 502). See JUN-177 for the latter.
         let transient_errors = [
             AppError::new(
                 "june_api_response_invalid",
                 "The processing service returned an invalid response.",
             ),
             AppError::new("june_request_failed", "upstream_provider_failed"),
-            AppError::new("june_request_failed", "metering_provider_failed"),
         ];
 
         for transient_error in transient_errors {
@@ -2196,11 +2189,10 @@ mod tests {
 
     #[tokio::test]
     async fn exhausted_invalid_tail_turn_stays_visible_as_failure() {
-        // When every retry of a turn is exhausted it stays a visible per-turn
-        // failure without dropping earlier successful turns — for each transient
-        // class, including the JUN-177 Venice gateway (502) and metering-provider
-        // (503) outages. The surfaced warning is user-facing copy, never the raw
-        // provider code.
+        // When a turn fails after the allowed attempt budget, or fails with a
+        // non-retryable post-ASR metering error, it stays a visible per-turn
+        // failure without dropping earlier successful turns. The surfaced
+        // warning is user-facing copy, never the raw provider code.
         let cases = [
             (
                 AppError::new(
@@ -2208,18 +2200,21 @@ mod tests {
                     "The processing service returned an invalid response.",
                 ),
                 "The processing service returned an invalid response.",
+                TRANSIENT_TRANSCRIPTION_ATTEMPTS,
             ),
             (
                 AppError::new("june_request_failed", "upstream_provider_failed"),
                 "The transcription provider could not process this audio.",
+                TRANSIENT_TRANSCRIPTION_ATTEMPTS,
             ),
             (
                 AppError::new("june_request_failed", "metering_provider_failed"),
                 "Billing is temporarily unavailable. Please try again in a moment.",
+                1,
             ),
         ];
 
-        for (tail_error, expected_warning) in cases {
+        for (tail_error, expected_warning, expected_attempts) in cases {
             let tail_attempts = Arc::new(AtomicUsize::new(0));
             let transcriber = {
                 let tail_attempts = Arc::clone(&tail_attempts);
@@ -2253,10 +2248,7 @@ mod tests {
             .await
             .expect("source lanes should complete despite a failed tail turn");
 
-            assert_eq!(
-                tail_attempts.load(Ordering::SeqCst),
-                TRANSIENT_TRANSCRIPTION_ATTEMPTS
-            );
+            assert_eq!(tail_attempts.load(Ordering::SeqCst), expected_attempts);
             assert_eq!(outcome.candidates.len(), 1);
             assert_eq!(outcome.failures.len(), 1);
             assert_eq!(outcome.candidates[0].input.text, "intro");
@@ -2294,14 +2286,16 @@ mod tests {
             "june_request_failed",
             "operation timed out"
         )));
-        // JUN-177: a transient Venice ASR gateway failure (502) and a
-        // metering-provider outage (503) both arrive as a `june_request_failed`
-        // envelope; both are transient and must retry, not fail the whole note.
+        // JUN-177: a transient Venice ASR gateway failure (502) arrives as a
+        // `june_request_failed` envelope before any charge can settle, so it
+        // must retry instead of failing the whole note.
         assert!(is_retryable_transcription_error(&AppError::new(
             "june_request_failed",
             "upstream_provider_failed"
         )));
-        assert!(is_retryable_transcription_error(&AppError::new(
+        // `metering_provider_failed` can come from a post-ASR charge failure;
+        // replaying the desktop request would redo paid upstream work.
+        assert!(!is_retryable_transcription_error(&AppError::new(
             "june_request_failed",
             "metering_provider_failed"
         )));


### PR DESCRIPTION
## Summary

- A meeting could fail entirely (`processingStatus: "failed"`, empty transcript, empty note) when a transient response/transport issue hit note transcription, because the desktop retry allowlist was too narrow.
- The desktop retry gate now keeps bounded retries for safe failure classes: invalid/empty June API responses, explicit transient request failures (`authorization_denied`, `timeout`), and client transport-style messages (`connection`, `error sending request`).
- The desktop deliberately does not retry generic `upstream_provider_failed` or `metering_provider_failed` envelopes. June API does not currently preserve a precise "retryable upstream" classification for the desktop; both generic envelopes can happen after a Hold is created, and replaying the full desktop note-transcribe request can create extra Holds or redo upstream work.
- Desktop-side retry classification only. No frontend change, no June API change.

## Root cause

The retryable allowlist in `is_retryable_transcription_error` (`src-tauri/src/domain/processing.rs`) matched only `june_api_response_invalid`, `empty_response`, or a `june_request_failed` whose message was `authorization_denied` / `timeout` / contained `connection` / `error sending request`.

The first draft broadened this to include `upstream_provider_failed` and `metering_provider_failed`, but review caught that those envelopes are too coarse:

- `metering_provider_failed` can be a post-ASR OS Accounts `/charge` failure, so replaying the desktop request can redo paid upstream ASR work.
- `upstream_provider_failed` can represent either a transient upstream 5xx or a deterministic provider 4xx/rejected request after June API has already taken a Hold.

The final implementation keeps the retry budget on safe, precise desktop-visible failures only. Retrying exhausted provider failures should wait until June API exposes a more precise retryable upstream signal.

## Validation

- `cargo fmt --check` from `src-tauri` - clean (exit 0).
- `cargo test processing::tests` from `src-tauri` - 34 passed, 0 failed.
- `cargo test` from `src-tauri` - 325 passed, 0 failed, 3 ignored, plus integration/doc tests green.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording). Not applicable: no UI change.
- [x] Needs a June API (backend) deploy before it works end to end. No.

## Out of scope

Deliberately not addressed here:

- A June API contract change that preserves retryable upstream provider classification for the desktop.
- Retrying post-ASR metering charge failures inside June API.
- Incremental/partial transcript persistence for the mic-only path.
- Auto-recovery of notes already stuck in `failed`.
- Recovery for validation-failure notes.

## Followups

- Add a June API response classification for exhausted retryable upstream failures if desktop should safely retry those later.
- Consider a separate issue for partial mic-only persistence so late hard failures do not discard already-transcribed chunks.

Closes JUN-177

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. Retry scope now explicitly avoids broad provider/metering envelopes that may have already created a Hold or run upstream ASR.
- [x] Workflow action references are pinned to full-length commit SHAs. No workflow changes.
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. None.
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. None: desktop-side classification only; no June API change.
- [x] User-facing copy follows the repo UI conventions. No new copy; existing failure messages reused.
