### PR TITLE
Revert dictation cleanup to Nemotron Nano

### DIFF
--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -19,11 +19,13 @@ use std::{
 // docker-compose.production.yml). NOT .network — that hostname has no DNS
 // record, and the v0.0.3 DMG shipped pointing at it.
 const DEFAULT_JUNE_API_URL: &str = "https://june-api.opensoftware.co";
-// GLM 5.2 over Nemotron Nano: benchmarked ~2-4s vs ~0.8s per utterance, but it
-// reliably keeps unnumbered items as prose and expands contractions in the
-// formal style, which the nano model skips. Slow outliers degrade gracefully:
-// past DICTATION_CLEANUP_TIMEOUT_MS the raw transcript is inserted as-is.
-const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "zai-org-glm-5-2";
+// Nemotron Nano over GLM 5.2: dictation is latency-critical and nano runs
+// ~0.8s per utterance vs GLM's 2-4s (12s outliers), which felt too slow in
+// daily use. Known nano tradeoffs, accepted for speed: explicit unnumbered
+// "make a list with" requests may still be listified (over-formatting, never
+// word loss) and the formal style sometimes skips contraction expansion. No
+// other catalog model beats it: everything smarter benchmarked 2-20x slower.
+const DEFAULT_DICTATION_CLEANUP_MODEL: &str = "nvidia-nemotron-3-nano-30b-a3b";
 const HTTP_TIMEOUT: Duration = Duration::from_secs(600);
 const AGENT_HTTP_TIMEOUT: Duration = Duration::from_secs(600);
 const AGENT_PROXY_MAX_MESSAGES: usize = 64;


### PR DESCRIPTION
Reverts #595 after real-world use: GLM 5.2's 2-4s typical cleanup latency (12s outliers) is too slow for the hold-key-speak-release dictation flow. Nano runs ~0.8s.

The word-preservation behavior is unaffected (it lives in the prompt, #593/#594, and holds on nano per the eval suite). Nano's two accepted quirks are documented at the constant: explicit unnumbered "make a list with" requests may still be listified, and the formal style sometimes skips contraction expansion. Both are over-formatting, never word loss. Benchmark across the private catalog (GLM 5/5.1/5.2, Kimi K2.6, glm-4.7-flash, mistral-small, minimax-m25) confirmed nothing smarter comes within 2x of nano's latency.

`cargo test --lib june_api` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)