### PR TITLE
fix: auto-title agent sessions in sentence case

### DIFF
--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -1632,10 +1632,10 @@ mod tests {
         );
         assert_eq!(
             clean_agent_session_title(
-                "Create a Quarterly Planning Briefing With Follow Up Action Items",
+                "Create a quarterly planning briefing with follow-up action items",
             )
             .as_deref(),
-            Some("Create a Quarterly Planning Briefing With Follow")
+            Some("Create a quarterly planning briefing with follow")
         );
         assert_eq!(clean_agent_session_title("   "), None);
     }

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -866,7 +866,7 @@ pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppErro
         "messages": [
             {
                 "role": "system",
-                "content": "Name this agent session by the work being done, not by repeating the user's request. Return only a concrete 2 to 5 word title. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations."
+                "content": "Name this agent session by the work being done, not by repeating the user's request. Return only a concrete 2 to 5 word title in sentence case: capitalize the first word and proper nouns only, never every word. Avoid first person, words like please/help/you, trailing ellipses, quotes, punctuation wrappers, markdown, or explanations."
             },
             {
                 "role": "user",

--- a/src/lib/hermes-adapter.ts
+++ b/src/lib/hermes-adapter.ts
@@ -244,7 +244,7 @@ export function titleFromPrompt(prompt: string) {
     .split(" ")
     .filter(Boolean)
     .slice(0, 6);
-  const title = titleCaseSessionTitle(words.join(" "));
+  const title = sentenceCaseSessionTitle(words.join(" "));
   if (title.length <= 72) return title || UNTITLED_SESSION_TITLE;
   return `${title.slice(0, 69).trim()}...`;
 }
@@ -283,37 +283,10 @@ function stripRequestPrefix(value: string) {
   return title;
 }
 
-function titleCaseSessionTitle(value: string) {
-  const smallWords = new Set([
-    "a",
-    "an",
-    "and",
-    "as",
-    "at",
-    "but",
-    "by",
-    "for",
-    "from",
-    "in",
-    "into",
-    "of",
-    "on",
-    "or",
-    "the",
-    "to",
-    "with",
-  ]);
-  return value
-    .split(" ")
-    .map((word, index) => {
-      if (!word) return word;
-      if (/[A-Z]/.test(word) && word === word.toUpperCase()) return word;
-      const lower = word.toLowerCase();
-      if (index > 0 && smallWords.has(lower)) return lower;
-      return lower.replace(/^([a-z])/, (match) => match.toUpperCase());
-    })
-    .join(" ")
-    .trim();
+// Sentence case per spec/sentence-case.md: capitalize the first word and keep
+// the user's own casing elsewhere (acronyms and proper nouns survive as typed).
+function sentenceCaseSessionTitle(value: string) {
+  return value.trim().replace(/^([a-z])/, (match) => match.toUpperCase());
 }
 
 function extractList(response: unknown, preferredKey: "sessions" | "messages") {

--- a/src/test/hermes-adapter.test.ts
+++ b/src/test/hermes-adapter.test.ts
@@ -53,7 +53,7 @@ describe("scheduled-run helpers", () => {
     });
     const session = sessions[0];
     expect(isScheduledRunSession(session as HermesSessionInfo)).toBe(true);
-    expect(session?.title).toBe("Summarize Github Activity for the Team");
+    expect(session?.title).toBe("Summarize GitHub activity for the team");
     expect(session?.title).not.toContain("IMPORTANT");
     expect(session?.preview?.startsWith("Summarize GitHub activity")).toBe(true);
   });
@@ -70,7 +70,7 @@ describe("scheduled-run helpers", () => {
         },
       ],
     });
-    expect(sessions[0]?.title).toBe("Post the Weekly Metrics Digest");
+    expect(sessions[0]?.title).toBe("Post the weekly metrics digest");
   });
 
   it("derives the title when the cron session still has the placeholder title", () => {
@@ -85,7 +85,7 @@ describe("scheduled-run helpers", () => {
         },
       ],
     });
-    expect(sessions[0]?.title).toBe("Prepare the Morning Brief for Today");
+    expect(sessions[0]?.title).toBe("Prepare the morning brief for today");
   });
 
   it("extracts the routine job id from a cron run session id", () => {
@@ -393,16 +393,16 @@ describe("Hermes adapter", () => {
         last_active: 1_780_603_200 as unknown as string,
       }),
     ).toBe("2026-06-04T20:00:00.000Z");
-    expect(titleFromPrompt("  Write   a note  ")).toBe("Write a Note");
+    expect(titleFromPrompt("  Write   a note  ")).toBe("Write a note");
     expect(titleFromPrompt("I want you to keep this running in my CLI")).toBe(
-      "Keep This Running in My CLI",
+      "Keep this running in my CLI",
     );
-    expect(titleFromPrompt("Help me to organize files")).toBe("Organize Files");
+    expect(titleFromPrompt("Help me to organize files")).toBe("Organize files");
     expect(
       titleFromPrompt(
         "please summarize the key points from today's standup\n\n--- Attached Context ---\n{}",
       ),
-    ).toBe("Summarize the Key Points from Today's");
+    ).toBe("Summarize the key points from today's");
     expect(titleFromPrompt("")).toBe("Untitled session");
   });
 });


### PR DESCRIPTION
## Summary

Auto-titled agent sessions now use sentence case (per spec/sentence-case.md) instead of title case. The LLM prompt now explicitly requests sentence case; the fallback replaces `titleCaseSessionTitle` with a simpler `sentenceCaseSessionTitle` that uppercases only the first letter, preserving acronyms and proper nouns as the user typed them.

## Validation

- [x] Frontend tests pass (`pnpm test`): 19/19 passing in hermes-adapter.test.ts
- [x] Type checking passes (`pnpm typecheck`)
- [x] Rust backend tests pass (`cargo test --lib june_api`): 27/27 passing
- [x] Linting passes (`pnpm check`, `cargo fmt --check`)

## Out of scope

Existing sessions retain their stored Title Case titles; this only affects titles generated from now on.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] User-facing copy follows the repo UI conventions.