### PR TITLE
Respawn the dictation helper when it dies (JUN-184)

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -14,7 +14,10 @@ use std::{
     io::{BufRead, BufReader, Write},
     path::PathBuf,
     process::{Child, ChildStdin, Command, Stdio},
-    sync::{Mutex, OnceLock},
+    sync::{
+        atomic::{AtomicBool, AtomicU32, Ordering},
+        Mutex, OnceLock,
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -36,6 +39,22 @@ pub struct HelperProcess {
 
 pub struct HelperState {
     process: Mutex<Option<HelperProcess>>,
+    /// Set only on intentional teardown (app quit / [`stop_helper`]) so the
+    /// supervisor can tell a deliberate stop from a crash and skip respawning.
+    shutting_down: AtomicBool,
+    /// Consecutive rapid respawn attempts, used to cap a crash loop. Reset once
+    /// a respawned helper survives long enough to be considered healthy.
+    respawn_failures: AtomicU32,
+}
+
+impl Default for HelperState {
+    fn default() -> Self {
+        Self {
+            process: Mutex::new(None),
+            shutting_down: AtomicBool::new(false),
+            respawn_failures: AtomicU32::new(0),
+        }
+    }
 }
 
 pub struct LastDictationEvent {
@@ -607,6 +626,7 @@ pub fn setup(app: &mut tauri::App) {
     let helper = spawn_helper(app.handle()).ok();
     app.manage(HelperState {
         process: Mutex::new(helper),
+        ..HelperState::default()
     });
 
     {
@@ -1241,7 +1261,6 @@ fn rect_contains(
 /// are registered.
 fn spawn_hud_hover_thread(app: AppHandle) {
     thread::spawn(move || {
-        use std::sync::atomic::Ordering;
         let tick = Duration::from_millis(33);
         loop {
             thread::sleep(tick);
@@ -1337,17 +1356,16 @@ fn spawn_hud_hover_thread(app: AppHandle) {
 
 pub fn stop_helper(app: &AppHandle) {
     let state = app.state::<HelperState>();
-    let Ok(mut guard) = state.process.lock() else {
-        return;
-    };
-    let Some(mut process) = guard.take() else {
-        return;
-    };
-
-    let _ = process.stdin.write_all(b"{\"type\":\"shutdown\"}\n");
-    let _ = process.stdin.flush();
-    let _ = process.child.kill();
-    let _ = process.child.wait();
+    // Mark the teardown as intentional before killing so the supervisor thread
+    // (woken by the resulting stdout EOF) skips respawning instead of fighting
+    // app quit.
+    state.shutting_down.store(true, Ordering::SeqCst);
+    // Take the helper out from under the lock, then kill outside it so the
+    // blocking wait() cannot stall a concurrent command thread.
+    let helper = state.process.lock().ok().and_then(|mut guard| guard.take());
+    if let Some(helper) = helper {
+        abandon_helper(helper);
+    }
 }
 
 pub(crate) fn dictation_helper_pid(app: &AppHandle) -> Option<u32> {
@@ -1844,12 +1862,21 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
         )
     })?;
 
+    // Recorded before handing stdout to the reader so the supervisor can tell a
+    // healthy helper (ran a while, then died) from a crash loop.
+    let spawn_instant = Instant::now();
+
     let output_app = app.clone();
     thread::spawn(move || {
         let reader = BufReader::new(stdout);
         for line in reader.lines().map_while(Result::ok) {
             handle_helper_event_line(&output_app, line);
         }
+        // The helper's event stream lives for the whole process lifetime, so
+        // stdout closing means the helper exited (crash, SIGKILL after an
+        // update swaps the bundle, or an intentional stop). Hand off to the
+        // supervisor to reap it and decide whether to respawn.
+        supervise_helper_exit(&output_app, spawn_instant);
     });
 
     let error_app = app.clone();
@@ -1861,6 +1888,241 @@ fn spawn_helper(app: &AppHandle) -> Result<HelperProcess, AppError> {
     });
 
     Ok(HelperProcess { child, stdin })
+}
+
+/// How many consecutive rapid respawns we attempt before giving up and showing
+/// the "relaunch to recover" notice. Bounds a genuine crash loop so it can't
+/// burn CPU forever, while still recovering from any isolated helper death.
+const HELPER_MAX_RESPAWN_ATTEMPTS: u32 = 5;
+/// Backoff before the first respawn; doubles each attempt up to the cap below.
+const HELPER_RESPAWN_BASE_BACKOFF: Duration = Duration::from_millis(500);
+const HELPER_RESPAWN_MAX_BACKOFF: Duration = Duration::from_secs(8);
+/// A helper that ran at least this long before dying is treated as healthy: its
+/// death starts a fresh failure count instead of counting toward the cap, so
+/// repeated manual kills (or a death long after launch) always recover.
+const HELPER_HEALTHY_RUNTIME: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy)]
+struct RespawnPolicy {
+    max_attempts: u32,
+    base_backoff: Duration,
+    max_backoff: Duration,
+    healthy_runtime: Duration,
+}
+
+impl Default for RespawnPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: HELPER_MAX_RESPAWN_ATTEMPTS,
+            base_backoff: HELPER_RESPAWN_BASE_BACKOFF,
+            max_backoff: HELPER_RESPAWN_MAX_BACKOFF,
+            healthy_runtime: HELPER_HEALTHY_RUNTIME,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RespawnAction {
+    /// Intentional shutdown: leave the helper down.
+    Skip,
+    /// Relaunch the helper after `backoff`. `attempt` is 1-based.
+    Respawn { attempt: u32, backoff: Duration },
+    /// Too many rapid failures: surface the unavailable notice and stop trying.
+    GiveUp,
+}
+
+/// Pure decision for what to do after the dictation helper process exits.
+///
+/// `prior_failures` is the count of consecutive rapid respawns so far;
+/// `survived` is how long the process that just exited had been running.
+/// Returns the action to take plus the new consecutive-failure count to persist
+/// (so the caller stays a thin, side-effecting shell around this logic).
+fn decide_respawn(
+    shutting_down: bool,
+    prior_failures: u32,
+    survived: Duration,
+    policy: &RespawnPolicy,
+) -> (RespawnAction, u32) {
+    if shutting_down {
+        return (RespawnAction::Skip, prior_failures);
+    }
+    let attempt = if survived >= policy.healthy_runtime {
+        1
+    } else {
+        prior_failures.saturating_add(1)
+    };
+    if attempt > policy.max_attempts {
+        return (RespawnAction::GiveUp, attempt);
+    }
+    (
+        RespawnAction::Respawn {
+            attempt,
+            backoff: respawn_backoff(attempt, policy),
+        },
+        attempt,
+    )
+}
+
+fn respawn_backoff(attempt: u32, policy: &RespawnPolicy) -> Duration {
+    // 1-based attempts: the first respawn waits `base_backoff`, each later one
+    // doubles, all clamped to `max_backoff`.
+    let shift = attempt.saturating_sub(1).min(16);
+    policy
+        .base_backoff
+        .checked_mul(1u32 << shift)
+        .unwrap_or(policy.max_backoff)
+        .min(policy.max_backoff)
+}
+
+fn helper_unavailable_event(reason: &str, message: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "helper_unavailable",
+        "payload": {
+            "reason": reason,
+            "message": message,
+        },
+    })
+}
+
+/// Runs on the helper's stdout reader thread once that stream closes (the helper
+/// exited or was killed). Reaps the child, then respawns with backoff unless the
+/// exit was an intentional shutdown or the retry cap is exhausted. A successful
+/// respawn re-applies settings and re-arms the hotkey, and its own reader thread
+/// takes over supervision, so this thread simply returns.
+fn supervise_helper_exit(app: &AppHandle, spawn_instant: Instant) {
+    let Some(state) = app.try_state::<HelperState>() else {
+        return;
+    };
+
+    // Reap the exited child so it does not linger as a zombie, and clear the
+    // stale handle so commands correctly see the helper as unavailable while
+    // it is down.
+    reap_exited_helper(&state);
+
+    let policy = RespawnPolicy::default();
+    let mut survived = spawn_instant.elapsed();
+    loop {
+        let shutting_down = state.shutting_down.load(Ordering::SeqCst);
+        let prior = state.respawn_failures.load(Ordering::SeqCst);
+        let (action, next_failures) = decide_respawn(shutting_down, prior, survived, &policy);
+        state.respawn_failures.store(next_failures, Ordering::SeqCst);
+
+        match action {
+            RespawnAction::Skip => return,
+            RespawnAction::GiveUp => {
+                tracing::error!(
+                    attempts = next_failures,
+                    "dictation helper kept exiting; giving up until relaunch"
+                );
+                emit_dictation_event_value(
+                    app,
+                    helper_unavailable_event(
+                        "exhausted",
+                        "Dictation stopped and could not restart. Relaunch June to restore it.",
+                    ),
+                );
+                return;
+            }
+            RespawnAction::Respawn { attempt, backoff } => {
+                tracing::warn!(
+                    attempt,
+                    ?backoff,
+                    "dictation helper exited unexpectedly; respawning"
+                );
+                // Surface the notice while the helper is down so the hotkey is
+                // never silently dead; a successful respawn clears it by
+                // re-emitting the hotkey-ready event.
+                emit_dictation_event_value(
+                    app,
+                    helper_unavailable_event("restarting", "Dictation stopped and is restarting."),
+                );
+                thread::sleep(backoff);
+                if state.shutting_down.load(Ordering::SeqCst) {
+                    return;
+                }
+                match spawn_helper(app) {
+                    Ok(helper) => {
+                        if store_respawned_helper(&state, helper) {
+                            reapply_helper_settings(app);
+                        }
+                        // Either the new helper is live (its reader thread now
+                        // supervises) or shutdown raced us and it was stopped.
+                        return;
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error.message,
+                            "failed to respawn dictation helper; retrying"
+                        );
+                        // A spawn failure (e.g. the bundle is still mid-swap)
+                        // counts as an immediate, unhealthy failure so the cap
+                        // still applies.
+                        survived = Duration::ZERO;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn reap_exited_helper(state: &HelperState) {
+    if let Ok(mut guard) = state.process.lock() {
+        if let Some(mut process) = guard.take() {
+            let _ = process.child.wait();
+        }
+    }
+}
+
+/// Installs a freshly respawned helper as the active process, unless an
+/// intentional shutdown raced in first, in which case the new helper is stopped
+/// so it does not leak. Returns true when the helper was stored and is live.
+fn store_respawned_helper(state: &HelperState, helper: HelperProcess) -> bool {
+    let Ok(mut guard) = state.process.lock() else {
+        // Poisoned lock: stop the orphan we just created rather than leak it.
+        abandon_helper(helper);
+        return false;
+    };
+    if state.shutting_down.load(Ordering::SeqCst) {
+        // Shutdown won the race. Drop the lock before the blocking kill so
+        // other command threads are not stalled on wait().
+        drop(guard);
+        abandon_helper(helper);
+        return false;
+    }
+    *guard = Some(helper);
+    true
+}
+
+/// Stops a helper we spawned but will not install (shutdown raced the respawn).
+/// Dropping a [`Child`] only detaches it, so we kill explicitly to avoid an
+/// orphaned helper holding the global hotkey tap.
+fn abandon_helper(mut helper: HelperProcess) {
+    let _ = helper.stdin.write_all(b"{\"type\":\"shutdown\"}\n");
+    let _ = helper.stdin.flush();
+    let _ = helper.child.kill();
+    let _ = helper.child.wait();
+}
+
+/// Re-applies the persisted microphone and shortcut settings to a just-respawned
+/// helper and re-arms the hotkey, mirroring the one-time wiring in [`setup`]. The
+/// hotkey-ready event also clears the "dictation restarting" notice in the UI.
+fn reapply_helper_settings(app: &AppHandle) {
+    let Some(helper_state) = app.try_state::<HelperState>() else {
+        return;
+    };
+    let settings = app
+        .try_state::<DictationSettingsState>()
+        .and_then(|state| state.settings.lock().ok().map(|settings| settings.clone()));
+    let Some(settings) = settings else {
+        return;
+    };
+    let _ = apply_microphone_setting(&helper_state, &settings.microphone);
+    let _ = apply_shortcut_settings(&helper_state, &settings);
+    let event = hotkey_ready_event(&settings);
+    if let Some(status) = app.try_state::<HotkeyStatus>() {
+        set_hotkey_status(&status, event.clone());
+    }
+    emit_dictation_event_value(app, event);
 }
 
 fn handle_helper_event_line(app: &AppHandle, line: String) {
@@ -3227,6 +3489,92 @@ pub fn key_code_for_code(code: &str) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_policy() -> RespawnPolicy {
+        RespawnPolicy {
+            max_attempts: 3,
+            base_backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_secs(1),
+            healthy_runtime: Duration::from_secs(30),
+        }
+    }
+
+    #[test]
+    fn intentional_shutdown_never_respawns() {
+        let policy = test_policy();
+        let (action, failures) = decide_respawn(true, 0, Duration::ZERO, &policy);
+        assert_eq!(action, RespawnAction::Skip);
+        // The failure count is left untouched on an intentional stop.
+        assert_eq!(failures, 0);
+
+        // Even mid-crash-loop, a shutdown wins and stops respawning.
+        let (action, _) = decide_respawn(true, 2, Duration::ZERO, &policy);
+        assert_eq!(action, RespawnAction::Skip);
+    }
+
+    #[test]
+    fn unexpected_exit_respawns_and_counts_up() {
+        let policy = test_policy();
+        let (action, failures) = decide_respawn(false, 0, Duration::ZERO, &policy);
+        assert_eq!(
+            action,
+            RespawnAction::Respawn {
+                attempt: 1,
+                backoff: Duration::from_millis(100),
+            }
+        );
+        assert_eq!(failures, 1);
+
+        let (action, failures) = decide_respawn(false, 1, Duration::ZERO, &policy);
+        assert_eq!(
+            action,
+            RespawnAction::Respawn {
+                attempt: 2,
+                backoff: Duration::from_millis(200),
+            }
+        );
+        assert_eq!(failures, 2);
+    }
+
+    #[test]
+    fn retry_cap_exhaustion_gives_up() {
+        let policy = test_policy();
+        // The last allowed attempt still respawns.
+        let (action, failures) = decide_respawn(false, 2, Duration::ZERO, &policy);
+        assert!(matches!(action, RespawnAction::Respawn { attempt: 3, .. }));
+        assert_eq!(failures, 3);
+
+        // One past the cap gives up instead of respawning.
+        let (action, _) = decide_respawn(false, 3, Duration::ZERO, &policy);
+        assert_eq!(action, RespawnAction::GiveUp);
+    }
+
+    #[test]
+    fn healthy_runtime_resets_the_failure_count() {
+        let policy = test_policy();
+        // A helper that had exhausted its retries but then ran healthily is
+        // treated as a fresh first failure, so an isolated later kill recovers.
+        let (action, failures) =
+            decide_respawn(false, 3, policy.healthy_runtime + Duration::from_secs(1), &policy);
+        assert_eq!(
+            action,
+            RespawnAction::Respawn {
+                attempt: 1,
+                backoff: Duration::from_millis(100),
+            }
+        );
+        assert_eq!(failures, 1);
+    }
+
+    #[test]
+    fn respawn_backoff_doubles_and_clamps() {
+        let policy = test_policy();
+        assert_eq!(respawn_backoff(1, &policy), Duration::from_millis(100));
+        assert_eq!(respawn_backoff(2, &policy), Duration::from_millis(200));
+        assert_eq!(respawn_backoff(3, &policy), Duration::from_millis(400));
+        // Clamped to max_backoff once doubling would overshoot it.
+        assert_eq!(respawn_backoff(20, &policy), policy.max_backoff);
+    }
 
     #[test]
     fn default_settings_use_keyboard_shortcuts_without_bare_fn() {

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -1997,15 +1997,15 @@ fn supervise_helper_exit(app: &AppHandle, spawn_instant: Instant) {
     // Reap the exited child so it does not linger as a zombie, and clear the
     // stale handle so commands correctly see the helper as unavailable while
     // it is down.
-    reap_exited_helper(&state);
+    if !reap_exited_helper(&state) {
+        return;
+    }
+    reset_shortcut_activation(app);
 
     let policy = RespawnPolicy::default();
     let mut survived = spawn_instant.elapsed();
     loop {
-        let shutting_down = state.shutting_down.load(Ordering::SeqCst);
-        let prior = state.respawn_failures.load(Ordering::SeqCst);
-        let (action, next_failures) = decide_respawn(shutting_down, prior, survived, &policy);
-        state.respawn_failures.store(next_failures, Ordering::SeqCst);
+        let (action, next_failures) = decide_and_record_respawn(&state, survived, &policy);
 
         match action {
             RespawnAction::Skip => return,
@@ -2014,12 +2014,10 @@ fn supervise_helper_exit(app: &AppHandle, spawn_instant: Instant) {
                     attempts = next_failures,
                     "dictation helper kept exiting; giving up until relaunch"
                 );
-                emit_dictation_event_value(
+                emit_helper_unavailable(
                     app,
-                    helper_unavailable_event(
-                        "exhausted",
-                        "Dictation stopped and could not restart. Relaunch June to restore it.",
-                    ),
+                    "exhausted",
+                    "Dictation stopped and could not restart. Relaunch June to restore it.",
                 );
                 return;
             }
@@ -2032,23 +2030,24 @@ fn supervise_helper_exit(app: &AppHandle, spawn_instant: Instant) {
                 // Surface the notice while the helper is down so the hotkey is
                 // never silently dead; a successful respawn clears it by
                 // re-emitting the hotkey-ready event.
-                emit_dictation_event_value(
-                    app,
-                    helper_unavailable_event("restarting", "Dictation stopped and is restarting."),
-                );
+                emit_helper_unavailable(app, "restarting", "Dictation stopped and is restarting.");
                 thread::sleep(backoff);
                 if state.shutting_down.load(Ordering::SeqCst) {
                     return;
                 }
                 match spawn_helper(app) {
-                    Ok(helper) => {
-                        if store_respawned_helper(&state, helper) {
+                    Ok(helper) => match store_respawned_helper(&state, helper) {
+                        StoreRespawnedHelper::Stored => {
                             reapply_helper_settings(app);
+                            // The new helper is live and its reader thread now
+                            // supervises.
+                            return;
                         }
-                        // Either the new helper is live (its reader thread now
-                        // supervises) or shutdown raced us and it was stopped.
-                        return;
-                    }
+                        StoreRespawnedHelper::ExitedBeforeStore => {
+                            survived = Duration::ZERO;
+                        }
+                        StoreRespawnedHelper::Abandoned => return,
+                    },
                     Err(error) => {
                         tracing::warn!(
                             error = %error.message,
@@ -2065,32 +2064,66 @@ fn supervise_helper_exit(app: &AppHandle, spawn_instant: Instant) {
     }
 }
 
-fn reap_exited_helper(state: &HelperState) {
-    if let Ok(mut guard) = state.process.lock() {
-        if let Some(mut process) = guard.take() {
-            let _ = process.child.wait();
+fn decide_and_record_respawn(
+    state: &HelperState,
+    survived: Duration,
+    policy: &RespawnPolicy,
+) -> (RespawnAction, u32) {
+    loop {
+        let shutting_down = state.shutting_down.load(Ordering::SeqCst);
+        let prior = state.respawn_failures.load(Ordering::SeqCst);
+        let (action, next_failures) = decide_respawn(shutting_down, prior, survived, policy);
+        if matches!(action, RespawnAction::Skip) {
+            return (action, next_failures);
+        }
+        if state
+            .respawn_failures
+            .compare_exchange(prior, next_failures, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            return (action, next_failures);
         }
     }
 }
 
+fn reap_exited_helper(state: &HelperState) -> bool {
+    if let Ok(mut guard) = state.process.lock() {
+        if let Some(mut process) = guard.take() {
+            let _ = process.child.wait();
+            return true;
+        }
+    }
+    false
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum StoreRespawnedHelper {
+    Stored,
+    ExitedBeforeStore,
+    Abandoned,
+}
+
 /// Installs a freshly respawned helper as the active process, unless an
 /// intentional shutdown raced in first, in which case the new helper is stopped
-/// so it does not leak. Returns true when the helper was stored and is live.
-fn store_respawned_helper(state: &HelperState, helper: HelperProcess) -> bool {
+/// so it does not leak.
+fn store_respawned_helper(state: &HelperState, mut helper: HelperProcess) -> StoreRespawnedHelper {
     let Ok(mut guard) = state.process.lock() else {
         // Poisoned lock: stop the orphan we just created rather than leak it.
         abandon_helper(helper);
-        return false;
+        return StoreRespawnedHelper::Abandoned;
     };
     if state.shutting_down.load(Ordering::SeqCst) {
         // Shutdown won the race. Drop the lock before the blocking kill so
         // other command threads are not stalled on wait().
         drop(guard);
         abandon_helper(helper);
-        return false;
+        return StoreRespawnedHelper::Abandoned;
+    }
+    if matches!(helper.child.try_wait(), Ok(Some(_))) {
+        return StoreRespawnedHelper::ExitedBeforeStore;
     }
     *guard = Some(helper);
-    true
+    StoreRespawnedHelper::Stored
 }
 
 /// Stops a helper we spawned but will not install (shutdown raced the respawn).
@@ -2119,6 +2152,14 @@ fn reapply_helper_settings(app: &AppHandle) {
     let _ = apply_microphone_setting(&helper_state, &settings.microphone);
     let _ = apply_shortcut_settings(&helper_state, &settings);
     let event = hotkey_ready_event(&settings);
+    if let Some(status) = app.try_state::<HotkeyStatus>() {
+        set_hotkey_status(&status, event.clone());
+    }
+    emit_dictation_event_value(app, event);
+}
+
+fn emit_helper_unavailable(app: &AppHandle, reason: &str, message: &str) {
+    let event = helper_unavailable_event(reason, message);
     if let Some(status) = app.try_state::<HotkeyStatus>() {
         set_hotkey_status(&status, event.clone());
     }
@@ -3083,9 +3124,13 @@ fn dictation_event_visibility(event_type: Option<&str>) -> DictationEventVisibil
             | "final_transcript"
             | "paste_target",
         ) => DictationEventVisibility::Show,
-        Some("paste_completed" | "agent_session_prompt" | "error" | "shutdown_ack") => {
-            DictationEventVisibility::Hide
-        }
+        Some(
+            "paste_completed"
+            | "agent_session_prompt"
+            | "error"
+            | "shutdown_ack"
+            | "helper_unavailable",
+        ) => DictationEventVisibility::Hide,
         _ => DictationEventVisibility::Ignore,
     }
 }
@@ -3554,8 +3599,12 @@ mod tests {
         let policy = test_policy();
         // A helper that had exhausted its retries but then ran healthily is
         // treated as a fresh first failure, so an isolated later kill recovers.
-        let (action, failures) =
-            decide_respawn(false, 3, policy.healthy_runtime + Duration::from_secs(1), &policy);
+        let (action, failures) = decide_respawn(
+            false,
+            3,
+            policy.healthy_runtime + Duration::from_secs(1),
+            &policy,
+        );
         assert_eq!(
             action,
             RespawnAction::Respawn {
@@ -3574,6 +3623,22 @@ mod tests {
         assert_eq!(respawn_backoff(3, &policy), Duration::from_millis(400));
         // Clamped to max_backoff once doubling would overshoot it.
         assert_eq!(respawn_backoff(20, &policy), policy.max_backoff);
+    }
+
+    #[test]
+    fn respawn_decision_records_failure_count() {
+        let state = HelperState::default();
+        let policy = test_policy();
+
+        let (action, failures) = decide_and_record_respawn(&state, Duration::ZERO, &policy);
+        assert!(matches!(action, RespawnAction::Respawn { attempt: 1, .. }));
+        assert_eq!(failures, 1);
+        assert_eq!(state.respawn_failures.load(Ordering::SeqCst), 1);
+
+        let (action, failures) = decide_and_record_respawn(&state, Duration::ZERO, &policy);
+        assert!(matches!(action, RespawnAction::Respawn { attempt: 2, .. }));
+        assert_eq!(failures, 2);
+        assert_eq!(state.respawn_failures.load(Ordering::SeqCst), 2);
     }
 
     #[test]
@@ -4359,6 +4424,14 @@ mod tests {
     fn agent_session_prompt_hides_dictation_hud() {
         assert!(matches!(
             dictation_event_visibility(Some("agent_session_prompt")),
+            DictationEventVisibility::Hide
+        ));
+    }
+
+    #[test]
+    fn helper_unavailable_hides_dictation_hud() {
+        assert!(matches!(
+            dictation_event_visibility(Some("helper_unavailable")),
             DictationEventVisibility::Hide
         ));
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2777,6 +2777,8 @@ export function App() {
                   activeTab={settingsTab}
                   onTabChange={setSettingsTab}
                   onCheckForUpdates={() => runUpdateCheck("manual")}
+                  updateReadyToRelaunch={readyUpdate != null}
+                  onRelaunch={handleRelaunchUpdate}
                   onReconcileToStable={handleReconcileToStable}
                   onReportIssue={handleReportIssue}
                   onStartBundleChat={handleStartBundleChat}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -283,6 +283,12 @@ type AppSettingsProps = {
   onTabChange?: (tab: SettingsTab) => void;
   // Runs the app updater's manual check flow.
   onCheckForUpdates?: () => void;
+  // True when an update is downloaded and waiting for a relaunch. The bundle
+  // swap is what can kill the dictation helper, so the "dictation paused"
+  // notice points the user at the relaunch that finishes the update.
+  updateReadyToRelaunch?: boolean;
+  // Relaunches June to finish a staged update (also restores the helper).
+  onRelaunch?: () => void;
   // Confirmed leave-rc reconcile: downloads and installs the current stable,
   // even if it is older than the running prerelease build (Q4-Q8).
   onReconcileToStable?: () => void;
@@ -309,6 +315,8 @@ export function AppSettings({
   activeTab: controlledTab,
   onTabChange,
   onCheckForUpdates,
+  updateReadyToRelaunch,
+  onRelaunch,
   onReconcileToStable,
   onReportIssue,
   onStartBundleChat,
@@ -340,6 +348,13 @@ export function AppSettings({
   const capturingShortcutRef = useRef<DictationShortcutKind>();
   const [shortcutError, setShortcutError] = useState<string>();
   const [status, setStatus] = useState<string>();
+  // Set when the dictation helper dies (crash or the bundle swap after an
+  // update) and cleared once it re-arms the hotkey, so the shortcuts pane never
+  // silently shows a dead hotkey.
+  const [helperUnavailable, setHelperUnavailable] = useState<{
+    reason: string;
+    message: string;
+  }>();
   const [micOpen, setMicOpen] = useState(false);
   const [theme, setTheme] = useState<ThemePreference>(() => getStoredTheme());
   const [brand, setBrand] = useState<BrandId>(() => getStoredBrand());
@@ -661,6 +676,18 @@ export function AppSettings({
     }
     if (helperEvent.type === "fn_monitor_unavailable") {
       setStatus(helperEvent.payload?.message ?? "Global shortcut monitoring is unavailable.");
+      return;
+    }
+    if (helperEvent.type === "helper_unavailable") {
+      setHelperUnavailable({
+        reason: stringPayload(helperEvent.payload?.reason) ?? "restarting",
+        message: helperEvent.payload?.message ?? "Dictation stopped and is restarting.",
+      });
+      return;
+    }
+    if (helperEvent.type === "hotkey_trigger_ready") {
+      // The helper re-armed the hotkey, so it is back: clear any down notice.
+      setHelperUnavailable(undefined);
       return;
     }
     if (helperEvent.type === "shortcut_capture_started") {
@@ -1220,6 +1247,25 @@ export function AppSettings({
             <h2 id="shortcuts-heading" className="settings-group-heading">
               Shortcuts
             </h2>
+            {helperUnavailable ? (
+              <InlineNotice
+                role="alert"
+                aria-label="Dictation unavailable"
+                eyebrow={updateReadyToRelaunch ? "Relaunch to finish updating" : "Dictation paused"}
+                body={
+                  updateReadyToRelaunch
+                    ? "Dictation is paused until you relaunch to finish updating."
+                    : helperUnavailable.message
+                }
+                actions={
+                  updateReadyToRelaunch && onRelaunch ? (
+                    <button type="button" className="btn btn-secondary" onClick={onRelaunch}>
+                      Relaunch June
+                    </button>
+                  ) : undefined
+                }
+              />
+            ) : null}
             <div className="settings-card">
               <div className="settings-rows">
                 {macLikePlatform ? (

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import {
   JUNE_COMMUNITY_URL,
+  dictationHotkeyStatus,
   dictationHelperCommand,
   dictationSettings,
   listVeniceModels,
@@ -500,6 +501,9 @@ export function AppSettings({
         const response = await dictationSettings();
         if (cancelled) return;
         setSettings(response.settings);
+        const hotkeyStatus = await dictationHotkeyStatus();
+        if (cancelled) return;
+        handleHelperEvent(hotkeyStatus);
         const modelResponse = await providerModelSettings();
         if (cancelled) return;
         // Merge over defaults so a settings payload that predates a field

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -162,6 +162,7 @@ export type DictationHelperEvent = {
     selectedID?: string;
     shortcut?: DictationShortcutSetting;
     message?: string;
+    reason?: string;
     code?: string;
     path?: string;
     durationMs?: number | string;

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -10,6 +10,7 @@ import { PROVIDER_MODEL_SETTINGS_CHANGED_EVENT } from "../lib/model-privacy";
 
 const mocks = vi.hoisted(() => ({
   dictationSettings: vi.fn(),
+  dictationHotkeyStatus: vi.fn(),
   dictationHelperCommand: vi.fn(),
   localAudioFileSrc: vi.fn(),
   providerModelSettings: vi.fn(),
@@ -68,6 +69,7 @@ vi.mock("../app/build-info", () => ({
 
 vi.mock("../lib/tauri", () => ({
   JUNE_COMMUNITY_URL: "https://t.me/osjune",
+  dictationHotkeyStatus: mocks.dictationHotkeyStatus,
   dictationSettings: mocks.dictationSettings,
   dictationHelperCommand: mocks.dictationHelperCommand,
   localAudioFileSrc: mocks.localAudioFileSrc,
@@ -216,6 +218,10 @@ describe("AppSettings", () => {
     localState = { baseUrl: "", modelId: "", apiKey: "", enabled: false };
     mocks.eventHandler = undefined;
     mocks.dictationSettings.mockResolvedValue({ settings: baseSettings });
+    mocks.dictationHotkeyStatus.mockResolvedValue({
+      type: "hotkey_trigger_ready",
+      payload: { shortcut: baseSettings.pushToTalkShortcut },
+    });
     mocks.localAudioFileSrc.mockImplementation((path) => `asset://${path}`);
     mocks.setDictationLanguage.mockImplementation(async (language) => ({
       ...baseSettings,
@@ -1589,6 +1595,39 @@ describe("AppSettings", () => {
         screen.queryByRole("alert", { name: "Dictation unavailable" }),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("shows persisted helper downtime when Settings opens after retries exhaust", async () => {
+    const user = userEvent.setup();
+    mocks.dictationHotkeyStatus.mockResolvedValue({
+      type: "helper_unavailable",
+      payload: {
+        reason: "exhausted",
+        message: "Dictation stopped and could not restart. Relaunch June to restore it.",
+      },
+    });
+
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
+
+    const notice = await screen.findByRole("alert", { name: "Dictation unavailable" });
+    expect(
+      within(notice).getByText(
+        "Dictation stopped and could not restart. Relaunch June to restore it.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("prompts a relaunch to finish updating when the helper is down mid-update", async () => {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1542,6 +1542,95 @@ describe("AppSettings", () => {
     });
   });
 
+  it("shows a restarting notice when the dictation helper goes unavailable", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
+    expect(await screen.findByText("Push to talk")).toBeInTheDocument();
+
+    act(() => {
+      mocks.eventHandler?.({
+        payload: JSON.stringify({
+          type: "helper_unavailable",
+          payload: { reason: "restarting", message: "Dictation stopped and is restarting." },
+        }),
+      });
+    });
+
+    const notice = await screen.findByRole("alert", { name: "Dictation unavailable" });
+    expect(within(notice).getByText("Dictation stopped and is restarting.")).toBeInTheDocument();
+    // Without a staged update there is no relaunch action.
+    expect(screen.queryByRole("button", { name: "Relaunch June" })).not.toBeInTheDocument();
+
+    // The helper re-arming the hotkey clears the notice.
+    act(() => {
+      mocks.eventHandler?.({
+        payload: JSON.stringify({
+          type: "hotkey_trigger_ready",
+          payload: { shortcut: "Ctrl+Opt+D" },
+        }),
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("alert", { name: "Dictation unavailable" }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("prompts a relaunch to finish updating when the helper is down mid-update", async () => {
+    const user = userEvent.setup();
+    const onRelaunch = vi.fn();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+        updateReadyToRelaunch
+        onRelaunch={onRelaunch}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Shortcuts" }));
+    expect(await screen.findByText("Push to talk")).toBeInTheDocument();
+
+    act(() => {
+      mocks.eventHandler?.({
+        payload: JSON.stringify({
+          type: "helper_unavailable",
+          payload: { reason: "restarting", message: "Dictation stopped and is restarting." },
+        }),
+      });
+    });
+
+    const notice = await screen.findByRole("alert", { name: "Dictation unavailable" });
+    expect(within(notice).getByText("Relaunch to finish updating")).toBeInTheDocument();
+    expect(
+      within(notice).getByText("Dictation is paused until you relaunch to finish updating."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Relaunch June" }));
+    expect(onRelaunch).toHaveBeenCalledTimes(1);
+  });
+
   it("resets customized dictation shortcuts and hides reset for defaults", async () => {
     const user = userEvent.setup();
     mocks.dictationSettings.mockResolvedValue({

--- a/src/test/dictation-events.test.ts
+++ b/src/test/dictation-events.test.ts
@@ -22,6 +22,18 @@ describe("parseDictationHelperEvent", () => {
     );
   });
 
+  it("parses helper_unavailable events with a reason", () => {
+    expect(
+      parseDictationHelperEvent({
+        type: "helper_unavailable",
+        payload: { reason: "restarting", message: "Dictation stopped and is restarting." },
+      }),
+    ).toEqual({
+      type: "helper_unavailable",
+      payload: { reason: "restarting", message: "Dictation stopped and is restarting." },
+    });
+  });
+
   it("ignores malformed payloads and events without a string type", () => {
     expect(parseDictationHelperEvent("{")).toBeUndefined();
     expect(parseDictationHelperEvent({ payload: {} })).toBeUndefined();


### PR DESCRIPTION
## Summary

Closes JUN-184.

The macOS dictation helper was spawned once at startup with no supervision, so any death left dictation fully dead (hotkey, recording, paste) until the app was relaunched, silently. The common trigger is the Tauri updater staging an update: the bundle swap unlinks the running helper's binary and macOS SIGKILLs it under hardened runtime, but a plain crash produces the same dead state.

This adds a supervisor and a UX backstop:

- **Supervisor (`src-tauri/src/dictation.rs`).** The helper's stdout reader thread now hands off to `supervise_helper_exit` when the stream closes (the event stream lives for the whole process lifetime, so stdout EOF means the process exited). It reaps the child, then respawns from a freshly resolved bundle path with exponential backoff and a retry cap. An intentional stop is distinguished via an atomic `shutting_down` flag set by `stop_helper`, so app quit does not trigger a respawn. After a successful respawn it re-applies the microphone and shortcut settings and re-arms the hotkey, mirroring `setup`. A helper that ran healthily (>= 30s) before dying resets the failure counter, so repeated manual kills each recover; a genuine crash loop gives up after 5 rapid attempts and shows the exhausted notice.
- **Decision is a pure function.** The "intentional shutdown vs unexpected exit -> respawn / give up" logic is factored into `decide_respawn(...)`, unit-tested for the intentional-shutdown, unexpected-exit, retry-cap-exhaustion, healthy-reset, and backoff cases.
- **UX backstop (`AppSettings.tsx`).** The helper emits a `helper_unavailable` dictation-event while it is down; the Shortcuts settings pane renders an `InlineNotice` so the hotkey is never silently dead. When an update is staged (threaded from `App.tsx` via `updateReadyToRelaunch` + `onRelaunch`) the copy becomes "Relaunch to finish updating" with a relaunch button; otherwise it shows the restarting/failed message. The notice clears when the helper re-arms the hotkey (`hotkey_trigger_ready`).

## Root cause

The helper is spawned once (`dictation.rs` setup / `spawn_helper`) and never supervised: the only `child.wait()` lived in the app-quit path and the reader threads exited silently on EOF. Because the helper owns the global hotkey `CGEventTap`, any exit (an update's bundle swap SIGKILL, or a crash) took dictation fully offline with no recovery and no user-visible signal until the next relaunch.

## Validation

- `pnpm test:rust` — full src-tauri suite green (330 lib tests incl. 5 new `decide_respawn`/`respawn_backoff` tests; all integration binaries pass).
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — clean.
- `pnpm test` — full FE suite green (1905 passed / 2 skipped), incl. 3 new tests: `dictation-events` parse of `helper_unavailable`, and two `app-settings` tests (restarting notice appears then clears on `hotkey_trigger_ready`; relaunch-to-update variant renders the copy + button and fires `onRelaunch`).
- `pnpm check` (Biome) and `pnpm typecheck` — clean (0 errors; only the repo's pre-existing ratcheted warnings remain, count unchanged).

- [x] Tested visually where it matters. The new notice is asserted at the DOM level (exact copy + relaunch button + callback) by the added `app-settings` tests. A live kill-the-helper walkthrough was **not** captured: the respawn is Rust supervisor + native Swift helper behavior (hardened-runtime SIGKILL, `CGEventTap`) that the web preview / Playwright harness cannot exercise (it uses a fake Tauri IPC and never runs the real helper), and driving it needs a full native `pnpm tauri:dev` build, which is out of reach here. The behavior is covered by the deterministic Rust decision tests plus the FE notice tests instead.
- [ ] Needs a June API (backend) deploy. No — desktop-only change.

## Out of scope

- Spawning the helper from a stable out-of-bundle copy so an update swap never kills it (needs an ADR plus on-device signing/TCC verification — the TCC grant is keyed on the Developer ID signature).
- The accessibility-trust paste gate (merged in #585).
- Transient-auth handling (#589, in review, also touches `dictation.rs` around the auth gate ~1596-1960; this PR owns the spawn/supervision regions ~600, ~1356, ~1862+ — no expected overlap; resolve at merge time if any).

## Followups

- Consider a global (non-settings) indicator for a downed helper, so the notice is visible even when the user is not in Settings > Shortcuts. Today the actionable notice lives in the Shortcuts pane where dictation is configured.
- Out-of-bundle helper copy ADR (see Out of scope).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (Touches helper process lifecycle under hardened runtime; no entitlement/signing/updater config changes.)
- [x] User-facing copy follows the repo UI conventions (sentence case, no em dashes, design tokens, `central-icons`).

<!-- Note: committed with a signed commit. -->

https://claude.ai/code/session_016jdLY1DsSVVAhJKCG8nZmS