### PR TITLE
Fix dictation and agent breaking on transient OS Accounts refresh failures (not a v0.0.27 regression)

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1596,10 +1596,18 @@ fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_l
         let app = app.clone();
         let label = shortcut_label.to_string();
         tauri::async_runtime::spawn(async move {
-            if crate::os_accounts::access_token().await.is_err() {
-                forward_dictation_command(&app, DictationCommand::DiscardListening, &label);
-                notify_dictation_not_signed_in(&app);
-                reset_shortcut_activation(&app);
+            match classify_dictation_auth(&crate::os_accounts::access_token().await) {
+                DictationAuthGate::Proceed => {}
+                // A transient outage at the key press must not kill a live
+                // dictation: let it record. The recording_ready backstop
+                // re-checks at the end and, if still unavailable, keeps the
+                // audio and shows a retriable error.
+                DictationAuthGate::Unavailable(_) => {}
+                DictationAuthGate::SignedOut => {
+                    forward_dictation_command(&app, DictationCommand::DiscardListening, &label);
+                    notify_dictation_not_signed_in(&app);
+                    reset_shortcut_activation(&app);
+                }
             }
         });
     }
@@ -1665,6 +1673,29 @@ fn dictation_not_signed_in_event() -> serde_json::Value {
             "message": "Sign in to use dictation.",
         },
     })
+}
+
+/// How a dictation auth check should be handled. A transient OS Accounts
+/// failure is distinct from a genuine sign-out: the recording must be kept and
+/// a retriable error shown, never discarded behind a sign-in prompt.
+enum DictationAuthGate {
+    /// The token is usable; continue with transcription.
+    Proceed,
+    /// OS Accounts was momentarily unreachable. Keep the recording; show a
+    /// retriable error carrying the upstream message.
+    Unavailable(AppError),
+    /// The user is genuinely signed out. Discard and prompt to sign in.
+    SignedOut,
+}
+
+fn classify_dictation_auth(result: &Result<String, AppError>) -> DictationAuthGate {
+    match result {
+        Ok(_) => DictationAuthGate::Proceed,
+        Err(error) if crate::os_accounts::is_transient_auth_error(error) => {
+            DictationAuthGate::Unavailable(error.clone())
+        }
+        Err(_) => DictationAuthGate::SignedOut,
+    }
 }
 
 fn focus_main_window(app: &AppHandle) {
@@ -1908,11 +1939,23 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     // Backstop for the toggle-start path (where the start-time gate in
     // send_dictation_command can't tell start from stop) and for tokens that
     // expired between start and finish.
-    if crate::os_accounts::access_token().await.is_err() {
-        let state = app.state::<HelperState>();
-        let _ = send_helper_command(&state, serde_json::json!({ "type": "discard_recording" }));
-        notify_dictation_not_signed_in(&app);
-        return;
+    match classify_dictation_auth(&crate::os_accounts::access_token().await) {
+        DictationAuthGate::Proceed => {}
+        DictationAuthGate::Unavailable(error) => {
+            // OS Accounts is momentarily unreachable (e.g. an upstream 5xx
+            // during a post-update restart). The recording is intact and the
+            // user is still signed in, so keep the audio (do NOT discard) and
+            // surface a retriable error instead of a misleading sign-in prompt.
+            // The helper drops the leftover file on the next start_listening.
+            emit_dictation_event_value(&app, app_error_event(error));
+            return;
+        }
+        DictationAuthGate::SignedOut => {
+            let state = app.state::<HelperState>();
+            let _ = send_helper_command(&state, serde_json::json!({ "type": "discard_recording" }));
+            notify_dictation_not_signed_in(&app);
+            return;
+        }
     }
     let provider = match dictation_transcription_provider(configured_transcription_provider()) {
         Ok(provider) => provider,
@@ -4277,5 +4320,62 @@ mod tests {
         // Must be classified as non-silent so the HUD renders the actionable
         // message instead of the "Nothing recorded" terminal state.
         assert_eq!(event["payload"]["silent"], false);
+    }
+
+    #[test]
+    fn dictation_auth_gate_keeps_recording_on_transient_failure() {
+        let transient: Result<String, AppError> = Err(AppError::new(
+            "auth_refresh_unavailable",
+            "Couldn't reach your account.",
+        ));
+        assert!(matches!(
+            classify_dictation_auth(&transient),
+            DictationAuthGate::Unavailable(_)
+        ));
+    }
+
+    #[test]
+    fn dictation_auth_gate_signs_out_on_genuine_rejection() {
+        let signed_out: Result<String, AppError> =
+            Err(AppError::new("signed_out", "Not signed in."));
+        assert!(matches!(
+            classify_dictation_auth(&signed_out),
+            DictationAuthGate::SignedOut
+        ));
+        let expired: Result<String, AppError> = Err(AppError::new(
+            "session_expired",
+            "Your session expired. Sign in again.",
+        ));
+        assert!(matches!(
+            classify_dictation_auth(&expired),
+            DictationAuthGate::SignedOut
+        ));
+    }
+
+    #[test]
+    fn dictation_auth_gate_proceeds_with_a_token() {
+        let ok: Result<String, AppError> = Ok("token".to_string());
+        assert!(matches!(
+            classify_dictation_auth(&ok),
+            DictationAuthGate::Proceed
+        ));
+    }
+
+    #[test]
+    fn transient_auth_error_renders_as_a_visible_hud_error() {
+        // The kept-recording branch emits app_error_event for the transient
+        // failure; it must not be silent-classified, or the HUD would swallow
+        // it and the user would see nothing after their dictation vanished.
+        let error = AppError::new(
+            "auth_refresh_unavailable",
+            "Couldn't reach your account. Try again in a moment.",
+        );
+        let mut event = app_error_event(error);
+        annotate_silent_error(&mut event);
+
+        assert_eq!(event["type"], "error");
+        assert_eq!(event["payload"]["code"], "auth_refresh_unavailable");
+        assert_eq!(event["payload"]["silent"], false);
+        assert!(!is_silent_transcription_error(&event));
     }
 }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -462,8 +462,15 @@ pub async fn os_accounts_status() -> Result<AccountStatus, AppError> {
                 portal_url: portal_url(&cfg),
             })
         }
-        Err(_) => {
-            set_cached_signed_in(false);
+        Err(error) => {
+            // A transient snapshot failure (OS Accounts briefly unreachable
+            // after an update restart) is not a sign-out: we still hold valid
+            // tokens. Only a definitive rejection clears the cached signed-in
+            // state, so a focus-triggered status poll during an outage can't
+            // disable meeting capture, which reads cached_signed_in().
+            if snapshot_failure_clears_session(&error) {
+                set_cached_signed_in(false);
+            }
             Ok(AccountStatus {
                 configured: cfg.configured(),
                 ..Default::default()
@@ -1094,6 +1101,14 @@ fn session_expired_error() -> AppError {
 /// retriable error instead of discarding work or dropping to a signed-out UI.
 pub(crate) fn is_transient_auth_error(error: &AppError) -> bool {
     error.code == AUTH_REFRESH_UNAVAILABLE_CODE
+}
+
+/// Whether a failed account snapshot means the stored session is definitively
+/// over (tokens invalid) versus a transient outage. `os_accounts_status` runs
+/// on every window focus, so a transient failure here must NOT clear the cached
+/// signed-in state that capture gating reads — only a definitive sign-out does.
+fn snapshot_failure_clears_session(error: &AppError) -> bool {
+    matches!(error.code.as_str(), "session_expired" | "signed_out")
 }
 
 /// Refresh with a bounded retry on transient upstream failures. Each attempt
@@ -1747,6 +1762,29 @@ mod tests {
         assert!(!is_transient_auth_error(&AppError::new(
             "signed_out",
             "Not signed in."
+        )));
+    }
+
+    #[test]
+    fn only_a_definitive_sign_out_clears_the_snapshot_session() {
+        // Definitive: the stored tokens are invalid — clear the cache.
+        assert!(snapshot_failure_clears_session(&session_expired_error()));
+        assert!(snapshot_failure_clears_session(&AppError::new(
+            "signed_out",
+            "Not signed in."
+        )));
+        // Transient / reachability failures keep the session so a focus poll
+        // during an outage does not disable capture.
+        assert!(!snapshot_failure_clears_session(
+            &auth_refresh_unavailable_error()
+        ));
+        assert!(!snapshot_failure_clears_session(&AppError::new(
+            "network_error",
+            "Could not reach OS Accounts."
+        )));
+        assert!(!snapshot_failure_clears_session(&AppError::new(
+            "request_failed",
+            "OS Accounts request failed."
         )));
     }
 }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -462,20 +462,7 @@ pub async fn os_accounts_status() -> Result<AccountStatus, AppError> {
                 portal_url: portal_url(&cfg),
             })
         }
-        Err(error) => {
-            // A transient snapshot failure (OS Accounts briefly unreachable
-            // after an update restart) is not a sign-out: we still hold valid
-            // tokens. Only a definitive rejection clears the cached signed-in
-            // state, so a focus-triggered status poll during an outage can't
-            // disable meeting capture, which reads cached_signed_in().
-            if snapshot_failure_clears_session(&error) {
-                set_cached_signed_in(false);
-            }
-            Ok(AccountStatus {
-                configured: cfg.configured(),
-                ..Default::default()
-            })
-        }
+        Err(error) => Ok(account_status_for_snapshot_failure(&cfg, &error)),
     }
 }
 
@@ -1114,23 +1101,61 @@ fn snapshot_failure_clears_session(error: &AppError) -> bool {
     matches!(error.code.as_str(), "session_expired" | "signed_out")
 }
 
+fn account_status_for_snapshot_failure(cfg: &Config, error: &AppError) -> AccountStatus {
+    if snapshot_failure_clears_session(error) {
+        set_cached_signed_in(false);
+        return AccountStatus {
+            configured: cfg.configured(),
+            ..Default::default()
+        };
+    }
+
+    // A transient snapshot failure (OS Accounts briefly unreachable after an
+    // update restart) is not a sign-out: we still hold tokens. Mark the session
+    // signed in for both the frontend gate and native capture checks, while
+    // leaving user/billing details unknown until a later status refresh succeeds.
+    set_cached_signed_in(true);
+    AccountStatus {
+        signed_in: true,
+        configured: cfg.configured(),
+        portal_url: portal_url(cfg),
+        ..Default::default()
+    }
+}
+
+fn terminal_refresh_error(error: AppError, first_transient_error: Option<AppError>) -> AppError {
+    if !is_transient_auth_error(&error) {
+        if let Some(transient_error) = first_transient_error {
+            return transient_error;
+        }
+    }
+    error
+}
+
 /// Refresh with a bounded retry on transient upstream failures. Each attempt
 /// calls `refresh_locked`, which re-acquires the refresh lock and re-reads the
 /// keychain, so the lock is released across the backoff sleep and a refresh
 /// completed by another caller during the wait is picked up for free. Stops
-/// immediately on success or a definitive rejection.
+/// immediately on success or on a definitive rejection before any transient
+/// attempt; after a transient attempt, keep reporting the transient error so a
+/// retry against a consumed rotating token cannot clear the session.
 async fn refresh_locked_with_retry(cfg: &Config) -> Result<String, AppError> {
     let mut attempt = 0;
+    let mut first_transient_error: Option<AppError> = None;
     loop {
         match refresh_locked(cfg).await {
             Ok(access) => return Ok(access),
             Err(error) => {
                 attempt += 1;
-                if attempt < AUTH_REFRESH_MAX_ATTEMPTS && is_transient_auth_error(&error) {
+                let transient = is_transient_auth_error(&error);
+                if transient && first_transient_error.is_none() {
+                    first_transient_error = Some(error.clone());
+                }
+                if attempt < AUTH_REFRESH_MAX_ATTEMPTS && transient {
                     tokio::time::sleep(AUTH_REFRESH_RETRY_BACKOFF * attempt as u32).await;
                     continue;
                 }
-                return Err(error);
+                return Err(terminal_refresh_error(error, first_transient_error));
             }
         }
     }
@@ -1237,7 +1262,7 @@ async fn authed_get<T: for<'de> Deserialize<'de>>(cfg: &Config, path: &str) -> R
                 .ok_or_else(|| AppError::new("empty_response", "OS Accounts returned no data."));
         }
         if resp.error_code == Some(ERR_TOKEN_EXPIRED) && attempt == 0 {
-            access = refresh_locked(cfg).await?;
+            access = refresh_locked_with_retry(cfg).await?;
             continue;
         }
         return Err(AppError::new(
@@ -1276,7 +1301,7 @@ async fn authed_post<T: for<'de> Deserialize<'de>>(
                 .ok_or_else(|| AppError::new("empty_response", "OS Accounts returned no data."));
         }
         if resp.error_code == Some(ERR_TOKEN_EXPIRED) && attempt == 0 {
-            access = refresh_locked(cfg).await?;
+            access = refresh_locked_with_retry(cfg).await?;
             continue;
         }
         return Err(AppError::new(
@@ -1789,5 +1814,60 @@ mod tests {
             "request_failed",
             "OS Accounts request failed."
         )));
+    }
+
+    #[test]
+    fn transient_snapshot_failure_reports_signed_in_status() {
+        let cfg = Config {
+            accounts_url: "https://accounts.opensoftware.co/".to_string(),
+            api_url: "https://api.accounts.opensoftware.co".to_string(),
+            client_id: "ocl_test".to_string(),
+            loopback_port: DEFAULT_LOOPBACK_PORT,
+        };
+
+        let status = account_status_for_snapshot_failure(&cfg, &auth_refresh_unavailable_error());
+
+        assert!(status.signed_in);
+        assert!(status.configured);
+        assert_eq!(
+            status.portal_url.as_deref(),
+            Some("https://accounts.opensoftware.co")
+        );
+        assert!(status.user.is_none());
+        assert!(status.balance.is_none());
+        assert!(status.subscription.is_none());
+    }
+
+    #[test]
+    fn definitive_snapshot_failure_reports_signed_out_status() {
+        let cfg = Config {
+            accounts_url: "https://accounts.opensoftware.co/".to_string(),
+            api_url: "https://api.accounts.opensoftware.co".to_string(),
+            client_id: "ocl_test".to_string(),
+            loopback_port: DEFAULT_LOOPBACK_PORT,
+        };
+
+        let status = account_status_for_snapshot_failure(&cfg, &session_expired_error());
+
+        assert!(!status.signed_in);
+        assert!(status.configured);
+        assert!(status.portal_url.is_none());
+    }
+
+    #[test]
+    fn retry_terminal_error_preserves_the_first_transient_failure() {
+        let error = terminal_refresh_error(
+            session_expired_error(),
+            Some(auth_refresh_unavailable_error()),
+        );
+
+        assert_eq!(error.code, AUTH_REFRESH_UNAVAILABLE_CODE);
+    }
+
+    #[test]
+    fn retry_terminal_error_keeps_definitive_rejection_without_prior_transient() {
+        let error = terminal_refresh_error(session_expired_error(), None);
+
+        assert_eq!(error.code, "session_expired");
     }
 }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -54,6 +54,20 @@ const LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
 const SOCKET_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const ERR_TOKEN_EXPIRED: i64 = 3001;
+/// Error code for a refresh that failed transiently (OS Accounts unreachable or
+/// wobbling), as opposed to a definitive rejection of the refresh token. A
+/// transient failure must NOT be treated as a sign-out: the user is still
+/// signed in, so callers keep their session and surface a retriable error
+/// instead of discarding work.
+const AUTH_REFRESH_UNAVAILABLE_CODE: &str = "auth_refresh_unavailable";
+/// Total refresh attempts (1 initial + retries) when the upstream is transiently
+/// unavailable. Bounded so a genuine outage fails fast instead of hanging the
+/// caller. Each attempt re-acquires the refresh lock, so backoff sleeps happen
+/// with the lock released.
+const AUTH_REFRESH_MAX_ATTEMPTS: usize = 3;
+/// Base backoff between transient refresh retries; multiplied by the attempt
+/// number for a short linear backoff (0.3s, 0.6s).
+const AUTH_REFRESH_RETRY_BACKOFF: Duration = Duration::from_millis(300);
 
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 static REFRESH_LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
@@ -994,7 +1008,12 @@ async fn refresh_locked(cfg: &Config) -> Result<String, AppError> {
             return Err(AppError::new("signed_out", "Not signed in."));
         }
     };
-    let resp: Envelope<TokenPair> = http_client()
+    // Read status and body separately so a transient upstream failure (a
+    // Cloudflare/TEE 5xx or an outright connection error) is not conflated with
+    // a definitive rejection of the refresh token. reqwest does not error on a
+    // 5xx status, and a proxy error page is often non-JSON, so classify from the
+    // HTTP status plus whether the body parsed as an explicit rejection.
+    let response = match http_client()
         .post(format!(
             "{}/auth/refresh",
             cfg.api_url.trim_end_matches('/')
@@ -1002,18 +1021,101 @@ async fn refresh_locked(cfg: &Config) -> Result<String, AppError> {
         .json(&serde_json::json!({ "refresh_token": pair.refresh_token }))
         .send()
         .await
-        .map_err(net_error)?
-        .json()
-        .await
-        .map_err(net_error)?;
-    let fresh = resp
-        .data
-        .filter(|_| resp.success)
-        .ok_or_else(|| AppError::new("session_expired", "Your session expired. Sign in again."))?;
-    let access = fresh.access_token.clone();
-    store_tokens(&fresh).await?;
-    set_cached_signed_in(true);
-    Ok(access)
+    {
+        Ok(response) => response,
+        // No response at all: DNS, connection reset, timeout. Always transient.
+        Err(_) => return Err(auth_refresh_unavailable_error()),
+    };
+    let status = response.status().as_u16();
+    let body = match response.text().await {
+        Ok(body) => body,
+        // The body stream broke mid-read: treat like a lost response.
+        Err(_) => return Err(auth_refresh_unavailable_error()),
+    };
+    match serde_json::from_str::<Envelope<TokenPair>>(&body) {
+        Ok(envelope) if envelope.success => match envelope.data {
+            Some(fresh) => {
+                let access = fresh.access_token.clone();
+                store_tokens(&fresh).await?;
+                set_cached_signed_in(true);
+                Ok(access)
+            }
+            // success=true with no token pair is a malformed upstream response,
+            // not a rejection — retry rather than sign the user out.
+            None => Err(auth_refresh_unavailable_error()),
+        },
+        // A well-formed envelope with success=false is an explicit rejection
+        // (an expired or revoked refresh token) unless the status says the
+        // upstream itself wobbled.
+        Ok(_) => Err(classify_refresh_failure(status, true)),
+        // Body was not a JSON envelope (proxy error page, empty body): lean on
+        // the HTTP status to decide.
+        Err(_) => Err(classify_refresh_failure(status, false)),
+    }
+}
+
+/// Map a failed refresh response to a transient or definitive error. `status`
+/// is the HTTP status; `parsed_rejection` is true when the body was a
+/// well-formed envelope explicitly reporting failure.
+fn classify_refresh_failure(status: u16, parsed_rejection: bool) -> AppError {
+    if refresh_failure_is_transient(status, parsed_rejection) {
+        auth_refresh_unavailable_error()
+    } else {
+        session_expired_error()
+    }
+}
+
+/// Whether a failed refresh is worth retrying. Server/infra wobble (5xx) and
+/// rate limiting (429) are transient; an explicit 2xx/4xx rejection of the
+/// refresh token is definitive. A 2xx body we could not parse is treated as a
+/// proxy shim (transient).
+fn refresh_failure_is_transient(status: u16, parsed_rejection: bool) -> bool {
+    match status {
+        500..=599 | 429 => true,
+        _ if parsed_rejection => false,
+        400..=499 => false,
+        _ => true,
+    }
+}
+
+fn auth_refresh_unavailable_error() -> AppError {
+    AppError::new(
+        AUTH_REFRESH_UNAVAILABLE_CODE,
+        "Couldn't reach your account. Try again in a moment.",
+    )
+}
+
+fn session_expired_error() -> AppError {
+    AppError::new("session_expired", "Your session expired. Sign in again.")
+}
+
+/// True when an auth error is a transient upstream failure rather than a
+/// genuine sign-out. Callers use this to keep the user signed in and show a
+/// retriable error instead of discarding work or dropping to a signed-out UI.
+pub(crate) fn is_transient_auth_error(error: &AppError) -> bool {
+    error.code == AUTH_REFRESH_UNAVAILABLE_CODE
+}
+
+/// Refresh with a bounded retry on transient upstream failures. Each attempt
+/// calls `refresh_locked`, which re-acquires the refresh lock and re-reads the
+/// keychain, so the lock is released across the backoff sleep and a refresh
+/// completed by another caller during the wait is picked up for free. Stops
+/// immediately on success or a definitive rejection.
+async fn refresh_locked_with_retry(cfg: &Config) -> Result<String, AppError> {
+    let mut attempt = 0;
+    loop {
+        match refresh_locked(cfg).await {
+            Ok(access) => return Ok(access),
+            Err(error) => {
+                attempt += 1;
+                if attempt < AUTH_REFRESH_MAX_ATTEMPTS && is_transient_auth_error(&error) {
+                    tokio::time::sleep(AUTH_REFRESH_RETRY_BACKOFF * attempt as u32).await;
+                    continue;
+                }
+                return Err(error);
+            }
+        }
+    }
 }
 
 /// Read the current access token without refreshing.
@@ -1034,10 +1136,15 @@ pub async fn access_token() -> Result<String, AppError> {
     // 401) would burn a request before discovering the token was stale.
     if access_token_is_stale(&pair.access_token) {
         let cfg = Config::load();
-        return match refresh_locked(&cfg).await {
+        return match refresh_locked_with_retry(&cfg).await {
             Ok(access) => Ok(access),
             Err(error) => {
-                set_cached_signed_in(false);
+                // A transient upstream failure is not a sign-out: keep the
+                // cached signed-in state so callers surface a retriable error
+                // instead of discarding work and dropping to a signed-out UI.
+                if !is_transient_auth_error(&error) {
+                    set_cached_signed_in(false);
+                }
                 Err(error)
             }
         };
@@ -1076,10 +1183,14 @@ pub async fn refresh_access_token() -> Result<String, AppError> {
         return Ok(local_dev_bearer_token());
     }
     let cfg = Config::load();
-    match refresh_locked(&cfg).await {
+    match refresh_locked_with_retry(&cfg).await {
         Ok(access) => Ok(access),
         Err(error) => {
-            set_cached_signed_in(false);
+            // Preserve the session on a transient upstream failure; only a
+            // definitive rejection flips the cached state to signed-out.
+            if !is_transient_auth_error(&error) {
+                set_cached_signed_in(false);
+            }
             Err(error)
         }
     }
@@ -1582,5 +1693,60 @@ mod tests {
         };
 
         assert_eq!(accounts_browser_logout_url(&cfg), None);
+    }
+
+    #[test]
+    fn refresh_5xx_is_transient_even_with_a_rejection_body() {
+        // A TEE/proxy 5xx can still carry a JSON error body; the status wins.
+        assert!(refresh_failure_is_transient(500, true));
+        assert!(refresh_failure_is_transient(502, false));
+        assert!(refresh_failure_is_transient(503, true));
+    }
+
+    #[test]
+    fn refresh_rate_limit_is_transient() {
+        assert!(refresh_failure_is_transient(429, false));
+    }
+
+    #[test]
+    fn refresh_client_rejection_is_definitive() {
+        // An expired/revoked refresh token comes back as a 4xx with an explicit
+        // failure envelope — the user must sign in again.
+        assert!(!refresh_failure_is_transient(400, true));
+        assert!(!refresh_failure_is_transient(401, true));
+        // A 4xx with no parseable envelope is still a definitive rejection.
+        assert!(!refresh_failure_is_transient(403, false));
+    }
+
+    #[test]
+    fn refresh_explicit_2xx_rejection_is_definitive() {
+        // success=false on a 200 is an explicit rejection, not a wobble.
+        assert!(!refresh_failure_is_transient(200, true));
+    }
+
+    #[test]
+    fn refresh_unparseable_2xx_is_transient() {
+        // A 200 whose body is not our envelope (a proxy shim page) should be
+        // retried rather than logging the user out.
+        assert!(refresh_failure_is_transient(200, false));
+    }
+
+    #[test]
+    fn classify_refresh_failure_maps_to_the_right_code() {
+        assert_eq!(
+            classify_refresh_failure(502, false).code,
+            AUTH_REFRESH_UNAVAILABLE_CODE
+        );
+        assert_eq!(classify_refresh_failure(401, true).code, "session_expired");
+    }
+
+    #[test]
+    fn transient_auth_error_is_recognised() {
+        assert!(is_transient_auth_error(&auth_refresh_unavailable_error()));
+        assert!(!is_transient_auth_error(&session_expired_error()));
+        assert!(!is_transient_auth_error(&AppError::new(
+            "signed_out",
+            "Not signed in."
+        )));
     }
 }

--- a/src-tauri/src/os_accounts.rs
+++ b/src-tauri/src/os_accounts.rs
@@ -1081,6 +1081,9 @@ fn refresh_failure_is_transient(status: u16, parsed_rejection: bool) -> bool {
         500..=599 | 429 => true,
         _ if parsed_rejection => false,
         400..=499 => false,
+        // Unrecognised status (a 2xx we couldn't parse, or a 1xx/3xx that
+        // reqwest's redirect-following should never surface): lean toward
+        // transient rather than signing the user out on an unexpected shape.
         _ => true,
     }
 }


### PR DESCRIPTION
## Summary

- v0.0.27 users reported dictation "completely broken" and agent chat dead after auto-updating. Root-caused as **not a v0.0.27 code regression** — it is a pre-existing conflation of a *transient OS Accounts refresh failure* with a genuine sign-out, exposed by the update-restart landing on an OS Accounts outage (their infra returned Cloudflare 502s this morning; os-platform and OS Accounts staging both wobbled).
- `src-tauri/src/os_accounts.rs`: `refresh_locked` now classifies refresh failures by HTTP status. Connection errors, 5xx, 429, and unparseable proxy bodies are **transient** → a distinct `auth_refresh_unavailable` error, a small bounded retry (3 attempts, 0.3s/0.6s backoff), and the cached signed-in state is **preserved**. An explicit `invalid_grant`-style rejection (4xx / 2xx `success:false`) stays the genuine `session_expired` / `signed_out` path and still flips to signed-out.
- `src-tauri/src/os_accounts.rs`: `os_accounts_status` (re-polled on every window focus) no longer clears the signed-in cache on *any* snapshot error — only on a definitive sign-out. Prevents a focus-triggered poll during the same outage from clobbering the cache the token path just preserved and disabling meeting capture (which reads `cached_signed_in()`). This addresses a finding from the pre-publish review pass.
- `src-tauri/src/dictation.rs`: on a transient auth failure the finished recording is **no longer discarded** and the misleading "Sign in to use dictation" prompt is replaced with a visible, retriable HUD error. A genuine sign-out keeps the existing discard + sign-in behavior. Both dictation auth gates (the start-time parallel check and the `recording_ready` backstop) share one classifier so a transient blip at either edge no longer kills the dictation.
- No frontend changes: the dictation HUD and the agent error surface already render `payload.message`, so the friendly copy flows straight from Rust. `AgentWorkspace.tsx` (touched by #586) is deliberately left untouched.

Reported via Slack (no tracker issue filed yet). Reference: Slack P0 report "this build broke everything" after updating to v0.0.27.

## Root cause

**Confirmed trigger:** the OS Accounts production domains (`accounts.opensoftware.co` / `accounts-api.opensoftware.co`) failed at the Cloudflare layer this morning, roughly 10:14 to 10:53 CEST; both recovered by ~11:21 CEST (JWKS 200, `/me` 403-without-token as expected). The reporter's login was bricked during the window and their own diagnostics pinned the failure to Cloudflare. June turned that transient outage into "signed out" and discarded dictation recordings — exactly the path this PR fixes. This is not a v0.0.27 code change; the update-restart merely coincided with the outage and forced the token reload that exposed the misclassification.

An app update forces a restart, so the in-memory access token is gone. `access_token()` reloads the token pair from the keychain, finds it stale, and calls `refresh_locked` → which hits the OS Accounts token endpoint. When that refresh failed **transiently** (OS Accounts 5xx / network blip), the code could not tell it apart from a real rejection: `access_token()` flipped `signed_in(false)` and returned an error indistinguishable from a genuine sign-out.

Consequences, all downstream of that one misclassification:
- `dictation.rs` gated on `access_token().is_err()` → sent `discard_recording` (the Swift helper deletes the audio) and showed "Sign in to use dictation" — the user's finished dictation was thrown away even though they were still signed in.
- The agent proxy and every metered action (`june_api.rs`) need the same token → they failed too, so "the agent is dead" and "everything is broken."
- The account-status poll (`os_accounts_status`) also mapped any failure to signed-out and, because it runs on window focus, re-cleared the cache used to gate capture.
- Dev machines dodged it via `local_dev_enabled()`'s early return; users whose cached token was still valid never re-refreshed — matching "broken for me, fine for others."

reqwest does not error on a 5xx status and a Cloudflare/TEE error page is usually non-JSON, so the fix reads status and body separately and classifies from the HTTP status plus whether the body parsed as an explicit rejection.

## Validation

- `cargo test --lib` (src-tauri): **337 passed, 0 failed**. New unit tests:
  - os_accounts: transient vs definitive classification across 5xx / 429 / 4xx-with-rejection / 4xx-without-body / 2xx-explicit-rejection / 2xx-unparseable; `classify_refresh_failure` code mapping; `is_transient_auth_error` recognition; `snapshot_failure_clears_session` (only session_expired / signed_out clear the cache).
  - dictation: the auth gate keeps the recording on a transient failure (`Unavailable`), signs out on a genuine rejection (`signed_out` / `session_expired`), proceeds with a token, and the transient error renders as a **visible** (non-silent) HUD error.
- `cargo fmt --check`: clean. `cargo clippy --lib`: clean. (Full `--all-targets` clippy was constrained by a full local disk mid-run; CI runs it — see the "Tauri Rust clippy and tests" check.)
- Independent pre-publish review pass (separate agent, line-by-line correctness / removed-behavior / lock discipline / retry safety / dictation state): no confirmed defects in the changed lines; its one flagged risk (the `os_accounts_status` cache clobber) is now fixed in this PR.
- Deterministic tests are the evidence: a live walkthrough would require OS Accounts to fail refresh on cue (a server-side outage we cannot trigger), and dev builds early-return past this path via `local_dev_enabled()`. The classification and gate decisions are pure functions covered by the unit tests above.

- [ ] Tested visually where it matters — n/a; failure requires an OS Accounts outage on cue and dev builds bypass the path. Evidence is the deterministic tests.
- [ ] Needs a June API (backend) deploy — **no**. Desktop-only change; no `/v1/*` contract touched.

## Out of scope

- Fixing OS Accounts server-side reliability (the actual outage source).
- The v0.0.27 local-model paths — verified dormant for this bug.
- Auto-degrade to local models on upstream failure.
- JUN-168's helper respawn.
- Changing what the account panel *renders* during an outage: `os_accounts_status` still returns a signed-out snapshot to the UI on failure (this PR only stops it clobbering the capture-gating cache). Making the panel show "temporarily unreachable" vs "signed out" is a followup.

## Followups

- OS Accounts-side reliability so transient 5xx stops happening at all.
- Surface auth state more granularly in Settings ("temporarily unreachable" vs "signed out") and reflect the preserved session in the returned `AccountStatus`, not just the cache.
- Dictation has **no** recovery/re-transcribe path (the `recovery.rs` machinery is meeting-only, DB status-driven). "Keeping the audio" here means not deleting the helper's temp `.m4a` mid-flight (the helper drops it on the next `start_listening`); the actionable recovery is the retriable prompt to re-dictate. A durable dictation retry queue could be a followup if desired.
- Token refresh is not idempotent under refresh-token rotation: a refresh that succeeds server-side but whose response is lost will fail the retry as `invalid_grant`. The bounded retry helps the common case (origin unreachable = request never processed) and does not make this rare case worse than the previous single-attempt behavior.

## Notes for reviewer

- Assumptions taken (AFK, no clarifying answers): kept scope to `src-tauri`; message copy `"Couldn't reach your account. Try again in a moment."` (sentence case, no dashes, not silent-classified); bounded retry = 3 attempts. Please sanity-check the copy and the retry count.
- The commits are **unsigned** (1Password SSH agent was not available in the build environment).
