### PR TITLE
Fix update-ready composer dictation prompt

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2902,6 +2902,8 @@ export function App() {
                   onSessionSelected={setActiveAgentSession}
                   topUpLabel={topUpLabel}
                   onTopUp={handleTopUp}
+                  updateReadyToRelaunch={readyUpdate != null}
+                  onRelaunch={handleRelaunchUpdate}
                   origin={
                     agentOriginFolder
                       ? {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -901,6 +901,8 @@ type AgentWorkspaceProps = {
   origin?: AgentWorkspaceOrigin;
   onSessionSelected?: (session: HermesSessionInfo | undefined) => void;
   onTopUp?: () => void | Promise<void>;
+  updateReadyToRelaunch?: boolean;
+  onRelaunch?: () => void;
   topUpLabel?: string;
 };
 
@@ -956,6 +958,7 @@ const ISSUE_REPORT_FOLLOW_UP_SUBMIT_FAILED_EVENT =
   "june-agent-issue-report-follow-up-submit-failed";
 const ISSUE_REPORT_SENT_MESSAGE =
   "Your report was sent to the June team. Thank you for helping improve June.";
+const DICTATION_UPDATE_READY_MESSAGE = "Dictation is paused until you relaunch to finish updating.";
 const ISSUE_REPORT_DIAGNOSIS_REFRESH_TIMEOUT_MS = 1500;
 const ISSUE_REPORT_DIAGNOSIS_BOUNDARY_SKEW_MS = 1500;
 const agentComposerDrafts = new Map<string, ComposerDraftSnapshot>();
@@ -1373,6 +1376,8 @@ export function AgentWorkspace({
   origin,
   onSessionSelected,
   onTopUp,
+  updateReadyToRelaunch = false,
+  onRelaunch,
   topUpLabel = "Upgrade",
 }: AgentWorkspaceProps = {}) {
   const initialSessionId = initialSession?.id ?? initialSessionIdProp;
@@ -2250,6 +2255,10 @@ export function AgentWorkspace({
   const visibleErrorRetryable =
     visibleError != null &&
     (GATEWAY_CONNECTION_ERROR.test(visibleError) || visibleError === HERMES_SERVER_ERROR_MESSAGE);
+  const visibleErrorPrimaryAction =
+    visibleError === DICTATION_UPDATE_READY_MESSAGE && updateReadyToRelaunch && onRelaunch
+      ? { label: "Relaunch June", onClick: onRelaunch }
+      : undefined;
   const visibleIssueReportNotice =
     issueReportNotice && issueReportNotice.sessionId === (selectedHermesSessionId ?? null)
       ? issueReportNotice.message
@@ -3963,6 +3972,10 @@ export function AgentWorkspace({
   // the same command the hotkey path sends. The helper records, shows the HUD,
   // and pastes the transcription into the focused field (the composer).
   async function startDictation() {
+    if (updateReadyToRelaunch) {
+      setError(DICTATION_UPDATE_READY_MESSAGE);
+      return;
+    }
     composerEditorRef.current?.focus();
     try {
       await dictationHelperCommand({
@@ -7421,6 +7434,7 @@ export function AgentWorkspace({
             <AgentErrorBanner
               message={visibleError}
               onRetry={visibleErrorRetryable ? () => void retryGatewayConnection() : undefined}
+              primaryAction={visibleErrorPrimaryAction}
               onReportBug={
                 visibleErrorState?.issueReport
                   ? () => void sendErrorIssueReport(visibleErrorState)
@@ -7491,6 +7505,7 @@ export function AgentWorkspace({
                 <AgentErrorBanner
                   message={visibleError}
                   onRetry={visibleErrorRetryable ? () => void retryGatewayConnection() : undefined}
+                  primaryAction={visibleErrorPrimaryAction}
                   onReportBug={
                     visibleErrorState?.issueReport
                       ? () => void sendErrorIssueReport(visibleErrorState)
@@ -9927,12 +9942,14 @@ function AgentErrorBanner({
   message,
   onDismiss,
   onReportBug,
+  primaryAction,
   onRetry,
   reportBugSubmitting = false,
 }: {
   message: string;
   onDismiss: () => void;
   onReportBug?: () => void;
+  primaryAction?: { label: string; onClick: () => void };
   onRetry?: () => void;
   reportBugSubmitting?: boolean;
 }) {
@@ -9943,6 +9960,11 @@ function AgentErrorBanner({
         {onRetry ? (
           <button type="button" onClick={onRetry}>
             Try again
+          </button>
+        ) : null}
+        {primaryAction ? (
+          <button type="button" onClick={primaryAction.onClick}>
+            {primaryAction.label}
           </button>
         ) : null}
         {onReportBug ? (

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -9963,7 +9963,13 @@ function AgentErrorBanner({
           </button>
         ) : null}
         {primaryAction ? (
-          <button type="button" onClick={primaryAction.onClick}>
+          <button
+            type="button"
+            onClick={() => {
+              onDismiss();
+              primaryAction.onClick();
+            }}
+          >
             {primaryAction.label}
           </button>
         ) : null}

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -354,10 +354,7 @@ describe("AgentWorkspace", () => {
 
     await user.click(screen.getByRole("button", { name: "Dictate" }));
 
-    expect(mocks.dictationHelperCommand).not.toHaveBeenCalledWith({
-      type: "toggle_listening",
-      shortcut: "Dictation",
-    });
+    expect(mocks.dictationHelperCommand).not.toHaveBeenCalled();
     expect(
       await screen.findByText("Dictation is paused until you relaunch to finish updating."),
     ).toBeInTheDocument();
@@ -365,6 +362,9 @@ describe("AgentWorkspace", () => {
     await user.click(screen.getByRole("button", { name: "Relaunch June" }));
 
     expect(onRelaunch).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText("Dictation is paused until you relaunch to finish updating."),
+    ).not.toBeInTheDocument();
   });
 
   it("lets users cancel a clean skill editor without making changes", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -31,6 +31,7 @@ const HERO_GREETING = new RegExp(
 const mocks = vi.hoisted(() => ({
   cancelAgentTask: vi.fn(),
   createAgentTask: vi.fn(),
+  dictationHelperCommand: vi.fn(),
   ensureHermesBridgeSession: vi.fn(),
   finalizeHermesBridgeBranch: vi.fn(),
   generateImage: vi.fn(),
@@ -89,6 +90,7 @@ vi.mock("../lib/tauri", () => ({
   invoke: vi.fn(async () => []),
   cancelAgentTask: mocks.cancelAgentTask,
   createAgentTask: mocks.createAgentTask,
+  dictationHelperCommand: mocks.dictationHelperCommand,
   ensureHermesBridgeSession: mocks.ensureHermesBridgeSession,
   finalizeHermesBridgeBranch: mocks.finalizeHermesBridgeBranch,
   generateImage: mocks.generateImage,
@@ -335,6 +337,34 @@ describe("AgentWorkspace", () => {
       }
       return Promise.resolve({});
     });
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+  });
+
+  it("prompts relaunch instead of starting composer dictation when an update is ready", async () => {
+    const user = userEvent.setup();
+    const onRelaunch = vi.fn();
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({ createdAt: Date.now() }),
+    );
+
+    render(<AgentWorkspace updateReadyToRelaunch onRelaunch={onRelaunch} />);
+
+    expect(await screen.findByRole("textbox")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Dictate" }));
+
+    expect(mocks.dictationHelperCommand).not.toHaveBeenCalledWith({
+      type: "toggle_listening",
+      shortcut: "Dictation",
+    });
+    expect(
+      await screen.findByText("Dictation is paused until you relaunch to finish updating."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Relaunch June" }));
+
+    expect(onRelaunch).toHaveBeenCalledTimes(1);
   });
 
   it("lets users cancel a clean skill editor without making changes", async () => {


### PR DESCRIPTION
## Summary

- Route the agent composer dictation button through the update-ready state.
- Show the existing relaunch-focused dictation message with a `Relaunch June` action instead of surfacing a misleading microphone permission error.
- Add a regression test that proves the composer does not call the dictation helper while an update is waiting for relaunch.

## Root cause

When an update was downloaded and waiting for relaunch, Settings already treated dictation as paused because the bundle swap can stop the dictation helper. The agent composer did not receive that update-ready state, so its microphone button still called `toggle_listening`. If the helper was unavailable mid-update, the lower-level helper error surfaced as a microphone permission problem even though the user needed to relaunch.

Fixes JUN-187: https://app.opensoftware.co/june/issues/JUN-187

## Validation

- `./node_modules/.bin/vitest run src/test/agent-workspace.test.tsx --testNamePattern "prompts relaunch instead of starting composer dictation"` passed.
- `./node_modules/.bin/vitest run src/test/agent-workspace.test.tsx` passed: 174 passed, 2 skipped.
- `./node_modules/.bin/tsc --noEmit` passed.
- `./node_modules/.bin/biome format src/app/App.tsx src/components/agent/AgentWorkspace.tsx src/test/agent-workspace.test.tsx` passed.
- Post-review checks passed after tightening the helper assertion and dismissing the banner before relaunch: focused regression, full `agent-workspace` test file, `tsc --noEmit`, and Biome format for changed agent files.
- `./node_modules/.bin/biome check src/app/App.tsx src/components/agent/AgentWorkspace.tsx src/test/agent-workspace.test.tsx` was blocked by pre-existing App/AgentWorkspace lint debt outside this diff.
- Live web QA was attempted with `./node_modules/.bin/vite --host 127.0.0.1`, but the preview stopped at the sign-in/onboarding surface and the dev update-card driver was not available there.

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). Not completed because the web preview was blocked before the app shell.
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Installing or relaunching a real update.
- Changing dictation helper recovery behavior.
- Cleaning up existing App/AgentWorkspace lint warnings.

## Followups

- None.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.
