### PR TITLE
Fix chat turn-actions overlap, tooltip flip jump, and wrapped tooltip width

### DIFF
--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -41,11 +41,26 @@ type TipCoords = {
 function widestLineWidth(element: HTMLElement): number {
   const range = document.createRange();
   range.selectNodeContents(element);
+  // One rect per inline fragment, not per visual line: inline markup (a
+  // <strong>, a link) splits a single line into adjacent rects. Rebuild each
+  // line by grouping fragments that overlap vertically (rects arrive in
+  // document order) and read its width as the group's horizontal span.
   const rects = range.getClientRects();
   let widest = 0;
+  let line: { bottom: number; left: number; right: number } | null = null;
   for (let index = 0; index < rects.length; index += 1) {
-    widest = Math.max(widest, rects[index].width);
+    const rect = rects[index];
+    if (rect.width === 0) continue;
+    if (line && (rect.top + rect.bottom) / 2 < line.bottom) {
+      line.left = Math.min(line.left, rect.left);
+      line.right = Math.max(line.right, rect.right);
+      line.bottom = Math.max(line.bottom, rect.bottom);
+    } else {
+      if (line) widest = Math.max(widest, line.right - line.left);
+      line = { bottom: rect.bottom, left: rect.left, right: rect.right };
+    }
   }
+  if (line) widest = Math.max(widest, line.right - line.left);
   return widest;
 }
 

--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -66,12 +66,9 @@ function widestLineWidth(element: HTMLElement): number {
 
 // The anchor geometry captured at open time. The side is decided later, in the
 // measure pass, from the tip's real height — but once decided for a mounted
-// tip it stays put (see `side` below) so a re-hover never teleports the visible
-// card from bottom to top. `top`/`bottom` are the two candidate gap edges.
+// tip it stays put (see `sideRef`) so neither a re-hover nor a content swap
+// teleports the visible card. `top`/`bottom` are the two candidate gap edges.
 type TipAnchor = {
-  // The already-committed side for a still-mounted tip. Undefined on a fresh
-  // open, which lets the measure pass pick the side from the measured height.
-  side?: "top" | "bottom";
   centerX: number;
   // Y of the tip's leading edge for each side: below the anchor, or above it.
   bottom: number;
@@ -127,6 +124,11 @@ export function HoverTip({
   const tipRef = useRef<HTMLSpanElement | null>(null);
   const hoverTimerRef = useRef<number | null>(null);
   const closeTimerRef = useRef<number | null>(null);
+  // The side committed by the first measure pass, held for the tip's whole
+  // mounted lifetime: a re-hover or a content swap (e.g. "Copy message" →
+  // "Copied") re-measures, and re-deciding the side then would visibly
+  // teleport the open card. Cleared on unmount so a fresh open decides anew.
+  const sideRef = useRef<"top" | "bottom" | undefined>(undefined);
   const tooltipId = useId();
   // The anchor geometry captured at open; drives the measure pass.
   const [anchor, setAnchor] = useState<TipAnchor>();
@@ -154,6 +156,7 @@ export function HoverTip({
 
   const unmount = useCallback(() => {
     cancelClose();
+    sideRef.current = undefined;
     setAnchor(undefined);
     setCoords(undefined);
     setPhase(undefined);
@@ -163,17 +166,12 @@ export function HoverTip({
     cancelClose();
     const rect = anchorRef.current?.getBoundingClientRect();
     if (!rect) return;
-    setAnchor((current) => ({
-      // A re-hover while the tip is still mounted (open or mid-fade) keeps the
-      // side it already committed to: recomputing it here is what made the
-      // visible card teleport bottom→top. Only a fresh open (no current
-      // anchor) leaves `side` undefined so the measure pass can decide it.
-      side: current?.side ?? coords?.side,
+    setAnchor({
       centerX: rect.left + rect.width / 2,
       bottom: rect.bottom + TIP_GAP,
       top: rect.top - TIP_GAP,
       spaceBelow: window.innerHeight - rect.bottom,
-    }));
+    });
     // A re-entry mid-fade reuses the mounted node: re-assert the open phase so
     // the render before the measure effect lands shows "open", not a stale
     // mid-fade "closing" frame.
@@ -203,19 +201,26 @@ export function HoverTip({
   useLayoutEffect(() => {
     if (!anchor) return;
     const node = tipRef.current;
+    // Measure at the natural (max-width-capped) size, not the previously
+    // tightened one: a content swap while open re-runs this pass, and keeping
+    // the old applied width would stop a longer label from growing back.
+    // Restored below before React re-applies the freshly computed width.
+    const appliedWidth = node?.style.width ?? "";
+    if (node) node.style.width = "";
     const rect = node?.getBoundingClientRect();
     const tipHeight = rect?.height ?? 0;
 
     // Decide the side from the tip's real height once, on a fresh open. If the
     // tip fits below (its height plus the gap and a viewport margin), keep it
-    // below; otherwise flip above. A committed side (`anchor.side`) is honored
-    // so a re-hover on a mounted tip never flips the visible card. Before any
+    // below; otherwise flip above. A committed side (`sideRef`) is honored so
+    // neither a re-hover nor a content swap flips the visible card. Before any
     // real measurement (jsdom), fall back to the fixed threshold.
     const fitsBelow =
       tipHeight > 0
         ? anchor.spaceBelow >= tipHeight + TIP_GAP + VIEWPORT_MARGIN
         : anchor.spaceBelow >= MIN_SPACE_BELOW;
-    const side = anchor.side ?? (fitsBelow ? "bottom" : "top");
+    const side = sideRef.current ?? (fitsBelow ? "bottom" : "top");
+    sideRef.current = side;
 
     // Tighten the width to the widest wrapped line (plus horizontal padding) so
     // a two-line tip hugs its text instead of keeping the full cap. `text-wrap:
@@ -238,6 +243,11 @@ export function HoverTip({
         }
       }
     }
+
+    // Hand the width the DOM had back to React before the commit below: if the
+    // computed width comes out unchanged, React skips the style write and the
+    // cleared inline width would otherwise leak into the painted frame.
+    if (node) node.style.width = appliedWidth;
 
     // Clamp the centered box to the viewport using the final (tightened) width.
     const boxWidth = width ?? rect?.width ?? 0;
@@ -298,7 +308,7 @@ export function HoverTip({
               id={tooltipId}
               className={compact ? "hover-tip hover-tip-compact" : "hover-tip"}
               role="tooltip"
-              data-side={coords?.side ?? anchor.side ?? "bottom"}
+              data-side={coords?.side ?? "bottom"}
               // Hidden until measured: the enter animation runs only once the
               // final position is revealed, never while offscreen.
               data-state={coords ? phase : "measuring"}

--- a/src/components/ui/HoverTip.tsx
+++ b/src/components/ui/HoverTip.tsx
@@ -13,8 +13,9 @@ import { createPortal } from "react-dom";
 const DEFAULT_TIP_WIDTH = 300;
 const TIP_GAP = 6;
 const VIEWPORT_MARGIN = 8;
-// Flip above the anchor when less than this remains below — enough for the
-// longest privacy explainer at the default cap without clipping.
+// Fallback flip threshold used only before the tip's real height is known (it
+// never is, since the side is decided in the measure pass from the measured
+// height — this just keeps a sane default if measurement ever yields nothing).
 const MIN_SPACE_BELOW = 200;
 // Hover-intent delay before the card opens — a pointer sweeping across the
 // anchor should not flash it. Matches the model popover's flyout debounce;
@@ -28,14 +29,41 @@ type TipCoords = {
   side: "top" | "bottom";
   top: number;
   left: number;
+  // The tightened width in px once the wrapped line boxes are measured, so a
+  // two-line tip hugs its text instead of keeping the full cap. Undefined when
+  // measurement can't run (jsdom) — the tip keeps its natural capped width.
+  width?: number;
 };
 
-// The anchor's midpoint x and its below/top gap coordinates, captured at open
-// time; the final left is derived once the tip's own width is measured.
+// The widest rendered line box of a wrapped element, via a Range over its text.
+// Returns 0 when the platform can't measure (jsdom returns no client rects),
+// which the caller reads as "leave the natural width alone".
+function widestLineWidth(element: HTMLElement): number {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const rects = range.getClientRects();
+  let widest = 0;
+  for (let index = 0; index < rects.length; index += 1) {
+    widest = Math.max(widest, rects[index].width);
+  }
+  return widest;
+}
+
+// The anchor geometry captured at open time. The side is decided later, in the
+// measure pass, from the tip's real height — but once decided for a mounted
+// tip it stays put (see `side` below) so a re-hover never teleports the visible
+// card from bottom to top. `top`/`bottom` are the two candidate gap edges.
 type TipAnchor = {
-  side: "top" | "bottom";
-  top: number;
+  // The already-committed side for a still-mounted tip. Undefined on a fresh
+  // open, which lets the measure pass pick the side from the measured height.
+  side?: "top" | "bottom";
   centerX: number;
+  // Y of the tip's leading edge for each side: below the anchor, or above it.
+  bottom: number;
+  top: number;
+  // Room from the anchor's bottom to the viewport floor — the measure pass
+  // compares this against the measured tip height to decide the side.
+  spaceBelow: number;
 };
 
 type HoverTipProps = HTMLAttributes<HTMLSpanElement> & {
@@ -120,12 +148,17 @@ export function HoverTip({
     cancelClose();
     const rect = anchorRef.current?.getBoundingClientRect();
     if (!rect) return;
-    const side = window.innerHeight - rect.bottom < MIN_SPACE_BELOW ? "top" : "bottom";
-    setAnchor({
-      side,
+    setAnchor((current) => ({
+      // A re-hover while the tip is still mounted (open or mid-fade) keeps the
+      // side it already committed to: recomputing it here is what made the
+      // visible card teleport bottom→top. Only a fresh open (no current
+      // anchor) leaves `side` undefined so the measure pass can decide it.
+      side: current?.side ?? coords?.side,
       centerX: rect.left + rect.width / 2,
-      top: side === "bottom" ? rect.bottom + TIP_GAP : rect.top - TIP_GAP,
-    });
+      bottom: rect.bottom + TIP_GAP,
+      top: rect.top - TIP_GAP,
+      spaceBelow: window.innerHeight - rect.bottom,
+    }));
     // A re-entry mid-fade reuses the mounted node: re-assert the open phase so
     // the render before the measure effect lands shows "open", not a stale
     // mid-fade "closing" frame.
@@ -154,12 +187,50 @@ export function HoverTip({
   // biome-ignore lint/correctness/useExhaustiveDependencies(tip): re-measure on content change
   useLayoutEffect(() => {
     if (!anchor) return;
-    const tipWidth = tipRef.current?.getBoundingClientRect().width ?? 0;
+    const node = tipRef.current;
+    const rect = node?.getBoundingClientRect();
+    const tipHeight = rect?.height ?? 0;
+
+    // Decide the side from the tip's real height once, on a fresh open. If the
+    // tip fits below (its height plus the gap and a viewport margin), keep it
+    // below; otherwise flip above. A committed side (`anchor.side`) is honored
+    // so a re-hover on a mounted tip never flips the visible card. Before any
+    // real measurement (jsdom), fall back to the fixed threshold.
+    const fitsBelow =
+      tipHeight > 0
+        ? anchor.spaceBelow >= tipHeight + TIP_GAP + VIEWPORT_MARGIN
+        : anchor.spaceBelow >= MIN_SPACE_BELOW;
+    const side = anchor.side ?? (fitsBelow ? "bottom" : "top");
+
+    // Tighten the width to the widest wrapped line (plus horizontal padding) so
+    // a two-line tip hugs its text instead of keeping the full cap. `text-wrap:
+    // balance` in CSS has already split the lines evenly by the time we measure.
+    let width: number | undefined;
+    if (node) {
+      const widest = widestLineWidth(node);
+      if (widest > 0) {
+        const style = window.getComputedStyle(node);
+        const hPadding =
+          Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.paddingRight);
+        const borders =
+          Number.parseFloat(style.borderLeftWidth) + Number.parseFloat(style.borderRightWidth);
+        const naturalWidth = rect?.width ?? 0;
+        const tightened = Math.ceil(widest + hPadding + borders);
+        // Never widen past the natural (capped) width — only pull in. Skip if
+        // padding/border couldn't be resolved (NaN) rather than set a bad width.
+        if (Number.isFinite(tightened)) {
+          width = naturalWidth > 0 ? Math.min(tightened, naturalWidth) : tightened;
+        }
+      }
+    }
+
+    // Clamp the centered box to the viewport using the final (tightened) width.
+    const boxWidth = width ?? rect?.width ?? 0;
     const left = Math.min(
-      Math.max(anchor.centerX - tipWidth / 2, VIEWPORT_MARGIN),
-      Math.max(window.innerWidth - tipWidth - VIEWPORT_MARGIN, VIEWPORT_MARGIN),
+      Math.max(anchor.centerX - boxWidth / 2, VIEWPORT_MARGIN),
+      Math.max(window.innerWidth - boxWidth - VIEWPORT_MARGIN, VIEWPORT_MARGIN),
     );
-    setCoords({ side: anchor.side, top: anchor.top, left });
+    setCoords({ side, top: side === "bottom" ? anchor.bottom : anchor.top, left, width });
   }, [anchor, tip]);
 
   useEffect(
@@ -212,7 +283,7 @@ export function HoverTip({
               id={tooltipId}
               className={compact ? "hover-tip hover-tip-compact" : "hover-tip"}
               role="tooltip"
-              data-side={coords?.side ?? anchor.side}
+              data-side={coords?.side ?? anchor.side ?? "bottom"}
               // Hidden until measured: the enter animation runs only once the
               // final position is revealed, never while offscreen.
               data-state={coords ? phase : "measuring"}
@@ -220,9 +291,12 @@ export function HoverTip({
                 if (event.propertyName === "opacity" && phase === "closing") unmount();
               }}
               style={{
-                top: coords?.top ?? anchor.top,
+                top: coords?.top ?? anchor.bottom,
                 left: coords?.left ?? 0,
                 maxWidth: width,
+                // Applied only after the tighten pass; while measuring the tip
+                // renders at its natural capped width so the wrap is real.
+                width: coords?.width,
               }}
             >
               {tip}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -698,7 +698,14 @@ input:focus-visible,
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: var(--sp-6);
+  /* The per-turn actions row (copy/branch/timestamp) is positioned out of flow
+   * into the space below each turn (see .agent-turn-actions). The inter-turn
+   * gap must be at least the row's own height, plus a little breathing room,
+   * so a revealed row never overlaps the next turn's "Thought" summary. Both
+   * the row and this gap size off --agent-turn-actions-h, so they stay in sync
+   * if the button size changes. */
+  --agent-turn-actions-h: calc(var(--sp-8) + var(--sp-px));
+  gap: calc(var(--agent-turn-actions-h) + var(--sp-2));
   /* Align the thread rail with the composer's text line, not its outer
    * border: 1px box border + sp-1 box padding + sp-5 textarea padding.
    * User turns stay right-aligned inside this rail. */
@@ -14054,6 +14061,10 @@ input:focus-visible,
   line-height: 1.5;
   text-align: left;
   white-space: normal;
+  /* Split a wrapped tip's lines evenly so a two-line tip reads as a balanced
+   * block. HoverTip measures the line boxes AFTER this applies and tightens the
+   * box width to hug the widest line, so the box edges match the text edges. */
+  text-wrap: balance;
   pointer-events: none;
 }
 

--- a/src/test/agent-turn-actions-css.test.ts
+++ b/src/test/agent-turn-actions-css.test.ts
@@ -36,6 +36,25 @@ describe("agent turn action styles", () => {
 }`);
   });
 
+  it("reserves an inter-turn gap at least as tall as the out-of-flow row", () => {
+    // The row is positioned into the space below each turn (inset-block-start:
+    // 100%), so the standing gap between turns must clear the row's full
+    // height or a revealed row overlaps the next turn's "Thought" summary.
+    // Both derive from --agent-turn-actions-h so they can't drift apart.
+    const timeline = cssRuleFor(".agent-timeline");
+    const rowHeightVar = "--agent-turn-actions-h: calc(var(--sp-8) + var(--sp-px));";
+    expect(timeline).toContain(rowHeightVar);
+    // The gap adds breathing room on top of the row height, never less than it.
+    expect(timeline).toContain("gap: calc(var(--agent-turn-actions-h) + var(--sp-2));");
+
+    // The row itself sizes off the same tokens the gap budgets for: an sp-8
+    // button plus its sp-px padding-top.
+    const actionButton = cssRuleFor(".agent-turn-action");
+    expect(actionButton).toContain("block-size: var(--sp-8);");
+    const inner = cssRuleFor(".agent-turn-actions-inner");
+    expect(inner).toContain("padding-top: var(--sp-px);");
+  });
+
   it("keeps the action row chromeless and alignable to the message edge", () => {
     const inner = cssRuleFor(".agent-turn-actions-inner");
     // A quiet icon row: any bg/border here fights the message bubble above it.

--- a/src/test/hover-tip.test.tsx
+++ b/src/test/hover-tip.test.tsx
@@ -114,6 +114,59 @@ describe("HoverTip", () => {
     }
   });
 
+  it("tightens to the widest visual line, not the widest inline fragment", () => {
+    window.innerHeight = 800;
+    window.innerWidth = 1000;
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.getAttribute("role") === "tooltip") {
+          return { top: 0, left: 0, right: 216, bottom: 40, width: 216, height: 40 } as DOMRect;
+        }
+        return { top: 100, left: 100, right: 132, bottom: 116, width: 32, height: 16 } as DOMRect;
+      });
+    const fragment = (left: number, right: number, top: number, bottom: number) =>
+      ({ left, right, top, bottom, width: right - left, height: bottom - top }) as DOMRect;
+    // First visual line split into two inline fragments (plain text + inline
+    // markup) spanning 10..160; second line a single 90px fragment. The widest
+    // single fragment is 90px, but the widest LINE is 150px — the box must be
+    // sized from the line, or one-line content would be forced to re-wrap.
+    const rangeSpy = vi
+      .spyOn(Range.prototype, "getClientRects")
+      .mockReturnValue([
+        fragment(10, 100, 0, 16),
+        fragment(100, 160, 0, 16),
+        fragment(10, 100, 16, 32),
+      ] as unknown as DOMRectList);
+    const realGetComputedStyle = window.getComputedStyle.bind(window);
+    const styleSpy = vi
+      .spyOn(window, "getComputedStyle")
+      .mockImplementation((el: Element, pseudo?: string | null) =>
+        (el as HTMLElement).getAttribute?.("role") === "tooltip"
+          ? ({
+              paddingLeft: "6px",
+              paddingRight: "6px",
+              borderLeftWidth: "1px",
+              borderRightWidth: "1px",
+            } as CSSStyleDeclaration)
+          : realGetComputedStyle(el, pseudo),
+      );
+    try {
+      render(
+        <HoverTip tip="Two-line tip with inline markup" width={216} tabIndex={0}>
+          Info
+        </HoverTip>,
+      );
+      fireEvent.focus(screen.getByText("Info"));
+      // ceil(150 line span + 12 padding + 2 borders) — not 90 + 14.
+      expect(screen.getByRole("tooltip").style.width).toBe("164px");
+    } finally {
+      rectSpy.mockRestore();
+      rangeSpy.mockRestore();
+      styleSpy.mockRestore();
+    }
+  });
+
   it("does not flip sides when the anchor is re-entered while the tip is open", () => {
     vi.useFakeTimers();
     // Anchor pinned so close to the viewport floor that the tip opens above it;

--- a/src/test/hover-tip.test.tsx
+++ b/src/test/hover-tip.test.tsx
@@ -205,6 +205,45 @@ describe("HoverTip", () => {
     }
   });
 
+  it("keeps its side when the tip content changes while mounted", () => {
+    // A content swap while open (e.g. "Copy message" → "Copied") re-runs the
+    // measure pass with the new height; the visible card must keep the side it
+    // committed to even when the new content would no longer fit there.
+    window.innerHeight = 800;
+    window.innerWidth = 1000;
+    const rectFor = (el: HTMLElement): DOMRect => {
+      if (el.getAttribute("role") === "tooltip") {
+        const height = el.textContent?.includes("much longer") ? 200 : 24;
+        return { top: 0, left: 0, right: 120, bottom: height, width: 120, height } as DOMRect;
+      }
+      // 40px below the anchor: the 24px tip fits there, the 200px one cannot.
+      return { top: 744, left: 100, right: 132, bottom: 760, width: 32, height: 16 } as DOMRect;
+    };
+    const spy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        return rectFor(this);
+      });
+    try {
+      const { rerender } = render(
+        <HoverTip tip="Copied" compact width={104} tabIndex={0}>
+          Copy
+        </HoverTip>,
+      );
+      fireEvent.focus(screen.getByText("Copy"));
+      expect(screen.getByRole("tooltip")).toHaveAttribute("data-side", "bottom");
+
+      rerender(
+        <HoverTip tip="A much longer label swapped in while open" compact width={104} tabIndex={0}>
+          Copy
+        </HoverTip>,
+      );
+      expect(screen.getByRole("tooltip")).toHaveAttribute("data-side", "bottom");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("cancels the exit when the anchor is re-entered mid-fade", () => {
     vi.useFakeTimers();
     try {

--- a/src/test/hover-tip.test.tsx
+++ b/src/test/hover-tip.test.tsx
@@ -82,6 +82,76 @@ describe("HoverTip", () => {
     }
   });
 
+  it("keeps a compact tip below the anchor near the viewport bottom when it fits", () => {
+    // jsdom has no layout, so feed the geometry the measure pass reads: a short
+    // anchor low in a tall-enough viewport, and a one-line tip that fits below.
+    window.innerHeight = 800;
+    window.innerWidth = 1000;
+    const rectFor = (el: Element): DOMRect => {
+      if (el instanceof HTMLElement && el.getAttribute("role") === "tooltip") {
+        // Compact one-line tip: ~24px tall.
+        return { top: 0, left: 0, right: 120, bottom: 24, width: 120, height: 24 } as DOMRect;
+      }
+      // Anchor sits 40px above the viewport floor — plenty for a 24px tip plus
+      // the gap and margin, so the tip should stay below.
+      return { top: 744, left: 100, right: 132, bottom: 760, width: 32, height: 16 } as DOMRect;
+    };
+    const spy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        return rectFor(this);
+      });
+    try {
+      render(
+        <HoverTip tip="Copy message" compact width={104} tabIndex={0}>
+          Copy
+        </HoverTip>,
+      );
+      fireEvent.focus(screen.getByText("Copy"));
+      expect(screen.getByRole("tooltip")).toHaveAttribute("data-side", "bottom");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does not flip sides when the anchor is re-entered while the tip is open", () => {
+    vi.useFakeTimers();
+    // Anchor pinned so close to the viewport floor that the tip opens above it;
+    // a re-hover must not teleport the visible card back below.
+    window.innerHeight = 800;
+    window.innerWidth = 1000;
+    const rectFor = (el: Element): DOMRect => {
+      if (el instanceof HTMLElement && el.getAttribute("role") === "tooltip") {
+        return { top: 0, left: 0, right: 120, bottom: 200, width: 120, height: 200 } as DOMRect;
+      }
+      // Only 20px of room below — a 200px tip can't fit, so it flips to top.
+      return { top: 764, left: 100, right: 132, bottom: 780, width: 32, height: 16 } as DOMRect;
+    };
+    const spy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        return rectFor(this);
+      });
+    try {
+      render(
+        <HoverTip tip="A tall explainer that flips above the anchor." tabIndex={0}>
+          Info
+        </HoverTip>,
+      );
+      const anchor = screen.getByText("Info");
+      fireEvent.focus(anchor);
+      expect(screen.getByRole("tooltip")).toHaveAttribute("data-side", "top");
+
+      // Fade out, then re-enter while still mounted — the side must hold.
+      fireEvent.blur(anchor);
+      fireEvent.focus(anchor);
+      expect(screen.getByRole("tooltip")).toHaveAttribute("data-side", "top");
+    } finally {
+      spy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("cancels the exit when the anchor is re-entered mid-fade", () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

- The per-turn hover actions row (copy/branch/timestamp) is positioned out of flow in the inter-turn gap, but the gap (16px) was smaller than the row (26px), so the row overlapped the next turn's "Thought" disclosure. The timeline gap now derives from the row's height (`--agent-turn-actions-h` + breathing room = 32px), keeping the large click targets and staying in sync if the button size changes.
- `HoverTip` flipped to the top whenever less than a fixed 200px remained below the anchor (a threshold sized for the largest explainer card), so compact one-line tips near the viewport bottom flipped unnecessarily - and a re-hover on a still-mounted tip recomputed the side, visibly teleporting the open tooltip from bottom to top. The side is now decided from the measured tip height during the existing hidden measuring pass, and a mounted tip keeps its committed side until it fully closes.
- Tooltips that wrap to two lines (e.g. the disabled branch action's "Branching is available once the message is saved") kept their full width cap, leaving lopsided padding. Tips now use balanced line wrapping and, during the measuring pass, tighten their box to the widest rendered line so the edges hug the text. Guarded for jsdom (falls back to the capped width when line rects can't be measured).

## Root cause

Three distinct causes: (1) the inter-turn gap and the out-of-flow actions row were sized independently, and the row outgrew the gap; (2) `HoverTip` chose its side from a fixed space-below constant instead of the tip's real height, and re-computed the side on every `show()` even while the tip was still mounted; (3) the tip box width was only ever capped, never re-fit to the wrapped line boxes.

## Validation

- `pnpm vitest run src/test/hover-tip.test.tsx src/test/agent-turn-actions-css.test.ts src/test/hermes-session-branch.test.tsx` - 25 passed, including new tests: compact tip near the viewport bottom stays on the bottom when it fits; the side does not change on re-entry while mounted; the timeline gap derives from the row height tokens.
- `pnpm typecheck` and `pnpm check` clean (no new warnings).

- [x] Tested visually where it matters (verified in the running app: overlap gone, tooltip no longer jumps).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Branching behavior itself (when the branch action is enabled/disabled) - only its tooltip rendering changed here.
- The pre-existing `noStaticElementInteractions` Biome warning on the HoverTip anchor span.

## Followups

- Branching fixes planned as a subsequent story.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)