### PR TITLE
Confirm, busy state, and grant polling for Upgrade to Max

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -139,11 +139,23 @@ import {
   shouldReplayOnboarding,
 } from "../lib/onboarding";
 import {
+  depletedBalanceAction,
   depletedBalanceActionLabel,
   shouldBlockOnFunding,
   shouldBlockOnSignIn,
 } from "../lib/account-gate";
 import { runDepletedBalanceAction } from "../lib/billing-actions";
+import {
+  MAX_UPGRADE_BUSY_LABEL,
+  MAX_UPGRADE_CONFIRM_BODY,
+  MAX_UPGRADE_CONFIRM_LABEL,
+  MAX_UPGRADE_CONFIRM_TITLE,
+  MAX_UPGRADE_READY_STATUS,
+  MAX_UPGRADE_SLOW_STATUS,
+  MAX_UPGRADE_WAITING_STATUS,
+  pollForMaxGrant,
+} from "../lib/max-upgrade";
+import { ConfirmDialog } from "../components/ui/ConfirmDialog";
 import { checkJuneUpdate, reconcileToStable, relaunchJune, type JuneUpdate } from "../lib/updater";
 import { PROCESSING_DEMO_NOTE_ID, shouldPollProcessingStatus } from "./processing-polling";
 import { attachScrollThumbFade } from "../lib/scroll-thumb-fade";
@@ -502,14 +514,59 @@ export function App() {
   const fundingRequired =
     !devAccountsUnconfigured && !signInRequired && shouldBlockOnFunding(account);
   const topUpLabel = depletedBalanceActionLabel(account);
+  // Confirm gate for the Pro -> Max upgrade reached from depleted-balance
+  // surfaces (note failure banner, agent workspace notice). The change
+  // charges the saved card the moment it runs, so it never fires straight
+  // from those buttons.
+  const [maxUpgradePromptOpen, setMaxUpgradePromptOpen] = useState(false);
+  const [maxUpgradeError, setMaxUpgradeError] = useState<string>();
+  // Transient billing feedback ("You are on Max now...") shown beside the
+  // error banner; cleared automatically once it has been seen.
+  const [billingNotice, setBillingNotice] = useState<string | null>(null);
+  const billingNoticeTimerRef = useRef<number | undefined>(undefined);
+  const showBillingNotice = useCallback((notice: string, autoClearMs?: number) => {
+    window.clearTimeout(billingNoticeTimerRef.current);
+    setBillingNotice(notice);
+    if (autoClearMs) {
+      billingNoticeTimerRef.current = window.setTimeout(() => setBillingNotice(null), autoClearMs);
+    }
+  }, []);
+  const confirmMaxUpgrade = useCallback(async () => {
+    const baselineCredits = account.balance?.credits ?? 0;
+    try {
+      const outcome = await runDepletedBalanceAction(account);
+      if (outcome !== "changed_plan") {
+        // Stale snapshot resolved another way (subscribe prompt): refresh and
+        // let the surfaces re-render; nothing was charged.
+        void refreshAccount();
+        return;
+      }
+    } catch (err) {
+      // Keep the dialog open with the failure inside it, next to retry.
+      setMaxUpgradeError(messageFromError(err));
+      throw err;
+    }
+    // The PATCH resolves before the webhook grants the credits: show interim
+    // feedback and poll briefly until the new balance lands.
+    showBillingNotice(MAX_UPGRADE_WAITING_STATUS);
+    void refreshAccount();
+    void pollForMaxGrant(refreshAccount, baselineCredits).then((landed) => {
+      showBillingNotice(landed ? MAX_UPGRADE_READY_STATUS : MAX_UPGRADE_SLOW_STATUS, 8000);
+    });
+  }, [account, refreshAccount, showBillingNotice]);
   const handleTopUp = useCallback(() => {
     // Tier-aware: Max tops up, Pro upgrades in place to Max, Free subscribes.
-    // changed_plan grants credits immediately with no browser round trip, so
-    // refresh to lift the funding gate. upgrade_required / subscribe_required
-    // mean the server proved our snapshot stale (top-up gated behind Max, or
-    // no active subscription): refresh so the depleted-balance surfaces
-    // re-render as the right prompt and the user chooses explicitly; no raw
-    // error, and never an automatic purchase.
+    // The upgrade is a charge, so it routes through an explicit confirm
+    // dialog. upgrade_required / subscribe_required mean the server proved
+    // our snapshot stale (top-up gated behind Max, or no active
+    // subscription): refresh so the depleted-balance surfaces re-render as
+    // the right prompt and the user chooses explicitly; no raw error, and
+    // never an automatic purchase.
+    if (depletedBalanceAction(account) === "upgrade_to_max") {
+      setMaxUpgradeError(undefined);
+      setMaxUpgradePromptOpen(true);
+      return;
+    }
     runDepletedBalanceAction(account)
       .then((outcome) => {
         if (outcome !== "opened_browser") void refreshAccount();
@@ -2765,6 +2822,11 @@ export function App() {
             data-note-detail-scroller={noteDetailScrollerActive ? "true" : undefined}
           >
             {error ? <p className="error-banner">{error}</p> : null}
+            {billingNotice ? (
+              <p className="notice-banner" role="status">
+                {billingNotice}
+              </p>
+            ) : null}
             <div className="workspace">
               {activeView === "settings" ? (
                 <AppSettings
@@ -3243,6 +3305,15 @@ export function App() {
         folders={state.folders}
         onSetFolder={(sessionId, folderId) => handleSetSessionFolder(sessionId, folderId)}
         onMoved={() => agentSessionsListRef.current?.resetSelection()}
+      />
+      <ConfirmDialog
+        open={maxUpgradePromptOpen}
+        onClose={() => setMaxUpgradePromptOpen(false)}
+        onConfirm={confirmMaxUpgrade}
+        title={MAX_UPGRADE_CONFIRM_TITLE}
+        description={maxUpgradeError ?? MAX_UPGRADE_CONFIRM_BODY}
+        confirmLabel={MAX_UPGRADE_CONFIRM_LABEL}
+        confirmBusyLabel={MAX_UPGRADE_BUSY_LABEL}
       />
     </main>
   );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -549,7 +549,9 @@ export function App() {
     // The PATCH resolves before the webhook grants the credits: show interim
     // feedback and poll briefly until the new balance lands.
     showBillingNotice(MAX_UPGRADE_WAITING_STATUS);
-    void refreshAccount();
+    // No separate refresh: the poll's first tick refreshes immediately, and a
+    // parallel request could resolve out of order and overwrite the poll's
+    // fresher snapshot with a stale pre-grant one.
     void pollForMaxGrant(refreshAccount, baselineCredits).then((landed) => {
       showBillingNotice(landed ? MAX_UPGRADE_READY_STATUS : MAX_UPGRADE_SLOW_STATUS, 8000);
     });

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -223,7 +223,9 @@ export function BillingSettingsSection({
       throw error;
     }
     setBillingStatus(MAX_UPGRADE_WAITING_STATUS);
-    void onRefresh();
+    // No separate refresh: the poll's first tick refreshes immediately, and a
+    // parallel request could resolve out of order and overwrite the poll's
+    // fresher snapshot with a stale pre-grant one.
     void pollForMaxGrant(onRefresh, baselineCredits).then((landed) => {
       setBillingStatus(landed ? MAX_UPGRADE_READY_STATUS : MAX_UPGRADE_SLOW_STATUS);
     });

--- a/src/components/account/AccountSettings.tsx
+++ b/src/components/account/AccountSettings.tsx
@@ -1,7 +1,18 @@
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { useState } from "react";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { hasLiveSubscription } from "../../lib/account-gate";
 import { errorCode } from "../../lib/errors";
+import {
+  MAX_UPGRADE_BUSY_LABEL,
+  MAX_UPGRADE_CONFIRM_BODY,
+  MAX_UPGRADE_CONFIRM_LABEL,
+  MAX_UPGRADE_CONFIRM_TITLE,
+  MAX_UPGRADE_READY_STATUS,
+  MAX_UPGRADE_SLOW_STATUS,
+  MAX_UPGRADE_WAITING_STATUS,
+  pollForMaxGrant,
+} from "../../lib/max-upgrade";
 import {
   BILLING_DEMO_FIXTURES,
   BILLING_DEMO_ORDER,
@@ -165,6 +176,10 @@ export function BillingSettingsSection({
   const [refreshing, setRefreshing] = useState(false);
   const [billingStatus, setBillingStatus] = useState<string>();
   const [spins, setSpins] = useState(0);
+  // The plan awaiting an explicit confirm. A plan change charges the saved
+  // card immediately, so it never fires straight from the card CTA.
+  const [planToConfirm, setPlanToConfirm] = useState<SubscriptionPlan | null>(null);
+  const [confirmError, setConfirmError] = useState<string>();
   const demoPlan = useForcedBillingPlan();
 
   async function handleUpgrade(plan: SubscriptionPlan) {
@@ -176,15 +191,16 @@ export function BillingSettingsSection({
     }
   }
 
-  // In-place upgrade for a paid subscriber (Pro -> Max). Unlike checkout, this
-  // changes the live subscription, so refresh to reflect the new plan and its
-  // freshly granted credits.
+  // In-place upgrade for a paid subscriber (Pro -> Max), run from the confirm
+  // dialog only. The PATCH resolves before the webhook grants the new
+  // credits, so on success this sets a "credits on the way" status and polls
+  // in the background until the grant lands (or a bounded timeout passes).
+  // Real failures rethrow so the dialog stays open showing the error.
   async function handleChangePlan(plan: SubscriptionPlan) {
     const planLabel = plan === "max" ? "Max" : "Pro";
+    const baselineCredits = account.balance?.credits ?? 0;
     try {
       await osAccountsChangePlan(plan);
-      setBillingStatus(`You are now on ${planLabel}. Your new credits are ready.`);
-      await onRefresh();
     } catch (error) {
       const code = errorCode(error);
       if (code === "already_on_plan") {
@@ -201,8 +217,16 @@ export function BillingSettingsSection({
         await onRefresh();
         return;
       }
-      setBillingStatus(messageFromError(error));
+      // Keep the dialog open (ConfirmDialog swallows the rethrow but stays
+      // up) and show the failure inside it, next to the retry affordance.
+      setConfirmError(messageFromError(error));
+      throw error;
     }
+    setBillingStatus(MAX_UPGRADE_WAITING_STATUS);
+    void onRefresh();
+    void pollForMaxGrant(onRefresh, baselineCredits).then((landed) => {
+      setBillingStatus(landed ? MAX_UPGRADE_READY_STATUS : MAX_UPGRADE_SLOW_STATUS);
+    });
   }
 
   async function handleManageSubscription() {
@@ -241,7 +265,11 @@ export function BillingSettingsSection({
     spins,
     onRefresh: () => void handleRefresh(),
     onUpgrade: (plan: SubscriptionPlan) => void handleUpgrade(plan),
-    onChangePlan: (plan: SubscriptionPlan) => void handleChangePlan(plan),
+    // Confirm first: the change charges the saved card the moment it runs.
+    onChangePlan: (plan: SubscriptionPlan) => {
+      setConfirmError(undefined);
+      setPlanToConfirm(plan);
+    },
     onManage: () => void handleManageSubscription(),
   };
 
@@ -266,6 +294,17 @@ export function BillingSettingsSection({
       ) : (
         <BillingCard account={demoAccount ?? account} {...cardProps} />
       )}
+      <ConfirmDialog
+        open={planToConfirm !== null}
+        onClose={() => setPlanToConfirm(null)}
+        onConfirm={async () => {
+          if (planToConfirm) await handleChangePlan(planToConfirm);
+        }}
+        title={MAX_UPGRADE_CONFIRM_TITLE}
+        description={confirmError ?? MAX_UPGRADE_CONFIRM_BODY}
+        confirmLabel={MAX_UPGRADE_CONFIRM_LABEL}
+        confirmBusyLabel={MAX_UPGRADE_BUSY_LABEL}
+      />
     </section>
   );
 }

--- a/src/components/account/FundingGate.tsx
+++ b/src/components/account/FundingGate.tsx
@@ -1,8 +1,16 @@
 import { useEffect, useState } from "react";
 import { hasLiveSubscription, isOnMaxPlan } from "../../lib/account-gate";
 import { errorCode } from "../../lib/errors";
+import {
+  MAX_UPGRADE_BUSY_LABEL,
+  MAX_UPGRADE_CONFIRM_BODY,
+  MAX_UPGRADE_CONFIRM_LABEL,
+  MAX_UPGRADE_CONFIRM_TITLE,
+  pollForMaxGrant,
+} from "../../lib/max-upgrade";
 import { osAccountsChangePlan, osAccountsOpenPortal, osAccountsUpgrade } from "../../lib/tauri";
 import type { AccountStatus, SubscriptionPlan } from "../../lib/tauri";
+import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { Spinner } from "../ui/Spinner";
 import { JuneMark } from "./AccountGate";
 
@@ -27,7 +35,13 @@ type GateCopy = {
 export function FundingGate({ account, onRefresh, onSignOut }: Props) {
   const [openedPortal, setOpenedPortal] = useState(false);
   const [checking, setChecking] = useState(false);
-  const [upgrading, setUpgrading] = useState(false);
+  // Upgrade to Max charges the saved card the moment it runs, so it only
+  // fires from an explicit confirm dialog.
+  const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
+  const [confirmError, setConfirmError] = useState<string>();
+  // True after a successful plan change while the webhook credit grant is
+  // still on its way; the gate lifts (via App's refresh) once it lands.
+  const [awaitingGrant, setAwaitingGrant] = useState(false);
   const [portalError, setPortalError] = useState<string>();
   // Remembered so "Reopen checkout" lands on the same plan the user picked.
   const [chosenPlan, setChosenPlan] = useState<SubscriptionPlan>("pro");
@@ -45,41 +59,50 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
   const proUpgradeRequired = topUpRequired && !isOnMaxPlan(account);
   const maxTopUpRequired = topUpRequired && isOnMaxPlan(account);
 
-  const copy: GateCopy = billingRecovery
+  // The waiting state wins over branch derivation: right after the plan
+  // change PATCH the snapshot reads "depleted Max" (plan flipped, webhook
+  // grant still pending), which would otherwise re-derive as the top-up
+  // prompt mid-upgrade.
+  const copy: GateCopy = awaitingGrant
     ? {
-        title: "Update billing",
-        subtitle: "Your payment needs attention. Update billing to keep using June.",
-        cta: "Manage billing",
-        waiting: "Waiting for your billing update",
-        reopen: "Reopen billing",
+        title: "Setting up Max",
+        subtitle: "Your upgrade went through. Your new credits are on the way.",
+        cta: "",
       }
-    : proUpgradeRequired
+    : billingRecovery
       ? {
-          // No waiting/reopen copy: the in-place upgrade never opens the
-          // browser (openedPortal stays false), and after a failure the
-          // primary CTA itself stays enabled with the error below, so it is
-          // the retry affordance.
-          title: "Upgrade to Max",
-          subtitle:
-            "You have used your Pro credits for this cycle. Upgrade to Max for 5x the monthly usage.",
-          cta: "Upgrade to Max",
+          title: "Update billing",
+          subtitle: "Your payment needs attention. Update billing to keep using June.",
+          cta: "Manage billing",
+          waiting: "Waiting for your billing update",
+          reopen: "Reopen billing",
         }
-      : maxTopUpRequired
+      : proUpgradeRequired
         ? {
-            title: "Top up credits",
-            subtitle: "Your credit balance is below zero. Top up credits to keep using June.",
-            cta: "Top up credits",
-            waiting: "Waiting for your top-up",
-            reopen: "Reopen account portal",
-          }
-        : {
-            title: "Upgrade to continue",
+            // No waiting/reopen copy: the in-place upgrade never opens the
+            // browser (openedPortal stays false). Failures show inside the
+            // confirm dialog, which stays open as the retry affordance.
+            title: "Upgrade to Max",
             subtitle:
-              "Your starter credits are used up. Upgrade to a paid plan to keep using June.",
-            cta: "Upgrade to Pro",
-            waiting: "Waiting for your upgrade",
-            reopen: "Reopen checkout",
-          };
+              "You have used your Pro credits for this cycle. Upgrade to Max for 5x the monthly usage.",
+            cta: "Upgrade to Max",
+          }
+        : maxTopUpRequired
+          ? {
+              title: "Top up credits",
+              subtitle: "Your credit balance is below zero. Top up credits to keep using June.",
+              cta: "Top up credits",
+              waiting: "Waiting for your top-up",
+              reopen: "Reopen account portal",
+            }
+          : {
+              title: "Upgrade to continue",
+              subtitle:
+                "Your starter credits are used up. Upgrade to a paid plan to keep using June.",
+              cta: "Upgrade to Pro",
+              waiting: "Waiting for your upgrade",
+              reopen: "Reopen checkout",
+            };
   // The Max upsell link only belongs on the Free/subscribe path; a depleted Pro
   // user already has exactly one path (upgrade to Max), and depleted Max users
   // top up. Neither shows a second affordance.
@@ -107,14 +130,15 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
     }
   }
 
-  // In-place Pro -> Max upgrade: OS Accounts prorates and grants Max credits
-  // immediately, so there is no browser to wait on. Refresh to lift the gate.
+  // In-place Pro -> Max upgrade, run from the confirm dialog only. The PATCH
+  // resolves before the webhook grants the new credits, so on success the
+  // gate flips to a waiting panel and polls until the balance reflects Max;
+  // App's refresh then lifts the gate. Real failures rethrow so the dialog
+  // stays open showing the error next to its retry affordance.
   async function handleUpgradeToMax() {
-    setPortalError(undefined);
-    setUpgrading(true);
+    const baselineCredits = account.balance?.credits ?? 0;
     try {
       await osAccountsChangePlan("max");
-      await onRefresh();
     } catch (error) {
       const code = errorCode(error);
       if (code === "already_on_plan" || code === "subscription_required") {
@@ -124,10 +148,16 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
         await onRefresh();
         return;
       }
-      setPortalError(messageFromError(error));
-    } finally {
-      setUpgrading(false);
+      setConfirmError(messageFromError(error));
+      throw error;
     }
+    setAwaitingGrant(true);
+    void onRefresh();
+    void pollForMaxGrant(onRefresh, baselineCredits).then(() => {
+      // Landed: the poll's refresh already lifted the gate. Timed out: drop
+      // back to the prompt state; the periodic refresh keeps reconciling.
+      setAwaitingGrant(false);
+    });
   }
 
   async function handleCheckNow() {
@@ -149,14 +179,31 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
         <p className="welcome-subtitle">{copy.subtitle}</p>
 
         <div className="welcome-providers">
-          {proUpgradeRequired ? (
+          {awaitingGrant ? (
+            <div className="welcome-auth-progress" role="status" aria-live="polite">
+              <span className="welcome-progress-label">
+                <Spinner className="welcome-spinner" aria-hidden />
+                <span>Waiting for your new credits</span>
+              </span>
+              <button
+                type="button"
+                className="welcome-cancel-btn"
+                disabled={checking}
+                onClick={() => void handleCheckNow()}
+              >
+                {checking ? "Checking..." : "Check again"}
+              </button>
+            </div>
+          ) : proUpgradeRequired ? (
             <button
               type="button"
               className="primary-action"
-              disabled={upgrading}
-              onClick={() => void handleUpgradeToMax()}
+              onClick={() => {
+                setConfirmError(undefined);
+                setConfirmingUpgrade(true);
+              }}
             >
-              {upgrading ? "Upgrading..." : copy.cta}
+              {copy.cta}
             </button>
           ) : openedPortal ? (
             <>
@@ -219,6 +266,15 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
           </button>
         </p>
       </div>
+      <ConfirmDialog
+        open={confirmingUpgrade}
+        onClose={() => setConfirmingUpgrade(false)}
+        onConfirm={handleUpgradeToMax}
+        title={MAX_UPGRADE_CONFIRM_TITLE}
+        description={confirmError ?? MAX_UPGRADE_CONFIRM_BODY}
+        confirmLabel={MAX_UPGRADE_CONFIRM_LABEL}
+        confirmBusyLabel={MAX_UPGRADE_BUSY_LABEL}
+      />
     </div>
   );
 }

--- a/src/components/account/FundingGate.tsx
+++ b/src/components/account/FundingGate.tsx
@@ -152,7 +152,9 @@ export function FundingGate({ account, onRefresh, onSignOut }: Props) {
       throw error;
     }
     setAwaitingGrant(true);
-    void onRefresh();
+    // No separate refresh here: the poll's first tick refreshes immediately,
+    // and a parallel request could resolve out of order and overwrite the
+    // poll's fresher snapshot with a stale pre-grant one.
     void pollForMaxGrant(onRefresh, baselineCredits).then(() => {
       // Landed: the poll's refresh already lifted the gate. Timed out: drop
       // back to the prompt state; the periodic refresh keeps reconciling.

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -9,6 +9,10 @@ type ConfirmDialogProps = {
   title: ReactNode;
   description?: ReactNode;
   confirmLabel?: string;
+  /** Label shown on the confirm button while onConfirm is in flight, for
+   * consequential actions whose pending state should read as progress
+   * ("Upgrading...") rather than a frozen button. */
+  confirmBusyLabel?: string;
   cancelLabel?: string;
   destructive?: boolean;
 };
@@ -20,6 +24,7 @@ export function ConfirmDialog({
   title,
   description,
   confirmLabel = "Confirm",
+  confirmBusyLabel,
   cancelLabel = "Cancel",
   destructive = false,
 }: ConfirmDialogProps) {
@@ -57,8 +62,9 @@ export function ConfirmDialog({
             className={`primary-action primary-solid${destructive ? " primary-destructive" : ""}`}
             onClick={() => void handleConfirm()}
             disabled={submitting}
+            aria-busy={submitting || undefined}
           >
-            {confirmLabel}
+            {submitting && confirmBusyLabel ? confirmBusyLabel : confirmLabel}
           </button>
         </>
       }

--- a/src/lib/max-upgrade.ts
+++ b/src/lib/max-upgrade.ts
@@ -1,0 +1,64 @@
+import type { AccountStatus } from "./tauri";
+
+// Single source of truth for the Max upgrade confirm and status copy. The
+// charge semantics live in the backend (today: full charge with the billing
+// cycle restarting immediately); if they shift, this is the ONE place the
+// wording changes.
+export const MAX_UPGRADE_CONFIRM_TITLE = "Upgrade to Max?";
+export const MAX_UPGRADE_CONFIRM_BODY =
+  "Max is $100 per month, charged to your saved card now. Your billing cycle restarts today.";
+export const MAX_UPGRADE_CONFIRM_LABEL = "Upgrade now";
+export const MAX_UPGRADE_BUSY_LABEL = "Upgrading...";
+// The PATCH returns before the credit grant lands (it arrives via webhook a
+// moment later), so success feedback comes in two steps.
+export const MAX_UPGRADE_WAITING_STATUS = "You are on Max now. Your new credits are on the way.";
+export const MAX_UPGRADE_READY_STATUS = "You are on Max now. Your new credits are ready.";
+export const MAX_UPGRADE_SLOW_STATUS =
+  "You are on Max now. Credits are taking longer than usual; refresh in a moment.";
+
+export const MAX_GRANT_POLL_INTERVAL_MS = 2500;
+export const MAX_GRANT_POLL_TIMEOUT_MS = 30_000;
+
+/** Whether a refreshed snapshot shows the Max credit grant landed: the plan
+ * flipped to Max AND the balance rose above where it stood before the
+ * upgrade (a depleted account crossing back over zero also qualifies). */
+export function maxGrantLanded(
+  account: AccountStatus | undefined,
+  baselineCredits: number,
+): boolean {
+  if (account?.subscription?.plan !== "max") return false;
+  const credits = account.balance?.credits;
+  return typeof credits === "number" && credits > Math.max(baselineCredits, 0);
+}
+
+export type MaxGrantPollOptions = {
+  intervalMs?: number;
+  timeoutMs?: number;
+};
+
+/** Polls `refresh` until the Max grant lands or the timeout passes. The plan
+ * change PATCH resolves before the webhook grants the new credits, so
+ * surfaces poll briefly instead of parking on a stale balance. Resolves true
+ * once the grant is visible (the last `refresh` has already pushed the fresh
+ * snapshot to the caller's state), false on timeout. */
+export async function pollForMaxGrant(
+  refresh: () => Promise<AccountStatus | undefined>,
+  baselineCredits: number,
+  options: MaxGrantPollOptions = {},
+): Promise<boolean> {
+  const intervalMs = options.intervalMs ?? MAX_GRANT_POLL_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? MAX_GRANT_POLL_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const next = await refresh();
+    if (maxGrantLanded(next, baselineCredits)) return true;
+    if (Date.now() + intervalMs > deadline) return false;
+    await sleep(intervalMs);
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}

--- a/src/lib/max-upgrade.ts
+++ b/src/lib/max-upgrade.ts
@@ -40,7 +40,12 @@ export type MaxGrantPollOptions = {
  * change PATCH resolves before the webhook grants the new credits, so
  * surfaces poll briefly instead of parking on a stale balance. Resolves true
  * once the grant is visible (the last `refresh` has already pushed the fresh
- * snapshot to the caller's state), false on timeout. */
+ * snapshot to the caller's state), false on timeout.
+ *
+ * The returned promise ALWAYS resolves, never rejects: callers chain their
+ * cleanup (clearing waiting panels and statuses) on the resolution, so a
+ * rejection would pin those surfaces forever. A refresh that throws on one
+ * tick is a transient miss and the poll keeps going until the deadline. */
 export async function pollForMaxGrant(
   refresh: () => Promise<AccountStatus | undefined>,
   baselineCredits: number,
@@ -49,10 +54,20 @@ export async function pollForMaxGrant(
   const intervalMs = options.intervalMs ?? MAX_GRANT_POLL_INTERVAL_MS;
   const timeoutMs = options.timeoutMs ?? MAX_GRANT_POLL_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
+  let lastRefreshError: unknown;
   for (;;) {
-    const next = await refresh();
-    if (maxGrantLanded(next, baselineCredits)) return true;
-    if (Date.now() + intervalMs > deadline) return false;
+    try {
+      const next = await refresh();
+      if (maxGrantLanded(next, baselineCredits)) return true;
+    } catch (error) {
+      lastRefreshError = error;
+    }
+    if (Date.now() + intervalMs > deadline) {
+      if (lastRefreshError !== undefined) {
+        console.debug("[max-upgrade] grant poll timed out with refresh failures", lastRefreshError);
+      }
+      return false;
+    }
     await sleep(intervalMs);
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9309,6 +9309,18 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
+/* Positive sibling of .error-banner for transient good news (billing
+ * feedback like "You are on Max now"). Same geometry, success palette. */
+.notice-banner {
+  margin: 0 0 var(--sp-5);
+  padding: var(--sp-3) var(--sp-4);
+  border: 1px solid color-mix(in oklch, var(--success) 40%, transparent);
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--success) 12%, transparent);
+  color: color-mix(in oklch, var(--success) 60%, var(--foreground));
+  font-size: var(--fs-md);
+}
+
 /* Agent variant: actions on the right, and breathing room below the sticky
  * session bar instead of sitting on its bottom edge. */
 .agent-main > .agent-error-banner {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   osAccountsCancelLogin: vi.fn(),
   osAccountsLogout: vi.fn(),
   osAccountsUpgrade: vi.fn(),
+  osAccountsChangePlan: vi.fn(),
   agentHudShow: vi.fn(),
   agentHudHide: vi.fn(),
   playRecordingSound: vi.fn(),
@@ -110,6 +111,7 @@ vi.mock("../lib/tauri", () => ({
   osAccountsCancelLogin: mocks.osAccountsCancelLogin,
   osAccountsLogout: mocks.osAccountsLogout,
   osAccountsUpgrade: mocks.osAccountsUpgrade,
+  osAccountsChangePlan: mocks.osAccountsChangePlan,
   agentHudShow: mocks.agentHudShow,
   agentHudHide: mocks.agentHudHide,
   // The agent workspace mounts at launch; a quiet, not-running bridge keeps
@@ -291,6 +293,11 @@ describe("notes recording reliability", () => {
     mocks.osAccountsLogout.mockResolvedValue(undefined);
     mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
     mocks.osAccountsUpgrade.mockResolvedValue(undefined);
+    mocks.osAccountsChangePlan.mockResolvedValue({
+      subscribed: true,
+      status: "active",
+      plan: "max",
+    });
     mocks.updateNote.mockImplementation(async (input) => ({
       ...first,
       ...input,
@@ -822,5 +829,60 @@ describe("notes recording reliability", () => {
         activeTab: "transcription",
       }),
     );
+  });
+
+  it("confirms before upgrading a Pro subscriber to Max from the failure banner", async () => {
+    const failedNote = {
+      ...first,
+      processingStatus: "failed" as const,
+      lastError: "Your balance is too low. Upgrade to continue.",
+    };
+    const proAccount: AccountStatus = {
+      signedIn: true,
+      configured: true,
+      user: { id: "usr_123", handle: "alex" },
+      balance: { credits: 10, usdMillis: 10 },
+      subscription: { subscribed: true, status: "active", plan: "pro" },
+    };
+    mocks.osAccountsStatus.mockResolvedValue(proAccount);
+    mocks.bootstrapApp.mockResolvedValue({
+      folders: [],
+      notes: [failedNote, second],
+      activeRecoveries: [],
+      providerConfigured: true,
+    });
+    mocks.getNote.mockImplementation(async (noteId: string) =>
+      noteId === "note-2" ? second : failedNote,
+    );
+
+    render(<App />);
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    await userEvent.click(await screen.findByRole("button", { name: "Meeting notes" }));
+    await userEvent.click(screen.getByRole("button", { name: /First note Preview/ }));
+
+    // The banner's action is the tier-correct in-place upgrade, and it never
+    // charges without an explicit confirm.
+    await userEvent.click(await screen.findByRole("button", { name: "Upgrade to Max" }));
+    expect(
+      await screen.findByText(
+        "Max is $100 per month, charged to your saved card now. Your billing cycle restarts today.",
+      ),
+    ).toBeInTheDocument();
+    expect(mocks.osAccountsChangePlan).not.toHaveBeenCalled();
+
+    // After the PATCH, the post-upgrade poll's refresh already reports the
+    // granted Max balance, so the success feedback lands immediately.
+    mocks.osAccountsStatus.mockResolvedValue({
+      ...proAccount,
+      balance: { credits: 50_000, usdMillis: 50_000 },
+      subscription: { subscribed: true, status: "active", plan: "max" },
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Upgrade now" }));
+
+    expect(mocks.osAccountsChangePlan).toHaveBeenCalledTimes(1);
+    expect(mocks.osAccountsChangePlan).toHaveBeenCalledWith("max");
+    expect(
+      await screen.findByText("You are on Max now. Your new credits are ready."),
+    ).toBeInTheDocument();
   });
 });

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppSettings } from "../components/settings/AppSettings";
-import type { DictationSettingsDto } from "../lib/tauri";
+import type { AccountStatus, DictationSettingsDto } from "../lib/tauri";
 import { APP_COMMIT_HASH, APP_VERSION } from "../app/build-info";
 import { AGENT_HUD_ENABLED_KEY } from "../lib/agent-hud-settings";
 import { MESSAGING_PLATFORMS_LOAD_TIMEOUT_MS } from "../lib/hermes-messaging";
@@ -842,9 +842,9 @@ describe("AppSettings", () => {
     expect(screen.queryByRole("button", { name: "Upgrade to Pro" })).not.toBeInTheDocument();
   });
 
-  it("lets a Pro subscriber upgrade in place to Max", async () => {
-    const user = userEvent.setup();
-    const onAccountRefresh = vi.fn(async () => undefined);
+  function renderProBillingSettings(
+    onAccountRefresh: () => Promise<AccountStatus | undefined> = vi.fn(async () => undefined),
+  ) {
     render(
       <AppSettings
         account={{
@@ -861,16 +861,97 @@ describe("AppSettings", () => {
         onEnableSystemAudio={vi.fn()}
       />,
     );
+    return onAccountRefresh;
+  }
+
+  const MAX_CONFIRM_BODY =
+    "Max is $100 per month, charged to your saved card now. Your billing cycle restarts today.";
+
+  it("never changes plans without an explicit confirm", async () => {
+    const user = userEvent.setup();
+    renderProBillingSettings();
 
     await user.click(screen.getByRole("tab", { name: "Billing" }));
     await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+
+    // The CTA opens the charge confirm; nothing has been billed yet.
+    expect(await screen.findByText(MAX_CONFIRM_BODY)).toBeInTheDocument();
+    expect(mocks.osAccountsChangePlan).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mocks.osAccountsChangePlan).not.toHaveBeenCalled();
+    expect(screen.queryByText(MAX_CONFIRM_BODY)).toBeNull();
+  });
+
+  it("lets a Pro subscriber upgrade in place to Max after confirming", async () => {
+    const user = userEvent.setup();
+    // The poll's first refresh already shows the granted Max balance.
+    const onAccountRefresh = renderProBillingSettings(
+      vi.fn(async () => ({
+        ...signedInAccount,
+        balance: { credits: 50_000, usdMillis: 50_000, usageRemainingPercent: 100 },
+        subscription: { subscribed: true, status: "active", plan: "max" },
+      })),
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+    await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await user.click(await screen.findByRole("button", { name: "Upgrade now" }));
 
     expect(mocks.osAccountsChangePlan).toHaveBeenCalledTimes(1);
     expect(mocks.osAccountsChangePlan).toHaveBeenCalledWith("max");
     // In-place change is not a browser checkout.
     expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
-    // Refreshes so the card reflects the new plan and its granted credits.
+    // The PATCH lands before the webhook grant, so the poll refreshes until
+    // the balance reflects Max and the status flips to "ready".
+    expect(
+      await screen.findByText("You are on Max now. Your new credits are ready."),
+    ).toBeInTheDocument();
     await waitFor(() => expect(onAccountRefresh).toHaveBeenCalled());
+  });
+
+  it("shows a pending confirm state and blocks double-fires while the change is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveChange: ((value: unknown) => void) | undefined;
+    mocks.osAccountsChangePlan.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveChange = resolve;
+        }),
+    );
+    renderProBillingSettings();
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+    await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    const confirm = await screen.findByRole("button", { name: "Upgrade now" });
+    await user.click(confirm);
+
+    // Busy feedback while the PATCH is in flight, disabled against a second
+    // fire; a rapid second click must not charge twice.
+    const busy = await screen.findByRole("button", { name: "Upgrading..." });
+    expect(busy).toBeDisabled();
+    fireEvent.click(busy);
+    expect(mocks.osAccountsChangePlan).toHaveBeenCalledTimes(1);
+
+    resolveChange?.({ subscribed: true, plan: "max", status: "active" });
+    await waitFor(() => expect(screen.queryByText(MAX_CONFIRM_BODY)).toBeNull());
+  });
+
+  it("keeps the confirm open showing the failure when the change errors", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsChangePlan.mockRejectedValueOnce({
+      code: "network_error",
+      message: "Could not reach OS Accounts.",
+    });
+    renderProBillingSettings();
+
+    await user.click(screen.getByRole("tab", { name: "Billing" }));
+    await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await user.click(await screen.findByRole("button", { name: "Upgrade now" }));
+
+    // The dialog stays up as the retry affordance, with the error inside it.
+    expect(await screen.findByText("Could not reach OS Accounts.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upgrade now" })).toBeEnabled();
   });
 
   it("treats already_on_plan as a benign refresh, not an error", async () => {
@@ -880,25 +961,11 @@ describe("AppSettings", () => {
       code: "already_on_plan",
       message: "You are already on this plan.",
     });
-    render(
-      <AppSettings
-        account={{
-          ...signedInAccount,
-          balance: { credits: 1200, usdMillis: 1200, usageRemainingPercent: 40 },
-          subscription: { subscribed: true, status: "active", plan: "pro" },
-        }}
-        accountLoading={false}
-        sourceMode="microphoneOnly"
-        checkingSourceReadiness={false}
-        onAccountChanged={vi.fn()}
-        onAccountRefresh={onAccountRefresh}
-        onSourceModeChange={vi.fn()}
-        onEnableSystemAudio={vi.fn()}
-      />,
-    );
+    renderProBillingSettings(onAccountRefresh);
 
     await user.click(screen.getByRole("tab", { name: "Billing" }));
     await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await user.click(await screen.findByRole("button", { name: "Upgrade now" }));
 
     // Benign copy plus a refresh so the card shows the server's current plan.
     expect(await screen.findByText("You are already on Max.")).toBeInTheDocument();

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -907,7 +907,10 @@ describe("AppSettings", () => {
     expect(
       await screen.findByText("You are on Max now. Your new credits are ready."),
     ).toBeInTheDocument();
-    await waitFor(() => expect(onAccountRefresh).toHaveBeenCalled());
+    // Single ordered refresh path: the poll's immediate tick is the only
+    // refresh, so a stale parallel response can never overwrite the granted
+    // Max snapshot.
+    await waitFor(() => expect(onAccountRefresh).toHaveBeenCalledTimes(1));
   });
 
   it("shows a pending confirm state and blocks double-fires while the change is in flight", async () => {

--- a/src/test/funding-gate.test.tsx
+++ b/src/test/funding-gate.test.tsx
@@ -181,7 +181,10 @@ describe("FundingGate", () => {
       screen.getByText("Your upgrade went through. Your new credits are on the way."),
     ).toBeInTheDocument();
     expect(screen.queryByText("Top up credits")).toBeNull();
-    expect(onRefresh).toHaveBeenCalled();
+    // Single ordered refresh path: only the poll's immediate tick runs, never
+    // a parallel fire-and-forget refresh that could resolve out of order and
+    // overwrite the poll's fresher snapshot with a stale pre-grant one.
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
   });
 
   it("cancelling the upgrade confirm never charges", async () => {

--- a/src/test/funding-gate.test.tsx
+++ b/src/test/funding-gate.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FundingGate } from "../components/account/FundingGate";
@@ -128,9 +128,10 @@ describe("FundingGate", () => {
     expect(mocks.osAccountsChangePlan).not.toHaveBeenCalled();
   });
 
-  it("offers a depleted Pro subscriber exactly one path: upgrade to Max in place", async () => {
-    const user = userEvent.setup();
-    const onRefresh = vi.fn(async () => baseAccount);
+  const MAX_CONFIRM_BODY =
+    "Max is $100 per month, charged to your saved card now. Your billing cycle restarts today.";
+
+  function renderDepletedProGate(onRefresh = vi.fn(async () => baseAccount)) {
     render(
       <FundingGate
         account={{
@@ -142,6 +143,12 @@ describe("FundingGate", () => {
         onSignOut={vi.fn()}
       />,
     );
+    return onRefresh;
+  }
+
+  it("offers a depleted Pro subscriber exactly one path: upgrade to Max in place", async () => {
+    const user = userEvent.setup();
+    const onRefresh = renderDepletedProGate();
 
     expect(screen.getByRole("heading", { name: "Upgrade to Max" })).toBeInTheDocument();
     expect(
@@ -153,39 +160,73 @@ describe("FundingGate", () => {
     expect(screen.queryByRole("button", { name: "Top up credits" })).not.toBeInTheDocument();
     expect(screen.queryByText("Want to go beyond Pro?")).not.toBeInTheDocument();
 
+    // The CTA opens the charge confirm; nothing is billed until confirmed.
     await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    expect(await screen.findByText(MAX_CONFIRM_BODY)).toBeInTheDocument();
+    expect(mocks.osAccountsChangePlan).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Upgrade now" }));
     expect(mocks.osAccountsChangePlan).toHaveBeenCalledWith("max");
-    // In-place upgrade grants credits immediately, so it refreshes rather than
-    // opening a browser or hitting checkout.
+    expect(mocks.osAccountsChangePlan).toHaveBeenCalledTimes(1);
+    // In-place upgrade never opens a browser or hits checkout.
     expect(mocks.osAccountsOpenPortal).not.toHaveBeenCalled();
     expect(mocks.osAccountsUpgrade).not.toHaveBeenCalled();
+    // The credit grant lands via webhook after the PATCH: the gate flips to a
+    // waiting panel and polls the account until the balance reflects Max. The
+    // waiting state wins over branch derivation, so the mid-upgrade snapshot
+    // (plan Max, credits still depleted) can never re-derive as a top-up
+    // prompt.
+    expect(await screen.findByRole("heading", { name: "Setting up Max" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Your upgrade went through. Your new credits are on the way."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Top up credits")).toBeNull();
     expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it("cancelling the upgrade confirm never charges", async () => {
+    const user = userEvent.setup();
+    renderDepletedProGate();
+
+    await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await screen.findByText(MAX_CONFIRM_BODY);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mocks.osAccountsChangePlan).not.toHaveBeenCalled();
+    expect(screen.queryByText(MAX_CONFIRM_BODY)).toBeNull();
+    // Back on the prompt, ready to try again.
+    expect(screen.getByRole("button", { name: "Upgrade to Max" })).toBeInTheDocument();
+  });
+
+  it("keeps the confirm open showing the failure when the change errors", async () => {
+    const user = userEvent.setup();
+    mocks.osAccountsChangePlan.mockRejectedValueOnce({
+      code: "network_error",
+      message: "Could not reach OS Accounts.",
+    });
+    renderDepletedProGate();
+
+    await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await user.click(await screen.findByRole("button", { name: "Upgrade now" }));
+
+    expect(await screen.findByText("Could not reach OS Accounts.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upgrade now" })).toBeEnabled();
   });
 
   it("recovers a stale plan-change rejection by refreshing, not erroring", async () => {
     const user = userEvent.setup();
-    const onRefresh = vi.fn(async () => baseAccount);
     mocks.osAccountsChangePlan.mockRejectedValueOnce({
       code: "already_on_plan",
       message: "You are already on this plan.",
     });
-    render(
-      <FundingGate
-        account={{
-          ...baseAccount,
-          balance: { credits: -1, usdMillis: -1 },
-          subscription: { subscribed: true, status: "active", plan: "pro" },
-        }}
-        onRefresh={onRefresh}
-        onSignOut={vi.fn()}
-      />,
-    );
+    const onRefresh = renderDepletedProGate();
 
     await user.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await user.click(await screen.findByRole("button", { name: "Upgrade now" }));
 
     // The gate refreshes and re-derives the right prompt; the stale-state
     // rejection never surfaces as an error message.
-    expect(onRefresh).toHaveBeenCalled();
+    await waitFor(() => expect(onRefresh).toHaveBeenCalled());
     expect(screen.queryByText("You are already on this plan.")).toBeNull();
   });
 

--- a/src/test/max-upgrade.test.ts
+++ b/src/test/max-upgrade.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { maxGrantLanded, pollForMaxGrant } from "../lib/max-upgrade";
+import type { AccountStatus } from "../lib/tauri";
+
+function account(plan: string, credits: number): AccountStatus {
+  return {
+    signedIn: true,
+    configured: true,
+    user: { id: "usr_1", handle: "alex" },
+    balance: { credits, usdMillis: credits },
+    subscription: { subscribed: true, status: "active", plan },
+  };
+}
+
+describe("maxGrantLanded", () => {
+  it("requires the plan to be Max", () => {
+    expect(maxGrantLanded(account("pro", 50_000), 4000)).toBe(false);
+  });
+
+  it("requires the balance to rise above the pre-upgrade baseline", () => {
+    // PATCH done, webhook grant not yet landed: plan is Max, credits stale.
+    expect(maxGrantLanded(account("max", 4000), 4000)).toBe(false);
+    expect(maxGrantLanded(account("max", 50_000), 4000)).toBe(true);
+  });
+
+  it("treats crossing back over zero as landed for depleted accounts", () => {
+    // Depleted baseline is negative; any positive balance means the grant hit.
+    expect(maxGrantLanded(account("max", -120), -120)).toBe(false);
+    expect(maxGrantLanded(account("max", 49_880), -120)).toBe(true);
+  });
+
+  it("is false without a snapshot or credits reading", () => {
+    expect(maxGrantLanded(undefined, 0)).toBe(false);
+    expect(
+      maxGrantLanded(
+        {
+          signedIn: true,
+          configured: true,
+          subscription: { subscribed: true, status: "active", plan: "max" },
+        },
+        0,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("pollForMaxGrant", () => {
+  it("polls staged snapshots until the grant lands", async () => {
+    const refresh = vi
+      .fn<() => Promise<AccountStatus | undefined>>()
+      // PATCH returned, plan flipped, credits still stale...
+      .mockResolvedValueOnce(account("max", -120))
+      .mockResolvedValueOnce(account("max", -120))
+      // ...then the webhook grant lands.
+      .mockResolvedValue(account("max", 49_880));
+
+    const landed = await pollForMaxGrant(refresh, -120, { intervalMs: 5, timeoutMs: 1000 });
+
+    expect(landed).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(3);
+  });
+
+  it("resolves immediately when the first refresh already shows the grant", async () => {
+    const refresh = vi
+      .fn<() => Promise<AccountStatus | undefined>>()
+      .mockResolvedValue(account("max", 50_000));
+
+    const landed = await pollForMaxGrant(refresh, 4000, { intervalMs: 5, timeoutMs: 1000 });
+
+    expect(landed).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after the timeout and stops polling", async () => {
+    const refresh = vi
+      .fn<() => Promise<AccountStatus | undefined>>()
+      .mockResolvedValue(account("max", -120));
+
+    const landed = await pollForMaxGrant(refresh, -120, { intervalMs: 10, timeoutMs: 45 });
+
+    expect(landed).toBe(false);
+    // Bounded: interval 10ms with a 45ms budget can fit at most a handful of
+    // polls; the point is it stopped rather than looping forever.
+    const calls = refresh.mock.calls.length;
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(calls).toBeLessThanOrEqual(6);
+    const callsAfterReturn = refresh.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(refresh.mock.calls.length).toBe(callsAfterReturn);
+  });
+
+  it("keeps polling past refreshes that fail to resolve a snapshot", async () => {
+    const refresh = vi
+      .fn<() => Promise<AccountStatus | undefined>>()
+      // A transient refresh failure surfaces as undefined, not a throw.
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue(account("max", 50_000));
+
+    const landed = await pollForMaxGrant(refresh, 0, { intervalMs: 5, timeoutMs: 1000 });
+
+    expect(landed).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/test/max-upgrade.test.ts
+++ b/src/test/max-upgrade.test.ts
@@ -101,4 +101,76 @@ describe("pollForMaxGrant", () => {
     expect(landed).toBe(true);
     expect(refresh).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps polling through a refresh that rejects, then completes on the grant", async () => {
+    const refresh = vi
+      .fn<() => Promise<AccountStatus | undefined>>()
+      // A refresh that throws (instead of resolving undefined) is a
+      // transient miss, not a reason to abort the poll.
+      .mockRejectedValueOnce(new Error("network wobble"))
+      .mockResolvedValue(account("max", 50_000));
+    const cleanup = vi.fn();
+
+    const landed = await pollForMaxGrant(refresh, 0, { intervalMs: 5, timeoutMs: 1000 }).then(
+      (result) => {
+        cleanup();
+        return result;
+      },
+    );
+
+    expect(landed).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    // The caller's cleanup chain ran; nothing rejected.
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("always resolves so caller cleanup runs even when every refresh rejects", async () => {
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      const refresh = vi
+        .fn<() => Promise<AccountStatus | undefined>>()
+        .mockRejectedValue(new Error("accounts unreachable"));
+      const cleanup = vi.fn();
+
+      // Mirrors the component chains (.then(() => setAwaitingGrant(false))):
+      // a rejection here would pin the waiting panels forever.
+      const landed = await pollForMaxGrant(refresh, 0, { intervalMs: 5, timeoutMs: 30 }).then(
+        (result) => {
+          cleanup();
+          return result;
+        },
+      );
+
+      expect(landed).toBe(false);
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(refresh.mock.calls.length).toBeGreaterThanOrEqual(2);
+      // Persistent failure leaves a debug trail instead of a rejection.
+      expect(debug).toHaveBeenCalled();
+    } finally {
+      debug.mockRestore();
+    }
+  });
+
+  it("issues refreshes strictly one at a time, never in parallel", async () => {
+    // The poll is the single refresh path after an upgrade; overlapping
+    // requests could resolve out of order and let a stale pre-grant snapshot
+    // overwrite a fresh Max one. Serialized awaits make that impossible.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let call = 0;
+    const refresh = vi.fn(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      inFlight -= 1;
+      call += 1;
+      return call >= 3 ? account("max", 50_000) : account("max", -120);
+    });
+
+    const landed = await pollForMaxGrant(refresh, -120, { intervalMs: 5, timeoutMs: 1000 });
+
+    expect(landed).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(3);
+    expect(maxInFlight).toBe(1);
+  });
 });


### PR DESCRIPTION
## What

Hardens the in-place Pro to Max upgrade (#599) against the two problems operator testing surfaced: it fired with no confirmation and no busy feedback, and the app never showed the increased credits afterwards (the grant lands via webhook after the PATCH returns).

- **Explicit confirm everywhere `osAccountsChangePlan` fires.** The billing card CTA, the depleted-Pro funding gate, and the depleted-balance banner path (note failure banner / agent workspace notice, via App) now open the house `ConfirmDialog` before anything is charged: "Max is $100 per month, charged to your saved card now. Your billing cycle restarts today." Cancel never charges. The copy is centralized in `src/lib/max-upgrade.ts`, so if the backend charge semantics shift it is a one-line edit.
- **Busy state.** `ConfirmDialog` gains an optional `confirmBusyLabel`; while the PATCH is in flight the confirm button reads "Upgrading...", is disabled, and double-clicks cannot double-charge.
- **Post-upgrade grant polling.** `pollForMaxGrant` refreshes account + subscription every 2.5s for up to 30s until the balance reflects the new plan, then stops. Settings shows "You are on Max now. Your new credits are on the way." then "...ready."; the funding gate shows a dedicated "Setting up Max" waiting panel; the App path shows a success notice banner (new `.notice-banner`, success-toned sibling of `.error-banner`).
- **Waiting state wins over branch derivation.** Found during QA: right after the PATCH the snapshot reads "depleted Max" (plan flipped, credits pending), which re-derived the funding gate as a top-up prompt mid-upgrade. The awaiting-grant state now takes precedence.
- Failures keep the dialog open with the error inside it as the retry affordance; `already_on_plan` / `subscription_required` stay benign refreshes.

## Validation

- `pnpm typecheck` clean; `pnpm check` (biome) clean.
- Full `pnpm exec vitest run`: 129 files, 1986 passed / 2 skipped. New/updated coverage: confirm gating (no PATCH without confirm; cancel never charges) in settings, gate, and the App banner path; pending state + double-fire protection; poll-until-grant with staged snapshots and timeout bounds (`max-upgrade.test.ts`); gate waiting panel precedence; benign stale-state recoveries.
- No Rust changes.

### QA video

- QA video (os-platform): https://app.opensoftware.co/api/v1/files/fil_RTNuLvV8zBgX/download

Walkthrough steps (each state asserted by the driver before capture):

1. Pro billing card: clicking "Upgrade to Max" opens the confirm dialog stating the $100 charge; nothing is billed.
2. Cancel closes the dialog; still on Pro, no PATCH fired.
3. Confirm: the button flips to "Upgrading..." and is disabled (double-click protection) while the PATCH is in flight.
4. Interim status "You are on Max now. Your new credits are on the way." while the webhook grant is pending; the page polls every 2.5s.
5. Grant lands: status flips to "...your new credits are ready.", the card shows Max plan with refilled usage.
6. Depleted-Pro funding gate: same confirm before any charge.
7. After confirm the gate shows the "Setting up Max" waiting panel (never a top-up prompt mid-upgrade) and polls.
8. Grant lands: the gate lifts to the Max plan card.

What the video is: the real React components (BillingSettingsSection, FundingGate, ConfirmDialog) rendered in isolation against a stubbed Tauri bridge with staged timing (PATCH delay, delayed webhook grant), driven by playwright. Backend behavior is covered by the os-accounts suites.

## Dependency note

UI-only; builds on #599 (already in main). The confirm copy assumes the parallel os-accounts change to full-charge-with-cycle-reset semantics; the string is centralized in `src/lib/max-upgrade.ts` if that shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)