### PR TITLE
Use GLM 5.2 for dictation cleanup

### DIFF
--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -19,7 +19,11 @@ use std::{
 // docker-compose.production.yml). NOT .network — that hostname has no DNS
 // record, and the v0.0.3 DMG shipped pointing at it.
 const DEFAULT_JUNE_API_URL: &str = "https://june-api.opensoftware.co";
-const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "nvidia-nemotron-3-nano-30b-a3b";
+// GLM 5.2 over Nemotron Nano: benchmarked ~2-4s vs ~0.8s per utterance, but it
+// reliably keeps unnumbered items as prose and expands contractions in the
+// formal style, which the nano model skips. Slow outliers degrade gracefully:
+// past DICTATION_CLEANUP_TIMEOUT_MS the raw transcript is inserted as-is.
+const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "zai-org-glm-5-2";
 const HTTP_TIMEOUT: Duration = Duration::from_secs(600);
 const AGENT_HTTP_TIMEOUT: Duration = Duration::from_secs(600);
 const AGENT_PROXY_MAX_MESSAGES: usize = 64;


### PR DESCRIPTION
Switches the pinned dictation cleanup model from Nemotron Nano 30B to GLM 5.2.

Benchmark on the cleanup eval suite (same prompt, temperature 0, six cases: punctuated backtrack, word-number list, unnumbered prose, hedge-heavy ramble, formal contractions, technical tokens):

| Model | Latency | Result |
|---|---|---|
| Nemotron Nano | 0.6-1.1s | Listifies unnumbered "make a list with" items; skips formal contraction expansion |
| GLM 5.2 | 1.8-12.2s (typ. 2-4s) | All six cases correct |

Latency cost is accepted for correctness; a slow outlier degrades gracefully because the client falls back to the raw transcript at the existing 15s cleanup timeout. GLM 5.2 maps to the Venice provider, so the bring-your-own-Venice-key path is unchanged.

`cargo test --lib` green (351 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)