### PR TITLE
Layered shadows, hairline-ring composer edge, and composer scroll fixes

### DIFF
--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -123,6 +123,14 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
       const frame = frameRef.current;
       if (!frame || !nextEditor || nextEditor.isDestroyed) return;
       const scroller = nextEditor.view.dom;
+      // A range selection paints a full-width highlight, and the edge fades
+      // shave it — which reads as the selection being clipped, not as content
+      // melting out of view. Drop the fades until the selection collapses.
+      if (!nextEditor.state.selection.empty) {
+        delete frame.dataset.fadeTop;
+        delete frame.dataset.fadeBottom;
+        return;
+      }
       const overflow = scroller.scrollHeight - scroller.clientHeight > 1;
       const atTop = scroller.scrollTop <= 1;
       const atBottom = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1;
@@ -170,6 +178,23 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           "aria-label": "Message June",
           "aria-multiline": "true",
         },
+        handleScrollToSelection: (view) => {
+          // ProseMirror's own scrollIntoView walks every scrollable ancestor,
+          // and the composer is a DOM child of the chat scroller
+          // (.agent-scroll) — so growing the draft (Shift+Enter, paste)
+          // dragged the conversation behind the fixed box. Scroll only the
+          // editor's own scroller and stop the walk.
+          const scroller = view.dom;
+          const caret = view.coordsAtPos(view.state.selection.head);
+          const box = scroller.getBoundingClientRect();
+          const margin = 6; // the editor's own vertical padding
+          if (caret.top < box.top + margin) {
+            scroller.scrollTop -= box.top + margin - caret.top;
+          } else if (caret.bottom > box.bottom - margin) {
+            scroller.scrollTop += caret.bottom - (box.bottom - margin);
+          }
+          return true;
+        },
         handleKeyDown: (_view, event) => {
           if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
             return false;
@@ -193,6 +218,9 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           serializePlainText(editor.state.doc),
           categoryFromDoc(editor.state.doc),
         );
+        requestAnimationFrame(() => updateScrollFades(editor));
+      },
+      onSelectionUpdate: ({ editor }) => {
         requestAnimationFrame(() => updateScrollFades(editor));
       },
     });

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -543,6 +543,13 @@ input:focus-visible,
   margin-top: var(--detail-bar-h);
 }
 
+/* The fixed composer is a DOM child of this scroller, so :focus-within holds
+ * for as long as a draft is being written — which kept the chat's scrollbar
+ * thumb painted behind the growing box. Reveal this thumb on hover only. */
+.agent-scroll:focus-within:not(:hover)::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
 .agent-main {
   display: flex;
   flex-direction: column;
@@ -4554,16 +4561,23 @@ input:focus-visible,
   max-width: min(var(--chat-max), var(--content-max));
   padding: var(--sp-1);
   --agent-composer-scroll-fade: var(--card);
-  border: 1px solid var(--border-subtle);
+  /* The edge is a hairline ring inside the shadow stack, not a border stroke,
+   * so it blends with the shadow instead of drawing a line (the transparent
+   * border only holds the layout box). Ring strength is a compromise, tuned
+   * by eye: --shadow-inset alone lost the top edge, full --border-subtle read
+   * as a stroke again. A variable so the hero/routines shadow overrides and
+   * the focus state recompose the stack instead of losing it. */
+  --composer-ring: 0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+  border: 1px solid transparent;
   /* Squircle, not a pill — a calmer rounded-rect. */
   border-radius: var(--r-xl);
   background: var(--card);
-  box-shadow: var(--shadow-sm);
+  /* md at rest (not sm) so the box always sits off the page; focus only
+   * firms the ring, the elevation never changes. */
+  box-shadow: var(--shadow-md), var(--composer-ring);
   /* Keeps child focus rings and media clipped to the rounded surface. */
   overflow: hidden;
-  transition:
-    border-color var(--t-fast) var(--ease-out),
-    box-shadow var(--t-fast) var(--ease-out);
+  transition: box-shadow var(--t-med) var(--ease-out);
 }
 
 .agent-composer-toolbar {
@@ -5111,10 +5125,10 @@ input:focus-visible,
 }
 
 .agent-composer-box:focus-within {
-  /* A touch firmer than the resting border, not the full focus ring — the
-   * docked box is already the obvious locus, a stark outline overshoots. */
-  border-color: color-mix(in oklch, var(--ring-focus) 40%, var(--border-subtle));
-  box-shadow: var(--shadow-md);
+  /* Focus firms the hairline past full --border-subtle (rest is 60% of it)
+   * with a hint of --ring-focus — enough to register, well short of the 40%
+   * mix that read as a stark outline. The base box-shadow recomposes. */
+  --composer-ring: 0 0 0 1px color-mix(in oklch, var(--ring-focus) 20%, var(--border-subtle));
 }
 
 /* The ProseMirror composer (replaces the old textarea). The element sizes
@@ -5656,7 +5670,7 @@ input:focus-visible,
   /* Deliberately compact — the hero box is an invitation, not a reading
    * column, so it does not track --chat-max up on larger displays. */
   max-width: 640px;
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-md), var(--composer-ring);
 }
 
 /* Big-box at rest: same two-row anatomy as the docked composer, just a
@@ -7050,9 +7064,7 @@ input:focus-visible,
   border-radius: var(--r-md);
   background: var(--popover);
   color: var(--popover-foreground);
-  box-shadow:
-    0 16px 36px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
 }
 
 .context-menu button {
@@ -7429,9 +7441,7 @@ input:focus-visible,
   border-radius: var(--r-md);
   background: var(--popover);
   color: var(--popover-foreground);
-  box-shadow:
-    0 16px 36px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-app-region: no-drag;
@@ -10142,23 +10152,29 @@ input:focus-visible,
   padding: 0;
   border: 0;
   border-radius: var(--r-pill);
-  background: transparent;
+  /* Each tone tints its own pill — a bare icon on the row background was
+   * too easy to miss when scanning the permissions list. */
+  background: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
   color: var(--muted-foreground);
 }
 
 .settings-permission-status[data-status="allowed"] {
+  background: color-mix(in oklch, var(--success) 14%, transparent);
   color: color-mix(in oklch, var(--success) 72%, var(--foreground));
 }
 
 .settings-permission-status[data-status="attention"] {
+  background: color-mix(in oklch, var(--warm-strong) 16%, transparent);
   color: color-mix(in oklch, var(--warm-strong) 82%, var(--foreground));
 }
 
 .settings-permission-status[data-status="blocked"] {
+  background: var(--destructive-soft);
   color: var(--destructive);
 }
 
 .settings-permission-status[data-status="unsupported"] {
+  background: color-mix(in oklch, var(--muted-foreground) 10%, transparent);
   color: var(--muted-foreground);
 }
 
@@ -14099,9 +14115,7 @@ input:focus-visible,
   background: var(--popover);
   color: var(--popover-foreground);
   border: 1px solid var(--popover-border);
-  box-shadow:
-    0 12px 32px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
 }
 
 .select-popover[data-placement="below"],
@@ -15225,9 +15239,7 @@ input:focus-visible,
   bottom: auto;
   left: auto;
   min-width: 172px;
-  box-shadow:
-    0 12px 32px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
 }
 
 .routines-action-menu .destructive {
@@ -15275,7 +15287,7 @@ input:focus-visible,
 
 .routines-describe-composer .agent-composer-box {
   max-width: none;
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-lg), var(--composer-ring);
 }
 
 /* Mirrors `.agent-composer textarea` — the box is reused outside the
@@ -16278,9 +16290,7 @@ input:focus-visible,
   border: 1px solid var(--popover-border);
   border-radius: var(--r-md);
   background: var(--popover);
-  box-shadow:
-    0 12px 32px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
 }
 
 .folders-sort-item {
@@ -17637,9 +17647,7 @@ input:focus-visible,
   border-radius: var(--r-md);
   background: var(--popover);
   color: var(--popover-foreground);
-  box-shadow:
-    0 12px 32px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
 }
 
 .folder-add-popover button {
@@ -18545,9 +18553,7 @@ input:focus-visible,
   border-radius: var(--r-md);
   background: var(--popover);
   color: var(--popover-foreground);
-  box-shadow:
-    0 12px 32px oklch(0% 0 none / 12%),
-    0 2px 6px oklch(0% 0 none / 6%);
+  box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
   gap: var(--sp-1);
@@ -19445,18 +19451,21 @@ input:focus-visible,
   flex-direction: column;
   gap: var(--sp-1);
   padding: var(--sp-1);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid transparent;
   border-radius: var(--r-xl);
   background: color-mix(in oklch, var(--card) 96%, white 4%);
-  box-shadow: var(--shadow-sm);
-  transition:
-    border-color var(--t-fast) var(--ease-out),
-    box-shadow var(--t-fast) var(--ease-out);
+  /* Same hairline-ring edge, resting elevation, and ring-only focus as
+   * .agent-composer-box. */
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+  transition: box-shadow var(--t-med) var(--ease-out);
 }
 
 .onboarding-practice-composer:focus-within {
-  border-color: color-mix(in oklch, var(--ring-focus) 45%, var(--border-subtle));
-  box-shadow: var(--shadow-md);
+  box-shadow:
+    var(--shadow-md),
+    0 0 0 1px color-mix(in oklch, var(--ring-focus) 20%, var(--border-subtle));
 }
 
 .onboarding-practice-toolbar {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -19456,16 +19456,13 @@ input:focus-visible,
   background: color-mix(in oklch, var(--card) 96%, white 4%);
   /* Same hairline-ring edge, resting elevation, and ring-only focus as
    * .agent-composer-box. */
-  box-shadow:
-    var(--shadow-md),
-    0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+  --composer-ring: 0 0 0 1px color-mix(in oklch, var(--border-subtle) 60%, transparent);
+  box-shadow: var(--shadow-md), var(--composer-ring);
   transition: box-shadow var(--t-med) var(--ease-out);
 }
 
 .onboarding-practice-composer:focus-within {
-  box-shadow:
-    var(--shadow-md),
-    0 0 0 1px color-mix(in oklch, var(--ring-focus) 20%, var(--border-subtle));
+  --composer-ring: 0 0 0 1px color-mix(in oklch, var(--ring-focus) 20%, var(--border-subtle));
 }
 
 .onboarding-practice-toolbar {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -275,9 +275,15 @@
   transition: --brand 220ms var(--ease-out);
 
   /* Shadows ---------------------------------------------------------- */
-  --shadow-sm: 0 1px 2px oklch(24% 0.002 84.59 / 6%);
-  --shadow-md: 0 4px 12px oklch(24% 0.002 84.59 / 6%), 0 1px 2px oklch(24% 0.002 84.59 / 4%);
-  --shadow-lg: 0 18px 40px oklch(24% 0.002 84.59 / 10%), 0 2px 6px oklch(24% 0.002 84.59 / 6%);
+  --shadow-sm: 0 1px 2px oklch(24% 0.002 84.59 / 5%), 0 2px 4px oklch(24% 0.002 84.59 / 3%);
+  /* md leans ambient: faint contact, weight in the wide blurs, so lifted
+   * surfaces glow softly instead of drawing a hard line under the edge. */
+  --shadow-md:
+    0 1px 2px oklch(24% 0.002 84.59 / 2%), 0 4px 10px oklch(24% 0.002 84.59 / 2%),
+    0 10px 24px oklch(24% 0.002 84.59 / 3%), 0 18px 36px oklch(24% 0.002 84.59 / 3%);
+  --shadow-lg:
+    0 1px 2px oklch(24% 0.002 84.59 / 4%), 0 2px 6px oklch(24% 0.002 84.59 / 5%),
+    0 8px 16px oklch(24% 0.002 84.59 / 4%), 0 18px 40px oklch(24% 0.002 84.59 / 8%);
   --shadow-inset: 0 0 0 1px oklch(0% 0 none / 4%);
 }
 
@@ -375,8 +381,13 @@
   --selection: oklch(0.52 0.015 84.59 / 38%);
   --selection-foreground: var(--foreground);
 
-  --shadow-sm: 0 1px 2px oklch(0% 0 none / 30%);
-  --shadow-md: 0 4px 12px oklch(0% 0 none / 32%), 0 1px 2px oklch(0% 0 none / 24%);
-  --shadow-lg: 0 18px 40px oklch(0% 0 none / 40%), 0 2px 6px oklch(0% 0 none / 28%);
+  --shadow-sm: 0 1px 2px oklch(0% 0 none / 24%), 0 2px 4px oklch(0% 0 none / 12%);
+  /* Same ambient bias as light md: soft contact, weight in the wide blurs. */
+  --shadow-md:
+    0 1px 2px oklch(0% 0 none / 12%), 0 4px 10px oklch(0% 0 none / 10%),
+    0 10px 24px oklch(0% 0 none / 12%), 0 18px 36px oklch(0% 0 none / 12%);
+  --shadow-lg:
+    0 1px 2px oklch(0% 0 none / 16%), 0 2px 6px oklch(0% 0 none / 20%),
+    0 8px 20px oklch(0% 0 none / 18%), 0 18px 40px oklch(0% 0 none / 28%);
   --shadow-inset: 0 0 0 1px oklch(100% 0 none / 5%);
 }


### PR DESCRIPTION
## Summary

- **Layered shadow tokens (both themes).** `--shadow-sm/md/lg` are now 2-4 layer stacks (tight contact + mid + wide soft ambient) instead of one or two heavy blurs. `md` deliberately leans ambient — faint contact, weight in the wide blurs — so lifted surfaces glow instead of drawing a hard line under the edge. Dark mode splits its old 30-40% single blurs into several lighter layers at similar total elevation.
- **Popover shadows theme correctly in dark mode.** `.context-menu`, `.select-popover`, the tab-overflow popover, `.routines-action-menu`, `.folders-sort-menu`, `.folder-add-popover`, and `.move-to-folder-popover` hard-coded light-tuned `0 16px 36px oklch(0% 0 none / 12%)`-style shadows with no dark override — essentially invisible on a near-black background. All now use `var(--shadow-lg)`.
- **Hairline-ring edge on the chatboxes.** The agent composer and onboarding practice composer replace their solid `--border-subtle` border with a hairline ring inside the shadow stack (a transparent border holds the layout box). Rest ring is 60% `--border-subtle`; focus firms it with a 20% `--ring-focus` mix. Elevation rests at `--shadow-md` and no longer changes on focus — the focus affordance is the ring alone. Wired as a `--composer-ring` variable so the hero/routines shadow overrides recompose it.
- **Composer-in-scroller fixes** (all rooted in the fixed composer being a DOM child of `.agent-scroll`):
  - the chat's scrollbar thumb painted the entire time a draft had focus (global `:focus-within` scrollbar reveal) — `.agent-scroll` now reveals on hover only;
  - Shift+Enter/paste dragged the conversation behind the box (ProseMirror's `scrollIntoView` walks every scrollable ancestor) — a custom `handleScrollToSelection` scrolls only the editor's own scroller;
  - the editor's edge fades shaved the full-width highlight of a range selection — fades now drop while a selection is active and return when it collapses.
- **Permission status pills.** The settings permission icons each tint their own pill background per tone (success / attention / destructive / muted) so state is visible when scanning the list.

## Validation

- `pnpm check`, `pnpm typecheck`, and the full vitest suite (127 files, 1947 passed) are green.

- [x] Tested visually where it matters (iterated live with the app across light/dark on the composer, popovers, and settings).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Surfaces with deliberate per-theme shadow stacks (`.sidebar-search`, the command palette, the sidebar recording indicator) keep their hand-tuned values.
- No change to `--shadow-inset` consumers (buttons, cards) beyond the token rework itself.
- Other bordered surfaces (cards, dialogs, popovers) keep real borders; the ring-in-shadow treatment is chatbox-only for now.

## Followups

- If the ring-in-shadow edge holds up, consider extending it to other elevated surfaces (popovers currently carry `--popover-border` + shadow).

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- no workflow changes -->
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- none -->
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- none -->
- [x] User-facing copy follows the repo UI conventions. <!-- no copy changes -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)