### PR TITLE
Proactively surface the Accessibility banner via helper trust polling (JUN-185)

### DIFF
--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -126,26 +126,25 @@ final class AccessibilityTrustMonitor {
         self.timer = timer
         timer.resume()
 
-        // Wake (timers don't advance during sleep) and app activation (returning
-        // to June, or toggling the grant in System Settings and switching back)
-        // each warrant an immediate re-check so the banner isn't gated on the
-        // next timer tick.
+        // Wake (timers don't advance during sleep) and system-wide app
+        // activation each warrant an immediate re-check so permission changes
+        // are not gated on the next timer tick.
         let center = NSWorkspace.shared.notificationCenter
         center.addObserver(
             self,
-            selector: #selector(handleWorkspaceEvent),
+            selector: #selector(handleWorkspaceEvent(_:)),
             name: NSWorkspace.didWakeNotification,
             object: nil
         )
         center.addObserver(
             self,
-            selector: #selector(handleWorkspaceEvent),
+            selector: #selector(handleWorkspaceEvent(_:)),
             name: NSWorkspace.didActivateApplicationNotification,
             object: nil
         )
     }
 
-    @objc private func handleWorkspaceEvent() {
+    @objc private func handleWorkspaceEvent(_: Notification) {
         poll()
     }
 

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -82,6 +82,83 @@ func requestAccessibilityPermission() {
     emit("permission_status", permissionPayload())
 }
 
+/// Pure decision for the accessibility-trust poller: re-emit only when the
+/// trust bit actually flips. `previous` is nil until the first observation
+/// (seeded at start without emitting, since the launch-time diagnostics already
+/// report the initial state), so the first real change always emits.
+func accessibilityTrustChanged(previous: Bool?, current: Bool) -> Bool {
+    previous != current
+}
+
+/// Surfaces Accessibility-trust changes proactively.
+///
+/// The paste path already fails loud when trust is missing at paste time, but a
+/// user whose grant was revoked mid-session (commonly after an app update
+/// changes the helper's signature) would otherwise only discover it by losing a
+/// dictation — during dictation they are focused in another app, so nothing
+/// re-checks. This polls `AXIsProcessTrusted()` on a low-frequency timer plus on
+/// wake and app activation, and re-emits `permission_status` the moment the bit
+/// changes so the existing in-app banner appears (or clears) without waiting for
+/// a failed paste.
+final class AccessibilityTrustMonitor {
+    static let shared = AccessibilityTrustMonitor()
+
+    // 30s is well under a human's patience for "why won't paste work" while
+    // costing nothing: AXIsProcessTrusted() is a cheap local check and we emit
+    // only on change, so a stable grant produces no events.
+    private let pollInterval: TimeInterval = 30
+    private var lastTrusted: Bool?
+    private var timer: DispatchSourceTimer?
+
+    private init() {}
+
+    func start() {
+        // Seed without emitting: the launch-time get_permission_status /
+        // emitDiagnostics already reported the current state, so a second
+        // identical event here would just be noise.
+        lastTrusted = AXIsProcessTrusted()
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+        timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
+        timer.setEventHandler { [weak self] in
+            self?.poll()
+        }
+        self.timer = timer
+        timer.resume()
+
+        // Wake (timers don't advance during sleep) and app activation (returning
+        // to June, or toggling the grant in System Settings and switching back)
+        // each warrant an immediate re-check so the banner isn't gated on the
+        // next timer tick.
+        let center = NSWorkspace.shared.notificationCenter
+        center.addObserver(
+            self,
+            selector: #selector(handleWorkspaceEvent),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleWorkspaceEvent),
+            name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleWorkspaceEvent() {
+        poll()
+    }
+
+    private func poll() {
+        let trusted = AXIsProcessTrusted()
+        guard accessibilityTrustChanged(previous: lastTrusted, current: trusted) else {
+            return
+        }
+        lastTrusted = trusted
+        emit("permission_status", permissionPayload())
+    }
+}
+
 func helperBundleIdentifier() -> String {
     Bundle.main.bundleIdentifier ?? "unknown"
 }
@@ -2022,6 +2099,7 @@ app.setActivationPolicy(.accessory)
 emit("ready")
 ShortcutKeyMonitor.shared.start()
 FocusTargetController.shared.start()
+AccessibilityTrustMonitor.shared.start()
 dictation.emitDiagnostics()
 
 Thread.detachNewThread {

--- a/src/test/app-permissions.test.ts
+++ b/src/test/app-permissions.test.ts
@@ -26,13 +26,11 @@ describe("isAccessibilityBlocked", () => {
 });
 
 // JUN-185: the helper now polls AXIsProcessTrusted() and re-emits
-// permission_status on change, so a mid-session revoke/re-grant flows through
-// the same accessibility-status state the banner is gated on. Each event just
-// overwrites accessibilityStatus, so banner visibility is exactly
-// isAccessibilityBlocked over that sequence — assert the whole revoke/re-grant
-// path so a future refactor can't silently strand the banner as "on".
+// permission_status on change. The app maps each emitted status through
+// isAccessibilityBlocked, so this guards the granted/missing/granted mapping
+// used by the banner without exercising the full IPC event pipeline.
 describe("accessibility banner across proactive status changes", () => {
-  it("shows on revoke and clears on re-grant without a failed paste", () => {
+  it("maps revoke and re-grant status changes to banner visibility", () => {
     // Trusted at launch: no banner.
     expect(isAccessibilityBlocked("granted")).toBe(false);
     // Grant revoked in System Settings mid-session (helper timer/wake poll

--- a/src/test/app-permissions.test.ts
+++ b/src/test/app-permissions.test.ts
@@ -24,3 +24,21 @@ describe("isAccessibilityBlocked", () => {
     expect(isAccessibilityBlocked("restricted")).toBe(true);
   });
 });
+
+// JUN-185: the helper now polls AXIsProcessTrusted() and re-emits
+// permission_status on change, so a mid-session revoke/re-grant flows through
+// the same accessibility-status state the banner is gated on. Each event just
+// overwrites accessibilityStatus, so banner visibility is exactly
+// isAccessibilityBlocked over that sequence — assert the whole revoke/re-grant
+// path so a future refactor can't silently strand the banner as "on".
+describe("accessibility banner across proactive status changes", () => {
+  it("shows on revoke and clears on re-grant without a failed paste", () => {
+    // Trusted at launch: no banner.
+    expect(isAccessibilityBlocked("granted")).toBe(false);
+    // Grant revoked in System Settings mid-session (helper timer/wake poll
+    // re-emits): banner appears with no dictation attempt.
+    expect(isAccessibilityBlocked("missing")).toBe(true);
+    // Re-granted (next change event): banner clears.
+    expect(isAccessibilityBlocked("granted")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes JUN-185

## Summary

The dictation helper now watches Accessibility trust proactively instead of only discovering a revocation at paste time. A new `AccessibilityTrustMonitor` in `mac-dictation-helper/main.swift` polls `AXIsProcessTrusted()` on a 30s timer, plus immediately on system wake and on app activation, and re-emits `permission_status` **only when the trust bit changes**. That event flows through the existing `permission_status` -> `accessibilityBlocked` -> banner pipeline in `App.tsx`, so the in-app banner appears (or clears) without the user having to lose a dictation first.

No new UI: this reuses the banner and the `isAccessibilityBlocked` gate already wired since PR #585.

## Motivation

Since PR #585 the helper fails loud when trust is missing **at paste time**, but the banner still only surfaced after a failed paste or on June-window focus. macOS commonly revokes the helper's grant after an app update changes its code signature; during dictation the user is focused in another app, so a fresh revocation was invisible until a paste silently failed. Polling the trust bit and emitting on change surfaces the problem ahead of the next dictation.

Change-detection (seed-without-emit at start, then emit only on flip) keeps this from spamming events: a stable grant produces zero events. The "should emit?" decision is factored into the pure free function `accessibilityTrustChanged(previous:current:)` for reviewability.

## Validation

- **Helper compiles**: `swiftc -typecheck` and a full single-arch build against the exact build frameworks (Foundation/AppKit/AVFoundation/Carbon/CoreMedia/CoreGraphics, `arm64-apple-macosx14.0`) both succeed.
- **Frontend**: `pnpm test src/test/app-permissions.test.ts` (5 passed) — added a test asserting the revoke -> re-grant sequence flips the banner gate on then off (the pipeline handled re-grant clearing already; this locks it in). `pnpm check` and `pnpm typecheck` clean (pre-existing repo-wide biome warnings only, none in touched files).
- **Live revoke/re-grant walkthrough: SKIPPED (not authorized).** Exercising the acceptance path requires revoking system Accessibility for the helper in System Settings, which was explicitly not authorized for this run. The change-detection decision is isolated in a pure function and the emit path reuses the already-shipped, banner-tested pipeline, so the risk of the skip is low. A reviewer with a local build can revoke the grant while June runs and confirm the banner appears within ~30s with no dictation attempt, then re-grant and confirm it clears.

There is no automated Swift unit test for the poller: the helper is a single-file executable with top-level code and no XCTest target, so the emit-on-change logic is verified by the pure `accessibilityTrustChanged` function's obviousness plus the FE pipeline test rather than a Swift unit test. Restructuring the helper into a testable library is out of scope.

## Needs June API deploy

No. Desktop/helper-only change.

## Out of scope

- The paste-time trust gate (PR #585, merged) — unchanged.
- Helper respawn on revocation (JUN-184) — owned by a parallel change touching `src-tauri/src/dictation.rs` and the FE notice areas; this PR only touches `main.swift` and `app-permissions.test.ts`.

## Followups

- If the 30s cadence proves too slow or too chatty in the field, the interval is a single constant to tune.
- App-window activation is also covered by the FE's existing focus re-check (`App.tsx`); the helper's activation observer additionally catches revocations while the user is away in another app.
