### PR TITLE
Windows dictation support

### DIFF
--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -9,8 +9,22 @@ Windows assets to the existing `open-software-network/os-june-releases` release.
 
 The Windows installer supports the app shell, OS Accounts sign-in, microphone
 recording, note generation, folders, and settings backed by the production June
-API. Global dictation shortcuts, dictation paste, macOS system-audio capture, and
-Seatbelt sandbox features are macOS-only.
+API. Global dictation (shortcut listening, microphone capture, transcription,
+and clipboard paste) also runs on Windows through an in-process helper, the
+platform twin of the macOS dictation helper. macOS system-audio capture and
+Seatbelt sandbox features remain macOS-only.
+
+Windows dictation ships with a few known gaps relative to macOS, all documented
+in the Windows dictation PR:
+
+- The HUD uses the shared web HUD window without the macOS native slide,
+  vibrancy, and non-activating panel behavior.
+- Clipboard restore after a paste covers plain text only, so a prior image or
+  rich-text clipboard is not preserved.
+- Bringing the target window to the foreground before paste is best effort
+  under the Windows foreground-window rules.
+- The keyboard hook is torn down by process exit rather than an explicit
+  unhook, and double-tap shortcut chords are not yet supported.
 
 Production Windows builds bundle the pinned Hermes runtime under `native/hermes`,
 so June can start the agent on a clean machine without Python, GitHub downloads,
@@ -106,10 +120,12 @@ Start-Process "$env:LOCALAPPDATA\June\June.exe"
 ```
 
 Confirm the signature status is `Valid`, the publisher is Open Software Network,
-the app launches as June, the sign-in copy mentions recording and notes without
+the app launches as June, the sign-in copy mentions recording, notes, and
 dictation, and the bundled agent starts on a clean VM with no Python installed.
 Record from the microphone and generate a note against production June API
-before linking the installer publicly.
+before linking the installer publicly. To smoke-test dictation, place the cursor
+in another app, press the toggle shortcut (Ctrl+Alt+T) or hold push to talk
+(Ctrl+Alt+D), speak, and confirm the transcript pastes at the cursor.
 
 For updater validation after a second Windows release, install an older
 updater-capable Windows build, run **June -> Check for updates...**, confirm the

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "window-vibrancy",
+ "windows 0.54.0",
  "zeroize",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,20 @@ window-vibrancy = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"] }
+# Already resolved transitively via cpal (WASAPI). Reused here for the
+# in-process dictation helper twin: global keyboard hook, foreground-window
+# tracking, clipboard, and synthesized Ctrl+V paste. Feature-gated to the exact
+# Win32 modules the helper touches.
+windows = { version = "0.54", features = [
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
+    "Win32_System_Ole",
+    "Win32_System_Threading",
+    "Win32_System_LibraryLoader",
+] }
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -728,6 +728,13 @@ pub fn set_dictation_shortcut(
     shortcut: DictationShortcutInput,
 ) -> Result<DictationSettings, AppError> {
     let shortcut = shortcut.into_setting()?;
+    // The shared validation accepts any modifier combination (macOS can arm
+    // e.g. Shift-only chords through its event tap), but the Windows keyboard
+    // hook cannot. Reject at save time rather than silently saving a shortcut
+    // apply_set_shortcut would drop from the hook, leaving the settings pane
+    // showing a shortcut that never fires.
+    #[cfg(target_os = "windows")]
+    crate::dictation_windows::validate_shortcut_for_windows(&shortcut.code, &shortcut.modifiers)?;
     let current_settings = state
         .settings
         .lock()
@@ -4033,6 +4040,29 @@ mod tests {
         assert_eq!(shortcut.code, "KeyT");
         assert!(shortcut.modifiers.control);
         assert_eq!(shortcut.press_count, 1);
+    }
+
+    #[test]
+    fn shortcut_input_still_accepts_shift_only_chords_for_the_shared_path() {
+        // The shared validation (macOS behavior) accepts any modifier,
+        // including Shift alone. The Windows save gate in
+        // set_dictation_shortcut (dictation_windows::
+        // validate_shortcut_for_windows) is layered on top of this and must
+        // not change what the shared path accepts.
+        let shortcut = DictationShortcutInput {
+            code: "KeyD".to_string(),
+            modifiers: DictationShortcutModifiers {
+                shift: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Shift+D".to_string(),
+            press_count: Some(1),
+        }
+        .into_setting()
+        .expect("shift-only chord passes the shared validation");
+
+        assert_eq!(shortcut.code, "KeyD");
+        assert!(shortcut.modifiers.shift);
     }
 
     #[test]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -347,7 +347,9 @@ impl DictationShortcutSetting {
         if is_modifier_only_input(&self.code, &self.modifiers) {
             return DictationShortcutSetting::modifier_only(self.modifiers);
         }
-        let Some(key_code) = key_code_for_code(&self.code) else {
+        let Some(key_code) =
+            shortcut_key_code_for_platform(&self.code, cfg!(target_os = "windows"))
+        else {
             return default_shortcut_for_kind(kind);
         };
         if !self.modifiers.has_any() {
@@ -544,12 +546,13 @@ impl DictationShortcutInput {
             return Ok(DictationShortcutSetting::modifier_only(self.modifiers));
         }
 
-        let key_code = key_code_for_code(&self.code).ok_or_else(|| {
-            AppError::new(
-                "dictation_shortcut_unsupported",
-                "Shortcut must include a supported non-modifier key.",
-            )
-        })?;
+        let key_code = shortcut_key_code_for_platform(&self.code, cfg!(target_os = "windows"))
+            .ok_or_else(|| {
+                AppError::new(
+                    "dictation_shortcut_unsupported",
+                    "Shortcut must include a supported non-modifier key.",
+                )
+            })?;
 
         if !self.modifiers.has_any() {
             return Err(AppError::new(
@@ -3647,6 +3650,25 @@ fn set_hotkey_status(state: &HotkeyStatus, event: serde_json::Value) {
     }
 }
 
+/// Resolve a shortcut's non-modifier key for the current platform. The shared
+/// table below is the macOS Carbon key-code map and predates Windows support,
+/// so it lacks keys the Windows hook can arm (e.g. F2-F12). On Windows, any
+/// key the hook's own mapping knows is accepted as a fallback, storing the
+/// Windows virtual key in `key_code` (the hook matches by `code`, so the
+/// numeric value is informational there). On macOS the fallback never runs,
+/// keeping validation byte-for-byte unchanged. Takes `windows` as a parameter
+/// (call sites pass `cfg!(target_os = "windows")`) so both branches are
+/// unit-testable on any host.
+fn shortcut_key_code_for_platform(code: &str, windows: bool) -> Option<u32> {
+    if let Some(key_code) = key_code_for_code(code) {
+        return Some(key_code);
+    }
+    if windows {
+        return crate::dictation_windows::vk_for_code(code).map(u32::from);
+    }
+    None
+}
+
 pub fn key_code_for_code(code: &str) -> Option<u32> {
     Some(match code {
         "KeyA" => 0x00,
@@ -4040,6 +4062,68 @@ mod tests {
         assert_eq!(shortcut.code, "KeyT");
         assert!(shortcut.modifiers.control);
         assert_eq!(shortcut.press_count, 1);
+    }
+
+    #[test]
+    fn windows_key_resolution_accepts_hook_armable_f_keys() {
+        // The shared table predates Windows support and lacks F2-F12, but the
+        // Windows hook can arm them (capture emits these codes), so the save
+        // path must resolve them on Windows.
+        assert_eq!(shortcut_key_code_for_platform("F7", true), Some(0x76));
+        assert_eq!(shortcut_key_code_for_platform("F2", true), Some(0x71));
+        // Keys in the shared table keep the shared value on Windows too.
+        assert_eq!(shortcut_key_code_for_platform("KeyD", true), Some(0x02));
+    }
+
+    #[test]
+    fn macos_key_resolution_is_unchanged() {
+        // macOS resolution must stay byte-for-byte what the shared table says:
+        // F1 resolves, F2-F12 stay rejected there today.
+        assert_eq!(shortcut_key_code_for_platform("F1", false), Some(0x7a));
+        assert_eq!(shortcut_key_code_for_platform("F7", false), None);
+        assert_eq!(shortcut_key_code_for_platform("KeyD", false), Some(0x02));
+    }
+
+    /// Pins today's macOS save behavior for an F-key chord: the shared table
+    /// has no F7, so into_setting rejects it (this test compiles the macOS
+    /// resolution path).
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn shortcut_input_f7_chord_is_still_rejected_on_macos() {
+        let error = DictationShortcutInput {
+            code: "F7".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                option: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+Opt+F7".to_string(),
+            press_count: Some(1),
+        }
+        .into_setting()
+        .expect_err("F7 has no macOS key code in the shared table");
+        assert_eq!(error.code, "dictation_shortcut_unsupported");
+    }
+
+    /// On Windows the same chord saves: capture emits F-key codes and the
+    /// hook can arm them, so into_setting must accept what capture produces.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn shortcut_input_f7_chord_saves_on_windows() {
+        let shortcut = DictationShortcutInput {
+            code: "F7".to_string(),
+            modifiers: DictationShortcutModifiers {
+                control: true,
+                option: true,
+                ..DictationShortcutModifiers::default()
+            },
+            label: "Ctrl+Alt+F7".to_string(),
+            press_count: Some(1),
+        }
+        .into_setting()
+        .expect("F7 chord must save on Windows");
+        assert_eq!(shortcut.code, "F7");
+        assert_eq!(shortcut.key_code, 0x76);
     }
 
     #[test]

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -42,6 +42,14 @@ const EMAIL_APP_BUNDLE_IDS: &[&str] = &[
     "com.mimestream.Mimestream",
     "com.superhuman.electron",
 ];
+/// Native email clients by Windows executable name. The Windows helper reports
+/// the foreground executable as the paste target's identity (in the same
+/// `targetBundleIdentifier` field the macOS helper fills with a bundle id), so
+/// the email app-context mapping recognizes those executables too. Kept
+/// platform-neutral so the mapping is unit-testable on any host: a real macOS
+/// bundle id never matches an `.exe` and vice versa, so OR-ing this into the
+/// bundle check leaves macOS behavior unchanged.
+const EMAIL_APP_EXECUTABLES: &[&str] = &["outlook.exe", "olk.exe", "thunderbird.exe"];
 const DICTATION_AUDIO_ACTIVITY_THRESHOLD: f32 = 0.04;
 const DICTATION_EVENT_LOG: &str = "dictation-events.log";
 
@@ -638,6 +646,12 @@ pub fn setup(app: &mut tauri::App) {
         controller: Mutex::new(ShortcutActivationController::default()),
     });
 
+    // Windows runs the helper in-process rather than as a child. Initialize it
+    // before settings are applied so the shortcut/microphone commands below
+    // reach the live helper.
+    #[cfg(target_os = "windows")]
+    crate::dictation_windows::init(app.handle());
+
     let helper = spawn_helper(app.handle()).ok();
     app.manage(HelperState {
         process: Mutex::new(helper),
@@ -704,7 +718,7 @@ pub async fn delete_dictation_history_item(app: AppHandle, id: String) -> Result
 }
 
 #[tauri::command]
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 pub fn set_dictation_shortcut(
     app: AppHandle,
     state: State<'_, DictationSettingsState>,
@@ -745,7 +759,7 @@ pub fn set_dictation_shortcut(
 }
 
 #[tauri::command]
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 pub fn set_dictation_shortcut(
     kind: DictationShortcutKind,
     shortcut: DictationShortcutInput,
@@ -753,7 +767,7 @@ pub fn set_dictation_shortcut(
     let _ = (kind, shortcut);
     Err(AppError::new(
         "dictation_shortcut_unsupported",
-        "Dictation shortcuts are only supported on macOS.",
+        "Dictation shortcuts are not supported on this platform.",
     ))
 }
 
@@ -767,7 +781,9 @@ pub fn set_dictation_microphone(
     let settings = update_settings(&state, |settings| {
         settings.microphone = DictationMicrophoneSetting { id, name };
     })?;
-    #[cfg(not(target_os = "macos"))]
+    // Platforms with neither a child helper (macOS) nor the in-process helper
+    // (Windows) have no sink for the microphone setting; persist and return.
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     if helper_state
         .process
         .lock()
@@ -808,12 +824,14 @@ pub fn dictation_helper_command(
     state: State<'_, HelperState>,
     command: serde_json::Value,
 ) -> Result<(), AppError> {
-    #[cfg(target_os = "macos")]
+    // macOS and Windows both drive the shared activation controller, so a stop
+    // or toggle command must reset it on either platform.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     if helper_command_resets_shortcut_activation(&command) {
         reset_shortcut_activation(&app);
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     if state
         .process
         .lock()
@@ -1370,6 +1388,8 @@ fn spawn_hud_hover_thread(app: AppHandle) {
 }
 
 pub fn stop_helper(app: &AppHandle) {
+    #[cfg(target_os = "windows")]
+    crate::dictation_windows::shutdown();
     let state = app.state::<HelperState>();
     // Mark the teardown as intentional before killing so the supervisor thread
     // (woken by the resulting stdout EOF) skips respawning instead of fighting
@@ -1395,6 +1415,25 @@ pub(crate) fn dictation_helper_pid(app: &AppHandle) -> Option<u32> {
 }
 
 fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Result<(), AppError> {
+    // Windows has no child helper process: the in-process helper twin owns
+    // capture, shortcuts and paste, so route the identical command protocol to
+    // it instead of a child's stdin.
+    #[cfg(target_os = "windows")]
+    {
+        let _ = state;
+        crate::dictation_windows::dispatch(command)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        send_helper_command_to_process(state, command)
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn send_helper_command_to_process(
+    state: &HelperState,
+    command: serde_json::Value,
+) -> Result<(), AppError> {
     let mut guard = state
         .process
         .lock()
@@ -1418,7 +1457,7 @@ fn send_helper_command(state: &HelperState, command: serde_json::Value) -> Resul
         .map_err(|error| AppError::new("dictation_helper_write_failed", error.to_string()))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 fn handle_missing_helper_command(
     app: &AppHandle,
     command: &serde_json::Value,
@@ -1458,7 +1497,7 @@ fn handle_missing_helper_command(
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 fn non_macos_permission_status_event() -> serde_json::Value {
     let (microphone, _) = crate::audio::capture::microphone_permission_state();
     serde_json::json!({
@@ -2212,6 +2251,14 @@ fn emit_helper_unavailable(app: &AppHandle, reason: &str, message: &str) {
     emit_dictation_event_value(app, event);
 }
 
+/// Feeds a structured helper event from the in-process Windows helper into the
+/// exact same ingestion path the macOS stdout reader uses, so shortcut
+/// handling, transcription and HUD/frontend routing stay shared.
+#[cfg(target_os = "windows")]
+pub(crate) fn ingest_helper_event(app: &AppHandle, event: serde_json::Value) {
+    handle_helper_event_line(app, event.to_string());
+}
+
 fn handle_helper_event_line(app: &AppHandle, line: String) {
     let event = serde_json::from_str::<serde_json::Value>(&line).ok();
     let event_type = event
@@ -2262,7 +2309,7 @@ async fn transcribe_recording_ready(app: AppHandle, recording: RecordingReadyInf
     let app_context = recording
         .target_bundle_id
         .as_deref()
-        .map(|bundle_id| is_email_app_bundle(bundle_id).then(|| APP_CONTEXT_EMAIL.to_string()))
+        .map(|identity| is_email_paste_target(identity).then(|| APP_CONTEXT_EMAIL.to_string()))
         .unwrap_or_else(frontmost_app_context);
     // Backstop for the toggle-start path (where the start-time gate in
     // send_dictation_command can't tell start from stop) and for tokens that
@@ -2366,6 +2413,18 @@ fn is_email_app_bundle(bundle_id: &str) -> bool {
     EMAIL_APP_BUNDLE_IDS
         .iter()
         .any(|known| bundle_id.eq_ignore_ascii_case(known))
+}
+
+fn is_email_app_executable(identity: &str) -> bool {
+    EMAIL_APP_EXECUTABLES
+        .iter()
+        .any(|known| identity.eq_ignore_ascii_case(known))
+}
+
+/// Whether the paste-target identity (a macOS bundle id or a Windows executable
+/// name) is a known native email client, so cleanup lays the text out for email.
+fn is_email_paste_target(identity: &str) -> bool {
+    is_email_app_bundle(identity) || is_email_app_executable(identity)
 }
 
 /// The app-context slug for the app the user is dictating into, read when
@@ -3549,18 +3608,18 @@ fn hotkey_ready_event(settings: &DictationSettings) -> serde_json::Value {
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn initial_hotkey_event(settings: &DictationSettings) -> serde_json::Value {
     hotkey_ready_event(settings)
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 fn initial_hotkey_event(_settings: &DictationSettings) -> serde_json::Value {
     serde_json::json!({
         "type": "hotkey_trigger_unavailable",
         "payload": {
             "reason": "unsupported",
-            "message": "Dictation shortcuts are only supported on macOS.",
+            "message": "Dictation shortcuts are not supported on this platform.",
         },
     })
 }
@@ -4473,6 +4532,29 @@ mod tests {
         assert!(is_email_app_bundle("com.microsoft.Outlook"));
         assert!(!is_email_app_bundle("com.google.Chrome"));
         assert!(!is_email_app_bundle(""));
+    }
+
+    #[test]
+    fn email_app_executables_map_to_the_email_context() {
+        // Windows paste targets arrive as executable names.
+        assert!(is_email_app_executable("outlook.exe"));
+        assert!(is_email_app_executable("OUTLOOK.EXE"));
+        assert!(is_email_app_executable("olk.exe"));
+        assert!(is_email_app_executable("thunderbird.exe"));
+        assert!(!is_email_app_executable("chrome.exe"));
+        assert!(!is_email_app_executable(""));
+        // A macOS bundle id must never match the executable list and vice
+        // versa, so OR-ing the two leaves each platform's mapping intact.
+        assert!(!is_email_app_executable("com.apple.mail"));
+        assert!(!is_email_app_bundle("outlook.exe"));
+    }
+
+    #[test]
+    fn email_paste_target_recognizes_both_identities() {
+        assert!(is_email_paste_target("com.apple.mail"));
+        assert!(is_email_paste_target("outlook.exe"));
+        assert!(!is_email_paste_target("chrome.exe"));
+        assert!(!is_email_paste_target("com.google.Chrome"));
     }
 
     #[test]

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -181,18 +181,28 @@ pub(crate) enum ShortcutEdgeAction {
 }
 
 /// Pure decision for a trigger-key edge, factored out of the raw hook
-/// callback so it is unit-testable on any host. `matched` is the shortcut the
-/// key+modifiers currently match (down edges only); `suppressed_kind` is set
-/// when this key's down edge was already suppressed and is still held. A held
-/// key whose repeats arrive is swallowed even if the modifiers were released
-/// mid-hold (`matched` gone), so a suppressed trigger can never leak repeats
-/// into the focused app before its release.
+/// callback so it is unit-testable on any host. `injected` is the
+/// KBDLLHOOKSTRUCT LLKHF_INJECTED / LLKHF_LOWER_IL_INJECTED state: injected
+/// events always pass through untouched, regardless of any shortcut match —
+/// our own synthesized Ctrl+V paste travels back through the same low-level
+/// hook, and matching it would swallow the V (so the target app never
+/// receives the paste) or re-trigger dictation mid-paste for a user who bound
+/// a colliding chord. `matched` is the shortcut the key+modifiers currently
+/// match (down edges only); `suppressed_kind` is set when this key's down
+/// edge was already suppressed and is still held. A held key whose repeats
+/// arrive is swallowed even if the modifiers were released mid-hold
+/// (`matched` gone), so a suppressed trigger can never leak repeats into the
+/// focused app before its release.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) fn shortcut_edge_action(
+    injected: bool,
     is_down: bool,
     matched: Option<DictationShortcutKind>,
     suppressed_kind: Option<DictationShortcutKind>,
 ) -> ShortcutEdgeAction {
+    if injected {
+        return ShortcutEdgeAction::PassThrough;
+    }
     if is_down {
         if suppressed_kind.is_some() {
             return ShortcutEdgeAction::SwallowRepeat;
@@ -251,8 +261,9 @@ mod windows_impl {
     };
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
-        SetForegroundWindow, SetWindowsHookExW, HC_ACTION, KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL,
-        WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
+        SetForegroundWindow, SetWindowsHookExW, HC_ACTION, KBDLLHOOKSTRUCT, LLKHF_INJECTED,
+        LLKHF_LOWER_IL_INJECTED, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,
+        WM_SYSKEYUP,
     };
 
     const VK_CONTROL: i32 = 0x11;
@@ -487,7 +498,11 @@ mod windows_impl {
             let vk = info.vkCode as u16;
             let is_down = message == WM_KEYDOWN || message == WM_SYSKEYDOWN;
             let is_up = message == WM_KEYUP || message == WM_SYSKEYUP;
-            if (is_down || is_up) && process_key(vk, is_down) {
+            // Synthesized input (including our own SendInput Ctrl+V paste)
+            // arrives back through this hook flagged as injected; it must
+            // never be treated as shortcut input or shortcut capture.
+            let injected = (info.flags.0 & (LLKHF_INJECTED.0 | LLKHF_LOWER_IL_INJECTED.0)) != 0;
+            if (is_down || is_up) && process_key(vk, is_down, injected) {
                 // Swallow the trigger key so the shortcut doesn't leak into the
                 // focused app (e.g. typing the push-to-talk key while dictating).
                 return LRESULT(1);
@@ -499,7 +514,7 @@ mod windows_impl {
     /// Pure-ish hook decision: matches the key against configured shortcuts (or
     /// records it in capture mode) and returns whether to suppress it. Only ever
     /// `try_lock`s the shared state so it can never block global input.
-    fn process_key(vk: u16, is_down: bool) -> bool {
+    fn process_key(vk: u16, is_down: bool, injected: bool) -> bool {
         let Some(state) = HOOK_STATE.get() else {
             return false;
         };
@@ -508,7 +523,9 @@ mod windows_impl {
         };
 
         if guard.capturing {
-            if is_down && !is_modifier_vk(vk) {
+            // Injected keys must not be recorded as a captured shortcut
+            // either (e.g. a paste synthesized while the capture UI is open).
+            if !injected && is_down && !is_modifier_vk(vk) {
                 guard.capturing = false;
                 let modifiers = current_modifiers();
                 if let Some(code) = code_for_vk(vk) {
@@ -548,7 +565,7 @@ mod windows_impl {
             .find(|(held, _)| *held == vk)
             .map(|(_, kind)| *kind);
 
-        match super::shortcut_edge_action(is_down, matched, suppressed_kind) {
+        match super::shortcut_edge_action(injected, is_down, matched, suppressed_kind) {
             super::ShortcutEdgeAction::PassThrough => false,
             super::ShortcutEdgeAction::SwallowRepeat => true,
             super::ShortcutEdgeAction::DispatchDown(kind) => {
@@ -862,6 +879,14 @@ mod windows_impl {
                 return;
             }
             let to_paste = format!("{trimmed} ");
+            // Mirror the macOS helper's ordering exactly: final_transcript is
+            // emitted with the padded paste text before the clipboard write.
+            // The dictation history view reloads on this event, so without it
+            // an open history view would stay stale after a Windows dictation.
+            self.emit(json!({
+                "type": "final_transcript",
+                "payload": { "text": to_paste },
+            }));
             let previous = clipboard_get_text();
             if let Err(error) = clipboard_set_text(&to_paste) {
                 self.emit(json!({
@@ -1322,13 +1347,14 @@ mod tests {
     fn key_repeat_for_a_held_trigger_is_swallowed_without_a_second_down_edge() {
         // First down: dispatch and suppress.
         assert_eq!(
-            shortcut_edge_action(true, Some(DictationShortcutKind::Toggle), None),
+            shortcut_edge_action(false, true, Some(DictationShortcutKind::Toggle), None),
             ShortcutEdgeAction::DispatchDown(DictationShortcutKind::Toggle)
         );
         // OS key repeat while held (key already suppressed): swallowed, no
         // second down edge — a repeat must not re-toggle dictation.
         assert_eq!(
             shortcut_edge_action(
+                false,
                 true,
                 Some(DictationShortcutKind::Toggle),
                 Some(DictationShortcutKind::Toggle)
@@ -1338,6 +1364,7 @@ mod tests {
         // Same for push-to-talk: no re-dispatched down on repeats.
         assert_eq!(
             shortcut_edge_action(
+                false,
                 true,
                 Some(DictationShortcutKind::PushToTalk),
                 Some(DictationShortcutKind::PushToTalk)
@@ -1347,7 +1374,7 @@ mod tests {
         // Repeats stay swallowed even if the modifiers were released mid-hold
         // (no current match), so a suppressed trigger never leaks into the app.
         assert_eq!(
-            shortcut_edge_action(true, None, Some(DictationShortcutKind::Toggle)),
+            shortcut_edge_action(false, true, None, Some(DictationShortcutKind::Toggle)),
             ShortcutEdgeAction::SwallowRepeat
         );
     }
@@ -1355,12 +1382,12 @@ mod tests {
     #[test]
     fn release_of_a_suppressed_trigger_dispatches_the_up_edge() {
         assert_eq!(
-            shortcut_edge_action(false, None, Some(DictationShortcutKind::PushToTalk)),
+            shortcut_edge_action(false, false, None, Some(DictationShortcutKind::PushToTalk)),
             ShortcutEdgeAction::DispatchUp(DictationShortcutKind::PushToTalk)
         );
         // A release we never suppressed passes through untouched.
         assert_eq!(
-            shortcut_edge_action(false, None, None),
+            shortcut_edge_action(false, false, None, None),
             ShortcutEdgeAction::PassThrough
         );
     }
@@ -1368,7 +1395,34 @@ mod tests {
     #[test]
     fn unmatched_keys_pass_through() {
         assert_eq!(
-            shortcut_edge_action(true, None, None),
+            shortcut_edge_action(false, true, None, None),
+            ShortcutEdgeAction::PassThrough
+        );
+    }
+
+    #[test]
+    fn injected_events_pass_through_regardless_of_match() {
+        // Our own synthesized Ctrl+V comes back through the hook flagged as
+        // injected. Even if it matches a configured shortcut (a user bound
+        // Ctrl+V, or a colliding toggle chord), it must pass through: matching
+        // would swallow the V so the paste never lands, or start a new
+        // dictation mid-paste.
+        assert_eq!(
+            shortcut_edge_action(true, true, Some(DictationShortcutKind::Toggle), None),
+            ShortcutEdgeAction::PassThrough
+        );
+        assert_eq!(
+            shortcut_edge_action(true, true, Some(DictationShortcutKind::PushToTalk), None),
+            ShortcutEdgeAction::PassThrough
+        );
+        // Injected events never touch the suppressed bookkeeping either, even
+        // while the same key is physically held and suppressed.
+        assert_eq!(
+            shortcut_edge_action(true, true, None, Some(DictationShortcutKind::Toggle)),
+            ShortcutEdgeAction::PassThrough
+        );
+        assert_eq!(
+            shortcut_edge_action(true, false, None, Some(DictationShortcutKind::Toggle)),
             ShortcutEdgeAction::PassThrough
         );
     }

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -246,6 +246,103 @@ pub(crate) fn shortcut_edge_action(
     }
 }
 
+/// Dictation session state for the Windows worker, mirroring the macOS
+/// helper's `isListening` / `isFinalizing` pair (`listening` there is
+/// `isListening || isFinalizing`).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum SessionState {
+    /// No utterance in flight.
+    #[default]
+    Idle,
+    /// Microphone capture running (macOS `isListening`).
+    Listening,
+    /// Capture stopped, recording_ready sent, transcription in flight until
+    /// the pipeline delivers paste_text or discard_recording (macOS
+    /// `isFinalizing`).
+    Finalizing,
+}
+
+/// Pure session state machine for the Windows dictation worker, the twin of
+/// the macOS helper's state handling: `start()` there rejects while
+/// `listening` (which includes finalizing) with an `already_listening` error,
+/// `stop()` rejects unless actively listening with `not_listening`, and paste
+/// or discard reset the state. Keeping the transitions here makes the
+/// wrong-session interleaving rules unit-testable on any host: without the
+/// finalizing gate, a start accepted while the previous utterance's
+/// transcription was still in flight would let that utterance's paste_text or
+/// discard_recording land on the new session.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+#[derive(Debug, Default)]
+pub(crate) struct SessionStateMachine {
+    state: SessionState,
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+impl SessionStateMachine {
+    pub(crate) fn state(&self) -> SessionState {
+        self.state
+    }
+
+    /// macOS `dictation.listening`: true while listening or finalizing. The
+    /// toggle command uses this to pick start vs stop.
+    pub(crate) fn is_engaged(&self) -> bool {
+        self.state != SessionState::Idle
+    }
+
+    /// start_listening arrived. False mirrors the macOS `already_listening`
+    /// rejection (start while listening, or while a transcription is still
+    /// finalizing). The state only advances via [`Self::capture_started`],
+    /// once the microphone actually opened.
+    pub(crate) fn request_start(&self) -> bool {
+        self.state == SessionState::Idle
+    }
+
+    /// Microphone capture opened successfully.
+    pub(crate) fn capture_started(&mut self) {
+        self.state = SessionState::Listening;
+    }
+
+    /// stop_and_paste arrived. False mirrors the macOS `not_listening`
+    /// rejection (stop while idle or already finalizing).
+    pub(crate) fn request_stop(&mut self) -> bool {
+        if self.state != SessionState::Listening {
+            return false;
+        }
+        self.state = SessionState::Finalizing;
+        true
+    }
+
+    /// paste_text arrived. True resolves the finalizing utterance (state
+    /// returns to idle). False means the paste is stale: a new utterance is
+    /// already listening (possible after a discard cleared the finalizing
+    /// state and a new start was accepted), so pasting now would inject the
+    /// superseded utterance's text into the new session; drop it instead.
+    pub(crate) fn paste_delivered(&mut self) -> bool {
+        if self.state == SessionState::Listening {
+            return false;
+        }
+        self.state = SessionState::Idle;
+        true
+    }
+
+    /// discard_recording arrived (or the session failed). Returns whether the
+    /// discard interrupted live listening, which is the only case the macOS
+    /// helper announces with recording_discarded (`wasListening` there reads
+    /// `isListening`, not the finalizing flag).
+    pub(crate) fn discarded(&mut self) -> bool {
+        let was_listening = self.state == SessionState::Listening;
+        self.state = SessionState::Idle;
+        was_listening
+    }
+
+    /// Unconditional reset for failure paths and shutdown, mirroring the
+    /// macOS resetRecordingState.
+    pub(crate) fn reset(&mut self) {
+        self.state = SessionState::Idle;
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub use windows_impl::{dispatch, init, shutdown};
 
@@ -253,6 +350,7 @@ pub use windows_impl::{dispatch, init, shutdown};
 mod windows_impl {
     use super::{
         code_for_vk, key_label_for_vk, shortcut_is_supported, vk_for_code, windows_shortcut_label,
+        SessionState, SessionStateMachine,
     };
     use crate::dictation::{
         ingest_helper_event, DictationShortcutKind, DictationShortcutModifiers,
@@ -730,7 +828,11 @@ mod windows_impl {
 
     struct Worker {
         app: AppHandle,
-        listening: bool,
+        /// Mirrors the macOS helper's isListening/isFinalizing pair; see
+        /// [`super::SessionStateMachine`]. The finalizing gate is what stops a
+        /// new start_listening from interleaving with the previous
+        /// utterance's still-in-flight paste_text/discard_recording.
+        session: SessionStateMachine,
         capture: Option<CaptureSession>,
         last_recording: Option<PathBuf>,
         target: Option<(isize, String)>,
@@ -740,7 +842,7 @@ mod windows_impl {
     fn run_worker(app: AppHandle, rx: Receiver<WorkerMsg>) {
         let mut worker = Worker {
             app,
-            listening: false,
+            session: SessionStateMachine::default(),
             capture: None,
             last_recording: None,
             target: None,
@@ -820,7 +922,9 @@ mod windows_impl {
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("hotkey")
                         .to_string();
-                    if self.listening {
+                    // macOS keys this off `dictation.listening`, which is
+                    // true while listening or finalizing.
+                    if self.session.is_engaged() {
                         self.emit(json!({
                             "type": "hotkey_trigger",
                             "payload": { "action": "stop", "shortcut": shortcut },
@@ -854,7 +958,10 @@ mod windows_impl {
                     self.emit_permission_status()
                 }
                 "shutdown" => {
-                    self.discard();
+                    // macOS shutdown resets state and cleans up without a
+                    // recording_discarded announcement.
+                    self.session.reset();
+                    self.cleanup_recordings();
                     self.emit(json!({ "type": "shutdown_ack" }));
                     return true;
                 }
@@ -868,7 +975,7 @@ mod windows_impl {
         }
 
         fn tick_level(&mut self) {
-            if !self.listening {
+            if self.session.state() != SessionState::Listening {
                 return;
             }
             let Some(session) = self.capture.as_ref() else {
@@ -889,7 +996,18 @@ mod windows_impl {
         }
 
         fn start(&mut self) {
-            if self.listening {
+            if !self.session.request_start() {
+                // Mirrors the macOS start() rejection: a start while
+                // listening, or while the previous utterance's transcription
+                // is still finalizing, must not open a second session that
+                // the in-flight paste_text/discard_recording could cross.
+                self.emit(json!({
+                    "type": "error",
+                    "payload": {
+                        "code": "already_listening",
+                        "message": "Dictation is already listening.",
+                    },
+                }));
                 return;
             }
             // Remember the app the user is dictating into (the foreground window
@@ -904,7 +1022,7 @@ mod windows_impl {
             match self.begin_capture() {
                 Ok(session) => {
                     self.capture = Some(session);
-                    self.listening = true;
+                    self.session.capture_started();
                     self.emit(json!({
                         "type": "listening_started",
                         "payload": {
@@ -923,12 +1041,23 @@ mod windows_impl {
         }
 
         fn stop(&mut self) {
-            if !self.listening {
+            if !self.session.request_stop() {
+                // Mirrors the macOS stop() rejection while idle or finalizing.
+                self.emit(json!({
+                    "type": "error",
+                    "payload": {
+                        "code": "not_listening",
+                        "message": "Dictation is not listening.",
+                    },
+                }));
                 return;
             }
-            self.listening = false;
+            // Finalizing from here until the pipeline delivers paste_text or
+            // discard_recording for this utterance; request_start rejects
+            // until then.
             self.emit(json!({ "type": "finalizing_transcript" }));
             let Some(session) = self.capture.take() else {
+                self.session.reset();
                 return;
             };
             let observed = finalize_capture(session);
@@ -946,6 +1075,10 @@ mod windows_impl {
                     }));
                 }
                 Err(error) => {
+                    // No recording_ready will follow, so no paste/discard
+                    // resolves this utterance; clear finalizing here (macOS
+                    // fail() resets state the same way).
+                    self.session.reset();
                     self.emit(json!({
                         "type": "error",
                         "payload": { "code": error.code, "message": error.message },
@@ -955,7 +1088,18 @@ mod windows_impl {
         }
 
         fn discard(&mut self) {
-            self.listening = false;
+            // macOS announces recording_discarded only when the discard
+            // interrupted live listening (wasListening reads isListening); a
+            // discard that resolves a finalizing utterance stays quiet and
+            // the pipeline's own error event drives the UI.
+            let interrupted_listening = self.session.discarded();
+            self.cleanup_recordings();
+            if interrupted_listening {
+                self.emit(json!({ "type": "recording_discarded" }));
+            }
+        }
+
+        fn cleanup_recordings(&mut self) {
             if let Some(session) = self.capture.take() {
                 let path = session.path.clone();
                 drop(session);
@@ -964,16 +1108,32 @@ mod windows_impl {
             if let Some(path) = self.last_recording.take() {
                 let _ = std::fs::remove_file(path);
             }
-            self.emit(json!({ "type": "recording_discarded" }));
         }
 
         fn paste(&mut self, text: String) {
+            if !self.session.paste_delivered() {
+                // Stale paste for a superseded utterance: a discard already
+                // cleared the finalizing state and a new recording is live.
+                // Pasting now would inject the old text into the new session.
+                tracing::warn!("dropping stale dictation paste for a superseded utterance");
+                return;
+            }
             // Drop the just-transcribed recording; it has served its purpose.
             if let Some(path) = self.last_recording.take() {
                 let _ = std::fs::remove_file(path);
             }
             let trimmed = text.trim();
             if trimmed.is_empty() {
+                // Mirrors the macOS fail(missingTranscript) path; the code is
+                // in the shared silent-error list so the HUD dismisses
+                // quietly.
+                self.emit(json!({
+                    "type": "error",
+                    "payload": {
+                        "code": "empty_transcript",
+                        "message": "No transcript text was available to paste.",
+                    },
+                }));
                 return;
             }
             let to_paste = format!("{trimmed} ");
@@ -1388,7 +1548,7 @@ mod tests {
     use super::{
         code_for_vk, key_label_for_vk, shortcut_edge_action, shortcut_is_supported,
         validate_shortcut_for_windows, vk_for_code, windows_shortcut_label, DictationShortcutKind,
-        DictationShortcutModifiers, ShortcutEdgeAction,
+        DictationShortcutModifiers, SessionState, SessionStateMachine, ShortcutEdgeAction,
     };
 
     fn ctrl_alt() -> DictationShortcutModifiers {
@@ -1539,6 +1699,76 @@ mod tests {
         // macOS-only bare Fn / modifier-only chords have no Windows key.
         assert!(!shortcut_is_supported("Fn", &ctrl_alt()));
         assert!(!shortcut_is_supported("Modifiers", &ctrl_alt()));
+    }
+
+    #[test]
+    fn start_is_rejected_while_the_previous_transcription_is_finalizing() {
+        let mut session = SessionStateMachine::default();
+        assert!(session.request_start());
+        session.capture_started();
+        assert!(session.request_stop());
+        assert_eq!(session.state(), SessionState::Finalizing);
+        // The previous utterance's transcription is in flight: a new start
+        // must be rejected (macOS already_listening) or its paste/discard
+        // could land on the wrong session.
+        assert!(!session.request_start());
+        // The toggle command still sees the session as engaged.
+        assert!(session.is_engaged());
+        // A second stop while finalizing is the macOS not_listening path.
+        assert!(!session.request_stop());
+    }
+
+    #[test]
+    fn start_is_accepted_after_the_paste_resolves_the_utterance() {
+        let mut session = SessionStateMachine::default();
+        session.capture_started();
+        assert!(session.request_stop());
+        assert!(session.paste_delivered());
+        assert_eq!(session.state(), SessionState::Idle);
+        assert!(session.request_start());
+    }
+
+    #[test]
+    fn start_is_accepted_after_a_discard_resolves_the_utterance() {
+        let mut session = SessionStateMachine::default();
+        session.capture_started();
+        assert!(session.request_stop());
+        // Discard during finalizing resolves quietly (no recording_discarded
+        // announcement, matching macOS wasListening reading isListening).
+        assert!(!session.discarded());
+        assert_eq!(session.state(), SessionState::Idle);
+        assert!(session.request_start());
+
+        // A discard that interrupts live listening does announce.
+        session.capture_started();
+        assert!(session.discarded());
+    }
+
+    #[test]
+    fn stale_paste_for_a_superseded_utterance_is_dropped() {
+        let mut session = SessionStateMachine::default();
+        // Utterance one records, stops, and the user discards while its
+        // transcription is still finalizing.
+        session.capture_started();
+        assert!(session.request_stop());
+        session.discarded();
+        // Utterance two starts recording.
+        assert!(session.request_start());
+        session.capture_started();
+        // Utterance one's paste_text arrives late: it must be dropped, not
+        // pasted into utterance two's live session.
+        assert!(!session.paste_delivered());
+        assert_eq!(session.state(), SessionState::Listening);
+        // Utterance two still resolves normally.
+        assert!(session.request_stop());
+        assert!(session.paste_delivered());
+    }
+
+    #[test]
+    fn stop_without_a_live_recording_is_rejected() {
+        let mut session = SessionStateMachine::default();
+        assert!(!session.request_stop());
+        assert_eq!(session.state(), SessionState::Idle);
     }
 
     #[test]

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -23,7 +23,7 @@
 //! tested on the host; everything that touches Win32 is behind
 //! `cfg(target_os = "windows")`.
 
-use crate::dictation::DictationShortcutModifiers;
+use crate::dictation::{DictationShortcutKind, DictationShortcutModifiers};
 
 /// Maps a subset of DOM `KeyboardEvent.code` values (how dictation shortcuts
 /// are stored, platform-neutrally) to Windows virtual-key codes. Covers the
@@ -159,6 +159,54 @@ pub(crate) fn windows_shortcut_label(modifiers: &DictationShortcutModifiers, key
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) fn shortcut_is_supported(code: &str, modifiers: &DictationShortcutModifiers) -> bool {
     vk_for_code(code).is_some() && (modifiers.control || modifiers.option || modifiers.command)
+}
+
+/// What the keyboard hook should do for one key event of a (potential)
+/// trigger key.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ShortcutEdgeAction {
+    /// Not a shortcut interaction: let the event through to the focused app.
+    PassThrough,
+    /// A newly pressed trigger: dispatch the down edge and swallow the key.
+    DispatchDown(DictationShortcutKind),
+    /// OS key repeat for a held, already-suppressed trigger: swallow it
+    /// without dispatching. A repeat is not a new press; re-dispatching the
+    /// down edge would make the shared activation controller re-toggle
+    /// (starting and then immediately stopping dictation on a held toggle
+    /// chord).
+    SwallowRepeat,
+    /// Release of a suppressed trigger: dispatch the up edge and swallow.
+    DispatchUp(DictationShortcutKind),
+}
+
+/// Pure decision for a trigger-key edge, factored out of the raw hook
+/// callback so it is unit-testable on any host. `matched` is the shortcut the
+/// key+modifiers currently match (down edges only); `suppressed_kind` is set
+/// when this key's down edge was already suppressed and is still held. A held
+/// key whose repeats arrive is swallowed even if the modifiers were released
+/// mid-hold (`matched` gone), so a suppressed trigger can never leak repeats
+/// into the focused app before its release.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn shortcut_edge_action(
+    is_down: bool,
+    matched: Option<DictationShortcutKind>,
+    suppressed_kind: Option<DictationShortcutKind>,
+) -> ShortcutEdgeAction {
+    if is_down {
+        if suppressed_kind.is_some() {
+            return ShortcutEdgeAction::SwallowRepeat;
+        }
+        match matched {
+            Some(kind) => ShortcutEdgeAction::DispatchDown(kind),
+            None => ShortcutEdgeAction::PassThrough,
+        }
+    } else {
+        match suppressed_kind {
+            Some(kind) => ShortcutEdgeAction::DispatchUp(kind),
+            None => ShortcutEdgeAction::PassThrough,
+        }
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -485,29 +533,35 @@ mod windows_impl {
             return false;
         }
 
-        if is_down {
-            let matched = guard
+        let matched = if is_down {
+            guard
                 .shortcuts
                 .iter()
                 .find(|shortcut| shortcut.vk == vk && shortcut.modifiers_match())
-                .map(|shortcut| shortcut.kind);
-            if let Some(kind) = matched {
-                if !guard.suppressed.iter().any(|(held, _)| *held == vk) {
-                    guard.suppressed.push((vk, kind));
-                }
-                dispatch_worker(WorkerMsg::ShortcutEdge { kind, down: true });
-                return true;
-            }
-            return false;
-        }
+                .map(|shortcut| shortcut.kind)
+        } else {
+            None
+        };
+        let suppressed_kind = guard
+            .suppressed
+            .iter()
+            .find(|(held, _)| *held == vk)
+            .map(|(_, kind)| *kind);
 
-        // Key up: release any suppressed trigger.
-        if let Some(position) = guard.suppressed.iter().position(|(held, _)| *held == vk) {
-            let (_, kind) = guard.suppressed.remove(position);
-            dispatch_worker(WorkerMsg::ShortcutEdge { kind, down: false });
-            return true;
+        match super::shortcut_edge_action(is_down, matched, suppressed_kind) {
+            super::ShortcutEdgeAction::PassThrough => false,
+            super::ShortcutEdgeAction::SwallowRepeat => true,
+            super::ShortcutEdgeAction::DispatchDown(kind) => {
+                guard.suppressed.push((vk, kind));
+                dispatch_worker(WorkerMsg::ShortcutEdge { kind, down: true });
+                true
+            }
+            super::ShortcutEdgeAction::DispatchUp(kind) => {
+                guard.suppressed.retain(|(held, _)| *held != vk);
+                dispatch_worker(WorkerMsg::ShortcutEdge { kind, down: false });
+                true
+            }
         }
-        false
     }
 
     fn dispatch_worker(msg: WorkerMsg) {
@@ -1206,8 +1260,9 @@ mod windows_impl {
 #[cfg(test)]
 mod tests {
     use super::{
-        code_for_vk, key_label_for_vk, shortcut_is_supported, vk_for_code, windows_shortcut_label,
-        DictationShortcutModifiers,
+        code_for_vk, key_label_for_vk, shortcut_edge_action, shortcut_is_supported, vk_for_code,
+        windows_shortcut_label, DictationShortcutKind, DictationShortcutModifiers,
+        ShortcutEdgeAction,
     };
 
     fn ctrl_alt() -> DictationShortcutModifiers {
@@ -1260,6 +1315,61 @@ mod tests {
         assert_eq!(
             windows_shortcut_label(&win_shift, "Space"),
             "Win+Shift+Space"
+        );
+    }
+
+    #[test]
+    fn key_repeat_for_a_held_trigger_is_swallowed_without_a_second_down_edge() {
+        // First down: dispatch and suppress.
+        assert_eq!(
+            shortcut_edge_action(true, Some(DictationShortcutKind::Toggle), None),
+            ShortcutEdgeAction::DispatchDown(DictationShortcutKind::Toggle)
+        );
+        // OS key repeat while held (key already suppressed): swallowed, no
+        // second down edge — a repeat must not re-toggle dictation.
+        assert_eq!(
+            shortcut_edge_action(
+                true,
+                Some(DictationShortcutKind::Toggle),
+                Some(DictationShortcutKind::Toggle)
+            ),
+            ShortcutEdgeAction::SwallowRepeat
+        );
+        // Same for push-to-talk: no re-dispatched down on repeats.
+        assert_eq!(
+            shortcut_edge_action(
+                true,
+                Some(DictationShortcutKind::PushToTalk),
+                Some(DictationShortcutKind::PushToTalk)
+            ),
+            ShortcutEdgeAction::SwallowRepeat
+        );
+        // Repeats stay swallowed even if the modifiers were released mid-hold
+        // (no current match), so a suppressed trigger never leaks into the app.
+        assert_eq!(
+            shortcut_edge_action(true, None, Some(DictationShortcutKind::Toggle)),
+            ShortcutEdgeAction::SwallowRepeat
+        );
+    }
+
+    #[test]
+    fn release_of_a_suppressed_trigger_dispatches_the_up_edge() {
+        assert_eq!(
+            shortcut_edge_action(false, None, Some(DictationShortcutKind::PushToTalk)),
+            ShortcutEdgeAction::DispatchUp(DictationShortcutKind::PushToTalk)
+        );
+        // A release we never suppressed passes through untouched.
+        assert_eq!(
+            shortcut_edge_action(false, None, None),
+            ShortcutEdgeAction::PassThrough
+        );
+    }
+
+    #[test]
+    fn unmatched_keys_pass_through() {
+        assert_eq!(
+            shortcut_edge_action(true, None, None),
+            ShortcutEdgeAction::PassThrough
         );
     }
 

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -152,13 +152,40 @@ pub(crate) fn windows_shortcut_label(modifiers: &DictationShortcutModifiers, key
     label
 }
 
-/// Whether a stored shortcut can be matched by the Windows keyboard hook. The
-/// macOS bare-`Fn` and modifier-only chords have no Windows equivalent, and a
-/// shortcut with no modifier would be a global key eater; both are rejected so
-/// the hook only ever fires on a real, modified key combo.
+/// Save-time validation for a dictation shortcut on Windows, the single source
+/// of truth for what the keyboard hook can arm. The macOS bare-`Fn` and
+/// modifier-only chords have no Windows equivalent; Shift alone auto-repeats
+/// plain typing (Shift+D is just a capital D), so a chord needs Ctrl, Alt, or
+/// the Windows key. Rejecting here keeps the settings pane honest: a chord the
+/// hook would silently drop must never save as a "ready" shortcut. Errors
+/// carry user-facing messages the settings UI renders next to the shortcut row.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn validate_shortcut_for_windows(
+    code: &str,
+    modifiers: &DictationShortcutModifiers,
+) -> Result<(), crate::domain::types::AppError> {
+    use crate::domain::types::AppError;
+    if vk_for_code(code).is_none() {
+        return Err(AppError::new(
+            "dictation_shortcut_unsupported",
+            "This key can't be used for a dictation shortcut on Windows.",
+        ));
+    }
+    if !(modifiers.control || modifiers.option || modifiers.command) {
+        return Err(AppError::new(
+            "dictation_shortcut_modifier_required",
+            "This shortcut needs Ctrl, Alt, or the Windows key on Windows.",
+        ));
+    }
+    Ok(())
+}
+
+/// Whether a stored shortcut can be matched by the Windows keyboard hook.
+/// Defined via [`validate_shortcut_for_windows`] so the hook's arming rule and
+/// the save-time validation can never diverge.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) fn shortcut_is_supported(code: &str, modifiers: &DictationShortcutModifiers) -> bool {
-    vk_for_code(code).is_some() && (modifiers.control || modifiers.option || modifiers.command)
+    validate_shortcut_for_windows(code, modifiers).is_ok()
 }
 
 /// What the keyboard hook should do for one key event of a (potential)
@@ -528,22 +555,46 @@ mod windows_impl {
             if !injected && is_down && !is_modifier_vk(vk) {
                 guard.capturing = false;
                 let modifiers = current_modifiers();
-                if let Some(code) = code_for_vk(vk) {
-                    let key = key_label_for_vk(vk).unwrap_or_else(|| code.clone());
-                    let label = windows_shortcut_label(&modifiers, &key);
-                    dispatch_worker(WorkerMsg::Captured {
-                        code,
-                        label,
-                        modifiers,
-                    });
-                } else {
-                    dispatch_worker(WorkerMsg::Command(json!({
-                        "type": "__emit",
-                        "event": {
-                            "type": "shortcut_capture_error",
-                            "payload": { "message": "That key can't be used as a Windows shortcut." },
-                        },
-                    })));
+                // Validate against the same rule the save path enforces, so
+                // an unsupported chord (unknown key, or no Ctrl/Alt/Win) is
+                // rejected here with the user-facing message instead of
+                // reaching the auto-save just to be rejected there.
+                match code_for_vk(vk) {
+                    Some(code)
+                        if super::validate_shortcut_for_windows(&code, &modifiers).is_ok() =>
+                    {
+                        let key = key_label_for_vk(vk).unwrap_or_else(|| code.clone());
+                        let label = windows_shortcut_label(&modifiers, &key);
+                        dispatch_worker(WorkerMsg::Captured {
+                            code,
+                            label,
+                            modifiers,
+                        });
+                    }
+                    Some(code) => {
+                        let message = super::validate_shortcut_for_windows(&code, &modifiers)
+                            .err()
+                            .map(|error| error.message)
+                            .unwrap_or_else(|| {
+                                "This shortcut can't be used on Windows.".to_string()
+                            });
+                        dispatch_worker(WorkerMsg::Command(json!({
+                            "type": "__emit",
+                            "event": {
+                                "type": "shortcut_capture_error",
+                                "payload": { "message": message },
+                            },
+                        })));
+                    }
+                    None => {
+                        dispatch_worker(WorkerMsg::Command(json!({
+                            "type": "__emit",
+                            "event": {
+                                "type": "shortcut_capture_error",
+                                "payload": { "message": "This key can't be used for a dictation shortcut on Windows." },
+                            },
+                        })));
+                    }
                 }
                 return true;
             }
@@ -1285,9 +1336,9 @@ mod windows_impl {
 #[cfg(test)]
 mod tests {
     use super::{
-        code_for_vk, key_label_for_vk, shortcut_edge_action, shortcut_is_supported, vk_for_code,
-        windows_shortcut_label, DictationShortcutKind, DictationShortcutModifiers,
-        ShortcutEdgeAction,
+        code_for_vk, key_label_for_vk, shortcut_edge_action, shortcut_is_supported,
+        validate_shortcut_for_windows, vk_for_code, windows_shortcut_label, DictationShortcutKind,
+        DictationShortcutModifiers, ShortcutEdgeAction,
     };
 
     fn ctrl_alt() -> DictationShortcutModifiers {
@@ -1438,5 +1489,48 @@ mod tests {
         // macOS-only bare Fn / modifier-only chords have no Windows key.
         assert!(!shortcut_is_supported("Fn", &ctrl_alt()));
         assert!(!shortcut_is_supported("Modifiers", &ctrl_alt()));
+    }
+
+    #[test]
+    fn windows_save_validation_rejects_chords_the_hook_cannot_arm() {
+        // Shift-only passes the shared (macOS) validation, but the Windows
+        // hook can't arm it; the save path must reject with a user-facing
+        // message instead of saving a shortcut that never fires.
+        let shift_only = DictationShortcutModifiers {
+            shift: true,
+            ..DictationShortcutModifiers::default()
+        };
+        let error = validate_shortcut_for_windows("KeyD", &shift_only)
+            .expect_err("shift-only chord must be rejected on Windows");
+        assert_eq!(error.code, "dictation_shortcut_modifier_required");
+        assert_eq!(
+            error.message,
+            "This shortcut needs Ctrl, Alt, or the Windows key on Windows."
+        );
+
+        // Keys with no Windows virtual-key mapping are rejected too.
+        let error = validate_shortcut_for_windows("Fn", &ctrl_alt())
+            .expect_err("bare Fn has no Windows key");
+        assert_eq!(error.code, "dictation_shortcut_unsupported");
+        assert_eq!(
+            error.message,
+            "This key can't be used for a dictation shortcut on Windows."
+        );
+    }
+
+    #[test]
+    fn windows_save_validation_accepts_armable_chords() {
+        assert!(validate_shortcut_for_windows("KeyD", &ctrl_alt()).is_ok());
+        let ctrl_only = DictationShortcutModifiers {
+            control: true,
+            ..DictationShortcutModifiers::default()
+        };
+        assert!(validate_shortcut_for_windows("KeyT", &ctrl_only).is_ok());
+        let win_shift = DictationShortcutModifiers {
+            command: true,
+            shift: true,
+            ..DictationShortcutModifiers::default()
+        };
+        assert!(validate_shortcut_for_windows("Space", &win_shift).is_ok());
     }
 }

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -1,0 +1,1273 @@
+//! Windows dictation backend — the platform twin of the macOS Swift dictation
+//! helper (`src-tauri/native/mac-dictation-helper/main.swift`).
+//!
+//! On macOS a separate Swift process owns global shortcut listening, microphone
+//! capture, focus tracking and paste injection, and talks to `dictation.rs`
+//! over a JSON line protocol. Windows has every one of those capabilities
+//! available in-process through Win32, so instead of a second binary this
+//! module runs an in-process helper that speaks the exact same event/command
+//! protocol:
+//!
+//! * shortcut edges are emitted as `shortcut_key_down` / `shortcut_key_up`
+//!   events (kind `toggle` / `push_to_talk`) that flow into the shared
+//!   [`crate::dictation`] activation controller, which decides start/stop;
+//! * microphone capture writes the same 16-bit PCM WAV the note-recording path
+//!   produces (via `cpal`/`hound`) and reports `recording_ready` with the
+//!   foreground executable as the paste target;
+//! * `paste_text` sets the clipboard and synthesizes Ctrl+V, restoring the
+//!   prior clipboard text afterwards.
+//!
+//! The transcription and cleanup pipeline stays entirely in `dictation.rs` and
+//! is shared with macOS. Only the pure, platform-neutral helpers below (key
+//! mapping, modifier labels) are compiled off-Windows so they can be unit
+//! tested on the host; everything that touches Win32 is behind
+//! `cfg(target_os = "windows")`.
+
+use crate::dictation::DictationShortcutModifiers;
+
+/// Maps a subset of DOM `KeyboardEvent.code` values (how dictation shortcuts
+/// are stored, platform-neutrally) to Windows virtual-key codes. Covers the
+/// letters, digits and a handful of common keys that a dictation shortcut is
+/// realistically bound to; anything outside the table (e.g. the macOS-only
+/// bare `Fn` or modifier-only chords) has no Windows equivalent and disables
+/// hook matching for that shortcut.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn vk_for_code(code: &str) -> Option<u16> {
+    // Letters: "KeyA".."KeyZ" -> 0x41..0x5A (VK == ASCII uppercase).
+    if let Some(letter) = code.strip_prefix("Key") {
+        let mut chars = letter.chars();
+        if let (Some(ch), None) = (chars.next(), chars.next()) {
+            if ch.is_ascii_alphabetic() {
+                return Some(ch.to_ascii_uppercase() as u16);
+            }
+        }
+    }
+    // Digit row: "Digit0".."Digit9" -> 0x30..0x39.
+    if let Some(digit) = code.strip_prefix("Digit") {
+        let mut chars = digit.chars();
+        if let (Some(ch), None) = (chars.next(), chars.next()) {
+            if ch.is_ascii_digit() {
+                return Some(ch as u16);
+            }
+        }
+    }
+    Some(match code {
+        "Space" => 0x20,
+        "Enter" => 0x0D,
+        "Tab" => 0x09,
+        "Backquote" => 0xC0,
+        "Minus" => 0xBD,
+        "Equal" => 0xBB,
+        "BracketLeft" => 0xDB,
+        "BracketRight" => 0xDD,
+        "Backslash" => 0xDC,
+        "Semicolon" => 0xBA,
+        "Quote" => 0xDE,
+        "Comma" => 0xBC,
+        "Period" => 0xBE,
+        "Slash" => 0xBF,
+        "F1" => 0x70,
+        "F2" => 0x71,
+        "F3" => 0x72,
+        "F4" => 0x73,
+        "F5" => 0x74,
+        "F6" => 0x75,
+        "F7" => 0x76,
+        "F8" => 0x77,
+        "F9" => 0x78,
+        "F10" => 0x79,
+        "F11" => 0x7A,
+        "F12" => 0x7B,
+        _ => return None,
+    })
+}
+
+/// Inverse of [`vk_for_code`] for the interactive shortcut-capture flow: turns
+/// a captured virtual-key code back into a DOM `KeyboardEvent.code` the
+/// settings UI understands.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn code_for_vk(vk: u16) -> Option<String> {
+    match vk {
+        0x41..=0x5A => Some(format!("Key{}", (vk as u8) as char)),
+        0x30..=0x39 => Some(format!("Digit{}", (vk as u8) as char)),
+        0x20 => Some("Space".to_string()),
+        0x0D => Some("Enter".to_string()),
+        0x09 => Some("Tab".to_string()),
+        0xC0 => Some("Backquote".to_string()),
+        0xBD => Some("Minus".to_string()),
+        0xBB => Some("Equal".to_string()),
+        0xDB => Some("BracketLeft".to_string()),
+        0xDD => Some("BracketRight".to_string()),
+        0xDC => Some("Backslash".to_string()),
+        0xBA => Some("Semicolon".to_string()),
+        0xDE => Some("Quote".to_string()),
+        0xBC => Some("Comma".to_string()),
+        0xBE => Some("Period".to_string()),
+        0xBF => Some("Slash".to_string()),
+        0x70..=0x7B => Some(format!("F{}", vk - 0x6F)),
+        _ => None,
+    }
+}
+
+/// Human-readable key label for the non-modifier key of a captured shortcut,
+/// e.g. VK `0x44` -> "D", `0x20` -> "Space".
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn key_label_for_vk(vk: u16) -> Option<String> {
+    match vk {
+        0x41..=0x5A => Some(((vk as u8) as char).to_string()),
+        0x30..=0x39 => Some(((vk as u8) as char).to_string()),
+        0x20 => Some("Space".to_string()),
+        0x0D => Some("Enter".to_string()),
+        0x09 => Some("Tab".to_string()),
+        0x70..=0x7B => Some(format!("F{}", vk - 0x6F)),
+        _ => code_for_vk(vk),
+    }
+}
+
+/// Windows-flavored shortcut label from modifiers plus a key label. Mirrors the
+/// order the macOS helper uses but with Windows modifier names (Ctrl / Alt /
+/// Win / Shift) so the settings copy reads correctly on Windows.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn windows_shortcut_label(modifiers: &DictationShortcutModifiers, key: &str) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if modifiers.control {
+        parts.push("Ctrl");
+    }
+    if modifiers.option {
+        parts.push("Alt");
+    }
+    if modifiers.command {
+        parts.push("Win");
+    }
+    if modifiers.shift {
+        parts.push("Shift");
+    }
+    let mut label = parts.join("+");
+    if !key.is_empty() {
+        if !label.is_empty() {
+            label.push('+');
+        }
+        label.push_str(key);
+    }
+    label
+}
+
+/// Whether a stored shortcut can be matched by the Windows keyboard hook. The
+/// macOS bare-`Fn` and modifier-only chords have no Windows equivalent, and a
+/// shortcut with no modifier would be a global key eater; both are rejected so
+/// the hook only ever fires on a real, modified key combo.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(crate) fn shortcut_is_supported(code: &str, modifiers: &DictationShortcutModifiers) -> bool {
+    vk_for_code(code).is_some() && (modifiers.control || modifiers.option || modifiers.command)
+}
+
+#[cfg(target_os = "windows")]
+pub use windows_impl::{dispatch, init, shutdown};
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use super::{
+        code_for_vk, key_label_for_vk, shortcut_is_supported, vk_for_code, windows_shortcut_label,
+    };
+    use crate::dictation::{
+        ingest_helper_event, DictationShortcutKind, DictationShortcutModifiers,
+    };
+    use crate::domain::types::AppError;
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use hound::{SampleFormat, WavSpec, WavWriter};
+    use serde_json::json;
+    use std::fs::File;
+    use std::io::BufWriter;
+    use std::path::PathBuf;
+    use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+    use std::sync::{Arc, Mutex, OnceLock};
+    use std::time::Duration;
+    use tauri::AppHandle;
+    use windows::core::{PCWSTR, PWSTR};
+    use windows::Win32::Foundation::{
+        CloseHandle, HANDLE, HGLOBAL, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM,
+    };
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
+    };
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows::Win32::System::Ole::CF_UNICODETEXT;
+    use windows::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        GetAsyncKeyState, SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
+        KEYEVENTF_KEYUP, VIRTUAL_KEY,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CallNextHookEx, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
+        SetForegroundWindow, SetWindowsHookExW, HC_ACTION, KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL,
+        WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN, WM_SYSKEYUP,
+    };
+
+    const VK_CONTROL: i32 = 0x11;
+    const VK_MENU: i32 = 0x12;
+    const VK_SHIFT: i32 = 0x10;
+    const VK_LWIN: i32 = 0x5B;
+    const VK_RWIN: i32 = 0x5C;
+    const VK_V: u16 = 0x56;
+    const VK_CONTROL_U16: u16 = 0x11;
+
+    /// A shortcut resolved for the keyboard hook: the trigger virtual-key plus
+    /// the exact modifier combination that must be held.
+    #[derive(Clone, Copy)]
+    struct WinShortcut {
+        kind: DictationShortcutKind,
+        vk: u16,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+        win: bool,
+    }
+
+    impl WinShortcut {
+        fn modifiers_match(&self) -> bool {
+            modifier_down(VK_CONTROL) == self.ctrl
+                && modifier_down(VK_MENU) == self.alt
+                && modifier_down(VK_SHIFT) == self.shift
+                && (modifier_down(VK_LWIN) || modifier_down(VK_RWIN)) == self.win
+        }
+    }
+
+    /// State the low-level keyboard hook reads on every key event. Guarded by a
+    /// mutex that the hook proc only ever `try_lock`s, so a slow lock can never
+    /// stall global input.
+    struct HookState {
+        shortcuts: Vec<WinShortcut>,
+        /// When set, the next non-modifier key is recorded and reported as a
+        /// captured shortcut instead of being matched.
+        capturing: bool,
+        /// Trigger keys whose down-edge we suppressed, so their up-edge is
+        /// suppressed too and reported as a release.
+        suppressed: Vec<(u16, DictationShortcutKind)>,
+    }
+
+    struct Helper {
+        worker: Sender<WorkerMsg>,
+    }
+
+    static HELPER: OnceLock<Helper> = OnceLock::new();
+    static HOOK_STATE: OnceLock<Mutex<HookState>> = OnceLock::new();
+    static WORKER_SENDER: OnceLock<Sender<WorkerMsg>> = OnceLock::new();
+
+    enum WorkerMsg {
+        ShortcutEdge {
+            kind: DictationShortcutKind,
+            down: bool,
+        },
+        Captured {
+            code: String,
+            label: String,
+            modifiers: DictationShortcutModifiers,
+        },
+        Command(serde_json::Value),
+    }
+
+    /// Initializes the in-process helper: spawns the capture/command worker and
+    /// installs the global keyboard hook. Called once from `dictation::setup`
+    /// before any shortcut/microphone settings are applied.
+    pub fn init(app: &AppHandle) {
+        if HELPER.get().is_some() {
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel::<WorkerMsg>();
+        let _ = HOOK_STATE.set(Mutex::new(HookState {
+            shortcuts: Vec::new(),
+            capturing: false,
+            suppressed: Vec::new(),
+        }));
+        let _ = WORKER_SENDER.set(tx.clone());
+        let _ = HELPER.set(Helper { worker: tx });
+
+        let worker_app = app.clone();
+        std::thread::Builder::new()
+            .name("june-dictation-worker".into())
+            .spawn(move || run_worker(worker_app, rx))
+            .ok();
+
+        std::thread::Builder::new()
+            .name("june-dictation-hook".into())
+            .spawn(run_hook_thread)
+            .ok();
+
+        ingest_helper_event(app, json!({ "type": "ready" }));
+    }
+
+    /// Routes a helper command from `dictation.rs`. Capture- and paste-related
+    /// commands are serialized onto the worker thread; hook configuration is
+    /// applied inline. Unknown commands are accepted as no-ops so the shared
+    /// command surface stays forgiving.
+    pub fn dispatch(command: serde_json::Value) -> Result<(), AppError> {
+        let kind = command
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        match kind {
+            "set_shortcut" => {
+                apply_set_shortcut(&command);
+                Ok(())
+            }
+            "start_shortcut_capture" => {
+                set_capturing(true);
+                emit(json!({ "type": "shortcut_capture_started" }));
+                Ok(())
+            }
+            "cancel_shortcut_capture" => {
+                set_capturing(false);
+                emit(json!({ "type": "shortcut_capture_cancelled" }));
+                Ok(())
+            }
+            _ => send_worker(WorkerMsg::Command(command)),
+        }
+    }
+
+    /// Stops the worker on app teardown. The global keyboard hook is torn down
+    /// by process exit.
+    pub fn shutdown() {
+        let _ = send_worker(WorkerMsg::Command(json!({ "type": "shutdown" })));
+    }
+
+    fn send_worker(msg: WorkerMsg) -> Result<(), AppError> {
+        let Some(helper) = HELPER.get() else {
+            return Err(AppError::new(
+                "dictation_helper_unavailable",
+                "Windows dictation helper is not initialized.",
+            ));
+        };
+        helper.worker.send(msg).map_err(|_| {
+            AppError::new(
+                "dictation_helper_unavailable",
+                "Windows dictation worker is not running.",
+            )
+        })
+    }
+
+    fn emit(event: serde_json::Value) {
+        if let Some(helper) = HELPER.get() {
+            let _ = helper.worker.send(WorkerMsg::Command(json!({
+                "type": "__emit",
+                "event": event,
+            })));
+        }
+    }
+
+    fn set_capturing(on: bool) {
+        if let Some(state) = HOOK_STATE.get() {
+            if let Ok(mut guard) = state.lock() {
+                guard.capturing = on;
+            }
+        }
+    }
+
+    fn apply_set_shortcut(command: &serde_json::Value) {
+        let Some(shortcut) = command.get("shortcut") else {
+            return;
+        };
+        let kind = match shortcut.get("kind").and_then(serde_json::Value::as_str) {
+            Some("push_to_talk") => DictationShortcutKind::PushToTalk,
+            Some("toggle") => DictationShortcutKind::Toggle,
+            _ => return,
+        };
+        let code = shortcut
+            .get("code")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        let modifiers: DictationShortcutModifiers = shortcut
+            .get("modifiers")
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default();
+
+        let resolved = if shortcut_is_supported(code, &modifiers) {
+            vk_for_code(code).map(|vk| WinShortcut {
+                kind,
+                vk,
+                ctrl: modifiers.control,
+                alt: modifiers.option,
+                shift: modifiers.shift,
+                win: modifiers.command,
+            })
+        } else {
+            None
+        };
+
+        if let Some(state) = HOOK_STATE.get() {
+            if let Ok(mut guard) = state.lock() {
+                guard.shortcuts.retain(|existing| existing.kind != kind);
+                if let Some(resolved) = resolved {
+                    guard.shortcuts.push(resolved);
+                }
+            }
+        }
+    }
+
+    // ---- keyboard hook ----------------------------------------------------
+
+    fn run_hook_thread() {
+        unsafe {
+            let module = GetModuleHandleW(PCWSTR::null()).unwrap_or_default();
+            let hook = SetWindowsHookExW(
+                WH_KEYBOARD_LL,
+                Some(keyboard_hook_proc),
+                HINSTANCE(module.0),
+                0,
+            );
+            if hook.is_err() {
+                return;
+            }
+            // Low-level hooks require the installing thread to pump messages;
+            // the proc itself runs between GetMessage calls.
+            let mut msg = MSG::default();
+            while GetMessageW(&mut msg, HWND(0), 0, 0).as_bool() {}
+        }
+    }
+
+    unsafe extern "system" fn keyboard_hook_proc(
+        code: i32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        if code == HC_ACTION as i32 {
+            let info = &*(lparam.0 as *const KBDLLHOOKSTRUCT);
+            let message = wparam.0 as u32;
+            let vk = info.vkCode as u16;
+            let is_down = message == WM_KEYDOWN || message == WM_SYSKEYDOWN;
+            let is_up = message == WM_KEYUP || message == WM_SYSKEYUP;
+            if (is_down || is_up) && process_key(vk, is_down) {
+                // Swallow the trigger key so the shortcut doesn't leak into the
+                // focused app (e.g. typing the push-to-talk key while dictating).
+                return LRESULT(1);
+            }
+        }
+        CallNextHookEx(None, code, wparam, lparam)
+    }
+
+    /// Pure-ish hook decision: matches the key against configured shortcuts (or
+    /// records it in capture mode) and returns whether to suppress it. Only ever
+    /// `try_lock`s the shared state so it can never block global input.
+    fn process_key(vk: u16, is_down: bool) -> bool {
+        let Some(state) = HOOK_STATE.get() else {
+            return false;
+        };
+        let Ok(mut guard) = state.try_lock() else {
+            return false;
+        };
+
+        if guard.capturing {
+            if is_down && !is_modifier_vk(vk) {
+                guard.capturing = false;
+                let modifiers = current_modifiers();
+                if let Some(code) = code_for_vk(vk) {
+                    let key = key_label_for_vk(vk).unwrap_or_else(|| code.clone());
+                    let label = windows_shortcut_label(&modifiers, &key);
+                    dispatch_worker(WorkerMsg::Captured {
+                        code,
+                        label,
+                        modifiers,
+                    });
+                } else {
+                    dispatch_worker(WorkerMsg::Command(json!({
+                        "type": "__emit",
+                        "event": {
+                            "type": "shortcut_capture_error",
+                            "payload": { "message": "That key can't be used as a Windows shortcut." },
+                        },
+                    })));
+                }
+                return true;
+            }
+            return false;
+        }
+
+        if is_down {
+            let matched = guard
+                .shortcuts
+                .iter()
+                .find(|shortcut| shortcut.vk == vk && shortcut.modifiers_match())
+                .map(|shortcut| shortcut.kind);
+            if let Some(kind) = matched {
+                if !guard.suppressed.iter().any(|(held, _)| *held == vk) {
+                    guard.suppressed.push((vk, kind));
+                }
+                dispatch_worker(WorkerMsg::ShortcutEdge { kind, down: true });
+                return true;
+            }
+            return false;
+        }
+
+        // Key up: release any suppressed trigger.
+        if let Some(position) = guard.suppressed.iter().position(|(held, _)| *held == vk) {
+            let (_, kind) = guard.suppressed.remove(position);
+            dispatch_worker(WorkerMsg::ShortcutEdge { kind, down: false });
+            return true;
+        }
+        false
+    }
+
+    fn dispatch_worker(msg: WorkerMsg) {
+        if let Some(sender) = WORKER_SENDER.get() {
+            let _ = sender.send(msg);
+        }
+    }
+
+    fn is_modifier_vk(vk: u16) -> bool {
+        matches!(
+            vk as i32,
+            VK_CONTROL | VK_MENU | VK_SHIFT | VK_LWIN | VK_RWIN
+        ) || vk == 0xA0 // LSHIFT
+            || vk == 0xA1 // RSHIFT
+            || vk == 0xA2 // LCONTROL
+            || vk == 0xA3 // RCONTROL
+            || vk == 0xA4 // LMENU
+            || vk == 0xA5 // RMENU
+    }
+
+    fn modifier_down(vk: i32) -> bool {
+        unsafe { (GetAsyncKeyState(vk) as u16 & 0x8000) != 0 }
+    }
+
+    fn current_modifiers() -> DictationShortcutModifiers {
+        DictationShortcutModifiers {
+            command: modifier_down(VK_LWIN) || modifier_down(VK_RWIN),
+            control: modifier_down(VK_CONTROL),
+            option: modifier_down(VK_MENU),
+            shift: modifier_down(VK_SHIFT),
+            function: false,
+        }
+    }
+
+    // ---- capture / command worker ----------------------------------------
+
+    #[derive(Default)]
+    struct LevelState {
+        /// Peak since the last audio_level tick (drives the live meter).
+        interval_peak: f32,
+        /// Max level seen for the whole utterance (reported with recording_ready).
+        observed_max: f32,
+    }
+
+    struct CaptureSession {
+        path: PathBuf,
+        writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
+        level: Arc<Mutex<LevelState>>,
+        _stream: cpal::Stream,
+    }
+
+    struct Worker {
+        app: AppHandle,
+        listening: bool,
+        capture: Option<CaptureSession>,
+        last_recording: Option<PathBuf>,
+        target: Option<(isize, String)>,
+        selected_mic: Option<String>,
+    }
+
+    fn run_worker(app: AppHandle, rx: Receiver<WorkerMsg>) {
+        let mut worker = Worker {
+            app,
+            listening: false,
+            capture: None,
+            last_recording: None,
+            target: None,
+            selected_mic: None,
+        };
+        loop {
+            match rx.recv_timeout(Duration::from_millis(60)) {
+                Ok(msg) => {
+                    if worker.handle(msg) {
+                        break;
+                    }
+                }
+                Err(RecvTimeoutError::Timeout) => worker.tick_level(),
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    }
+
+    impl Worker {
+        /// Returns true when the worker should stop.
+        fn handle(&mut self, msg: WorkerMsg) -> bool {
+            match msg {
+                WorkerMsg::ShortcutEdge { kind, down } => {
+                    let event_type = if down {
+                        "shortcut_key_down"
+                    } else {
+                        "shortcut_key_up"
+                    };
+                    let payload_kind = match kind {
+                        DictationShortcutKind::PushToTalk => "push_to_talk",
+                        DictationShortcutKind::Toggle => "toggle",
+                    };
+                    self.emit(json!({
+                        "type": event_type,
+                        "payload": { "kind": payload_kind },
+                    }));
+                }
+                WorkerMsg::Captured {
+                    code,
+                    label,
+                    modifiers,
+                } => {
+                    self.emit(json!({
+                        "type": "shortcut_captured",
+                        "payload": {
+                            "shortcut": {
+                                "code": code,
+                                "label": label,
+                                "modifiers": modifiers,
+                                "pressCount": 1,
+                            },
+                        },
+                    }));
+                }
+                WorkerMsg::Command(command) => return self.handle_command(command),
+            }
+            false
+        }
+
+        fn handle_command(&mut self, command: serde_json::Value) -> bool {
+            let kind = command
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default();
+            match kind {
+                "__emit" => {
+                    if let Some(event) = command.get("event") {
+                        self.emit(event.clone());
+                    }
+                }
+                "start_listening" => self.start(),
+                "stop_and_paste" => self.stop(),
+                "discard_recording" => self.discard(),
+                "toggle_listening" => {
+                    let shortcut = command
+                        .get("shortcut")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("hotkey")
+                        .to_string();
+                    if self.listening {
+                        self.emit(json!({
+                            "type": "hotkey_trigger",
+                            "payload": { "action": "stop", "shortcut": shortcut },
+                        }));
+                        self.stop();
+                    } else {
+                        self.emit(json!({
+                            "type": "hotkey_trigger",
+                            "payload": { "action": "start", "shortcut": shortcut },
+                        }));
+                        self.start();
+                    }
+                }
+                "paste_text" => {
+                    let text = command
+                        .get("text")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    self.paste(text);
+                }
+                "set_microphone" => {
+                    self.selected_mic = command
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|name| !name.trim().is_empty())
+                        .map(str::to_string);
+                }
+                "list_microphones" => self.emit_microphones(),
+                "get_permission_status" | "request_microphone_permission" => {
+                    self.emit_permission_status()
+                }
+                "shutdown" => {
+                    self.discard();
+                    self.emit(json!({ "type": "shutdown_ack" }));
+                    return true;
+                }
+                _ => {}
+            }
+            false
+        }
+
+        fn emit(&self, event: serde_json::Value) {
+            ingest_helper_event(&self.app, event);
+        }
+
+        fn tick_level(&mut self) {
+            if !self.listening {
+                return;
+            }
+            let Some(session) = self.capture.as_ref() else {
+                return;
+            };
+            let level = {
+                let Ok(mut guard) = session.level.lock() else {
+                    return;
+                };
+                let peak = guard.interval_peak;
+                guard.interval_peak = 0.0;
+                peak
+            };
+            self.emit(json!({
+                "type": "audio_level",
+                "payload": { "level": format!("{level:.4}") },
+            }));
+        }
+
+        fn start(&mut self) {
+            if self.listening {
+                return;
+            }
+            // Remember the app the user is dictating into (the foreground window
+            // now, before our non-focusable HUD appears) as the paste target.
+            self.target = foreground_target();
+            if let Some((_, ref name)) = self.target {
+                self.emit(json!({
+                    "type": "focus_target",
+                    "payload": { "app": name },
+                }));
+            }
+            match self.begin_capture() {
+                Ok(session) => {
+                    self.capture = Some(session);
+                    self.listening = true;
+                    self.emit(json!({
+                        "type": "listening_started",
+                        "payload": {
+                            "recognitionMode": "venice_recording",
+                            "microphone": self.selected_mic.clone().unwrap_or_default(),
+                        },
+                    }));
+                }
+                Err(error) => {
+                    self.emit(json!({
+                        "type": "error",
+                        "payload": { "code": error.code, "message": error.message },
+                    }));
+                }
+            }
+        }
+
+        fn stop(&mut self) {
+            if !self.listening {
+                return;
+            }
+            self.listening = false;
+            self.emit(json!({ "type": "finalizing_transcript" }));
+            let Some(session) = self.capture.take() else {
+                return;
+            };
+            let observed = finalize_capture(session);
+            match observed {
+                Ok((path, observed_max)) => {
+                    self.last_recording = Some(path.clone());
+                    let target = self.target.as_ref().map(|(_, name)| name.clone());
+                    self.emit(json!({
+                        "type": "recording_ready",
+                        "payload": {
+                            "path": path.to_string_lossy(),
+                            "observedAudioLevel": format!("{observed_max:.4}"),
+                            "targetBundleIdentifier": target.unwrap_or_default(),
+                        },
+                    }));
+                }
+                Err(error) => {
+                    self.emit(json!({
+                        "type": "error",
+                        "payload": { "code": error.code, "message": error.message },
+                    }));
+                }
+            }
+        }
+
+        fn discard(&mut self) {
+            self.listening = false;
+            if let Some(session) = self.capture.take() {
+                let path = session.path.clone();
+                drop(session);
+                let _ = std::fs::remove_file(&path);
+            }
+            if let Some(path) = self.last_recording.take() {
+                let _ = std::fs::remove_file(path);
+            }
+            self.emit(json!({ "type": "recording_discarded" }));
+        }
+
+        fn paste(&mut self, text: String) {
+            // Drop the just-transcribed recording; it has served its purpose.
+            if let Some(path) = self.last_recording.take() {
+                let _ = std::fs::remove_file(path);
+            }
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return;
+            }
+            let to_paste = format!("{trimmed} ");
+            let previous = clipboard_get_text();
+            if let Err(error) = clipboard_set_text(&to_paste) {
+                self.emit(json!({
+                    "type": "error",
+                    "payload": { "code": error.code, "message": error.message },
+                }));
+                return;
+            }
+            let activated = self
+                .target
+                .as_ref()
+                .map(|(hwnd, _)| activate_window(*hwnd))
+                .unwrap_or(false);
+            let target_name = self
+                .target
+                .as_ref()
+                .map(|(_, name)| name.clone())
+                .unwrap_or_else(|| "unknown".to_string());
+            self.emit(json!({
+                "type": "paste_target",
+                "payload": { "app": target_name, "activated": activated },
+            }));
+            // Restore the clipboard on a detached timer once the paste has had a
+            // moment to land, so we never clobber the app's own paste in flight.
+            let app = self.app.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(180));
+                send_ctrl_v();
+                ingest_helper_event(&app, json!({ "type": "paste_completed" }));
+                std::thread::sleep(Duration::from_millis(700));
+                if clipboard_get_text().as_deref() == Some(to_paste.as_str()) {
+                    match previous {
+                        Some(previous) => {
+                            let _ = clipboard_set_text(&previous);
+                        }
+                        None => clipboard_clear(),
+                    }
+                }
+            });
+        }
+
+        fn begin_capture(&self) -> Result<CaptureSession, AppError> {
+            let host = cpal::default_host();
+            let device = self
+                .selected_mic
+                .as_ref()
+                .and_then(|name| {
+                    host.input_devices().ok().and_then(|mut devices| {
+                        devices.find(|device| device.name().ok().as_deref() == Some(name.as_str()))
+                    })
+                })
+                .or_else(|| host.default_input_device())
+                .ok_or_else(|| {
+                    AppError::new(
+                        "microphone_unavailable",
+                        "No microphone input device is available.",
+                    )
+                })?;
+            let config = device
+                .default_input_config()
+                .map_err(|error| AppError::new("microphone_unavailable", error.to_string()))?;
+            let sample_rate = config.sample_rate().0;
+            let channels = config.channels();
+
+            let path = std::env::temp_dir()
+                .join(format!("os-june-dictation-{}.wav", uuid::Uuid::new_v4()));
+            let writer = WavWriter::create(
+                &path,
+                WavSpec {
+                    channels,
+                    sample_rate,
+                    bits_per_sample: 16,
+                    sample_format: SampleFormat::Int,
+                },
+            )
+            .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
+            let writer = Arc::new(Mutex::new(Some(writer)));
+            let level = Arc::new(Mutex::new(LevelState::default()));
+
+            let stream = build_input_stream(&device, &config, writer.clone(), level.clone())?;
+            stream
+                .play()
+                .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
+
+            Ok(CaptureSession {
+                path,
+                writer,
+                level,
+                _stream: stream,
+            })
+        }
+
+        fn emit_microphones(&self) {
+            let host = cpal::default_host();
+            let selected = self
+                .selected_mic
+                .clone()
+                .or_else(|| {
+                    host.default_input_device()
+                        .and_then(|device| device.name().ok())
+                })
+                .unwrap_or_default();
+            let devices: Vec<serde_json::Value> = host
+                .input_devices()
+                .map(|devices| {
+                    devices
+                        .filter_map(|device| device.name().ok())
+                        .map(|name| json!({ "id": name, "name": name }))
+                        .collect()
+                })
+                .unwrap_or_default();
+            self.emit(json!({
+                "type": "microphone_devices",
+                "payload": { "devices": devices, "selectedID": selected },
+            }));
+        }
+
+        fn emit_permission_status(&self) {
+            let (microphone, _) = crate::audio::capture::microphone_permission_state();
+            self.emit(json!({
+                "type": "permission_status",
+                "payload": { "microphone": microphone, "accessibility": "granted" },
+            }));
+        }
+    }
+
+    fn build_input_stream(
+        device: &cpal::Device,
+        config: &cpal::SupportedStreamConfig,
+        writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
+        level: Arc<Mutex<LevelState>>,
+    ) -> Result<cpal::Stream, AppError> {
+        let err_fn = |error| tracing::warn!(%error, "dictation capture stream error");
+        let stream_config: cpal::StreamConfig = config.clone().into();
+        let stream = match config.sample_format() {
+            cpal::SampleFormat::F32 => device.build_input_stream(
+                &stream_config,
+                move |data: &[f32], _| write_samples(data.iter().copied(), &writer, &level),
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::I16 => device.build_input_stream(
+                &stream_config,
+                move |data: &[i16], _| {
+                    write_samples(
+                        data.iter().map(|sample| *sample as f32 / i16::MAX as f32),
+                        &writer,
+                        &level,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            cpal::SampleFormat::U16 => device.build_input_stream(
+                &stream_config,
+                move |data: &[u16], _| {
+                    write_samples(
+                        data.iter()
+                            .map(|sample| (*sample as f32 - 32768.0) / 32768.0),
+                        &writer,
+                        &level,
+                    )
+                },
+                err_fn,
+                None,
+            ),
+            _ => {
+                return Err(AppError::new(
+                    "microphone_unavailable",
+                    "Unsupported microphone sample format.",
+                ))
+            }
+        }
+        .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
+        Ok(stream)
+    }
+
+    fn write_samples<I>(
+        data: I,
+        writer: &Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
+        level: &Arc<Mutex<LevelState>>,
+    ) where
+        I: Iterator<Item = f32>,
+    {
+        let Ok(mut writer_guard) = writer.lock() else {
+            return;
+        };
+        let Some(writer) = writer_guard.as_mut() else {
+            return;
+        };
+        let mut peak = 0.0_f32;
+        for sample in data {
+            let clamped = sample.clamp(-1.0, 1.0);
+            peak = peak.max(clamped.abs());
+            let _ = writer.write_sample((clamped * i16::MAX as f32) as i16);
+        }
+        drop(writer_guard);
+        if let Ok(mut level) = level.lock() {
+            level.interval_peak = level.interval_peak.max(peak);
+            level.observed_max = level.observed_max.max(peak);
+        }
+    }
+
+    /// Finalizes the WAV and returns the path plus the max observed level.
+    fn finalize_capture(session: CaptureSession) -> Result<(PathBuf, f32), AppError> {
+        let CaptureSession {
+            path,
+            writer,
+            level,
+            _stream,
+        } = session;
+        drop(_stream);
+        let observed_max = level.lock().map(|guard| guard.observed_max).unwrap_or(0.0);
+        if let Some(writer) = writer
+            .lock()
+            .map_err(|_| AppError::new("audio_finalization_failed", "Audio writer lock failed."))?
+            .take()
+        {
+            writer
+                .finalize()
+                .map_err(|error| AppError::new("audio_finalization_failed", error.to_string()))?;
+        }
+        Ok((path, observed_max))
+    }
+
+    // ---- foreground window ------------------------------------------------
+
+    /// The foreground window's executable identity, used both as the HUD focus
+    /// label and as the `targetBundleIdentifier`-equivalent for the email
+    /// app-context mapping. Returns the raw HWND (as `isize`, since HWND is not
+    /// `Send`) plus the lowercased executable file name (e.g. "outlook.exe").
+    fn foreground_target() -> Option<(isize, String)> {
+        unsafe {
+            let hwnd = GetForegroundWindow();
+            if hwnd.0 == 0 {
+                return None;
+            }
+            let mut pid: u32 = 0;
+            GetWindowThreadProcessId(hwnd, Some(&mut pid));
+            if pid == 0 {
+                return Some((hwnd.0, String::new()));
+            }
+            let name = process_executable_name(pid).unwrap_or_default();
+            Some((hwnd.0, name))
+        }
+    }
+
+    unsafe fn process_executable_name(pid: u32) -> Option<String> {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+        let mut buffer = [0u16; 260];
+        let mut size = buffer.len() as u32;
+        let result = QueryFullProcessImageNameW(
+            handle,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut size,
+        );
+        let _ = CloseHandle(handle);
+        result.ok()?;
+        let full = String::from_utf16_lossy(&buffer[..size as usize]);
+        full.rsplit(['\\', '/'])
+            .next()
+            .map(|name| name.to_ascii_lowercase())
+    }
+
+    fn activate_window(hwnd: isize) -> bool {
+        if hwnd == 0 {
+            return false;
+        }
+        unsafe { SetForegroundWindow(HWND(hwnd)).as_bool() }
+    }
+
+    // ---- clipboard + paste synthesis -------------------------------------
+
+    fn send_ctrl_v() {
+        unsafe {
+            let inputs = [
+                key_input(VK_CONTROL_U16, false),
+                key_input(VK_V, false),
+                key_input(VK_V, true),
+                key_input(VK_CONTROL_U16, true),
+            ];
+            SendInput(&inputs, std::mem::size_of::<INPUT>() as i32);
+        }
+    }
+
+    fn key_input(vk: u16, up: bool) -> INPUT {
+        INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: VIRTUAL_KEY(vk),
+                    wScan: 0,
+                    dwFlags: if up {
+                        KEYEVENTF_KEYUP
+                    } else {
+                        KEYBD_EVENT_FLAGS(0)
+                    },
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    fn clipboard_get_text() -> Option<String> {
+        unsafe {
+            if OpenClipboard(HWND(0)).is_err() {
+                return None;
+            }
+            let result = (|| {
+                let handle = GetClipboardData(CF_UNICODETEXT.0 as u32).ok()?;
+                let hglobal = HGLOBAL(handle.0 as *mut core::ffi::c_void);
+                let ptr = GlobalLock(hglobal) as *const u16;
+                if ptr.is_null() {
+                    return None;
+                }
+                let mut len = 0usize;
+                while *ptr.add(len) != 0 {
+                    len += 1;
+                }
+                let slice = std::slice::from_raw_parts(ptr, len);
+                let text = String::from_utf16_lossy(slice);
+                let _ = GlobalUnlock(hglobal);
+                Some(text)
+            })();
+            let _ = CloseClipboard();
+            result
+        }
+    }
+
+    fn clipboard_set_text(text: &str) -> Result<(), AppError> {
+        let mut utf16: Vec<u16> = text.encode_utf16().collect();
+        utf16.push(0);
+        unsafe {
+            OpenClipboard(HWND(0)).map_err(|_| {
+                AppError::new(
+                    "pasteboard_write_failed",
+                    "Could not open the Windows clipboard.",
+                )
+            })?;
+            let result = (|| -> Result<(), AppError> {
+                EmptyClipboard().map_err(|_| {
+                    AppError::new(
+                        "pasteboard_write_failed",
+                        "Could not clear the Windows clipboard.",
+                    )
+                })?;
+                let bytes = utf16.len() * std::mem::size_of::<u16>();
+                let hglobal = GlobalAlloc(GMEM_MOVEABLE, bytes).map_err(|_| {
+                    AppError::new(
+                        "pasteboard_write_failed",
+                        "Could not allocate clipboard memory.",
+                    )
+                })?;
+                let ptr = GlobalLock(hglobal) as *mut u16;
+                if ptr.is_null() {
+                    return Err(AppError::new(
+                        "pasteboard_write_failed",
+                        "Could not lock clipboard memory.",
+                    ));
+                }
+                std::ptr::copy_nonoverlapping(utf16.as_ptr(), ptr, utf16.len());
+                let _ = GlobalUnlock(hglobal);
+                // On success the system owns the memory, so we must not free it.
+                SetClipboardData(CF_UNICODETEXT.0 as u32, HANDLE(hglobal.0 as isize)).map_err(
+                    |_| {
+                        AppError::new(
+                            "pasteboard_write_failed",
+                            "Could not write transcript to the clipboard.",
+                        )
+                    },
+                )?;
+                Ok(())
+            })();
+            let _ = CloseClipboard();
+            result
+        }
+    }
+
+    fn clipboard_clear() {
+        unsafe {
+            if OpenClipboard(HWND(0)).is_ok() {
+                let _ = EmptyClipboard();
+                let _ = CloseClipboard();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        code_for_vk, key_label_for_vk, shortcut_is_supported, vk_for_code, windows_shortcut_label,
+        DictationShortcutModifiers,
+    };
+
+    fn ctrl_alt() -> DictationShortcutModifiers {
+        DictationShortcutModifiers {
+            control: true,
+            option: true,
+            ..DictationShortcutModifiers::default()
+        }
+    }
+
+    #[test]
+    fn vk_for_code_maps_letters_digits_and_named_keys() {
+        assert_eq!(vk_for_code("KeyD"), Some(0x44));
+        assert_eq!(vk_for_code("KeyT"), Some(0x54));
+        assert_eq!(vk_for_code("Digit5"), Some(0x35));
+        assert_eq!(vk_for_code("Space"), Some(0x20));
+        assert_eq!(vk_for_code("F7"), Some(0x76));
+    }
+
+    #[test]
+    fn vk_for_code_rejects_macos_only_shapes() {
+        assert_eq!(vk_for_code("Fn"), None);
+        assert_eq!(vk_for_code("Modifiers"), None);
+        assert_eq!(vk_for_code("KeyDD"), None);
+    }
+
+    #[test]
+    fn code_for_vk_round_trips() {
+        for code in ["KeyD", "KeyT", "Digit0", "Space", "F12"] {
+            let vk = vk_for_code(code).expect("vk");
+            assert_eq!(code_for_vk(vk).as_deref(), Some(code));
+        }
+    }
+
+    #[test]
+    fn key_label_is_human_readable() {
+        assert_eq!(key_label_for_vk(0x44).as_deref(), Some("D"));
+        assert_eq!(key_label_for_vk(0x20).as_deref(), Some("Space"));
+        assert_eq!(key_label_for_vk(0x76).as_deref(), Some("F7"));
+    }
+
+    #[test]
+    fn windows_label_uses_windows_modifier_names() {
+        assert_eq!(windows_shortcut_label(&ctrl_alt(), "D"), "Ctrl+Alt+D");
+        let win_shift = DictationShortcutModifiers {
+            command: true,
+            shift: true,
+            ..DictationShortcutModifiers::default()
+        };
+        assert_eq!(
+            windows_shortcut_label(&win_shift, "Space"),
+            "Win+Shift+Space"
+        );
+    }
+
+    #[test]
+    fn supported_requires_a_real_key_and_a_modifier() {
+        assert!(shortcut_is_supported("KeyD", &ctrl_alt()));
+        // No modifier: would be a global key eater.
+        assert!(!shortcut_is_supported(
+            "KeyD",
+            &DictationShortcutModifiers::default()
+        ));
+        // macOS-only bare Fn / modifier-only chords have no Windows key.
+        assert!(!shortcut_is_supported("Fn", &ctrl_alt()));
+        assert!(!shortcut_is_supported("Modifiers", &ctrl_alt()));
+    }
+}

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -264,6 +264,7 @@ mod windows_impl {
     use std::fs::File;
     use std::io::BufWriter;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicIsize, Ordering};
     use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
     use std::sync::{Arc, Mutex, OnceLock};
     use std::time::Duration;
@@ -287,9 +288,10 @@ mod windows_impl {
         KEYEVENTF_KEYUP, VIRTUAL_KEY,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
-        CallNextHookEx, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
-        SetForegroundWindow, SetWindowsHookExW, HC_ACTION, KBDLLHOOKSTRUCT, LLKHF_INJECTED,
-        LLKHF_LOWER_IL_INJECTED, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,
+        CallNextHookEx, CreateWindowExW, GetForegroundWindow, GetMessageW,
+        GetWindowThreadProcessId, SetForegroundWindow, SetWindowsHookExW, HC_ACTION, HMENU,
+        HWND_MESSAGE, KBDLLHOOKSTRUCT, LLKHF_INJECTED, LLKHF_LOWER_IL_INJECTED, MSG,
+        WH_KEYBOARD_LL, WINDOW_EX_STYLE, WINDOW_STYLE, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,
         WM_SYSKEYUP,
     };
 
@@ -495,9 +497,52 @@ mod windows_impl {
 
     // ---- keyboard hook ----------------------------------------------------
 
+    /// HWND of the hidden clipboard-owner window as an isize (HWND is not
+    /// Send). Zero until the hook thread has created it.
+    static CLIPBOARD_OWNER: AtomicIsize = AtomicIsize::new(0);
+
+    /// The window that owns our clipboard sessions. Win32 documents (on
+    /// EmptyClipboard) that opening the clipboard with a NULL hwnd and then
+    /// calling EmptyClipboard sets the clipboard owner to NULL, "which causes
+    /// SetClipboardData to fail" — so the paste path must open the clipboard
+    /// with a real window. Falls back to HWND(0) if the owner window could
+    /// not be created (degraded, but no worse than not owning one).
+    fn clipboard_owner() -> HWND {
+        HWND(CLIPBOARD_OWNER.load(Ordering::Acquire))
+    }
+
     fn run_hook_thread() {
         unsafe {
             let module = GetModuleHandleW(PCWSTR::null()).unwrap_or_default();
+
+            // Hidden message-only window (HWND_MESSAGE parent) that serves as
+            // the clipboard owner for paste_text; see clipboard_owner(). The
+            // pre-registered STATIC class avoids registering our own. It lives
+            // on this thread, which already pumps messages for the keyboard
+            // hook, and is intentionally never destroyed: like the hook, it is
+            // owned for the lifetime of the process (there is no hook-thread
+            // teardown path; the OS reclaims both at process exit).
+            let class: Vec<u16> = "STATIC\0".encode_utf16().collect();
+            let owner = CreateWindowExW(
+                WINDOW_EX_STYLE(0),
+                PCWSTR(class.as_ptr()),
+                PCWSTR::null(),
+                WINDOW_STYLE(0),
+                0,
+                0,
+                0,
+                0,
+                HWND_MESSAGE,
+                HMENU(0),
+                HINSTANCE(module.0),
+                None,
+            );
+            if owner.0 != 0 {
+                CLIPBOARD_OWNER.store(owner.0, Ordering::Release);
+            } else {
+                tracing::warn!("failed to create clipboard owner window for dictation paste");
+            }
+
             let hook = SetWindowsHookExW(
                 WH_KEYBOARD_LL,
                 Some(keyboard_hook_proc),
@@ -505,10 +550,12 @@ mod windows_impl {
                 0,
             );
             if hook.is_err() {
-                return;
+                tracing::warn!("failed to install dictation keyboard hook");
             }
-            // Low-level hooks require the installing thread to pump messages;
-            // the proc itself runs between GetMessage calls.
+            // Low-level hooks require the installing thread to pump messages
+            // (the proc runs between GetMessage calls), and the owner window
+            // needs the same pump. Keep pumping even if the hook failed so
+            // clipboard ownership still works.
             let mut msg = MSG::default();
             while GetMessageW(&mut msg, HWND(0), 0, 0).as_bool() {}
         }
@@ -1245,7 +1292,7 @@ mod windows_impl {
 
     fn clipboard_get_text() -> Option<String> {
         unsafe {
-            if OpenClipboard(HWND(0)).is_err() {
+            if OpenClipboard(clipboard_owner()).is_err() {
                 return None;
             }
             let result = (|| {
@@ -1273,7 +1320,10 @@ mod windows_impl {
         let mut utf16: Vec<u16> = text.encode_utf16().collect();
         utf16.push(0);
         unsafe {
-            OpenClipboard(HWND(0)).map_err(|_| {
+            // Open with the owner window: after OpenClipboard(NULL) +
+            // EmptyClipboard the clipboard owner is NULL and SetClipboardData
+            // is documented to fail. See clipboard_owner().
+            OpenClipboard(clipboard_owner()).map_err(|_| {
                 AppError::new(
                     "pasteboard_write_failed",
                     "Could not open the Windows clipboard.",
@@ -1325,7 +1375,7 @@ mod windows_impl {
 
     fn clipboard_clear() {
         unsafe {
-            if OpenClipboard(HWND(0)).is_ok() {
+            if OpenClipboard(clipboard_owner()).is_ok() {
                 let _ = EmptyClipboard();
                 let _ = CloseClipboard();
             }

--- a/src-tauri/src/dictation_windows.rs
+++ b/src-tauri/src/dictation_windows.rs
@@ -185,7 +185,7 @@ mod windows_impl {
     use tauri::AppHandle;
     use windows::core::{PCWSTR, PWSTR};
     use windows::Win32::Foundation::{
-        CloseHandle, HANDLE, HGLOBAL, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM,
+        CloseHandle, GlobalFree, HANDLE, HGLOBAL, HINSTANCE, HWND, LPARAM, LRESULT, WPARAM,
     };
     use windows::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
@@ -1163,8 +1163,14 @@ mod windows_impl {
                         "Could not allocate clipboard memory.",
                     )
                 })?;
+                // Win32 clipboard ownership rule: once SetClipboardData
+                // succeeds, the system owns the HGLOBAL and the app must NOT
+                // free it. On every path where SetClipboardData is not
+                // reached, or fails, the allocation is still ours and must be
+                // released with GlobalFree or it leaks.
                 let ptr = GlobalLock(hglobal) as *mut u16;
                 if ptr.is_null() {
+                    let _ = GlobalFree(hglobal);
                     return Err(AppError::new(
                         "pasteboard_write_failed",
                         "Could not lock clipboard memory.",
@@ -1172,15 +1178,14 @@ mod windows_impl {
                 }
                 std::ptr::copy_nonoverlapping(utf16.as_ptr(), ptr, utf16.len());
                 let _ = GlobalUnlock(hglobal);
-                // On success the system owns the memory, so we must not free it.
-                SetClipboardData(CF_UNICODETEXT.0 as u32, HANDLE(hglobal.0 as isize)).map_err(
-                    |_| {
-                        AppError::new(
-                            "pasteboard_write_failed",
-                            "Could not write transcript to the clipboard.",
-                        )
-                    },
-                )?;
+                if SetClipboardData(CF_UNICODETEXT.0 as u32, HANDLE(hglobal.0 as isize)).is_err() {
+                    let _ = GlobalFree(hglobal);
+                    return Err(AppError::new(
+                        "pasteboard_write_failed",
+                        "Could not write transcript to the clipboard.",
+                    ));
+                }
+                // Ownership transferred to the clipboard; do not free.
                 Ok(())
             })();
             let _ = CloseClipboard();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod audio;
 pub mod commands;
 pub mod db;
 pub mod dictation;
+pub mod dictation_windows;
 pub mod domain;
 pub mod hermes_bridge;
 pub mod june_api;

--- a/src/components/account/AccountGate.tsx
+++ b/src/components/account/AccountGate.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useState } from "react";
-import { isMacLikePlatform } from "../../lib/platform";
+import { isDictationSupportedPlatform } from "../../lib/platform";
 import { osAccountsCancelLogin, osAccountsLogin } from "../../lib/tauri";
 import type { AccountStatus } from "../../lib/tauri";
 import { BrandPrimaryButton } from "../ui/BrandPrimaryButton";
@@ -13,7 +13,7 @@ type Props = {
 export function AccountGate({ account, loading, onAccountChanged }: Props) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();
-  const subtitle = isMacLikePlatform()
+  const subtitle = isDictationSupportedPlatform()
     ? "Record conversations, turn them into notes, and dictate with your OpenSoftware account."
     : "Record conversations and turn them into notes with your OpenSoftware account.";
 

--- a/src/components/dictation/DictationHistoryView.tsx
+++ b/src/components/dictation/DictationHistoryView.tsx
@@ -33,7 +33,7 @@ import {
 } from "../../lib/tauri";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
-import { isMacLikePlatform } from "../../lib/platform";
+import { displayShortcutLabel, isDictationSupportedPlatform } from "../../lib/platform";
 
 const NO_DICTATIONS: DictationHistoryItemDto[] = [];
 
@@ -88,7 +88,7 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
   const [dictionaryCount, setDictionaryCount] = useState<number | null>(null);
   const [hintDismissed, setHintDismissed] = useState(readHintDismissed);
   const [pendingDelete, setPendingDelete] = useState<DictationHistoryItemDto | null>(null);
-  const dictationAvailable = isMacLikePlatform();
+  const dictationAvailable = isDictationSupportedPlatform();
 
   const loadHistory = useCallback(async () => {
     try {
@@ -149,8 +149,8 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
 
   const groups = useMemo(() => groupHistoryItems(filtered), [filtered]);
 
-  const pushToTalk = settings?.pushToTalkShortcut.label ?? "Ctrl+Opt+D";
-  const toggle = settings?.toggleShortcut.label ?? "Ctrl+Opt+T";
+  const pushToTalk = displayShortcutLabel(settings?.pushToTalkShortcut.label ?? "Ctrl+Opt+D");
+  const toggle = displayShortcutLabel(settings?.toggleShortcut.label ?? "Ctrl+Opt+T");
 
   // Show each optional feature only while it's still unconfigured, and only
   // once we know its state (avoids the card flashing in then vanishing). The
@@ -241,7 +241,9 @@ export function DictationHistoryView({ onNavigateToSettings }: DictationHistoryV
           label={dictationAvailable ? "Start dictating" : "Dictation unavailable"}
           icon={<IconMicrophoneSparkleFilled size={28} />}
           title={
-            dictationAvailable ? "Start dictating anywhere" : "Dictation is only supported on macOS"
+            dictationAvailable
+              ? "Start dictating anywhere"
+              : "Dictation is not available on this device"
           }
           description={
             dictationAvailable

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -10,8 +10,9 @@ import { OsMark } from "../../account/AccountGate";
 import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 
 // macOS can introduce the full agent, dictation, and notes surface because the
-// release bundle includes the runtime and helpers. Windows narrows the welcome
-// promise below until its Hermes and dictation support is turnkey.
+// release bundle includes the runtime and helpers. Windows now ships dictation
+// too (via the in-process helper), so it promises notes and dictation and
+// narrows only the agent promise until Windows agent support is turnkey.
 const JUNE_POINTS = [
   {
     icon: IconSparkle,
@@ -46,6 +47,8 @@ const WINDOWS_JUNE_POINTS = [
     title: "Meeting notes from your mic",
     detail: "Record meetings from your microphone and turn them into notes.",
   },
+  // Dictation ("Speak instead of type"); shared with the macOS promise.
+  JUNE_POINTS[1],
   JUNE_POINTS[3],
 ];
 

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -3,7 +3,7 @@ import { IconCalendar1 } from "central-icons/IconCalendar1";
 import { IconLock } from "central-icons/IconLock";
 import { IconMicrophone } from "central-icons/IconMicrophone";
 import { IconSparkle } from "central-icons/IconSparkle";
-import { isMacLikePlatform } from "../../../lib/platform";
+import { isDictationSupportedPlatform, isMacLikePlatform } from "../../../lib/platform";
 import { juneOpenCommunityPage, osAccountsCancelLogin, osAccountsLogin } from "../../../lib/tauri";
 import type { AccountStatus } from "../../../lib/tauri";
 import { OsMark } from "../../account/AccountGate";
@@ -13,6 +13,8 @@ import { OnboardingPrimaryButton, StepCard } from "../StepChrome";
 // release bundle includes the runtime and helpers. Windows now ships dictation
 // too (via the in-process helper), so it promises notes and dictation and
 // narrows only the agent promise until Windows agent support is turnkey.
+// Other platforms (Linux) promise notes only: the dictation bullet is gated on
+// the same isDictationSupportedPlatform predicate the rest of the app uses.
 const JUNE_POINTS = [
   {
     icon: IconSparkle,
@@ -36,7 +38,7 @@ const JUNE_POINTS = [
   },
 ];
 
-const WINDOWS_JUNE_POINTS = [
+const NON_MAC_BASE_POINTS = [
   {
     icon: IconSparkle,
     title: "Desktop notes for your work",
@@ -47,10 +49,12 @@ const WINDOWS_JUNE_POINTS = [
     title: "Meeting notes from your mic",
     detail: "Record meetings from your microphone and turn them into notes.",
   },
-  // Dictation ("Speak instead of type"); shared with the macOS promise.
-  JUNE_POINTS[1],
-  JUNE_POINTS[3],
 ];
+
+// Dictation ("Speak instead of type") is shared with the macOS promise and
+// only shown where dictation actually ships (Windows today).
+const WINDOWS_JUNE_POINTS = [...NON_MAC_BASE_POINTS, JUNE_POINTS[1], JUNE_POINTS[3]];
+const LINUX_JUNE_POINTS = [...NON_MAC_BASE_POINTS, JUNE_POINTS[3]];
 
 /**
  * Step 1: welcome + sign-in, fused into one screen so the wizard frames the
@@ -70,7 +74,11 @@ export function SignInStep({
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string>();
   const isMac = isMacLikePlatform();
-  const points = isMac ? JUNE_POINTS : WINDOWS_JUNE_POINTS;
+  const points = isMac
+    ? JUNE_POINTS
+    : isDictationSupportedPlatform()
+      ? WINDOWS_JUNE_POINTS
+      : LINUX_JUNE_POINTS;
 
   const cancelInFlight = useCallback(async () => {
     try {

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -73,7 +73,11 @@ import {
   setReleaseChannel,
   type ReleaseChannel,
 } from "../../lib/updater";
-import { isMacLikePlatform } from "../../lib/platform";
+import {
+  displayShortcutLabel,
+  isDictationSupportedPlatform,
+  isMacLikePlatform,
+} from "../../lib/platform";
 import { parseDictationHelperEvent } from "../../lib/dictation-events";
 import { dispatchProviderModelSettingsChanged } from "../../lib/model-privacy";
 import {
@@ -386,6 +390,7 @@ export function AppSettings({
     ? SETTINGS_TABS.filter((tab) => tab.id !== "billing")
     : SETTINGS_TABS;
   const macLikePlatform = isMacLikePlatform();
+  const dictationShortcutsSupported = isDictationSupportedPlatform();
   const setActiveTab = (tab: SettingsTab) => {
     if (controlled) {
       onTabChange?.(tab);
@@ -1272,7 +1277,7 @@ export function AppSettings({
             ) : null}
             <div className="settings-card">
               <div className="settings-rows">
-                {macLikePlatform ? (
+                {dictationShortcutsSupported ? (
                   <>
                     <ShortcutRow
                       title="Push to talk"
@@ -1307,7 +1312,7 @@ export function AppSettings({
                     <div className="settings-row-info">
                       <h3 className="settings-row-title">Dictation shortcuts unavailable</h3>
                       <p className="settings-row-description">
-                        Global dictation shortcuts are only supported on macOS.
+                        Global dictation shortcuts are available on macOS and Windows.
                       </p>
                     </div>
                   </div>
@@ -2250,7 +2255,7 @@ function ShortcutRow({
         {error ? <p className="settings-row-error">{error}</p> : null}
       </div>
       <div className="settings-row-control">
-        <KeycapShortcut label={shortcut.label} capturing={capturing} />
+        <KeycapShortcut label={displayShortcutLabel(shortcut.label)} capturing={capturing} />
         <button
           type="button"
           className="btn btn-secondary"

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -7,6 +7,34 @@ export function isMacLikePlatform() {
   return true;
 }
 
+export function isWindowsPlatform() {
+  const platform =
+    typeof navigator === "undefined" ? "" : `${navigator.platform} ${navigator.userAgent}`;
+  return /Windows|Win32|Win64/i.test(platform);
+}
+
+// Dictation (global shortcuts, capture, paste) ships on macOS and Windows.
+// Other platforms (Linux) fall back to microphone note recording only.
+export function isDictationSupportedPlatform() {
+  return isMacLikePlatform() || isWindowsPlatform();
+}
+
+// Rewrites a stored shortcut label into the current platform's modifier
+// names. Dictation shortcut defaults are stored with macOS modifier names
+// ("Ctrl+Opt+D"); on Windows those read as "Ctrl+Alt+D".
+export function displayShortcutLabel(label: string) {
+  if (!isWindowsPlatform()) {
+    return label;
+  }
+  return label
+    .replace(/\bOpt\b/g, "Alt")
+    .replace(/\bCmd\b/g, "Win")
+    .replace(/⌘/g, "Win")
+    .replace(/⌥/g, "Alt")
+    .replace(/⌃/g, "Ctrl")
+    .replace(/⇧/g, "Shift");
+}
+
 export function primaryShortcutLabel(key: string) {
   // No space after the ⌘ glyph (it reads tight), but keep one after the
   // "Ctrl" word so Windows labels don't run together as "CtrlN".

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,16 +1,15 @@
+// Single source string for all platform detectors, so the predicates can never
+// diverge in what they read and composed calls don't rebuild it twice.
+function platformString() {
+  return typeof navigator === "undefined" ? "" : `${navigator.platform} ${navigator.userAgent}`;
+}
+
 export function isMacLikePlatform() {
-  const platform =
-    typeof navigator === "undefined" ? "" : `${navigator.platform} ${navigator.userAgent}`;
-  if (/Windows|Win32|Win64|Linux|Android/i.test(platform)) {
-    return false;
-  }
-  return true;
+  return !/Windows|Win32|Win64|Linux|Android/i.test(platformString());
 }
 
 export function isWindowsPlatform() {
-  const platform =
-    typeof navigator === "undefined" ? "" : `${navigator.platform} ${navigator.userAgent}`;
-  return /Windows|Win32|Win64/i.test(platform);
+  return /Windows|Win32|Win64/i.test(platformString());
 }
 
 // Dictation (global shortcuts, capture, paste) ships on macOS and Windows.

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -1434,9 +1434,13 @@ describe("AppSettings", () => {
         }),
       ).not.toBeInTheDocument();
 
+      // Windows supports global dictation shortcuts, so the shortcut rows are
+      // shown (the "unavailable" fallback is Linux-only now).
       await userEvent.click(screen.getByRole("tab", { name: "Shortcuts" }));
-      expect(screen.getByText("Dictation shortcuts unavailable")).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Change" })).toBeNull();
+      expect(screen.queryByText("Dictation shortcuts unavailable")).toBeNull();
+      expect(screen.getByText("Push to talk")).toBeInTheDocument();
+      expect(screen.getByText("Toggle dictation")).toBeInTheDocument();
+      expect(screen.getAllByRole("button", { name: "Change" }).length).toBeGreaterThan(0);
     } finally {
       restoreNavigator();
     }

--- a/src/test/app-shortcut.test.tsx
+++ b/src/test/app-shortcut.test.tsx
@@ -1165,12 +1165,12 @@ describe("App shortcuts", () => {
     try {
       render(<App />);
 
+      // Windows supports dictation, so the sign-in copy advertises it.
       expect(
         await screen.findByText(
-          "Record conversations and turn them into notes with your OpenSoftware account.",
+          "Record conversations, turn them into notes, and dictate with your OpenSoftware account.",
         ),
       ).toBeInTheDocument();
-      expect(screen.queryByText(/dictate with/)).not.toBeInTheDocument();
 
       await user.click(screen.getByRole("button", { name: "Continue with OpenSoftware" }));
 

--- a/src/test/dictation-history.test.tsx
+++ b/src/test/dictation-history.test.tsx
@@ -121,7 +121,7 @@ describe("DictationHistoryView", () => {
     await waitFor(() => expect(mocks.writeText).toHaveBeenCalledWith("Send the follow up. "));
   });
 
-  it("does not advertise shortcut dictation on Windows", async () => {
+  it("advertises shortcut dictation on Windows with Windows modifier labels", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
       "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
@@ -134,7 +134,32 @@ describe("DictationHistoryView", () => {
 
       render(<DictationHistoryView />);
 
-      expect(await screen.findByText("Dictation is only supported on macOS")).toBeInTheDocument();
+      expect(await screen.findByText("Start dictating anywhere")).toBeInTheDocument();
+      expect(screen.queryByText("Dictation is not available on this device")).toBeNull();
+      // The macOS default labels ("Ctrl+Opt+T") render with Windows modifier
+      // names on Windows.
+      expect(screen.getByLabelText("Shortcut Ctrl+Alt+T")).toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
+  it("does not advertise shortcut dictation on Linux", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Linux x86_64",
+      "Mozilla/5.0 (X11; Linux x86_64)",
+    );
+    try {
+      mocks.listDictationHistory.mockResolvedValue({
+        retentionDays: 7,
+        items: [],
+      });
+
+      render(<DictationHistoryView />);
+
+      expect(
+        await screen.findByText("Dictation is not available on this device"),
+      ).toBeInTheDocument();
       expect(
         screen.getByText("Meeting notes still work with microphone recording on this device."),
       ).toBeInTheDocument();

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -429,10 +429,12 @@ describe("OnboardingFlow", () => {
       expect(
         screen.getByText("Record meetings from your microphone and turn them into notes."),
       ).toBeInTheDocument();
-      expect(screen.queryByText("Speak instead of type")).not.toBeInTheDocument();
+      // Windows now ships dictation, so the welcome promises it.
+      expect(screen.getByText("Speak instead of type")).toBeInTheDocument();
       expect(
-        screen.queryByText(/June turns your voice into polished writing/),
-      ).not.toBeInTheDocument();
+        screen.getByText(/June turns your voice into polished writing/),
+      ).toBeInTheDocument();
+      // Meeting auto-capture and the agent remain macOS-only.
       expect(screen.queryByText("Effortlessly capture meetings")).not.toBeInTheDocument();
       expect(screen.queryByText("Chat and work with June")).not.toBeInTheDocument();
     } finally {

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -440,6 +440,30 @@ describe("OnboardingFlow", () => {
     }
   });
 
+  it("does not promise dictation in the Linux welcome copy", async () => {
+    const restoreNavigator = stubNavigatorPlatform(
+      "Linux x86_64",
+      "Mozilla/5.0 (X11; Linux x86_64)",
+    );
+    try {
+      render(<OnboardingFlow {...flowProps({ account: signedOutAccount })} />);
+
+      await screen.findByRole("heading", { name: "Welcome to June" });
+      expect(screen.getByText("Desktop notes for your work")).toBeInTheDocument();
+      expect(screen.getByText("Meeting notes from your mic")).toBeInTheDocument();
+      expect(screen.getByText("Private by default")).toBeInTheDocument();
+      // Dictation does not ship on Linux, so the welcome must not promise it.
+      expect(screen.queryByText("Speak instead of type")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/June turns your voice into polished writing/),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Effortlessly capture meetings")).not.toBeInTheDocument();
+      expect(screen.queryByText("Chat and work with June")).not.toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("does not ask unsubscribed users for a card during onboarding", async () => {
     const user = userEvent.setup();
     render(<OnboardingFlow {...flowProps({ account: unsubscribedAccount })} />);

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -431,9 +431,7 @@ describe("OnboardingFlow", () => {
       ).toBeInTheDocument();
       // Windows now ships dictation, so the welcome promises it.
       expect(screen.getByText("Speak instead of type")).toBeInTheDocument();
-      expect(
-        screen.getByText(/June turns your voice into polished writing/),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/June turns your voice into polished writing/)).toBeInTheDocument();
       // Meeting auto-capture and the agent remain macOS-only.
       expect(screen.queryByText("Effortlessly capture meetings")).not.toBeInTheDocument();
       expect(screen.queryByText("Chat and work with June")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

June dictation was macOS-only. A Swift helper
(`src-tauri/native/mac-dictation-helper/main.swift`) owned global shortcut
listening (push-to-talk and toggle), microphone capture, audio-level events,
focus-target tracking, and paste injection, and talked to
`src-tauri/src/dictation.rs` over a JSON line protocol. `dictation.rs` drives
the helper and runs transcription + cleanup through June API (platform-neutral).

This PR adds a Windows dictation backend architected as the platform twin of the
Swift helper, not a rewrite of `dictation.rs`. The shared transcription and
cleanup pipeline is untouched and stays common to both platforms.

## Architecture

New `src-tauri/src/dictation_windows.rs` runs the helper in-process through
Win32 (the `windows` crate, already resolved transitively via cpal's WASAPI
backend) and speaks the exact same event/command protocol `dictation.rs`
already consumes:

- **Global shortcuts** use a `WH_KEYBOARD_LL` low-level keyboard hook on a
  dedicated message-pump thread. It matches the configured shortcuts by DOM
  `KeyboardEvent.code` -> virtual key plus modifier state and emits
  `shortcut_key_down` / `shortcut_key_up` events (kind `toggle` /
  `push_to_talk`) into the shared `ShortcutActivationController`, which decides
  start / stop / toggle exactly as on macOS. The trigger key is suppressed so it
  doesn't leak into the focused app while dictating. Both toggle
  (default Ctrl+Alt+T) and push-to-talk (default Ctrl+Alt+D) work.
- **Microphone capture** reuses the note-recording stack (`cpal` + `hound`) to
  write the same 16-bit PCM WAV the transcription path expects. It tracks a live
  peak for `audio_level` events and a max observed level reported with
  `recording_ready`.
- **Focus target + paste**: the foreground window's executable is captured at
  start (`GetForegroundWindow` -> `GetWindowThreadProcessId` ->
  `QueryFullProcessImageNameW`) and sent as the `targetBundleIdentifier`
  equivalent. On `paste_text` the module snapshots the clipboard, sets the
  cleaned text, brings the target window forward, synthesizes Ctrl+V via
  `SendInput`, and restores the prior clipboard text.
- **App context**: known email executables (`outlook.exe`, `olk.exe`,
  `thunderbird.exe`) map to the `email` app-context that shipped in #597
  (verified on `main`), alongside the existing macOS bundle ids.

Wiring in `dictation.rs` is additive or `cfg(target_os = "windows")`-gated:
`send_helper_command` routes to the in-process dispatch on Windows; `setup`
initializes the helper; the shortcut/microphone/hotkey command surface and the
initial hotkey-ready event are enabled for Windows. **macOS code paths are
behavior-preserving** (the `cfg` changes are no-ops on macOS, and the shared
`send_helper_command` refactor and email-target mapping preserve macOS
behavior). The HUD is the shared web HUD window, which already exists on all
platforms; its macOS-only native motion/vibrancy is already gated.

Frontend: dictation settings shortcuts, dictation history availability, the
sign-in subtitle, and the Windows onboarding welcome now advertise dictation on
Windows, with a `displayShortcutLabel` helper rendering Windows modifier names
(the stored macOS defaults "Ctrl+Opt+D" read as "Ctrl+Alt+D").

## What works

- Toggle and push-to-talk global shortcuts (default Ctrl+Alt+T / Ctrl+Alt+D).
- Microphone capture -> June API transcription + cleanup -> clipboard paste at
  the cursor, with prior clipboard text restored.
- Foreground app identity as the paste target, email-client app-context.
- Live audio-level HUD, focus-target and paste events, mic selection,
  permission-status and mic-device listing, and interactive shortcut re-binding.
- Settings/history/sign-in copy enabled with Windows-accurate shortcut labels.

## Explicit gaps (documented in `docs/release-windows.md`)

- **HUD**: reuses the shared web HUD window without the macOS native slide,
  vibrancy, or non-activating-panel behavior. Events still flow and the pill
  shows/hides.
- **Clipboard restore** covers plain text only, so a prior image or rich-text
  clipboard is not preserved.
- **Foreground activation** before paste is best effort under Windows
  foreground-window rules; if it fails, Ctrl+V still targets the current
  foreground window.
- **Double-tap shortcut chords** and macOS-only shapes (bare Fn, modifier-only)
  are not supported; the keyboard hook is torn down by process exit rather than
  an explicit unhook.
- **Mic test** and the macOS Accessibility/system-audio permission rows stay
  macOS-only (Windows paste needs no accessibility grant).

## Validation performed (macOS host, no Windows hardware)

- `cargo check`/`clippy` for `x86_64-pc-windows-msvc` via `cargo-xwin`: green,
  `Cargo.lock` current under `--locked`, no new warnings from this change.
- Windows lib **test binary links** (`cargo test --no-run`).
- macOS: `cargo test --lib` (387 pass, includes new protocol/mapping/label unit
  tests) and `cargo clippy --lib`: zero warnings. `cargo fmt --check` clean.
- Frontend: `bun install`, `tsc --noEmit`, `biome check` (no new warnings), and
  touched `vitest` suites (dictation-history, app-settings, app-shortcut,
  onboarding) pass.

Runtime behavior needs real Windows hardware to verify.

## Needs a June API deploy?

No. Transcription uses the existing `/v1/dictate` contract with a WAV upload
(already accepted by the transcription path).

## QA checklist (real Windows 11)

- [ ] Toggle shortcut (Ctrl+Alt+T) starts/stops dictation; transcript pastes at
      the cursor in Notepad, a browser field, and Word.
- [ ] Push-to-talk (Ctrl+Alt+D) records while held and pastes on release; a
      quick graze discards.
- [ ] The trigger key does not leak into the focused document.
- [ ] Clipboard text present before dictation is restored after paste.
- [ ] Dictating into Outlook/Thunderbird lays out for the email context.
- [ ] HUD pill shows on start, tracks audio level, and hides after paste.
- [ ] Settings -> Shortcuts shows both rows with Windows labels and re-binding
      works; mic selection changes the capture device.
- [ ] CI Windows build (`production-desktop-windows`) compiles and bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- Settings keycap rows render macOS modifier glyphs on Windows; Windows keycap labels (Ctrl, Alt, Win) are a cosmetic follow-up.
