### PR TITLE
Windows system audio capture for meeting notes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "window-vibrancy",
+ "windows 0.61.3",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,15 @@ window-vibrancy = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
+# Meeting detection enumerates active WASAPI capture sessions (see
+# meeting_detection.rs). Keep the feature set minimal: WASAPI session APIs,
+# COM bootstrap, base handles, and pid -> executable name resolution.
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Media_Audio",
+    "Win32_System_Com",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -5,7 +5,7 @@ use crate::{
             start_live_transcript_preview, start_system_live_transcript_preview,
             LivePreviewController, LivePreviewSink, SystemLivePreviewController,
         },
-        system_macos::SystemAudioCapture,
+        SystemAudioCapture,
     },
     domain::types::{
         AppError, AudioLevelDto, RecordingSessionDto, RecordingSource, RecordingSourceMode,

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,7 +1,29 @@
 pub mod capture;
 pub mod live_preview;
 pub mod recovery;
-pub mod system_macos;
 pub mod turns;
 pub mod validation;
 pub mod waveform;
+
+// Per-platform system-audio backends. Each exposes the same `SystemAudioCapture`
+// type plus `system_audio_readiness` / `helper_permission_check`, re-exported
+// below under one path so `capture.rs` and `commands.rs` are platform agnostic.
+// A Linux backend slots in here the same way: add `mod system_linux;` gated on
+// `target_os = "linux"`, re-export it, and narrow the stub's `cfg`.
+#[cfg(target_os = "macos")]
+mod system_macos;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod system_stub;
+#[cfg(target_os = "windows")]
+mod system_windows;
+
+// Shared wall-clock alignment / level math for the non-macOS backends. Compiled
+// on every host so its cross-platform unit tests run under the macOS CI gate.
+mod system_timeline;
+
+#[cfg(target_os = "macos")]
+pub use system_macos::{helper_permission_check, system_audio_readiness, SystemAudioCapture};
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub use system_stub::{helper_permission_check, system_audio_readiness, SystemAudioCapture};
+#[cfg(target_os = "windows")]
+pub use system_windows::{helper_permission_check, system_audio_readiness, SystemAudioCapture};

--- a/src-tauri/src/audio/system_stub.rs
+++ b/src-tauri/src/audio/system_stub.rs
@@ -1,0 +1,65 @@
+//! Fallback system-audio backend for platforms without a native implementation.
+//!
+//! macOS uses `system_macos`, Windows uses `system_windows`, and a Linux
+//! backend slots in the same way (its module would be gated in `audio::mod` and
+//! narrow this stub's `cfg` to `not(any(macos, windows, linux))`). Until then,
+//! any other OS reports system audio as unsupported and never constructs a
+//! capture. The API mirrors the real backends so `audio::capture` compiles
+//! unchanged.
+
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub struct SystemAudioCapture {
+    _never: std::convert::Infallible,
+}
+
+impl SystemAudioCapture {
+    pub fn start(
+        _partial_path: PathBuf,
+        _final_path: PathBuf,
+        _timeline_offset: Duration,
+    ) -> Result<Self, AppError> {
+        Err(AppError::new(
+            "system_audio_unavailable",
+            "System audio capture is not supported on this platform.",
+        ))
+    }
+
+    pub fn pause(&mut self) {
+        match self._never {}
+    }
+
+    pub fn resume(&mut self) {
+        match self._never {}
+    }
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        match self._never {}
+    }
+
+    pub fn stop(self) -> Result<PathBuf, AppError> {
+        match self._never {}
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    SourceReadinessDto {
+        source: RecordingSource::System,
+        required: true,
+        ready: false,
+        permission_state: "unsupported".to_string(),
+        device_available: false,
+        capture_available: false,
+        recovery_action: None,
+        message: Some("System audio capture is not supported on this platform.".to_string()),
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    Err(AppError::new(
+        "system_audio_unavailable",
+        "System audio capture is not supported on this platform.",
+    ))
+}

--- a/src-tauri/src/audio/system_timeline.rs
+++ b/src-tauri/src/audio/system_timeline.rs
@@ -1,0 +1,237 @@
+//! Wall-clock alignment and level math shared by the non-macOS system-audio
+//! backends. The macOS backend (`system_macos`) offloads this to the Swift
+//! helper's `writeTimelineSilenceIfNeeded` / `emitLevel`; the Windows backend
+//! (`system_windows`, and a Linux backend that slots in alongside it) drive a
+//! WASAPI/loopback stream from Rust and reproduce the same observable behavior
+//! here. Keeping the pure math in one place lets the unit tests run on any host
+//! (including the macOS CI host) instead of only on Windows.
+//!
+//! `allow(dead_code)` is scoped to this module because on a host whose backend
+//! does not consume these helpers (e.g. macOS) they are only referenced by the
+//! cross-platform tests below, which would otherwise trip `dead_code` in the
+//! non-test library build.
+#![allow(dead_code)]
+
+use crate::domain::types::AudioLevelDto;
+use std::{collections::VecDeque, time::Duration};
+
+/// Matches the microphone level window in `capture.rs` (`recent_peaks` keeps the
+/// most recent 24 per-callback peaks).
+pub(crate) const RECENT_PEAKS_CAP: usize = 24;
+
+/// Silence-fill tolerance in seconds. Mirrors the Swift helper's
+/// `toleranceFrames = format.sampleRate * 0.08`: gaps smaller than 80 ms are
+/// left for the next real buffer instead of being papered over with silence, so
+/// ordinary device jitter does not fragment the file.
+pub(crate) const SILENCE_TOLERANCE_SECS: f64 = 0.08;
+
+/// Upper bound on a single silence write, mirroring the Swift helper's
+/// `min(missingFrames, sampleRate / 2)` chunking so a long gap does not require
+/// one huge allocation.
+pub(crate) fn max_silence_chunk_frames(sample_rate: u32) -> i64 {
+    (sample_rate / 2).max(1) as i64
+}
+
+/// Number of per-channel frames of tolerance before silence is inserted.
+pub(crate) fn tolerance_frames(sample_rate: u32) -> i64 {
+    (sample_rate as f64 * SILENCE_TOLERANCE_SECS) as i64
+}
+
+/// Active (unpaused) elapsed time the output file should represent.
+///
+/// Mirrors the Swift helper, where `activeStartedAt = start - timelineOffset`
+/// and `activeElapsed = max(0, now - activeStartedAt - pausedOffset)`. Folding
+/// `timeline_offset` in here reproduces the helper's leading-silence alignment:
+/// at t=0 the expected timeline is already `timeline_offset` long, so the first
+/// thing written to the file is `timeline_offset` of silence, lining the system
+/// track up with a microphone track that began `timeline_offset` earlier.
+pub(crate) fn active_elapsed(
+    elapsed_since_start: Duration,
+    timeline_offset: Duration,
+    paused_offset: Duration,
+) -> Duration {
+    (elapsed_since_start + timeline_offset).saturating_sub(paused_offset)
+}
+
+/// Per-channel frame count the file should contain for a given active elapsed.
+pub(crate) fn expected_frames(active_elapsed: Duration, sample_rate: u32) -> i64 {
+    (active_elapsed.as_secs_f64() * sample_rate as f64) as i64
+}
+
+/// How many per-channel silence frames to insert before writing the next real
+/// buffer. Mirrors the Swift helper: fill the whole gap once it exceeds the
+/// tolerance, otherwise nothing. `incoming_frames` is the real buffer about to
+/// be written (0 for a silence-only tick or the trailing stop() flush).
+pub(crate) fn silence_frames_to_fill(
+    expected_frames: i64,
+    frames_written: i64,
+    incoming_frames: i64,
+    tolerance_frames: i64,
+) -> i64 {
+    let missing = expected_frames - frames_written - incoming_frames;
+    if missing > tolerance_frames {
+        missing
+    } else {
+        0
+    }
+}
+
+/// Running audio level, computed exactly like the microphone path in
+/// `capture.rs`: `peak` is the max absolute sample over the whole recording,
+/// `rms` is the root-mean-square over the whole recording, and `recent_peaks`
+/// is a sliding window of the most recent per-callback peaks.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LevelAccumulator {
+    peak: f32,
+    sum_square: f64,
+    samples: u64,
+    recent_peaks: VecDeque<f32>,
+}
+
+impl LevelAccumulator {
+    /// Fold one capture callback's worth of samples into the running level.
+    /// `samples` yields signed, normalized values in `[-1.0, 1.0]` (one item per
+    /// interleaved sample, all channels), matching `write_input_data`.
+    pub(crate) fn record_callback<I>(&mut self, samples: I)
+    where
+        I: IntoIterator<Item = f32>,
+    {
+        let mut callback_peak = 0.0_f32;
+        let mut saw_sample = false;
+        for sample in samples {
+            saw_sample = true;
+            let normalized = sample.abs();
+            callback_peak = callback_peak.max(normalized);
+            self.peak = self.peak.max(normalized);
+            self.sum_square += (normalized as f64).powi(2);
+            self.samples += 1;
+        }
+        if saw_sample {
+            if self.recent_peaks.len() == RECENT_PEAKS_CAP {
+                self.recent_peaks.pop_front();
+            }
+            self.recent_peaks.push_back(callback_peak);
+        }
+    }
+
+    pub(crate) fn level(&self) -> AudioLevelDto {
+        let rms = if self.samples == 0 {
+            0.0
+        } else {
+            (self.sum_square / self.samples as f64).sqrt() as f32
+        };
+        AudioLevelDto {
+            peak: self.peak,
+            rms,
+            recent_peaks: self.recent_peaks.iter().copied().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_silence_when_gap_within_tolerance() {
+        // 48 kHz, tolerance is 0.08 s = 3840 frames. A 1000-frame gap is left
+        // for the next real buffer.
+        let tol = tolerance_frames(48_000);
+        assert_eq!(tol, 3840);
+        assert_eq!(silence_frames_to_fill(1_000, 0, 0, tol), 0);
+        assert_eq!(silence_frames_to_fill(4_840, 1_000, 0, tol), 0);
+    }
+
+    #[test]
+    fn fills_whole_gap_once_past_tolerance() {
+        let tol = tolerance_frames(48_000);
+        // expected 48000, written 0, no incoming -> 48000 > 3840 -> fill 48000.
+        assert_eq!(silence_frames_to_fill(48_000, 0, 0, tol), 48_000);
+        // Incoming real frames count against the gap.
+        assert_eq!(silence_frames_to_fill(48_000, 0, 5_000, tol), 43_000);
+    }
+
+    #[test]
+    fn never_fills_when_already_ahead() {
+        let tol = tolerance_frames(48_000);
+        assert_eq!(silence_frames_to_fill(1_000, 5_000, 0, tol), 0);
+        assert_eq!(silence_frames_to_fill(1_000, 0, 5_000, tol), 0);
+    }
+
+    #[test]
+    fn timeline_offset_produces_leading_silence() {
+        // Half a second of offset, no elapsed time yet, no pause: the file
+        // should already owe ~0.5 s of silence.
+        let elapsed = active_elapsed(Duration::ZERO, Duration::from_millis(500), Duration::ZERO);
+        assert_eq!(elapsed, Duration::from_millis(500));
+        assert_eq!(expected_frames(elapsed, 48_000), 24_000);
+    }
+
+    #[test]
+    fn paused_time_is_excluded_not_filled() {
+        // 10 s of wall clock, 4 s of it paused: the file should represent 6 s,
+        // matching the microphone track which also drops paused audio. Paused
+        // time is therefore never written as silence.
+        let elapsed = active_elapsed(
+            Duration::from_secs(10),
+            Duration::ZERO,
+            Duration::from_secs(4),
+        );
+        assert_eq!(elapsed, Duration::from_secs(6));
+        assert_eq!(expected_frames(elapsed, 16_000), 96_000);
+    }
+
+    #[test]
+    fn paused_offset_larger_than_elapsed_clamps_to_zero() {
+        let elapsed = active_elapsed(
+            Duration::from_secs(1),
+            Duration::ZERO,
+            Duration::from_secs(5),
+        );
+        assert_eq!(elapsed, Duration::ZERO);
+        assert_eq!(expected_frames(elapsed, 48_000), 0);
+    }
+
+    #[test]
+    fn max_silence_chunk_is_half_a_second() {
+        assert_eq!(max_silence_chunk_frames(48_000), 24_000);
+        assert_eq!(max_silence_chunk_frames(0), 1);
+    }
+
+    #[test]
+    fn level_matches_microphone_windowing() {
+        let mut level = LevelAccumulator::default();
+        // Two callbacks; peaks 0.5 and 0.25.
+        level.record_callback([0.5_f32, -0.5, 0.1]);
+        level.record_callback([0.25_f32, -0.2]);
+        let dto = level.level();
+        assert_eq!(dto.peak, 0.5);
+        assert_eq!(dto.recent_peaks, vec![0.5, 0.25]);
+        // rms = sqrt((0.25+0.25+0.01+0.0625+0.04)/5)
+        let expected_rms = ((0.25_f64 + 0.25 + 0.01 + 0.0625 + 0.04) / 5.0).sqrt() as f32;
+        assert!((dto.rms - expected_rms).abs() < 1e-6);
+    }
+
+    #[test]
+    fn level_recent_peaks_window_caps_at_24() {
+        let mut level = LevelAccumulator::default();
+        for index in 0..30 {
+            level.record_callback([index as f32 / 100.0]);
+        }
+        let dto = level.level();
+        assert_eq!(dto.recent_peaks.len(), RECENT_PEAKS_CAP);
+        // Oldest six callbacks (0..6) have been evicted; window starts at 0.06.
+        assert!((dto.recent_peaks[0] - 0.06).abs() < 1e-6);
+        assert!((dto.recent_peaks[RECENT_PEAKS_CAP - 1] - 0.29).abs() < 1e-6);
+    }
+
+    #[test]
+    fn empty_callback_does_not_push_a_peak() {
+        let mut level = LevelAccumulator::default();
+        level.record_callback(std::iter::empty::<f32>());
+        let dto = level.level();
+        assert_eq!(dto.peak, 0.0);
+        assert_eq!(dto.rms, 0.0);
+        assert!(dto.recent_peaks.is_empty());
+    }
+}

--- a/src-tauri/src/audio/system_windows.rs
+++ b/src-tauri/src/audio/system_windows.rs
@@ -536,34 +536,186 @@ fn system_stream_error_message(error: &cpal::StreamError) -> String {
     }
 }
 
-pub fn system_audio_readiness() -> SourceReadinessDto {
+/// Sample formats `build_loopback_stream` has a conversion arm for. Keep in
+/// sync with its `match`: a format missing here fails stream build with the
+/// unsupported-format error, so readiness must not promise it.
+fn is_supported_loopback_sample_format(format: cpal::SampleFormat) -> bool {
+    matches!(
+        format,
+        cpal::SampleFormat::F32
+            | cpal::SampleFormat::I16
+            | cpal::SampleFormat::U16
+            | cpal::SampleFormat::I32
+            | cpal::SampleFormat::F64
+    )
+}
+
+/// Outcome of the cheap capture-prerequisite probe behind
+/// `system_audio_readiness`.
+enum LoopbackSupport {
+    Ready,
+    NoDevice,
+    /// The render device exists but reported no usable mix config (e.g. a
+    /// stale endpoint). Carries the cpal error text for the readiness message.
+    ConfigUnavailable(String),
+    /// The mix config uses a sample format `build_loopback_stream` cannot
+    /// convert. Carries the format's debug name for the readiness message.
+    UnsupportedFormat(String),
+}
+
+/// Validate the same prerequisites `SystemAudioCapture::start` needs, short of
+/// opening a stream: a default render device, a readable mix config, and a
+/// sample format the loopback arms can convert.
+///
+/// Deliberately does NOT open a loopback stream. Readiness runs repeatedly
+/// (mount, focus refreshes, the enable-toggle poll), and opening a WASAPI
+/// stream on every probe is heavy and can perturb the endpoint. The residual
+/// window where `start` can still fail (e.g. an exclusive-mode client grabs
+/// the endpoint between probe and record) is handled by the existing
+/// start_recording error path.
+fn probe_loopback_support() -> LoopbackSupport {
     let host = cpal::default_host();
-    let device_available = host.default_output_device().is_some();
-    SourceReadinessDto {
-        source: RecordingSource::System,
-        required: true,
-        ready: device_available,
-        // WASAPI loopback needs no OS permission, so the permission gate is
-        // always "granted"; the only thing that can block capture is the
-        // absence of an output device to loop back from.
-        permission_state: "granted".to_string(),
-        device_available,
-        capture_available: device_available,
-        // No recovery_action: there is no system-audio privacy pane to send the
-        // user to on Windows, so the frontend simply does not offer one.
-        recovery_action: None,
-        message: if device_available {
-            None
-        } else {
+    let Some(device) = host.default_output_device() else {
+        return LoopbackSupport::NoDevice;
+    };
+    match device.default_output_config() {
+        Err(error) => LoopbackSupport::ConfigUnavailable(error.to_string()),
+        Ok(config) if !is_supported_loopback_sample_format(config.sample_format()) => {
+            LoopbackSupport::UnsupportedFormat(format!("{:?}", config.sample_format()))
+        }
+        Ok(_) => LoopbackSupport::Ready,
+    }
+}
+
+/// Map a probe outcome onto the readiness DTO. Factored out of
+/// `system_audio_readiness` so the decision logic is unit-testable without a
+/// real audio endpoint.
+fn readiness_from_loopback_support(support: LoopbackSupport) -> SourceReadinessDto {
+    let (device_available, capture_available, message) = match support {
+        LoopbackSupport::Ready => (true, true, None),
+        LoopbackSupport::NoDevice => (
+            false,
+            false,
             Some(
                 "No audio output device is available. Connect speakers or headphones to capture system audio."
                     .to_string(),
-            )
-        },
+            ),
+        ),
+        LoopbackSupport::ConfigUnavailable(detail) => (
+            true,
+            false,
+            Some(format!(
+                "The audio output device did not report a usable format for system audio capture ({detail})."
+            )),
+        ),
+        LoopbackSupport::UnsupportedFormat(format) => (
+            true,
+            false,
+            Some(format!(
+                "The audio output device uses a sample format that system audio capture does not support ({format})."
+            )),
+        ),
+    };
+    SourceReadinessDto {
+        source: RecordingSource::System,
+        required: true,
+        ready: capture_available,
+        // WASAPI loopback needs no OS permission, so the permission gate is
+        // always "granted"; what can block capture is the absence of a render
+        // device to loop back from, or a device whose mix config the loopback
+        // stream cannot consume.
+        permission_state: "granted".to_string(),
+        device_available,
+        capture_available,
+        // No recovery_action: there is no system-audio privacy pane to send the
+        // user to on Windows, so the frontend simply does not offer one.
+        recovery_action: None,
+        message,
     }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    readiness_from_loopback_support(probe_loopback_support())
 }
 
 pub fn helper_permission_check() -> Result<(), AppError> {
     // Loopback capture requires no permission grant on Windows.
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_formats_match_the_loopback_stream_arms() {
+        for format in [
+            cpal::SampleFormat::F32,
+            cpal::SampleFormat::I16,
+            cpal::SampleFormat::U16,
+            cpal::SampleFormat::I32,
+            cpal::SampleFormat::F64,
+        ] {
+            assert!(
+                is_supported_loopback_sample_format(format),
+                "{format:?} should be supported"
+            );
+        }
+        for format in [
+            cpal::SampleFormat::I8,
+            cpal::SampleFormat::U8,
+            cpal::SampleFormat::I64,
+            cpal::SampleFormat::U32,
+            cpal::SampleFormat::U64,
+        ] {
+            assert!(
+                !is_supported_loopback_sample_format(format),
+                "{format:?} has no conversion arm"
+            );
+        }
+    }
+
+    #[test]
+    fn readiness_ready_when_probe_passes() {
+        let readiness = readiness_from_loopback_support(LoopbackSupport::Ready);
+        assert!(readiness.ready);
+        assert!(readiness.device_available);
+        assert!(readiness.capture_available);
+        assert_eq!(readiness.permission_state, "granted");
+        assert!(readiness.message.is_none());
+    }
+
+    #[test]
+    fn readiness_not_ready_without_device() {
+        let readiness = readiness_from_loopback_support(LoopbackSupport::NoDevice);
+        assert!(!readiness.ready);
+        assert!(!readiness.device_available);
+        assert!(!readiness.capture_available);
+        assert_eq!(readiness.permission_state, "granted");
+        assert!(readiness.message.is_some());
+    }
+
+    #[test]
+    fn readiness_not_ready_when_mix_config_is_unavailable() {
+        let readiness = readiness_from_loopback_support(LoopbackSupport::ConfigUnavailable(
+            "device not available".to_string(),
+        ));
+        assert!(!readiness.ready);
+        assert!(readiness.device_available);
+        assert!(!readiness.capture_available);
+        let message = readiness.message.expect("message");
+        assert!(message.contains("device not available"));
+    }
+
+    #[test]
+    fn readiness_not_ready_on_unsupported_sample_format() {
+        let readiness =
+            readiness_from_loopback_support(LoopbackSupport::UnsupportedFormat("U8".to_string()));
+        assert!(!readiness.ready);
+        assert!(readiness.device_available);
+        assert!(!readiness.capture_available);
+        assert_eq!(readiness.permission_state, "granted");
+        let message = readiness.message.expect("message");
+        assert!(message.contains("U8"));
+    }
 }

--- a/src-tauri/src/audio/system_windows.rs
+++ b/src-tauri/src/audio/system_windows.rs
@@ -1,0 +1,542 @@
+//! Windows system-audio capture via WASAPI loopback.
+//!
+//! On Windows, building a cpal *input* stream on an *output* (render) device
+//! captures a loopback of everything that device is playing. cpal 0.15.3's
+//! WASAPI backend does this transparently: `Device::build_input_stream_raw`
+//! sets `AUDCLNT_STREAMFLAGS_LOOPBACK` whenever the device's data flow is
+//! `eRender` (see cpal `src/host/wasapi/device.rs`). No OS permission prompt is
+//! involved, which is why `system_audio_readiness()` reports `granted`.
+//!
+//! The public API mirrors `system_macos::SystemAudioCapture` exactly so
+//! `audio::capture` can consume either backend through the re-export in
+//! `audio::mod`. The observable file behavior also mirrors the macOS Swift
+//! helper:
+//!   * a 16-bit signed-int interleaved WAV at the device's native rate/channels,
+//!   * `timeline_offset` of leading silence so the system track lines up with a
+//!     microphone track that started `timeline_offset` earlier,
+//!   * wall-clock silence fill for gaps (mirroring `writeTimelineSilenceIfNeeded`),
+//!   * paused wall-clock excluded from the timeline rather than filled (see the
+//!     pause semantics note on `pause`).
+//!
+//! Design difference from macOS worth calling out: the macOS aggregate-device
+//! IOProc fires on the output device's clock even during silence, so the helper
+//! can fill gaps from inside its callback. WASAPI loopback delivers no packets
+//! while the endpoint is idle, so a callback-only design would stop advancing
+//! the timeline during silence. We therefore run a dedicated writer thread on a
+//! fixed tick that owns the WAV file and the wall clock: the cpal callback only
+//! buffers samples and updates the level meter, and the writer thread fills
+//! silence and appends real audio, keeping the file wall-clock aligned whether
+//! or not audio is currently playing.
+
+use crate::audio::system_timeline::{
+    active_elapsed, expected_frames, max_silence_chunk_frames, silence_frames_to_fill,
+    tolerance_frames, LevelAccumulator,
+};
+use crate::domain::types::{AppError, AudioLevelDto, RecordingSource, SourceReadinessDto};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use hound::{SampleFormat, WavSpec, WavWriter};
+use std::{
+    fs::File,
+    io::BufWriter,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+/// How often the writer thread wakes to drain buffered audio and top up
+/// silence. Comfortably below the 80 ms silence tolerance so the file stays
+/// aligned without busy-waiting.
+const WRITER_TICK: Duration = Duration::from_millis(40);
+
+/// Shared between the cpal capture callback (producer) and the writer thread
+/// (consumer) plus `status()` (reader). Kept lock-light: the callback never
+/// touches the file, so it cannot block on disk I/O.
+#[derive(Default)]
+struct Shared {
+    /// Interleaved i16 samples captured but not yet written to the WAV.
+    pending: Vec<i16>,
+    level: LevelAccumulator,
+    /// WAV data bytes written so far (real audio + silence fill).
+    bytes_written: i64,
+    last_error: Option<String>,
+}
+
+/// Wall-clock pause bookkeeping, mirroring the Swift helper's
+/// `accumulatedPausedDuration` / `pausedAt`. Read by the writer thread to
+/// exclude paused time from the timeline.
+#[derive(Default)]
+struct PauseState {
+    paused: bool,
+    paused_at: Option<Instant>,
+    accumulated_paused: Duration,
+}
+
+impl PauseState {
+    /// Total paused time to subtract from elapsed wall clock right now,
+    /// including an in-progress pause.
+    fn paused_offset(&self) -> Duration {
+        let active = if self.paused {
+            self.paused_at.map(|at| at.elapsed()).unwrap_or_default()
+        } else {
+            Duration::ZERO
+        };
+        self.accumulated_paused + active
+    }
+}
+
+pub struct SystemAudioCapture {
+    // Dropping the stream stops the WASAPI loopback callback. `cpal::Stream` is
+    // `!Send`; this struct is only ever held inside `ActiveRecording`, which is
+    // force-`Send` (see `capture.rs`), exactly as the macOS backend relies on.
+    stream: Option<cpal::Stream>,
+    writer_handle: Option<JoinHandle<Result<(), String>>>,
+    shared: Arc<Mutex<Shared>>,
+    pause_state: Arc<Mutex<PauseState>>,
+    pause_flag: Arc<AtomicBool>,
+    stop_flag: Arc<AtomicBool>,
+    partial_path: PathBuf,
+    final_path: PathBuf,
+}
+
+impl SystemAudioCapture {
+    pub fn start(
+        partial_path: PathBuf,
+        final_path: PathBuf,
+        timeline_offset: Duration,
+    ) -> Result<Self, AppError> {
+        let host = cpal::default_host();
+        let device = host.default_output_device().ok_or_else(|| {
+            AppError::new(
+                "system_audio_unavailable",
+                "No audio output device is available to capture system audio.",
+            )
+        })?;
+        // Loopback capture reads the render device's mix format; an output
+        // device has no *input* config, so we derive the WAV spec and the
+        // callback sample type from the output (mix) config.
+        let supported = device.default_output_config().map_err(|error| {
+            AppError::new("system_audio_capture_unavailable", error.to_string())
+        })?;
+        let sample_format = supported.sample_format();
+        let sample_rate = supported.sample_rate().0;
+        let channels = supported.channels();
+        let stream_config: cpal::StreamConfig = supported.into();
+
+        let writer = WavWriter::create(
+            &partial_path,
+            WavSpec {
+                channels,
+                sample_rate,
+                bits_per_sample: 16,
+                sample_format: SampleFormat::Int,
+            },
+        )
+        .map_err(|error| AppError::new("system_audio_capture_unavailable", error.to_string()))?;
+
+        let shared = Arc::new(Mutex::new(Shared::default()));
+        let pause_state = Arc::new(Mutex::new(PauseState::default()));
+        let pause_flag = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::new(AtomicBool::new(false));
+
+        let stream = match build_loopback_stream(
+            &device,
+            &stream_config,
+            sample_format,
+            Arc::clone(&shared),
+            Arc::clone(&pause_flag),
+        ) {
+            Ok(stream) => stream,
+            Err(error) => {
+                // Building the stream failed; drop the writer and remove the
+                // half-created file so a failed start leaves nothing behind.
+                drop(writer);
+                let _ = std::fs::remove_file(&partial_path);
+                return Err(error);
+            }
+        };
+
+        // The writer thread owns the WAV file and the wall clock from here on.
+        let writer_handle = spawn_writer_thread(
+            writer,
+            channels,
+            sample_rate,
+            timeline_offset,
+            Arc::clone(&shared),
+            Arc::clone(&pause_state),
+            Arc::clone(&stop_flag),
+        );
+
+        if let Err(error) = stream.play() {
+            stop_flag.store(true, Ordering::Release);
+            let _ = writer_handle.join();
+            let _ = std::fs::remove_file(&partial_path);
+            return Err(AppError::new(
+                "system_audio_capture_unavailable",
+                error.to_string(),
+            ));
+        }
+
+        Ok(Self {
+            stream: Some(stream),
+            writer_handle: Some(writer_handle),
+            shared,
+            pause_state,
+            pause_flag,
+            stop_flag,
+            partial_path,
+            final_path,
+        })
+    }
+
+    pub fn pause(&mut self) {
+        self.pause_flag.store(true, Ordering::Release);
+        if let Ok(mut state) = self.pause_state.lock() {
+            if !state.paused {
+                state.paused_at = Some(Instant::now());
+            }
+            state.paused = true;
+        }
+    }
+
+    pub fn resume(&mut self) {
+        self.pause_flag.store(false, Ordering::Release);
+        if let Ok(mut state) = self.pause_state.lock() {
+            if let Some(paused_at) = state.paused_at.take() {
+                state.accumulated_paused += paused_at.elapsed();
+            }
+            state.paused = false;
+        }
+    }
+
+    pub fn status(&self) -> (AudioLevelDto, i64, Option<String>) {
+        let Ok(shared) = self.shared.lock() else {
+            return (AudioLevelDto::default(), 0, None);
+        };
+        (
+            shared.level.level(),
+            shared.bytes_written,
+            shared.last_error.clone(),
+        )
+    }
+
+    pub fn stop(mut self) -> Result<PathBuf, AppError> {
+        // Stop the loopback callback first so no more samples arrive while the
+        // writer thread performs its final drain and trailing-silence flush.
+        drop(self.stream.take());
+        self.stop_flag.store(true, Ordering::Release);
+        if let Some(handle) = self.writer_handle.take() {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(message)) => {
+                    return Err(AppError::new("audio_finalization_failed", message));
+                }
+                Err(_) => {
+                    return Err(AppError::new(
+                        "audio_finalization_failed",
+                        "System audio writer thread panicked.",
+                    ));
+                }
+            }
+        }
+        if self.partial_path.exists() {
+            std::fs::rename(&self.partial_path, &self.final_path)
+                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        }
+        Ok(self.final_path.clone())
+    }
+}
+
+impl Drop for SystemAudioCapture {
+    fn drop(&mut self) {
+        // `stop()` consumes `self` and clears these; this only runs if a capture
+        // is dropped without `stop()` (e.g. a panic unwinds `start`). Make sure
+        // the loopback callback and writer thread do not outlive the struct.
+        drop(self.stream.take());
+        self.stop_flag.store(true, Ordering::Release);
+        if let Some(handle) = self.writer_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Build the WASAPI loopback input stream on the render `device`, converting
+/// whatever the mix format delivers into interleaved i16 for the writer thread
+/// while feeding a normalized copy into the level meter.
+fn build_loopback_stream(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    sample_format: cpal::SampleFormat,
+    shared: Arc<Mutex<Shared>>,
+    pause_flag: Arc<AtomicBool>,
+) -> Result<cpal::Stream, AppError> {
+    let error_shared = Arc::clone(&shared);
+    let err_fn = move |error: cpal::StreamError| {
+        // Surface device invalidation / stream faults through status() rather
+        // than panicking. The capture keeps its file; the writer thread keeps
+        // filling silence so the timeline stays intact.
+        if let Ok(mut shared) = error_shared.lock() {
+            shared.last_error = Some(system_stream_error_message(&error));
+        }
+    };
+
+    let build = |device: &cpal::Device| -> Result<cpal::Stream, cpal::BuildStreamError> {
+        match sample_format {
+            cpal::SampleFormat::F32 => device.build_input_stream(
+                config,
+                move |data: &[f32], _| {
+                    ingest_samples(
+                        data.iter().map(|sample| sample.clamp(-1.0, 1.0)),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::I16 => device.build_input_stream(
+                config,
+                move |data: &[i16], _| {
+                    ingest_samples(
+                        data.iter().map(|sample| *sample as f32 / i16::MAX as f32),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::U16 => device.build_input_stream(
+                config,
+                move |data: &[u16], _| {
+                    ingest_samples(
+                        data.iter()
+                            .map(|sample| (*sample as f32 - 32768.0) / 32768.0),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            other => Err(cpal::BuildStreamError::BackendSpecific {
+                err: cpal::BackendSpecificError {
+                    description: format!(
+                        "Unsupported system audio loopback sample format {other:?}."
+                    ),
+                },
+            }),
+        }
+    };
+
+    build(device)
+        .map_err(|error| AppError::new("system_audio_capture_unavailable", error.to_string()))
+}
+
+/// Convert one callback's normalized samples to i16, buffer them for the writer
+/// thread and fold them into the level meter. Skips everything while paused so
+/// paused audio is dropped, matching the microphone path in `capture.rs`.
+fn ingest_samples<I>(samples: I, shared: &Arc<Mutex<Shared>>, pause_flag: &AtomicBool)
+where
+    I: Iterator<Item = f32>,
+{
+    if pause_flag.load(Ordering::Acquire) {
+        return;
+    }
+    let pcm: Vec<i16> = samples
+        .map(|sample| (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
+        .collect();
+    if pcm.is_empty() {
+        return;
+    }
+    let Ok(mut shared) = shared.lock() else {
+        return;
+    };
+    shared
+        .level
+        .record_callback(pcm.iter().map(|sample| *sample as f32 / i16::MAX as f32));
+    shared.pending.extend_from_slice(&pcm);
+}
+
+/// Spawn the thread that owns the WAV file and the wall clock. Returns a handle
+/// whose value is the finalize result (`Err` maps to `audio_finalization_failed`).
+fn spawn_writer_thread(
+    mut writer: WavWriter<BufWriter<File>>,
+    channels: u16,
+    sample_rate: u32,
+    timeline_offset: Duration,
+    shared: Arc<Mutex<Shared>>,
+    pause_state: Arc<Mutex<PauseState>>,
+    stop_flag: Arc<AtomicBool>,
+) -> JoinHandle<Result<(), String>> {
+    std::thread::spawn(move || {
+        let channels = channels.max(1) as i64;
+        let tolerance = tolerance_frames(sample_rate);
+        let chunk_cap = max_silence_chunk_frames(sample_rate);
+        let started = Instant::now();
+        // Per-channel frames written to the file (real audio + silence).
+        let mut frames_written: i64 = 0;
+
+        loop {
+            let stopping = stop_flag.load(Ordering::Acquire);
+            let pending = take_pending(&shared);
+            let paused_offset = pause_state
+                .lock()
+                .map(|state| state.paused_offset())
+                .unwrap_or_default();
+            let elapsed = active_elapsed(started.elapsed(), timeline_offset, paused_offset);
+            let expected = expected_frames(elapsed, sample_rate);
+
+            if let Err(message) = write_tick(
+                &mut writer,
+                &pending,
+                channels,
+                expected,
+                &mut frames_written,
+                tolerance,
+                chunk_cap,
+                &shared,
+            ) {
+                record_error(&shared, message);
+            }
+
+            if stopping {
+                // One trailing pass with no real audio flushes silence up to the
+                // stop instant, mirroring the helper's flushTimelineSilenceToNow.
+                let paused_offset = pause_state
+                    .lock()
+                    .map(|state| state.paused_offset())
+                    .unwrap_or_default();
+                let elapsed = active_elapsed(started.elapsed(), timeline_offset, paused_offset);
+                let expected = expected_frames(elapsed, sample_rate);
+                if let Err(message) = write_tick(
+                    &mut writer,
+                    &[],
+                    channels,
+                    expected,
+                    &mut frames_written,
+                    tolerance,
+                    chunk_cap,
+                    &shared,
+                ) {
+                    record_error(&shared, message);
+                }
+                break;
+            }
+
+            std::thread::sleep(WRITER_TICK);
+        }
+
+        writer.finalize().map_err(|error| error.to_string())
+    })
+}
+
+/// Take the buffered samples out of the shared state without holding the lock
+/// across the file write that follows.
+fn take_pending(shared: &Arc<Mutex<Shared>>) -> Vec<i16> {
+    match shared.lock() {
+        Ok(mut shared) => std::mem::take(&mut shared.pending),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Fill any missing silence, then append the real buffer, keeping the file
+/// aligned to `expected` per-channel frames. Updates `frames_written` and the
+/// shared byte counter. Mirrors `writeTimelineSilenceIfNeeded` followed by the
+/// real `audioFile.write`.
+#[allow(clippy::too_many_arguments)]
+fn write_tick(
+    writer: &mut WavWriter<BufWriter<File>>,
+    pending: &[i16],
+    channels: i64,
+    expected: i64,
+    frames_written: &mut i64,
+    tolerance: i64,
+    chunk_cap: i64,
+    shared: &Arc<Mutex<Shared>>,
+) -> Result<(), String> {
+    let incoming_frames = pending.len() as i64 / channels;
+    let mut silence_frames =
+        silence_frames_to_fill(expected, *frames_written, incoming_frames, tolerance);
+    let mut written_samples: i64 = 0;
+
+    while silence_frames > 0 {
+        let chunk = silence_frames.min(chunk_cap);
+        for _ in 0..(chunk * channels) {
+            writer
+                .write_sample(0i16)
+                .map_err(|error| error.to_string())?;
+        }
+        *frames_written += chunk;
+        written_samples += chunk * channels;
+        silence_frames -= chunk;
+    }
+
+    for sample in pending {
+        writer
+            .write_sample(*sample)
+            .map_err(|error| error.to_string())?;
+    }
+    *frames_written += incoming_frames;
+    written_samples += pending.len() as i64;
+
+    if written_samples > 0 {
+        if let Ok(mut shared) = shared.lock() {
+            shared.bytes_written += written_samples * 2;
+        }
+    }
+    Ok(())
+}
+
+fn record_error(shared: &Arc<Mutex<Shared>>, message: String) {
+    if let Ok(mut shared) = shared.lock() {
+        shared.last_error = Some(message);
+    }
+}
+
+fn system_stream_error_message(error: &cpal::StreamError) -> String {
+    match error {
+        cpal::StreamError::DeviceNotAvailable => {
+            "System audio output device became unavailable. Reconnect the output device and restart the recording to resume system audio."
+                .to_string()
+        }
+        cpal::StreamError::BackendSpecific { err } => {
+            format!("System audio capture error: {}", err.description)
+        }
+    }
+}
+
+pub fn system_audio_readiness() -> SourceReadinessDto {
+    let host = cpal::default_host();
+    let device_available = host.default_output_device().is_some();
+    SourceReadinessDto {
+        source: RecordingSource::System,
+        required: true,
+        ready: device_available,
+        // WASAPI loopback needs no OS permission, so the permission gate is
+        // always "granted"; the only thing that can block capture is the
+        // absence of an output device to loop back from.
+        permission_state: "granted".to_string(),
+        device_available,
+        capture_available: device_available,
+        // No recovery_action: there is no system-audio privacy pane to send the
+        // user to on Windows, so the frontend simply does not offer one.
+        recovery_action: None,
+        message: if device_available {
+            None
+        } else {
+            Some(
+                "No audio output device is available. Connect speakers or headphones to capture system audio."
+                    .to_string(),
+            )
+        },
+    }
+}
+
+pub fn helper_permission_check() -> Result<(), AppError> {
+    // Loopback capture requires no permission grant on Windows.
+    Ok(())
+}

--- a/src-tauri/src/audio/system_windows.rs
+++ b/src-tauri/src/audio/system_windows.rs
@@ -406,6 +406,11 @@ fn spawn_writer_thread(
         let started = Instant::now();
         // Per-channel frames written to the file (real audio + silence).
         let mut frames_written: i64 = 0;
+        // First mid-capture write failure (disk full, I/O error). Recorded in
+        // shared state for live status(), and returned from the thread so
+        // stop() fails the recording instead of finalizing a file that
+        // silently lost audio.
+        let mut first_write_error: Option<String> = None;
 
         loop {
             let stopping = stop_flag.load(Ordering::Acquire);
@@ -427,7 +432,8 @@ fn spawn_writer_thread(
                 chunk_cap,
                 &shared,
             ) {
-                record_error(&shared, message);
+                record_error(&shared, message.clone());
+                first_write_error.get_or_insert(message);
             }
 
             if stopping {
@@ -449,7 +455,8 @@ fn spawn_writer_thread(
                     chunk_cap,
                     &shared,
                 ) {
-                    record_error(&shared, message);
+                    record_error(&shared, message.clone());
+                    first_write_error.get_or_insert(message);
                 }
                 break;
             }
@@ -457,8 +464,26 @@ fn spawn_writer_thread(
             std::thread::sleep(WRITER_TICK);
         }
 
-        writer.finalize().map_err(|error| error.to_string())
+        // Finalize regardless (a truncated-but-valid WAV beats a corrupt one),
+        // then report the outcome with the first write failure taking
+        // precedence over the finalize result.
+        let finalize_result = writer.finalize().map_err(|error| error.to_string());
+        writer_thread_outcome(first_write_error, finalize_result)
     })
+}
+
+/// The writer thread's exit value, which `stop()` maps onto
+/// `audio_finalization_failed`: the first mid-capture write failure wins over
+/// the finalize result, because audio has already been lost even when finalize
+/// itself later succeeds. Factored out so the precedence is unit-testable.
+fn writer_thread_outcome(
+    first_write_error: Option<String>,
+    finalize_result: Result<(), String>,
+) -> Result<(), String> {
+    match first_write_error {
+        Some(message) => Err(message),
+        None => finalize_result,
+    }
 }
 
 /// Take the buffered samples out of the shared state without holding the lock
@@ -705,6 +730,34 @@ mod tests {
         assert!(!readiness.capture_available);
         let message = readiness.message.expect("message");
         assert!(message.contains("device not available"));
+    }
+
+    #[test]
+    fn writer_outcome_propagates_a_mid_capture_write_failure() {
+        // A write failure must fail the recording even when finalize itself
+        // succeeds, otherwise the file finalizes after silently losing audio.
+        assert_eq!(
+            writer_thread_outcome(Some("disk full".to_string()), Ok(())),
+            Err("disk full".to_string())
+        );
+        // The first write failure also wins over a later finalize failure:
+        // it is the root cause the user should see.
+        assert_eq!(
+            writer_thread_outcome(
+                Some("disk full".to_string()),
+                Err("finalize failed".to_string())
+            ),
+            Err("disk full".to_string())
+        );
+    }
+
+    #[test]
+    fn writer_outcome_reports_finalize_result_without_write_failures() {
+        assert_eq!(writer_thread_outcome(None, Ok(())), Ok(()));
+        assert_eq!(
+            writer_thread_outcome(None, Err("finalize failed".to_string())),
+            Err("finalize failed".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/system_windows.rs
+++ b/src-tauri/src/audio/system_windows.rs
@@ -322,6 +322,33 @@ fn build_loopback_stream(
                 err_fn,
                 None,
             ),
+            // The WASAPI shared-mode mix engine is F32 in practice, but some
+            // professional or HDMI render devices expose 32-bit int or 64-bit
+            // float mix formats; capture those too instead of failing outright.
+            cpal::SampleFormat::I32 => device.build_input_stream(
+                config,
+                move |data: &[i32], _| {
+                    ingest_samples(
+                        data.iter().map(|sample| *sample as f32 / i32::MAX as f32),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::F64 => device.build_input_stream(
+                config,
+                move |data: &[f64], _| {
+                    ingest_samples(
+                        data.iter().map(|sample| sample.clamp(-1.0, 1.0) as f32),
+                        &shared,
+                        &pause_flag,
+                    )
+                },
+                err_fn,
+                None,
+            ),
             other => Err(cpal::BuildStreamError::BackendSpecific {
                 err: cpal::BackendSpecificError {
                     description: format!(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1278,11 +1278,11 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
         message: microphone_hint,
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
-        let mut system = crate::audio::system_macos::system_audio_readiness();
+        let mut system = crate::audio::system_audio_readiness();
         if should_probe_system_audio_permission(system.ready, is_capture_active()) {
             system = apply_system_audio_permission_probe_result(
                 system,
-                crate::audio::system_macos::helper_permission_check(),
+                crate::audio::helper_permission_check(),
             );
         }
         sources.push(system);

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -862,6 +862,15 @@ mod tests {
             .collect()
     }
 
+    // The tests below feed macOS bundle ids through the platform dispatchers
+    // (`MicrophoneInputProcess::new` -> `app_label_from_bundle_id`,
+    // `active_allowed_external_processes` -> `is_allowed_microphone_app`).
+    // On Windows those dispatch to the executable-name matcher, which rightly
+    // rejects bundle ids, so they are gated to the targets whose matcher they
+    // test: every non-Windows target, mirroring the dispatch `cfg` itself.
+    // Windows twins covering the same shared pipeline with executable names
+    // follow the pure allow-list tests further down.
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn deduped_app_labels_collapses_helper_processes_in_detection_order() {
         let processes = vec![
@@ -874,6 +883,7 @@ mod tests {
         assert!(deduped_app_labels(&[]).is_empty());
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn active_allowed_external_processes_excludes_owned_processes() {
         let owned = BTreeSet::from([10, 20]);
@@ -898,6 +908,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn chrome_mic_process_triggers_detection_filter() {
         let exact = input_process(30, "com.google.Chrome");
@@ -908,6 +919,7 @@ mod tests {
         assert_eq!(allowed_pids(&[exact, helper]), vec![30, 31]);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn arc_mic_process_triggers_detection_filter() {
         let exact = input_process(40, "company.thebrowser.Browser");
@@ -918,6 +930,7 @@ mod tests {
         assert_eq!(allowed_pids(&[exact, helper]), vec![40, 41]);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn safari_mic_process_triggers_detection_filter() {
         let exact = input_process(42, "com.apple.Safari");
@@ -928,6 +941,7 @@ mod tests {
         assert_eq!(allowed_pids(&[exact, helper]), vec![42, 43]);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn teams_mic_process_triggers_detection_filter() {
         let classic = input_process(44, "com.microsoft.teams");
@@ -945,6 +959,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn zoom_mic_process_triggers_detection_filter() {
         let exact = input_process(48, "us.zoom.xos");
@@ -955,6 +970,7 @@ mod tests {
         assert_eq!(allowed_pids(&[exact, helper]), vec![48, 49]);
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn unlisted_mic_process_does_not_trigger_detection_filter() {
         assert!(allowed_pids(&[
@@ -1007,6 +1023,85 @@ mod tests {
         assert_eq!(windows_app_label_from_executable("  Zoom.exe  "), "Zoom");
     }
 
+    // Windows twins of the bundle-id pipeline tests above: same shared code
+    // path (`MicrophoneInputProcess::new` -> dispatcher -> filtering -> state
+    // machine), driven with executable names, running only where the
+    // dispatchers route to the executable-name matcher.
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_mic_processes_trigger_detection_filter_by_executable() {
+        let zoom = input_process(30, "Zoom.exe");
+        let teams = input_process(31, "ms-teams.exe");
+        let chrome = input_process(32, "chrome.exe");
+        let unlisted = input_process(33, "notepad.exe");
+
+        assert_eq!(zoom.app_label, "Zoom");
+        assert_eq!(teams.app_label, "Teams");
+        assert_eq!(chrome.app_label, "Chrome");
+        assert_eq!(
+            allowed_pids(&[zoom, teams, chrome, unlisted]),
+            vec![30, 31, 32]
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_deduped_app_labels_collapses_duplicate_executables() {
+        let processes = vec![
+            input_process(30, "Zoom.exe"),
+            input_process(31, "zoom.exe"),
+            input_process(32, "chrome.exe"),
+        ];
+
+        assert_eq!(deduped_app_labels(&processes), vec!["Zoom", "Chrome"]);
+        assert!(deduped_app_labels(&[]).is_empty());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_active_allowed_external_processes_excludes_owned_processes() {
+        let owned = BTreeSet::from([10, 20]);
+        let processes = vec![
+            MicrophoneInputProcess {
+                pid: 0,
+                bundle_id: "chrome.exe".to_string(),
+                app_label: "Chrome".to_string(),
+            },
+            input_process(10, "chrome.exe"),
+            input_process(30, "chrome.exe"),
+            input_process(20, "zoom.exe"),
+            input_process(40, "zoom.exe"),
+        ];
+
+        assert_eq!(
+            active_allowed_external_processes(&processes, &owned)
+                .into_iter()
+                .map(|process| process.pid)
+                .collect::<Vec<_>>(),
+            vec![30, 40]
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_detector_clears_when_allowed_mic_process_becomes_unlisted() {
+        let mut state = MeetingDetectionState::default();
+        let active_allowed = allowed_pids(&[input_process(60, "chrome.exe")]);
+        let active_unlisted = allowed_pids(&[input_process(61, "notepad.exe")]);
+
+        assert_eq!(
+            state.update(true, !active_allowed.is_empty(), false),
+            Some(MeetingDetectionEvent::Detected)
+        );
+        assert_eq!(state.update(true, !active_unlisted.is_empty(), false), None);
+        assert_eq!(
+            state.update(true, !active_unlisted.is_empty(), false),
+            Some(MeetingDetectionEvent::Cleared)
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn detector_clears_when_allowed_mic_process_becomes_unlisted() {
         let mut state = MeetingDetectionState::default();

--- a/src-tauri/src/meeting_detection.rs
+++ b/src-tauri/src/meeting_detection.rs
@@ -1,11 +1,14 @@
 use serde::Serialize;
-use std::{collections::BTreeSet, thread, time::Duration};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::thread;
+use std::{collections::BTreeSet, time::Duration};
 use tauri::{AppHandle, Emitter};
 
 const CLEAR_AFTER_INACTIVE_POLLS: u8 = 2;
 const HEARTBEAT_EVERY_ACTIVE_POLLS: u8 = 5;
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const MEETING_DETECTION_EVENT_NAME: &str = "meeting-detection-event";
+#[cfg(not(target_os = "windows"))]
 const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] = &[
     "company.thebrowser.Browser",
     "com.google.Chrome",
@@ -16,10 +19,10 @@ const ALLOWED_MIC_APP_BUNDLE_PREFIXES: &[&str] = &[
 ];
 
 pub fn setup(app: &mut tauri::App) {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     spawn_monitor(app.handle().clone());
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let _ = app;
 }
 
@@ -128,12 +131,37 @@ pub(crate) fn active_allowed_external_processes(
         .collect()
 }
 
-fn is_allowed_microphone_app(bundle_id: &str) -> bool {
+// The allow-list and friendly-label lookups are keyed on a platform-specific
+// identifier: a bundle id on macOS, an executable name on Windows. Both paths
+// feed the same `MicrophoneInputProcess` shape and the same shared filtering,
+// so the dispatchers below keep their original names and signatures.
+
+fn is_allowed_microphone_app(identifier: &str) -> bool {
+    #[cfg(target_os = "windows")]
+    let allowed = is_allowed_windows_microphone_app(identifier);
+    #[cfg(not(target_os = "windows"))]
+    let allowed = is_allowed_macos_microphone_app(identifier);
+    allowed
+}
+
+fn app_label_from_bundle_id(identifier: &str) -> String {
+    #[cfg(target_os = "windows")]
+    let label = windows_app_label_from_executable(identifier);
+    #[cfg(not(target_os = "windows"))]
+    let label = macos_app_label_from_bundle_id(identifier);
+    label
+}
+
+// ---- macOS bundle-id matching --------------------------------------------
+
+#[cfg(not(target_os = "windows"))]
+fn is_allowed_macos_microphone_app(bundle_id: &str) -> bool {
     ALLOWED_MIC_APP_BUNDLE_PREFIXES
         .iter()
         .any(|prefix| bundle_id_matches_prefix(bundle_id, prefix))
 }
 
+#[cfg(not(target_os = "windows"))]
 fn bundle_id_matches_prefix(bundle_id: &str, prefix: &str) -> bool {
     let bundle_id = bundle_id.trim().to_ascii_lowercase();
     let prefix = prefix.trim().to_ascii_lowercase();
@@ -143,7 +171,8 @@ fn bundle_id_matches_prefix(bundle_id: &str, prefix: &str) -> bool {
             .is_some_and(|suffix| suffix.starts_with('.'))
 }
 
-fn app_label_from_bundle_id(bundle_id: &str) -> String {
+#[cfg(not(target_os = "windows"))]
+fn macos_app_label_from_bundle_id(bundle_id: &str) -> String {
     if bundle_id_matches_prefix(bundle_id, "company.thebrowser.Browser") {
         return "Arc".to_string();
     }
@@ -168,7 +197,58 @@ fn app_label_from_bundle_id(bundle_id: &str) -> String {
         .to_string()
 }
 
-#[cfg(target_os = "macos")]
+// ---- Windows executable-name matching ------------------------------------
+
+/// Allow-list of Windows meeting apps keyed on lowercase executable names,
+/// mapped to the same friendly labels the macOS bundle-id path produces.
+/// June's own future WASAPI capture helper is excluded by pid (`owned_pids`),
+/// not by name, so it does not belong here.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+const ALLOWED_WINDOWS_MIC_APPS: &[(&str, &str)] = &[
+    ("ms-teams.exe", "Teams"),
+    ("teams.exe", "Teams"),
+    ("zoom.exe", "Zoom"),
+    ("chrome.exe", "Chrome"),
+    ("msedge.exe", "Edge"),
+    ("arc.exe", "Arc"),
+    ("firefox.exe", "Firefox"),
+    ("brave.exe", "Brave"),
+];
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn is_allowed_windows_microphone_app(executable: &str) -> bool {
+    let executable = executable.trim().to_ascii_lowercase();
+    ALLOWED_WINDOWS_MIC_APPS
+        .iter()
+        .any(|(name, _)| *name == executable)
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn windows_app_label_from_executable(executable: &str) -> String {
+    let executable = executable.trim();
+    let lowercased = executable.to_ascii_lowercase();
+    if let Some((_, label)) = ALLOWED_WINDOWS_MIC_APPS
+        .iter()
+        .find(|(name, _)| *name == lowercased)
+    {
+        return (*label).to_string();
+    }
+    // Unlisted apps are dropped by the allow-list, so this label only surfaces
+    // defensively. Strip a trailing ".exe" (case-insensitively) so it reads as
+    // an app name rather than a file.
+    let stem = if lowercased.ends_with(".exe") {
+        &executable[..executable.len() - ".exe".len()]
+    } else {
+        executable
+    };
+    if stem.is_empty() {
+        executable.to_string()
+    } else {
+        stem.to_string()
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn spawn_monitor(app: AppHandle) {
     thread::spawn(move || {
         let mut state = MeetingDetectionState::default();
@@ -208,10 +288,20 @@ fn spawn_monitor(app: AppHandle) {
 }
 
 fn owned_pids(app: &AppHandle) -> BTreeSet<u32> {
+    // Only the macOS branch mutates `pids` today; keep `mut` warning-free where
+    // no helper pid is inserted.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut pids = BTreeSet::from([std::process::id()]);
+    // macOS spawns a dictation helper that also holds the microphone; exclude
+    // it so June's own capture never looks like an external meeting. Windows
+    // has no such helper yet, so its owned set is just this process. When a
+    // Windows capture helper lands, insert its pid here under a windows cfg.
+    #[cfg(target_os = "macos")]
     if let Some(helper_pid) = crate::dictation::dictation_helper_pid(app) {
         pids.insert(helper_pid);
     }
+    #[cfg(not(target_os = "macos"))]
+    let _ = app;
     pids
 }
 
@@ -280,7 +370,10 @@ fn emit_detection_event(
 #[cfg(target_os = "macos")]
 pub(crate) use macos::active_input_processes;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+pub(crate) use windows::active_input_processes;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 pub(crate) fn active_input_processes() -> Result<Vec<MicrophoneInputProcess>, ProbeError> {
     Ok(Vec::new())
 }
@@ -299,9 +392,11 @@ impl ProbeError {
 
 impl std::fmt::Display for ProbeError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `status` carries an OSStatus on macOS and an HRESULT on Windows;
+        // both are 32-bit and read fine as a signed decimal in the log line.
         write!(
             formatter,
-            "{} failed with OSStatus {}",
+            "{} failed with status {}",
             self.operation, self.status
         )
     }
@@ -599,6 +694,159 @@ mod macos {
     }
 }
 
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::{MicrophoneInputProcess, ProbeError};
+    use std::cell::Cell;
+    use std::collections::BTreeSet;
+
+    use ::windows::core::Interface;
+    use ::windows::Win32::Foundation::CloseHandle;
+    use ::windows::Win32::Media::Audio::{
+        eCapture, AudioSessionStateActive, IAudioSessionControl2, IAudioSessionManager2,
+        IMMDeviceEnumerator, MMDeviceEnumerator, DEVICE_STATE_ACTIVE,
+    };
+    use ::windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_MULTITHREADED,
+    };
+    use ::windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    thread_local! {
+        // COM must be initialised once per thread before any WASAPI call. The
+        // monitor owns a single long-lived polling thread, so we join the MTA on
+        // the first probe and never uninitialise (the thread outlives the app).
+        static COM_READY: Cell<bool> = const { Cell::new(false) };
+    }
+
+    fn ensure_com_initialized() {
+        COM_READY.with(|ready| {
+            if ready.get() {
+                return;
+            }
+            // SAFETY: CoInitializeEx with a null reserved pointer is the
+            // documented way to join an apartment. If the thread were already an
+            // STA this returns RPC_E_CHANGED_MODE; we proceed regardless because
+            // COM stays usable in whichever mode won and the objects below are
+            // apartment-neutral. The polling thread is fresh, so MTA wins.
+            unsafe {
+                let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+            }
+            ready.set(true);
+        });
+    }
+
+    pub(crate) fn active_input_processes() -> Result<Vec<MicrophoneInputProcess>, ProbeError> {
+        ensure_com_initialized();
+
+        // Dedupe pids across endpoints: one app capturing from a headset mic and
+        // a webcam mic shows up as two sessions on two endpoints, but is one app.
+        let mut pids: BTreeSet<u32> = BTreeSet::new();
+
+        // SAFETY: every interface below comes from a checked COM call and lives
+        // only within this scope; the `windows` crate ref-counts the pointers.
+        unsafe {
+            let enumerator: IMMDeviceEnumerator =
+                CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                    .map_err(|error| probe(error, "create device enumerator"))?;
+
+            // Enumerate ALL active capture endpoints, not just the default: a
+            // meeting app may bind to any microphone the machine exposes.
+            let endpoints = enumerator
+                .EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE)
+                .map_err(|error| probe(error, "enumerate capture endpoints"))?;
+            let endpoint_count = endpoints
+                .GetCount()
+                .map_err(|error| probe(error, "count capture endpoints"))?;
+
+            for endpoint_index in 0..endpoint_count {
+                let Ok(device) = endpoints.Item(endpoint_index) else {
+                    continue;
+                };
+                let Ok(session_manager) =
+                    device.Activate::<IAudioSessionManager2>(CLSCTX_ALL, None)
+                else {
+                    continue;
+                };
+                let Ok(sessions) = session_manager.GetSessionEnumerator() else {
+                    continue;
+                };
+                let session_count = sessions.GetCount().unwrap_or(0);
+                for session_index in 0..session_count {
+                    let Ok(control) = sessions.GetSession(session_index) else {
+                        continue;
+                    };
+                    let Ok(control) = control.cast::<IAudioSessionControl2>() else {
+                        continue;
+                    };
+                    // Only sessions still actively capturing count. Sessions can
+                    // linger Active briefly after capture stops, and idle apps
+                    // keep Inactive sessions open; both would be false positives,
+                    // so require exactly AudioSessionStateActive.
+                    if !matches!(control.GetState(), Ok(state) if state == AudioSessionStateActive)
+                    {
+                        continue;
+                    }
+                    let Ok(pid) = control.GetProcessId() else {
+                        continue;
+                    };
+                    // pid 0 is the shared system-sounds pseudo-session; skip it.
+                    if pid != 0 {
+                        pids.insert(pid);
+                    }
+                }
+            }
+        }
+
+        let mut processes = Vec::new();
+        for pid in pids {
+            if let Some(executable) = process_executable_name(pid) {
+                if let Some(process) = MicrophoneInputProcess::new(pid, executable) {
+                    processes.push(process);
+                }
+            }
+        }
+        processes.sort_by_key(|process| process.pid);
+        Ok(processes)
+    }
+
+    fn probe(error: ::windows::core::Error, operation: &'static str) -> ProbeError {
+        ProbeError::new(operation, error.code().0)
+    }
+
+    /// Resolve a pid to its executable file name (e.g. `Zoom.exe`). Uses the
+    /// limited-information access right so it succeeds across sessions and
+    /// elevation levels where full query access would be denied.
+    fn process_executable_name(pid: u32) -> Option<String> {
+        // SAFETY: the process handle is closed on every return path, and
+        // QueryFullProcessImageNameW writes into `buffer` and reports the
+        // character count it produced back through `size`.
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+            let mut buffer = [0u16; 260];
+            let mut size = buffer.len() as u32;
+            let query = QueryFullProcessImageNameW(
+                handle,
+                PROCESS_NAME_WIN32,
+                ::windows::core::PWSTR(buffer.as_mut_ptr()),
+                &mut size,
+            );
+            let _ = CloseHandle(handle);
+            query.ok()?;
+
+            let full_path = String::from_utf16_lossy(&buffer[..size as usize]);
+            let file_name = full_path
+                .rsplit(['\\', '/'])
+                .next()
+                .unwrap_or(&full_path)
+                .trim();
+            (!file_name.is_empty()).then(|| file_name.to_string())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -715,6 +963,48 @@ mod tests {
             input_process(53, "com.apple.WebKit.WebContent"),
         ])
         .is_empty());
+    }
+
+    #[test]
+    fn windows_allow_list_matches_meeting_executables_case_insensitively() {
+        for (executable, label) in [
+            ("Zoom.exe", "Zoom"),
+            ("zoom.exe", "Zoom"),
+            ("ms-teams.exe", "Teams"),
+            ("Teams.exe", "Teams"),
+            ("chrome.exe", "Chrome"),
+            ("MSEDGE.EXE", "Edge"),
+            ("Arc.exe", "Arc"),
+            ("firefox.exe", "Firefox"),
+            ("brave.exe", "Brave"),
+        ] {
+            assert!(
+                is_allowed_windows_microphone_app(executable),
+                "{executable} should be allowed"
+            );
+            assert_eq!(windows_app_label_from_executable(executable), label);
+        }
+    }
+
+    #[test]
+    fn windows_allow_list_rejects_unlisted_executables() {
+        for executable in ["notepad.exe", "explorer.exe", "obs64.exe", ""] {
+            assert!(
+                !is_allowed_windows_microphone_app(executable),
+                "{executable} should not be allowed"
+            );
+        }
+        // Unlisted apps still get a sensible fallback label with the ".exe" tail
+        // stripped, even though the allow-list drops them before it is shown.
+        assert_eq!(windows_app_label_from_executable("notepad.exe"), "notepad");
+        assert_eq!(windows_app_label_from_executable("weird"), "weird");
+        assert_eq!(windows_app_label_from_executable(".exe"), ".exe");
+    }
+
+    #[test]
+    fn windows_allow_list_ignores_surrounding_whitespace() {
+        assert!(is_allowed_windows_microphone_app("  Zoom.exe  "));
+        assert_eq!(windows_app_label_from_executable("  Zoom.exe  "), "Zoom");
     }
 
     #[test]

--- a/src-tauri/tests/source_readiness.rs
+++ b/src-tauri/tests/source_readiness.rs
@@ -1,4 +1,4 @@
-use os_june_lib::{audio::system_macos::system_audio_readiness, domain::types::RecordingSource};
+use os_june_lib::{audio::system_audio_readiness, domain::types::RecordingSource};
 
 #[test]
 fn system_audio_readiness_reports_system_source() {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1670,6 +1670,18 @@ export function App() {
 
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");
+    // A mic-only recording preflight stores a readiness result with no system
+    // entry, which zeroes systemGranted, so intent alone cannot bring
+    // sourceMode back to microphonePlusSystem. Re-probe the full mode through
+    // the existing refresh channel (the effect above polls immediately and
+    // stops as soon as the system source reports ready) so systemGranted
+    // recovers and sourceMode follows the toggle.
+    const readinessCoversSystem = sourceReadiness?.sources.some(
+      (source) => source.source === "system",
+    );
+    if (next === "microphonePlusSystem" && !readinessCoversSystem) {
+      setSystemAudioRefreshRequest((request) => request + 1);
+    }
   }
 
   // Explicit "Enable" action when system audio is denied. Sets intent on

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1670,16 +1670,20 @@ export function App() {
 
   function handleSourceModeChange(next: RecordingSourceMode) {
     setUserWantsSystemAudio(next === "microphonePlusSystem");
-    // A mic-only recording preflight stores a readiness result with no system
-    // entry, which zeroes systemGranted, so intent alone cannot bring
-    // sourceMode back to microphonePlusSystem. Re-probe the full mode through
-    // the existing refresh channel (the effect above polls immediately and
-    // stops as soon as the system source reports ready) so systemGranted
-    // recovers and sourceMode follows the toggle.
-    const readinessCoversSystem = sourceReadiness?.sources.some(
-      (source) => source.source === "system",
-    );
-    if (next === "microphonePlusSystem" && !readinessCoversSystem) {
+    // sourceMode derives from systemGranted, so when the system source is not
+    // currently ready, intent alone cannot bring it back to
+    // microphonePlusSystem. That covers a mic-only preflight having stored a
+    // readiness result with no system entry, and an entry that is present but
+    // not ready (e.g. Windows with no output device connected at the last
+    // check). Re-probe the full mode through the existing refresh channel:
+    // the effect above polls immediately and stops as soon as the system
+    // source reports ready, and it self-gates on systemGranted, so this bump
+    // is a no-op whenever system audio is already usable. Safe on every
+    // platform: the macOS denied path cannot reach here (both switches are
+    // disabled while denied, and its Enable button bumps this channel through
+    // handleEnableSystemAudio instead), and for other not-ready macOS states
+    // the probe matches what the mount and focus refreshes already do.
+    if (next === "microphonePlusSystem" && !systemGranted) {
       setSystemAudioRefreshRequest((request) => request + 1);
     }
   }

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -192,7 +192,11 @@ export function NoteEditor({
   const systemDenied =
     systemSource?.permissionState === "denied" || systemSource?.permissionState === "restricted";
   const systemUnsupported = systemSource?.permissionState === "unsupported";
-  const showRecordingOptions = isMacLikePlatform();
+  // Recording options (the system-audio toggle) show wherever a system-audio
+  // backend exists. macOS always qualifies; Windows qualifies once readiness
+  // reports a supported system source (WASAPI loopback, no permission needed).
+  // Platforms without a backend report "unsupported" and stay hidden.
+  const showRecordingOptions = isMacLikePlatform() || (systemSource != null && !systemUnsupported);
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.
   const micDenied = microphoneBlocked;

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -28,6 +28,7 @@ import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
 import { isMacLikePlatform } from "../../lib/platform";
+import { useSystemAudioSupport } from "../../lib/use-system-audio-support";
 import {
   isInvalidJuneResponseMessage,
   NoteFailureBanner,
@@ -196,11 +197,13 @@ export function NoteEditor({
   // backend exists. macOS always qualifies; Windows qualifies once readiness
   // reports a supported system source (WASAPI loopback, no permission needed).
   // Platforms without a backend report "unsupported" and stay hidden, and an
-  // unknown state (readiness not yet loaded, so systemSource is undefined)
+  // unknown state (no readiness result has covered the system source yet)
   // also reads as unsupported on non-macOS hosts so nothing flashes while the
-  // first readiness check is in flight.
-  const systemSupportConfirmed = systemSource != null && !systemUnsupported;
-  const showRecordingOptions = isMacLikePlatform() || systemSupportConfirmed;
+  // first readiness check is in flight. Support is sticky across mic-only
+  // preflights, which drop the system source from the DTO, so turning system
+  // audio off never hides the way to turn it back on.
+  const systemAudioSupport = useSystemAudioSupport(sourceReadiness);
+  const showRecordingOptions = isMacLikePlatform() || systemAudioSupport === "supported";
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.
   const micDenied = microphoneBlocked;

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -195,8 +195,12 @@ export function NoteEditor({
   // Recording options (the system-audio toggle) show wherever a system-audio
   // backend exists. macOS always qualifies; Windows qualifies once readiness
   // reports a supported system source (WASAPI loopback, no permission needed).
-  // Platforms without a backend report "unsupported" and stay hidden.
-  const showRecordingOptions = isMacLikePlatform() || (systemSource != null && !systemUnsupported);
+  // Platforms without a backend report "unsupported" and stay hidden, and an
+  // unknown state (readiness not yet loaded, so systemSource is undefined)
+  // also reads as unsupported on non-macOS hosts so nothing flashes while the
+  // first readiness check is in flight.
+  const systemSupportConfirmed = systemSource != null && !systemUnsupported;
+  const showRecordingOptions = isMacLikePlatform() || systemSupportConfirmed;
   // Mic denial is sourced from App via the dictation helper, not from
   // sourceReadiness — the Rust cpal-based check can't see TCC denials.
   const micDenied = microphoneBlocked;

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -402,7 +402,11 @@ export function AppSettings({
   );
   const systemState = systemReadiness?.permissionState;
   const systemDenied = systemState === "denied" || systemState === "restricted";
-  const systemUnavailable = !macLikePlatform || systemState === "unsupported";
+  // System audio availability follows the backend readiness rather than the
+  // host OS: macOS and Windows both ship a capture backend (Windows via WASAPI
+  // loopback, which needs no permission), while platforms without one report
+  // "unsupported" from the stub backend and hide the control.
+  const systemUnavailable = systemState === "unsupported";
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -405,8 +405,12 @@ export function AppSettings({
   // System audio availability follows the backend readiness rather than the
   // host OS: macOS and Windows both ship a capture backend (Windows via WASAPI
   // loopback, which needs no permission), while platforms without one report
-  // "unsupported" from the stub backend and hide the control.
-  const systemUnavailable = systemState === "unsupported";
+  // "unsupported" from the stub backend and hide the control. Before readiness
+  // first arrives, non-macOS platforms treat the unknown state as unavailable
+  // so unsupported hosts never flash the toggle; macOS keeps showing it while
+  // loading, as it always has.
+  const systemUnavailable =
+    systemState === "unsupported" || (!macLikePlatform && systemState === undefined);
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -74,6 +74,7 @@ import {
   type ReleaseChannel,
 } from "../../lib/updater";
 import { isMacLikePlatform } from "../../lib/platform";
+import { useSystemAudioSupport } from "../../lib/use-system-audio-support";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
 import {
@@ -405,12 +406,17 @@ export function AppSettings({
   // System audio availability follows the backend readiness rather than the
   // host OS: macOS and Windows both ship a capture backend (Windows via WASAPI
   // loopback, which needs no permission), while platforms without one report
-  // "unsupported" from the stub backend and hide the control. Before readiness
-  // first arrives, non-macOS platforms treat the unknown state as unavailable
-  // so unsupported hosts never flash the toggle; macOS keeps showing it while
-  // loading, as it always has.
-  const systemUnavailable =
-    systemState === "unsupported" || (!macLikePlatform && systemState === undefined);
+  // "unsupported" from the stub backend and hide the control. On non-macOS
+  // platforms the unknown state (no readiness result has covered the system
+  // source yet) also reads as unavailable so unsupported hosts never flash the
+  // toggle; support is sticky across mic-only preflights, which drop the
+  // system source from the DTO, so turning system audio off never hides the
+  // way to turn it back on. macOS keeps showing the toggle while readiness
+  // loads, as it always has.
+  const systemAudioSupport = useSystemAudioSupport(sourceReadiness);
+  const systemUnavailable = macLikePlatform
+    ? systemState === "unsupported"
+    : systemAudioSupport !== "supported";
 
   useEffect(() => {
     capturingShortcutRef.current = capturingShortcut;

--- a/src/lib/use-system-audio-support.ts
+++ b/src/lib/use-system-audio-support.ts
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import type { RecordingSourceReadinessDto } from "./tauri";
+
+export type SystemAudioSupport = "unknown" | "supported" | "unsupported";
+
+/**
+ * Whether the host has a working system-audio backend, remembered across
+ * readiness checks that do not cover the system source.
+ *
+ * Readiness DTOs only include a system entry when the check was made for
+ * sourceMode microphonePlusSystem; a microphoneOnly preflight (stored after
+ * the user turns system audio off) carries no system source at all. Backend
+ * capability is a property of the host, not of the last-checked mode, so this
+ * hook keeps the answer from the most recent readiness result that did include
+ * the system source instead of letting a mic-only check erase it:
+ *
+ * - "unknown" until any readiness result has covered the system source
+ * - "supported" / "unsupported" from the most recent result that covered it
+ */
+export function useSystemAudioSupport(
+  sourceReadiness: RecordingSourceReadinessDto | undefined,
+): SystemAudioSupport {
+  const systemSource = sourceReadiness?.sources.find((source) => source.source === "system");
+  const latest: SystemAudioSupport | null =
+    systemSource == null
+      ? null
+      : systemSource.permissionState === "unsupported"
+        ? "unsupported"
+        : "supported";
+  const [remembered, setRemembered] = useState<SystemAudioSupport | null>(null);
+  if (latest != null && latest !== remembered) {
+    // React's "adjust state during render" pattern: the update re-renders
+    // before commit, so consumers never paint a frame with the stale answer.
+    setRemembered(latest);
+  }
+  return latest ?? remembered ?? "unknown";
+}

--- a/src/lib/use-system-audio-support.ts
+++ b/src/lib/use-system-audio-support.ts
@@ -1,18 +1,57 @@
-import { useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import type { RecordingSourceReadinessDto } from "./tauri";
 
 export type SystemAudioSupport = "unknown" | "supported" | "unsupported";
 
+// The remembered answer lives at module scope (the same external-store shape
+// as billing-demo) so it survives component remounts: a NoteEditor or
+// AppSettings instance mounted after a mic-only preflight overwrote the app's
+// sourceReadiness must still know the host supports system audio, or
+// navigation would hide the only way to turn it back on. Host capability
+// cannot change mid-session, so the value is never reset; "unsupported" is
+// exactly as sticky as "supported".
+let remembered: SystemAudioSupport | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(onChange: () => void) {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
+function getSnapshot(): SystemAudioSupport | null {
+  return remembered;
+}
+
+function remember(next: SystemAudioSupport) {
+  if (remembered === next) return;
+  remembered = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * Test-only: clears the module-scoped memory so vitest cases stay independent.
+ * Production code never resets it (host capability is fixed for the session).
+ */
+export function resetSystemAudioSupportForTests() {
+  remembered = null;
+}
+
 /**
  * Whether the host has a working system-audio backend, remembered across
- * readiness checks that do not cover the system source.
+ * readiness checks that do not cover the system source and across component
+ * remounts.
  *
  * Readiness DTOs only include a system entry when the check was made for
  * sourceMode microphonePlusSystem; a microphoneOnly preflight (stored after
  * the user turns system audio off) carries no system source at all. Backend
- * capability is a property of the host, not of the last-checked mode, so this
- * hook keeps the answer from the most recent readiness result that did include
- * the system source instead of letting a mic-only check erase it:
+ * capability is a property of the host, not of the last-checked mode or of
+ * any one component instance, so this hook keeps the answer from the most
+ * recent readiness result that did include the system source instead of
+ * letting a mic-only check or a remount erase it:
  *
  * - "unknown" until any readiness result has covered the system source
  * - "supported" / "unsupported" from the most recent result that covered it
@@ -27,11 +66,14 @@ export function useSystemAudioSupport(
       : systemSource.permissionState === "unsupported"
         ? "unsupported"
         : "supported";
-  const [remembered, setRemembered] = useState<SystemAudioSupport | null>(null);
-  if (latest != null && latest !== remembered) {
-    // React's "adjust state during render" pattern: the update re-renders
-    // before commit, so consumers never paint a frame with the stale answer.
-    setRemembered(latest);
-  }
-  return latest ?? remembered ?? "unknown";
+  const stored = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  useEffect(() => {
+    if (latest != null) {
+      remember(latest);
+    }
+  }, [latest]);
+  // `latest` wins for the instance whose readiness covers the system source
+  // right now, so a fresh answer never waits on the effect above; the store
+  // covers instances whose readiness lacks the system entry.
+  return latest ?? stored ?? "unknown";
 }

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1385,11 +1385,10 @@ describe("AppSettings", () => {
               {
                 source: "system",
                 required: true,
-                ready: false,
-                permissionState: "denied",
+                ready: true,
+                permissionState: "granted",
                 deviceAvailable: true,
-                captureAvailable: false,
-                recoveryAction: "openSystemAudioSettings",
+                captureAvailable: true,
               },
             ],
           }}
@@ -1405,6 +1404,8 @@ describe("AppSettings", () => {
         />,
       );
 
+      // The permissions list stays microphone-only on Windows: there is no
+      // accessibility handoff and system audio needs no OS permission grant.
       expect(screen.getByText("Access used for recording audio.")).toBeInTheDocument();
       expect(screen.getByText("Microphone")).toBeInTheDocument();
       expect(screen.queryByText("Accessibility")).not.toBeInTheDocument();
@@ -1422,12 +1423,14 @@ describe("AppSettings", () => {
       expect(onEnableAccessibility).not.toHaveBeenCalled();
       expect(onEnableSystemAudio).not.toHaveBeenCalled();
 
+      // The Audio tab still offers the system-audio capture toggle on Windows
+      // (WASAPI loopback is supported); only the macOS-only mic test is hidden.
       await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
       expect(
-        screen.queryByRole("switch", {
+        screen.getByRole("switch", {
           name: "Capture system audio for notes",
         }),
-      ).not.toBeInTheDocument();
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", {
           name: "Start test",

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1445,6 +1445,40 @@ describe("AppSettings", () => {
     }
   });
 
+  it("hides the system audio toggle on Windows until source readiness first loads", async () => {
+    // Before the first readiness check resolves, sourceReadiness is undefined.
+    // Non-macOS hosts must treat that unknown state as unavailable so hosts
+    // whose backend will report "unsupported" never flash the toggle.
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(
+        <AppSettings
+          account={signedInAccount}
+          accountLoading={false}
+          sourceMode="microphoneOnly"
+          sourceReadiness={undefined}
+          checkingSourceReadiness={true}
+          onAccountChanged={vi.fn()}
+          onAccountRefresh={vi.fn()}
+          onSourceModeChange={vi.fn()}
+          onEnableSystemAudio={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
+      expect(
+        screen.queryByRole("switch", {
+          name: "Capture system audio for notes",
+        }),
+      ).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("records push-to-talk and toggle dictation shortcuts in settings", async () => {
     const user = userEvent.setup();
     render(

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1479,6 +1479,90 @@ describe("AppSettings", () => {
     }
   });
 
+  it("keeps the system audio toggle on Windows after a mic-only readiness check", async () => {
+    // Turning system audio off makes the recording preflight store a
+    // microphoneOnly readiness with no system source. Backend support is a
+    // property of the host, not of the last-checked mode, so the toggle must
+    // stay visible or the user could never turn system audio back on.
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    const microphoneSource = {
+      source: "microphone" as const,
+      required: true,
+      ready: true,
+      permissionState: "granted" as const,
+      deviceAvailable: true,
+      captureAvailable: true,
+    };
+    const onSourceModeChange = vi.fn();
+    const sharedProps = {
+      account: signedInAccount,
+      accountLoading: false,
+      checkingSourceReadiness: false,
+      onAccountChanged: vi.fn(),
+      onAccountRefresh: vi.fn(),
+      onSourceModeChange,
+      onEnableSystemAudio: vi.fn(),
+    };
+    try {
+      const { rerender } = render(
+        <AppSettings
+          {...sharedProps}
+          sourceMode="microphonePlusSystem"
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: true,
+            checkedAt: "2026-06-08T12:00:00Z",
+            sources: [
+              microphoneSource,
+              {
+                source: "system",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+            ],
+          }}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("tab", { name: "Audio" }));
+      expect(
+        screen.getByRole("switch", { name: "Capture system audio for notes" }),
+      ).toBeInTheDocument();
+
+      // System audio switched off; the preflight readiness now covers only
+      // the microphone.
+      rerender(
+        <AppSettings
+          {...sharedProps}
+          sourceMode="microphoneOnly"
+          sourceReadiness={{
+            sourceMode: "microphoneOnly",
+            ready: true,
+            checkedAt: "2026-06-08T12:01:00Z",
+            sources: [microphoneSource],
+          }}
+        />,
+      );
+
+      const systemSwitch = screen.getByRole("switch", {
+        name: "Capture system audio for notes",
+      });
+      expect(systemSwitch).toBeEnabled();
+
+      // And the user can turn system audio back on.
+      await userEvent.click(systemSwitch);
+      expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("records push-to-talk and toggle dictation shortcuts in settings", async () => {
     const user = userEvent.setup();
     render(

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetSystemAudioSupportForTests } from "../lib/use-system-audio-support";
 import { AppSettings } from "../components/settings/AppSettings";
 import type { DictationSettingsDto } from "../lib/tauri";
 import { APP_COMMIT_HASH, APP_VERSION } from "../app/build-info";
@@ -215,6 +216,9 @@ function stubNavigatorPlatform(platform: string, userAgent: string) {
 
 describe("AppSettings", () => {
   beforeEach(() => {
+    // The remembered system-audio support is module-scoped on purpose (it must
+    // survive remounts in the app); tests reset it so cases stay independent.
+    resetSystemAudioSupportForTests();
     vi.clearAllMocks();
     localStorage.clear();
     localState = { baseUrl: "", modelId: "", apiKey: "", enabled: false };

--- a/src/test/app-system-audio.test.tsx
+++ b/src/test/app-system-audio.test.tsx
@@ -1,0 +1,307 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "../app/App";
+import type {
+  AccountStatus,
+  BootstrapResponse,
+  NoteDto,
+  RecordingSourceReadinessDto,
+} from "../lib/tauri";
+
+type TauriListener = (event: { payload: unknown }) => unknown;
+
+const mocks = vi.hoisted(() => ({
+  listeners: new Map<string, TauriListener>(),
+  listen: vi.fn((event: string, listener: TauriListener) => {
+    mocks.listeners.set(event, listener);
+    return Promise.resolve(vi.fn());
+  }),
+  getCurrentWindow: vi.fn(),
+  bootstrapApp: vi.fn(),
+  createNote: vi.fn(),
+  createFolder: vi.fn(),
+  deleteFolder: vi.fn(),
+  renameFolder: vi.fn(),
+  assignNoteToFolder: vi.fn(),
+  removeNoteFromFolder: vi.fn(),
+  listNotes: vi.fn(),
+  getNote: vi.fn(),
+  deleteNote: vi.fn(),
+  updateNote: vi.fn(),
+  checkRecordingSourceReadiness: vi.fn(),
+  openPrivacySettings: vi.fn(),
+  startRecording: vi.fn(),
+  pauseRecording: vi.fn(),
+  resumeRecording: vi.fn(),
+  getRecordingStatus: vi.fn(),
+  finishRecording: vi.fn(),
+  retryProcessing: vi.fn(),
+  recoverRecording: vi.fn(),
+  dictationHelperCommand: vi.fn(),
+  listDictationHistory: vi.fn(),
+  osAccountsStatus: vi.fn(),
+  osAccountsLogin: vi.fn(),
+  osAccountsCancelLogin: vi.fn(),
+  osAccountsLogout: vi.fn(),
+  osAccountsUpgrade: vi.fn(),
+  agentHudShow: vi.fn(),
+  agentHudHide: vi.fn(),
+  playRecordingSound: vi.fn(),
+  preloadRecordingSounds: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: mocks.getCurrentWindow,
+}));
+
+vi.mock("../lib/recording-sounds", () => ({
+  playRecordingSound: mocks.playRecordingSound,
+  preloadRecordingSounds: mocks.preloadRecordingSounds,
+}));
+
+vi.mock("../lib/tauri", () => ({
+  LIVE_TRANSCRIPT_EVENT: "live-transcript-event",
+  bootstrapApp: mocks.bootstrapApp,
+  createNote: mocks.createNote,
+  createFolder: mocks.createFolder,
+  deleteFolder: mocks.deleteFolder,
+  renameFolder: mocks.renameFolder,
+  assignNoteToFolder: mocks.assignNoteToFolder,
+  listSessionFolders: vi.fn(async () => []),
+  assignSessionToFolder: vi.fn(async () => undefined),
+  removeSessionFromFolder: vi.fn(async () => undefined),
+  removeNoteFromFolder: mocks.removeNoteFromFolder,
+  listNotes: mocks.listNotes,
+  getNote: mocks.getNote,
+  deleteNote: mocks.deleteNote,
+  updateNote: mocks.updateNote,
+  checkRecordingSourceReadiness: mocks.checkRecordingSourceReadiness,
+  openPrivacySettings: mocks.openPrivacySettings,
+  startRecording: mocks.startRecording,
+  pauseRecording: mocks.pauseRecording,
+  resumeRecording: mocks.resumeRecording,
+  getRecordingStatus: mocks.getRecordingStatus,
+  finishRecording: mocks.finishRecording,
+  retryProcessing: mocks.retryProcessing,
+  recoverRecording: mocks.recoverRecording,
+  dictationHelperCommand: mocks.dictationHelperCommand,
+  listDictationHistory: mocks.listDictationHistory,
+  osAccountsStatus: mocks.osAccountsStatus,
+  osAccountsStatusLocal: mocks.osAccountsStatus,
+  osAccountsLogin: mocks.osAccountsLogin,
+  osAccountsCancelLogin: mocks.osAccountsCancelLogin,
+  osAccountsLogout: mocks.osAccountsLogout,
+  osAccountsUpgrade: mocks.osAccountsUpgrade,
+  agentHudShow: mocks.agentHudShow,
+  agentHudHide: mocks.agentHudHide,
+  // The agent workspace mounts at launch; a quiet, not-running bridge keeps
+  // these tests focused on the meetings surfaces.
+  hermesBridgeStatus: vi.fn(async () => ({ running: false })),
+  listAgentTasks: vi.fn(async () => ({ items: [] })),
+  juneVerifyUrl: vi.fn(async () => ""),
+  providerModelSettings: vi.fn(async () => ({
+    settings: { generationModel: "" },
+  })),
+  setVeniceApiKey: vi.fn(async () => ({
+    generationModel: "",
+    veniceApiKeyConfigured: true,
+  })),
+  clearVeniceApiKey: vi.fn(async () => ({
+    generationModel: "",
+    veniceApiKeyConfigured: false,
+  })),
+  hermesAgentCliAccess: vi.fn(async () => ({ enabled: false })),
+  listVeniceModels: vi.fn(async () => ({
+    mode: "generation",
+    modelType: "text",
+    selectedModel: "",
+    models: [],
+  })),
+}));
+
+const now = "2026-05-19T10:00:00Z";
+
+function note(overrides: Partial<NoteDto> = {}): NoteDto {
+  return {
+    id: "note-1",
+    title: "First note",
+    preview: "Preview",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    generatedContent: "Existing note",
+    activeTab: "notes",
+    ...overrides,
+  };
+}
+
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
+const microphoneSource = {
+  source: "microphone" as const,
+  required: true,
+  ready: true,
+  permissionState: "granted" as const,
+  deviceAvailable: true,
+  captureAvailable: true,
+};
+
+const systemSource = {
+  source: "system" as const,
+  required: true,
+  ready: true,
+  permissionState: "granted" as const,
+  deviceAvailable: true,
+  captureAvailable: true,
+};
+
+const fullReadiness: RecordingSourceReadinessDto = {
+  sourceMode: "microphonePlusSystem",
+  ready: true,
+  checkedAt: now,
+  sources: [microphoneSource, systemSource],
+};
+
+// What a mic-only recording preflight stores: no system entry at all.
+const micOnlyReadiness: RecordingSourceReadinessDto = {
+  sourceMode: "microphoneOnly",
+  ready: true,
+  checkedAt: now,
+  sources: [microphoneSource],
+};
+
+describe("system audio round trip on Windows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listeners.clear();
+
+    const first = note();
+    const payload: BootstrapResponse = {
+      folders: [],
+      notes: [first],
+      activeRecoveries: [],
+      providerConfigured: true,
+    };
+    const account: AccountStatus = {
+      signedIn: true,
+      configured: true,
+      user: { id: "usr_123", handle: "alex", email: "alex@example.com" },
+      balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
+    };
+
+    mocks.getCurrentWindow.mockReturnValue({
+      show: vi.fn().mockResolvedValue(undefined),
+      unminimize: vi.fn().mockResolvedValue(undefined),
+      setFocus: vi.fn().mockResolvedValue(undefined),
+      startDragging: vi.fn().mockResolvedValue(undefined),
+    });
+    mocks.bootstrapApp.mockResolvedValue(payload);
+    mocks.getNote.mockResolvedValue(first);
+    mocks.checkRecordingSourceReadiness.mockResolvedValue(fullReadiness);
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.listDictationHistory.mockResolvedValue({
+      items: [],
+      retentionDays: 7,
+    });
+    mocks.osAccountsStatus.mockResolvedValue(account);
+    mocks.osAccountsLogin.mockResolvedValue(account);
+    mocks.osAccountsLogout.mockResolvedValue(undefined);
+    mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
+    mocks.updateNote.mockImplementation(async (input) => ({
+      ...first,
+      ...input,
+    }));
+  });
+
+  it("re-probes readiness and restores microphonePlusSystem when re-enabled", async () => {
+    // The full loop Codex flagged: turning system audio off leads to a
+    // mic-only preflight whose stored readiness has no system entry, which
+    // zeroes systemGranted. Toggling back on must re-probe the full mode so
+    // sourceMode actually returns to microphonePlusSystem, not just record
+    // intent.
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(<App />);
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      // Open the note from the Meetings list so the editor (and its record
+      // shell) is on screen.
+      await user.click(await screen.findByRole("button", { name: "Meeting notes" }));
+      await user.click(await screen.findByRole("button", { name: /First note Preview/ }));
+
+      // Mount probe stored the full readiness; the system toggle reflects
+      // microphonePlusSystem.
+      await user.click(await screen.findByRole("button", { name: "Recording options" }));
+      const systemSwitch = await screen.findByRole("switch", { name: "Capture system audio" });
+      await waitFor(() => expect(systemSwitch).toBeChecked());
+
+      // User turns system audio off.
+      await user.click(systemSwitch);
+      await waitFor(() => expect(systemSwitch).not.toBeChecked());
+
+      // A later refresh (here: the window-focus one, standing in for the
+      // recording preflight) stores a readiness result with no system entry.
+      mocks.checkRecordingSourceReadiness.mockResolvedValue(micOnlyReadiness);
+      const callsBeforeFocus = mocks.checkRecordingSourceReadiness.mock.calls.length;
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+      });
+      await waitFor(() =>
+        expect(mocks.checkRecordingSourceReadiness.mock.calls.length).toBeGreaterThan(
+          callsBeforeFocus,
+        ),
+      );
+
+      // Sticky support keeps the toggle visible; turning it back on must
+      // re-probe the full mode, not just set intent.
+      mocks.checkRecordingSourceReadiness.mockResolvedValue(fullReadiness);
+      const callsBeforeReenable = mocks.checkRecordingSourceReadiness.mock.calls.length;
+      await user.click(systemSwitch);
+
+      await waitFor(() => {
+        const reprobes = mocks.checkRecordingSourceReadiness.mock.calls.slice(callsBeforeReenable);
+        expect(reprobes.some((call) => call[0] === "microphonePlusSystem")).toBe(true);
+      });
+      // The re-probe restored systemGranted, so sourceMode followed the
+      // intent back to microphonePlusSystem.
+      await waitFor(() => expect(systemSwitch).toBeChecked());
+    } finally {
+      restoreNavigator();
+    }
+  });
+});

--- a/src/test/app-system-audio.test.tsx
+++ b/src/test/app-system-audio.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
+import { resetSystemAudioSupportForTests } from "../lib/use-system-audio-support";
 import type {
   AccountStatus,
   BootstrapResponse,
@@ -201,6 +202,7 @@ const micOnlyReadiness: RecordingSourceReadinessDto = {
 
 describe("system audio round trip on Windows", () => {
   beforeEach(() => {
+    resetSystemAudioSupportForTests();
     vi.clearAllMocks();
     mocks.listeners.clear();
 

--- a/src/test/app-system-audio.test.tsx
+++ b/src/test/app-system-audio.test.tsx
@@ -200,6 +200,24 @@ const micOnlyReadiness: RecordingSourceReadinessDto = {
   sources: [microphoneSource],
 };
 
+// The system entry exists but is not ready: Windows with no output device
+// connected at the last check. Permission is granted (WASAPI loopback never
+// needs one), so the toggle stays visible and enabled.
+const systemNotReadyReadiness: RecordingSourceReadinessDto = {
+  sourceMode: "microphonePlusSystem",
+  ready: false,
+  checkedAt: now,
+  sources: [
+    microphoneSource,
+    {
+      ...systemSource,
+      ready: false,
+      deviceAvailable: false,
+      captureAvailable: false,
+    },
+  ],
+};
+
 describe("system audio round trip on Windows", () => {
   beforeEach(() => {
     resetSystemAudioSupportForTests();
@@ -301,6 +319,46 @@ describe("system audio round trip on Windows", () => {
       });
       // The re-probe restored systemGranted, so sourceMode followed the
       // intent back to microphonePlusSystem.
+      await waitFor(() => expect(systemSwitch).toBeChecked());
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("re-probes when enabling while the system entry is present but not ready", async () => {
+    // The stored readiness can contain a system entry with ready=false, e.g.
+    // Windows with no output device connected at the last check. Toggling on
+    // must re-probe (the gate is "system source not ready", not "entry
+    // absent") so that once the device is back, the switch recovers without
+    // waiting for an unrelated focus refresh.
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      mocks.checkRecordingSourceReadiness.mockResolvedValue(systemNotReadyReadiness);
+      render(<App />);
+      await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+      await user.click(await screen.findByRole("button", { name: "Meeting notes" }));
+      await user.click(await screen.findByRole("button", { name: /First note Preview/ }));
+
+      // Permission is granted, so the toggle is visible and enabled, but the
+      // unready system source keeps sourceMode at microphoneOnly.
+      await user.click(await screen.findByRole("button", { name: "Recording options" }));
+      const systemSwitch = await screen.findByRole("switch", { name: "Capture system audio" });
+      await waitFor(() => expect(systemSwitch).not.toBeChecked());
+
+      // The output device is back: the next probe reports ready.
+      mocks.checkRecordingSourceReadiness.mockResolvedValue(fullReadiness);
+      const callsBeforeEnable = mocks.checkRecordingSourceReadiness.mock.calls.length;
+      await user.click(systemSwitch);
+
+      await waitFor(() => {
+        const reprobes = mocks.checkRecordingSourceReadiness.mock.calls.slice(callsBeforeEnable);
+        expect(reprobes.some((call) => call[0] === "microphonePlusSystem")).toBe(true);
+      });
       await waitFor(() => expect(systemSwitch).toBeChecked());
     } finally {
       restoreNavigator();

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -711,10 +711,12 @@ describe("NoteEditor", () => {
     expect(onEnableSystemAudio).toHaveBeenCalledOnce();
   });
 
-  it("hides system audio recording options on Windows", () => {
+  it("hides system audio recording options when the system source is unsupported", () => {
+    // A platform without a system-audio backend reports "unsupported" from the
+    // stub backend; the recording options stay hidden regardless of host OS.
     const restoreNavigator = stubNavigatorPlatform(
-      "Win32",
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+      "Linux x86_64",
+      "Mozilla/5.0 (X11; Linux x86_64)",
     );
     try {
       render(
@@ -750,6 +752,56 @@ describe("NoteEditor", () => {
       expect(screen.getByRole("button", { name: "Record" })).toBeEnabled();
       expect(screen.queryByRole("button", { name: "Recording options" })).not.toBeInTheDocument();
       expect(screen.queryByText("Capture system audio")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("System audio requires macOS 14.2 or later."),
+      ).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("shows system audio recording options on Windows when supported", async () => {
+    // Windows ships a WASAPI loopback backend, so readiness reports the system
+    // source as granted and the recording options appear like they do on macOS.
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(
+        <NoteEditor
+          {...props}
+          note={note()}
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: true,
+            checkedAt: now,
+            sources: [
+              {
+                source: "microphone",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+              {
+                source: "system",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+            ],
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Recording options" }));
+      const systemSwitch = screen.getByRole("switch", { name: "Capture system audio" });
+      expect(systemSwitch).toBeEnabled();
       expect(
         screen.queryByText("System audio requires macOS 14.2 or later."),
       ).not.toBeInTheDocument();

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NoteEditor } from "../components/note-editor/NoteEditor";
 import type { NoteDto, RecoverableRecordingDto } from "../lib/tauri";
+import { resetSystemAudioSupportForTests } from "../lib/use-system-audio-support";
 
 const now = "2026-05-19T10:00:00Z";
 
@@ -82,6 +83,12 @@ function stubNavigatorPlatform(platform: string, userAgent: string) {
 }
 
 describe("NoteEditor", () => {
+  beforeEach(() => {
+    // The remembered system-audio support is module-scoped on purpose (it must
+    // survive remounts in the app); tests reset it so cases stay independent.
+    resetSystemAudioSupportForTests();
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -898,6 +905,73 @@ describe("NoteEditor", () => {
       // And the user can turn system audio back on.
       await user.click(systemSwitch);
       expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("keeps recording options on Windows across a remount after a mic-only check", async () => {
+    // Support is remembered at module scope, not per component instance: a
+    // NoteEditor mounted after a mic-only preflight overwrote sourceReadiness
+    // (e.g. the user navigated away and back) must still show the options, or
+    // navigation would reintroduce the lost-toggle bug.
+    const user = userEvent.setup();
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    const microphoneSource = {
+      source: "microphone" as const,
+      required: true,
+      ready: true,
+      permissionState: "granted" as const,
+      deviceAvailable: true,
+      captureAvailable: true,
+    };
+    try {
+      // First mount sees a readiness result that covers the system source.
+      const { unmount } = render(
+        <NoteEditor
+          {...props}
+          note={note()}
+          sourceMode="microphonePlusSystem"
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: true,
+            checkedAt: now,
+            sources: [
+              microphoneSource,
+              {
+                source: "system",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+            ],
+          }}
+        />,
+      );
+      unmount();
+
+      // A fresh instance mounts while the stored readiness is mic-only.
+      render(
+        <NoteEditor
+          {...props}
+          note={note()}
+          sourceMode="microphoneOnly"
+          sourceReadiness={{
+            sourceMode: "microphoneOnly",
+            ready: true,
+            checkedAt: now,
+            sources: [microphoneSource],
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Recording options" }));
+      expect(screen.getByRole("switch", { name: "Capture system audio" })).toBeEnabled();
     } finally {
       restoreNavigator();
     }

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -810,6 +810,25 @@ describe("NoteEditor", () => {
     }
   });
 
+  it("hides recording options on Windows until source readiness first loads", () => {
+    // Before the first readiness check resolves, sourceReadiness is undefined.
+    // Non-macOS hosts must treat that unknown state as unsupported so nothing
+    // flashes on platforms whose backend will report "unsupported".
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    try {
+      render(<NoteEditor {...props} note={note()} sourceReadiness={undefined} />);
+
+      expect(screen.getByRole("button", { name: "Record" })).toBeEnabled();
+      expect(screen.queryByRole("button", { name: "Recording options" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Capture system audio")).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("surfaces a dismissible consent reminder after the recorder settles", async () => {
     vi.useFakeTimers();
     render(

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -829,6 +829,80 @@ describe("NoteEditor", () => {
     }
   });
 
+  it("keeps recording options on Windows after a mic-only readiness check", async () => {
+    // Turning system audio off makes the recording preflight store a
+    // microphoneOnly readiness with no system source. Backend support is a
+    // property of the host, not of the last-checked mode, so the options must
+    // stay visible or the user could never turn system audio back on.
+    const user = userEvent.setup();
+    const onSourceModeChange = vi.fn();
+    const restoreNavigator = stubNavigatorPlatform(
+      "Win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    );
+    const microphoneSource = {
+      source: "microphone" as const,
+      required: true,
+      ready: true,
+      permissionState: "granted" as const,
+      deviceAvailable: true,
+      captureAvailable: true,
+    };
+    try {
+      const { rerender } = render(
+        <NoteEditor
+          {...props}
+          note={note()}
+          sourceMode="microphonePlusSystem"
+          onSourceModeChange={onSourceModeChange}
+          sourceReadiness={{
+            sourceMode: "microphonePlusSystem",
+            ready: true,
+            checkedAt: now,
+            sources: [
+              microphoneSource,
+              {
+                source: "system",
+                required: true,
+                ready: true,
+                permissionState: "granted",
+                deviceAvailable: true,
+                captureAvailable: true,
+              },
+            ],
+          }}
+        />,
+      );
+
+      // System audio switched off; the preflight readiness now covers only
+      // the microphone.
+      rerender(
+        <NoteEditor
+          {...props}
+          note={note()}
+          sourceMode="microphoneOnly"
+          onSourceModeChange={onSourceModeChange}
+          sourceReadiness={{
+            sourceMode: "microphoneOnly",
+            ready: true,
+            checkedAt: now,
+            sources: [microphoneSource],
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: "Recording options" }));
+      const systemSwitch = screen.getByRole("switch", { name: "Capture system audio" });
+      expect(systemSwitch).toBeEnabled();
+
+      // And the user can turn system audio back on.
+      await user.click(systemSwitch);
+      expect(onSourceModeChange).toHaveBeenCalledWith("microphonePlusSystem");
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("surfaces a dismissible consent reminder after the recorder settles", async () => {
     vi.useFakeTimers();
     render(


### PR DESCRIPTION
## Summary

Adds a Windows system-audio capture path for meeting notes, at parity with the
macOS Core Audio tap backend, plus Windows meeting detection. macOS behavior is
unchanged. This is app code only: it does not touch release plumbing, which is
owned by #568.

The Rust work is a port of four proven prior-art commits that were written about
44 main-commits ago and never merged, cherry-picked onto today's main and
adapted where main had moved:

- `refactor(audio): split system-audio capture into per-platform backends` (`65c14c56`)
- `feat(audio): Windows system-audio capture via WASAPI loopback` (`d27a03e9`)
- `build: add windows crate for meeting-detection WASAPI probing` (`23f27e38`)
- `feat(meeting-detection): detect meetings on Windows via WASAPI sessions` (`0433b146`)

### What the port does

- Recording with source mode `microphonePlusSystem` gains a Windows capture
  path via WASAPI loopback (a cpal input stream built on the default render
  device), behind `cfg(target_os = "windows")`. A dedicated writer thread owns
  the WAV file and wall clock so the timeline keeps advancing during silence,
  since loopback delivers no packets while the endpoint is idle. It mirrors the
  macOS helper's observable output: 16-bit int WAV at the device's native
  rate/channels, leading silence for mic alignment, 80 ms-tolerance silence
  fill, and paused wall clock excluded from the timeline. No OS permission is
  required, so readiness reports `granted`.
- The macOS helper is gated behind `cfg(target_os = "macos")` and both backends
  are routed through one re-export in `audio::mod`, so `capture.rs` and
  `commands.rs` stay platform agnostic. A `system_stub` fallback reports
  `unsupported` on platforms without a backend, and a shared `system_timeline`
  module holds the wall-clock/level math with host-agnostic unit tests.
- Meeting detection reaches Windows by enumerating active WASAPI capture
  sessions (`IMMDeviceEnumerator` + `IAudioSessionManager2`), keeping only
  `AudioSessionStateActive` sessions and resolving each pid to an executable
  name. The shared state machine, event payload, and emission are byte-for-byte
  the same as macOS; only the probe source and its allow-list/label lookups
  become platform-specific.

### Ported vs adapted, per commit

- `65c14c56` (backend split): applied cleanly. No adaptation.
- `d27a03e9` (Windows WASAPI backend, new file): applied cleanly. No adaptation.
  Verified the current `SourceReadinessDto` shape still matches the fields it
  constructs.
- `23f27e38` (windows crate dependency): auto-merged. `windows 0.61.3` is
  already present in current main's `Cargo.lock` as a transitive dependency, so
  adding it as a direct dependency with the minimal WASAPI feature set only adds
  the one dependency edge on the `os-june` package. `--locked` builds are
  preserved.
- `0433b146` (Windows meeting detection): one conflict, in the `std::thread`
  import. Main had changed it to an unconditional `use std::{..., thread, ...}`,
  while the port gates `thread` to `any(macos, windows)`. Kept the port's gating
  because it matches exactly where `thread` is used (`spawn_monitor`, now widened
  to `any(macos, windows)`), which keeps the import warning-free on all targets.

### Frontend

Availability was hard-gated to macOS in two places: the settings Audio tab
(`systemUnavailable = !macLikePlatform || ...`) and the note recording options
(`showRecordingOptions = isMacLikePlatform()`). Both now follow the backend
readiness instead, so Windows offers the system-audio toggle when its backend
reports a supported source, while platforms with the stub backend report
`unsupported` and stay hidden. macOS is unchanged (it still qualifies via
`isMacLikePlatform()` and never reports `unsupported`). No macOS-naming copy
needed changing on the Windows path: the only macOS-specific strings render
solely under macOS-gated branches.

## Validation

Validated on a macOS host with no Windows machine, using an MSVC cross-toolchain
(`cargo-xwin` with LLVM `clang-cl`/`llvm-lib`) for the Windows target:

- `cargo xwin check --target x86_64-pc-windows-msvc --locked`: passes. The plain
  `cargo check --target x86_64-pc-windows-msvc` cannot compile `sqlite3-sys`'s C
  bundle from macOS (the MSVC CRT headers are absent), which is a pre-existing
  host-toolchain limitation unrelated to this change; `cargo-xwin` supplies the
  SDK and gets a real type-check of the Windows-gated Rust.
- `cargo xwin clippy --target x86_64-pc-windows-msvc --locked`: clean. The only
  warnings are pre-existing dead-code on the Windows target from macOS-gated
  code in untouched files (`hermes_bridge.rs`, `meeting_hud.rs`, `dictation.rs`);
  none from the ported files.
- `cargo xwin test --no-run --target x86_64-pc-windows-msvc --locked`: all test
  executables compile and link for Windows.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --locked` (macOS): 389
  passed. The full suite (all integration targets) is green too. The 13 ported
  host-agnostic unit tests (10 `system_timeline`, 3 Windows allow-list/label)
  run and pass on macOS.
- `cargo clippy --all-targets --locked` (macOS): zero warnings. `cargo fmt --check`: clean.
- Frontend: `bun install`, `bunx vitest run` for the two touched suites (88
  passed), `bunx tsc --noEmit` clean, and Biome clean on the touched files.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

Runtime verification on real Windows hardware is still pending: the actual
loopback capture, WAV alignment, and live session detection have not been
exercised on a Windows machine. That is deferred to the CI Windows build and
manual QA.

## Out of scope

- Release, packaging, signing, and updater plumbing for Windows and Linux
  (owned by #568). This branch is app code only and deliberately duplicates none
  of it.
- A Windows capture-helper process. `owned_pids` on Windows is just this process
  today; a helper pid slots in under a `windows` cfg when one lands.
- A Linux system-audio backend. The stub is wired so one can slot in the same
  way the Windows backend did.

## Followups

- Real Windows QA: verify loopback capture output, mic/system timeline
  alignment, and meeting detection against Teams, Zoom, and browser calls.
- Revisit the Windows meeting-app allow-list once QA confirms real executable
  names across installers.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None here; see #568.)
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (None.)
- [x] User-facing copy follows the repo UI conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
