### PR TITLE
Hero presets: stage-only clicks, note-native suggestions, hide chips while drafting

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -233,7 +233,11 @@ import {
 } from "../../lib/agent-composer-slash-commands";
 import { generateChatImage } from "../../lib/chat-image-generation";
 import { IMAGE_GENERATION_ENABLED } from "../../lib/feature-flags";
-import { ComposerEditor, type ComposerEditorHandle } from "./composer/ComposerEditor";
+import {
+  ComposerEditor,
+  type ComposerEditorHandle,
+  stripPlaceholder,
+} from "./composer/ComposerEditor";
 import { CategoryIcon } from "./composer/CategoryIcon";
 import { FileTypeIcon, fileTypeIconComponent } from "./FileTypeIcon";
 import {
@@ -523,8 +527,10 @@ type AgentShortcut = {
   description: string;
   prompt: string;
   /**
-   * "prefill" drops the prompt into the composer for the user to finish
-   * (selecting the <placeholder> if there is one); "attach" prefills and
+   * "prefill" drops the prompt into the composer for the user to finish; the
+   * first `<placeholder>` token arrives as its bare phrase, selected for
+   * overtyping — the angle brackets are authoring syntax and never reach the
+   * composer. "attach" prefills and
    * opens the file picker. There is deliberately no action that submits on
    * click: every preset lands in the composer first, so the person sees
    * exactly what will run — and approves the spend — before it costs tokens.
@@ -564,7 +570,7 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     title: "Research a topic",
     description: "Get a short, sourced write-up on anything.",
     prompt:
-      "Research <topic> and write a short summary (a few paragraphs) of what you find, with sources.",
+      "Research <a topic> and write a short summary (a few paragraphs) of what you find, with sources.",
     action: "prefill",
   },
   {
@@ -5309,7 +5315,11 @@ export function AgentWorkspace({
     composerEditorRef.current?.setContent(shortcut.prompt, null, {
       selectPlaceholder: true,
     });
-    rememberComposerDraft(composerDraftKeyRef.current, shortcut.prompt, null);
+    rememberComposerDraft(
+      composerDraftKeyRef.current,
+      stripPlaceholder(shortcut.prompt)?.text ?? shortcut.prompt,
+      null,
+    );
   }
 
   async function cancelTask(taskId: string) {
@@ -6853,9 +6863,15 @@ export function AgentWorkspace({
           {composer}
           {activePanel === "chat" ? (
             <div className="agent-hero-suggestions">
+              {/* The chips bow out while the composer holds a draft: staging a
+                  chip runs setContent, which replaces the whole composer
+                  document, so a click here would clobber what the person
+                  typed. Once they're typing, the suggestions have done their
+                  job. They return when the field is cleared. */}
               <div
                 className="agent-hero-chips"
                 data-phase={heroChipPhase}
+                data-hidden={draft.trim() ? "true" : undefined}
                 onMouseEnter={() => {
                   heroChipsHoverRef.current = true;
                 }}

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -37,14 +37,15 @@ import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal
 import { IconFiles } from "central-icons/IconFiles";
 import { IconFileSparkle } from "central-icons/IconFileSparkle";
 import { IconFileText } from "central-icons/IconFileText";
+import { IconEmail1Sparkle } from "central-icons/IconEmail1Sparkle";
 import { IconGauge } from "central-icons/IconGauge";
 import { IconGhost2 } from "central-icons/IconGhost2";
 import { IconHeartBeat } from "central-icons/IconHeartBeat";
-import { IconHistory } from "central-icons/IconHistory";
-import { IconListBullets } from "central-icons/IconListBullets";
 import { IconLock } from "central-icons/IconLock";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophone } from "central-icons/IconMicrophone";
+import { IconNotes } from "central-icons/IconNotes";
+import { IconPageTextSearch } from "central-icons/IconPageTextSearch";
 import { IconPencil } from "central-icons/IconPencil";
 import { IconPencilLine } from "central-icons/IconPencilLine";
 import { IconPieChart1 } from "central-icons/IconPieChart1";
@@ -535,9 +536,11 @@ type AgentShortcut = {
  * Suggestion pool for the new-session hero. Shown HERO_SHORTCUT_COUNT at a
  * time and reshuffled on each visit, so the entry point stays a handful of
  * fresh ideas instead of a wall of ten cards. Pool order matters: the leading
- * window is the curated first-impression mix (a ready-to-send prompt, a
- * placeholder prefill, an attach flow, and a health check) that shows when
- * the shuffle is identity (e.g. in tests with Math.random mocked to 0).
+ * window is the curated first-impression mix (a note-native ready-to-send
+ * prompt, a placeholder prefill, an attach flow) that shows when the shuffle
+ * is identity (e.g. in tests with Math.random mocked to 0). At least one
+ * chip in that window should be something only June can do — recapping your
+ * own notes — not a generic computer chore.
  *
  * Every suggestion must succeed inside the default write-jail: reads are
  * broad, but writes land only in the agent workspace. Don't add shortcuts
@@ -547,12 +550,12 @@ type AgentShortcut = {
  */
 const AGENT_SHORTCUTS: AgentShortcut[] = [
   {
-    key: "recent-files",
-    icon: <IconHistory size={18} />,
-    title: "Catch up on recent files",
-    description: "A quick rundown of what's new across your folders.",
+    key: "recap-notes",
+    icon: <IconNotes size={18} />,
+    title: "Recap my notes",
+    description: "What happened, what got decided, what's still open.",
     prompt:
-      "Look through my Desktop, Documents, and Downloads folders for files added or changed in the last week and give me a quick rundown of what's new, grouped by what they seem to be for. Don't move or change anything.",
+      "Look through my recent meeting notes and give me a quick recap: what happened, what got decided, and any action items still open. Keep it brief.",
     action: "prefill",
   },
   {
@@ -560,7 +563,8 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     icon: <IconDeepSearch size={18} />,
     title: "Research a topic",
     description: "Get a short, sourced write-up on anything.",
-    prompt: "Research <topic> and write a short summary of what you find, with sources.",
+    prompt:
+      "Research <topic> and write a short summary (a few paragraphs) of what you find, with sources.",
     action: "prefill",
   },
   {
@@ -574,10 +578,19 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
   {
     key: "health-check",
     icon: <IconHeartBeat size={18} />,
-    title: "Check my computer's health",
+    title: "Check my Mac's health",
     description: "Disk, memory, and login items that need attention.",
     prompt:
       "Give my computer a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
+    action: "prefill",
+  },
+  {
+    key: "draft-follow-up",
+    icon: <IconEmail1Sparkle size={18} />,
+    title: "Draft a follow-up",
+    description: "Turn your latest meeting note into a follow-up message.",
+    prompt:
+      "From my most recent meeting note, draft a short follow-up message covering the decisions and next steps.",
     action: "prefill",
   },
   {
@@ -585,7 +598,8 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     icon: <IconMagnifyingGlass size={18} />,
     title: "Find a file",
     description: "Describe what you remember; June tracks it down.",
-    prompt: "Find <a file I half-remember> on my computer and tell me where it is.",
+    prompt:
+      "Find <a file I half-remember> on my computer and tell me where it is. If several candidates match, list them with paths and dates.",
     action: "prefill",
   },
   {
@@ -598,20 +612,12 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     action: "attach",
   },
   {
-    key: "extract-text",
-    icon: <IconFileText size={18} />,
-    title: "Extract text from a file",
-    description: "Pull clean text out of a PDF, image, or scan.",
-    prompt: "Extract all the text from the attached file and clean it up into tidy Markdown.",
-    action: "attach",
-  },
-  {
-    key: "plan-project",
-    icon: <IconListBullets size={18} />,
-    title: "Plan a project",
-    description: "Turn a vague goal into concrete first steps.",
+    key: "search-notes",
+    icon: <IconPageTextSearch size={18} />,
+    title: "Search my notes",
+    description: "Find where something came up across your meetings.",
     prompt:
-      "Help me plan <a project>: break it into concrete steps, flag the risks, and suggest what to tackle first.",
+      "Search my notes and transcripts for <what I'm trying to remember> and show me where it came up.",
     action: "prefill",
   },
 ];

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -522,20 +522,22 @@ type AgentShortcut = {
   description: string;
   prompt: string;
   /**
-   * "run" submits the prompt immediately; "prefill" drops it into the
-   * composer for the user to finish (selecting the <placeholder> if there is
-   * one); "attach" prefills and opens the file picker.
+   * "prefill" drops the prompt into the composer for the user to finish
+   * (selecting the <placeholder> if there is one); "attach" prefills and
+   * opens the file picker. There is deliberately no action that submits on
+   * click: every preset lands in the composer first, so the person sees
+   * exactly what will run — and approves the spend — before it costs tokens.
    */
-  action: "run" | "prefill" | "attach";
+  action: "prefill" | "attach";
 };
 
 /**
  * Suggestion pool for the new-session hero. Shown HERO_SHORTCUT_COUNT at a
  * time and reshuffled on each visit, so the entry point stays a handful of
  * fresh ideas instead of a wall of ten cards. Pool order matters: the leading
- * window is the curated first-impression mix (an instant run, a prefill, an
- * attach flow, and a health check) that shows when the shuffle is identity
- * (e.g. in tests with Math.random mocked to 0).
+ * window is the curated first-impression mix (a ready-to-send prompt, a
+ * placeholder prefill, an attach flow, and a health check) that shows when
+ * the shuffle is identity (e.g. in tests with Math.random mocked to 0).
  *
  * Every suggestion must succeed inside the default write-jail: reads are
  * broad, but writes land only in the agent workspace. Don't add shortcuts
@@ -551,7 +553,7 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     description: "A quick rundown of what's new across your folders.",
     prompt:
       "Look through my Desktop, Documents, and Downloads folders for files added or changed in the last week and give me a quick rundown of what's new, grouped by what they seem to be for. Don't move or change anything.",
-    action: "run",
+    action: "prefill",
   },
   {
     key: "research",
@@ -576,7 +578,7 @@ const AGENT_SHORTCUTS: AgentShortcut[] = [
     description: "Disk, memory, and login items that need attention.",
     prompt:
       "Give my computer a quick health check: free disk space, memory pressure, login items, and anything else worth flagging. Summarize what looks fine and what needs attention.",
-    action: "run",
+    action: "prefill",
   },
   {
     key: "find-file",
@@ -3336,9 +3338,9 @@ export function AgentWorkspace({
       ? reviewableIssueReportsRef.current[reportFollowUpSessionId]
       : undefined;
     const submittedDraftKey = composerDraftKeyRef.current;
-    // A typed hero submit plays the same teardown as a run shortcut: greeting
-    // up, suggestions down during the session-create latency. Without it they
-    // sit frozen through the wait and then vanish in a single frame when the
+    // A hero submit plays the teardown transition: greeting up, suggestions
+    // down during the session-create latency. Without it they sit frozen
+    // through the wait and then vanish in a single frame when the
     // conversation takes over.
     if (heroMode) setHeroLeaving(true);
     setSubmitting(true);
@@ -5286,46 +5288,10 @@ export function AgentWorkspace({
     }
   }
 
-  // Run shortcuts fire the session directly — the prompt never touches the
-  // composer, so there's no flash of text + send button before the submit.
-  // The hero plays its exit transition during the session-create latency.
-  async function launchShortcutSession(prompt: string) {
-    if (submitting || importingFiles) return;
-    setHeroLeaving(true);
-    dispatchAgentSessionStatus({
-      prompt,
-      title: titleFromPrompt(prompt),
-      status: "starting",
-      summary: "Starting June.",
-    });
-    setSubmitting(true);
-    try {
-      await submitHermesSession(prompt);
-      setError(null);
-    } catch (err) {
-      // Bring the hero back and park the prompt in the composer so the user
-      // can see what would have run and retry it.
-      if (composerEditorRef.current?.isEmpty() ?? true) {
-        composerEditorRef.current?.setContent(prompt);
-      }
-      setError(messageFromError(err));
-      dispatchAgentSessionStatus({
-        prompt,
-        title: titleFromPrompt(prompt),
-        status: "failed",
-        summary: messageFromError(err),
-      });
-    } finally {
-      setSubmitting(false);
-      setHeroLeaving(false);
-    }
-  }
-
+  // Shortcuts never submit on click — they stage the prompt in the composer
+  // so the person reads what will run and sends it themselves. The click is
+  // free; only the explicit send spends tokens.
   function runShortcut(shortcut: AgentShortcut) {
-    if (shortcut.action === "run") {
-      void launchShortcutSession(shortcut.prompt);
-      return;
-    }
     if (shortcut.action === "attach") {
       rememberComposerDraft(composerDraftKeyRef.current, shortcut.prompt, null);
       composerEditorRef.current?.setContent(shortcut.prompt);

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -20,7 +20,8 @@ export type ComposerEditorHandle = {
   /** Replaces the whole document with plain text plus an optional leading
    * category chip. Used to prefill (hero shortcuts, HUD replies) and to restore
    * the composer after a failed send. With `selectPlaceholder`, the first
-   * `<placeholder>` token is selected so the user can overtype it in place. */
+   * `<placeholder>` token's brackets are stripped and the bare phrase left
+   * selected so the user can overtype it in place. */
   setContent: (
     text: string,
     category?: ReportCategory | null,
@@ -61,15 +62,21 @@ function focusEnd(editor: Editor | null) {
   editor.view.focus();
 }
 
-/** Maps the first `<placeholder>` token in a prefilled single-paragraph prompt
- * to its ProseMirror selection range, so a hero shortcut can highlight it. The
- * paragraph's opening boundary occupies position 0, so a string index `i` maps
- * to document position `i + 1`; the range spans `<` through `>` inclusive. */
-export function placeholderSelection(text: string): { from: number; to: number } | null {
+/** Prepares a prefilled single-paragraph prompt for staging: strips the angle
+ * brackets off the first `<placeholder>` token (authoring syntax that should
+ * never reach the user's eyes) and maps the bare phrase to its ProseMirror
+ * selection range so a hero shortcut can highlight it for overtyping. The
+ * paragraph's opening boundary occupies position 0, so a string index `i`
+ * maps to document position `i + 1`. Null when there is no placeholder. */
+export function stripPlaceholder(text: string): { text: string; from: number; to: number } | null {
   const start = text.indexOf("<");
   const end = text.indexOf(">");
   if (start < 0 || end <= start) return null;
-  return { from: start + 1, to: end + 2 };
+  return {
+    text: text.slice(0, start) + text.slice(start + 1, end) + text.slice(end + 1),
+    from: start + 1,
+    to: end,
+  };
 }
 
 function buildDoc(text: string, category?: ReportCategory | null) {
@@ -218,12 +225,15 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         clear: () => editor?.commands.clearContent(true),
         setContent: (text, category, options) => {
           if (!editor) return;
-          editor.commands.setContent(buildDoc(text, category), {
+          const staged = options?.selectPlaceholder && !category ? stripPlaceholder(text) : null;
+          editor.commands.setContent(buildDoc(staged?.text ?? text, category), {
             emitUpdate: true,
           });
-          // A hero shortcut prefills a "<placeholder>" token; select it (rather
-          // than parking the caret at the end) so typing overtypes it in place.
-          const range = options?.selectPlaceholder && !category ? placeholderSelection(text) : null;
+          // A hero shortcut authors a "<placeholder>" token; the brackets are
+          // stripped before the text hits the document and the bare phrase left
+          // selected (rather than parking the caret at the end) so typing
+          // overtypes it in place.
+          const range = staged ? { from: staged.from, to: staged.to } : null;
           const shouldFocus = options?.focus !== false;
           if (range) {
             editor.commands.setTextSelection(range);

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -18,7 +18,7 @@ export type ComposerEditorHandle = {
   focus: () => void;
   clear: () => void;
   /** Replaces the whole document with plain text plus an optional leading
-   * category chip. Used to prefill (run shortcuts, HUD replies) and to restore
+   * category chip. Used to prefill (hero shortcuts, HUD replies) and to restore
    * the composer after a failed send. With `selectPlaceholder`, the first
    * `<placeholder>` token is selected so the user can overtype it in place. */
   setContent: (
@@ -62,7 +62,7 @@ function focusEnd(editor: Editor | null) {
 }
 
 /** Maps the first `<placeholder>` token in a prefilled single-paragraph prompt
- * to its ProseMirror selection range, so a run shortcut can highlight it. The
+ * to its ProseMirror selection range, so a hero shortcut can highlight it. The
  * paragraph's opening boundary occupies position 0, so a string index `i` maps
  * to document position `i + 1`; the range spans `<` through `>` inclusive. */
 export function placeholderSelection(text: string): { from: number; to: number } | null {
@@ -221,7 +221,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           editor.commands.setContent(buildDoc(text, category), {
             emitUpdate: true,
           });
-          // A run shortcut prefills a "<placeholder>" token; select it (rather
+          // A hero shortcut prefills a "<placeholder>" token; select it (rather
           // than parking the caret at the end) so typing overtypes it in place.
           const range = options?.selectPlaceholder && !category ? placeholderSelection(text) : null;
           const shouldFocus = options?.focus !== false;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5431,6 +5431,27 @@ input:focus-visible,
   transition-delay: 0s, 0s, calc(var(--chip-i, 0) * 90ms), calc(var(--chip-i, 0) * 90ms);
 }
 
+/* Composer holds a draft: the chips bow out. The suggestions have done
+ * their job once the person is typing, and a click here would stage over
+ * (replace) what they typed — see runShortcut. Same wave as the rotation's
+ * exit; visibility flips after the fade so the invisible buttons also
+ * leave the tab order and the accessibility tree. Coming back (field
+ * cleared), the base transition runs and visibility snaps on instantly. */
+.agent-hero-chips[data-hidden="true"] .agent-hero-chip {
+  opacity: 0;
+  transform: translateY(4px);
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    border-color var(--t-fast) var(--ease-out),
+    opacity 300ms var(--ease-in-out),
+    transform 300ms var(--ease-in-out),
+    visibility 0s linear;
+  transition-delay: 0s, 0s, calc(var(--chip-i, 0) * 90ms),
+    calc(var(--chip-i, 0) * 90ms), calc(var(--chip-i, 0) * 90ms + 300ms);
+}
+
 .agent-hero-chip:hover:not(:disabled) {
   /* Soft dusty wash in the brand family (not neutral grey) so the backdrop
      echoes the accent the chip's icon already carries. */

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5448,8 +5448,9 @@ input:focus-visible,
     opacity 300ms var(--ease-in-out),
     transform 300ms var(--ease-in-out),
     visibility 0s linear;
-  transition-delay: 0s, 0s, calc(var(--chip-i, 0) * 90ms),
-    calc(var(--chip-i, 0) * 90ms), calc(var(--chip-i, 0) * 90ms + 300ms);
+  transition-delay:
+    0s, 0s, calc(var(--chip-i, 0) * 90ms), calc(var(--chip-i, 0) * 90ms),
+    calc(var(--chip-i, 0) * 90ms + 300ms);
 }
 
 .agent-hero-chip:hover:not(:disabled) {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6200,6 +6200,11 @@ describe("AgentWorkspace", () => {
       );
       expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
 
+      // Staging a prompt counts as "composer has content": the chip row bows
+      // out so a second click can't stage over the draft.
+      const chips = document.querySelector(".agent-hero-chips");
+      expect(chips).toHaveAttribute("data-hidden", "true");
+
       await user.click(screen.getByRole("button", { name: "Start session" }));
 
       await waitFor(() =>
@@ -6393,7 +6398,11 @@ describe("AgentWorkspace", () => {
       await user.click(await screen.findByRole("button", { name: /Research a topic/ }));
 
       const composer = screen.getByRole("textbox");
-      await waitFor(() => expect(composer.textContent ?? "").toContain("Research <topic>"));
+      await waitFor(() =>
+        expect(composer.textContent ?? "").toContain("Research a topic and write a short summary"),
+      );
+      // The <placeholder> brackets are authoring syntax; they must never render.
+      expect(composer.textContent ?? "").not.toContain("<");
       expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
     } finally {
       randomSpy.mockRestore();

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6185,18 +6185,18 @@ describe("AgentWorkspace", () => {
       JSON.stringify({ createdAt: Date.now() }),
     );
     // rand() of 0 keeps the rotating hero suggestions in curated pool order,
-    // so the leading window (incl. "Catch up on recent files") is what renders.
+    // so the leading window (incl. "Recap my notes") is what renders.
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
     try {
       render(<AgentWorkspace />);
       const user = userEvent.setup();
 
-      await user.click(await screen.findByRole("button", { name: /Catch up on recent files/ }));
+      await user.click(await screen.findByRole("button", { name: /Recap my notes/ }));
 
       // The click only stages the prompt: nothing may be submitted (and no
       // tokens spent) until the person sends it themselves.
       await waitFor(() =>
-        expect(screen.getByRole("textbox")).toHaveTextContent(/changed in the last week/),
+        expect(screen.getByRole("textbox")).toHaveTextContent(/action items still open/),
       );
       expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
 
@@ -6206,7 +6206,7 @@ describe("AgentWorkspace", () => {
         expect(mocks.gatewayRequest).toHaveBeenCalledWith(
           "prompt.submit",
           expect.objectContaining({
-            text: expect.stringContaining("changed in the last week"),
+            text: expect.stringContaining("action items still open"),
           }),
         ),
       );

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -6179,7 +6179,7 @@ describe("AgentWorkspace", () => {
     }
   });
 
-  it("launches a session immediately from a run shortcut", async () => {
+  it("prefills the composer from a hero shortcut instead of auto-submitting", async () => {
     window.sessionStorage.setItem(
       AGENT_NEW_SESSION_PENDING_KEY,
       JSON.stringify({ createdAt: Date.now() }),
@@ -6192,6 +6192,15 @@ describe("AgentWorkspace", () => {
       const user = userEvent.setup();
 
       await user.click(await screen.findByRole("button", { name: /Catch up on recent files/ }));
+
+      // The click only stages the prompt: nothing may be submitted (and no
+      // tokens spent) until the person sends it themselves.
+      await waitFor(() =>
+        expect(screen.getByRole("textbox")).toHaveTextContent(/changed in the last week/),
+      );
+      expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("prompt.submit", expect.anything());
+
+      await user.click(screen.getByRole("button", { name: "Start session" }));
 
       await waitFor(() =>
         expect(mocks.gatewayRequest).toHaveBeenCalledWith(

--- a/src/test/category-chip.test.ts
+++ b/src/test/category-chip.test.ts
@@ -8,10 +8,7 @@ import {
   categoryFromDoc,
   insertReportCategory,
 } from "../components/agent/composer/categoryChip";
-import {
-  placeholderSelection,
-  serializePlainText,
-} from "../components/agent/composer/ComposerEditor";
+import { serializePlainText, stripPlaceholder } from "../components/agent/composer/ComposerEditor";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 
 let editor: Editor | null = null;
@@ -60,20 +57,17 @@ describe("category chip insertion", () => {
   });
 });
 
-describe("run-shortcut placeholder selection", () => {
-  it("maps the <placeholder> token to its document range", () => {
-    // "Research <topic>" — the doc range must span "<topic>" inclusive so a run
-    // shortcut highlights it for the user to overtype.
-    const prompt = "Research <topic>";
-    const range = placeholderSelection(prompt);
-    expect(range).toEqual({ from: 10, to: 17 });
-    // The selected slice (positions shifted back by the paragraph boundary) is
-    // exactly the placeholder token.
-    expect(prompt.slice(range!.from - 1, range!.to - 1)).toBe("<topic>");
+describe("hero-shortcut placeholder staging", () => {
+  it("strips the brackets and maps the bare phrase to its document range", () => {
+    const staged = stripPlaceholder("Research <a topic> and summarize it");
+    expect(staged?.text).toBe("Research a topic and summarize it");
+    // The selected slice (positions shifted back by the paragraph boundary)
+    // is exactly the bare phrase, no brackets.
+    expect(staged!.text.slice(staged!.from - 1, staged!.to - 1)).toBe("a topic");
   });
 
-  it("returns null when there is no placeholder to select", () => {
-    expect(placeholderSelection("Summarize my notes")).toBeNull();
-    expect(placeholderSelection("a > b but no opener")).toBeNull();
+  it("returns null when there is no placeholder", () => {
+    expect(stripPlaceholder("Summarize my notes")).toBeNull();
+    expect(stripPlaceholder("a > b but no opener")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Reworks the new-session hero presets around one principle: a preset click is free, and the composer is the approval surface.

- **No preset auto-submits.** The `"run"` action is gone; every preset stages its prompt in the composer, so the person reads exactly what will run — and approves the spend — before it costs tokens. On submit failure the prompt parks back in the composer for retry.
- **Note-native suggestion pool.** Swapped three generic computer chores for things only June can do: "Recap my notes", "Draft a follow-up" (from the latest meeting note), and "Search my notes". The curated first-impression window is now a note-native ready-to-send prompt, a placeholder prefill, and an attach flow.
- **Chips hide while the composer holds a draft.** Staging replaces the whole composer document, so a visible chip next to a typed draft was effectively a destroy-my-draft button; and once someone is typing, the suggestions have done their job. The row fades with the same wave as the idle rotation (visibility flips after the fade so hidden chips leave the tab order and the accessibility tree) and returns when the field is cleared. The privacy footnote stays put.
- **Placeholder brackets never render.** `<placeholder>` tokens in preset prompts are authoring syntax only: staging strips the brackets and selects the bare phrase, so the composer shows "Research a topic …" with "a topic" highlighted for overtyping instead of literal `<topic>`. Phrases are worded to read naturally even if sent unfilled — June just asks for the missing detail.

## Validation

- `agent-workspace` + `category-chip` vitest suites green (154 passed, 2 skipped); tests cover: no submit until explicit send, chips flagged hidden once a prompt is staged, staged text contains no angle brackets, and the strip/selection range math.
- `pnpm typecheck` and `pnpm check` (Biome) clean on touched files.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- Andrew verifies in-app -->
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Attachments without text do not hide the chips (only a text draft does); a prefill click does not clear previously attached files.
- The idle chip-rotation cadence and hover-pause behavior are unchanged.
- No changes to the docked (non-hero) composer or HUD reply prefill paths beyond the shared bracket-stripping in `setContent`.

## Followups

- None planned.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)