### PR TITLE
refactor: make the control plane the sole reader of raw Hermes frames

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,7 +113,9 @@ _Avoid_: control plane, API.
 
 **Control plane**:
 The typed seam (`src/lib/hermes-control-plane/`) that turns raw Hermes frames
-into the total `JuneHermesEvent` union and typed outbound methods.
+into the total `JuneHermesEvent` union and typed outbound methods. The union
+also carries locally minted first-party events (see **Steer**) that the
+classifier never emits.
 _Avoid_: gateway, adapter.
 
 **Runtime mode**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,6 +138,15 @@ A `/name arg` handled client-side before submit — builtin `/model` and
 image *generation* is an upstream Hermes tool, not a June slash command.)
 _Avoid_: gateway command.
 
+**Steer**:
+A user instruction delivered into a still-running agent session without
+interrupting it. A steer is first-party and local to June — never a Hermes
+wire frame. A steer the run never consumed is resent as an ordinary follow-up
+when the run completes cleanly, and dropped when the run fails or is
+cancelled.
+_Avoid_: interrupt/stop (a steer never halts the run), follow-up (that is the
+fallback delivery, not the steer), mid-run message.
+
 **Model capability**:
 An authoritative boolean flag from the live Venice catalog `capabilities`
 (`supportsFunctionCalling` → tools, `supportsVision` → image input), never

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -158,6 +158,7 @@ import {
   classifyHermesEvent,
   createHermesMethods,
   hermesModeFor,
+  isTerminalHermesEvent,
   isHermesFeatureSupported,
   isSensitiveKey,
   type HermesMode,
@@ -182,7 +183,7 @@ import {
 import { normalizeSteerText, steeringLiveEvent } from "../../lib/hermes-session-steer";
 import { unsupportedEventStore } from "../../lib/hermes-unsupported-events";
 import { pendingActionStore } from "../../lib/hermes-pending-actions";
-import { hermesActivityStore } from "../../lib/hermes-activity-store";
+import { hermesActivityStore, type AgentActivityRecord } from "../../lib/hermes-activity-store";
 import {
   hermesArtifactStore,
   // The store's record shape collides by name with this file's local
@@ -762,8 +763,6 @@ function reportableAgentErrorOptions(
   return { ...options, issueReport };
 }
 
-type HermesToolEventPhase = "start" | "progress" | "complete";
-
 type AgentWorkspaceError = {
   message: string;
   /** Null means the error belongs to the no-session workspace surface. */
@@ -874,26 +873,25 @@ type AgentWorkspaceProps = {
 // Mid-run continuity across remounts. While June is working, a session has
 // state that exists nowhere outside this component: the optimistic list entry
 // (title + preview), the just-sent user bubble Hermes hasn't persisted yet,
-// the working/waiting flags that drive the reconcile poll, the stored→runtime
-// session mapping, the buffered live events, the title override, and any
-// queued issue report draft, the review-ready report waiting for the user to
-// send, and the delayed diagnosis refresh that makes the final June answer
-// available to the report payload.
+// the stored→runtime session mapping, the buffered live events, the title
+// override, and any queued issue report draft, the review-ready report waiting
+// for the user to send, and the delayed diagnosis refresh that makes the final
+// June answer available to the report payload. Working/waiting/tool-call
+// display state lives in the module-global activity store, which survives this
+// workspace unmount.
 // Navigating away (e.g. to Settings) unmounts the workspace; without this
 // snapshot the remount restores only the selected id from localStorage, and a
 // session whose first turn hasn't persisted renders as an empty "Untitled
-// session" that nothing ever polls back to life. Captured on unmount for the
-// sessions with active work, hydrated by the next mount's state initializers
-// so the working poll picks the run straight back up.
+// session" that nothing ever polls back to life. Captured on unmount for
+// sessions with activity-store work or local pending/report state, hydrated by
+// the next mount's state initializers so the working poll picks the run
+// straight back up.
 type AgentSessionContinuity = {
   sessionItems: HermesSessionInfo[];
   pendingMessages: Record<string, HermesSessionMessage[]>;
-  workingSessionIds: string[];
-  waitingSessionIds: string[];
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, JuneHermesEvent[]>;
   titleOverrides: Record<string, string>;
-  activeToolCallsBySession: Record<string, Record<string, number>>;
   pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
   diagnosisRefreshIssueReportSessionIds: string[];
@@ -1015,50 +1013,32 @@ function removeStoredNewSessionDraft() {
   }
 }
 
+function activeHermesActivitySessionIds() {
+  const activeIds = new Set<string>();
+  for (const record of hermesActivityStore.getRecords()) {
+    if (record.phase === "running" || record.phase === "waiting" || record.phase === "background") {
+      activeIds.add(record.sessionId);
+    }
+  }
+  return activeIds;
+}
+
 function shouldOpenNewSessionOnMount() {
   return hasPendingNewSessionRequest() || hasNewSessionComposerDraft();
-}
-
-function activeToolCallsRecord(
-  activeToolCallsBySession: Map<string, Map<string, number>>,
-): Record<string, Record<string, number>> {
-  return Object.fromEntries(
-    Array.from(activeToolCallsBySession.entries())
-      .filter(([, tools]) => tools.size > 0)
-      .map(([sessionId, tools]) => [sessionId, Object.fromEntries(tools)]),
-  );
-}
-
-function activeToolCallsMap(
-  activeToolCallsBySession: Record<string, Record<string, number>> | undefined,
-) {
-  return new Map(
-    Object.entries(activeToolCallsBySession ?? {}).map(([sessionId, tools]) => [
-      sessionId,
-      new Map(
-        Object.entries(tools).filter(
-          (entry): entry is [string, number] => Number.isFinite(entry[1]) && entry[1] > 0,
-        ),
-      ),
-    ]),
-  );
 }
 
 function captureSessionContinuity(state: {
   sessionItems: HermesSessionInfo[];
   pendingMessages: Record<string, HermesSessionMessage[]>;
-  workingSessionIds: Set<string>;
-  waitingSessionIds: Set<string>;
   runtimeSessionIds: Record<string, string>;
   liveEvents: Record<string, JuneHermesEvent[]>;
   titleOverrides: Record<string, string>;
-  activeToolCallsBySession: Record<string, Record<string, number>>;
   pendingIssueReports: Record<string, PendingIssueReport>;
   reviewableIssueReports: Record<string, PendingIssueReport>;
   diagnosisRefreshIssueReportSessionIds: Set<string>;
   submittingIssueReportSessionIds: Set<string>;
 }): AgentSessionContinuity | null {
-  const activeIds = new Set([...state.workingSessionIds, ...state.waitingSessionIds]);
+  const activeIds = activeHermesActivitySessionIds();
   for (const [sessionId, pending] of Object.entries(state.pendingMessages)) {
     if (pending.length > 0) activeIds.add(sessionId);
   }
@@ -1074,21 +1054,15 @@ function captureSessionContinuity(state: {
   for (const sessionId of state.submittingIssueReportSessionIds) {
     activeIds.add(sessionId);
   }
-  for (const sessionId of Object.keys(state.activeToolCallsBySession)) {
-    activeIds.add(sessionId);
-  }
   if (activeIds.size === 0) return null;
   const pick = <T,>(record: Record<string, T>) =>
     Object.fromEntries(Object.entries(record).filter(([sessionId]) => activeIds.has(sessionId)));
   return {
     sessionItems: state.sessionItems.filter((session) => activeIds.has(session.id)),
     pendingMessages: pick(state.pendingMessages),
-    workingSessionIds: [...state.workingSessionIds],
-    waitingSessionIds: [...state.waitingSessionIds],
     runtimeSessionIds: pick(state.runtimeSessionIds),
     liveEvents: pick(state.liveEvents),
     titleOverrides: pick(state.titleOverrides),
-    activeToolCallsBySession: pick(state.activeToolCallsBySession),
     pendingIssueReports: pick(state.pendingIssueReports),
     reviewableIssueReports: pick(state.reviewableIssueReports),
     diagnosisRefreshIssueReportSessionIds: [...state.diagnosisRefreshIssueReportSessionIds].filter(
@@ -1192,12 +1166,9 @@ function updateContinuityAfterIssueReportDelivery(detail: IssueReportDeliverySet
   sessionContinuity = captureSessionContinuity({
     sessionItems: sessionContinuity.sessionItems,
     pendingMessages: sessionContinuity.pendingMessages,
-    workingSessionIds: new Set(sessionContinuity.workingSessionIds),
-    waitingSessionIds: new Set(sessionContinuity.waitingSessionIds),
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
-    activeToolCallsBySession: sessionContinuity.activeToolCallsBySession,
     pendingIssueReports,
     reviewableIssueReports,
     diagnosisRefreshIssueReportSessionIds,
@@ -1227,12 +1198,9 @@ function updateContinuityAfterIssueReportFollowUpSubmitFailed(
   sessionContinuity = captureSessionContinuity({
     sessionItems: sessionContinuity.sessionItems,
     pendingMessages: sessionContinuity.pendingMessages,
-    workingSessionIds: new Set(sessionContinuity.workingSessionIds),
-    waitingSessionIds: new Set(sessionContinuity.waitingSessionIds),
     runtimeSessionIds: sessionContinuity.runtimeSessionIds,
     liveEvents: sessionContinuity.liveEvents,
     titleOverrides: sessionContinuity.titleOverrides,
-    activeToolCallsBySession: sessionContinuity.activeToolCallsBySession,
     pendingIssueReports,
     reviewableIssueReports,
     diagnosisRefreshIssueReportSessionIds: new Set(
@@ -1310,6 +1278,9 @@ export function resetAgentSessionContinuity() {
   sessionContinuity = null;
   agentComposerDrafts.clear();
   removeStoredNewSessionDraft();
+  for (const record of hermesActivityStore.getRecords()) {
+    hermesActivityStore.clearSession(record.sessionId);
+  }
 }
 
 /** The catalog id that represents the current global generation selection:
@@ -1512,13 +1483,22 @@ export function AgentWorkspace({
   );
   const [thinkingOpenByKey, setThinkingOpenByKey] = useState<Record<string, boolean>>({});
   const [workingTaskIds, setWorkingTaskIds] = useState<Set<string>>(() => new Set());
-  const [workingSessionIds, setWorkingSessionIds] = useState<Set<string>>(
-    () => new Set(continuity?.workingSessionIds),
+  const activityStoreVersion = useSyncExternalStore(
+    hermesActivityStore.subscribe,
+    hermesActivityStore.getVersion,
+    hermesActivityStore.getVersion,
   );
+  const activityRecords = useMemo(
+    () => hermesActivityStore.getRecords(),
+    // `activityStoreVersion` is the change signal; the read returns live rows.
+    [activityStoreVersion],
+  );
+  const activityLevels = useMemo(
+    () => projectAgentActivityLevels(activityRecords),
+    [activityRecords],
+  );
+  const { toolCallSessionIds, waitingSessionIds, workingSessionIds } = activityLevels;
   const workingSessionIdsRef = useRef<Set<string>>(workingSessionIds);
-  const [toolCallSessionIds, setToolCallSessionIds] = useState<Set<string>>(
-    () => new Set(Object.keys(continuity?.activeToolCallsBySession ?? {})),
-  );
   const toolCallSessionIdsRef = useRef<Set<string>>(toolCallSessionIds);
   // Steers we've sent that Hermes may not have delivered yet. Hermes only
   // injects a steer into the next tool result, so a no-tool turn drops it; we
@@ -1527,12 +1507,6 @@ export function AgentWorkspace({
   const pendingSteerBySessionIdRef = useRef<
     Record<string, { text: string; accepted: boolean; toolDrained: boolean }[]>
   >({});
-  const activeToolCallsBySessionRef = useRef<Map<string, Map<string, number>>>(
-    activeToolCallsMap(continuity?.activeToolCallsBySession),
-  );
-  const [waitingSessionIds, setWaitingSessionIds] = useState<Set<string>>(
-    () => new Set(continuity?.waitingSessionIds),
-  );
   const waitingSessionIdsRef = useRef<Set<string>>(waitingSessionIds);
   const [runtimeSessionIds, setRuntimeSessionIds] = useState<Record<string, string>>(
     () => continuity?.runtimeSessionIds ?? {},
@@ -1833,7 +1807,7 @@ export function AgentWorkspace({
   }, [runtimeSessionIds]);
 
   useEffect(() => {
-    const restoredSessionIds = continuity?.workingSessionIds ?? [];
+    const restoredSessionIds = Array.from(workingSessionIdsRef.current);
     if (!restoredSessionIds.length) return;
     let cancelled = false;
 
@@ -1881,136 +1855,50 @@ export function AgentWorkspace({
     workingSessionIds,
   ]);
 
-  const setSessionToolCallActive = useCallback((sessionId: string, active: boolean) => {
-    setToolCallSessionIds((current) => {
-      const next = new Set(current);
-      if (active) {
-        next.add(sessionId);
-      } else {
-        next.delete(sessionId);
-      }
-      toolCallSessionIdsRef.current = next;
-      return next;
-    });
-  }, []);
-
-  function clearSessionToolCalls(sessionId: string) {
-    activeToolCallsBySessionRef.current.delete(sessionId);
-    setSessionToolCallActive(sessionId, false);
+  function recordSessionRunningActivity(sessionId: string) {
+    hermesActivityStore.record(
+      { kind: "lifecycle", sessionId, status: "running", receivedAt: new Date().toISOString() },
+      hermesModeFor(sessionId),
+    );
   }
 
-  function updateSessionToolCallActivity(
-    sessionId: string,
-    event: HermesGatewayEvent,
-    phase: HermesToolEventPhase,
-  ) {
-    const eventKey = toolEventActivityKey(event);
-    const current = new Map(activeToolCallsBySessionRef.current.get(sessionId) ?? []);
-
-    if (phase === "progress" && eventKey === undefined) {
-      return current.size > 0;
-    }
-
-    const key = eventKey ?? "__anonymous_tool__";
-
-    if (phase === "start") {
-      current.set(key, (current.get(key) ?? 0) + 1);
-    } else if (phase === "progress") {
-      if (!current.has(key)) current.set(key, 1);
-    } else {
-      const count = current.get(key) ?? 0;
-      if (count > 1) {
-        current.set(key, count - 1);
-      } else {
-        current.delete(key);
-      }
-    }
-
-    if (current.size > 0) {
-      activeToolCallsBySessionRef.current.set(sessionId, current);
-      setSessionToolCallActive(sessionId, true);
-      return true;
-    }
-
-    activeToolCallsBySessionRef.current.delete(sessionId);
-    setSessionToolCallActive(sessionId, false);
-    return false;
+  function recordSessionErrorActivity(sessionId: string, message: string) {
+    hermesActivityStore.record(
+      { kind: "error", sessionId, message, receivedAt: new Date().toISOString() },
+      hermesModeFor(sessionId),
+    );
   }
 
-  const setSessionWorking = useCallback((sessionId: string, working: boolean) => {
-    setWorkingSessionIds((current) => {
-      const next = new Set(current);
-      if (working) {
-        next.add(sessionId);
-      } else {
-        next.delete(sessionId);
-      }
-      workingSessionIdsRef.current = next;
-      return next;
-    });
+  const clearSessionActivity = useCallback((sessionId: string, status = "completed") => {
+    hermesActivityStore.record(
+      { kind: "lifecycle", sessionId, status, receivedAt: new Date().toISOString() },
+      hermesModeFor(sessionId),
+    );
+    return agentActivityCountsFromStore();
   }, []);
-
-  const setSessionWaiting = useCallback((sessionId: string, waiting: boolean) => {
-    setWaitingSessionIds((current) => {
-      const next = new Set(current);
-      if (waiting) {
-        next.add(sessionId);
-      } else {
-        next.delete(sessionId);
-      }
-      waitingSessionIdsRef.current = next;
-      return next;
-    });
-  }, []);
-
-  const clearSessionActivity = useCallback(
-    (sessionId: string) => {
-      clearSessionToolCalls(sessionId);
-
-      const nextWorking = new Set(workingSessionIdsRef.current);
-      nextWorking.delete(sessionId);
-      workingSessionIdsRef.current = nextWorking;
-      setWorkingSessionIds(nextWorking);
-
-      const nextWaiting = new Set(waitingSessionIdsRef.current);
-      nextWaiting.delete(sessionId);
-      waitingSessionIdsRef.current = nextWaiting;
-      setWaitingSessionIds(nextWaiting);
-
-      return {
-        activeCount: nextWorking.size + nextWaiting.size,
-        needsUserCount: nextWaiting.size,
-      };
-    },
-    [setSessionToolCallActive],
-  );
 
   // Shared teardown for a session that is going away: its messages, pending
-  // sends, working/waiting flags, live gateway listener, and buffered live
-  // events. Both delete paths (sidebar event and session-bar menu) run this so
-  // neither leaves a phantom "working" session with a leaked listener behind.
-  const scrubHermesSessionState = useCallback(
-    (sessionId: string) => {
-      setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
-      setPendingHermesMessages((current) => {
-        const next = omitRecordKey(current, sessionId);
-        pendingHermesMessagesRef.current = next;
-        return next;
-      });
-      clearSessionActivity(sessionId);
-      // Feature 11: a deleted session has no activity to show, so drop its row
-      // from the activity drawer's store as well.
-      hermesActivityStore.clearSession(sessionId);
-      // Feature 14: likewise drop its artifact timeline.
-      hermesArtifactStore.clearSession(sessionId);
-      sessionGatewayUnlistenRef.current.get(sessionId)?.();
-      liveEventsRef.current = omitRecordKey(liveEventsRef.current, sessionId);
-      setLiveEvents(liveEventsRef.current);
-      // A deleted session must not be the restore target on the next mount.
-      forgetLastOpenSessionId(sessionId);
-    },
-    [clearSessionActivity],
-  );
+  // sends, activity-store row, live gateway listener, and buffered live events.
+  // Both delete paths (sidebar event and session-bar menu) run this so neither
+  // leaves a phantom "working" session with a leaked listener behind.
+  const scrubHermesSessionState = useCallback((sessionId: string) => {
+    setHermesSessionMessages((current) => omitRecordKey(current, sessionId));
+    setPendingHermesMessages((current) => {
+      const next = omitRecordKey(current, sessionId);
+      pendingHermesMessagesRef.current = next;
+      return next;
+    });
+    // Feature 11: a deleted session has no activity to show, so drop its row
+    // from the activity drawer's store as well.
+    hermesActivityStore.clearSession(sessionId);
+    // Feature 14: likewise drop its artifact timeline.
+    hermesArtifactStore.clearSession(sessionId);
+    sessionGatewayUnlistenRef.current.get(sessionId)?.();
+    liveEventsRef.current = omitRecordKey(liveEventsRef.current, sessionId);
+    setLiveEvents(liveEventsRef.current);
+    // A deleted session must not be the restore target on the next mount.
+    forgetLastOpenSessionId(sessionId);
+  }, []);
 
   const selectedTask = useMemo(
     () => tasks.find((task) => task.id === selectedTaskId),
@@ -2240,16 +2128,6 @@ export function AgentWorkspace({
   // this flag back to true to restore it.
   const ACTIVITY_DRAWER_ENABLED = false;
   const [activityDrawerOpen, setActivityDrawerOpen] = useState(false);
-  const activityStoreVersion = useSyncExternalStore(
-    hermesActivityStore.subscribe,
-    hermesActivityStore.getVersion,
-    hermesActivityStore.getVersion,
-  );
-  const activityRecords = useMemo(
-    () => hermesActivityStore.getRecords(),
-    // `activityStoreVersion` is the change signal; the read returns live rows.
-    [activityStoreVersion],
-  );
   // The store only knows the count once a session has reported activity; treat a
   // never-touched store as "loading" so the very first paint shows a spinner
   // copy rather than the empty state flashing before any event lands.
@@ -3045,7 +2923,7 @@ export function AgentWorkspace({
           // latest message is the user's, so re-arm working state — the
           // working-gated poll below picks the session back up and
           // reconciles it from persisted messages.
-          setSessionWorking(selectedHermesSessionId, true);
+          recordSessionRunningActivity(selectedHermesSessionId);
         }
         if (sessionHasAssistantAfterLatestUser(combined)) {
           promotePendingIssueReportToReview(selectedHermesSessionId, {
@@ -3148,12 +3026,9 @@ export function AgentWorkspace({
       sessionContinuity = captureSessionContinuity({
         sessionItems: hermesSessionItemsRef.current,
         pendingMessages: pendingHermesMessagesRef.current,
-        workingSessionIds: workingSessionIdsRef.current,
-        waitingSessionIds: waitingSessionIdsRef.current,
         runtimeSessionIds: runtimeSessionIdsRef.current,
         liveEvents: liveEventsRef.current,
         titleOverrides: sessionTitleOverridesRef.current,
-        activeToolCallsBySession: activeToolCallsRecord(activeToolCallsBySessionRef.current),
         pendingIssueReports: Object.fromEntries(pendingIssueReportsRef.current),
         reviewableIssueReports: reviewableIssueReportsRef.current,
         diagnosisRefreshIssueReportSessionIds: diagnosisRefreshIssueReportSessionIdsRef.current,
@@ -4167,8 +4042,7 @@ export function AgentWorkspace({
       pendingHermesMessagesRef.current = next;
       return next;
     });
-    setSessionWorking(sessionId, true);
-    setSessionWaiting(sessionId, false);
+    recordSessionRunningActivity(sessionId);
     dispatchAgentSessionStatus({
       title,
       prompt: displayContent,
@@ -4223,18 +4097,8 @@ export function AgentWorkspace({
     });
     liveEventsRef.current = moveRecordKey(liveEventsRef.current, fromSessionId, toSessionId);
     setLiveEvents(liveEventsRef.current);
-    setWorkingSessionIds((current) => {
-      const next = new Set(current);
-      if (next.delete(fromSessionId)) next.add(toSessionId);
-      workingSessionIdsRef.current = next;
-      return next;
-    });
-    setWaitingSessionIds((current) => {
-      const next = new Set(current);
-      if (next.delete(fromSessionId)) next.add(toSessionId);
-      waitingSessionIdsRef.current = next;
-      return next;
-    });
+    hermesActivityStore.clearSession(fromSessionId);
+    recordSessionRunningActivity(toSessionId);
     selectedHermesSessionIdRef.current = toSessionId;
     setSelectedHermesSessionId(toSessionId);
   }
@@ -4261,18 +4125,7 @@ export function AgentWorkspace({
     for (const id of ids) nextLiveEvents = omitRecordKey(nextLiveEvents, id);
     liveEventsRef.current = nextLiveEvents;
     setLiveEvents(nextLiveEvents);
-    setWorkingSessionIds((current) => {
-      const next = new Set(current);
-      for (const id of ids) next.delete(id);
-      workingSessionIdsRef.current = next;
-      return next;
-    });
-    setWaitingSessionIds((current) => {
-      const next = new Set(current);
-      for (const id of ids) next.delete(id);
-      waitingSessionIdsRef.current = next;
-      return next;
-    });
+    for (const id of ids) hermesActivityStore.clearSession(id);
     const selectedSessionId = selectedHermesSessionIdRef.current;
     if (selectedSessionId && ids.has(selectedSessionId)) {
       selectedHermesSessionIdRef.current = undefined;
@@ -4301,7 +4154,7 @@ export function AgentWorkspace({
       // Classify the raw frame once at ingress. Stores and transcript rendering
       // consume the typed event; the raw frame remains only for trace capture
       // and the Stage B status helpers below.
-      const classified = classifyHermesEvent(liveEvent);
+      const classified = withStoredHermesSessionId(classifyHermesEvent(liveEvent), storedSessionId);
       // Feature 15: record every inbound frame (raw type + the kind it
       // classified to) into the bounded, sanitized trace buffer so the dev/debug
       // trace panel can reconstruct the session. recordInbound re-classifies and
@@ -4352,8 +4205,10 @@ export function AgentWorkspace({
         [storedSessionId]: nextSessionEvents,
       };
       setLiveEvents(liveEventsRef.current);
-      const toolEventPhase = hermesToolEventPhase(event.type);
+      const toolEventPhase = classified.kind === "tool" ? classified.phase : undefined;
       if (toolEventPhase === "complete") {
+        // The classifier treats any tool.*complete* subtype as complete, a
+        // superset of the old exact tool.complete drain trigger.
         // Hermes drains every accepted steer into the tool result it just
         // produced (run_agent.steer). Mark the pending entries drained rather
         // than removing them here: whether a steer was ACCEPTED is settled
@@ -4367,21 +4222,10 @@ export function AgentWorkspace({
           for (const entry of list) entry.toolDrained = true;
         }
       }
-      const hasActiveToolCalls =
-        toolEventPhase !== undefined
-          ? updateSessionToolCallActivity(storedSessionId, event, toolEventPhase)
-          : toolCallSessionIdsRef.current.has(storedSessionId);
-      const status = agentStatusFromHermesEvent(event);
-      if (status === "waitingForUser") {
-        setSessionWorking(storedSessionId, false);
-        setSessionWaiting(storedSessionId, true);
-      } else if (status === "running") {
-        setSessionWaiting(storedSessionId, false);
-        setSessionWorking(storedSessionId, true);
-      }
+      const status = agentStatusFromHermesEvent(classified);
       const activityCounts =
         status === "completed" || status === "failed" || status === "cancelled"
-          ? clearSessionActivity(storedSessionId)
+          ? agentActivityCountsFromStore()
           : undefined;
       if (activityCounts) {
         // Feature 04: the session reached a terminal state (completed, a
@@ -4396,11 +4240,11 @@ export function AgentWorkspace({
           sessionId: storedSessionId,
           title: sessionDisplayTitle,
           status,
-          summary: agentStatusSummaryFromHermesEvent(event, status),
+          summary: agentStatusSummaryFromHermesEvent(classified, status),
           ...activityCounts,
         });
       }
-      if (isTerminalHermesEvent(event.type)) {
+      if (isTerminalHermesEvent(classified)) {
         unlisten();
         if (!activityCounts) {
           clearSessionActivity(storedSessionId);
@@ -4736,8 +4580,7 @@ export function AgentWorkspace({
     // the model is never called and no "working" loader competes with the
     // image's own in-thread loader.
     if (options?.skipPrompt) return storedSessionId;
-    setSessionWorking(storedSessionId, true);
-    setSessionWaiting(storedSessionId, false);
+    recordSessionRunningActivity(storedSessionId);
     dispatchAgentSessionStatus({
       sessionId: storedSessionId,
       title: sessionDisplayTitle,
@@ -4800,8 +4643,7 @@ export function AgentWorkspace({
         throw err;
       }
       sessionGatewayUnlistenRef.current.get(storedSessionId)?.();
-      setSessionWorking(storedSessionId, false);
-      setSessionWaiting(storedSessionId, false);
+      recordSessionErrorActivity(storedSessionId, messageFromError(err));
       dispatchAgentSessionStatus({
         sessionId: storedSessionId,
         title: sessionDisplayTitle,
@@ -5476,6 +5318,13 @@ export function AgentWorkspace({
     } as HermesGatewayEvent & { receivedAt: string });
   }
 
+  function withStoredHermesSessionId(
+    event: JuneHermesEvent,
+    storedSessionId: string,
+  ): JuneHermesEvent {
+    return { ...event, sessionId: storedSessionId } as JuneHermesEvent;
+  }
+
   function pushLiveEvent(key: string, event: JuneHermesEvent) {
     const nextEvents = [...(liveEventsRef.current[key] ?? []), event].slice(-200);
     liveEventsRef.current = {
@@ -5723,7 +5572,7 @@ export function AgentWorkspace({
   }
 
   // Stops a running June turn: interrupts the runtime session over the
-  // gateway, then clears the local working/waiting flags regardless — the
+  // gateway, then records a terminal activity-store level regardless — the
   // user asked for it to stop, so the UI must not stay "thinking" even when
   // the RPC fails (gateway drop, runtime session already gone).
   async function stopHermesSession(sessionId: string) {
@@ -5744,15 +5593,7 @@ export function AgentWorkspace({
     // too -- otherwise a steer typed-then-stopped lingers and could auto-submit
     // as a follow-up after a later run in the same session.
     delete pendingSteerBySessionIdRef.current[sessionId];
-    const activityCounts = clearSessionActivity(sessionId);
-    // Feature 11: the per-session listener is gone, so no terminal frame will
-    // reach the activity store to retire this row. Record a synthetic terminal
-    // lifecycle so the drawer flips the session out of "running" the instant
-    // the user clicks stop (the row persists, now reading as complete).
-    hermesActivityStore.record(
-      { kind: "lifecycle", sessionId, status: "cancelled", receivedAt: new Date().toISOString() },
-      hermesModeFor(sessionId),
-    );
+    const activityCounts = clearSessionActivity(sessionId, "cancelled");
     dispatchAgentSessionStatus({
       sessionId,
       title:
@@ -5921,8 +5762,8 @@ export function AgentWorkspace({
 
   // Drops a deleted session from local state. Removing it from items fires
   // the sessions-changed effect, which syncs the sidebar; the shared scrub
-  // clears messages, pending sends, working/waiting flags, and live events so
-  // a running session doesn't linger as phantom "working" work.
+  // clears messages, pending sends, activity-store state, and live events so a
+  // running session doesn't linger as phantom "working" work.
   function removeHermesSessionLocally(sessionId: string, selectNext = true) {
     setHermesSessionItems((current) => {
       const next = current.filter((session) => session.id !== sessionId);
@@ -11388,8 +11229,11 @@ function renderInlineMarkdown(
   return nodes;
 }
 
-function eventText(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
+function payloadText(payloadValue: unknown) {
+  const payload =
+    payloadValue && typeof payloadValue === "object" && !Array.isArray(payloadValue)
+      ? (payloadValue as Record<string, unknown>)
+      : undefined;
   if (!payload) return "";
   for (const key of [
     "text",
@@ -11848,80 +11692,76 @@ function sessionHasActiveWork(
   );
 }
 
-function isTerminalHermesEvent(type: string) {
-  const normalized = type.toLowerCase();
-  return (
-    normalized === "error" ||
-    normalized === "message.complete" ||
-    normalized === "message.completed" ||
-    normalized === "turn.complete" ||
-    normalized === "turn.completed" ||
-    normalized === "session.complete" ||
-    normalized === "session.completed" ||
-    normalized === "background.complete" ||
-    normalized === "background.completed"
-  );
-}
+type AgentActivityLevelProjection = {
+  workingSessionIds: Set<string>;
+  waitingSessionIds: Set<string>;
+  toolCallSessionIds: Set<string>;
+};
 
-function hermesToolEventPhase(type: string): HermesToolEventPhase | undefined {
-  const normalized = type.toLowerCase();
-  if (normalized === "tool.complete") return "complete";
-  if (normalized === "tool.start") return "start";
-  if (normalized === "tool.progress") return "progress";
-  return undefined;
-}
-
-function toolEventActivityKey(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
-  return (
-    stringValue(payload?.tool_id) ??
-    stringValue(payload?.tool_call_id) ??
-    stringValue(payload?.call_id) ??
-    stringValue(payload?.id) ??
-    stringValue(payload?.request_id)
-  );
-}
-
-function agentStatusFromHermesEvent(event: HermesGatewayEvent): AgentSessionStatusKind | undefined {
-  if (event.type === "error") return "failed";
-  if (event.type === "clarify.request" || event.type === "approval.request") {
-    return "waitingForUser";
+function projectAgentActivityLevels(records: AgentActivityRecord[]): AgentActivityLevelProjection {
+  const workingSessionIds = new Set<string>();
+  const waitingSessionIds = new Set<string>();
+  const toolCallSessionIds = new Set<string>();
+  for (const record of records) {
+    if (record.phase === "running" || record.phase === "background") {
+      workingSessionIds.add(record.sessionId);
+    } else if (record.phase === "waiting") {
+      waitingSessionIds.add(record.sessionId);
+    }
+    if (record.currentTool) {
+      toolCallSessionIds.add(record.sessionId);
+    }
   }
-  if (event.type === "clarify.response" || event.type === "approval.response") {
-    return "running";
-  }
-  if (isTerminalHermesEvent(event.type)) return "completed";
+  return { toolCallSessionIds, waitingSessionIds, workingSessionIds };
+}
+
+function agentActivityCountsFromStore() {
+  const projection = projectAgentActivityLevels(hermesActivityStore.getRecords());
+  return {
+    activeCount: projection.workingSessionIds.size + projection.waitingSessionIds.size,
+    needsUserCount: projection.waitingSessionIds.size,
+  };
+}
+
+function lifecycleStatusLooksRunning(event: Extract<JuneHermesEvent, { kind: "lifecycle" }>) {
+  return event.rawType === "status.update";
+}
+
+function agentStatusFromHermesEvent(event: JuneHermesEvent): AgentSessionStatusKind | undefined {
+  if (event.kind === "error") return "failed";
+  if (event.kind === "pending_action") return "waitingForUser";
+  if (event.kind === "pending_action_resolution") return "running";
+  if (isTerminalHermesEvent(event)) return "completed";
   if (
-    event.type === "message.start" ||
-    event.type === "thinking.delta" ||
-    event.type === "reasoning.delta" ||
-    event.type === "status.update" ||
-    event.type.startsWith("tool.")
+    event.kind === "tool" ||
+    event.kind === "reasoning" ||
+    // Only a turn START flips status (delta === undefined). Text deltas never
+    // re-dispatched status on the raw path either — per-chunk dispatch would
+    // churn app state on every streamed token.
+    (event.kind === "transcript" && !event.complete && event.delta === undefined) ||
+    (event.kind === "lifecycle" && lifecycleStatusLooksRunning(event))
   ) {
     return "running";
   }
   return undefined;
 }
 
-function agentStatusSummaryFromHermesEvent(
-  event: HermesGatewayEvent,
-  status: AgentSessionStatusKind,
-) {
+function agentStatusSummaryFromHermesEvent(event: JuneHermesEvent, status: AgentSessionStatusKind) {
   if (status === "waitingForUser") {
-    return event.type === "approval.request" ? "June needs approval." : "June has a question.";
+    if (event.kind !== "pending_action") return "June has a question.";
+    return event.action.kind === "clarify" ? "June has a question." : "June needs approval.";
   }
   if (status === "completed") return "June finished.";
-  if (status === "failed") return eventText(event) || "June hit a problem.";
-  if (event.type === "status.update") {
-    return eventText(event) || "June is working.";
+  if (status === "failed") {
+    return event.kind === "error" ? event.message || "June hit a problem." : "June hit a problem.";
   }
-  if (event.type.startsWith("tool.")) {
-    const payload = event.payload as Record<string, unknown> | undefined;
-    const name =
-      stringValue(payload?.name) ?? stringValue(payload?.tool_name) ?? stringValue(payload?.tool);
-    return toolActivitySentence(name, payload);
+  if (event.kind === "lifecycle") {
+    return payloadText(event.payload) || "June is working.";
   }
-  if (event.type === "thinking.delta" || event.type === "reasoning.delta") {
+  if (event.kind === "tool") {
+    return toolActivitySentence(event.name, event.sanitizedPayload);
+  }
+  if (event.kind === "reasoning") {
     return "Thinking.";
   }
   return "June is working.";

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4176,19 +4176,19 @@ export function AgentWorkspace({
       // classified to) into the bounded, sanitized trace buffer so the dev/debug
       // trace panel can reconstruct the session. recordInbound re-classifies and
       // sanitizes internally; nothing raw is retained.
-      hermesTraceBuffer.recordInbound(liveEvent);
-      if (classified.kind === "unsupported") {
+      hermesTraceBuffer.recordInbound(liveEvent, { storedSessionId });
+      if (storedClassified.kind === "unsupported") {
         // Feed the bounded per-session store so the user gets a recoverable
         // notice (when this is the active session) and developers get a
         // sanitized, issue-report-safe export. The payload is already sanitized
         // by the classifier; nothing raw is retained or logged.
-        unsupportedEventStore.record(classified);
+        unsupportedEventStore.record(storedClassified);
         if (import.meta.env.DEV) {
           // biome-ignore lint/suspicious/noConsole: dev-only unsupported-event diagnostic
           console.debug(
             "[hermes] unsupported event",
-            classified.rawType,
-            classified.sanitizedPayload,
+            storedClassified.rawType,
+            storedClassified.sanitizedPayload,
           );
         }
       } else if (storedClassified.kind === "pending_action") {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1493,10 +1493,12 @@ export function AgentWorkspace({
     // `activityStoreVersion` is the change signal; the read returns live rows.
     [activityStoreVersion],
   );
-  const activityLevels = useMemo(
-    () => projectAgentActivityLevels(activityRecords),
-    [activityRecords],
-  );
+  const previousActivityLevelsRef = useRef<AgentActivityLevelProjection | undefined>(undefined);
+  const activityLevels = useMemo(() => {
+    const next = projectAgentActivityLevels(activityRecords, previousActivityLevelsRef.current);
+    previousActivityLevelsRef.current = next;
+    return next;
+  }, [activityRecords]);
   const { toolCallSessionIds, waitingSessionIds, workingSessionIds } = activityLevels;
   const workingSessionIdsRef = useRef<Set<string>>(workingSessionIds);
   const toolCallSessionIdsRef = useRef<Set<string>>(toolCallSessionIds);
@@ -1857,7 +1859,14 @@ export function AgentWorkspace({
 
   function recordSessionRunningActivity(sessionId: string) {
     hermesActivityStore.record(
-      { kind: "lifecycle", sessionId, status: "running", receivedAt: new Date().toISOString() },
+      {
+        kind: "lifecycle",
+        sessionId,
+        flavor: "running",
+        status: "running",
+        text: "",
+        receivedAt: new Date().toISOString(),
+      },
       hermesModeFor(sessionId),
     );
   }
@@ -1871,7 +1880,14 @@ export function AgentWorkspace({
 
   const clearSessionActivity = useCallback((sessionId: string, status = "completed") => {
     hermesActivityStore.record(
-      { kind: "lifecycle", sessionId, status, receivedAt: new Date().toISOString() },
+      {
+        kind: "lifecycle",
+        sessionId,
+        flavor: "terminal",
+        status,
+        text: "",
+        receivedAt: new Date().toISOString(),
+      },
       hermesModeFor(sessionId),
     );
     return agentActivityCountsFromStore();
@@ -4154,7 +4170,7 @@ export function AgentWorkspace({
       // Classify the raw frame once at ingress. Stores and transcript rendering
       // consume the typed event; the raw frame remains only for trace capture
       // and the Stage B status helpers below.
-      const classified = withStoredHermesSessionId(classifyHermesEvent(liveEvent), storedSessionId);
+      const classified = classifyHermesEvent(liveEvent);
       // Feature 15: record every inbound frame (raw type + the kind it
       // classified to) into the bounded, sanitized trace buffer so the dev/debug
       // trace panel can reconstruct the session. recordInbound re-classifies and
@@ -4188,7 +4204,10 @@ export function AgentWorkspace({
       // derives the session's phase (running/waiting/background/error/complete),
       // current tool, and subagent count from the normalized event — never from
       // the raw frame (raw JSON belongs to feature 15's trace panel).
-      hermesActivityStore.record(classified, hermesModeFor(storedSessionId));
+      hermesActivityStore.record(
+        withStoredHermesSessionId(classified, storedSessionId),
+        hermesModeFor(storedSessionId),
+      );
       // Feature 14: extract any file/artifact reference this event carries into
       // the per-session artifact timeline behind the drawer's "Artifacts"
       // section. The store is total and only acts on `tool` completions that
@@ -11229,43 +11248,6 @@ function renderInlineMarkdown(
   return nodes;
 }
 
-function payloadText(payloadValue: unknown) {
-  const payload =
-    payloadValue && typeof payloadValue === "object" && !Array.isArray(payloadValue)
-      ? (payloadValue as Record<string, unknown>)
-      : undefined;
-  if (!payload) return "";
-  for (const key of [
-    "text",
-    "delta",
-    "message",
-    "summary",
-    "status",
-    "content",
-    "output",
-    "result",
-    "command",
-  ]) {
-    const value = stringValue(
-      payload[key],
-      key === "text" || key === "delta" || key === "message" || key === "content",
-    );
-    if (value) return value;
-  }
-  return "";
-}
-
-function stringValue(value: unknown, preserveWhitespace = false) {
-  if (typeof value === "string") {
-    if (!value.trim()) return undefined;
-    return preserveWhitespace ? value : value.trim();
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return undefined;
-}
-
 function capabilityMatches(
   item: HermesSkillInfo | HermesToolsetInfo | HermesMessagingPlatformInfo,
   query: string,
@@ -11692,13 +11674,16 @@ function sessionHasActiveWork(
   );
 }
 
-type AgentActivityLevelProjection = {
+export type AgentActivityLevelProjection = {
   workingSessionIds: Set<string>;
   waitingSessionIds: Set<string>;
   toolCallSessionIds: Set<string>;
 };
 
-function projectAgentActivityLevels(records: AgentActivityRecord[]): AgentActivityLevelProjection {
+export function projectAgentActivityLevels(
+  records: AgentActivityRecord[],
+  previous?: AgentActivityLevelProjection,
+): AgentActivityLevelProjection {
   const workingSessionIds = new Set<string>();
   const waitingSessionIds = new Set<string>();
   const toolCallSessionIds = new Set<string>();
@@ -11712,7 +11697,19 @@ function projectAgentActivityLevels(records: AgentActivityRecord[]): AgentActivi
       toolCallSessionIds.add(record.sessionId);
     }
   }
-  return { toolCallSessionIds, waitingSessionIds, workingSessionIds };
+  return {
+    workingSessionIds: stableSet(workingSessionIds, previous?.workingSessionIds),
+    waitingSessionIds: stableSet(waitingSessionIds, previous?.waitingSessionIds),
+    toolCallSessionIds: stableSet(toolCallSessionIds, previous?.toolCallSessionIds),
+  };
+}
+
+function stableSet(next: Set<string>, previous: Set<string> | undefined): Set<string> {
+  if (!previous || previous.size !== next.size) return next;
+  for (const value of next) {
+    if (!previous.has(value)) return next;
+  }
+  return previous;
 }
 
 function agentActivityCountsFromStore() {
@@ -11724,7 +11721,7 @@ function agentActivityCountsFromStore() {
 }
 
 function lifecycleStatusLooksRunning(event: Extract<JuneHermesEvent, { kind: "lifecycle" }>) {
-  return event.rawType === "status.update";
+  return event.flavor === "running";
 }
 
 function agentStatusFromHermesEvent(event: JuneHermesEvent): AgentSessionStatusKind | undefined {
@@ -11756,7 +11753,7 @@ function agentStatusSummaryFromHermesEvent(event: JuneHermesEvent, status: Agent
     return event.kind === "error" ? event.message || "June hit a problem." : "June hit a problem.";
   }
   if (event.kind === "lifecycle") {
-    return payloadText(event.payload) || "June is working.";
+    return event.text || "June is working.";
   }
   if (event.kind === "tool") {
     return toolActivitySentence(event.name, event.sanitizedPayload);

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5736,7 +5736,7 @@ export function AgentWorkspace({
     // lifecycle so the drawer flips the session out of "running" the instant
     // the user clicks stop (the row persists, now reading as complete).
     hermesActivityStore.record(
-      { kind: "lifecycle", sessionId, status: "cancelled" },
+      { kind: "lifecycle", sessionId, status: "cancelled", receivedAt: new Date().toISOString() },
       hermesModeFor(sessionId),
     );
     dispatchAgentSessionStatus({

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4171,6 +4171,7 @@ export function AgentWorkspace({
       // consume the typed event; the raw frame remains only for trace capture
       // and the Stage B status helpers below.
       const classified = classifyHermesEvent(liveEvent);
+      const storedClassified = withStoredHermesSessionId(classified, storedSessionId);
       // Feature 15: record every inbound frame (raw type + the kind it
       // classified to) into the bounded, sanitized trace buffer so the dev/debug
       // trace panel can reconstruct the session. recordInbound re-classifies and
@@ -4190,13 +4191,13 @@ export function AgentWorkspace({
             classified.sanitizedPayload,
           );
         }
-      } else if (classified.kind === "pending_action") {
+      } else if (storedClassified.kind === "pending_action") {
         // Feature 04: aggregate this blocker into the pending-action store
         // keyed by mode + session + request. The session's mode comes from its
         // recorded opt-in (sudo carries its own; the rest derive it here). A
         // fresh event for a known request also re-confirms a row that went
         // stale across a reconnect (see the store's reconcile logic).
-        pendingActionStore.record(classified, hermesModeFor(storedSessionId));
+        pendingActionStore.record(storedClassified, hermesModeFor(storedSessionId));
       }
       // Feature 11: roll EVERY classified event into the global activity store
       // that backs the Agent activity drawer. The store is total and ignores
@@ -4204,10 +4205,7 @@ export function AgentWorkspace({
       // derives the session's phase (running/waiting/background/error/complete),
       // current tool, and subagent count from the normalized event — never from
       // the raw frame (raw JSON belongs to feature 15's trace panel).
-      hermesActivityStore.record(
-        withStoredHermesSessionId(classified, storedSessionId),
-        hermesModeFor(storedSessionId),
-      );
+      hermesActivityStore.record(storedClassified, hermesModeFor(storedSessionId));
       // Feature 14: extract any file/artifact reference this event carries into
       // the per-session artifact timeline behind the drawer's "Artifacts"
       // section. The store is total and only acts on `tool` completions that
@@ -5042,7 +5040,7 @@ export function AgentWorkspace({
       );
       // Feature 04: the user just answered this approval — clear its global
       // "Needs you" row immediately (the response itself is the resolution).
-      pendingActionStore.resolveRequest(sessionId, requestId);
+      pendingActionStore.resolveRequest(liveEventKey, requestId);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
@@ -5065,7 +5063,7 @@ export function AgentWorkspace({
         setLiveEvents(liveEventsRef.current);
         // The request can never be answered now — retire its card so neither the
         // sidebar count nor the inline prompt offers a dead-end "Respond".
-        pendingActionStore.resolveRequest(sessionId, requestId);
+        pendingActionStore.resolveRequest(liveEventKey, requestId);
         void loadHermesSessions();
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
@@ -5155,14 +5153,14 @@ export function AgentWorkspace({
         }),
       );
       // Feature 04: the user resolved the sudo prompt — clear its pending record.
-      pendingActionStore.resolveRequest(sessionId, requestId);
+      pendingActionStore.resolveRequest(liveEventKey, requestId);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
       if (isSessionGoneError(message)) {
         // The runtime is gone, so this prompt can never be answered — retire
         // its card and say so plainly instead of leaking the raw 404.
-        pendingActionStore.resolveRequest(sessionId, requestId);
+        pendingActionStore.resolveRequest(liveEventKey, requestId);
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
         setError(message, { sessionId });
@@ -5203,14 +5201,14 @@ export function AgentWorkspace({
         }),
       );
       // Feature 04: the user provided the secret — clear its pending record.
-      pendingActionStore.resolveRequest(sessionId, requestId);
+      pendingActionStore.resolveRequest(liveEventKey, requestId);
       setError(null);
     } catch (err) {
       const message = messageFromError(err);
       if (isSessionGoneError(message)) {
         // The runtime is gone, so this secret prompt can never be answered —
         // retire its card and say so plainly instead of leaking the raw 404.
-        pendingActionStore.resolveRequest(sessionId, requestId);
+        pendingActionStore.resolveRequest(liveEventKey, requestId);
         setError(SESSION_GONE_MESSAGE, { sessionId });
       } else {
         setError(message, { sessionId });
@@ -11746,7 +11744,8 @@ function agentStatusFromHermesEvent(event: JuneHermesEvent): AgentSessionStatusK
 function agentStatusSummaryFromHermesEvent(event: JuneHermesEvent, status: AgentSessionStatusKind) {
   if (status === "waitingForUser") {
     if (event.kind !== "pending_action") return "June has a question.";
-    return event.action.kind === "clarify" ? "June has a question." : "June needs approval.";
+    // Sudo and secret deliberately keep the generic sentence for visible-copy parity with main.
+    return event.action.kind === "approval" ? "June needs approval." : "June has a question.";
   }
   if (status === "completed") return "June finished.";
   if (status === "failed") {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -161,6 +161,7 @@ import {
   isHermesFeatureSupported,
   isSensitiveKey,
   type HermesMode,
+  type JuneHermesEvent,
 } from "../../lib/hermes-control-plane";
 import {
   attachImageToSession,
@@ -276,7 +277,6 @@ import {
   type AgentApprovalChoice,
   type AgentChatPart,
   type AgentChatTurn,
-  type LiveHermesEvent,
 } from "../../lib/agent-chat-runtime";
 import { toolActivitySentence } from "../../lib/agent-tool-labels";
 import {
@@ -891,7 +891,7 @@ type AgentSessionContinuity = {
   workingSessionIds: string[];
   waitingSessionIds: string[];
   runtimeSessionIds: Record<string, string>;
-  liveEvents: Record<string, LiveHermesEvent[]>;
+  liveEvents: Record<string, JuneHermesEvent[]>;
   titleOverrides: Record<string, string>;
   activeToolCallsBySession: Record<string, Record<string, number>>;
   pendingIssueReports: Record<string, PendingIssueReport>;
@@ -1050,7 +1050,7 @@ function captureSessionContinuity(state: {
   workingSessionIds: Set<string>;
   waitingSessionIds: Set<string>;
   runtimeSessionIds: Record<string, string>;
-  liveEvents: Record<string, LiveHermesEvent[]>;
+  liveEvents: Record<string, JuneHermesEvent[]>;
   titleOverrides: Record<string, string>;
   activeToolCallsBySession: Record<string, Record<string, number>>;
   pendingIssueReports: Record<string, PendingIssueReport>;
@@ -1507,7 +1507,7 @@ export function AgentWorkspace({
   const sessionMessagesFetchSeqRef = useRef<Map<string, number>>(new Map());
   const sessionMessagesAppliedSeqRef = useRef<Map<string, number>>(new Map());
   const [hermesSessionsLoading, setHermesSessionsLoading] = useState(false);
-  const [liveEvents, setLiveEvents] = useState<Record<string, LiveHermesEvent[]>>(
+  const [liveEvents, setLiveEvents] = useState<Record<string, JuneHermesEvent[]>>(
     () => continuity?.liveEvents ?? {},
   );
   const [thinkingOpenByKey, setThinkingOpenByKey] = useState<Record<string, boolean>>({});
@@ -1653,7 +1653,7 @@ export function AgentWorkspace({
   // the previous turn is still streaming must replace the old handler, not
   // stack a second one — otherwise every event lands twice in liveEvents.
   const sessionGatewayUnlistenRef = useRef<Map<string, () => void>>(new Map());
-  const liveEventsRef = useRef<Record<string, LiveHermesEvent[]>>(liveEvents);
+  const liveEventsRef = useRef<Record<string, JuneHermesEvent[]>>(liveEvents);
   const hydratedTaskIdsRef = useRef<Set<string>>(new Set());
   // Tasks whose hydration fetch has resolved (hydratedTaskIdsRef only says
   // the fetch *started*) — the scroll-settling logic needs the landing.
@@ -4298,13 +4298,9 @@ export function AgentWorkspace({
     const removeListener = gateway.onEvent((event) => {
       if (event.session_id !== runtimeSessionId && event.session_id !== storedSessionId) return;
       const liveEvent = { ...event, receivedAt: new Date().toISOString() };
-      // Run every live frame through the typed control plane alongside the
-      // existing string-based handling below. This is the first consumer of
-      // the classifier: it doesn't drive rendering yet (later features migrate
-      // families onto it incrementally), but it proves the live path is typed
-      // and surfaces any raw type June can't yet model. Unknown frames classify
-      // as `unsupported` rather than being dropped, so a Hermes upgrade that
-      // adds an event shows up in dev instead of silently doing nothing.
+      // Classify the raw frame once at ingress. Stores and transcript rendering
+      // consume the typed event; the raw frame remains only for trace capture
+      // and the Stage B status helpers below.
       const classified = classifyHermesEvent(liveEvent);
       // Feature 15: record every inbound frame (raw type + the kind it
       // classified to) into the bounded, sanitized trace buffer so the dev/debug
@@ -4349,7 +4345,7 @@ export function AgentWorkspace({
       hermesArtifactStore.record(classified, hermesModeFor(storedSessionId));
       const nextSessionEvents = [
         ...(liveEventsRef.current[storedSessionId] ?? []),
-        liveEvent,
+        classified,
       ].slice(-200);
       liveEventsRef.current = {
         ...liveEventsRef.current,
@@ -5175,11 +5171,14 @@ export function AgentWorkspace({
         session_id: sessionId,
         choice,
       });
-      pushLiveEvent(liveEventKey, {
-        type: "approval.response",
-        session_id: sessionId,
-        payload: { request_id: requestId, choice },
-      });
+      pushLiveEvent(
+        liveEventKey,
+        classifyOptimisticLiveEvent({
+          type: "approval.response",
+          session_id: sessionId,
+          payload: { request_id: requestId, choice },
+        }),
+      );
       // Feature 04: the user just answered this approval — clear its global
       // "Needs you" row immediately (the response itself is the resolution).
       pendingActionStore.resolveRequest(sessionId, requestId);
@@ -5233,10 +5232,13 @@ export function AgentWorkspace({
         request_id: requestId,
         answer,
       });
-      pushLiveEvent(liveEventKey, {
-        type: "clarify.response",
-        payload: { request_id: requestId, answer },
-      });
+      pushLiveEvent(
+        liveEventKey,
+        classifyOptimisticLiveEvent({
+          type: "clarify.response",
+          payload: { request_id: requestId, answer },
+        }),
+      );
       // Feature 04: the user answered the clarification — clear its pending record.
       pendingActionStore.resolveRequest(liveEventKey, requestId);
       setError(null);
@@ -5283,11 +5285,14 @@ export function AgentWorkspace({
         approved,
         mode,
       });
-      pushLiveEvent(liveEventKey, {
-        type: "sudo.response",
-        session_id: sessionId,
-        payload: { request_id: requestId, granted: approved, mode },
-      });
+      pushLiveEvent(
+        liveEventKey,
+        classifyOptimisticLiveEvent({
+          type: "sudo.response",
+          session_id: sessionId,
+          payload: { request_id: requestId, granted: approved, mode },
+        }),
+      );
       // Feature 04: the user resolved the sudo prompt — clear its pending record.
       pendingActionStore.resolveRequest(sessionId, requestId);
       setError(null);
@@ -5328,11 +5333,14 @@ export function AgentWorkspace({
         requestId,
         value,
       });
-      pushLiveEvent(liveEventKey, {
-        type: "secret.response",
-        session_id: sessionId,
-        payload: { request_id: requestId, provided: true },
-      });
+      pushLiveEvent(
+        liveEventKey,
+        classifyOptimisticLiveEvent({
+          type: "secret.response",
+          session_id: sessionId,
+          payload: { request_id: requestId, provided: true },
+        }),
+      );
       // Feature 04: the user provided the secret — clear its pending record.
       pendingActionStore.resolveRequest(sessionId, requestId);
       setError(null);
@@ -5461,9 +5469,15 @@ export function AgentWorkspace({
     }
   }
 
-  function pushLiveEvent(key: string, event: HermesGatewayEvent) {
-    const liveEvent = { ...event, receivedAt: new Date().toISOString() };
-    const nextEvents = [...(liveEventsRef.current[key] ?? []), liveEvent].slice(-200);
+  function classifyOptimisticLiveEvent(event: HermesGatewayEvent): JuneHermesEvent {
+    return classifyHermesEvent({
+      ...event,
+      receivedAt: new Date().toISOString(),
+    } as HermesGatewayEvent & { receivedAt: string });
+  }
+
+  function pushLiveEvent(key: string, event: JuneHermesEvent) {
+    const nextEvents = [...(liveEventsRef.current[key] ?? []), event].slice(-200);
     liveEventsRef.current = {
       ...liveEventsRef.current,
       [key]: nextEvents,
@@ -11825,7 +11839,7 @@ function sessionHasActiveWork(
   sessionId: string,
   workingSessionIds: Set<string>,
   waitingSessionIds: Set<string>,
-  liveEvents: Record<string, LiveHermesEvent[]>,
+  liveEvents: Record<string, JuneHermesEvent[]>,
 ) {
   return (
     workingSessionIds.has(sessionId) ||

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4212,7 +4212,7 @@ export function AgentWorkspace({
       // name a known file/url field (conservative — never parses prose), so one
       // unconditional call is safe for every kind. Mode rides along so each
       // artifact can show its blast radius (sandboxed copy vs unrestricted path).
-      hermesArtifactStore.record(classified, hermesModeFor(storedSessionId));
+      hermesArtifactStore.record(storedClassified, hermesModeFor(storedSessionId));
       const nextSessionEvents = [
         ...(liveEventsRef.current[storedSessionId] ?? []),
         classified,

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -672,7 +672,18 @@ function appendLiveHermesEvents(turns: AgentChatTurn[], events: JuneHermesEvent[
         break;
       }
 
-      case "lifecycle":
+      case "lifecycle": {
+        if (event.flavor === "terminal") {
+          const target = currentAssistant ?? lastAssistantTurn(turns);
+          if (target?.status === "running") {
+            target.status = "complete";
+            completeRunningParts(target.parts);
+          }
+          currentAssistant = null;
+        }
+        break;
+      }
+
       case "unsupported":
         break;
     }

--- a/src/lib/agent-chat-runtime.ts
+++ b/src/lib/agent-chat-runtime.ts
@@ -4,7 +4,6 @@ import type {
   AgentToolEventStatus,
   HermesSessionMessage,
 } from "./tauri";
-import type { HermesGatewayEvent } from "./hermes-gateway";
 import {
   isContextOverflowErrorSentinel,
   isContextOverflowMessage,
@@ -13,13 +12,8 @@ import {
 import { isScheduledRunPreamble, stripScheduledRunPreamble } from "./hermes-adapter";
 import { displayedUserMessageText } from "./issue-report-prompt";
 import { displayedSkillInvocationText } from "./skill-slash-commands";
-import { STEER_EVENT_TYPE, steeringPartText } from "./hermes-session-steer";
-import { parseHermesMode } from "./hermes-control-plane";
+import type { JuneHermesEvent } from "./hermes-control-plane";
 import { toolActivityLabel } from "./agent-tool-labels";
-
-export type LiveHermesEvent = HermesGatewayEvent & {
-  receivedAt: string;
-};
 
 export type AgentChatTextPart = {
   type: "text";
@@ -176,7 +170,7 @@ function sortAgentChatTurns(turns: AgentChatTurn[]) {
 export function buildAgentChatTurns(
   messages: AgentMessageDto[],
   toolEvents: AgentToolEventDto[],
-  liveEvents: LiveHermesEvent[] = [],
+  liveEvents: JuneHermesEvent[] = [],
 ): AgentChatTurn[] {
   const turns = messages.map(messageToTurn);
   appendPersistedToolEvents(turns, toolEvents);
@@ -190,7 +184,7 @@ export function buildAgentChatTurns(
 
 export function buildHermesSessionChatTurns(
   messages: HermesSessionMessage[],
-  liveEvents: LiveHermesEvent[] = [],
+  liveEvents: JuneHermesEvent[] = [],
 ): AgentChatTurn[] {
   const turns: AgentChatTurn[] = [];
   const toolResults = new Map<string, HermesSessionMessage>();
@@ -304,7 +298,7 @@ export function repairContractionSpacing(text: string): string {
   );
 }
 
-export function completedHermesMessageText(events: LiveHermesEvent[]) {
+export function completedHermesMessageText(events: JuneHermesEvent[]) {
   const turn = buildAgentChatTurns([], [], events)
     .filter((item) => item.role === "assistant")
     .at(-1);
@@ -418,345 +412,269 @@ function assistantTurnForTimestamp(turns: AgentChatTurn[], createdAt: string | u
   return undefined;
 }
 
-function appendLiveHermesEvents(turns: AgentChatTurn[], events: LiveHermesEvent[]) {
+function appendLiveHermesEvents(turns: AgentChatTurn[], events: JuneHermesEvent[]) {
   let currentAssistant: AgentChatTurn | null = null;
   const toolCreatedTurns = new Set<AgentChatTurn>();
 
   for (const event of events) {
-    const text = eventText(event);
-    if (event.type === STEER_EVENT_TYPE) {
-      // A user instruction steered into the running turn (feature 06). It is a
-      // local, first-party event — not a Hermes frame — so it gets its own
-      // quiet system turn at its `receivedAt` order. Close any open assistant
-      // turn so the instruction reads as a beat between what June was doing and
-      // what it does next.
-      const instruction = steeringPartText(event.payload).trim();
-      if (instruction) {
-        turns.push({
-          id: `steering:${event.receivedAt}:${turns.length}`,
-          role: "system",
-          createdAt: event.receivedAt,
-          status: "complete",
-          parts: [{ type: "steering", text: instruction }],
-        });
-        currentAssistant = null;
-      }
-      continue;
-    }
-
-    if (event.type === "message.start") {
-      currentAssistant = createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      continue;
-    }
-
-    if (event.type === "message.delta") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      appendAssistantTextPart(currentAssistant.parts, deltaEventText(event), "running");
-      continue;
-    }
-
-    if (event.type === "message.complete") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      const payload = event.payload as Record<string, unknown> | undefined;
-      // A billing failure is recognizable from its "Error:" text prefix; a
-      // context overflow is not, so only fold it when the turn actually failed
-      // — an ordinary sentence that mentions "context length" stays prose.
-      const failed = stringValue(payload?.status)?.toLowerCase() === "error";
-      const notice = text
-        ? (creditsNoticeFromTurnText(text) ?? (failed ? contextOverflowNotice(text) : undefined))
-        : undefined;
-      if (notice) {
-        // The complete text is authoritative for the turn (see
-        // completeAssistantTextPart); when it's a billing failure, any
-        // partially streamed text is superseded along with it.
-        currentAssistant.parts = currentAssistant.parts.filter((part) => part.type !== "text");
-        currentAssistant.parts.push(notice);
-      } else if (text) {
-        completeAssistantTextPart(currentAssistant.parts, text);
-      }
-      currentAssistant.status = "complete";
-      completeRunningParts(currentAssistant.parts);
-      currentAssistant = null;
-      continue;
-    }
-
-    if (event.type === "thinking.delta" || event.type === "reasoning.delta") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      appendReasoningPart(currentAssistant.parts, deltaEventText(event));
-      continue;
-    }
-
-    if (event.type.startsWith("subagent.")) {
-      // Delegated subagents (the model's `delegate_task`) stream their own
-      // lifecycle: subagent.start / .tool / .progress / .thinking / .complete,
-      // each carrying the subagent's goal and identity. The gateway forwards
-      // them over the same socket as everything else; without this branch they
-      // were silently dropped and the spawn never appeared in the chat. Render
-      // each subagent as a tool-style row keyed by its id, so N parallel
-      // subagents show as N live rows that resolve as they finish.
-      if (!currentAssistant) {
-        currentAssistant = createAssistantTurn(turns, event.receivedAt);
-        toolCreatedTurns.add(currentAssistant);
-      }
-      const payload = event.payload as Record<string, unknown> | undefined;
-      const subagentId = stringValue(payload?.subagent_id);
-      const taskIndexRaw = payload?.task_index;
-      const taskIndex = typeof taskIndexRaw === "number" ? taskIndexRaw : undefined;
-      const key = subagentId ?? (taskIndex !== undefined ? `task-${taskIndex}` : "subagent");
-      const partId = `subagent:${key}`;
-      const goal = stringValue(payload?.goal);
-      const taskCountRaw = payload?.task_count;
-      const taskCount = typeof taskCountRaw === "number" ? taskCountRaw : undefined;
-      // Keep the richest label we have seen for this subagent: progress and
-      // tool events often omit the goal, and downgrading to the generic
-      // "Subagent" would make the row flicker. Prefer the goal, else the name
-      // already shown, else a task-position label.
-      const existingName = currentAssistant.parts.find(
-        (part): part is AgentChatToolPart => part.type === "tool" && part.id === partId,
-      )?.name;
-      const label = goal
-        ? `Subagent: ${goal}`
-        : (existingName ??
-          (taskCount && taskCount > 1 && taskIndex !== undefined
-            ? `Subagent ${taskIndex + 1} of ${taskCount}`
-            : "Subagent"));
-      // Terminal on `subagent.complete` or any failure-flavored subtype the
-      // gateway might add (fail/cancel/timeout/abort/interrupt). Keyed off the
-      // subtype, not a fixed allow-list, so a new terminal event can't strand
-      // a row as "running" forever.
-      const subtype = event.type.slice("subagent.".length).toLowerCase();
-      const reportedStatus = stringValue(payload?.status)?.toLowerCase() ?? "";
-      const failurePattern = /fail|error|cancel|timeout|abort|interrupt/;
-      const failed = failurePattern.test(subtype) || failurePattern.test(reportedStatus);
-      const completed = subtype === "complete" || subtype === "done" || failed;
-      const status: AgentChatToolPart["status"] = completed
-        ? failed
-          ? "failed"
-          : "complete"
-        : "running";
-      if (status === "running") {
-        currentAssistant.status = "running";
-      } else if (toolCreatedTurns.has(currentAssistant)) {
-        currentAssistant.status = "complete";
-      }
-      // The live line: a completion summary, else whatever the subagent is
-      // doing now (its latest tool preview).
-      const activity =
-        stringValue(payload?.summary) ??
-        stringValue(payload?.tool_preview) ??
-        (completed ? undefined : stringValue(payload?.text));
-      upsertToolPart(currentAssistant.parts, {
-        id: partId,
-        name: label,
-        text: activity ?? "",
-        status,
-      });
-      continue;
-    }
-
-    if (event.type.startsWith("tool.")) {
-      if (isClarifyToolEvent(event)) {
-        if (event.type.includes("complete") || event.type.includes("fail")) {
-          completePendingClarifyParts((currentAssistant ?? lastAssistantTurn(turns))?.parts ?? []);
+    switch (event.kind) {
+      case "steering": {
+        // A user instruction steered into the running turn (feature 06). It is
+        // local first-party state, so it gets its own quiet system turn at its
+        // `receivedAt` order. Close any open assistant turn so the instruction
+        // reads as a beat between what June was doing and what it does next.
+        const instruction = event.text.trim();
+        if (instruction) {
+          turns.push({
+            id: `steering:${event.receivedAt}:${turns.length}`,
+            role: "system",
+            createdAt: event.receivedAt,
+            status: "complete",
+            parts: [{ type: "steering", text: instruction }],
+          });
+          currentAssistant = null;
         }
-        continue;
+        break;
       }
-      if (!currentAssistant) {
-        currentAssistant = createAssistantTurn(turns, event.receivedAt);
-        toolCreatedTurns.add(currentAssistant);
-      }
-      const status = toolEventStatus(event);
-      if (status === "running") {
-        currentAssistant.status = "running";
-      } else if (toolCreatedTurns.has(currentAssistant)) {
-        // A turn that exists only because of tool events has nothing left to
-        // stream once its tool reaches a terminal state.
+
+      case "transcript": {
+        if (!event.complete && event.delta === undefined) {
+          currentAssistant = createAssistantTurn(turns, event.receivedAt);
+          currentAssistant.status = "running";
+          break;
+        }
+        currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+        if (!event.complete) {
+          currentAssistant.status = "running";
+          appendAssistantTextPart(currentAssistant.parts, event.delta ?? "", "running");
+          break;
+        }
+        const text = event.delta ?? "";
+        // A billing failure is recognizable from its "Error:" text prefix; a
+        // context overflow is not, so only fold it when the turn actually
+        // failed — an ordinary sentence that mentions "context length" stays prose.
+        const notice = text
+          ? (creditsNoticeFromTurnText(text) ??
+            (event.failed ? contextOverflowNotice(text) : undefined))
+          : undefined;
+        if (notice) {
+          // The complete text is authoritative for the turn (see
+          // completeAssistantTextPart); when it's a billing failure, any
+          // partially streamed text is superseded along with it.
+          currentAssistant.parts = currentAssistant.parts.filter((part) => part.type !== "text");
+          currentAssistant.parts.push(notice);
+        } else if (text) {
+          completeAssistantTextPart(currentAssistant.parts, text);
+        }
         currentAssistant.status = "complete";
+        completeRunningParts(currentAssistant.parts);
+        currentAssistant = null;
+        break;
       }
-      const payload = event.payload as Record<string, unknown> | undefined;
-      const name =
-        stringValue(payload?.name) ??
-        stringValue(payload?.tool_name) ??
-        stringValue(payload?.tool) ??
-        "tool";
-      upsertToolPart(currentAssistant.parts, {
-        id: toolEventKey(event),
-        name: toolActivityLabel(name, payload),
-        text,
-        status,
-      });
-      continue;
-    }
 
-    if (event.type === "clarify.request") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      const payload = event.payload as Record<string, unknown> | undefined;
-      upsertClarifyPart(currentAssistant.parts, {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `clarify:${event.receivedAt}`,
-        sessionId: event.session_id,
-        question:
-          stringValue(payload?.question, true) ?? "Hermes needs clarification before continuing.",
-        choices: stringArrayValue(payload?.choices),
-        status: "pending",
-      });
-      continue;
-    }
+      case "reasoning": {
+        currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+        currentAssistant.status = "running";
+        appendReasoningPart(currentAssistant.parts, event.delta);
+        break;
+      }
 
-    if (event.type === "clarify.response") {
-      const payload = event.payload as Record<string, unknown> | undefined;
-      upsertClarifyPart((currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [], {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `clarify:${event.receivedAt}`,
-        sessionId: event.session_id,
-        question: stringValue(payload?.question, true) ?? "",
-        choices: stringArrayValue(payload?.choices),
-        answer: stringValue(payload?.answer, true) ?? "",
-        status: "resolved",
-      });
-      continue;
-    }
-
-    if (event.type === "approval.request") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      const payload = event.payload as Record<string, unknown> | undefined;
-      upsertApprovalPart(currentAssistant.parts, {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `approval:${event.receivedAt}`,
-        command: stringValue(payload?.command, true) ?? "",
-        description:
-          stringValue(payload?.description, true) ?? "Hermes needs approval before continuing.",
-        sessionId: event.session_id,
-        allowPermanent: payload?.allow_permanent !== false,
-        status: "pending",
-      });
-      continue;
-    }
-
-    if (event.type === "approval.response") {
-      const payload = event.payload as Record<string, unknown> | undefined;
-      upsertApprovalPart((currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [], {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `approval:${event.receivedAt}`,
-        command: stringValue(payload?.command, true) ?? "",
-        description: stringValue(payload?.description, true) ?? "",
-        sessionId: event.session_id,
-        allowPermanent: payload?.allow_permanent !== false,
-        choice: approvalChoiceValue(payload?.choice),
-        status: "resolved",
-      });
-      continue;
-    }
-
-    if (event.type === "sudo.request") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      const payload = event.payload as Record<string, unknown> | undefined;
-      upsertSudoPart(currentAssistant.parts, {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `sudo:${event.receivedAt}`,
-        sessionId: event.session_id,
-        command: stringValue(payload?.command, true),
-        reason: stringValue(payload?.reason, true),
-        mode: parseHermesMode(payload?.mode),
-        status: "pending",
-      });
-      continue;
-    }
-
-    if (event.type === "sudo.response") {
-      const payload = event.payload as Record<string, unknown> | undefined;
-      // Hermes spells the outcome `granted`; `approved` is accepted as a synonym
-      // so a slightly different gateway build still resolves the card.
-      const granted =
-        typeof payload?.granted === "boolean"
-          ? payload.granted
-          : typeof payload?.approved === "boolean"
-            ? payload.approved
-            : undefined;
-      upsertSudoPart((currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [], {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `sudo:${event.receivedAt}`,
-        sessionId: event.session_id,
-        mode: parseHermesMode(payload?.mode),
-        approved: granted,
-        status: "resolved",
-      });
-      continue;
-    }
-
-    if (event.type === "secret.request") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      currentAssistant.status = "running";
-      const payload = event.payload as Record<string, unknown> | undefined;
-      // Read ONLY the metadata fields — never `value`/`api_key`, even if the
-      // gateway erroneously includes them, so the secret value can never reach
-      // a part or the serialized turn tree.
-      upsertSecretPart(currentAssistant.parts, {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `secret:${event.receivedAt}`,
-        sessionId: event.session_id,
-        keyName:
-          stringValue(payload?.key_name) ??
-          stringValue(payload?.keyName) ??
-          stringValue(payload?.key) ??
-          stringValue(payload?.name),
-        reason: stringValue(payload?.reason, true),
-        status: "pending",
-      });
-      continue;
-    }
-
-    if (event.type === "secret.response") {
-      const payload = event.payload as Record<string, unknown> | undefined;
-      // Again metadata only: the response carries a `provided` flag, never the
-      // value the user typed.
-      upsertSecretPart((currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [], {
-        id:
-          stringValue(payload?.request_id) ??
-          stringValue(payload?.id) ??
-          `secret:${event.receivedAt}`,
-        sessionId: event.session_id,
-        status: "resolved",
-      });
-      continue;
-    }
-
-    if (event.type === "error") {
-      currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
-      const notice = text ? turnNotice(text) : undefined;
-      if (notice) {
-        currentAssistant.parts.push(notice);
-      } else {
+      case "background_activity": {
+        // Delegated subagents (the model's `delegate_task`) stream lifecycle
+        // and progress over the same live channel. Render each subagent as a
+        // tool-style row keyed by its id, so N parallel subagents show as N live
+        // rows that resolve as they finish.
+        if (!currentAssistant) {
+          currentAssistant = createAssistantTurn(turns, event.receivedAt);
+          toolCreatedTurns.add(currentAssistant);
+        }
+        const { activity } = event;
+        const key =
+          activity.subagentId === "subagent" && activity.taskIndex !== undefined
+            ? `task-${activity.taskIndex}`
+            : activity.subagentId;
+        const partId = `subagent:${key}`;
+        // Keep the richest label we have seen for this subagent: progress and
+        // tool events often omit the goal, and downgrading to the generic
+        // "Subagent" would make the row flicker. Prefer the goal, else the name
+        // already shown, else a task-position label.
+        const existingName = currentAssistant.parts.find(
+          (part): part is AgentChatToolPart => part.type === "tool" && part.id === partId,
+        )?.name;
+        const label = activity.goal
+          ? `Subagent: ${activity.goal}`
+          : (existingName ??
+            (activity.taskCount && activity.taskCount > 1 && activity.taskIndex !== undefined
+              ? `Subagent ${activity.taskIndex + 1} of ${activity.taskCount}`
+              : "Subagent"));
+        // `blocked` is resumable, mirroring the activity store's non-terminal phase.
+        const status: AgentChatToolPart["status"] =
+          activity.phase === "complete"
+            ? "complete"
+            : activity.phase === "error"
+              ? "failed"
+              : "running";
+        if (status === "running") {
+          currentAssistant.status = "running";
+        } else if (toolCreatedTurns.has(currentAssistant)) {
+          currentAssistant.status = "complete";
+        }
         upsertToolPart(currentAssistant.parts, {
-          id: `error:${event.receivedAt}`,
-          name: "Error",
-          text: text || "The agent reported an error.",
-          status: "failed",
+          id: partId,
+          name: label,
+          text: activity.resultPreview ?? "",
+          status,
         });
+        break;
       }
-      currentAssistant.status = "complete";
-      completeRunningParts(currentAssistant.parts);
-      currentAssistant = null;
+
+      case "tool": {
+        if (event.isClarify) {
+          if (event.phase === "complete" || event.phase === "failed") {
+            completePendingClarifyParts(
+              (currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [],
+            );
+          }
+          break;
+        }
+        if (!currentAssistant) {
+          currentAssistant = createAssistantTurn(turns, event.receivedAt);
+          toolCreatedTurns.add(currentAssistant);
+        }
+        const status: AgentChatToolPart["status"] =
+          event.phase === "complete" ? "complete" : event.phase === "failed" ? "failed" : "running";
+        if (status === "running") {
+          currentAssistant.status = "running";
+        } else if (toolCreatedTurns.has(currentAssistant)) {
+          // A turn that exists only because of tool events has nothing left to
+          // stream once its tool reaches a terminal state.
+          currentAssistant.status = "complete";
+        }
+        upsertToolPart(currentAssistant.parts, {
+          id: event.key,
+          name: toolActivityLabel(event.name ?? "tool", event.sanitizedPayload),
+          text: event.text,
+          status,
+        });
+        break;
+      }
+
+      case "pending_action": {
+        currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+        currentAssistant.status = "running";
+        const { action } = event;
+        switch (action.kind) {
+          case "clarify":
+            upsertClarifyPart(currentAssistant.parts, {
+              id: action.requestId,
+              sessionId: optionalSessionId(event.sessionId),
+              question: action.question,
+              choices: action.choices ?? [],
+              status: "pending",
+            });
+            break;
+          case "approval":
+            upsertApprovalPart(currentAssistant.parts, {
+              id: action.requestId,
+              command: action.command ?? "",
+              description: action.description ?? "Hermes needs approval before continuing.",
+              sessionId: optionalSessionId(event.sessionId),
+              allowPermanent: action.allowPermanent,
+              status: "pending",
+            });
+            break;
+          case "sudo":
+            upsertSudoPart(currentAssistant.parts, {
+              id: action.requestId,
+              sessionId: optionalSessionId(event.sessionId),
+              command: action.command,
+              reason: action.reason,
+              mode: action.mode,
+              status: "pending",
+            });
+            break;
+          case "secret":
+            upsertSecretPart(currentAssistant.parts, {
+              id: action.requestId,
+              sessionId: optionalSessionId(event.sessionId),
+              keyName: action.keyName,
+              reason: action.reason,
+              status: "pending",
+            });
+            break;
+        }
+        break;
+      }
+
+      case "pending_action_resolution": {
+        const targetParts = (currentAssistant ?? lastAssistantTurn(turns))?.parts ?? [];
+        const { action } = event;
+        switch (action.kind) {
+          case "clarify":
+            upsertClarifyPart(targetParts, {
+              id: action.requestId,
+              sessionId: optionalSessionId(event.sessionId),
+              question: action.question,
+              choices: action.choices,
+              answer: action.answer,
+              status: "resolved",
+            });
+            break;
+          case "approval":
+            upsertApprovalPart(targetParts, {
+              id: action.requestId,
+              command: action.command,
+              description: action.description,
+              sessionId: optionalSessionId(event.sessionId),
+              allowPermanent: action.allowPermanent,
+              choice: action.choice,
+              status: "resolved",
+            });
+            break;
+          case "sudo":
+            upsertSudoPart(targetParts, {
+              id: action.requestId,
+              sessionId: optionalSessionId(event.sessionId),
+              mode: action.mode,
+              approved: action.granted,
+              status: "resolved",
+            });
+            break;
+          case "secret":
+            upsertSecretPart(targetParts, {
+              id: action.requestId,
+              sessionId: optionalSessionId(event.sessionId),
+              keyName: action.keyName,
+              reason: action.reason,
+              status: "resolved",
+            });
+            break;
+        }
+        break;
+      }
+
+      case "error": {
+        currentAssistant ??= createAssistantTurn(turns, event.receivedAt);
+        const notice = event.message ? turnNotice(event.message) : undefined;
+        if (notice) {
+          currentAssistant.parts.push(notice);
+        } else {
+          upsertToolPart(currentAssistant.parts, {
+            id: `error:${event.receivedAt}`,
+            name: "Error",
+            text: event.message || "The agent reported an error.",
+            status: "failed",
+          });
+        }
+        currentAssistant.status = "complete";
+        completeRunningParts(currentAssistant.parts);
+        currentAssistant = null;
+        break;
+      }
+
+      case "lifecycle":
+      case "unsupported":
+        break;
     }
   }
 }
@@ -795,6 +713,10 @@ function lastAssistantTurn(turns: AgentChatTurn[]) {
     if (turns[index]?.role === "assistant") return turns[index];
   }
   return undefined;
+}
+
+function optionalSessionId(sessionId: string | undefined) {
+  return sessionId || undefined;
 }
 
 function appendAssistantTextPart(
@@ -1037,41 +959,6 @@ function upsertSecretPart(
   });
 }
 
-function eventText(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
-  if (!payload) return "";
-  for (const key of [
-    "text",
-    "delta",
-    "message",
-    "summary",
-    "status",
-    "content",
-    "output",
-    "result",
-    "command",
-  ]) {
-    const value = stringValue(
-      payload[key],
-      key === "text" || key === "delta" || key === "message" || key === "content",
-    );
-    if (value) return value;
-  }
-  return "";
-}
-
-// Streaming deltas must be appended verbatim — including whitespace-only
-// chunks — so this intentionally bypasses the trimming in `stringValue`.
-function deltaEventText(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
-  if (!payload) return "";
-  for (const key of ["text", "delta", "message", "content"]) {
-    const value = payload[key];
-    if (typeof value === "string" && value) return value;
-  }
-  return "";
-}
-
 function messageTimestamp(message: HermesSessionMessage) {
   return timestampString(message.timestamp ?? message.created_at);
 }
@@ -1242,25 +1129,6 @@ function stringifyObject(value: unknown) {
   }
 }
 
-export function toolEventKey(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
-  return (
-    stringValue(payload?.tool_id) ??
-    stringValue(payload?.id) ??
-    stringValue(payload?.call_id) ??
-    stringValue(payload?.tool_call_id) ??
-    stringValue(payload?.name) ??
-    `tool:${event.type}:${(event as LiveHermesEvent).receivedAt}`
-  );
-}
-
-function isClarifyToolEvent(event: HermesGatewayEvent) {
-  const payload = event.payload as Record<string, unknown> | undefined;
-  const name =
-    stringValue(payload?.name) ?? stringValue(payload?.tool_name) ?? stringValue(payload?.tool);
-  return name?.toLowerCase() === "clarify";
-}
-
 function completePendingClarifyParts(parts: AgentChatPart[]) {
   const pending = [...parts]
     .reverse()
@@ -1268,12 +1136,6 @@ function completePendingClarifyParts(parts: AgentChatPart[]) {
       (part): part is AgentChatClarifyPart => part.type === "clarify" && part.status === "pending",
     );
   if (pending) pending.status = "resolved";
-}
-
-function toolEventStatus(event: HermesGatewayEvent): AgentChatToolPart["status"] {
-  if (event.type.includes("complete")) return "complete";
-  if (event.type.includes("error") || event.type.includes("fail")) return "failed";
-  return "running";
 }
 
 function toolStatus(status: AgentToolEventStatus): AgentChatToolPart["status"] {
@@ -1299,25 +1161,12 @@ function partText(part: AgentChatPart) {
   return part.text;
 }
 
-function approvalChoiceValue(value: unknown): AgentApprovalChoice | undefined {
-  if (value === "once" || value === "session" || value === "always" || value === "deny") {
-    return value;
-  }
-  return undefined;
-}
-
 function appendLogText(current: string, next: string) {
   if (!next.trim()) return current;
   if (!current) return next;
   if (current.endsWith(next)) return current;
   const separator = /\n$/.test(current) || /^\s/.test(next) || /^[.,!?;:]/.test(next) ? "" : "\n";
   return `${current}${separator}${next}`;
-}
-
-function stringArrayValue(value: unknown) {
-  return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === "string")
-    : [];
 }
 
 function stringValue(value: unknown, preserveWhitespace = false) {

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -306,8 +306,8 @@ type InternalRecord = {
  * - `pending_action_resolution`-> running (the user answered; the agent resumes).
  * - `background_activity`     -> background, and track the subagent's id/count.
  * - `error`                   -> error.
- * - `lifecycle`               -> complete when the status is terminal, else
- *                                running (the session is alive and progressing).
+ * - `lifecycle`               -> complete when the flavor or status is terminal,
+ *                                else running (the session is alive and progressing).
  * - `transcript`              -> complete on message completion, else running.
  * - `reasoning`               -> running (the agent is producing output).
  * - `steering`                -> no phase change (local transcript marker).
@@ -336,7 +336,11 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       row.phase = "error";
       return;
     case "lifecycle":
-      row.phase = isTerminalHermesLifecycleStatus(event.status) ? "complete" : "running";
+      // Raw terminal frames can carry non-terminal status words such as "success".
+      row.phase =
+        event.flavor === "terminal" || isTerminalHermesLifecycleStatus(event.status)
+          ? "complete"
+          : "running";
       return;
     case "transcript":
       if (event.complete) {

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -40,7 +40,7 @@ import type {
   HermesMode,
   JuneHermesEvent,
 } from "./hermes-control-plane";
-import { nonEmpty } from "./hermes-control-plane";
+import { isTerminalHermesLifecycleStatus, nonEmpty } from "./hermes-control-plane";
 import { pendingActionStore } from "./hermes-pending-actions";
 
 /**
@@ -299,7 +299,8 @@ type InternalRecord = {
  * - `error`                   -> error.
  * - `lifecycle`               -> complete when the status is terminal, else
  *                                running (the session is alive and progressing).
- * - `transcript` / `reasoning`-> running (the agent is producing output).
+ * - `transcript`              -> complete on message completion, else running.
+ * - `reasoning`               -> running (the agent is producing output).
  * - `steering`                -> no phase change (local transcript marker).
  * - `unsupported`             -> no phase change (don't let an unknown frame
  *                                misreport the session's state).
@@ -326,9 +327,18 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       row.phase = "error";
       return;
     case "lifecycle":
-      row.phase = isTerminalLifecycleStatus(event.status) ? "complete" : "running";
+      row.phase = isTerminalHermesLifecycleStatus(event.status) ? "complete" : "running";
       return;
     case "transcript":
+      if (event.complete) {
+        row.phase = "complete";
+        row.currentTool = undefined;
+        return;
+      }
+      // The agent is actively producing output — running, unless it has already
+      // reached a terminal state this turn (a late delta shouldn't un-complete).
+      if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
+      return;
     case "reasoning":
       // The agent is actively producing output — running, unless it has already
       // reached a terminal state this turn (a late delta shouldn't un-complete).
@@ -422,27 +432,6 @@ function countActiveSubagents(subagents: Map<string, BackgroundHermesActivity>):
     if (!isTerminalSubagentPhase(subagent.phase)) count += 1;
   }
   return count;
-}
-
-/**
- * Whether a lifecycle status string means the session is done. The classifier
- * sets `status` to the payload's status field or the raw type (e.g.
- * `session.complete`), so match terminal-flavored strings defensively. Mirrors
- * the spirit of AgentWorkspace's `isTerminalHermesEvent`.
- */
-function isTerminalLifecycleStatus(status: string | undefined): boolean {
-  if (typeof status !== "string") return false;
-  const normalized = status.toLowerCase();
-  return (
-    normalized === "complete" ||
-    normalized === "completed" ||
-    normalized === "done" ||
-    normalized === "finished" ||
-    normalized === "cancelled" ||
-    normalized === "canceled" ||
-    normalized.endsWith(".complete") ||
-    normalized.endsWith(".completed")
-  );
 }
 
 /**

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -225,12 +225,21 @@ export function createHermesActivityStore(
     return version;
   }
 
-  /** Keep the map within the cap by dropping the oldest (least recently active). */
+  /** Keep the map within the cap, preferring completed/errored rows over live work. */
   function evict(): void {
     while (bySession.size > ACTIVITY_SESSIONS_CAP) {
-      const oldest = bySession.keys().next().value;
-      if (oldest === undefined) break;
-      bySession.delete(oldest);
+      let evicted = false;
+      for (const [sessionId, row] of bySession) {
+        if (!ACTIVE_PHASES.has(row.phase)) {
+          bySession.delete(sessionId);
+          evicted = true;
+          break;
+        }
+      }
+      if (evicted) continue;
+      const oldestActive = bySession.keys().next().value;
+      if (oldestActive === undefined) break;
+      bySession.delete(oldestActive);
     }
   }
 
@@ -337,12 +346,12 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       }
       // The agent is actively producing output — running, unless it has already
       // reached a terminal state this turn (a late delta shouldn't un-complete).
-      if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
+      if (row.phase !== "complete") row.phase = "running";
       return;
     case "reasoning":
       // The agent is actively producing output — running, unless it has already
       // reached a terminal state this turn (a late delta shouldn't un-complete).
-      if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
+      if (row.phase !== "complete") row.phase = "running";
       return;
     case "steering":
       // Steering is a local transcript marker, not evidence of new agent work.
@@ -444,9 +453,9 @@ function sessionIdOf(event: JuneHermesEvent): string | undefined {
 }
 
 /**
- * Resolve an event's timestamp to epoch ms. Background activity carries an ISO
- * `lastEventAt` from the classifier; everything else is "now" (the moment we
- * processed it). A bad ISO string falls back to now rather than NaN.
+ * Resolve an event's observed timestamp to epoch ms. The classifier stamps
+ * every kind with `receivedAt`; a bad ISO string falls back to now rather than
+ * NaN.
  */
 function eventTimestamp(event: JuneHermesEvent): number {
   const parsed = Date.parse(event.receivedAt);

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -40,7 +40,7 @@ import type {
   HermesMode,
   JuneHermesEvent,
 } from "./hermes-control-plane";
-import { isTerminalHermesLifecycleStatus, nonEmpty } from "./hermes-control-plane";
+import { nonEmpty } from "./hermes-control-plane";
 import { pendingActionStore } from "./hermes-pending-actions";
 
 /**
@@ -168,6 +168,7 @@ export function createHermesActivityStore(
     if (!sessionId) return;
 
     const existing = bySession.get(sessionId);
+    if (!existing && event.kind === "lifecycle" && event.flavor === "info") return;
     const row: InternalRecord = existing ?? {
       sessionId,
       mode,
@@ -307,7 +308,7 @@ type InternalRecord = {
  * - `background_activity`     -> background, and track the subagent's id/count.
  * - `error`                   -> error.
  * - `lifecycle`               -> complete when the flavor is terminal, running when
- *                                the flavor is running, else fall back to status.
+ *                                the flavor is running, no-op when informational.
  * - `transcript`              -> complete on message completion, else running.
  * - `reasoning`               -> running (the agent is producing output).
  * - `steering`                -> no phase change (local transcript marker).
@@ -336,13 +337,13 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       row.phase = "error";
       return;
     case "lifecycle":
-      // Raw terminal frames can carry non-terminal status words such as "success".
-      // A running flavor is a type-derived liveness signal and status text must not override it.
-      row.phase =
-        event.flavor === "terminal" ||
-        (event.flavor === "info" && isTerminalHermesLifecycleStatus(event.status))
-          ? "complete"
-          : "running";
+      // Genuine completions arrive as terminal-flavored frames (lifecycle.complete(d),
+      // session/turn/background completions, plus the workspace's synthetic terminal
+      // write). An info frame's status text must never retire a live row, and info
+      // frames must not flip idle rows to running; this matches main's event-driven
+      // spinner semantics.
+      if (event.flavor === "terminal") row.phase = "complete";
+      if (event.flavor === "running") row.phase = "running";
       return;
     case "transcript":
       if (event.complete) {

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -294,11 +294,13 @@ type InternalRecord = {
  * derived from event kind:
  * - `tool` (any phase)        -> running, and remember the tool name.
  * - `pending_action`          -> waiting (the agent is blocked on the user).
+ * - `pending_action_resolution`-> running (the user answered; the agent resumes).
  * - `background_activity`     -> background, and track the subagent's id/count.
  * - `error`                   -> error.
  * - `lifecycle`               -> complete when the status is terminal, else
  *                                running (the session is alive and progressing).
  * - `transcript` / `reasoning`-> running (the agent is producing output).
+ * - `steering`                -> no phase change (local transcript marker).
  * - `unsupported`             -> no phase change (don't let an unknown frame
  *                                misreport the session's state).
  */
@@ -308,10 +310,14 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       row.phase = "running";
       if (nonEmpty(event.name)) row.currentTool = event.name;
       // A finished tool call leaves no tool in flight.
-      if (event.phase === "complete") row.currentTool = undefined;
+      if (event.phase === "complete" || event.phase === "failed") row.currentTool = undefined;
       return;
     case "pending_action":
       row.phase = "waiting";
+      return;
+    case "pending_action_resolution":
+      // The user answered, so the run resumes unless a terminal event already won.
+      if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
       return;
     case "background_activity":
       applyBackgroundActivity(row, event);
@@ -327,6 +333,9 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       // The agent is actively producing output — running, unless it has already
       // reached a terminal state this turn (a late delta shouldn't un-complete).
       if (row.phase !== "complete" && row.phase !== "error") row.phase = "running";
+      return;
+    case "steering":
+      // Steering is a local transcript marker, not evidence of new agent work.
       return;
     case "unsupported":
       // An event June can't model must not silently change the reported phase.
@@ -451,9 +460,7 @@ function sessionIdOf(event: JuneHermesEvent): string | undefined {
  * processed it). A bad ISO string falls back to now rather than NaN.
  */
 function eventTimestamp(event: JuneHermesEvent): number {
-  if (event.kind === "background_activity") {
-    const parsed = Date.parse(event.activity.lastEventAt);
-    if (!Number.isNaN(parsed)) return parsed;
-  }
+  const parsed = Date.parse(event.receivedAt);
+  if (!Number.isNaN(parsed)) return parsed;
   return Date.now();
 }

--- a/src/lib/hermes-activity-store.ts
+++ b/src/lib/hermes-activity-store.ts
@@ -306,8 +306,8 @@ type InternalRecord = {
  * - `pending_action_resolution`-> running (the user answered; the agent resumes).
  * - `background_activity`     -> background, and track the subagent's id/count.
  * - `error`                   -> error.
- * - `lifecycle`               -> complete when the flavor or status is terminal,
- *                                else running (the session is alive and progressing).
+ * - `lifecycle`               -> complete when the flavor is terminal, running when
+ *                                the flavor is running, else fall back to status.
  * - `transcript`              -> complete on message completion, else running.
  * - `reasoning`               -> running (the agent is producing output).
  * - `steering`                -> no phase change (local transcript marker).
@@ -337,8 +337,10 @@ function applyEvent(row: InternalRecord, event: JuneHermesEvent): void {
       return;
     case "lifecycle":
       // Raw terminal frames can carry non-terminal status words such as "success".
+      // A running flavor is a type-derived liveness signal and status text must not override it.
       row.phase =
-        event.flavor === "terminal" || isTerminalHermesLifecycleStatus(event.status)
+        event.flavor === "terminal" ||
+        (event.flavor === "info" && isTerminalHermesLifecycleStatus(event.status))
           ? "complete"
           : "running";
       return;

--- a/src/lib/hermes-artifact-store.ts
+++ b/src/lib/hermes-artifact-store.ts
@@ -292,7 +292,7 @@ export function artifactsFromToolEvent(event: JuneHermesEvent): AgentArtifact[] 
   const sessionId = nonEmpty(event.sessionId);
   if (!sessionId) return [];
 
-  const payload = asRecord(event.payload);
+  const payload = asRecord(event.sanitizedPayload);
   if (!payload) return [];
 
   const locations = locationsFromPayload(payload);

--- a/src/lib/hermes-control-plane/README.md
+++ b/src/lib/hermes-control-plane/README.md
@@ -27,7 +27,10 @@ raw HermesGatewayEvent ──▶ classifyHermesEvent() ──▶ JuneHermesEvent
                                                        ├─ tool
                                                        ├─ pending_action ─▶ PendingHermesAction
                                                        │                     (clarify | approval | sudo | secret)
+                                                       ├─ pending_action_resolution
+                                                       │                  └▶ PendingHermesActionResolution
                                                        ├─ background_activity ─▶ BackgroundHermesActivity
+                                                       ├─ steering       (local June event; never classified)
                                                        ├─ lifecycle
                                                        ├─ error
                                                        └─ unsupported   (anything unknown — never dropped)
@@ -38,8 +41,12 @@ typed call ──▶ createHermesMethods(request).<method>() ──▶ gateway.r
 - `classifyHermesEvent` is **total**: it returns exactly one `JuneHermesEvent`
   for every frame and never returns `undefined`. Consumers can `switch (e.kind)`
   exhaustively with no `default`.
+- Every normalized event carries `receivedAt`, the ISO timestamp when June
+  observed the raw frame or minted the local event.
 - Unknown raw types become `{ kind: "unsupported", rawType, sanitizedPayload }`
   so a Hermes upgrade that adds an event is **visible**, not silently ignored.
+- `createSteeringEvent(...)` is first-party June state for a sent steer. It is
+  never produced by `classifyHermesEvent` because steering is not a Hermes frame.
 - `HermesMode = "sandboxed" | "unrestricted"` is the canonical session-mode
   type. Derive it from a session id with `hermesModeFor(sessionId)` (absence =
   `sandboxed`, the safe default).

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -31,7 +31,6 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     case "message.start":
     case "message.delta":
     case "message.complete":
-    case "message.completed":
       return classifyTranscript(type, sessionId, payload, receivedAt);
 
     case "thinking.delta":
@@ -86,8 +85,9 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     return {
       kind: "lifecycle",
       sessionId,
-      rawType: type,
+      flavor: lifecycleFlavor(type),
       status: lifecycleStatus(type, payload),
+      text: eventText(payload),
       payload: payload ? sanitizePayload(payload) : undefined,
       receivedAt,
     };
@@ -108,7 +108,7 @@ function classifyTranscript(
   payload: RawHermesPayload | undefined,
   receivedAt: string,
 ): JuneHermesEvent {
-  const complete = type === "message.complete" || type === "message.completed";
+  const complete = type === "message.complete";
   const delta =
     type === "message.delta" ? rawDeltaText(payload) : complete ? eventText(payload) : undefined;
   const failed = complete && stringValue(payload?.status)?.toLowerCase() === "error";
@@ -156,10 +156,9 @@ function classifyTool(
     text: eventText(payload),
     // Clarify tool calls are action-card plumbing in the builder, not tool rows.
     isClarify: isClarifyTool(payload),
-    // Tool cards render arguments/output, so keep the payload — sanitized, in
-    // case a tool's args happen to embed a secret.
+    // Tool cards render arguments/output, so keep the sanitized payload in case
+    // a tool's args happen to embed a secret.
     sanitizedPayload,
-    payload: sanitizedPayload,
     receivedAt,
   };
 }
@@ -319,12 +318,9 @@ function classifyError(
   return {
     kind: "error",
     sessionId,
-    // The human-readable message is safe to surface; everything else stays out
-    // unless explicitly modeled, so a secret in some other field can't leak.
-    message:
-      stringValue(payload?.message, true) ??
-      stringValue(payload?.text, true) ??
-      "The agent reported an error.",
+    // Main already rendered the broad visible-text chain for error frames; keep
+    // that user-facing text while leaving every unmodeled field out.
+    message: eventText(payload) || "The agent reported an error.",
     code: numberValue(payload?.code),
     recoverable: typeof payload?.recoverable === "boolean" ? payload.recoverable : undefined,
     receivedAt,
@@ -341,11 +337,13 @@ const SUBAGENT_PHASES: Record<string, BackgroundHermesPhase> = {
   blocked: "blocked",
 };
 
+const FAILURE_WORD = /fail|error|cancel|timeout|abort|interrupt/;
+
 function subagentPhase(type: string, payload: RawHermesPayload | undefined): BackgroundHermesPhase {
   const subtype = type.slice("subagent.".length).toLowerCase();
   const reportedStatus = stringValue(payload?.status)?.toLowerCase() ?? "";
-  if (/fail|error|cancel|timeout|abort|interrupt/.test(subtype)) return "error";
-  if (/fail|error|cancel|timeout|abort|interrupt/.test(reportedStatus)) return "error";
+  if (FAILURE_WORD.test(subtype)) return "error";
+  if (FAILURE_WORD.test(reportedStatus)) return "error";
   if (subtype in SUBAGENT_PHASES) return SUBAGENT_PHASES[subtype];
   // Unknown subagent subtype: classify by failure-flavored keywords, else
   // treat as progress so the row still updates rather than vanishing.
@@ -360,6 +358,7 @@ const LIFECYCLE_TYPES = new Set([
   "session.start",
   "session.complete",
   "session.completed",
+  "message.completed",
   // Workspace terminal detection predates the union; these raw frames are
   // lifecycle-flavored terminals even though they are not session.* names.
   "turn.complete",
@@ -374,6 +373,23 @@ function isLifecycleType(type: string): boolean {
 
 function lifecycleStatus(type: string, payload: RawHermesPayload | undefined): string {
   return stringValue(payload?.status, true) ?? type;
+}
+
+function lifecycleFlavor(type: string): Extract<JuneHermesEvent, { kind: "lifecycle" }>["flavor"] {
+  switch (type.toLowerCase()) {
+    case "message.completed":
+    case "turn.complete":
+    case "turn.completed":
+    case "session.complete":
+    case "session.completed":
+    case "background.complete":
+    case "background.completed":
+      return "terminal";
+    case "status.update":
+      return "running";
+    default:
+      return "info";
+  }
 }
 
 function requestIdOf(
@@ -434,9 +450,7 @@ function toolPhase(type: string): Extract<JuneHermesEvent, { kind: "tool" }>["ph
   const normalized = type.toLowerCase();
   if (normalized.includes("complete")) return "complete";
   if (normalized.includes("error") || normalized.includes("fail")) return "failed";
-  if (normalized === "tool.start") return "start";
-  if (normalized === "tool.progress") return "progress";
-  return "progress";
+  return normalized === "tool.start" ? "start" : "progress";
 }
 
 function toolEventKey(

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -4,6 +4,7 @@ import type {
   BackgroundHermesPhase,
   JuneHermesEvent,
   PendingHermesAction,
+  PendingHermesActionResolution,
 } from "./events";
 import { parseHermesMode } from "./events";
 import type { RawHermesPayload } from "./raw-types";
@@ -30,7 +31,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     case "message.start":
     case "message.delta":
     case "message.complete":
-      return classifyTranscript(type, sessionId, payload);
+      return classifyTranscript(type, sessionId, payload, receivedAt);
 
     case "thinking.delta":
     case "reasoning.delta":
@@ -38,12 +39,8 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
         kind: "reasoning",
         sessionId: sessionId ?? "",
         delta: rawDeltaText(payload),
+        receivedAt,
       };
-
-    case "tool.start":
-    case "tool.progress":
-    case "tool.complete":
-      return classifyTool(type, sessionId, payload);
 
     case "clarify.request":
     case "approval.request":
@@ -53,13 +50,31 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
         kind: "pending_action",
         sessionId: sessionId ?? "",
         action: classifyPendingAction(type, payload, receivedAt),
+        receivedAt,
+      };
+
+    case "clarify.response":
+    case "approval.response":
+    case "sudo.response":
+    case "secret.response":
+      return {
+        // Transcript rendering already resolves these cards; the typed seam
+        // follows that visible behavior instead of treating responses as gaps.
+        kind: "pending_action_resolution",
+        sessionId: sessionId ?? "",
+        action: classifyPendingActionResolution(type, payload, receivedAt),
+        receivedAt,
       };
 
     case "error":
-      return classifyError(sessionId, payload);
+      return classifyError(sessionId, payload, receivedAt);
 
     default:
       break;
+  }
+
+  if (type.startsWith("tool.")) {
+    return classifyTool(type, sessionId, payload, receivedAt);
   }
 
   if (type.startsWith("subagent.")) {
@@ -72,6 +87,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
       sessionId,
       status: lifecycleStatus(type, payload),
       payload: payload ? sanitizePayload(payload) : undefined,
+      receivedAt,
     };
   }
 
@@ -80,6 +96,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     sessionId,
     rawType: type || undefined,
     sanitizedPayload: payload === undefined ? undefined : sanitizePayload(payload),
+    receivedAt,
   };
 }
 
@@ -87,21 +104,25 @@ function classifyTranscript(
   type: string,
   sessionId: string | undefined,
   payload: RawHermesPayload | undefined,
+  receivedAt: string,
 ): JuneHermesEvent {
   const complete = type === "message.complete";
   const delta =
-    type === "message.delta"
-      ? rawDeltaText(payload)
-      : complete
-        ? rawCompleteText(payload)
-        : undefined;
+    type === "message.delta" ? rawDeltaText(payload) : complete ? eventText(payload) : undefined;
+  const failed = complete && stringValue(payload?.status)?.toLowerCase() === "error";
   return {
     kind: "transcript",
     sessionId: sessionId ?? "",
     messageId: stringValue(payload?.message_id) ?? stringValue(payload?.messageId),
+    // Complete text follows the builder's nine-key visible-text chain, not the
+    // old four-key classifier fallback, so summary/status-only turns survive.
     delta,
     complete,
+    // The transcript builder gates failed-turn notices on message.complete
+    // status=error; carry the same flag so the typed seam cannot drift.
+    failed,
     role: messageRole(payload),
+    receivedAt,
   };
 }
 
@@ -109,9 +130,9 @@ function classifyTool(
   type: string,
   sessionId: string | undefined,
   payload: RawHermesPayload | undefined,
+  receivedAt: string,
 ): JuneHermesEvent {
-  const phase =
-    type === "tool.start" ? "start" : type === "tool.progress" ? "progress" : "complete";
+  const sanitizedPayload = payload === undefined ? undefined : sanitizePayload(payload);
   return {
     kind: "tool",
     sessionId: sessionId ?? "",
@@ -120,12 +141,24 @@ function classifyTool(
       stringValue(payload?.toolCallId) ??
       stringValue(payload?.call_id) ??
       stringValue(payload?.id),
-    phase,
+    // The builder treats failure-flavored tool event names as terminal failed,
+    // while unknown tool.* names still update the in-flight row as progress.
+    phase: toolPhase(type),
+    // Transcript dedupe keys prefer tool_id/id before tool_call_id; toolCallId
+    // intentionally keeps the store-oriented precedence above.
+    key: toolEventKey(type, payload, receivedAt),
     name:
       stringValue(payload?.name) ?? stringValue(payload?.tool_name) ?? stringValue(payload?.tool),
+    // Tool output text uses the same broad visible-text chain as the transcript
+    // builder so complete/status-only tool frames do not disappear.
+    text: eventText(payload),
+    // Clarify tool calls are action-card plumbing in the builder, not tool rows.
+    isClarify: isClarifyTool(payload),
     // Tool cards render arguments/output, so keep the payload — sanitized, in
     // case a tool's args happen to embed a secret.
-    payload: payload === undefined ? undefined : sanitizePayload(payload),
+    sanitizedPayload,
+    payload: sanitizedPayload,
+    receivedAt,
   };
 }
 
@@ -144,7 +177,11 @@ function classifyPendingAction(
           stringValue(payload?.tool_name) ??
           stringValue(payload?.tool) ??
           stringValue(payload?.name),
+        command: stringValue(payload?.command, true),
         description: stringValue(payload?.description, true) ?? stringValue(payload?.command, true),
+        // Approval cards already allow permanence unless Hermes explicitly says
+        // false; expose the same default instead of burying it in raw details.
+        allowPermanent: payload?.allow_permanent !== false,
         // Approval cards may show structured details; sanitize defensively.
         payload: payload === undefined ? undefined : sanitizePayload(payload),
       };
@@ -182,6 +219,57 @@ function classifyPendingAction(
   }
 }
 
+function classifyPendingActionResolution(
+  type: string,
+  payload: RawHermesPayload | undefined,
+  receivedAt: string,
+): PendingHermesActionResolution {
+  const requestId = requestIdOf(payload, type, receivedAt);
+  switch (type) {
+    case "approval.response":
+      return {
+        kind: "approval",
+        requestId,
+        command: stringValue(payload?.command, true) ?? "",
+        description: stringValue(payload?.description, true) ?? "",
+        // The builder treats only explicit false as disallowing permanence.
+        allowPermanent: payload?.allow_permanent !== false,
+        choice: approvalChoiceValue(payload?.choice),
+      };
+    case "sudo.response":
+      return {
+        kind: "sudo",
+        requestId,
+        mode: parseHermesMode(payload?.mode),
+        // Hermes spells this `granted`; `approved` is accepted because the
+        // transcript builder already resolves cards from either gateway shape.
+        granted: booleanValue(payload?.granted) ?? booleanValue(payload?.approved),
+      };
+    case "secret.response":
+      // Metadata only: never read `value`/`api_key`, even if a gateway echoes
+      // them, so the secret cannot cross the normalized event boundary.
+      return {
+        kind: "secret",
+        requestId,
+        keyName:
+          stringValue(payload?.key_name) ??
+          stringValue(payload?.keyName) ??
+          stringValue(payload?.key) ??
+          stringValue(payload?.name),
+        reason: stringValue(payload?.reason, true),
+        redacted: true,
+      };
+    default:
+      return {
+        kind: "clarify",
+        requestId,
+        question: stringValue(payload?.question, true) ?? "",
+        choices: stringArrayValue(payload?.choices),
+        answer: stringValue(payload?.answer, true) ?? "",
+      };
+  }
+}
+
 function classifyBackgroundActivity(
   type: string,
   sessionId: string | undefined,
@@ -199,7 +287,9 @@ function classifyBackgroundActivity(
     handle: stringValue(payload?.handle),
     parentSessionId:
       stringValue(payload?.parent_session_id) ?? stringValue(payload?.parentSessionId) ?? sessionId,
-    phase: subagentPhase(type),
+    // The transcript builder treats payload.status failure words as terminal
+    // even when the subtype is only progress; keep the control plane aligned.
+    phase: subagentPhase(type, payload),
     goal: stringValue(payload?.goal, true),
     currentTool:
       stringValue(payload?.tool_name) ?? stringValue(payload?.tool) ?? stringValue(payload?.name),
@@ -207,18 +297,22 @@ function classifyBackgroundActivity(
       stringValue(payload?.summary, true) ??
       stringValue(payload?.tool_preview, true) ??
       stringValue(payload?.text, true),
+    taskIndex: numberField(payload?.task_index),
+    taskCount: numberField(payload?.task_count),
     lastEventAt: receivedAt,
   };
   return {
     kind: "background_activity",
     sessionId: sessionId ?? subagentId,
     activity,
+    receivedAt,
   };
 }
 
 function classifyError(
   sessionId: string | undefined,
   payload: RawHermesPayload | undefined,
+  receivedAt: string,
 ): JuneHermesEvent {
   return {
     kind: "error",
@@ -231,6 +325,7 @@ function classifyError(
       "The agent reported an error.",
     code: numberValue(payload?.code),
     recoverable: typeof payload?.recoverable === "boolean" ? payload.recoverable : undefined,
+    receivedAt,
   };
 }
 
@@ -244,12 +339,14 @@ const SUBAGENT_PHASES: Record<string, BackgroundHermesPhase> = {
   blocked: "blocked",
 };
 
-function subagentPhase(type: string): BackgroundHermesPhase {
+function subagentPhase(type: string, payload: RawHermesPayload | undefined): BackgroundHermesPhase {
   const subtype = type.slice("subagent.".length).toLowerCase();
+  const reportedStatus = stringValue(payload?.status)?.toLowerCase() ?? "";
+  if (/fail|error|cancel|timeout|abort|interrupt/.test(subtype)) return "error";
+  if (/fail|error|cancel|timeout|abort|interrupt/.test(reportedStatus)) return "error";
   if (subtype in SUBAGENT_PHASES) return SUBAGENT_PHASES[subtype];
   // Unknown subagent subtype: classify by failure-flavored keywords, else
   // treat as progress so the row still updates rather than vanishing.
-  if (/fail|error|cancel|timeout|abort|interrupt/.test(subtype)) return "error";
   if (subtype === "done") return "complete";
   return "progress";
 }
@@ -303,12 +400,56 @@ function rawDeltaText(payload: RawHermesPayload | undefined): string {
   return "";
 }
 
-function rawCompleteText(payload: RawHermesPayload | undefined): string | undefined {
-  for (const key of ["text", "message", "content", "delta"] as const) {
-    const value = payload?.[key];
-    if (typeof value === "string" && value) return value;
+function eventText(payload: RawHermesPayload | undefined): string {
+  if (!payload) return "";
+  for (const key of [
+    "text",
+    "delta",
+    "message",
+    "summary",
+    "status",
+    "content",
+    "output",
+    "result",
+    "command",
+  ] as const) {
+    const value = stringValue(
+      payload[key],
+      key === "text" || key === "delta" || key === "message" || key === "content",
+    );
+    if (value) return value;
   }
-  return undefined;
+  return "";
+}
+
+function toolPhase(type: string): Extract<JuneHermesEvent, { kind: "tool" }>["phase"] {
+  const normalized = type.toLowerCase();
+  if (normalized.includes("complete")) return "complete";
+  if (normalized.includes("error") || normalized.includes("fail")) return "failed";
+  if (normalized === "tool.start") return "start";
+  if (normalized === "tool.progress") return "progress";
+  return "progress";
+}
+
+function toolEventKey(
+  type: string,
+  payload: RawHermesPayload | undefined,
+  receivedAt: string,
+): string {
+  return (
+    stringValue(payload?.tool_id) ??
+    stringValue(payload?.id) ??
+    stringValue(payload?.call_id) ??
+    stringValue(payload?.tool_call_id) ??
+    stringValue(payload?.name) ??
+    `tool:${type}:${receivedAt}`
+  );
+}
+
+function isClarifyTool(payload: RawHermesPayload | undefined): boolean {
+  const name =
+    stringValue(payload?.name) ?? stringValue(payload?.tool_name) ?? stringValue(payload?.tool);
+  return name?.toLowerCase() === "clarify";
 }
 
 function receivedAtOf(raw: HermesGatewayEvent): string {
@@ -321,6 +462,12 @@ function optionalStringArray(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const items = value.filter((item): item is string => typeof item === "string");
   return items.length ? items : undefined;
+}
+
+function stringArrayValue(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
 }
 
 function stringValue(value: unknown, preserveWhitespace = false): string | undefined {
@@ -339,6 +486,23 @@ function numberValue(value: unknown): number | undefined {
   if (typeof value === "string" && value.trim()) {
     const parsed = Number(value);
     if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+type ApprovalChoice = Extract<PendingHermesActionResolution, { kind: "approval" }>["choice"];
+
+function approvalChoiceValue(value: unknown): ApprovalChoice {
+  if (value === "once" || value === "session" || value === "always" || value === "deny") {
+    return value;
   }
   return undefined;
 }

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -31,6 +31,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     case "message.start":
     case "message.delta":
     case "message.complete":
+    case "message.completed":
       return classifyTranscript(type, sessionId, payload, receivedAt);
 
     case "thinking.delta":
@@ -85,6 +86,7 @@ export function classifyHermesEvent(raw: HermesGatewayEvent): JuneHermesEvent {
     return {
       kind: "lifecycle",
       sessionId,
+      rawType: type,
       status: lifecycleStatus(type, payload),
       payload: payload ? sanitizePayload(payload) : undefined,
       receivedAt,
@@ -106,7 +108,7 @@ function classifyTranscript(
   payload: RawHermesPayload | undefined,
   receivedAt: string,
 ): JuneHermesEvent {
-  const complete = type === "message.complete";
+  const complete = type === "message.complete" || type === "message.completed";
   const delta =
     type === "message.delta" ? rawDeltaText(payload) : complete ? eventText(payload) : undefined;
   const failed = complete && stringValue(payload?.status)?.toLowerCase() === "error";
@@ -358,6 +360,12 @@ const LIFECYCLE_TYPES = new Set([
   "session.start",
   "session.complete",
   "session.completed",
+  // Workspace terminal detection predates the union; these raw frames are
+  // lifecycle-flavored terminals even though they are not session.* names.
+  "turn.complete",
+  "turn.completed",
+  "background.complete",
+  "background.completed",
 ]);
 
 function isLifecycleType(type: string): boolean {

--- a/src/lib/hermes-control-plane/event-classifier.ts
+++ b/src/lib/hermes-control-plane/event-classifier.ts
@@ -377,6 +377,10 @@ function lifecycleStatus(type: string, payload: RawHermesPayload | undefined): s
 
 function lifecycleFlavor(type: string): Extract<JuneHermesEvent, { kind: "lifecycle" }>["flavor"] {
   switch (type.toLowerCase()) {
+    // Intentional extension beyond main's terminal type list: main never tore
+    // down on lifecycle.complete, but June's typed lifecycle union does.
+    case "lifecycle.complete":
+    case "lifecycle.completed":
     case "message.completed":
     case "turn.complete":
     case "turn.completed":

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -180,9 +180,6 @@ export type JuneHermesEvent =
       /** Sanitized opaque payload for display/details. Keep consumers from
        * depending on raw wire structure. */
       sanitizedPayload?: unknown;
-      /** Existing store-facing alias for the sanitized payload; stage A2 can
-       * migrate consumers to `sanitizedPayload` when transcript rendering moves. */
-      payload?: unknown;
     })
   | (JuneHermesEventBase & {
       kind: "pending_action";
@@ -207,8 +204,9 @@ export type JuneHermesEvent =
   | (JuneHermesEventBase & {
       kind: "lifecycle";
       sessionId?: string;
-      rawType?: string;
+      flavor: "terminal" | "running" | "info";
       status: string;
+      text: string;
       payload?: unknown;
     })
   | (JuneHermesEventBase & {
@@ -257,7 +255,7 @@ export function isTerminalHermesEvent(event: JuneHermesEvent): boolean {
     case "transcript":
       return event.complete === true;
     case "lifecycle":
-      return isTerminalHermesLifecycleStatus(event.status);
+      return event.flavor === "terminal";
     default:
       return false;
   }

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -207,6 +207,7 @@ export type JuneHermesEvent =
   | (JuneHermesEventBase & {
       kind: "lifecycle";
       sessionId?: string;
+      rawType?: string;
       status: string;
       payload?: unknown;
     })
@@ -227,6 +228,40 @@ export type JuneHermesEvent =
 /** The discriminant strings of {@link JuneHermesEvent}, handy for tests and
  * exhaustiveness assertions. */
 export type JuneHermesEventKind = JuneHermesEvent["kind"];
+
+/**
+ * Whether a lifecycle status string means the session is done. The classifier
+ * sets `status` to the payload's status field or the raw type (for example
+ * `session.complete`), so match terminal-flavored strings defensively.
+ */
+export function isTerminalHermesLifecycleStatus(status: string | undefined): boolean {
+  if (typeof status !== "string") return false;
+  const normalized = status.toLowerCase();
+  return (
+    normalized === "complete" ||
+    normalized === "completed" ||
+    normalized === "done" ||
+    normalized === "finished" ||
+    normalized === "cancelled" ||
+    normalized === "canceled" ||
+    normalized.endsWith(".complete") ||
+    normalized.endsWith(".completed")
+  );
+}
+
+/** True for classified events that end the current workspace turn. */
+export function isTerminalHermesEvent(event: JuneHermesEvent): boolean {
+  switch (event.kind) {
+    case "error":
+      return true;
+    case "transcript":
+      return event.complete === true;
+    case "lifecycle":
+      return isTerminalHermesLifecycleStatus(event.status);
+    default:
+      return false;
+  }
+}
 
 /**
  * Build a first-party steering event for a user instruction sent into an

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -41,8 +41,8 @@ export function parseHermesMode(value: unknown): HermesMode | undefined {
 /**
  * An action the agent is blocked on until the user responds. Surfaced through
  * `pending_action` events and resolved with the matching method in
- * `methods.ts` (clarify/approval responses flow through the existing chat
- * runtime today; sudo/secret are wired by later features).
+ * `methods.ts`; matching `*.response` frames surface separately as
+ * `pending_action_resolution` events.
  */
 export type PendingHermesAction =
   | { kind: "clarify"; requestId: string; question: string; choices?: string[] }
@@ -50,7 +50,9 @@ export type PendingHermesAction =
       kind: "approval";
       requestId: string;
       toolName?: string;
+      command?: string;
       description?: string;
+      allowPermanent: boolean;
       payload?: unknown;
     }
   | {
@@ -67,6 +69,41 @@ export type PendingHermesAction =
       reason?: string;
       /** Discriminator and a guarantee: the secret value is never carried on
        * this event, only the request for one. */
+      redacted: true;
+    };
+
+/** A user response that resolves a previously pending Hermes action. These
+ * events are distinct from `pending_action`: the user already answered, so the
+ * agent is expected to resume rather than remain blocked. */
+export type PendingHermesActionResolution =
+  | {
+      kind: "clarify";
+      requestId: string;
+      question: string;
+      choices: string[];
+      answer: string;
+    }
+  | {
+      kind: "approval";
+      requestId: string;
+      command: string;
+      description: string;
+      allowPermanent: boolean;
+      choice?: "once" | "session" | "always" | "deny";
+    }
+  | {
+      kind: "sudo";
+      requestId: string;
+      mode?: HermesMode;
+      granted?: boolean;
+    }
+  | {
+      kind: "secret";
+      requestId: string;
+      keyName?: string;
+      reason?: string;
+      /** Discriminator and a guarantee: a resolved secret event still carries
+       * only metadata, never the value the user entered. */
       redacted: true;
     };
 
@@ -99,9 +136,19 @@ export type BackgroundHermesActivity = {
   currentTool?: string;
   /** A short preview of the subagent's latest output or completion summary. */
   resultPreview?: string;
+  /** Zero-based task position when Hermes reports a fan-out batch. */
+  taskIndex?: number;
+  /** Total task count when Hermes reports a fan-out batch. */
+  taskCount?: number;
   /** ISO timestamp this activity was observed (the event's `receivedAt` when
    * available, else classification time). */
   lastEventAt: string;
+};
+
+/** Common fields all normalized June events carry. */
+type JuneHermesEventBase = {
+  /** ISO timestamp when June observed or minted the event. */
+  receivedAt: string;
 };
 
 /**
@@ -111,44 +158,90 @@ export type BackgroundHermesActivity = {
  * event.
  */
 export type JuneHermesEvent =
-  | {
+  | (JuneHermesEventBase & {
       kind: "transcript";
       sessionId: string;
       messageId?: string;
       delta?: string;
       complete?: boolean;
+      failed: boolean;
       role?: "assistant" | "user" | "system";
-    }
-  | { kind: "reasoning"; sessionId: string; delta: string }
-  | {
+    })
+  | (JuneHermesEventBase & { kind: "reasoning"; sessionId: string; delta: string })
+  | (JuneHermesEventBase & {
       kind: "tool";
       sessionId: string;
       toolCallId?: string;
-      phase: "start" | "progress" | "complete";
+      phase: "start" | "progress" | "complete" | "failed";
+      key: string;
       name?: string;
+      text: string;
+      isClarify: boolean;
+      /** Sanitized opaque payload for display/details. Keep consumers from
+       * depending on raw wire structure. */
+      sanitizedPayload?: unknown;
+      /** Existing store-facing alias for the sanitized payload; stage A2 can
+       * migrate consumers to `sanitizedPayload` when transcript rendering moves. */
       payload?: unknown;
-    }
-  | { kind: "pending_action"; sessionId: string; action: PendingHermesAction }
-  | {
+    })
+  | (JuneHermesEventBase & {
+      kind: "pending_action";
+      sessionId: string;
+      action: PendingHermesAction;
+    })
+  | (JuneHermesEventBase & {
+      kind: "pending_action_resolution";
+      sessionId: string;
+      action: PendingHermesActionResolution;
+    })
+  | (JuneHermesEventBase & {
       kind: "background_activity";
       sessionId: string;
       activity: BackgroundHermesActivity;
-    }
-  | { kind: "lifecycle"; sessionId?: string; status: string; payload?: unknown }
-  | {
+    })
+  | (JuneHermesEventBase & {
+      kind: "steering";
+      sessionId: string;
+      text: string;
+    })
+  | (JuneHermesEventBase & {
+      kind: "lifecycle";
+      sessionId?: string;
+      status: string;
+      payload?: unknown;
+    })
+  | (JuneHermesEventBase & {
       kind: "error";
       sessionId?: string;
       message: string;
       code?: number;
       recoverable?: boolean;
-    }
-  | {
+    })
+  | (JuneHermesEventBase & {
       kind: "unsupported";
       sessionId?: string;
       rawType?: string;
       sanitizedPayload?: unknown;
-    };
+    });
 
 /** The discriminant strings of {@link JuneHermesEvent}, handy for tests and
  * exhaustiveness assertions. */
 export type JuneHermesEventKind = JuneHermesEvent["kind"];
+
+/**
+ * Build a first-party steering event for a user instruction sent into an
+ * already-running session. This is local June state, NEVER produced by
+ * `classifyHermesEvent`, because steering is not a Hermes wire frame.
+ */
+export function createSteeringEvent(
+  sessionId: string,
+  text: string,
+  receivedAt: string,
+): JuneHermesEvent {
+  return {
+    kind: "steering",
+    sessionId,
+    text,
+    receivedAt,
+  };
+}

--- a/src/lib/hermes-control-plane/events.ts
+++ b/src/lib/hermes-control-plane/events.ts
@@ -227,26 +227,6 @@ export type JuneHermesEvent =
  * exhaustiveness assertions. */
 export type JuneHermesEventKind = JuneHermesEvent["kind"];
 
-/**
- * Whether a lifecycle status string means the session is done. The classifier
- * sets `status` to the payload's status field or the raw type (for example
- * `session.complete`), so match terminal-flavored strings defensively.
- */
-export function isTerminalHermesLifecycleStatus(status: string | undefined): boolean {
-  if (typeof status !== "string") return false;
-  const normalized = status.toLowerCase();
-  return (
-    normalized === "complete" ||
-    normalized === "completed" ||
-    normalized === "done" ||
-    normalized === "finished" ||
-    normalized === "cancelled" ||
-    normalized === "canceled" ||
-    normalized.endsWith(".complete") ||
-    normalized.endsWith(".completed")
-  );
-}
-
 /** True for classified events that end the current workspace turn. */
 export function isTerminalHermesEvent(event: JuneHermesEvent): boolean {
   switch (event.kind) {

--- a/src/lib/hermes-control-plane/fixtures/approval-request-response.json
+++ b/src/lib/hermes-control-plane/fixtures/approval-request-response.json
@@ -3,7 +3,7 @@
   "hermesVersion": "v2026.6.19",
   "recordedFrom": "tui-gateway",
   "sanitized": true,
-  "_note": "An approval prompt and its resolution. approval.request -> pending_action/approval. approval.response is NOT a new pending action; the classifier currently routes it to unsupported (locked here as honest current behavior).",
+  "_note": "An approval prompt and its resolution. approval.request -> pending_action/approval. approval.response -> pending_action_resolution/approval.",
   "frames": [
     {
       "type": "approval.request",

--- a/src/lib/hermes-control-plane/fixtures/clarify-request-response.json
+++ b/src/lib/hermes-control-plane/fixtures/clarify-request-response.json
@@ -3,7 +3,7 @@
   "hermesVersion": "v2026.6.19",
   "recordedFrom": "tui-gateway",
   "sanitized": true,
-  "_note": "A clarify prompt and its answer. clarify.request -> pending_action/clarify. clarify.response is not a new pending action; classifier routes it to unsupported today (locked as honest current behavior).",
+  "_note": "A clarify prompt and its answer. clarify.request -> pending_action/clarify. clarify.response -> pending_action_resolution/clarify.",
   "frames": [
     {
       "type": "clarify.request",

--- a/src/lib/hermes-control-plane/fixtures/secret-request-response.json
+++ b/src/lib/hermes-control-plane/fixtures/secret-request-response.json
@@ -3,7 +3,7 @@
   "hermesVersion": "v2026.6.19",
   "recordedFrom": "tui-gateway",
   "sanitized": true,
-  "_note": "SECURITY fixture. A misbehaving gateway includes the secret value in the request payload (api_key + value). The classifier must surface secret.request -> pending_action/secret with redacted:true and carry ONLY metadata (key name), never the value. The replay test asserts the placeholder value below is absent from the serialized classified event. The value is an OBVIOUSLY FAKE placeholder, safe to commit. secret.response is not modeled as a gateway event yet; classifier routes it to unsupported today.",
+  "_note": "SECURITY fixture. A misbehaving gateway includes the secret value in the request payload (api_key + value). The classifier must surface secret.request -> pending_action/secret with redacted:true and carry ONLY metadata (key name), never the value. The replay test asserts the placeholder value below is absent from the serialized classified event. The value is an OBVIOUSLY FAKE placeholder, safe to commit. secret.response -> pending_action_resolution/secret and also carries metadata only.",
   "_secretValuePlaceholder": "sk-FAKE-PLACEHOLDER-secret-value-do-not-use-0000000000",
   "frames": [
     {

--- a/src/lib/hermes-control-plane/fixtures/sudo-request-response.json
+++ b/src/lib/hermes-control-plane/fixtures/sudo-request-response.json
@@ -3,7 +3,7 @@
   "hermesVersion": "v2026.6.19",
   "recordedFrom": "tui-gateway",
   "sanitized": true,
-  "_note": "A privilege-escalation prompt and its resolution. sudo.request -> pending_action/sudo carrying the mode. sudo.response is not modeled as a gateway event yet; classifier routes it to unsupported today (locked as honest current behavior; feature 03 wires the response method).",
+  "_note": "A privilege-escalation prompt and its resolution. sudo.request -> pending_action/sudo carrying the mode. sudo.response -> pending_action_resolution/sudo.",
   "frames": [
     {
       "type": "sudo.request",

--- a/src/lib/hermes-control-plane/raw-types.ts
+++ b/src/lib/hermes-control-plane/raw-types.ts
@@ -57,7 +57,9 @@ export type RawHermesEventName =
   | "approval.request"
   | "approval.response"
   | "sudo.request"
+  | "sudo.response"
   | "secret.request"
+  | "secret.response"
   // Subagents / background activity
   | "subagent.start"
   | "subagent.tool"

--- a/src/lib/hermes-session-steer.ts
+++ b/src/lib/hermes-session-steer.ts
@@ -11,8 +11,8 @@
  * - maps a rejected `steerSession(...)` into clear, recoverable UI copy
  *   (session busy, dropped connection, or a generic instruction failure)
  *   without leaking JSON-RPC codes or raw provider noise;
- * - builds the synthetic LOCAL live event that renders the user's instruction
- *   as a "Steering: <text>" system item in the transcript.
+ * - builds the first-party control-plane event that renders the user's
+ *   instruction as a "Steering: <text>" system item in the transcript.
  *
  * It is deliberately UI- and gateway-free so it stays trivially unit-testable
  * and so only this seam changes if the wire payload shape moves.
@@ -20,16 +20,7 @@
 
 import { isSessionBusyError } from "./hermes-gateway";
 import { messageFromError } from "./errors";
-import type { LiveHermesEvent } from "./agent-chat-runtime";
-
-/**
- * Synthetic event type for a steering instruction. It is NOT a Hermes frame —
- * it is minted locally and pushed onto the same per-session live-event channel
- * the gateway frames flow through, so the existing turn builder renders it,
- * orders it by timestamp, and survives re-renders for free. The `june.` prefix
- * keeps it clearly first-party and outside Hermes' namespace.
- */
-export const STEER_EVENT_TYPE = "june.steer" as const;
+import { createSteeringEvent, type JuneHermesEvent } from "./hermes-control-plane";
 
 /** Trim an instruction and reject blank input. Interior whitespace/newlines are
  * preserved; only a fully empty/whitespace string yields `undefined` so callers
@@ -65,30 +56,16 @@ function isConnectionError(err: unknown): boolean {
   );
 }
 
-/** The instruction text carried by a steering live event's payload, or "". */
-export function steeringPartText(payload: unknown): string {
-  if (payload && typeof payload === "object" && "text" in payload) {
-    const text = (payload as { text: unknown }).text;
-    if (typeof text === "string") return text;
-  }
-  return "";
-}
-
 /**
- * Build the synthetic local live event for a sent instruction. Pushed onto the
- * session's live-event list so {@link buildHermesSessionChatTurns} renders it as
- * a steering system turn at `receivedAt` order. Carries only the normalized text
- * — no gateway result, no secret material.
+ * Build the first-party local live event for a sent instruction. Pushed onto
+ * the session's live-event list so {@link buildHermesSessionChatTurns} renders
+ * it as a steering system turn at `receivedAt` order. Carries only the
+ * normalized text — no gateway result, no secret material.
  */
 export function steeringLiveEvent(params: {
   sessionId: string;
   text: string;
   receivedAt: string;
-}): LiveHermesEvent {
-  return {
-    type: STEER_EVENT_TYPE,
-    session_id: params.sessionId,
-    payload: { text: params.text },
-    receivedAt: params.receivedAt,
-  };
+}): JuneHermesEvent {
+  return createSteeringEvent(params.sessionId, params.text, params.receivedAt);
 }

--- a/src/lib/hermes-trace-buffer.ts
+++ b/src/lib/hermes-trace-buffer.ts
@@ -57,6 +57,8 @@ export type HermesTraceEntry = {
   direction: HermesTraceDirection;
   observedAt: string;
   sessionId?: string;
+  /** Inbound only: the live Hermes runtime/wire session id, when it differs. */
+  runtimeSessionId?: string;
   /** Inbound only: the raw wire `type`. */
   rawType?: string;
   /** Inbound only: the kind the classifier mapped the frame to. */
@@ -81,6 +83,11 @@ export type SanitizedTraceBundle = {
 /** Inbound recording takes the raw gateway frame and classifies it internally. */
 export type InboundTraceInput = HermesGatewayEvent;
 
+/** Optional stored-session remap for inbound frames whose wire id is transient. */
+export type InboundTraceOptions = {
+  storedSessionId?: string;
+};
+
 /** Outbound recording: the typed method call that was sent to the gateway. */
 export type OutboundTraceInput = {
   sessionId?: string;
@@ -97,7 +104,7 @@ export type ErrorTraceInput = {
 
 export type HermesTraceBuffer = {
   /** Record one inbound raw frame, classifying it for the normalized column. */
-  recordInbound(frame: InboundTraceInput): void;
+  recordInbound(frame: InboundTraceInput, options?: InboundTraceOptions): void;
   /** Record one outbound method call (params sanitized). */
   recordOutbound(call: OutboundTraceInput): void;
   /** Record one error/rejection. */
@@ -142,15 +149,17 @@ export function createHermesTraceBuffer(): HermesTraceBuffer {
     emit();
   }
 
-  function recordInbound(frame: InboundTraceInput): void {
+  function recordInbound(frame: InboundTraceInput, options: InboundTraceOptions = {}): void {
     const classified: JuneHermesEvent = classifyHermesEvent(frame);
-    const sessionId = nonEmpty(frame?.session_id) ?? nonEmpty(eventSession(classified));
+    const runtimeSessionId = nonEmpty(frame?.session_id) ?? nonEmpty(eventSession(classified));
+    const sessionId = nonEmpty(options.storedSessionId) ?? runtimeSessionId;
     const { payloadKeys, payloadPreview } = describePayload(frame?.payload);
     push(sessionId, {
       id: nextId++,
       direction: "inbound",
       observedAt: new Date().toISOString(),
       sessionId,
+      runtimeSessionId: runtimeSessionId !== sessionId ? runtimeSessionId : undefined,
       rawType: nonEmpty(typeof frame?.type === "string" ? frame.type : undefined),
       normalizedKind: classified.kind,
       payloadKeys,

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyHermesEvent,
+  isTerminalHermesEvent,
+  type JuneHermesEvent,
+} from "../lib/hermes-control-plane";
+import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
   completedHermesMessageText,
   displayedComposerUserMessageText,
   repairContractionSpacing,
 } from "../lib/agent-chat-runtime";
-import type { JuneHermesEvent } from "../lib/hermes-control-plane";
 import { categoryPrompt } from "../lib/issue-report-prompt";
 import { explicitSkillInvocationPrompt } from "../lib/skill-slash-commands";
 import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
@@ -1033,6 +1037,35 @@ describe("Agent chat runtime", () => {
     expect(toolParts?.[0]?.status).toBe("complete");
   });
 
+  it("ignores message.completed for transcript turns while keeping it terminal", () => {
+    const completed = classifyHermesEvent({
+      type: "message.completed",
+      session_id: "runtime-session",
+      payload: { text: "Should not render" },
+    });
+
+    expect(isTerminalHermesEvent(completed)).toBe(true);
+    expect(buildAgentChatTurns([], [], [completed])).toEqual([]);
+  });
+
+  it("does not duplicate assistant text when message.completed follows message.complete", () => {
+    const complete = classifyHermesEvent({
+      type: "message.complete",
+      session_id: "runtime-session",
+      payload: { text: "Done." },
+    });
+    const completed = classifyHermesEvent({
+      type: "message.completed",
+      session_id: "runtime-session",
+      payload: { text: "Done." },
+    });
+
+    const turns = buildAgentChatTurns([], [], [complete, completed]);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.parts).toEqual([{ type: "text", text: "Done.", status: "complete" }]);
+  });
+
   it("does not merge same-name tool calls with distinct tool ids", () => {
     const turns = buildAgentChatTurns(
       [],
@@ -1343,6 +1376,19 @@ describe("Agent chat runtime", () => {
         }),
       ],
     );
+
+    expect(turns[0]?.parts).toEqual([{ type: "notice", kind: "credits", text: CREDITS_ERROR }]);
+  });
+
+  it("folds a summary-only classified error into the same notice path", () => {
+    const event = classifyHermesEvent({
+      type: "error",
+      session_id: "runtime-session",
+      payload: { summary: CREDITS_ERROR },
+    });
+    expect(event.kind).toBe("error");
+
+    const turns = buildAgentChatTurns([], [], [event]);
 
     expect(turns[0]?.parts).toEqual([{ type: "notice", kind: "credits", text: CREDITS_ERROR }]);
   });

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -5,11 +5,107 @@ import {
   completedHermesMessageText,
   displayedComposerUserMessageText,
   repairContractionSpacing,
-  toolEventKey,
 } from "../lib/agent-chat-runtime";
+import type { JuneHermesEvent } from "../lib/hermes-control-plane";
 import { categoryPrompt } from "../lib/issue-report-prompt";
 import { explicitSkillInvocationPrompt } from "../lib/skill-slash-commands";
 import type { AgentMessageDto, HermesSessionMessage } from "../lib/tauri";
+
+const DEFAULT_RECEIVED_AT = "2026-06-04T10:00:00.000Z";
+
+type TranscriptEvent = Extract<JuneHermesEvent, { kind: "transcript" }>;
+type ReasoningEvent = Extract<JuneHermesEvent, { kind: "reasoning" }>;
+type ToolEvent = Extract<JuneHermesEvent, { kind: "tool" }>;
+type PendingActionEvent = Extract<JuneHermesEvent, { kind: "pending_action" }>;
+type PendingActionResolutionEvent = Extract<JuneHermesEvent, { kind: "pending_action_resolution" }>;
+type BackgroundActivityEvent = Extract<JuneHermesEvent, { kind: "background_activity" }>;
+type ErrorEvent = Extract<JuneHermesEvent, { kind: "error" }>;
+
+function transcriptEvent(event: Partial<TranscriptEvent> = {}): TranscriptEvent {
+  return {
+    kind: "transcript",
+    sessionId: "",
+    complete: false,
+    failed: false,
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function reasoningEvent(
+  event: Pick<ReasoningEvent, "delta"> & Partial<ReasoningEvent>,
+): ReasoningEvent {
+  return {
+    kind: "reasoning",
+    sessionId: "",
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function toolEvent(event: Partial<ToolEvent> & Pick<ToolEvent, "key">): ToolEvent {
+  return {
+    kind: "tool",
+    sessionId: "",
+    phase: "progress",
+    text: "",
+    isClarify: false,
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function pendingActionEvent(
+  event: Pick<PendingActionEvent, "action"> & Partial<PendingActionEvent>,
+): PendingActionEvent {
+  return {
+    kind: "pending_action",
+    sessionId: "",
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function pendingActionResolutionEvent(
+  event: Pick<PendingActionResolutionEvent, "action"> & Partial<PendingActionResolutionEvent>,
+): PendingActionResolutionEvent {
+  return {
+    kind: "pending_action_resolution",
+    sessionId: "",
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function backgroundActivityEvent(
+  event: Omit<Partial<BackgroundActivityEvent>, "activity"> & {
+    activity: Partial<BackgroundActivityEvent["activity"]> &
+      Pick<BackgroundActivityEvent["activity"], "phase">;
+  },
+): BackgroundActivityEvent {
+  const receivedAt = event.receivedAt ?? DEFAULT_RECEIVED_AT;
+  const { activity, ...rest } = event;
+  return {
+    kind: "background_activity",
+    sessionId: "",
+    receivedAt,
+    ...rest,
+    activity: {
+      ...activity,
+      subagentId: activity.subagentId ?? "subagent",
+      lastEventAt: activity.lastEventAt ?? receivedAt,
+    },
+  };
+}
+
+function errorEvent(event: Partial<ErrorEvent> = {}): ErrorEvent {
+  return {
+    kind: "error",
+    message: "The agent reported an error.",
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
 
 describe("repairContractionSpacing", () => {
   it("re-inserts the space the gateway drops after a contraction", () => {
@@ -258,11 +354,13 @@ describe("Agent chat runtime", () => {
     const turns = buildAgentChatTurns(
       [],
       [],
-      Array.from({ length: 12 }, (_, index) => ({
-        type: "message.complete",
-        receivedAt,
-        payload: { text: `Reply ${index}` },
-      })),
+      Array.from({ length: 12 }, (_, index) =>
+        transcriptEvent({
+          receivedAt,
+          complete: true,
+          delta: `Reply ${index}`,
+        }),
+      ),
     );
 
     expect(
@@ -491,21 +589,17 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.start",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {},
-        },
-        {
-          type: "thinking.delta",
+        }),
+        reasoningEvent({
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: { text: "I should prefer" },
-        },
-        {
-          type: "thinking.delta",
+          delta: "I should prefer",
+        }),
+        reasoningEvent({
           receivedAt: "2026-06-04T10:00:00.200Z",
-          payload: { text: "ably use Homebrew." },
-        },
+          delta: "ably use Homebrew.",
+        }),
       ],
     );
 
@@ -523,21 +617,24 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "tool.start",
+        toolEvent({
+          key: "tool-1",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { tool_id: "tool-1", name: "clarify" },
-        },
-        {
-          type: "clarify.request",
-          session_id: "runtime-session",
+          name: "clarify",
+          isClarify: true,
+          sanitizedPayload: { tool_id: "tool-1", name: "clarify" },
+        }),
+        pendingActionEvent({
+          sessionId: "runtime-session",
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: {
-            request_id: "clarify-1",
+          action: {
+            kind: "clarify",
+            requestId: "clarify-1",
             question: "Which email provider should I configure?",
             choices: ["Gmail", "Fastmail"],
           },
-        },
+        }),
       ],
     );
 
@@ -558,25 +655,33 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "clarify.request",
+        pendingActionEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {
-            request_id: "clarify-1",
+          action: {
+            kind: "clarify",
+            requestId: "clarify-1",
             question: "Use Gmail?",
             choices: ["Yes", "No"],
           },
-        },
-        {
-          type: "clarify.response",
+        }),
+        pendingActionResolutionEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { request_id: "clarify-1", answer: "Yes" },
-        },
-        {
-          type: "tool.complete",
+          action: {
+            kind: "clarify",
+            requestId: "clarify-1",
+            question: "",
+            choices: [],
+            answer: "Yes",
+          },
+        }),
+        toolEvent({
+          key: "tool-1",
+          phase: "complete",
           receivedAt: "2026-06-04T10:00:02.000Z",
-          payload: { tool_id: "tool-1", name: "clarify" },
-        },
+          name: "clarify",
+          isClarify: true,
+          sanitizedPayload: { tool_id: "tool-1", name: "clarify" },
+        }),
       ],
     );
 
@@ -597,23 +702,29 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "approval.request",
-          session_id: "runtime-session",
+        pendingActionEvent({
+          sessionId: "runtime-session",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {
-            request_id: "approval-1",
+          action: {
+            kind: "approval",
+            requestId: "approval-1",
             command: "python script.py",
             description: "Run this command?",
-            allow_permanent: true,
+            allowPermanent: true,
           },
-        },
-        {
-          type: "approval.response",
-          session_id: "runtime-session",
+        }),
+        pendingActionResolutionEvent({
+          sessionId: "runtime-session",
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { request_id: "approval-1", choice: "session" },
-        },
+          action: {
+            kind: "approval",
+            requestId: "approval-1",
+            command: "",
+            description: "",
+            allowPermanent: true,
+            choice: "session",
+          },
+        }),
       ],
     );
 
@@ -636,26 +747,21 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.start",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {},
-        },
-        {
-          type: "message.delta",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: { text: "Hello" },
-        },
-        {
-          type: "message.delta",
+          delta: "Hello",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.200Z",
-          payload: { text: "\n\n" },
-        },
-        {
-          type: "message.delta",
+          delta: "\n\n",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.300Z",
-          payload: { text: "World" },
-        },
+          delta: "World",
+        }),
       ],
     );
 
@@ -667,21 +773,17 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.start",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {},
-        },
-        {
-          type: "message.delta",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: { text: "no" },
-        },
-        {
-          type: "message.delta",
+          delta: "no",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.200Z",
-          payload: { text: "no" },
-        },
+          delta: "no",
+        }),
       ],
     );
 
@@ -716,21 +818,18 @@ describe("Agent chat runtime", () => {
 
   it("returns the raw completed message text for persistence", () => {
     const text = completedHermesMessageText([
-      {
-        type: "message.start",
+      transcriptEvent({
         receivedAt: "2026-06-04T10:00:00.000Z",
-        payload: {},
-      },
-      {
-        type: "message.delta",
+      }),
+      transcriptEvent({
         receivedAt: "2026-06-04T10:00:00.100Z",
-        payload: { text: "Yes.\n\nYes." },
-      },
-      {
-        type: "message.complete",
+        delta: "Yes.\n\nYes.",
+      }),
+      transcriptEvent({
         receivedAt: "2026-06-04T10:00:01.000Z",
-        payload: { text: "Yes.\n\nYes." },
-      },
+        complete: true,
+        delta: "Yes.\n\nYes.",
+      }),
     ]);
 
     expect(text).toBe("Yes.\n\nYes.");
@@ -741,36 +840,36 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.start",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {},
-        },
-        {
-          type: "message.delta",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: { text: "Let me check." },
-        },
-        {
-          type: "tool.start",
+          delta: "Let me check.",
+        }),
+        toolEvent({
+          key: "tool-1",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.200Z",
-          payload: { tool_id: "tool-1", name: "search" },
-        },
-        {
-          type: "tool.complete",
+          name: "search",
+          sanitizedPayload: { tool_id: "tool-1", name: "search" },
+        }),
+        toolEvent({
+          key: "tool-1",
+          phase: "complete",
           receivedAt: "2026-06-04T10:00:00.300Z",
-          payload: { tool_id: "tool-1", name: "search" },
-        },
-        {
-          type: "message.delta",
+          name: "search",
+          sanitizedPayload: { tool_id: "tool-1", name: "search" },
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.400Z",
-          payload: { text: "Here is the answer." },
-        },
-        {
-          type: "message.complete",
+          delta: "Here is the answer.",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: "Let me check.Here is the answer." },
-        },
+          complete: true,
+          delta: "Let me check.Here is the answer.",
+        }),
       ],
     );
 
@@ -787,26 +886,26 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.delta",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { text: "Partial garble" },
-        },
-        {
-          type: "tool.start",
+          delta: "Partial garble",
+        }),
+        toolEvent({
+          key: "tool-1",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: { tool_id: "tool-1", name: "search" },
-        },
-        {
-          type: "message.delta",
+          name: "search",
+          sanitizedPayload: { tool_id: "tool-1", name: "search" },
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.200Z",
-          payload: { text: "more" },
-        },
-        {
-          type: "message.complete",
+          delta: "more",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: "The authoritative answer." },
-        },
+          complete: true,
+          delta: "The authoritative answer.",
+        }),
       ],
     );
 
@@ -821,16 +920,15 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.delta",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { text: "Let me explore it." },
-        },
-        {
-          type: "message.complete",
+          delta: "Let me explore it.",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: "Let me exploreit." },
-        },
+          complete: true,
+          delta: "Let me exploreit.",
+        }),
       ],
     );
 
@@ -844,16 +942,15 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.delta",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { text: "return\nvalue" },
-        },
-        {
-          type: "message.complete",
+          delta: "return\nvalue",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: "return value" },
-        },
+          complete: true,
+          delta: "return value",
+        }),
       ],
     );
 
@@ -867,16 +964,15 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.delta",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { text: "Here is the full answer." },
-        },
-        {
-          type: "message.complete",
+          delta: "Here is the full answer.",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: "Here is the full" },
-        },
+          complete: true,
+          delta: "Here is the full",
+        }),
       ],
     );
 
@@ -891,10 +987,10 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        { type: "message.start", receivedAt, payload: {} },
-        { type: "message.complete", receivedAt, payload: { text: "One" } },
-        { type: "message.start", receivedAt, payload: {} },
-        { type: "message.complete", receivedAt, payload: { text: "Two" } },
+        transcriptEvent({ receivedAt }),
+        transcriptEvent({ receivedAt, complete: true, delta: "One" }),
+        transcriptEvent({ receivedAt }),
+        transcriptEvent({ receivedAt, complete: true, delta: "Two" }),
       ],
     );
 
@@ -903,22 +999,32 @@ describe("Agent chat runtime", () => {
   });
 
   it("keys tool events by tool_id so terminal events update the same part", () => {
-    expect(toolEventKey({ type: "tool.start", payload: { tool_id: "tool-9" } })).toBe("tool-9");
+    const event = toolEvent({
+      key: "tool-9",
+      phase: "start",
+      receivedAt: "2026-06-04T10:00:00.000Z",
+      sanitizedPayload: { tool_id: "tool-9" },
+    });
+    expect(event.key).toBe("tool-9");
 
     const turns = buildAgentChatTurns(
       [],
       [],
       [
-        {
-          type: "tool.start",
+        toolEvent({
+          key: "tool-9",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { tool_id: "tool-9", name: "search", text: "Searching" },
-        },
-        {
-          type: "tool.complete",
+          name: "search",
+          text: "Searching",
+          sanitizedPayload: { tool_id: "tool-9", name: "search", text: "Searching" },
+        }),
+        toolEvent({
+          key: "tool-9",
+          phase: "complete",
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { tool_id: "tool-9" },
-        },
+          sanitizedPayload: { tool_id: "tool-9" },
+        }),
       ],
     );
 
@@ -932,16 +1038,22 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "tool.start",
+        toolEvent({
+          key: "tool-a",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { tool_id: "tool-a", name: "search", text: "First" },
-        },
-        {
-          type: "tool.start",
+          name: "search",
+          text: "First",
+          sanitizedPayload: { tool_id: "tool-a", name: "search", text: "First" },
+        }),
+        toolEvent({
+          key: "tool-b",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { tool_id: "tool-b", name: "search", text: "Second" },
-        },
+          name: "search",
+          text: "Second",
+          sanitizedPayload: { tool_id: "tool-b", name: "search", text: "Second" },
+        }),
       ],
     );
 
@@ -1065,11 +1177,14 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "tool.complete",
+        toolEvent({
+          key: "tool-1",
+          phase: "complete",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { tool_id: "tool-1", name: "search", text: "Done" },
-        },
+          name: "search",
+          text: "Done",
+          sanitizedPayload: { tool_id: "tool-1", name: "search", text: "Done" },
+        }),
       ],
     );
 
@@ -1081,15 +1196,17 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "tool.start",
+        toolEvent({
+          key: "tool-1",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {
+          name: "terminal",
+          sanitizedPayload: {
             tool_id: "tool-1",
             name: "terminal",
             command: "curl https://example.com/docs",
           },
-        },
+        }),
       ],
     );
 
@@ -1105,31 +1222,37 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "tool.start",
+        toolEvent({
+          key: "tool-1",
+          phase: "start",
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {
+          name: "terminal",
+          sanitizedPayload: {
             tool_id: "tool-1",
             name: "terminal",
             command: "curl https://example.com/docs",
           },
-        },
-        {
-          type: "tool.progress",
+        }),
+        toolEvent({
+          key: "tool-1",
+          phase: "progress",
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: {
+          text: "Fetched 42 lines",
+          sanitizedPayload: {
             tool_id: "tool-1",
             output: "Fetched 42 lines",
           },
-        },
-        {
-          type: "tool.complete",
+        }),
+        toolEvent({
+          key: "tool-1",
+          phase: "complete",
           receivedAt: "2026-06-04T10:00:02.000Z",
-          payload: {
+          text: "Done",
+          sanitizedPayload: {
             tool_id: "tool-1",
             result: "Done",
           },
-        },
+        }),
       ],
     );
 
@@ -1181,21 +1304,16 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "message.start",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {},
-        },
-        {
-          type: "message.delta",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.100Z",
-          payload: { text: "Working on it" },
-        },
-        {
-          type: "error",
+          delta: "Working on it",
+        }),
+        errorEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: {},
-        },
+        }),
       ],
     );
 
@@ -1219,11 +1337,10 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "error",
+        errorEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { message: CREDITS_ERROR },
-        },
+          message: CREDITS_ERROR,
+        }),
       ],
     );
 
@@ -1247,16 +1364,16 @@ describe("Agent chat runtime", () => {
     const turns = buildHermesSessionChatTurns(
       [],
       [
-        {
-          type: "message.delta",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { text: "Let me check" },
-        },
-        {
-          type: "message.complete",
+          delta: "Let me check",
+        }),
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: CREDITS_ERROR, status: "error" },
-        },
+          complete: true,
+          delta: CREDITS_ERROR,
+          failed: true,
+        }),
       ],
     );
 
@@ -1267,11 +1384,12 @@ describe("Agent chat runtime", () => {
     const turns = buildHermesSessionChatTurns(
       [],
       [
-        {
-          type: "message.complete",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: CREDITS_ERROR, status: "error" },
-        },
+          complete: true,
+          delta: CREDITS_ERROR,
+          failed: true,
+        }),
       ],
     );
 
@@ -1302,11 +1420,10 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "error",
+        errorEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { message: OVERFLOW_ERROR },
-        },
+          message: OVERFLOW_ERROR,
+        }),
       ],
     );
 
@@ -1324,11 +1441,10 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "error",
+        errorEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { message: text },
-        },
+          message: text,
+        }),
       ],
     );
 
@@ -1339,11 +1455,12 @@ describe("Agent chat runtime", () => {
     const turns = buildHermesSessionChatTurns(
       [],
       [
-        {
-          type: "message.complete",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: OVERFLOW_ERROR, status: "error" },
-        },
+          complete: true,
+          delta: OVERFLOW_ERROR,
+          failed: true,
+        }),
       ],
     );
 
@@ -1429,11 +1546,12 @@ describe("Agent chat runtime", () => {
     const turns = buildHermesSessionChatTurns(
       [],
       [
-        {
-          type: "message.complete",
+        transcriptEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { text: prose, status: "complete" },
-        },
+          complete: true,
+          delta: prose,
+          failed: false,
+        }),
       ],
     );
 
@@ -1445,44 +1563,44 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "subagent.start",
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: {
-            subagent_id: "sa-1",
-            task_index: 0,
-            task_count: 2,
+          activity: {
+            subagentId: "sa-1",
+            phase: "start",
+            taskIndex: 0,
+            taskCount: 2,
             goal: "Write the privacy page",
           },
-        },
-        {
-          type: "subagent.start",
+        }),
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:00.050Z",
-          payload: {
-            subagent_id: "sa-2",
-            task_index: 1,
-            task_count: 2,
+          activity: {
+            subagentId: "sa-2",
+            phase: "start",
+            taskIndex: 1,
+            taskCount: 2,
             goal: "Write the terms page",
           },
-        },
-        {
-          type: "subagent.tool",
+        }),
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: {
-            subagent_id: "sa-1",
+          activity: {
+            subagentId: "sa-1",
+            phase: "tool",
             goal: "Write the privacy page",
-            tool_preview: "edit privacy.tsx",
+            resultPreview: "edit privacy.tsx",
           },
-        },
-        {
-          type: "subagent.complete",
+        }),
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:02.000Z",
-          payload: {
-            subagent_id: "sa-1",
+          activity: {
+            subagentId: "sa-1",
+            phase: "complete",
             goal: "Write the privacy page",
-            summary: "Done: 1 file written",
+            resultPreview: "Done: 1 file written",
           },
-        },
+        }),
       ],
     );
 
@@ -1509,17 +1627,15 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "subagent.start",
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { subagent_id: "sa-1", goal: "Write the privacy page" },
-        },
+          activity: { subagentId: "sa-1", phase: "start", goal: "Write the privacy page" },
+        }),
         // A tool event carrying only the id + preview, no goal.
-        {
-          type: "subagent.tool",
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { subagent_id: "sa-1", tool_preview: "edit privacy.tsx" },
-        },
+          activity: { subagentId: "sa-1", phase: "tool", resultPreview: "edit privacy.tsx" },
+        }),
       ],
     );
     const tool = turns[0]?.parts.find((part) => part.type === "tool");
@@ -1535,17 +1651,15 @@ describe("Agent chat runtime", () => {
       [],
       [],
       [
-        {
-          type: "subagent.start",
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { subagent_id: "sa-1", goal: "Write the privacy page" },
-        },
+          activity: { subagentId: "sa-1", phase: "start", goal: "Write the privacy page" },
+        }),
         // A subtype not in the documented union; must still terminate the row.
-        {
-          type: "subagent.timeout",
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:05.000Z",
-          payload: { subagent_id: "sa-1" },
-        },
+          activity: { subagentId: "sa-1", phase: "error" },
+        }),
       ],
     );
     const tool = turns[0]?.parts.find((part) => part.type === "tool");
@@ -1555,21 +1669,41 @@ describe("Agent chat runtime", () => {
     });
   });
 
+  it("keeps blocked subagent rows running because they can resume", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        backgroundActivityEvent({
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          activity: { subagentId: "sa-1", phase: "start", goal: "Write the privacy page" },
+        }),
+        backgroundActivityEvent({
+          receivedAt: "2026-06-04T10:00:05.000Z",
+          activity: { subagentId: "sa-1", phase: "blocked" },
+        }),
+      ],
+    );
+    const tool = turns[0]?.parts.find((part) => part.type === "tool");
+    expect(tool).toMatchObject({
+      name: "Subagent: Write the privacy page",
+      status: "running",
+    });
+  });
+
   it("labels a goal-less subagent by its task position and marks failures", () => {
     const turns = buildAgentChatTurns(
       [],
       [],
       [
-        {
-          type: "subagent.start",
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:00.000Z",
-          payload: { task_index: 2, task_count: 5 },
-        },
-        {
-          type: "subagent.complete",
+          activity: { phase: "start", taskIndex: 2, taskCount: 5 },
+        }),
+        backgroundActivityEvent({
           receivedAt: "2026-06-04T10:00:01.000Z",
-          payload: { task_index: 2, task_count: 5, status: "failed" },
-        },
+          activity: { phase: "error", taskIndex: 2, taskCount: 5 },
+        }),
       ],
     );
     const tool = turns[0]?.parts.find((part) => part.type === "tool");

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -625,6 +625,52 @@ describe("Agent chat runtime", () => {
     ]);
   });
 
+  it("closes a running reasoning turn when only a terminal lifecycle event follows", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        reasoningEvent({
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          delta: "Checking the workspace.",
+        }),
+        lifecycleEvent({
+          sessionId: "runtime-session",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          flavor: "terminal",
+          status: "turn.complete",
+        }),
+      ],
+    );
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]?.status).toBe("complete");
+    expect(turns[0]?.parts).toEqual([
+      {
+        type: "reasoning",
+        text: "Checking the workspace.",
+        status: "complete",
+      },
+    ]);
+  });
+
+  it("does not create a turn for a terminal lifecycle event without an assistant turn", () => {
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        lifecycleEvent({
+          sessionId: "runtime-session",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          flavor: "terminal",
+          status: "turn.complete",
+        }),
+      ],
+    );
+
+    expect(turns).toEqual([]);
+  });
+
   it("renders live clarify requests as answerable chat parts", () => {
     const turns = buildAgentChatTurns(
       [],

--- a/src/test/agent-chat-runtime.test.ts
+++ b/src/test/agent-chat-runtime.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  classifyHermesEvent,
-  isTerminalHermesEvent,
-  type JuneHermesEvent,
-} from "../lib/hermes-control-plane";
+import { isTerminalHermesEvent, type JuneHermesEvent } from "../lib/hermes-control-plane";
 import {
   buildAgentChatTurns,
   buildHermesSessionChatTurns,
@@ -24,6 +20,7 @@ type PendingActionEvent = Extract<JuneHermesEvent, { kind: "pending_action" }>;
 type PendingActionResolutionEvent = Extract<JuneHermesEvent, { kind: "pending_action_resolution" }>;
 type BackgroundActivityEvent = Extract<JuneHermesEvent, { kind: "background_activity" }>;
 type ErrorEvent = Extract<JuneHermesEvent, { kind: "error" }>;
+type LifecycleEvent = Extract<JuneHermesEvent, { kind: "lifecycle" }>;
 
 function transcriptEvent(event: Partial<TranscriptEvent> = {}): TranscriptEvent {
   return {
@@ -106,6 +103,18 @@ function errorEvent(event: Partial<ErrorEvent> = {}): ErrorEvent {
   return {
     kind: "error",
     message: "The agent reported an error.",
+    receivedAt: DEFAULT_RECEIVED_AT,
+    ...event,
+  };
+}
+
+function lifecycleEvent(event: Partial<LifecycleEvent> = {}): LifecycleEvent {
+  return {
+    kind: "lifecycle",
+    sessionId: "",
+    flavor: "info",
+    status: "status.update",
+    text: "",
     receivedAt: DEFAULT_RECEIVED_AT,
     ...event,
   };
@@ -1038,9 +1047,11 @@ describe("Agent chat runtime", () => {
   });
 
   it("ignores message.completed for transcript turns while keeping it terminal", () => {
-    const completed = classifyHermesEvent({
-      type: "message.completed",
-      session_id: "runtime-session",
+    const completed = lifecycleEvent({
+      sessionId: "runtime-session",
+      flavor: "terminal",
+      status: "message.completed",
+      text: "Should not render",
       payload: { text: "Should not render" },
     });
 
@@ -1049,14 +1060,17 @@ describe("Agent chat runtime", () => {
   });
 
   it("does not duplicate assistant text when message.completed follows message.complete", () => {
-    const complete = classifyHermesEvent({
-      type: "message.complete",
-      session_id: "runtime-session",
-      payload: { text: "Done." },
+    const complete = transcriptEvent({
+      sessionId: "runtime-session",
+      complete: true,
+      failed: false,
+      delta: "Done.",
     });
-    const completed = classifyHermesEvent({
-      type: "message.completed",
-      session_id: "runtime-session",
+    const completed = lifecycleEvent({
+      sessionId: "runtime-session",
+      flavor: "terminal",
+      status: "message.completed",
+      text: "Done.",
       payload: { text: "Done." },
     });
 
@@ -1381,10 +1395,9 @@ describe("Agent chat runtime", () => {
   });
 
   it("folds a summary-only classified error into the same notice path", () => {
-    const event = classifyHermesEvent({
-      type: "error",
-      session_id: "runtime-session",
-      payload: { summary: CREDITS_ERROR },
+    const event = errorEvent({
+      sessionId: "runtime-session",
+      message: CREDITS_ERROR,
     });
     expect(event.kind).toBe("error");
 

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -9,6 +9,7 @@ import {
   AgentWorkspace,
   HERO_GREETINGS,
   SkillsToolsPanel,
+  projectAgentActivityLevels,
   resetAgentSessionContinuity,
   type AgentSessionsChangedDetail,
 } from "../components/agent/AgentWorkspace";
@@ -19,6 +20,7 @@ import {
 } from "../lib/model-privacy";
 import { HermesGatewayError } from "../lib/hermes-gateway";
 import { classifyHermesEvent } from "../lib/hermes-control-plane";
+import { hermesActivityStore, type AgentActivityRecord } from "../lib/hermes-activity-store";
 import { hermesArtifactStore } from "../lib/hermes-artifact-store";
 import { hermesTraceBuffer } from "../lib/hermes-trace-buffer";
 import { pendingActionStore } from "../lib/hermes-pending-actions";
@@ -328,6 +330,26 @@ describe("AgentWorkspace", () => {
       }
       return Promise.resolve({});
     });
+  });
+
+  it("reuses activity projection set identities when membership is unchanged", () => {
+    const record: AgentActivityRecord = {
+      id: "session-1",
+      mode: "sandboxed",
+      sessionId: "session-1",
+      phase: "running",
+      pendingActionCount: 0,
+      subagentCount: 0,
+      subagents: [],
+      lastEventAt: 1,
+    };
+    const first = projectAgentActivityLevels([record]);
+
+    const second = projectAgentActivityLevels([{ ...record, lastEventAt: 2 }], first);
+
+    expect(second.workingSessionIds).toBe(first.workingSessionIds);
+    expect(second.waitingSessionIds).toBe(first.waitingSessionIds);
+    expect(second.toolCallSessionIds).toBe(first.toolCallSessionIds);
   });
 
   it("lets users cancel a clean skill editor without making changes", async () => {
@@ -4072,6 +4094,56 @@ describe("AgentWorkspace", () => {
       ),
     ).toBeInTheDocument();
     expect(mocks.explainAgentApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps approval cards on the runtime session while activity uses the stored session", async () => {
+    const user = userEvent.setup();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the build",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the build",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "approval.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "approval-runtime",
+            description: "Security scan requires approval.",
+            command: "npm run build",
+            allow_permanent: true,
+          },
+        });
+      }
+    });
+
+    expect(await screen.findByText("Approval required")).toBeInTheDocument();
+    expect(hermesActivityStore.getRecord("runtime-session-2")).toBeUndefined();
+    expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("waiting");
+    const projection = projectAgentActivityLevels(hermesActivityStore.getRecords());
+    expect(projection.waitingSessionIds.has("session-2")).toBe(true);
+    expect(projection.waitingSessionIds.has("runtime-session-2")).toBe(false);
+
+    await user.click(screen.getByRole("button", { name: "Approve once" }));
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("approval.respond", {
+        session_id: "runtime-session-2",
+        choice: "once",
+      }),
+    );
   });
 
   it("retires a pending approval and explains when its runtime session is gone", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -25,6 +25,7 @@ import { hermesActivityStore, type AgentActivityRecord } from "../lib/hermes-act
 import { hermesArtifactStore } from "../lib/hermes-artifact-store";
 import { hermesTraceBuffer } from "../lib/hermes-trace-buffer";
 import { pendingActionStore } from "../lib/hermes-pending-actions";
+import { unsupportedEventStore } from "../lib/hermes-unsupported-events";
 
 // The hero greeting cycles per visit, so tests match any entry in the pool.
 const HERO_GREETING = new RegExp(
@@ -4157,6 +4158,58 @@ describe("AgentWorkspace", () => {
         pendingActionStore.openRecords().some((record) => record.requestId === "approval-runtime"),
       ).toBe(false),
     );
+  });
+
+  it("keys inbound diagnostics by the stored session id", async () => {
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.create") {
+        return Promise.resolve({
+          session_id: "runtime-diagnostics-session",
+          stored_session_id: "stored-diagnostics-session",
+        });
+      }
+      if (method === "session.resume") {
+        return Promise.resolve({ session_id: "runtime-session-1" });
+      }
+      return Promise.resolve({});
+    });
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "inspect diagnostics",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-diagnostics-session",
+        text: "inspect diagnostics",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "future.diagnostic",
+          session_id: "runtime-diagnostics-session",
+          payload: { detail: "unknown" },
+        });
+      }
+    });
+
+    expect(unsupportedEventStore.activeNotice("runtime-diagnostics-session")).toBeUndefined();
+    expect(unsupportedEventStore.activeNotice("stored-diagnostics-session")?.type).toBe(
+      "future.diagnostic",
+    );
+    expect(hermesTraceBuffer.entriesFor("runtime-diagnostics-session")).toHaveLength(0);
+    const traceEntry = hermesTraceBuffer
+      .entriesFor("stored-diagnostics-session")
+      .find((entry) => entry.rawType === "future.diagnostic");
+    expect(traceEntry).toBeDefined();
+    expect(traceEntry?.sessionId).toBe("stored-diagnostics-session");
+    expect(traceEntry?.runtimeSessionId).toBe("runtime-diagnostics-session");
   });
 
   it("treats lifecycle.complete as a terminal workspace edge", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -19,6 +19,7 @@ import {
   PROVIDER_MODEL_SETTINGS_CHANGED_EVENT,
 } from "../lib/model-privacy";
 import { HermesGatewayError } from "../lib/hermes-gateway";
+import { AGENT_SESSION_STATUS_EVENT, type AgentSessionStatusDetail } from "../lib/agent-events";
 import { classifyHermesEvent } from "../lib/hermes-control-plane";
 import { hermesActivityStore, type AgentActivityRecord } from "../lib/hermes-activity-store";
 import { hermesArtifactStore } from "../lib/hermes-artifact-store";
@@ -4132,6 +4133,13 @@ describe("AgentWorkspace", () => {
     expect(await screen.findByText("Approval required")).toBeInTheDocument();
     expect(hermesActivityStore.getRecord("runtime-session-2")).toBeUndefined();
     expect(hermesActivityStore.getRecord("session-2")?.phase).toBe("waiting");
+    const [pendingRecord] = pendingActionStore.openRecords().filter((record) => {
+      return record.requestId === "approval-runtime";
+    });
+    expect(pendingRecord?.sessionId).toBe("session-2");
+    expect(
+      pendingActionStore.openRecords().some((record) => record.sessionId === "runtime-session-2"),
+    ).toBe(false);
     const projection = projectAgentActivityLevels(hermesActivityStore.getRecords());
     expect(projection.waitingSessionIds.has("session-2")).toBe(true);
     expect(projection.waitingSessionIds.has("runtime-session-2")).toBe(false);
@@ -4144,6 +4152,71 @@ describe("AgentWorkspace", () => {
         choice: "once",
       }),
     );
+    await waitFor(() =>
+      expect(
+        pendingActionStore.openRecords().some((record) => record.requestId === "approval-runtime"),
+      ).toBe(false),
+    );
+  });
+
+  it("keeps sudo and secret pending status copy generic", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the build",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the build",
+      }),
+    );
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "sudo.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "sudo-copy",
+            command: "npm run build",
+          },
+        });
+        handler({
+          type: "secret.request",
+          session_id: "runtime-session-2",
+          payload: {
+            request_id: "secret-copy",
+            key_name: "API_KEY",
+          },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(
+        statusDetails
+          .filter((detail) => detail.status === "waitingForUser")
+          .map((detail) => ({
+            sessionId: detail.sessionId,
+            summary: detail.summary,
+          })),
+      ).toEqual([
+        { sessionId: "session-2", summary: "June has a question." },
+        { sessionId: "session-2", summary: "June has a question." },
+      ]),
+    );
+    expect(statusDetails.some((detail) => detail.summary === "June needs approval.")).toBe(false);
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
   });
 
   it("retires a pending approval and explains when its runtime session is gone", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -4159,6 +4159,53 @@ describe("AgentWorkspace", () => {
     );
   });
 
+  it("treats lifecycle.complete as a terminal workspace edge", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        prompt: "run the build",
+      }),
+    );
+
+    render(<AgentWorkspace />);
+
+    await waitFor(() =>
+      expect(mocks.gatewayRequest).toHaveBeenCalledWith("prompt.submit", {
+        session_id: "runtime-session-2",
+        text: "run the build",
+      }),
+    );
+    expect(mocks.gatewayEventHandlers.size).toBe(1);
+
+    act(() => {
+      for (const handler of mocks.gatewayEventHandlers) {
+        handler({
+          type: "lifecycle.complete",
+          session_id: "runtime-session-2",
+          payload: { status: "success" },
+        });
+      }
+    });
+
+    await waitFor(() =>
+      expect(statusDetails).toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-2",
+          status: "completed",
+          summary: "June finished.",
+        }),
+      ),
+    );
+    expect(mocks.gatewayEventHandlers.size).toBe(0);
+    window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+  });
+
   it("keeps sudo and secret pending status copy generic", async () => {
     const statusDetails: AgentSessionStatusDetail[] = [];
     const handleStatus = (event: Event) => {

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -129,6 +129,16 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(0);
   });
 
+  it("uses terminal lifecycle flavor even when the payload status is non-terminal", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
+
+    store.record(classified("turn.complete", "s1", { status: "success" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("complete");
+    expect(store.activeCount()).toBe(0);
+  });
+
   it("message completion flips the session to phase 'complete'", () => {
     const store = createHermesActivityStore();
     store.record(classified("message.start", "s1"), "sandboxed");

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -207,6 +207,17 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(0);
   });
 
+  it("lets parent transcript streaming recover visibility after a subagent error", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("subagent.error", "s1", { subagent_id: "a1" }), "sandboxed");
+    expect(store.getRecord("s1")?.phase).toBe("error");
+
+    store.record(classified("message.delta", "s1", { delta: "Still streaming" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("running");
+    expect(store.activeCount()).toBe(1);
+  });
+
   it("keeps the parent in 'background' while any sibling subagent is still working", () => {
     const store = createHermesActivityStore();
     store.record(classified("subagent.start", "s1", { subagent_id: "a1" }), "sandboxed");
@@ -299,5 +310,22 @@ describe("createHermesActivityStore", () => {
     expect(store.getRecords().length).toBeLessThanOrEqual(ACTIVITY_SESSIONS_CAP);
     // The very first session should have been evicted.
     expect(store.getRecord("s0")).toBeUndefined();
+  });
+
+  it("evicts completed rows before an older live row when over capacity", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "running", { tool_name: "bash" }), "sandboxed");
+    advance(1);
+
+    for (let i = 0; i < ACTIVITY_SESSIONS_CAP; i++) {
+      const sessionId = `complete-${i}`;
+      store.record(classified("tool.start", sessionId, { tool_name: "bash" }), "sandboxed");
+      store.record(classified("session.complete", sessionId), "sandboxed");
+      advance(1);
+    }
+
+    expect(store.getRecords()).toHaveLength(ACTIVITY_SESSIONS_CAP);
+    expect(store.getRecord("running")?.phase).toBe("running");
+    expect(store.activeCount()).toBe(1);
   });
 });

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -149,14 +149,34 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(1);
   });
 
-  it("falls back to terminal payload status for info lifecycle flavor", () => {
+  it("leaves a running row active when info lifecycle status text looks terminal", () => {
     const store = createHermesActivityStore();
     store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
 
     store.record(classified("lifecycle.update", "s1", { status: "completed" }), "sandboxed");
 
-    expect(store.getRecord("s1")?.phase).toBe("complete");
+    expect(store.getRecord("s1")?.phase).toBe("running");
+    expect(store.activeCount()).toBe(1);
+  });
+
+  it("ignores info lifecycle status text for an absent row", () => {
+    const store = createHermesActivityStore();
+
+    store.record(classified("lifecycle.update", "s1", { status: "done" }), "sandboxed");
+
+    expect(store.getRecord("s1")).toBeUndefined();
     expect(store.activeCount()).toBe(0);
+  });
+
+  it("keeps accepting transcript deltas after info lifecycle status text looks terminal", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
+    store.record(classified("lifecycle.update", "s1", { status: "done" }), "sandboxed");
+
+    store.record(classified("message.delta", "s1", { delta: "still streaming" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("running");
+    expect(store.activeCount()).toBe(1);
   });
 
   it("message completion flips the session to phase 'complete'", () => {

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -139,6 +139,26 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(0);
   });
 
+  it("keeps running lifecycle flavor active even when the payload status is terminal", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
+
+    store.record(classified("status.update", "s1", { status: "done" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("running");
+    expect(store.activeCount()).toBe(1);
+  });
+
+  it("falls back to terminal payload status for info lifecycle flavor", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
+
+    store.record(classified("lifecycle.update", "s1", { status: "completed" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("complete");
+    expect(store.activeCount()).toBe(0);
+  });
+
   it("message completion flips the session to phase 'complete'", () => {
     const store = createHermesActivityStore();
     store.record(classified("message.start", "s1"), "sandboxed");

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { classifyHermesEvent } from "../lib/hermes-control-plane";
+import { classifyHermesEvent, createSteeringEvent } from "../lib/hermes-control-plane";
 import type { JuneHermesEvent } from "../lib/hermes-control-plane";
 import { ACTIVITY_SESSIONS_CAP, createHermesActivityStore } from "../lib/hermes-activity-store";
 
@@ -68,6 +68,49 @@ describe("createHermesActivityStore", () => {
     expect(record?.phase).toBe("waiting");
     // Count is pulled live from feature 04's store, not counted here.
     expect(record?.pendingActionCount).toBe(2);
+  });
+
+  it("a pending action resolution moves a non-terminal session back to running", () => {
+    const store = createHermesActivityStore();
+    store.record(
+      classified("clarify.request", "s1", {
+        request_id: "r1",
+        question: "Which file?",
+      }),
+      "sandboxed",
+    );
+    expect(store.getRecord("s1")?.phase).toBe("waiting");
+
+    store.record(
+      classified("clarify.response", "s1", {
+        request_id: "r1",
+        answer: "vite.config.ts",
+      }),
+      "sandboxed",
+    );
+    expect(store.getRecord("s1")?.phase).toBe("running");
+  });
+
+  it("a failed tool event clears the in-flight tool", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
+    expect(store.getRecord("s1")?.currentTool).toBe("bash");
+
+    store.record(classified("tool.error", "s1", { tool_name: "bash" }), "sandboxed");
+    const record = store.getRecord("s1");
+    expect(record?.phase).toBe("running");
+    expect(record?.currentTool).toBeUndefined();
+  });
+
+  it("a steering event is a no-op for activity phase", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");
+    store.record(
+      createSteeringEvent("s1", "focus on tests", new Date().toISOString()),
+      "sandboxed",
+    );
+    expect(store.getRecord("s1")?.phase).toBe("running");
+    expect(store.getRecord("s1")?.currentTool).toBe("bash");
   });
 
   it("completion flips the session to phase 'complete' but keeps the row", () => {

--- a/src/test/hermes-activity-store.test.ts
+++ b/src/test/hermes-activity-store.test.ts
@@ -129,6 +129,17 @@ describe("createHermesActivityStore", () => {
     expect(store.activeCount()).toBe(0);
   });
 
+  it("message completion flips the session to phase 'complete'", () => {
+    const store = createHermesActivityStore();
+    store.record(classified("message.start", "s1"), "sandboxed");
+    expect(store.getRecord("s1")?.phase).toBe("running");
+
+    store.record(classified("message.complete", "s1", { text: "Done" }), "sandboxed");
+
+    expect(store.getRecord("s1")?.phase).toBe("complete");
+    expect(store.activeCount()).toBe(0);
+  });
+
   it("an error frame moves the session to phase 'error'", () => {
     const store = createHermesActivityStore();
     store.record(classified("tool.start", "s1", { tool_name: "bash" }), "sandboxed");

--- a/src/test/hermes-artifact-store.test.ts
+++ b/src/test/hermes-artifact-store.test.ts
@@ -216,6 +216,23 @@ describe("createHermesArtifactStore", () => {
     expect(artifacts[0].createdAt).toBe(now);
   });
 
+  it("records resumed live artifacts under the stored session id used by the drawer", () => {
+    const store = createHermesArtifactStore();
+    const runtimeEvent = toolClassified("tool.complete", "runtime-session", {
+      name: "write_file",
+      file_path: "/tmp/resumed.md",
+    });
+    store.record({ ...runtimeEvent, sessionId: "stored-session" }, "sandboxed");
+
+    expect(store.getRecordsForSession("runtime-session")).toEqual([]);
+    expect(store.getRecordsForSession("stored-session")).toMatchObject([
+      {
+        sessionId: "stored-session",
+        path: "/tmp/resumed.md",
+      },
+    ]);
+  });
+
   it("the timeline shows the real long path, not [redacted]", () => {
     // End-to-end: classify (which sanitizes) -> store.record -> drawer read.
     // Proves the artifact a user clicks opens the real file.

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { HermesGatewayEvent } from "../lib/hermes-gateway";
 import {
   classifyHermesEvent,
+  createSteeringEvent,
   isSensitiveKey,
   parseHermesMode,
   sanitizePayload,
@@ -11,6 +12,8 @@ import type {
   JuneHermesEvent,
   PendingHermesAction,
 } from "../lib/hermes-control-plane";
+
+const RECEIVED_AT = "2026-06-24T12:00:00.000Z";
 
 // Every name the gateway currently models (HermesGatewayEventName), so the
 // classifier's exhaustiveness is pinned to the transport's surface. If the
@@ -31,6 +34,10 @@ const CURRENT_GATEWAY_EVENT_NAMES = [
   "clarify.response",
   "approval.request",
   "approval.response",
+  "sudo.request",
+  "sudo.response",
+  "secret.request",
+  "secret.response",
   "subagent.start",
   "subagent.tool",
   "subagent.progress",
@@ -40,7 +47,7 @@ const CURRENT_GATEWAY_EVENT_NAMES = [
 ] as const;
 
 function event<P>(type: string, payload?: P, sessionId = "sess-1") {
-  return { type, session_id: sessionId, payload } as HermesGatewayEvent<P>;
+  return { type, session_id: sessionId, payload, receivedAt: RECEIVED_AT } as HermesGatewayEvent<P>;
 }
 
 describe("classifyHermesEvent — totality", () => {
@@ -69,6 +76,36 @@ describe("classifyHermesEvent — totality", () => {
     } as unknown as HermesGatewayEvent);
     expect(result.kind).toBe("unsupported");
   });
+
+  it("carries receivedAt on every JuneHermesEvent kind", () => {
+    const samples = [
+      classifyHermesEvent(event("message.start", {})),
+      classifyHermesEvent(event("reasoning.delta", { delta: "thinking" })),
+      classifyHermesEvent(event("tool.start", { name: "read_file" })),
+      classifyHermesEvent(event("clarify.request", { request_id: "c1" })),
+      classifyHermesEvent(event("clarify.response", { request_id: "c1" })),
+      classifyHermesEvent(event("subagent.start", { subagent_id: "sub-1" })),
+      createSteeringEvent("sess-1", "focus on tests", RECEIVED_AT),
+      classifyHermesEvent(event("session.complete", {})),
+      classifyHermesEvent(event("error", { message: "boom" })),
+      classifyHermesEvent(event("future.event", {})),
+    ];
+    expect(samples.map((sample) => sample.kind).sort()).toEqual(
+      [
+        "background_activity",
+        "error",
+        "lifecycle",
+        "pending_action",
+        "pending_action_resolution",
+        "reasoning",
+        "steering",
+        "tool",
+        "transcript",
+        "unsupported",
+      ].sort(),
+    );
+    for (const sample of samples) expect(sample.receivedAt).toBe(RECEIVED_AT);
+  });
 });
 
 describe("classifyHermesEvent — transcript", () => {
@@ -94,6 +131,7 @@ describe("classifyHermesEvent — transcript", () => {
     expect(complete).toMatchObject({
       kind: "transcript",
       complete: true,
+      failed: false,
     });
     if (complete.kind === "transcript") {
       expect(complete.delta).toBe("Hello");
@@ -106,6 +144,18 @@ describe("classifyHermesEvent — transcript", () => {
       expect(delta.delta).toBe("  ");
     } else {
       throw new Error("expected transcript");
+    }
+  });
+
+  it("marks failed completes and reads complete text from the builder's summary chain", () => {
+    const complete = classifyHermesEvent(
+      event("message.complete", { summary: "  Summary only  ", status: "ERROR" }),
+    );
+    expect(complete.kind).toBe("transcript");
+    if (complete.kind === "transcript") {
+      expect(complete.complete).toBe(true);
+      expect(complete.failed).toBe(true);
+      expect(complete.delta).toBe("Summary only");
     }
   });
 });
@@ -136,11 +186,15 @@ describe("classifyHermesEvent — tools", () => {
       kind: "tool",
       phase: "start",
       toolCallId: "tc1",
+      key: "tc1",
       name: "read_file",
+      text: "",
+      isClarify: false,
     });
     if (start.kind === "tool") {
       // The raw payload is preserved so a tool card can render arguments.
       expect(start.payload).toMatchObject({ path: "/tmp/x" });
+      expect(start.sanitizedPayload).toMatchObject({ path: "/tmp/x" });
     }
 
     expect(classifyHermesEvent(event("tool.progress", {}))).toMatchObject({
@@ -158,6 +212,26 @@ describe("classifyHermesEvent — tools", () => {
     if (byToolName.kind === "tool") expect(byToolName.name).toBe("shell");
     const byTool = classifyHermesEvent(event("tool.start", { tool: "grep" }));
     if (byTool.kind === "tool") expect(byTool.name).toBe("grep");
+  });
+
+  it("classifies the broader tool.* family and marks tool.error as failed", () => {
+    const result = classifyHermesEvent(
+      event("tool.error", {
+        tool_id: "tool-id",
+        id: "event-id",
+        tool_call_id: "call-id",
+        name: "clarify",
+        summary: "Need an answer",
+      }),
+    );
+    expect(result.kind).toBe("tool");
+    if (result.kind === "tool") {
+      expect(result.phase).toBe("failed");
+      expect(result.toolCallId).toBe("call-id");
+      expect(result.key).toBe("tool-id");
+      expect(result.text).toBe("Need an answer");
+      expect(result.isClarify).toBe(true);
+    }
   });
 });
 
@@ -195,7 +269,9 @@ describe("classifyHermesEvent — pending actions", () => {
     if (result.kind === "pending_action" && result.action.kind === "approval") {
       expect(result.action.requestId).toBe("a1");
       expect(result.action.toolName).toBe("shell");
+      expect(result.action.command).toBe("pnpm build");
       expect(result.action.description).toBe("Run the build");
+      expect(result.action.allowPermanent).toBe(true);
     }
   });
 
@@ -245,11 +321,78 @@ describe("classifyHermesEvent — pending actions", () => {
   });
 });
 
-describe("classifyHermesEvent — clarify/approval responses are lifecycle, not pending", () => {
-  it("does not surface a .response as a new pending action", () => {
-    for (const name of ["clarify.response", "approval.response"]) {
-      const result = classifyHermesEvent(event(name, { request_id: "x" }));
-      expect(result.kind).not.toBe("pending_action");
+describe("classifyHermesEvent — pending action resolutions", () => {
+  it("maps clarify.response to a resolved clarify action", () => {
+    const result = classifyHermesEvent(
+      event("clarify.response", {
+        request_id: "c1",
+        question: "Which file?",
+        choices: ["a.ts", "b.ts"],
+        answer: "a.ts",
+      }),
+    );
+    expect(result.kind).toBe("pending_action_resolution");
+    if (result.kind === "pending_action_resolution" && result.action.kind === "clarify") {
+      expect(result.action.requestId).toBe("c1");
+      expect(result.action.question).toBe("Which file?");
+      expect(result.action.choices).toEqual(["a.ts", "b.ts"]);
+      expect(result.action.answer).toBe("a.ts");
+    }
+  });
+
+  it("maps approval.response to a resolved approval action", () => {
+    const result = classifyHermesEvent(
+      event("approval.response", {
+        request_id: "a1",
+        command: "pnpm build",
+        description: "Run the build",
+        allow_permanent: false,
+        choice: "session",
+      }),
+    );
+    expect(result.kind).toBe("pending_action_resolution");
+    if (result.kind === "pending_action_resolution" && result.action.kind === "approval") {
+      expect(result.action.requestId).toBe("a1");
+      expect(result.action.command).toBe("pnpm build");
+      expect(result.action.description).toBe("Run the build");
+      expect(result.action.allowPermanent).toBe(false);
+      expect(result.action.choice).toBe("session");
+    }
+  });
+
+  it("maps sudo.response to a resolved sudo action with approved as a granted synonym", () => {
+    const result = classifyHermesEvent(
+      event("sudo.response", {
+        request_id: "su1",
+        mode: "unrestricted",
+        approved: true,
+      }),
+    );
+    expect(result.kind).toBe("pending_action_resolution");
+    if (result.kind === "pending_action_resolution" && result.action.kind === "sudo") {
+      expect(result.action.requestId).toBe("su1");
+      expect(result.action.mode).toBe("unrestricted");
+      expect(result.action.granted).toBe(true);
+    }
+  });
+
+  it("maps secret.response to metadata-only resolution and never carries a value", () => {
+    const result = classifyHermesEvent(
+      event("secret.response", {
+        request_id: "se1",
+        key_name: "OPENAI_API_KEY",
+        reason: "needed for an API",
+        api_key: "sk-leak-me",
+        value: "sk-leak-me",
+      }),
+    );
+    expect(result.kind).toBe("pending_action_resolution");
+    if (result.kind === "pending_action_resolution" && result.action.kind === "secret") {
+      expect(result.action.requestId).toBe("se1");
+      expect(result.action.keyName).toBe("OPENAI_API_KEY");
+      expect(result.action.reason).toBe("needed for an API");
+      expect(result.action.redacted).toBe(true);
+      expect(JSON.stringify(result.action)).not.toContain("sk-leak-me");
     }
   });
 });
@@ -306,6 +449,31 @@ describe("classifyHermesEvent — background activity", () => {
       expect(result.activity.subagentId).toBe("h-9");
       expect(result.activity.handle).toBe("h-9");
       expect(result.activity.currentTool).toBe("grep");
+    }
+  });
+
+  it("carries task index/count when Hermes reports numeric fan-out metadata", () => {
+    const result = classifyHermesEvent(
+      event("subagent.progress", {
+        subagent_id: "s",
+        task_index: 1,
+        task_count: 3,
+      }),
+    );
+    expect(result.kind).toBe("background_activity");
+    if (result.kind === "background_activity") {
+      expect(result.activity.taskIndex).toBe(1);
+      expect(result.activity.taskCount).toBe(3);
+    }
+  });
+
+  it("marks a subagent failed from reported status even when the subtype is non-terminal", () => {
+    const result = classifyHermesEvent(
+      event("subagent.progress", { subagent_id: "s", status: "timeout waiting for worker" }),
+    );
+    expect(result.kind).toBe("background_activity");
+    if (result.kind === "background_activity") {
+      expect(result.activity.phase).toBe("error");
     }
   });
 });
@@ -450,8 +618,12 @@ describe("exhaustive switch ergonomics", () => {
           return "tool";
         case "pending_action":
           return "pending";
+        case "pending_action_resolution":
+          return "resolved";
         case "background_activity":
           return "background";
+        case "steering":
+          return "steering";
         case "lifecycle":
           return "lifecycle";
         case "error":
@@ -470,6 +642,7 @@ describe("exhaustive switch ergonomics", () => {
         kind: "pending_action",
         sessionId: "s",
         action,
+        receivedAt: RECEIVED_AT,
       }),
     ).toBe("pending");
   });

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -137,15 +137,6 @@ describe("classifyHermesEvent — transcript", () => {
     if (complete.kind === "transcript") {
       expect(complete.delta).toBe("Hello");
     }
-
-    const completed = classifyHermesEvent(
-      event("message.completed", { message_id: "m1", text: "Hello again" }),
-    );
-    expect(completed).toMatchObject({
-      kind: "transcript",
-      complete: true,
-      failed: false,
-    });
   });
 
   it("preserves whitespace-only deltas verbatim", () => {
@@ -202,8 +193,8 @@ describe("classifyHermesEvent — tools", () => {
       isClarify: false,
     });
     if (start.kind === "tool") {
-      // The raw payload is preserved so a tool card can render arguments.
-      expect(start.payload).toMatchObject({ path: "/tmp/x" });
+      // The sanitized payload is preserved so a tool card can render arguments.
+      expect("payload" in start).toBe(false);
       expect(start.sanitizedPayload).toMatchObject({ path: "/tmp/x" });
     }
 
@@ -503,12 +494,14 @@ describe("classifyHermesEvent — lifecycle", () => {
       expect(result.kind, `expected lifecycle for ${name}`).toBe("lifecycle");
       if (result.kind === "lifecycle") {
         expect(result.status).toBeTruthy();
+        expect(result.text).toBe("ready");
       }
     }
   });
 
   it("maps turn/background completion aliases to terminal lifecycle events", () => {
     for (const name of [
+      "message.completed",
       "turn.complete",
       "turn.completed",
       "background.complete",
@@ -518,8 +511,29 @@ describe("classifyHermesEvent — lifecycle", () => {
       expect(result.kind, `expected lifecycle for ${name}`).toBe("lifecycle");
       if (result.kind === "lifecycle") {
         expect(result.status).toBe(name);
+        expect(result.flavor).toBe("terminal");
         expect(isTerminalHermesEvent(result)).toBe(true);
       }
+    }
+  });
+
+  it("keys terminal lifecycle flavor from raw type rather than payload status", () => {
+    const result = classifyHermesEvent(event("turn.complete", { status: "success" }));
+    expect(result.kind).toBe("lifecycle");
+    if (result.kind === "lifecycle") {
+      expect(result.status).toBe("success");
+      expect(result.flavor).toBe("terminal");
+      expect(isTerminalHermesEvent(result)).toBe(true);
+    }
+  });
+
+  it("keeps status.update running even when payload status sounds terminal", () => {
+    const result = classifyHermesEvent(event("status.update", { status: "done" }));
+    expect(result.kind).toBe("lifecycle");
+    if (result.kind === "lifecycle") {
+      expect(result.status).toBe("done");
+      expect(result.flavor).toBe("running");
+      expect(isTerminalHermesEvent(result)).toBe(false);
     }
   });
 });
@@ -550,6 +564,14 @@ describe("classifyHermesEvent — error redaction", () => {
     const result = classifyHermesEvent(event("error", { code: 500 }));
     if (result.kind === "error") {
       expect(result.message).toBeTruthy();
+    }
+  });
+
+  it("reads error text from the broad rendered summary chain", () => {
+    const result = classifyHermesEvent(event("error", { summary: "  Summary-only failure  " }));
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toBe("Summary-only failure");
     }
   });
 });

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -3,6 +3,7 @@ import type { HermesGatewayEvent } from "../lib/hermes-gateway";
 import {
   classifyHermesEvent,
   createSteeringEvent,
+  isTerminalHermesEvent,
   isSensitiveKey,
   parseHermesMode,
   sanitizePayload,
@@ -136,6 +137,15 @@ describe("classifyHermesEvent — transcript", () => {
     if (complete.kind === "transcript") {
       expect(complete.delta).toBe("Hello");
     }
+
+    const completed = classifyHermesEvent(
+      event("message.completed", { message_id: "m1", text: "Hello again" }),
+    );
+    expect(completed).toMatchObject({
+      kind: "transcript",
+      complete: true,
+      failed: false,
+    });
   });
 
   it("preserves whitespace-only deltas verbatim", () => {
@@ -493,6 +503,22 @@ describe("classifyHermesEvent — lifecycle", () => {
       expect(result.kind, `expected lifecycle for ${name}`).toBe("lifecycle");
       if (result.kind === "lifecycle") {
         expect(result.status).toBeTruthy();
+      }
+    }
+  });
+
+  it("maps turn/background completion aliases to terminal lifecycle events", () => {
+    for (const name of [
+      "turn.complete",
+      "turn.completed",
+      "background.complete",
+      "background.completed",
+    ]) {
+      const result = classifyHermesEvent(event(name, {}));
+      expect(result.kind, `expected lifecycle for ${name}`).toBe("lifecycle");
+      if (result.kind === "lifecycle") {
+        expect(result.status).toBe(name);
+        expect(isTerminalHermesEvent(result)).toBe(true);
       }
     }
   });

--- a/src/test/hermes-control-plane-classifier.test.ts
+++ b/src/test/hermes-control-plane-classifier.test.ts
@@ -499,8 +499,10 @@ describe("classifyHermesEvent — lifecycle", () => {
     }
   });
 
-  it("maps turn/background completion aliases to terminal lifecycle events", () => {
+  it("maps lifecycle and turn/background completion aliases to terminal lifecycle events", () => {
     for (const name of [
+      "lifecycle.complete",
+      "lifecycle.completed",
       "message.completed",
       "turn.complete",
       "turn.completed",
@@ -533,6 +535,16 @@ describe("classifyHermesEvent — lifecycle", () => {
     if (result.kind === "lifecycle") {
       expect(result.status).toBe("done");
       expect(result.flavor).toBe("running");
+      expect(isTerminalHermesEvent(result)).toBe(false);
+    }
+  });
+
+  it("keeps lifecycle.update non-terminal", () => {
+    const result = classifyHermesEvent(event("lifecycle.update", { status: "done" }));
+    expect(result.kind).toBe("lifecycle");
+    if (result.kind === "lifecycle") {
+      expect(result.status).toBe("done");
+      expect(result.flavor).toBe("info");
       expect(isTerminalHermesEvent(result)).toBe(false);
     }
   });

--- a/src/test/hermes-control-plane-replay.test.ts
+++ b/src/test/hermes-control-plane-replay.test.ts
@@ -10,6 +10,7 @@ import type {
   JuneHermesEvent,
   JuneHermesEventKind,
   PendingHermesAction,
+  PendingHermesActionResolution,
 } from "../lib/hermes-control-plane";
 
 // Recorded raw-frame corpus. Fixture DATA lives beside the module
@@ -47,7 +48,9 @@ const KNOWN_KINDS: readonly JuneHermesEventKind[] = [
   "reasoning",
   "tool",
   "pending_action",
+  "pending_action_resolution",
   "background_activity",
+  "steering",
   "lifecycle",
   "error",
   "unsupported",
@@ -58,7 +61,7 @@ const KNOWN_KIND_SET = new Set<string>(KNOWN_KINDS);
  * `pending_action` frames so approval/clarify/sudo/secret stay distinct. */
 type FrameExpectation = {
   kind: JuneHermesEventKind;
-  action?: PendingHermesAction["kind"];
+  action?: PendingHermesAction["kind"] | PendingHermesActionResolution["kind"];
 };
 
 type FixtureCase = {
@@ -104,22 +107,19 @@ const CASES: Record<string, FixtureCase> = {
   },
   "approval-request-response": {
     fixture: approvalRequestResponse as HermesReplayFixture,
-    // The .response is not a new pending action; it currently lands in
-    // `unsupported` (locked; see existing classifier test asserting a response
-    // is never a pending_action).
-    expected: [k("pending_action", "approval"), k("unsupported")],
+    expected: [k("pending_action", "approval"), k("pending_action_resolution", "approval")],
   },
   "clarify-request-response": {
     fixture: clarifyRequestResponse as HermesReplayFixture,
-    expected: [k("pending_action", "clarify"), k("unsupported")],
+    expected: [k("pending_action", "clarify"), k("pending_action_resolution", "clarify")],
   },
   "sudo-request-response": {
     fixture: sudoRequestResponse as HermesReplayFixture,
-    expected: [k("pending_action", "sudo"), k("unsupported")],
+    expected: [k("pending_action", "sudo"), k("pending_action_resolution", "sudo")],
   },
   "secret-request-response": {
     fixture: secretRequestResponse as HermesReplayFixture,
-    expected: [k("pending_action", "secret"), k("unsupported")],
+    expected: [k("pending_action", "secret"), k("pending_action_resolution", "secret")],
   },
   "subagent-lifecycle": {
     fixture: subagentLifecycle as HermesReplayFixture,
@@ -239,12 +239,12 @@ describe("hermes replay — family-specific expectations", () => {
           `${name}#${index} (raw type "${raw.type}") expected ${want.kind}, got ${event.kind}`,
         ).toBe(want.kind);
         if (want.action) {
-          expect(event.kind).toBe("pending_action");
-          if (event.kind === "pending_action") {
-            expect(
-              event.action.kind,
-              `${name}#${index} expected pending action ${want.action}`,
-            ).toBe(want.action);
+          if (event.kind === "pending_action" || event.kind === "pending_action_resolution") {
+            expect(event.action.kind, `${name}#${index} expected action ${want.action}`).toBe(
+              want.action,
+            );
+          } else {
+            throw new Error(`${name}#${index} expected action ${want.action}`);
           }
         }
       }

--- a/src/test/hermes-session-steer.test.ts
+++ b/src/test/hermes-session-steer.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
-  STEER_EVENT_TYPE,
   normalizeSteerText,
   steerErrorNotice,
   steeringLiveEvent,
-  steeringPartText,
 } from "../lib/hermes-session-steer";
 import { HermesGatewayError } from "../lib/hermes-gateway";
 import { buildHermesSessionChatTurns } from "../lib/agent-chat-runtime";
@@ -60,16 +58,17 @@ describe("steerErrorNotice", () => {
 });
 
 describe("steeringLiveEvent", () => {
-  it("builds a synthetic local event carrying the instruction text and timestamp", () => {
+  it("builds a first-party local event carrying the instruction text and timestamp", () => {
     const event = steeringLiveEvent({
       sessionId: "sess-1",
       text: "focus on tests",
       receivedAt: "2026-06-24T10:00:00.000Z",
     });
-    expect(event.type).toBe(STEER_EVENT_TYPE);
-    expect(event.session_id).toBe("sess-1");
+    expect(event.kind).toBe("steering");
+    if (event.kind !== "steering") throw new Error("expected steering event");
+    expect(event.sessionId).toBe("sess-1");
     expect(event.receivedAt).toBe("2026-06-24T10:00:00.000Z");
-    expect(steeringPartText(event.payload)).toBe("focus on tests");
+    expect(event.text).toBe("focus on tests");
   });
 });
 
@@ -124,9 +123,12 @@ describe("steering transcript item via buildHermesSessionChatTurns", () => {
       [],
       [
         {
-          type: "message.delta",
+          kind: "transcript",
+          sessionId: "",
           receivedAt,
-          payload: { text: "Working on the current plan." },
+          delta: "Working on the current plan.",
+          complete: false,
+          failed: false,
         },
         steeringLiveEvent({
           sessionId: "sess-1",

--- a/src/test/hermes-sudo-secret-actions.test.ts
+++ b/src/test/hermes-sudo-secret-actions.test.ts
@@ -1,24 +1,39 @@
 import { describe, expect, it } from "vitest";
 import { buildAgentChatTurns } from "../lib/agent-chat-runtime";
-import sudoFixture from "../lib/hermes-control-plane/fixtures/sudo-request-response.json";
-import secretFixture from "../lib/hermes-control-plane/fixtures/secret-request-response.json";
+import type { JuneHermesEvent } from "../lib/hermes-control-plane";
 
-// The feature-05 fixtures carry the canonical wire shapes. The secret fixture
-// deliberately includes a fake secret value in its request payload; the
-// runtime must never surface it on a part.
-const SECRET_VALUE_PLACEHOLDER = secretFixture._secretValuePlaceholder;
+const SECRET_VALUE_PLACEHOLDER = "sk-FAKE-PLACEHOLDER-secret-value-do-not-use-0000000000";
 
-function liveFrame(
-  frame: { type: string; session_id?: string; payload?: unknown },
-  receivedAt: string,
+function pendingAction(event: Extract<JuneHermesEvent, { kind: "pending_action" }>) {
+  return event;
+}
+
+function pendingActionResolution(
+  event: Extract<JuneHermesEvent, { kind: "pending_action_resolution" }>,
 ) {
-  return { ...frame, receivedAt };
+  return event;
 }
 
 describe("Hermes sudo pending action — runtime", () => {
   it("renders a live sudo.request as a pending sudo chat part", () => {
-    const [request] = sudoFixture.frames;
-    const turns = buildAgentChatTurns([], [], [liveFrame(request, "2026-06-04T10:00:00.000Z")]);
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        pendingAction({
+          kind: "pending_action",
+          sessionId: "sess-sudo",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          action: {
+            kind: "sudo",
+            requestId: "su-1",
+            command: "apt-get install ripgrep",
+            reason: "ripgrep is required to search the dependency tree",
+            mode: "unrestricted",
+          },
+        }),
+      ],
+    );
 
     expect(turns[0]?.parts).toEqual([
       {
@@ -34,13 +49,33 @@ describe("Hermes sudo pending action — runtime", () => {
   });
 
   it("marks a sudo request resolved after a sudo.response", () => {
-    const [request, response] = sudoFixture.frames;
     const turns = buildAgentChatTurns(
       [],
       [],
       [
-        liveFrame(request, "2026-06-04T10:00:00.000Z"),
-        liveFrame(response, "2026-06-04T10:00:01.000Z"),
+        pendingAction({
+          kind: "pending_action",
+          sessionId: "sess-sudo",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          action: {
+            kind: "sudo",
+            requestId: "su-1",
+            command: "apt-get install ripgrep",
+            reason: "ripgrep is required to search the dependency tree",
+            mode: "unrestricted",
+          },
+        }),
+        pendingActionResolution({
+          kind: "pending_action_resolution",
+          sessionId: "sess-sudo",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          action: {
+            kind: "sudo",
+            requestId: "su-1",
+            mode: "unrestricted",
+            granted: true,
+          },
+        }),
       ],
     );
 
@@ -58,10 +93,15 @@ describe("Hermes sudo pending action — runtime", () => {
       [],
       [],
       [
-        liveFrame(
-          { type: "sudo.request", payload: { request_id: "su-bare" } },
-          "2026-06-04T10:00:00.000Z",
-        ),
+        pendingAction({
+          kind: "pending_action",
+          sessionId: "",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          action: {
+            kind: "sudo",
+            requestId: "su-bare",
+          },
+        }),
       ],
     );
 
@@ -79,8 +119,24 @@ describe("Hermes sudo pending action — runtime", () => {
 
 describe("Hermes secret pending action — runtime", () => {
   it("renders a live secret.request as a pending secret chat part with metadata only", () => {
-    const [request] = secretFixture.frames;
-    const turns = buildAgentChatTurns([], [], [liveFrame(request, "2026-06-04T10:00:00.000Z")]);
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        pendingAction({
+          kind: "pending_action",
+          sessionId: "sess-secret",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          action: {
+            kind: "secret",
+            requestId: "se-1",
+            keyName: "OPENAI_API_KEY",
+            reason: "Needed to call the OpenAI API on your behalf",
+            redacted: true,
+          },
+        }),
+      ],
+    );
 
     expect(turns[0]?.parts).toEqual([
       {
@@ -95,8 +151,24 @@ describe("Hermes secret pending action — runtime", () => {
   });
 
   it("never carries the secret value onto the part even when the gateway leaks it", () => {
-    const [request] = secretFixture.frames;
-    const turns = buildAgentChatTurns([], [], [liveFrame(request, "2026-06-04T10:00:00.000Z")]);
+    const turns = buildAgentChatTurns(
+      [],
+      [],
+      [
+        pendingAction({
+          kind: "pending_action",
+          sessionId: "sess-secret",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          action: {
+            kind: "secret",
+            requestId: "se-1",
+            keyName: "OPENAI_API_KEY",
+            reason: "Needed to call the OpenAI API on your behalf",
+            redacted: true,
+          },
+        }),
+      ],
+    );
 
     // The whole serialized turn tree must be free of the leaked value.
     const serialized = JSON.stringify(turns);
@@ -105,13 +177,32 @@ describe("Hermes secret pending action — runtime", () => {
   });
 
   it("marks a secret request resolved after a secret.response without echoing the value", () => {
-    const [request, response] = secretFixture.frames;
     const turns = buildAgentChatTurns(
       [],
       [],
       [
-        liveFrame(request, "2026-06-04T10:00:00.000Z"),
-        liveFrame(response, "2026-06-04T10:00:01.000Z"),
+        pendingAction({
+          kind: "pending_action",
+          sessionId: "sess-secret",
+          receivedAt: "2026-06-04T10:00:00.000Z",
+          action: {
+            kind: "secret",
+            requestId: "se-1",
+            keyName: "OPENAI_API_KEY",
+            reason: "Needed to call the OpenAI API on your behalf",
+            redacted: true,
+          },
+        }),
+        pendingActionResolution({
+          kind: "pending_action_resolution",
+          sessionId: "sess-secret",
+          receivedAt: "2026-06-04T10:00:01.000Z",
+          action: {
+            kind: "secret",
+            requestId: "se-1",
+            redacted: true,
+          },
+        }),
       ],
     );
 

--- a/src/test/hermes-trace-buffer.test.ts
+++ b/src/test/hermes-trace-buffer.test.ts
@@ -40,6 +40,21 @@ describe("createHermesTraceBuffer", () => {
     expect(entries[0].observedAt).toBe("2026-06-24T12:00:00.000Z");
   });
 
+  it("keys inbound frames by stored session id while preserving the runtime id", () => {
+    const buffer = createHermesTraceBuffer();
+
+    buffer.recordInbound(rawFrame("message.delta", "runtime-s1", { delta: "hi" }), {
+      storedSessionId: "stored-s1",
+    });
+
+    expect(buffer.entriesFor("runtime-s1")).toHaveLength(0);
+    const entries = buffer.entriesFor("stored-s1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sessionId).toBe("stored-s1");
+    expect(entries[0].runtimeSessionId).toBe("runtime-s1");
+    expect(buffer.exportSanitizedTrace("stored-s1").entries[0].rawType).toBe("message.delta");
+  });
+
   it("records an outbound method call with its method name and sanitized params", () => {
     const buffer = createHermesTraceBuffer();
     buffer.recordOutbound({


### PR DESCRIPTION
## Summary

- The control plane (`src/lib/hermes-control-plane/`) is now the **only** reader of raw Hermes frames on the live path. Classification happens once at gateway ingress; the per-session live buffer stores typed `JuneHermesEvent`s; the transcript builder switches on `kind` and every raw-frame helper it used is deleted.
- **A1 — union widening**: `receivedAt` on every kind; `pending_action_resolution` for the four `*.response` frames (previously `unsupported`); `steering` as a locally minted first-party kind (a steer is never a wire frame — glossary updated); transcript `failed` flag; tool events carry `key`/`text`/`isClarify` and a failed-capable phase over the whole `tool.*` family; subagent task metadata. Divergence policy: where the old duplicate parsers disagreed, transcript-visible behavior wins, and each adopted choice has a rationale comment at the field.
- **A2 — builder migration**: `appendLiveHermesEvents` consumes the union; the previously hand-maintained duplicates (subagent phase rules, the secret-redaction invariant "key name only, never value") now live once, in the classifier. Builder suites construct typed fixtures.
- **B — status split**: terminal vocabulary has one home in the control plane (`isTerminalHermesEvent` + a type-derived lifecycle `flavor`); the activity store imports it instead of mirroring it. The `working`/`waiting`/`toolCall` Sets became an identity-stable projection of store phase; `stopping`/`runtime` stay local intent. Edge timing (unlisten, steer resend, issue promotion) is unchanged, including `message.complete` as per-turn terminal.
- **Review fixes**: a 27-agent review of the branch confirmed 10 findings, all fixed with regression tests — most notably: respond RPCs keep the wire (runtime) session id while only the activity store gets stored-id keying; store eviction prefers inactive rows; a subagent error no longer strands the working spinner; the projection reuses Set identities so streamed tokens don't tear down effects.
- Security-relevant: the secret-redaction invariant is now asserted at a single seam (classifier) instead of duplicated across two files.

## Validation

- `pnpm typecheck`, `pnpm check` (Biome, 0 errors), `pnpm test`: 127 files, **1,935 passed / 0 failed** (includes new classifier, replay-corpus, store, builder, and workspace regression tests).
- Recorded-fixture replay corpus updated: the four `*.response` fixtures now pin `pending_action_resolution` instead of `unsupported`.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- behavior-preserving refactor; no intended visual change. Covered by the workspace rendering suites; not visually re-tested. -->
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- frontend-only; no backend change -->

## Out of scope

- Stage D of the design: a stateful `TranscriptAccumulator` (incremental fold instead of rebuild-last-200-per-render). Deliberately deferred until this ships and only if perf/ordering bugs surface.
- Unifying the tool dedupe `key` (builder precedence) with `toolCallId` (store precedence) — two precedences kept on purpose for behavior preservation.
- `pending_action_resolution` frames resolving pendingActionStore rows directly (today rows still clear on session terminal, as on main).
- Rust shell and June API untouched.

## Followups

- Consider a small golden raw→classify→build snapshot suite as a divergence backstop now that builder fixtures are typed.
- Migrate the artifact store's remaining payload interpretation onto typed fields when it next changes.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none in this PR -->
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none in this PR -->
- [x] User-facing copy follows the repo UI conventions. <!-- status sentences preserved verbatim -->

https://claude.ai/code/session_016jdLY1DsSVVAhJKCG8nZmS