### PR TITLE
feat: reference a specific note in agent chat (JUN-186)

### DIFF
--- a/.agents/skills/repo-review/CALIBRATION.md
+++ b/.agents/skills/repo-review/CALIBRATION.md
@@ -20,3 +20,8 @@ data-driven: discount reviewer patterns with a bad true/findings ratio
 | #612 | Spec (claude) | 0 | — | clean verdict, verified all 11 amendments individually, but missed the marker drift codex caught |
 | #612 | Adversarial (codex, 6 rounds) | 9 | 8 | steady 1-2/round narrowing; r6 was a restatement of a documented trade-off (loop exit); high precision, incremental depth |
 | #612 | Adversarial (claude, 1 round) | 4 | 4 | best single run of the cycle: bash 5.2 patsub, allowlist≠sandbox, git --output writes, sink drift; also reproduced the bash 3.2 crash live |
+| #615 | Standards (claude, r1+final) | 0 | — | clean twice; pre-cleared the get_meeting_note "meeting" naming call with entity-scoped reasoning |
+| #615 | Spec (claude, r1+final) | 0 | — | clean twice; individually verified amendments A1-A12 incl. the superseded-constraint trail |
+| #615 | Adversarial (claude, r1-r4) | 8 | 7 | found transcript scan-order + WHERE-divergence + draft-degrade chain; 1 deliberate (token-is-reference, ADR'd); r4 approve |
+| #615 | Adversarial (codex, r4-r6) | 2 | 2 | both high-value and missed by 4 claude rounds (search predicate on suppressed rows; cleared note body resurrection) — disjoint-blind-spots confirmed again; r6 approve |
+| #615 | Browser walkthrough (playwright) | 1 | 1 | @-trigger prefix bug invisible to jsdom (needed composed state); walkthroughs earn their cost on composer features |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,6 +177,16 @@ A file or image imported into the Hermes workspace and referenced by path;
 images additionally get a structured `image.attach_bytes`.
 _Avoid_: upload (unqualified).
 
+**Note reference**:
+A plain-text token — `@note:<id>`, optionally followed by the quoted note
+title — that points the agent at one specific note. Inserted as a composer
+chip via `@`, seeded by "Ask June" on a note, or pasted from "Copy note
+reference"; the agent resolves it on demand through `june_context`'s
+`get_meeting_note` tool (see
+[ADR-0010](docs/adr/0010-note-references-in-agent-chat.md)).
+_Avoid_: note link (no URL or deep link is involved), note mention (the chip
+is UI; the reference is the token).
+
 **Skill / Toolset / MCP server**:
 A Skill is a bundled/installed capability pack; a Toolset is a togglable tool
 group; an MCP server is an external tool provider (June ships `june_context`

--- a/docs/adr/0010-note-references-in-agent-chat.md
+++ b/docs/adr/0010-note-references-in-agent-chat.md
@@ -1,0 +1,83 @@
+# 0010 — Note references in agent chat: text token + fetch-by-id tool
+
+- Status: accepted
+- Date: 2026-07-03
+- Issue: JUN-186
+
+## Context
+
+June's agent can search the user's notes through the `june_context` MCP server
+(`search_meeting_notes`), but there was no way to point a chat at a *specific*
+note. Users who had just finished a meeting had to describe the note in prose
+and hope retrieval surfaced the right one, and search results carry
+snippet-capped text (900 chars), so even a correct hit could not feed a whole
+note into the conversation.
+
+JUN-186 asked for a way to "copy a link to a notes session and paste it into
+June," or alternatively to chat from inside the note view. Several carriers
+for the reference were considered:
+
+1. **Inline the note content client-side** — the app pastes the full note
+   (and possibly transcript) into the prompt at submit.
+2. **A Hermes workspace file attachment** — import the note as a file the way
+   `/file` attachments work.
+3. **A deep link** (`osjune://note/<id>`) resolved by the shell.
+4. **A plain-text reference token resolved by the agent** — the message
+   carries `@note:<id>` and the agent fetches content on demand through a new
+   `june_context` tool.
+
+## Decision
+
+A note reference is a **plain-text token in the prompt** with the canonical
+form:
+
+```
+@note:<id> ("<title>")   // title sanitized: whitespace collapsed, quotes
+@note:<id>               // stripped, capped at 80 chars; omitted when empty
+```
+
+and the `june_context` MCP server gains a read-only **`get_meeting_note`**
+tool (`note_id`, optional `include_transcript`, content capped at 60k chars
+with explicit truncation flags). SOUL guidance teaches the model to resolve
+the token via the tool and to say so when a note is not found.
+
+The composer renders the reference as an atom chip (built on the same TipTap
+mention machinery as the category chip) that serializes to the token at send;
+"Ask June" in the note view pre-seeds a fresh chat with the chip (never
+auto-submits); "Copy note reference" copies the same token for pasting
+anywhere a prompt can be typed.
+
+## Rationale
+
+- **One wire format, many affordances.** Because the reference is just text,
+  the chip, the copy button, a pasted token, a scheduled/cron prompt, and a
+  teammate's pasted message all work identically. Affordances stay UI sugar;
+  none of them is load-bearing.
+- **Context economy.** Inlining (option 1) bloats every turn with up to an
+  entire transcript whether or not the model needs it, and the content
+  freezes at submit time. The token defers loading to the model, which can
+  choose `include_transcript` only when needed and always reads current
+  content.
+- **No new trust surface.** Option 2 (workspace file) copies note content
+  into the Hermes workspace, creating a second, stale copy of private data
+  outside the notes DB; the tool reads the existing SQLite DB read-only.
+- **Deep links stay out of scope.** Option 3 requires an OS-level URL route
+  (today `osjune://` serves only the OS Accounts auth callback) and only pays
+  off for *outside-the-app* linking, which JUN-186 does not require. The
+  token does not preclude adding a deep link later that resolves to the same
+  id.
+
+## Consequences
+
+- The token format is a compatibility contract between the composer
+  serializer, the copy affordance, and the SOUL guidance — change it only
+  additively (the agent must keep resolving tokens already embedded in old
+  chat transcripts).
+- `get_meeting_note` evolves additively: new tools/fields only, no
+  repurposing (mirrors the June API compatibility boundary in AGENTS.md,
+  though this server ships with the app and has no cross-version wire
+  exposure).
+- Composer drafts persist as plain text, so a restored draft shows the
+  literal token instead of a live chip; accepted for v1.
+- An inline chat surface inside the note view (the second half of JUN-186)
+  remains open as a follow-up; it would reuse the same token + tool.

--- a/docs/adr/0010-note-references-in-agent-chat.md
+++ b/docs/adr/0010-note-references-in-agent-chat.md
@@ -73,6 +73,11 @@ anywhere a prompt can be typed.
   serializer, the copy affordance, and the SOUL guidance — change it only
   additively (the agent must keep resolving tokens already embedded in old
   chat transcripts).
+- Token-shaped text **is** a reference, everywhere, by design: the agent
+  resolves it whether it arrived as a chip, a paste, or literal typing, and
+  draft restore renders it as a chip. There is deliberately no "inert" spelling
+  of the token; an id that resolves to nothing yields the tool's not-found
+  answer rather than silent text.
 - `get_meeting_note` evolves additively: new tools/fields only, no
   repurposing (mirrors the June API compatibility boundary in AGENTS.md,
   though this server ships with the app and has no cross-version wire

--- a/docs/adr/0010-note-references-in-agent-chat.md
+++ b/docs/adr/0010-note-references-in-agent-chat.md
@@ -77,7 +77,8 @@ anywhere a prompt can be typed.
   repurposing (mirrors the June API compatibility boundary in AGENTS.md,
   though this server ships with the app and has no cross-version wire
   exposure).
-- Composer drafts persist as plain text, so a restored draft shows the
-  literal token instead of a live chip; accepted for v1.
+- Composer drafts persist as the serialized plain text; restoring a draft
+  rehydrates `@note:` tokens back into chips (`buildDoc`), which is lossless
+  precisely because the chip serializes to the token.
 - An inline chat surface inside the note view (the second half of JUN-186)
   remains open as a follow-up; it would reuse the same token + tool.

--- a/docs/hermes-architecture.md
+++ b/docs/hermes-architecture.md
@@ -18,8 +18,10 @@ June wraps Hermes in four layers, cleanly separated:
   processes under a macOS Seatbelt sandbox, injects the `SOUL.md` identity, runs
   a shared on-device provider proxy (identity stripping / retention enforcement
   before any inference leaves the device), bundles two Python MCP servers
-  (`june_context` = search the user's notes/dictation, `june_web` = web via a
-  token-gated loopback proxy), and exposes ~50 Tauri commands.
+  (`june_context` = search the user's notes/dictation plus `get_meeting_note`
+  fetch-by-id for **note references** (`@note:<id>`, see
+  [ADR-0010](adr/0010-note-references-in-agent-chat.md)), `june_web` = web via
+  a token-gated loopback proxy), and exposes ~50 Tauri commands.
 - **Gateway** (`src/lib/hermes-gateway.ts`) — `HermesGatewayClient`: pure
   JSON-RPC-over-WebSocket transport (connect coalescing, request/response
   correlation, timeouts, `4009` "session busy").

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ decision. See "When to add an ADR" in [AGENTS.md](../AGENTS.md).
 - [adr/0007](adr/0007-model-capability-source-of-truth.md) — model capabilities come from the live Venice catalog, not marketing traits
 - [adr/0008](adr/0008-image-generation-and-editing-tools.md) — image generation/editing: `/image` fast path + LLM tools, via Venice
 - [adr/0009](adr/0009-hermes-config-shared-ownership-merge.md) — config.yaml is shared with the Hermes dashboard; June deep-merges on spawn, never overwrites
+- [adr/0010](adr/0010-note-references-in-agent-chat.md) — note references in agent chat: `@note:<id>` text token + `get_meeting_note` fetch-by-id
 
 ## Enforceable rules (spec/)
 

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -26,11 +26,20 @@ FULL_TEXT_CHARS = 60_000
 # Keep this in sync with DICTATION_HISTORY_RETENTION_DAYS in db/repositories.rs.
 DICTATION_HISTORY_RETENTION_DAYS = 7
 
+# The app's note editor (NoteEditor.tsx) shows the note body as
+# editedContent ?? generatedContent ?? "". Mirror that exactly: edited_content
+# wins when it is not NULL, even when it is an empty string; only NULL falls
+# back to generated_content.
+APP_VISIBLE_NOTE_BODY_SQL = (
+    "CASE WHEN n.edited_content IS NOT NULL THEN n.edited_content "
+    "ELSE coalesce(n.generated_content, '') END"
+)
+
 # The app's transcript view (transcriptToText in NoteEditor.tsx) shows the
 # turn-based rows when any exist and otherwise falls back to the latest
-# whole-file transcript — never a mix. Mirror both halves: `turns_text`
+# whole-file transcript - never a mix. Mirror both halves: `turns_text`
 # matches source_transcripts in db/repositories.rs (same filter, same
-# canonical order — turns land out of insertion order because dual-source
+# canonical order - turns land out of insertion order because dual-source
 # recordings interleave by start_ms and a note can stack several recording
 # sessions), and `latest_text` matches latest_transcript. Callers pick
 # turns_text first, latest_text as the fallback.
@@ -299,21 +308,19 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
         needle = f"%{query.lower()}%"
         where = """
         WHERE lower(coalesce(title, '')) LIKE ?
-           OR lower(coalesce(generated_content, '')) LIKE ?
-           OR lower(coalesce(edited_content, '')) LIKE ?
+           OR lower(coalesce(note_body, '')) LIKE ?
            OR lower(coalesce(
                 CASE WHEN visible_turn_rows > 0 THEN turns_text ELSE latest_text END,
                 ''
            )) LIKE ?
         """
-        params.extend([needle, needle, needle, needle])
+        params.extend([needle, needle, needle])
 
     sql = f"""
         SELECT
             id,
             title,
-            generated_content,
-            edited_content,
+            note_body,
             processing_status,
             created_at,
             updated_at,
@@ -325,8 +332,7 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
                 n.rowid AS note_rowid,
                 n.id,
                 n.title,
-                n.generated_content,
-                n.edited_content,
+                {APP_VISIBLE_NOTE_BODY_SQL} AS note_body,
                 n.processing_status,
                 n.created_at,
                 n.updated_at,
@@ -344,7 +350,7 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
 
     items = []
     for row in rows:
-        note_text = first_text(row["edited_content"], row["generated_content"])
+        note_text = row["note_body"] or ""
         transcript_text = transcript_text_from_row(row)
         items.append(
             {
@@ -376,8 +382,7 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
         SELECT
             n.id,
             n.title,
-            n.generated_content,
-            n.edited_content,
+            {APP_VISIBLE_NOTE_BODY_SQL} AS note_body,
             n.processing_status,
             n.created_at,
             n.updated_at,
@@ -397,7 +402,7 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
             "message": "No note with this id.",
         }
 
-    note_text = first_text(row["edited_content"], row["generated_content"])
+    note_text = row["note_body"] or ""
     note_content, note_content_truncated = capped_text(note_text)
     transcript_text = transcript_text_from_row(row)
     transcript, transcript_truncated = capped_text(transcript_text)
@@ -490,13 +495,6 @@ def bounded_limit(value: Any) -> int:
     except (TypeError, ValueError):
         limit = DEFAULT_LIMIT
     return max(1, min(MAX_LIMIT, limit))
-
-
-def first_text(*values: str | None) -> str:
-    for value in values:
-        if value and value.strip():
-            return value
-    return ""
 
 
 def capped_text(text: str) -> tuple[str, bool]:

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -298,31 +298,43 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
     if query:
         needle = f"%{query.lower()}%"
         where = """
-        WHERE lower(coalesce(n.title, '')) LIKE ?
-           OR lower(coalesce(n.generated_content, '')) LIKE ?
-           OR lower(coalesce(n.edited_content, '')) LIKE ?
-           OR EXISTS (
-                SELECT 1
-                FROM transcripts tx
-                WHERE tx.note_id = n.id
-                  AND lower(coalesce(tx.text, '')) LIKE ?
-           )
+        WHERE lower(coalesce(title, '')) LIKE ?
+           OR lower(coalesce(generated_content, '')) LIKE ?
+           OR lower(coalesce(edited_content, '')) LIKE ?
+           OR lower(coalesce(
+                CASE WHEN visible_turn_rows > 0 THEN turns_text ELSE latest_text END,
+                ''
+           )) LIKE ?
         """
         params.extend([needle, needle, needle, needle])
 
     sql = f"""
         SELECT
-            n.id,
-            n.title,
-            n.generated_content,
-            n.edited_content,
-            n.processing_status,
-            n.created_at,
-            n.updated_at,
-            {TRANSCRIPT_TEXT_SUBQUERIES}
-        FROM notes n
+            id,
+            title,
+            generated_content,
+            edited_content,
+            processing_status,
+            created_at,
+            updated_at,
+            turns_text,
+            visible_turn_rows,
+            latest_text
+        FROM (
+            SELECT
+                n.rowid AS note_rowid,
+                n.id,
+                n.title,
+                n.generated_content,
+                n.edited_content,
+                n.processing_status,
+                n.created_at,
+                n.updated_at,
+                {TRANSCRIPT_TEXT_SUBQUERIES}
+            FROM notes n
+        )
         {where}
-        ORDER BY n.updated_at DESC, n.created_at DESC, n.rowid DESC
+        ORDER BY updated_at DESC, created_at DESC, note_rowid DESC
         LIMIT ?
     """
     params.append(limit)

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -53,6 +53,17 @@ TRANSCRIPT_TEXT_SUBQUERIES = """
         )
     ) AS turns_text,
     (
+        SELECT COUNT(*)
+        FROM transcripts t
+        WHERE t.note_id = n.id
+          AND t.recording_session_id IS NOT NULL
+          AND t.turn_index IS NOT NULL
+          AND (
+                trim(coalesce(t.text, '')) != ''
+                OR trim(coalesce(t.last_error, '')) != ''
+          )
+    ) AS visible_turn_rows,
+    (
         SELECT t.text
         FROM transcripts t
         WHERE t.note_id = n.id
@@ -63,10 +74,13 @@ TRANSCRIPT_TEXT_SUBQUERIES = """
 
 
 def transcript_text_from_row(row: sqlite3.Row) -> str:
-    """The transcript the app itself would show: turns first, else latest."""
-    turns = row["turns_text"] or ""
-    if turns.strip():
-        return turns
+    """The transcript the app itself would show. The app takes the turns
+    branch whenever any visible turn row exists — including all-failed turns
+    (empty text, lastError set), which render as an empty transcript — so an
+    older whole-file transcript must not resurface behind them. Only a note
+    with no visible turn rows at all falls back to the latest transcript."""
+    if row["visible_turn_rows"]:
+        return row["turns_text"] or ""
     return row["latest_text"] or ""
 
 

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -35,30 +35,36 @@ APP_VISIBLE_NOTE_BODY_SQL = (
     "ELSE coalesce(n.generated_content, '') END"
 )
 
-# The app's transcript view (transcriptToText in NoteEditor.tsx) shows the
-# turn-based rows when any exist and otherwise falls back to the latest
-# whole-file transcript - never a mix. Mirror both halves: `turns_text`
-# matches source_transcripts in db/repositories.rs (same filter, same
-# canonical order - turns land out of insertion order because dual-source
-# recordings interleave by start_ms and a note can stack several recording
-# sessions), and `latest_text` matches latest_transcript. Callers pick
-# turns_text first, latest_text as the fallback.
-TRANSCRIPT_TEXT_SUBQUERIES = """
-    (
-        SELECT group_concat(text, char(10)) FROM (
-            SELECT t.text
-            FROM transcripts t
-            LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
-            WHERE t.note_id = n.id
+# Turn text queries share this filter/order. The fragments expect transcript
+# rows aliased as `t` and recording sessions aliased as `rs`.
+TURN_TEXT_FILTER_SQL = """
               AND t.recording_session_id IS NOT NULL
               AND t.turn_index IS NOT NULL
               AND trim(coalesce(t.text, '')) != ''
+"""
+
+TURN_TEXT_ORDER_SQL = """
             ORDER BY COALESCE(rs.started_at, t.created_at) ASC,
                      COALESCE(rs.rowid, 9223372036854775807) ASC,
                      COALESCE(t.turn_index, 999999),
                      COALESCE(t.start_ms, 999999999),
                      t.created_at ASC,
                      t.rowid ASC
+"""
+
+# The app's transcript view (transcriptToText in NoteEditor.tsx) shows turn
+# rows when any visible turn exists and otherwise falls back to the latest
+# whole-file transcript - never a mix. `turns_text` stays unlabeled for search;
+# `get_meeting_note` formats labeled turn blocks from a second row query.
+TRANSCRIPT_TEXT_SUBQUERIES = f"""
+    (
+        SELECT group_concat(text, char(10)) FROM (
+            SELECT t.text
+            FROM transcripts t
+            LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
+            WHERE t.note_id = n.id
+{TURN_TEXT_FILTER_SQL}
+{TURN_TEXT_ORDER_SQL}
         )
     ) AS turns_text,
     (
@@ -81,16 +87,49 @@ TRANSCRIPT_TEXT_SUBQUERIES = """
     ) AS latest_text
 """
 
+LABELED_TURN_TEXT_SQL = f"""
+    SELECT t.source, t.start_ms, t.end_ms, t.text
+    FROM transcripts t
+    LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
+    WHERE t.note_id = ?
+{TURN_TEXT_FILTER_SQL}
+{TURN_TEXT_ORDER_SQL}
+"""
+
 
 def transcript_text_from_row(row: sqlite3.Row) -> str:
-    """The transcript the app itself would show. The app takes the turns
-    branch whenever any visible turn row exists — including all-failed turns
-    (empty text, lastError set), which render as an empty transcript — so an
-    older whole-file transcript must not resurface behind them. Only a note
-    with no visible turn rows at all falls back to the latest transcript."""
+    """The unlabeled transcript used by search.
+
+    It still follows the app's turn-vs-whole-file branch decision so an older
+    whole-file transcript cannot resurface behind visible turn rows.
+    """
     if row["visible_turn_rows"]:
         return row["turns_text"] or ""
     return row["latest_text"] or ""
+
+
+def labeled_transcript_from_turn_rows(rows: list[sqlite3.Row]) -> str:
+    blocks = []
+    for row in rows:
+        text = row["text"] or ""
+        if not text.strip():
+            continue
+        label = "System" if row["source"] == "system" else "Microphone"
+        turn_time = format_turn_time(row["start_ms"], row["end_ms"])
+        meta = f"{label} {turn_time}" if turn_time else label
+        blocks.append(f"{meta}\n{text}")
+    return "\n\n".join(blocks)
+
+
+def format_turn_time(start_ms: Any, end_ms: Any) -> str | None:
+    if start_ms is None or end_ms is None or end_ms <= start_ms:
+        return None
+
+    def format_ms(value: Any) -> str:
+        seconds = int(max(0, value) / 1000 + 0.5)
+        return f"{seconds // 60}:{seconds % 60:02d}"
+
+    return f"{format_ms(start_ms)}-{format_ms(end_ms)}"
 
 
 TOOLS: list[dict[str, Any]] = [
@@ -351,6 +390,9 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
     items = []
     for row in rows:
         note_text = row["note_body"] or ""
+        # Search intentionally keeps turn transcripts unlabeled: labels would
+        # make queries like "system" match every dual-source note and spend
+        # snippet budget on metadata instead of user text.
         transcript_text = transcript_text_from_row(row)
         items.append(
             {
@@ -392,8 +434,11 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
         LIMIT 1
     """
 
+    turn_rows: list[sqlite3.Row] = []
     with connect_readonly(db_path) as conn:
         row = conn.execute(sql, [note_id]).fetchone()
+        if row is not None and row["visible_turn_rows"]:
+            turn_rows = conn.execute(LABELED_TURN_TEXT_SQL, [note_id]).fetchall()
 
     if row is None:
         return {
@@ -404,7 +449,10 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
 
     note_text = row["note_body"] or ""
     note_content, note_content_truncated = capped_text(note_text)
-    transcript_text = transcript_text_from_row(row)
+    if row["visible_turn_rows"]:
+        transcript_text = labeled_transcript_from_turn_rows(turn_rows)
+    else:
+        transcript_text = row["latest_text"] or ""
     transcript, transcript_truncated = capped_text(transcript_text)
 
     result = {

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -26,6 +26,28 @@ FULL_TEXT_CHARS = 60_000
 # Keep this in sync with DICTATION_HISTORY_RETENTION_DAYS in db/repositories.rs.
 DICTATION_HISTORY_RETENTION_DAYS = 7
 
+# Turns land out of insertion order (dual-source recordings interleave by
+# start_ms; a note can stack several recording sessions), so any transcript
+# assembly must sort the way the app's canonical read path does — see
+# source_transcripts in db/repositories.rs and keep the two in sync.
+TRANSCRIPT_TEXT_SUBQUERY = """
+    (
+        SELECT group_concat(text, char(10)) FROM (
+            SELECT t.text
+            FROM transcripts t
+            LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
+            WHERE t.note_id = n.id
+              AND trim(coalesce(t.text, '')) != ''
+            ORDER BY COALESCE(rs.started_at, t.created_at) ASC,
+                     COALESCE(rs.rowid, 9223372036854775807) ASC,
+                     COALESCE(t.turn_index, 999999),
+                     COALESCE(t.start_ms, 999999999),
+                     t.created_at ASC,
+                     t.rowid ASC
+        )
+    ) AS transcript_text
+"""
+
 
 TOOLS: list[dict[str, Any]] = [
     {
@@ -262,12 +284,7 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
             n.processing_status,
             n.created_at,
             n.updated_at,
-            (
-                SELECT group_concat(t.text, char(10))
-                FROM transcripts t
-                WHERE t.note_id = n.id
-                  AND trim(coalesce(t.text, '')) != ''
-            ) AS transcript_text
+            {TRANSCRIPT_TEXT_SUBQUERY}
         FROM notes n
         {where}
         ORDER BY n.updated_at DESC, n.created_at DESC, n.rowid DESC
@@ -308,7 +325,7 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
             "message": "June notes database does not exist yet.",
         }
 
-    sql = """
+    sql = f"""
         SELECT
             n.id,
             n.title,
@@ -317,12 +334,7 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
             n.processing_status,
             n.created_at,
             n.updated_at,
-            (
-                SELECT group_concat(t.text, char(10))
-                FROM transcripts t
-                WHERE t.note_id = n.id
-                  AND trim(coalesce(t.text, '')) != ''
-            ) AS transcript_text
+            {TRANSCRIPT_TEXT_SUBQUERY}
         FROM notes n
         WHERE n.id = ?
         LIMIT 1

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -369,7 +369,7 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
 def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]:
     note_id = str(arguments.get("note_id") or "").strip()
     if not note_id:
-        raise ValueError("note_id is required")
+        return {"noteId": note_id, "found": False, "message": "note_id is required."}
 
     if not db_path.exists():
         return {

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -26,17 +26,23 @@ FULL_TEXT_CHARS = 60_000
 # Keep this in sync with DICTATION_HISTORY_RETENTION_DAYS in db/repositories.rs.
 DICTATION_HISTORY_RETENTION_DAYS = 7
 
-# Turns land out of insertion order (dual-source recordings interleave by
-# start_ms; a note can stack several recording sessions), so any transcript
-# assembly must sort the way the app's canonical read path does — see
-# source_transcripts in db/repositories.rs and keep the two in sync.
-TRANSCRIPT_TEXT_SUBQUERY = """
+# The app's transcript view (transcriptToText in NoteEditor.tsx) shows the
+# turn-based rows when any exist and otherwise falls back to the latest
+# whole-file transcript — never a mix. Mirror both halves: `turns_text`
+# matches source_transcripts in db/repositories.rs (same filter, same
+# canonical order — turns land out of insertion order because dual-source
+# recordings interleave by start_ms and a note can stack several recording
+# sessions), and `latest_text` matches latest_transcript. Callers pick
+# turns_text first, latest_text as the fallback.
+TRANSCRIPT_TEXT_SUBQUERIES = """
     (
         SELECT group_concat(text, char(10)) FROM (
             SELECT t.text
             FROM transcripts t
             LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
             WHERE t.note_id = n.id
+              AND t.recording_session_id IS NOT NULL
+              AND t.turn_index IS NOT NULL
               AND trim(coalesce(t.text, '')) != ''
             ORDER BY COALESCE(rs.started_at, t.created_at) ASC,
                      COALESCE(rs.rowid, 9223372036854775807) ASC,
@@ -45,8 +51,23 @@ TRANSCRIPT_TEXT_SUBQUERY = """
                      t.created_at ASC,
                      t.rowid ASC
         )
-    ) AS transcript_text
+    ) AS turns_text,
+    (
+        SELECT t.text
+        FROM transcripts t
+        WHERE t.note_id = n.id
+        ORDER BY t.created_at DESC
+        LIMIT 1
+    ) AS latest_text
 """
+
+
+def transcript_text_from_row(row: sqlite3.Row) -> str:
+    """The transcript the app itself would show: turns first, else latest."""
+    turns = row["turns_text"] or ""
+    if turns.strip():
+        return turns
+    return row["latest_text"] or ""
 
 
 TOOLS: list[dict[str, Any]] = [
@@ -284,7 +305,7 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
             n.processing_status,
             n.created_at,
             n.updated_at,
-            {TRANSCRIPT_TEXT_SUBQUERY}
+            {TRANSCRIPT_TEXT_SUBQUERIES}
         FROM notes n
         {where}
         ORDER BY n.updated_at DESC, n.created_at DESC, n.rowid DESC
@@ -298,7 +319,7 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
     items = []
     for row in rows:
         note_text = first_text(row["edited_content"], row["generated_content"])
-        transcript_text = row["transcript_text"] or ""
+        transcript_text = transcript_text_from_row(row)
         items.append(
             {
                 "id": row["id"],
@@ -334,7 +355,7 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
             n.processing_status,
             n.created_at,
             n.updated_at,
-            {TRANSCRIPT_TEXT_SUBQUERY}
+            {TRANSCRIPT_TEXT_SUBQUERIES}
         FROM notes n
         WHERE n.id = ?
         LIMIT 1
@@ -352,7 +373,7 @@ def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]
 
     note_text = first_text(row["edited_content"], row["generated_content"])
     note_content, note_content_truncated = capped_text(note_text)
-    transcript_text = row["transcript_text"] or ""
+    transcript_text = transcript_text_from_row(row)
     transcript, transcript_truncated = capped_text(transcript_text)
 
     result = {

--- a/src-tauri/src/hermes/june_context_mcp.py
+++ b/src-tauri/src/hermes/june_context_mcp.py
@@ -18,10 +18,11 @@ from typing import Any
 
 
 PROTOCOL_VERSION = "2025-03-26"
-SERVER_INFO = {"name": "june-context", "version": "0.1.0"}
+SERVER_INFO = {"name": "june-context", "version": "0.2.0"}
 MAX_LIMIT = 20
 DEFAULT_LIMIT = 8
 SNIPPET_CHARS = 900
+FULL_TEXT_CHARS = 60_000
 # Keep this in sync with DICTATION_HISTORY_RETENTION_DAYS in db/repositories.rs.
 DICTATION_HISTORY_RETENTION_DAYS = 7
 
@@ -70,6 +71,32 @@ TOOLS: list[dict[str, Any]] = [
                     "default": DEFAULT_LIMIT,
                 },
             },
+        },
+    },
+    {
+        "name": "get_meeting_note",
+        "description": (
+            "Fetch one June meeting note in full by its id. Use this when a "
+            "message references a specific note (for example an `@note:<id>` "
+            "reference) or when a search result's snippet is not enough. Set "
+            "include_transcript only when the note content alone cannot answer."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "note_id": {
+                    "type": "string",
+                    "description": (
+                        "The note id, e.g. from an @note:<id> reference or a "
+                        "search_meeting_notes result."
+                    ),
+                },
+                "include_transcript": {
+                    "type": "boolean",
+                    "default": False,
+                },
+            },
+            "required": ["note_id"],
         },
     },
 ]
@@ -160,6 +187,8 @@ def call_tool(db_path: Path, request_id: Any, params: dict[str, Any]) -> dict[st
             result = search_meeting_notes(db_path, arguments)
         elif name == "search_dictation_history":
             result = search_dictation_history(db_path, arguments)
+        elif name == "get_meeting_note":
+            result = get_meeting_note(db_path, arguments)
         else:
             return error_response(request_id, -32602, f"Unknown tool: {name}")
     except Exception as exc:
@@ -267,6 +296,70 @@ def search_meeting_notes(db_path: Path, arguments: dict[str, Any]) -> dict[str, 
     return {"query": query, "count": len(items), "items": items}
 
 
+def get_meeting_note(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]:
+    note_id = str(arguments.get("note_id") or "").strip()
+    if not note_id:
+        raise ValueError("note_id is required")
+
+    if not db_path.exists():
+        return {
+            "noteId": note_id,
+            "found": False,
+            "message": "June notes database does not exist yet.",
+        }
+
+    sql = """
+        SELECT
+            n.id,
+            n.title,
+            n.generated_content,
+            n.edited_content,
+            n.processing_status,
+            n.created_at,
+            n.updated_at,
+            (
+                SELECT group_concat(t.text, char(10))
+                FROM transcripts t
+                WHERE t.note_id = n.id
+                  AND trim(coalesce(t.text, '')) != ''
+            ) AS transcript_text
+        FROM notes n
+        WHERE n.id = ?
+        LIMIT 1
+    """
+
+    with connect_readonly(db_path) as conn:
+        row = conn.execute(sql, [note_id]).fetchone()
+
+    if row is None:
+        return {
+            "noteId": note_id,
+            "found": False,
+            "message": "No note with this id.",
+        }
+
+    note_text = first_text(row["edited_content"], row["generated_content"])
+    note_content, note_content_truncated = capped_text(note_text)
+    transcript_text = row["transcript_text"] or ""
+    transcript, transcript_truncated = capped_text(transcript_text)
+
+    result = {
+        "noteId": row["id"],
+        "found": True,
+        "title": row["title"] or "Untitled note",
+        "processingStatus": row["processing_status"],
+        "createdAt": row["created_at"],
+        "updatedAt": row["updated_at"],
+        "noteContent": note_content,
+        "noteContentTruncated": note_content_truncated,
+        "transcriptChars": len(transcript_text),
+    }
+    if arguments.get("include_transcript"):
+        result["transcript"] = transcript
+        result["transcriptTruncated"] = transcript_truncated
+    return result
+
+
 def search_dictation_history(db_path: Path, arguments: dict[str, Any]) -> dict[str, Any]:
     query = str(arguments.get("query") or "").strip()
     limit = bounded_limit(arguments.get("limit"))
@@ -345,6 +438,12 @@ def first_text(*values: str | None) -> str:
         if value and value.strip():
             return value
     return ""
+
+
+def capped_text(text: str) -> tuple[str, bool]:
+    if len(text) <= FULL_TEXT_CHARS:
+        return text, False
+    return text[:FULL_TEXT_CHARS], True
 
 
 def snippet(text: str, query: str) -> str:

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -87,6 +87,7 @@ You are helpful, knowledgeable, and direct. Communicate clearly, admit uncertain
 /// prompt note teaches the model when to spend tool calls on that local data.
 const JUNE_SOUL_CONTEXT_MD: &str = r#"
 June context tools: you have access to a local `june_context` MCP toolset for searching the user's June meeting notes, saved note transcripts, and dictation history. Use it when the user asks about prior meetings, calls, recordings, notes, decisions, follow-ups, or dictated text. Query it on demand instead of assuming you already know those entries, and summarize only what the retrieved results support.
+Messages may reference a specific note as `@note:<id>`, usually followed by the note title in quotes. When you see such a reference, call the `june_context` tool `get_meeting_note` with that id to load the note before answering, and rely on what it returns. Ask for the transcript with `include_transcript` only when the note content is not enough. If the tool reports the note was not found, say so instead of guessing.
 "#;
 
 /// Appended to `SOUL.md` for every runtime. This calibrates June's first-turn
@@ -7963,6 +7964,9 @@ mcp_servers:
         assert!(soul.contains("meeting notes"));
         assert!(soul.contains("dictation history"));
         assert!(soul.contains("Query it on demand"));
+        assert!(soul.contains("@note:<id>"));
+        assert!(soul.contains("get_meeting_note"));
+        assert!(soul.contains("include_transcript"));
     }
 
     #[test]

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2068,6 +2068,21 @@ export function App() {
     }, 0);
   }
 
+  function handleAskJuneAboutNote(noteRef: { id: string; title: string }) {
+    pendingSessionProjectRef.current = null;
+    setAgentOrigin(undefined);
+    markAgentNewSessionPending(undefined, { noteRef });
+    setActiveAgentSession(undefined);
+    setActiveView("agent");
+    window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent<AgentNewSessionDetail>(AGENT_NEW_SESSION_EVENT, {
+          detail: { noteRef },
+        }),
+      );
+    }, 0);
+  }
+
   // "Start chat with this bundle" from the Bundles settings tab: the same
   // fresh-chat handshake the dictation prompt path uses, auto-submitting the
   // bundle's slash command so Hermes resolves the bundle and loads its skills.
@@ -3168,6 +3183,12 @@ export function App() {
                       onPauseRecording={(sessionId) => void handlePauseRecording(sessionId)}
                       onResumeRecording={(sessionId) => void handleResumeRecording(sessionId)}
                       onFinishRecording={(sessionId) => void handleFinishRecording(sessionId)}
+                      onAskJune={() =>
+                        handleAskJuneAboutNote({
+                          id: selectedNote.id,
+                          title: selectedNote.title,
+                        })
+                      }
                       onRetry={async () => {
                         if (!selectedNote) return;
                         try {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -1,4 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
+import type { Editor as TiptapEditor } from "@tiptap/react";
 import { IconArrowDown } from "central-icons/IconArrowDown";
 import { IconArrowInbox } from "central-icons/IconArrowInbox";
 import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
@@ -44,6 +45,7 @@ import { IconHeartBeat } from "central-icons/IconHeartBeat";
 import { IconLock } from "central-icons/IconLock";
 import { IconMagnifyingGlass } from "central-icons/IconMagnifyingGlass";
 import { IconMicrophone } from "central-icons/IconMicrophone";
+import { IconNoteText } from "central-icons/IconNoteText";
 import { IconNotes } from "central-icons/IconNotes";
 import { IconPageTextSearch } from "central-icons/IconPageTextSearch";
 import { IconPencil } from "central-icons/IconPencil";
@@ -257,6 +259,7 @@ import {
   type ComposerEditorHandle,
   stripPlaceholder,
 } from "./composer/ComposerEditor";
+import { noteReferenceToken, type NoteReferenceInput } from "./composer/noteReference";
 import { CategoryIcon } from "./composer/CategoryIcon";
 import { FileTypeIcon, fileTypeIconComponent } from "./FileTypeIcon";
 import {
@@ -738,6 +741,9 @@ export type AgentNewSessionDetail = {
   /** Seeds the composer with a category chip (and skips auto-submit) so the
    * user lands ready to type a tagged report instead of an ordinary message. */
   category?: ReportCategory;
+  /** Seeds the composer with a note chip (and skips auto-submit) so the user
+   * lands ready to ask about that note instead of starting an ordinary ask. */
+  noteRef?: NoteReferenceInput;
 };
 
 /** Frames the user's bug report for June: investigate and write a diagnosis
@@ -1716,10 +1722,17 @@ export function AgentWorkspace({
   const listRef = useRef<HTMLDivElement | null>(null);
   const agentScrollRef = useRef<HTMLDivElement | null>(null);
   const composerEditorRef = useRef<ComposerEditorHandle | null>(null);
+  const composerTiptapEditorRef = useRef<TiptapEditor | null>(null);
   const composerBoxRef = useRef<HTMLDivElement | null>(null);
   // A category to seed into the composer chip once the editor is ready, set by
   // startNewTask for the sidebar/settings report entry points.
   const pendingSeedCategoryRef = useRef<ReportCategory | null>(null);
+  // A note reference to seed once the editor is ready, set by startNewTask for
+  // note-level "Ask June" entry points.
+  const pendingSeedNoteRefRef = useRef<{
+    noteRef: NoteReferenceInput;
+    prompt: string;
+  } | null>(null);
 
   function setReviewableIssueReport(sessionId: string, report: PendingIssueReport | null) {
     const next = { ...reviewableIssueReportsRef.current };
@@ -5578,10 +5591,14 @@ export function AgentWorkspace({
   ) {
     clearPendingNewSessionRequest();
     const seedCategory = request?.category ?? null;
+    const seedNoteRef = seedCategory ? null : (request?.noteRef ?? null);
+    const seedPrompt = request?.prompt?.trim() ?? "";
     // A seeded report never auto-submits: the category chip lands in the
     // composer for the user to type their report after, whatever prompt the
     // request carried.
-    const initialPrompt = seedCategory ? "" : (request?.prompt?.trim() ?? "");
+    // A seeded note reference follows the same rule: the chip lands in the
+    // composer and the user decides what to send.
+    const initialPrompt = seedCategory || seedNoteRef ? "" : seedPrompt;
     // The pending-marker mount path and the AGENT_NEW_SESSION_EVENT dispatch
     // can deliver the same request twice (App marks the marker, then fires
     // the event in a setTimeout for already-mounted workspaces). Submitting
@@ -5605,13 +5622,24 @@ export function AgentWorkspace({
     selectedHermesSessionIdRef.current = undefined;
     composerDraftKeyRef.current = NEW_SESSION_DRAFT_KEY;
     setSelectedHermesSessionId(undefined);
-    // Seed the composer: a category chip for a report, the prompt otherwise.
-    // The editor may not be mounted yet on a cold open, so stash the category
-    // for ComposerEditor's onReady to pick up and also try to apply now.
+    // Seed the composer: a category chip for a report, a note chip for a note
+    // entry point, the prompt otherwise. The editor may not be mounted yet on
+    // a cold open, so stash chips for ComposerEditor's onReady to pick up and
+    // also try to apply now.
     pendingSeedCategoryRef.current = seedCategory;
+    pendingSeedNoteRefRef.current = seedNoteRef
+      ? {
+          noteRef: seedNoteRef,
+          prompt: seedPrompt,
+        }
+      : null;
     if (seedCategory) {
+      pendingSeedNoteRefRef.current = null;
       clearComposerDraft(NEW_SESSION_DRAFT_KEY);
       seedComposerCategory({ defer: options.deferCategorySeed });
+    } else if (seedNoteRef) {
+      clearComposerDraft(NEW_SESSION_DRAFT_KEY);
+      seedComposerNoteRef({ defer: options.deferCategorySeed });
     } else if (initialPrompt) {
       rememberComposerDraft(NEW_SESSION_DRAFT_KEY, initialPrompt, null);
       composerEditorRef.current?.setContent(initialPrompt);
@@ -5702,6 +5730,7 @@ export function AgentWorkspace({
       const currentEditor = composerEditorRef.current;
       if (!seed || !currentEditor) return;
       pendingSeedCategoryRef.current = null;
+      pendingSeedNoteRefRef.current = null;
       draftRef.current = "";
       categoryRef.current = seed;
       setDraft("");
@@ -5709,6 +5738,43 @@ export function AgentWorkspace({
       rememberComposerDraft(NEW_SESSION_DRAFT_KEY, "", seed);
       restoredComposerDraftKeyRef.current = NEW_SESSION_DRAFT_KEY;
       currentEditor.setContent("", seed);
+    };
+    if (options.defer) {
+      window.setTimeout(applySeed, 0);
+    } else {
+      applySeed();
+    }
+  }
+
+  /** Applies any pending note reference to the composer once the editor is
+   * available. Mirrors seedComposerCategory for cold-open note entry points. */
+  function seedComposerNoteRef(options: { defer?: boolean } = {}) {
+    if (!pendingSeedNoteRefRef.current) return;
+    const editor = composerEditorRef.current;
+    const tiptapEditor = composerTiptapEditorRef.current;
+    // Not mounted yet (cold open) — leave it pending for onReady to apply.
+    if (!editor || !tiptapEditor || tiptapEditor.isDestroyed) return;
+    const applySeed = () => {
+      const seed = pendingSeedNoteRefRef.current;
+      const currentEditor = composerEditorRef.current;
+      const currentTiptapEditor = composerTiptapEditorRef.current;
+      if (!seed || !currentEditor || !currentTiptapEditor || currentTiptapEditor.isDestroyed) {
+        return;
+      }
+      pendingSeedNoteRefRef.current = null;
+      draftRef.current = `${noteReferenceToken(seed.noteRef)} ${seed.prompt}`;
+      categoryRef.current = null;
+      setDraft(draftRef.current);
+      setCategory(null);
+      rememberComposerDraft(NEW_SESSION_DRAFT_KEY, draftRef.current, null);
+      restoredComposerDraftKeyRef.current = NEW_SESSION_DRAFT_KEY;
+      currentEditor.setContent("", null);
+      currentEditor.insertNoteReference(seed.noteRef);
+      if (seed.prompt) {
+        currentTiptapEditor.chain().focus().insertContent(seed.prompt).run();
+      } else {
+        currentEditor.focus();
+      }
     };
     if (options.defer) {
       window.setTimeout(applySeed, 0);
@@ -6718,9 +6784,11 @@ export function AgentWorkspace({
               );
             }}
             onSubmit={() => void submit()}
-            onReady={() => {
+            onReady={(editor) => {
+              composerTiptapEditorRef.current = editor;
               restoreComposerDraft(composerDraftKeyRef.current);
               seedComposerCategory({ defer: true });
+              seedComposerNoteRef({ defer: true });
             }}
           />
           <div className="agent-composer-toolbar">
@@ -6839,6 +6907,24 @@ export function AgentWorkspace({
                 <IconFileText size={16} aria-hidden />
               </span>
               <span className="agent-attach-menu-label">Attach files</span>
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setAttachMenuOpen(false);
+                const editor = composerTiptapEditorRef.current;
+                if (editor && !editor.isDestroyed) {
+                  editor.chain().focus().insertContent("@").run();
+                } else {
+                  composerEditorRef.current?.focus();
+                }
+              }}
+            >
+              <span className="agent-attach-menu-icon">
+                <IconNoteText size={16} aria-hidden />
+              </span>
+              <span className="agent-attach-menu-label">Reference a note</span>
             </button>
             <div className="agent-attach-menu-divider" role="separator" />
             {REPORT_CATEGORIES.map((reportCategory) => (
@@ -12334,13 +12420,14 @@ function writeLastOpenSessionId(sessionId: string) {
 
 export function markAgentNewSessionPending(
   prompt?: string,
-  options?: { category?: ReportCategory },
+  options?: { category?: ReportCategory; noteRef?: NoteReferenceInput },
 ) {
   try {
     const payload = JSON.stringify({
       createdAt: Date.now(),
       prompt: prompt?.trim() || undefined,
       category: options?.category,
+      noteRef: options?.noteRef,
     });
     window.sessionStorage.setItem(AGENT_NEW_SESSION_PENDING_KEY, payload);
   } catch {
@@ -12373,7 +12460,17 @@ function hasPendingNewSessionRequest(): boolean {
   }
 }
 
-function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
+function parsePendingNoteRef(value: unknown): NoteReferenceInput | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as { id?: unknown; title?: unknown };
+  if (typeof record.id !== "string" || record.id.trim().length === 0) return undefined;
+  return {
+    id: record.id,
+    title: typeof record.title === "string" ? record.title : "",
+  };
+}
+
+export function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
   try {
     const value = window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY);
     if (value == null) return undefined;
@@ -12385,6 +12482,7 @@ function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
         createdAt?: number;
         prompt?: string;
         category?: string;
+        noteRef?: unknown;
       };
       if (
         typeof parsed.createdAt !== "number" ||
@@ -12392,9 +12490,12 @@ function pendingNewSessionRequest(): AgentNewSessionDetail | undefined {
       ) {
         return undefined;
       }
+      const category = isReportCategory(parsed.category) ? parsed.category : undefined;
+      const noteRef = category ? undefined : parsePendingNoteRef(parsed.noteRef);
       return {
         ...(typeof parsed.prompt === "string" ? { prompt: parsed.prompt } : {}),
-        ...(isReportCategory(parsed.category) ? { category: parsed.category } : {}),
+        ...(category ? { category } : {}),
+        ...(noteRef ? { noteRef } : {}),
       };
     } catch {
       return undefined;

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5771,7 +5771,12 @@ export function AgentWorkspace({
       currentEditor.setContent("", null);
       currentEditor.insertNoteReference(seed.noteRef);
       if (seed.prompt) {
-        currentTiptapEditor.chain().focus().insertContent(seed.prompt).run();
+        // String insertContent parses HTML; a node insert keeps the prompt literal.
+        currentTiptapEditor
+          .chain()
+          .focus()
+          .insertContent({ type: "text", text: seed.prompt })
+          .run();
       } else {
         currentEditor.focus();
       }

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -6915,7 +6915,17 @@ export function AgentWorkspace({
                 setAttachMenuOpen(false);
                 const editor = composerTiptapEditorRef.current;
                 if (editor && !editor.isDestroyed) {
-                  editor.chain().focus().insertContent("@").run();
+                  // The suggestion plugin only matches a trigger preceded by
+                  // whitespace or a line start, so pad the "@" when the caret
+                  // sits right after text or an atom chip.
+                  const nodeBefore = editor.state.selection.$from.nodeBefore;
+                  const lastChar = nodeBefore?.isText ? (nodeBefore.text?.slice(-1) ?? "") : "";
+                  const needsSpace = nodeBefore != null && !/\s/.test(lastChar || "x");
+                  editor
+                    .chain()
+                    .focus()
+                    .insertContent(needsSpace ? " @" : "@")
+                    .run();
                 } else {
                   composerEditorRef.current?.focus();
                 }

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -121,11 +121,19 @@ function inlineContent(line: string) {
   return nodes;
 }
 
-export function buildDoc(text: string, category?: ReportCategory | null) {
+export function buildDoc(
+  text: string,
+  category?: ReportCategory | null,
+  options?: { rehydrateNoteTokens?: boolean },
+) {
+  // Placeholder-staged prefills skip rehydration: stripPlaceholder maps raw
+  // string indices to doc positions, which only holds while every character
+  // stays a size-1 text position — a chip atom would shift the selection.
+  const rehydrate = options?.rehydrateNoteTokens !== false;
   const paragraphs = text.split("\n").map((line) => ({
     type: "paragraph",
     // A text node may not be empty, so a blank line is an empty paragraph.
-    content: inlineContent(line),
+    content: rehydrate ? inlineContent(line) : line ? [{ type: "text", text: line }] : [],
   }));
   if (paragraphs.length === 0) paragraphs.push({ type: "paragraph", content: [] });
   if (category) {
@@ -297,9 +305,12 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         setContent: (text, category, options) => {
           if (!editor) return;
           const staged = options?.selectPlaceholder && !category ? stripPlaceholder(text) : null;
-          editor.commands.setContent(buildDoc(staged?.text ?? text, category), {
-            emitUpdate: true,
-          });
+          editor.commands.setContent(
+            buildDoc(staged?.text ?? text, category, { rehydrateNoteTokens: !staged }),
+            {
+              emitUpdate: true,
+            },
+          );
           // A hero shortcut authors a "<placeholder>" token; the brackets are
           // stripped before the text hits the document and the bare phrase left
           // selected (rather than parking the caret at the end) so typing

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -11,6 +11,13 @@ import {
   createCategoryChip,
   insertReportCategory,
 } from "./categoryChip";
+import {
+  NOTE_REFERENCE_NODE,
+  createNoteReference,
+  insertNoteReference,
+  noteReferenceToken,
+  type NoteReferenceInput,
+} from "./noteReference";
 import type { ReportCategory } from "./reportCategory";
 import type { HermesSkillInfo } from "../../../lib/tauri";
 
@@ -29,6 +36,9 @@ export type ComposerEditorHandle = {
   ) => void;
   /** Inserts or swaps the message's single category tag at the caret. */
   insertCategory: (category: ReportCategory) => void;
+  /** Inserts a note reference chip at the caret. Multiple references can
+   * coexist because they serialize into the prompt text. */
+  insertNoteReference: (ref: NoteReferenceInput) => void;
   isEmpty: () => boolean;
 };
 
@@ -43,12 +53,20 @@ type ComposerEditorProps = {
 };
 
 /** Serializes the doc to the plain string sent to June: paragraph and
- * hard-break boundaries become newlines, and the category chip (a leaf atom)
- * contributes nothing — its meaning rides along as the category, not as text. */
+ * hard-break boundaries become newlines, the category chip contributes
+ * nothing, and note reference atoms emit the stable token Hermes resolves via
+ * June's note context tool. */
 export function serializePlainText(doc: ProseMirrorNode): string {
-  return doc.textBetween(0, doc.content.size, "\n", (leaf) =>
-    leaf.type.name === "hardBreak" ? "\n" : "",
-  );
+  return doc.textBetween(0, doc.content.size, "\n", (leaf) => {
+    if (leaf.type.name === "hardBreak") return "\n";
+    if (leaf.type.name === NOTE_REFERENCE_NODE) {
+      return noteReferenceToken({
+        id: typeof leaf.attrs.noteId === "string" ? leaf.attrs.noteId : "",
+        title: typeof leaf.attrs.title === "string" ? leaf.attrs.title : "",
+      });
+    }
+    return "";
+  });
 }
 
 /** Focuses the editor with the caret at the end, synchronously. tiptap's
@@ -170,6 +188,7 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         }),
         Placeholder.configure({ placeholder }),
         createCategoryChip({ skills: () => skillsRef.current }),
+        createNoteReference(),
       ],
       editorProps: {
         attributes: {
@@ -199,8 +218,8 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
           if (event.key !== "Enter" || event.shiftKey || event.isComposing) {
             return false;
           }
-          // The "/" palette owns Enter while it's open (it commits the
-          // highlighted category); only a closed palette submits the message.
+          // Suggestion palettes own Enter while open (they commit the
+          // highlighted row); only a closed palette submits the message.
           if (document.querySelector(".agent-category-menu-host")) return false;
           event.preventDefault();
           onSubmitRef.current();
@@ -272,6 +291,9 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
         },
         insertCategory: (category) => {
           if (editor) insertReportCategory(editor, category);
+        },
+        insertNoteReference: (noteReference) => {
+          if (editor) insertNoteReference(editor, noteReference);
         },
         isEmpty: () => editor?.isEmpty ?? true,
       }),

--- a/src/components/agent/composer/ComposerEditor.tsx
+++ b/src/components/agent/composer/ComposerEditor.tsx
@@ -97,11 +97,35 @@ export function stripPlaceholder(text: string): { text: string; from: number; to
   };
 }
 
-function buildDoc(text: string, category?: ReportCategory | null) {
+/** Splits a line into text nodes and note-reference chips. Drafts persist as
+ * the serialized plain string, so a restored draft carries reference tokens
+ * as text; rebuilding the chip here keeps the pill UX across restores. The
+ * round-trip is lossless because serializePlainText re-emits the token. */
+function inlineContent(line: string) {
+  const nodes: Array<Record<string, unknown>> = [];
+  const tokenPattern = /@note:([\w-]+)(?: \("([^"]*)"\))?/g;
+  let consumed = 0;
+  for (const match of line.matchAll(tokenPattern)) {
+    if (match.index > consumed) {
+      nodes.push({ type: "text", text: line.slice(consumed, match.index) });
+    }
+    nodes.push({
+      type: NOTE_REFERENCE_NODE,
+      attrs: { noteId: match[1], title: match[2] ?? "" },
+    });
+    consumed = match.index + match[0].length;
+  }
+  if (consumed < line.length) {
+    nodes.push({ type: "text", text: line.slice(consumed) });
+  }
+  return nodes;
+}
+
+export function buildDoc(text: string, category?: ReportCategory | null) {
   const paragraphs = text.split("\n").map((line) => ({
     type: "paragraph",
     // A text node may not be empty, so a blank line is an empty paragraph.
-    content: line ? [{ type: "text", text: line }] : [],
+    content: inlineContent(line),
   }));
   if (paragraphs.length === 0) paragraphs.push({ type: "paragraph", content: [] });
   if (category) {

--- a/src/components/agent/composer/NoteReferenceChipView.tsx
+++ b/src/components/agent/composer/NoteReferenceChipView.tsx
@@ -1,0 +1,25 @@
+import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { IconNoteText } from "central-icons/IconNoteText";
+
+function displayTitle(title: string) {
+  return title.trim() || "New note";
+}
+
+export function NoteReferenceChipView({ node }: NodeViewProps) {
+  const title = typeof node.attrs.title === "string" ? node.attrs.title : "";
+  const noteId = typeof node.attrs.noteId === "string" ? node.attrs.noteId : "";
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      className="agent-note-reference-chip"
+      data-note-id={noteId}
+      contentEditable={false}
+    >
+      <span className="agent-note-reference-chip-icon" aria-hidden="true">
+        <IconNoteText size={10} />
+      </span>
+      <span className="agent-note-reference-chip-title">{displayTitle(title)}</span>
+    </NodeViewWrapper>
+  );
+}

--- a/src/components/agent/composer/NoteReferenceChipView.tsx
+++ b/src/components/agent/composer/NoteReferenceChipView.tsx
@@ -1,9 +1,7 @@
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { IconNoteText } from "central-icons/IconNoteText";
 
-function displayTitle(title: string) {
-  return title.trim() || "New note";
-}
+import { displayNoteTitle } from "./noteReference";
 
 export function NoteReferenceChipView({ node }: NodeViewProps) {
   const title = typeof node.attrs.title === "string" ? node.attrs.title : "";
@@ -19,7 +17,7 @@ export function NoteReferenceChipView({ node }: NodeViewProps) {
       <span className="agent-note-reference-chip-icon" aria-hidden="true">
         <IconNoteText size={10} />
       </span>
-      <span className="agent-note-reference-chip-title">{displayTitle(title)}</span>
+      <span className="agent-note-reference-chip-title">{displayNoteTitle(title)}</span>
     </NodeViewWrapper>
   );
 }

--- a/src/components/agent/composer/NoteSuggestionList.tsx
+++ b/src/components/agent/composer/NoteSuggestionList.tsx
@@ -1,0 +1,165 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { IconNoteText } from "central-icons/IconNoteText";
+
+import type { NoteListItemDto } from "../../../lib/tauri";
+
+export type NoteSuggestionListProps = {
+  items: NoteListItemDto[];
+  command: (item: NoteListItemDto) => void;
+};
+
+export type NoteSuggestionListHandle = {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+};
+
+/** The floating palette that opens when the user types "@" in the composer.
+ * It mirrors the slash palette's keyboard contract but only lists notes. */
+export const NoteSuggestionList = forwardRef<NoteSuggestionListHandle, NoteSuggestionListProps>(
+  ({ items, command }, ref) => {
+    const [selected, setSelected] = useState(0);
+    const [activeSource, setActiveSource] = useState<"keyboard" | "pointer" | null>(null);
+    const [fade, setFade] = useState({ top: false, bottom: false });
+    const menuRef = useRef<HTMLDivElement | null>(null);
+    const itemIds = items.map((item) => item.id).join("\u0000");
+    const lastItemIdsRef = useRef(itemIds);
+
+    const updateFade = useCallback(() => {
+      const el = menuRef.current;
+      if (!el) return;
+      const canScroll = el.scrollHeight - el.clientHeight > 1;
+      const atTop = el.scrollTop <= 1;
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+      setFade((prev) => {
+        const top = canScroll && !atTop;
+        const bottom = canScroll && !atBottom;
+        return prev.top === top && prev.bottom === bottom ? prev : { top, bottom };
+      });
+    }, []);
+
+    useLayoutEffect(() => {
+      // Reset the highlight whenever filtering changes the result set so Enter
+      // always targets a visible row.
+      if (lastItemIdsRef.current !== itemIds) {
+        lastItemIdsRef.current = itemIds;
+        setSelected(0);
+        setActiveSource(null);
+      }
+      updateFade();
+      const frame = window.requestAnimationFrame(updateFade);
+      return () => window.cancelAnimationFrame(frame);
+    }, [itemIds, updateFade]);
+
+    useEffect(() => {
+      const el = menuRef.current;
+      if (!el || typeof ResizeObserver === "undefined") return;
+      const observer = new ResizeObserver(updateFade);
+      observer.observe(el);
+      return () => observer.disconnect();
+    }, [updateFade]);
+
+    const choose = useCallback(
+      (index: number) => {
+        const item = items[index];
+        if (item) command(item);
+      },
+      [items, command],
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        onKeyDown: (event) => {
+          if (items.length === 0) return false;
+          if (event.key === "ArrowDown") {
+            setSelected((index) => {
+              setActiveSource("keyboard");
+              return (index + 1) % items.length;
+            });
+            return true;
+          }
+          if (event.key === "ArrowUp") {
+            setSelected((index) => {
+              setActiveSource("keyboard");
+              return (index - 1 + items.length) % items.length;
+            });
+            return true;
+          }
+          if (event.key === "Enter" || event.key === "Tab") {
+            choose(selected);
+            return true;
+          }
+          return false;
+        },
+      }),
+      [items, selected, choose],
+    );
+
+    if (items.length === 0) {
+      return <div className="agent-category-menu agent-category-menu-empty">No notes found</div>;
+    }
+
+    return (
+      <div className="agent-category-menu-shell agent-note-suggestion-menu-shell">
+        <div
+          className="agent-category-menu-scroll-wrap"
+          data-fade-top={fade.top || undefined}
+          data-fade-bottom={fade.bottom || undefined}
+        >
+          <div
+            ref={menuRef}
+            className="agent-category-menu agent-note-suggestion-menu"
+            role="listbox"
+            aria-label="Reference a note"
+            onScroll={() => {
+              updateFade();
+            }}
+          >
+            {items.map((item, index) => (
+              <button
+                key={item.id}
+                type="button"
+                role="option"
+                aria-selected={index === selected}
+                data-active={activeSource && index === selected ? true : undefined}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  choose(index);
+                }}
+                onMouseEnter={() => {
+                  setSelected(index);
+                  setActiveSource("pointer");
+                }}
+                onFocus={() => {
+                  setSelected(index);
+                  setActiveSource("keyboard");
+                }}
+              >
+                <span className="agent-category-menu-icon agent-note-suggestion-menu-icon">
+                  <IconNoteText size={16} aria-hidden />
+                </span>
+                <span className="agent-category-menu-copy">
+                  <span className="agent-category-menu-label agent-note-suggestion-menu-label">
+                    {displayTitle(item.title)}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+NoteSuggestionList.displayName = "NoteSuggestionList";
+
+function displayTitle(title: string) {
+  return title.trim() || "New note";
+}

--- a/src/components/agent/composer/NoteSuggestionList.tsx
+++ b/src/components/agent/composer/NoteSuggestionList.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { IconNoteText } from "central-icons/IconNoteText";
 
+import { displayNoteTitle } from "./noteReference";
 import type { NoteListItemDto } from "../../../lib/tauri";
 
 export type NoteSuggestionListProps = {
@@ -147,7 +148,7 @@ export const NoteSuggestionList = forwardRef<NoteSuggestionListHandle, NoteSugge
                 </span>
                 <span className="agent-category-menu-copy">
                   <span className="agent-category-menu-label agent-note-suggestion-menu-label">
-                    {displayTitle(item.title)}
+                    {displayNoteTitle(item.title)}
                   </span>
                 </span>
               </button>
@@ -159,7 +160,3 @@ export const NoteSuggestionList = forwardRef<NoteSuggestionListHandle, NoteSugge
   },
 );
 NoteSuggestionList.displayName = "NoteSuggestionList";
-
-function displayTitle(title: string) {
-  return title.trim() || "New note";
-}

--- a/src/components/agent/composer/noteReference.ts
+++ b/src/components/agent/composer/noteReference.ts
@@ -124,8 +124,14 @@ const NoteReferenceBase = Mention.extend({
   },
 });
 
+// The list_notes command defaults to the 100 most recent notes, which reads
+// as "that note doesn't exist" in the palette for heavy users. 500 keeps the
+// fetch cheap (one palette-open, lightweight rows) while covering realistic
+// libraries; server-side search is the follow-up if that ever falls short.
+const PALETTE_FETCH_LIMIT = 500;
+
 async function defaultFetchNotes() {
-  const response = await listNotes();
+  const response = await listNotes(undefined, PALETTE_FETCH_LIMIT);
   return response.items;
 }
 

--- a/src/components/agent/composer/noteReference.ts
+++ b/src/components/agent/composer/noteReference.ts
@@ -31,6 +31,11 @@ export type NoteReferenceOptions = {
   fetchNotes?: () => Promise<NoteListItemDto[]>;
 };
 
+/** Fallback matches the note title input's placeholder. */
+export function displayNoteTitle(title: string): string {
+  return title.trim() || "New note";
+}
+
 export function noteReferenceToken(ref: NoteReferenceInput): string {
   const title = ref.title.replace(/\s+/g, " ").replaceAll('"', "").trim().slice(0, 80);
   return title ? `@note:${ref.id} ("${title}")` : `@note:${ref.id}`;

--- a/src/components/agent/composer/noteReference.ts
+++ b/src/components/agent/composer/noteReference.ts
@@ -1,0 +1,294 @@
+import Mention from "@tiptap/extension-mention";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { PluginKey, TextSelection } from "@tiptap/pm/state";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+import { ReactNodeViewRenderer, ReactRenderer } from "@tiptap/react";
+
+import { NoteReferenceChipView } from "./NoteReferenceChipView";
+import {
+  NoteSuggestionList,
+  type NoteSuggestionListHandle,
+  type NoteSuggestionListProps,
+} from "./NoteSuggestionList";
+import { listNotes, type NoteListItemDto } from "../../../lib/tauri";
+
+/** Node name for the inline note reference chip. It stays distinct from the
+ * category chip because note references serialize into prompt text and may
+ * appear many times in one message. */
+export const NOTE_REFERENCE_NODE = "noteReference";
+
+const TRIGGER_CHAR = "@";
+const NOTE_SUGGESTION_LIMIT = 8;
+const NOTE_REFERENCE_SUGGESTION_PLUGIN_KEY = new PluginKey("agentNoteReferenceSuggestion");
+
+export type NoteReferenceInput = {
+  id: string;
+  title: string;
+};
+
+export type NoteReferenceOptions = {
+  fetchNotes?: () => Promise<NoteListItemDto[]>;
+};
+
+export function noteReferenceToken(ref: NoteReferenceInput): string {
+  const title = ref.title.replace(/\s+/g, " ").replaceAll('"', "").trim().slice(0, 80);
+  return title ? `@note:${ref.id} ("${title}")` : `@note:${ref.id}`;
+}
+
+export function filterNoteSuggestions(
+  notes: NoteListItemDto[],
+  query: string,
+  limit: number,
+): NoteListItemDto[] {
+  const cappedLimit = Math.max(0, limit);
+  if (cappedLimit === 0) return [];
+  const needle = query.trim().toLowerCase();
+  if (!needle) return notes.slice(0, cappedLimit);
+  return notes.filter((note) => note.title.toLowerCase().includes(needle)).slice(0, cappedLimit);
+}
+
+/** A tiptap command that inserts a note reference atom at `range` when the
+ * suggestion palette owns an "@query" span, or at the current selection when
+ * called imperatively. Unlike category tags, note chips are references inside
+ * the prompt, so multiple chips are allowed and no existing chip is cleared. */
+function insertNoteReferenceCommand(ref: NoteReferenceInput, range?: { from: number; to: number }) {
+  return ({
+    tr,
+    state,
+    dispatch,
+  }: {
+    tr: Transaction;
+    state: EditorState;
+    dispatch?: (tr: Transaction) => void;
+  }) => {
+    const chip = state.schema.nodes[NOTE_REFERENCE_NODE]?.create({
+      noteId: ref.id,
+      title: ref.title,
+    });
+    if (!chip) return false;
+    if (!dispatch) return true;
+
+    const from = tr.mapping.map(range ? range.from : state.selection.from);
+    const to = tr.mapping.map(range ? range.to : state.selection.to);
+    tr.replaceWith(from, to, chip);
+
+    // Land the caret on text after the chip, adding a space when the chip
+    // would otherwise butt against the next character (or the doc end).
+    const afterChip = from + chip.nodeSize;
+    const $after = tr.doc.resolve(afterChip);
+    const next = $after.nodeAfter;
+    if (!next?.isText || !next.text?.startsWith(" ")) {
+      tr.insert(afterChip, state.schema.text(" "));
+    }
+    tr.setSelection(TextSelection.create(tr.doc, afterChip + 1));
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+
+/** Inserts a note reference chip at the current selection. Used by follow-up
+ * composer affordances that already know which note the user picked. */
+export function insertNoteReference(editor: Editor, ref: NoteReferenceInput) {
+  editor.chain().focus().command(insertNoteReferenceCommand(ref)).run();
+}
+
+const NoteReferenceBase = Mention.extend({
+  name: NOTE_REFERENCE_NODE,
+
+  addAttributes() {
+    return {
+      noteId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-note-id"),
+        renderHTML: (attributes) =>
+          attributes.noteId ? { "data-note-id": attributes.noteId as string } : {},
+      },
+      title: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-title") ?? "",
+        renderHTML: (attributes) => ({ "data-title": (attributes.title as string) ?? "" }),
+      },
+    };
+  },
+
+  renderText({ node }: { node: ProseMirrorNode }) {
+    return noteReferenceToken({
+      id: typeof node.attrs.noteId === "string" ? node.attrs.noteId : "",
+      title: typeof node.attrs.title === "string" ? node.attrs.title : "",
+    });
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(NoteReferenceChipView);
+  },
+});
+
+async function defaultFetchNotes() {
+  const response = await listNotes();
+  return response.items;
+}
+
+export function createNoteReference(options: NoteReferenceOptions = {}) {
+  const fetchNotes = options.fetchNotes ?? defaultFetchNotes;
+  let paletteNotesPromise: Promise<NoteListItemDto[]> | null = null;
+
+  function notesForPaletteSession() {
+    paletteNotesPromise ??= fetchNotes();
+    return paletteNotesPromise;
+  }
+
+  function clearPaletteSession() {
+    paletteNotesPromise = null;
+  }
+
+  return NoteReferenceBase.configure({
+    deleteTriggerWithBackspace: true,
+    renderHTML({ node }) {
+      return [
+        "span",
+        {
+          class: "agent-note-reference-chip",
+          "data-note-id": (node.attrs.noteId as string) ?? "",
+          "data-title": (node.attrs.title as string) ?? "",
+        },
+        (node.attrs.title as string) ?? "",
+      ];
+    },
+    suggestion: {
+      char: TRIGGER_CHAR,
+      pluginKey: NOTE_REFERENCE_SUGGESTION_PLUGIN_KEY,
+      // Keep the v1 matcher narrow: email-like mid-word "@" text should not
+      // leave a sticky note palette behind.
+      allowSpaces: false,
+      items: async ({ query }) =>
+        filterNoteSuggestions(await notesForPaletteSession(), query, NOTE_SUGGESTION_LIMIT),
+      command: ({ editor, range, props }) => {
+        const item = props as NoteListItemDto;
+        editor
+          .chain()
+          .focus()
+          .command(insertNoteReferenceCommand({ id: item.id, title: item.title }, range))
+          .run();
+      },
+      render: () => {
+        let renderer: ReactRenderer<NoteSuggestionListHandle, NoteSuggestionListProps> | null =
+          null;
+        let host: HTMLDivElement | null = null;
+        let latestProps: {
+          command: NoteSuggestionListProps["command"];
+          editor: Editor;
+          clientRect?: (() => DOMRect | null) | null;
+        } | null = null;
+        let ownerDocument: Document | null = null;
+
+        function position(props: { clientRect?: (() => DOMRect | null) | null; editor: Editor }) {
+          if (!host || !props.clientRect) return;
+          const rect = props.clientRect();
+          if (!rect) return;
+          const gap = 6;
+          const pad = 8;
+          const composerBox = props.editor.view.dom.closest<HTMLElement>(".agent-composer-box");
+          const composerRect = composerBox?.getBoundingClientRect();
+          const width = Math.min(
+            composerRect?.width ?? host.getBoundingClientRect().width,
+            window.innerWidth - pad * 2,
+          );
+          host.style.setProperty("--agent-category-menu-width", `${width}px`);
+          const maxLeft = window.innerWidth - width - pad;
+          const left = Math.min(
+            Math.max(composerRect?.left ?? rect.left, pad),
+            Math.max(pad, maxLeft),
+          );
+          const anchorRect = composerRect ?? rect;
+          const belowTop = anchorRect.bottom + gap;
+          const belowSpace = window.innerHeight - belowTop - pad;
+          const aboveSpace = anchorRect.top - gap - pad;
+          const hostRect = host.getBoundingClientRect();
+          const fitsBelow = belowSpace >= hostRect.height;
+          const placeBelow = fitsBelow || belowSpace >= aboveSpace;
+          const maxHeight = Math.max(88, Math.min(placeBelow ? belowSpace : aboveSpace, 280));
+          const top = placeBelow
+            ? belowTop
+            : Math.max(anchorRect.top - Math.min(hostRect.height, maxHeight) - gap, pad);
+
+          host.style.setProperty("--agent-category-menu-max-height", `${maxHeight}px`);
+          host.style.bottom = "";
+          host.style.top = `${Math.max(top, pad)}px`;
+          host.style.left = `${left}px`;
+        }
+
+        function updateLatestProps(props: {
+          command: unknown;
+          editor: Editor;
+          clientRect?: (() => DOMRect | null) | null;
+        }) {
+          latestProps = {
+            ...props,
+            command: props.command as NoteSuggestionListProps["command"],
+          };
+        }
+
+        function dismissFromPointerDown(event: PointerEvent) {
+          const target = event.target;
+          if (!(target instanceof Node) || host?.contains(target)) return;
+          const view = latestProps?.editor.view;
+          if (!view) return;
+          view.dispatch(
+            view.state.tr.setMeta(NOTE_REFERENCE_SUGGESTION_PLUGIN_KEY, {
+              exit: true,
+            }),
+          );
+        }
+
+        function cleanupPopover() {
+          renderer?.destroy();
+          ownerDocument?.removeEventListener("pointerdown", dismissFromPointerDown, true);
+          host?.remove();
+          renderer = null;
+          host = null;
+          latestProps = null;
+          ownerDocument = null;
+          clearPaletteSession();
+        }
+
+        return {
+          onStart(props) {
+            updateLatestProps(props);
+            renderer = new ReactRenderer(NoteSuggestionList, {
+              props: { items: props.items, command: props.command },
+              editor: props.editor,
+            });
+            host = document.createElement("div");
+            // Reuse the category-menu host contract so Enter-to-submit lets an
+            // open note palette consume Enter, just like the "/" palette.
+            host.className = "agent-category-menu-host agent-note-reference-menu-host";
+            host.appendChild(renderer.element);
+            document.body.appendChild(host);
+            ownerDocument = props.editor.view.dom.ownerDocument;
+            ownerDocument.addEventListener("pointerdown", dismissFromPointerDown, true);
+            position(props);
+          },
+          onUpdate(props) {
+            updateLatestProps(props);
+            renderer?.updateProps({
+              items: props.items,
+              command: props.command,
+            });
+            position(props);
+          },
+          onKeyDown(props) {
+            if (props.event.key === "Escape") {
+              cleanupPopover();
+              return true;
+            }
+            return renderer?.ref?.onKeyDown(props.event) ?? false;
+          },
+          onExit() {
+            cleanupPopover();
+          },
+        };
+      },
+    },
+  });
+}

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -1,3 +1,4 @@
+import { IconBubble3 } from "central-icons/IconBubble3";
 import { IconClipboard } from "central-icons/IconClipboard";
 import { IconChevronRightSmall } from "central-icons/IconChevronRightSmall";
 import { IconProjects } from "central-icons/IconProjects";
@@ -27,6 +28,7 @@ import { InlineNotice } from "../ui/InlineNotice";
 import { SegmentedControl } from "../ui/SegmentedControl";
 import { RecorderBar } from "../recorder/RecorderBar";
 import { NoteRecoveryPrompt } from "../recorder/NoteRecoveryPrompt";
+import { noteReferenceToken } from "../agent/composer/noteReference";
 import { isMacLikePlatform } from "../../lib/platform";
 import {
   isInvalidJuneResponseMessage,
@@ -54,6 +56,7 @@ type NoteEditorProps = {
   onPauseRecording: (sessionId: string) => void;
   onResumeRecording: (sessionId: string) => void;
   onFinishRecording: (sessionId: string) => void;
+  onAskJune?: () => void;
   onRetry: () => void | Promise<void>;
   onTopUp: () => void;
   topUpLabel?: string;
@@ -133,6 +136,7 @@ export function NoteEditor({
   onPauseRecording,
   onResumeRecording,
   onFinishRecording,
+  onAskJune,
   onRetry,
   onTopUp,
   topUpLabel,
@@ -295,16 +299,25 @@ export function NoteEditor({
     <article className="note-editor">
       <header className="editor-header">
         <div className="note-overline">
-          <span className="note-overline-date">{updatedAtLabel}</span>
-          <span className="note-overline-dot" aria-hidden="true" />
-          <FolderChip
-            folders={folders}
-            folderIds={note.folderIds}
-            onAssign={onAssignFolder}
-            onRemove={onRemoveFolder}
-            onCreateAndAssign={onCreateAndAssignFolder}
-            onNavigateToFolder={onNavigateToFolder}
-          />
+          <div className="note-overline-meta">
+            <span className="note-overline-date">{updatedAtLabel}</span>
+            <span className="note-overline-dot" aria-hidden="true" />
+            <FolderChip
+              folders={folders}
+              folderIds={note.folderIds}
+              onAssign={onAssignFolder}
+              onRemove={onRemoveFolder}
+              onCreateAndAssign={onCreateAndAssignFolder}
+              onNavigateToFolder={onNavigateToFolder}
+            />
+          </div>
+          <div className="note-header-actions">
+            <button type="button" className="note-header-ask" onClick={() => onAskJune?.()}>
+              <IconBubble3 size={14} aria-hidden />
+              Ask June
+            </button>
+            <CopyNoteReferenceButton noteId={note.id} title={note.title} />
+          </div>
         </div>
         <input
           className="note-title"
@@ -1016,6 +1029,39 @@ function sourceTurnFailureMessage(message?: string) {
     return "Audio for this part could not be transcribed.";
   }
   return userFacingFailureMessage(message) ?? "";
+}
+
+function CopyNoteReferenceButton({ noteId, title }: { noteId: string; title: string }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1600);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(noteReferenceToken({ id: noteId, title }));
+      setCopied(true);
+    } catch {
+      // Clipboard API can fail in restricted contexts; stay silent
+      // rather than nag, since the user can retry.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className="note-reference-copy"
+      onClick={() => void handleCopy()}
+      data-copied={copied || undefined}
+      aria-label="Copy note reference"
+      title={copied ? "Copied" : "Copy note reference"}
+    >
+      {copied ? <IconCheckmark1 size={14} /> : <IconClipboard size={14} />}
+    </button>
+  );
 }
 
 function CopyTranscriptButton({ text }: { text: string }) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1359,8 +1359,8 @@ export async function openHermesTuiDebug(input: { sessionId: string; unrestricte
   return invoke<void>("open_hermes_tui_debug", { request: input });
 }
 
-export async function listNotes(folderId?: string) {
-  return invoke<ListNotesResponse>("list_notes", { request: { folderId } });
+export async function listNotes(folderId?: string, limit?: number) {
+  return invoke<ListNotesResponse>("list_notes", { request: { folderId, limit } });
 }
 
 export async function getNote(noteId: string) {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -7749,17 +7749,38 @@ input:focus-visible,
   gap: var(--sp-3);
 }
 
-/* Overline — quiet metadata row sitting above the title. Date is plain
- * text; the folder chip is the one actionable affordance. Status (when
- * present) floats to the right end so it never crowds the chip. */
+/* Overline - quiet metadata row sitting above the title. Date and project
+ * stay left; note actions wrap on the right before they crowd the header. */
 .note-overline {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  width: 100%;
   font-size: var(--fs-sm);
   color: var(--muted-foreground);
 }
 
+.note-overline-meta,
+.note-header-actions {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.note-overline-meta {
+  flex: 1 1 auto;
+}
+
+.note-header-actions {
+  flex: 0 0 auto;
+  gap: var(--sp-1);
+  margin-left: auto;
+}
+
 .note-overline-date {
+  flex: 0 0 auto;
   white-space: nowrap;
 }
 
@@ -7801,6 +7822,41 @@ input:focus-visible,
 .folder-chip:hover,
 .folder-chip[aria-expanded="true"] {
   background: var(--muted);
+  color: var(--foreground);
+}
+
+.note-header-ask,
+.note-reference-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--control-sm);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition:
+    background-color var(--t-fast) var(--ease-out),
+    color var(--t-fast) var(--ease-out);
+}
+
+.note-header-ask {
+  gap: var(--sp-1);
+  padding: 0 var(--sp-2);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+}
+
+.note-reference-copy {
+  width: var(--control-sm);
+  padding: 0;
+}
+
+.note-header-ask:hover,
+.note-reference-copy:hover,
+.note-reference-copy[data-copied="true"] {
+  background: color-mix(in oklch, var(--muted) 55%, transparent);
   color: var(--foreground);
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5259,6 +5259,45 @@ input:focus-visible,
   outline-offset: 1px;
 }
 
+/* Inline note references are prompt content, not message metadata. They keep
+ * the category chip's atom affordance but use neutral note styling and allow
+ * several references in one composer message. */
+.agent-note-reference-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: min(calc(var(--sp-12) * 6), 100%);
+  gap: var(--sp-px);
+  vertical-align: baseline;
+  padding: var(--sp-px) var(--sp-2);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklch, var(--muted) 58%, transparent);
+  color: var(--foreground);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.agent-note-reference-chip-icon {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+.agent-note-reference-chip-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-note-reference-chip.ProseMirror-selectednode {
+  outline: 2px solid color-mix(in oklch, var(--foreground) 24%, transparent);
+  outline-offset: var(--sp-px);
+}
+
 /* "/" suggestion palette + "+" popover share the floating-menu look. */
 .agent-category-menu-host {
   position: fixed;
@@ -5472,6 +5511,14 @@ input:focus-visible,
 .agent-category-menu-icon[data-category="feature"],
 .agent-attach-menu-icon[data-category="feature"] {
   color: var(--success);
+}
+
+.agent-note-suggestion-menu-label {
+  min-width: 0;
+}
+
+.agent-note-suggestion-menu-icon {
+  color: var(--muted-foreground);
 }
 
 /* Opens upward, just above the toolbar where the "+" trigger sits (the box

--- a/src/test/agent-note-entry-points.test.ts
+++ b/src/test/agent-note-entry-points.test.ts
@@ -1,0 +1,216 @@
+import type { Editor } from "@tiptap/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AGENT_NEW_SESSION_PENDING_KEY,
+  markAgentNewSessionPending,
+  pendingNewSessionRequest,
+} from "../components/agent/AgentWorkspace";
+import { ComposerEditor } from "../components/agent/composer/ComposerEditor";
+import { noteReferenceToken } from "../components/agent/composer/noteReference";
+import { NoteEditor } from "../components/note-editor/NoteEditor";
+import type { NoteDto } from "../lib/tauri";
+
+const mocks = vi.hoisted(() => ({
+  listNotes: vi.fn(),
+}));
+
+vi.mock("../lib/tauri", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/tauri")>();
+
+  return {
+    ...actual,
+    listNotes: mocks.listNotes,
+  };
+});
+
+const now = "2026-07-03T10:00:00Z";
+
+function note(overrides: Partial<NoteDto> = {}): NoteDto {
+  return {
+    id: "note-1",
+    title: "Launch plan",
+    preview: "Preview",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: now,
+    updatedAt: now,
+    generatedContent: "Notes",
+    activeTab: "notes",
+    ...overrides,
+  };
+}
+
+function noteEditorProps(overrides: Partial<Parameters<typeof NoteEditor>[0]> = {}) {
+  return {
+    note: note(),
+    folders: [],
+    sourceMode: "microphonePlusSystem" as const,
+    onTitleChange: vi.fn(),
+    onContentChange: vi.fn(),
+    onSourceModeChange: vi.fn(),
+    onEnableSystemAudio: vi.fn(),
+    onEnableMicrophone: vi.fn(),
+    microphoneBlocked: false,
+    onStartRecording: vi.fn(),
+    onPauseRecording: vi.fn(),
+    onResumeRecording: vi.fn(),
+    onFinishRecording: vi.fn(),
+    onAskJune: vi.fn(),
+    onRetry: vi.fn(),
+    onTopUp: vi.fn(),
+    onRecoverRecording: vi.fn(),
+    onDiscardRecording: vi.fn(),
+    onAssignFolder: vi.fn(),
+    onRemoveFolder: vi.fn(),
+    onCreateAndAssignFolder: vi.fn(),
+    onNavigateToFolder: vi.fn(),
+    onTabChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+function installClipboard(writeText = vi.fn().mockResolvedValue(undefined)) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  return writeText;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.sessionStorage.clear();
+  mocks.listNotes.mockResolvedValue({
+    items: [
+      {
+        id: "note-1",
+        title: "Launch plan",
+        preview: "",
+        processingStatus: "ready",
+        folderIds: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  window.sessionStorage.clear();
+});
+
+describe("agent note entry point pending request", () => {
+  it("round-trips a note reference through the new-session pending marker", () => {
+    markAgentNewSessionPending(undefined, {
+      noteRef: { id: "note-1", title: "Launch plan" },
+    });
+
+    expect(pendingNewSessionRequest()).toEqual({
+      noteRef: { id: "note-1", title: "Launch plan" },
+    });
+    expect(window.sessionStorage.getItem(AGENT_NEW_SESSION_PENDING_KEY)).toBeNull();
+  });
+
+  it("defaults a missing note title while parsing the pending marker", () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        noteRef: { id: "note-1" },
+      }),
+    );
+
+    expect(pendingNewSessionRequest()).toEqual({
+      noteRef: { id: "note-1", title: "" },
+    });
+  });
+
+  it("drops an expired note reference marker", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(now));
+
+    markAgentNewSessionPending(undefined, {
+      noteRef: { id: "note-1", title: "Launch plan" },
+    });
+    vi.advanceTimersByTime(15_001);
+
+    expect(pendingNewSessionRequest()).toBeUndefined();
+  });
+
+  it("drops malformed note references without dropping the pending request", () => {
+    window.sessionStorage.setItem(
+      AGENT_NEW_SESSION_PENDING_KEY,
+      JSON.stringify({
+        createdAt: Date.now(),
+        noteRef: { id: 123, title: "Bad reference" },
+      }),
+    );
+
+    expect(pendingNewSessionRequest()).toEqual({});
+  });
+
+  it("lets category seeding take precedence over note reference seeding", () => {
+    markAgentNewSessionPending(undefined, {
+      category: "bug",
+      noteRef: { id: "note-1", title: "Launch plan" },
+    });
+
+    expect(pendingNewSessionRequest()).toEqual({ category: "bug" });
+  });
+});
+
+describe("note editor note entry points", () => {
+  it("calls the Ask June handler from the note header", async () => {
+    const user = userEvent.setup();
+    const onAskJune = vi.fn();
+    render(createElement(NoteEditor, noteEditorProps({ onAskJune })));
+
+    await user.click(screen.getByRole("button", { name: "Ask June" }));
+
+    expect(onAskJune).toHaveBeenCalledTimes(1);
+  });
+
+  it("copies the exact note reference token", async () => {
+    const user = userEvent.setup();
+    const writeText = installClipboard();
+    render(createElement(NoteEditor, noteEditorProps()));
+
+    const copyButton = screen.getByRole("button", { name: "Copy note reference" });
+    await user.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith(
+      noteReferenceToken({ id: "note-1", title: "Launch plan" }),
+    );
+    await waitFor(() => expect(copyButton).toHaveAttribute("data-copied", "true"));
+  });
+});
+
+describe("composer note reference trigger", () => {
+  it("opens the note palette when a literal at sign is inserted at the caret", async () => {
+    let editor: Editor | null = null;
+
+    render(
+      createElement(ComposerEditor, {
+        placeholder: "Message June",
+        onChange: vi.fn(),
+        onSubmit: vi.fn(),
+        onReady: (readyEditor: Editor) => {
+          editor = readyEditor;
+        },
+      }),
+    );
+
+    await waitFor(() => expect(editor).not.toBeNull());
+    act(() => {
+      editor?.chain().focus().insertContent("@").run();
+    });
+
+    expect(await screen.findByRole("listbox", { name: "Reference a note" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "Launch plan" })).toBeInTheDocument();
+  });
+});

--- a/src/test/agent-note-entry-points.test.ts
+++ b/src/test/agent-note-entry-points.test.ts
@@ -213,4 +213,34 @@ describe("composer note reference trigger", () => {
     expect(await screen.findByRole("listbox", { name: "Reference a note" })).toBeInTheDocument();
     expect(await screen.findByRole("option", { name: "Launch plan" })).toBeInTheDocument();
   });
+
+  it("pads the trigger with a space when the caret follows text", async () => {
+    // The suggestion plugin only matches "@" after whitespace or a line
+    // start, so the attach-menu entry point pads it; a bare "@" after text
+    // must NOT open the palette (this is the regression the padding fixes).
+    let editor: Editor | null = null;
+
+    render(
+      createElement(ComposerEditor, {
+        placeholder: "Message June",
+        onChange: vi.fn(),
+        onSubmit: vi.fn(),
+        onReady: (readyEditor: Editor) => {
+          editor = readyEditor;
+        },
+      }),
+    );
+
+    await waitFor(() => expect(editor).not.toBeNull());
+    act(() => {
+      editor?.chain().focus().insertContent("What were the action items?@").run();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(screen.queryByRole("listbox", { name: "Reference a note" })).not.toBeInTheDocument();
+
+    act(() => {
+      editor?.chain().focus().insertContent(" @").run();
+    });
+    expect(await screen.findByRole("listbox", { name: "Reference a note" })).toBeInTheDocument();
+  });
 });

--- a/src/test/composer-note-reference.test.ts
+++ b/src/test/composer-note-reference.test.ts
@@ -196,6 +196,12 @@ describe("draft rehydration", () => {
     expect(doc.content).toHaveLength(2);
     expect(doc.content[0].content).toEqual([{ type: "text", text: "just a line" }]);
   });
+
+  it("skips rehydration when asked, keeping placeholder position math valid", () => {
+    const line = '@note:note-1 ("Launch plan") ask about it';
+    const doc = buildDoc(line, null, { rehydrateNoteTokens: false });
+    expect(doc.content[0].content).toEqual([{ type: "text", text: line }]);
+  });
 });
 
 describe("note suggestion filtering", () => {

--- a/src/test/composer-note-reference.test.ts
+++ b/src/test/composer-note-reference.test.ts
@@ -1,0 +1,194 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Editor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CATEGORY_CHIP_NODE, CategoryChip } from "../components/agent/composer/categoryChip";
+import { serializePlainText } from "../components/agent/composer/ComposerEditor";
+import {
+  NOTE_REFERENCE_NODE,
+  createNoteReference,
+  filterNoteSuggestions,
+  insertNoteReference,
+  noteReferenceToken,
+} from "../components/agent/composer/noteReference";
+import type { NoteListItemDto } from "../lib/tauri";
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function makeEditor() {
+  return new Editor({
+    element: document.createElement("div"),
+    extensions: [StarterKit, CategoryChip, createNoteReference({ fetchNotes: async () => [] })],
+    content: "",
+  });
+}
+
+function note(id: string, title: string): NoteListItemDto {
+  return {
+    id,
+    title,
+    preview: "",
+    processingStatus: "ready",
+    folderIds: [],
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+  };
+}
+
+function nodeCount(doc: ProseMirrorNode, name: string) {
+  let count = 0;
+  doc.descendants((node) => {
+    if (node.type.name === name) count += 1;
+  });
+  return count;
+}
+
+describe("note reference token", () => {
+  it("serializes a normal title", () => {
+    expect(noteReferenceToken({ id: "note-1", title: "Launch plan" })).toBe(
+      '@note:note-1 ("Launch plan")',
+    );
+  });
+
+  it("omits the title when sanitizing leaves it empty", () => {
+    expect(noteReferenceToken({ id: "note-2", title: ' \n "" \t ' })).toBe("@note:note-2");
+  });
+
+  it("collapses whitespace, strips quotes, trims, and caps the title", () => {
+    const longTitle = `${"A".repeat(40)}\n"${"B".repeat(60)}"`;
+
+    expect(noteReferenceToken({ id: "note-3", title: longTitle })).toBe(
+      `@note:note-3 ("${`${"A".repeat(40)} ${"B".repeat(60)}`.slice(0, 80)}")`,
+    );
+  });
+});
+
+describe("note reference serialization", () => {
+  it("serializes text with one note chip", () => {
+    editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Review " },
+            { type: NOTE_REFERENCE_NODE, attrs: { noteId: "note-1", title: "Launch plan" } },
+            { type: "text", text: " before standup" },
+          ],
+        },
+      ],
+    });
+
+    expect(serializePlainText(editor.state.doc)).toBe(
+      'Review @note:note-1 ("Launch plan") before standup',
+    );
+  });
+
+  it("serializes multiple note chips", () => {
+    editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: NOTE_REFERENCE_NODE, attrs: { noteId: "note-1", title: "Launch plan" } },
+            { type: "text", text: " and " },
+            { type: NOTE_REFERENCE_NODE, attrs: { noteId: "note-2", title: "Retro" } },
+          ],
+        },
+      ],
+    });
+
+    expect(serializePlainText(editor.state.doc)).toBe(
+      '@note:note-1 ("Launch plan") and @note:note-2 ("Retro")',
+    );
+  });
+
+  it("serializes a chip-only document", () => {
+    editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: NOTE_REFERENCE_NODE, attrs: { noteId: "note-1", title: "Launch plan" } },
+          ],
+        },
+      ],
+    });
+
+    expect(serializePlainText(editor.state.doc)).toBe('@note:note-1 ("Launch plan")');
+  });
+
+  it("keeps category chips out of the serialized text", () => {
+    editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: CATEGORY_CHIP_NODE, attrs: { category: "bug" } }],
+        },
+      ],
+    });
+
+    expect(serializePlainText(editor.state.doc)).toBe("");
+  });
+});
+
+describe("note reference insertion", () => {
+  it("inserts an atom with a trailing space", () => {
+    editor = makeEditor();
+    insertNoteReference(editor, { id: "note-1", title: "Launch plan" });
+
+    expect(nodeCount(editor.state.doc, NOTE_REFERENCE_NODE)).toBe(1);
+    expect(serializePlainText(editor.state.doc)).toBe('@note:note-1 ("Launch plan") ');
+  });
+
+  it("allows two note references to coexist", () => {
+    editor = makeEditor();
+    insertNoteReference(editor, { id: "note-1", title: "Launch plan" });
+    insertNoteReference(editor, { id: "note-2", title: "Retro" });
+
+    expect(nodeCount(editor.state.doc, NOTE_REFERENCE_NODE)).toBe(2);
+    expect(serializePlainText(editor.state.doc)).toBe(
+      '@note:note-1 ("Launch plan") @note:note-2 ("Retro") ',
+    );
+  });
+});
+
+describe("note suggestion filtering", () => {
+  const notes = [
+    note("note-1", "Launch plan"),
+    note("note-2", "Customer retro"),
+    note("note-3", "Engineering roadmap"),
+    note("note-4", "Launch follow-up"),
+  ];
+
+  it("matches title substrings case-insensitively", () => {
+    expect(filterNoteSuggestions(notes, "LAUNCH", 8).map((item) => item.id)).toEqual([
+      "note-1",
+      "note-4",
+    ]);
+  });
+
+  it("respects the result limit", () => {
+    expect(filterNoteSuggestions(notes, "launch", 1).map((item) => item.id)).toEqual(["note-1"]);
+  });
+
+  it("returns the head of the list for an empty query", () => {
+    expect(filterNoteSuggestions(notes, "", 2).map((item) => item.id)).toEqual([
+      "note-1",
+      "note-2",
+    ]);
+  });
+});

--- a/src/test/composer-note-reference.test.ts
+++ b/src/test/composer-note-reference.test.ts
@@ -4,7 +4,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { CATEGORY_CHIP_NODE, CategoryChip } from "../components/agent/composer/categoryChip";
-import { serializePlainText } from "../components/agent/composer/ComposerEditor";
+import { buildDoc, serializePlainText } from "../components/agent/composer/ComposerEditor";
 import {
   NOTE_REFERENCE_NODE,
   createNoteReference,
@@ -163,6 +163,38 @@ describe("note reference insertion", () => {
     expect(serializePlainText(editor.state.doc)).toBe(
       '@note:note-1 ("Launch plan") @note:note-2 ("Retro") ',
     );
+  });
+});
+
+describe("draft rehydration", () => {
+  it("rebuilds a note chip from a persisted token", () => {
+    editor = makeEditor();
+    editor.commands.setContent(
+      buildDoc('@note:note-1 ("Launch plan") what were the action items?'),
+    );
+
+    expect(nodeCount(editor.state.doc, NOTE_REFERENCE_NODE)).toBe(1);
+    editor.state.doc.descendants((node) => {
+      if (node.type.name !== NOTE_REFERENCE_NODE) return true;
+      expect(node.attrs.noteId).toBe("note-1");
+      expect(node.attrs.title).toBe("Launch plan");
+      return false;
+    });
+  });
+
+  it("round-trips a restored draft losslessly", () => {
+    const draft = 'before @note:note-1 ("Launch plan") between @note:note-2 after';
+    editor = makeEditor();
+    editor.commands.setContent(buildDoc(draft));
+
+    expect(nodeCount(editor.state.doc, NOTE_REFERENCE_NODE)).toBe(2);
+    expect(serializePlainText(editor.state.doc)).toBe(draft);
+  });
+
+  it("leaves plain text without tokens untouched", () => {
+    const doc = buildDoc("just a line\nand another");
+    expect(doc.content).toHaveLength(2);
+    expect(doc.content[0].content).toEqual([{ type: "text", text: "just a line" }]);
   });
 });
 


### PR DESCRIPTION
Closes JUN-186.

## Summary

Lets a chat target one specific note instead of relying on search. One wire format, three affordances:

- **Note reference token** — `@note:<id> ("<title>")`, a plain-text token in the prompt. A new read-only `june_context` MCP tool `get_meeting_note(note_id, include_transcript)` resolves it to full note content on demand (60k-char cap with truncation flags; `found: false` for unknown ids), and SOUL guidance teaches the model the token form and the tool. No June API involvement; the MCP server ships with the desktop bundle and the change is additive.
- **`@`-mention in the composer** — typing `@` opens a note picker (clone of the `/` category-chip machinery on `@tiptap/extension-mention`); picking a note inserts an atom chip that serializes to the token at send. Multiple chips per message allowed; the category chip's single-chip and empty-serialization behavior is untouched. Also reachable from the composer "+" menu ("Reference a note"). Restored drafts rehydrate tokens back into chips (lossless round-trip).
- **Note view header affordances** — "Ask June" opens a fresh agent session with the note's chip pre-inserted (focused, **never auto-submitted** — no surprise credit spend), via a `noteRef` extension of the existing new-session handshake; "Copy note reference" copies the same token, which answers the issue's literal "copy a link and paste it into June" ask.

Transcript assembly in the MCP now mirrors the app's visible-transcript semantics exactly (canonical turn ordering; turns-else-latest selection; search matches only app-visible text) — see Validation for how those defects were found pre-publish.

Decision record: [ADR 0010](docs/adr/0010-note-references-in-agent-chat.md) (token + fetch-by-id vs inlining/attachment/deep-link; the token-is-a-reference-everywhere invariant); CONTEXT.md gains the **Note reference** term.

## Validation

- `pnpm check`, `pnpm typecheck` — clean (pre-existing Biome warning backlog only).
- `pnpm test` — 131 files, 2076 passed / 0 failed, including new suites `composer-note-reference.test.ts` (token sanitization, serialization incl. category-chip regression, multi-chip insertion, palette filtering, draft rehydration incl. the placeholder guard) and `agent-note-entry-points.test.ts` (pending-marker round-trip/TTL/precedence, header actions, clipboard token, palette trigger incl. the padding regression).
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --lib` — 380 passed / 0 failed on the rebased tree (SOUL guidance assertions extended); `python3 -m py_compile` on the MCP script.
- **MCP stdio fixture harness** (local, drives the real server over JSON-RPC against a synthetic DB): canonical turn ordering across scrambled dual-source/two-session insertion, whole-file-fallback and all-failed-turn selection, search matching only app-visible text, 60k truncation flags, `include_transcript` gating, not-found shape. Committed Python test infra is a follow-up (repo has no Python test runner).
- **Browser QA walkthrough** (Playwright against the Vite frontend with a faked Tauri IPC bridge; scripted assertions, not just eyeballs): notes list → note view → copy reference (clipboard verified byte-exact against the token) → Ask June (chip seeded, no auto-submit) → typed question → "+" menu → "Reference a note" (palette opens) → filter → second chip. Video (os-platform, private visibility): https://app.opensoftware.co/api/v1/files/fil_81Ef9S3zuV5s/download
- **Pre-publish review battery** (Standards / Spec / adversarial axes; adversarial converged over 5 rounds across both Claude and Codex reviewers — the finding sets were disjoint, as the battery's calibration predicts). Defects found and fixed before publish, each with a regression test:
  - the "+"-menu `@` trigger never opened the palette after typed text (suggestion plugin needs a whitespace prefix) — found by the browser walkthrough;
  - `group_concat` transcript assembly returned turns in scan order (jumbled meetings) — Claude adversarial R1;
  - transcript selection could interleave/resurface superseded whole-file rows the app never shows — Claude adversarial R2/R3;
  - search matched raw transcript rows the snippet/fetch path suppresses (unsubstantiatable hits) — Codex adversarial R4;
  - seeded note chips degraded to raw token text on draft restore — Claude adversarial R3 (fixed via `buildDoc` rehydration).

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

## Out of scope

- Inline chat panel inside the note view (the issue's second proposal) — deliberately deferred; it would reuse the same token + tool.
- `osjune://note/<id>` OS-level deep link — only pays off for outside-the-app linking; the scheme currently serves only the OS Accounts auth callback.

## Followups

- Committed test coverage for `june_context_mcp.py` (the repo has no Python test runner today; the stdio fixture harness used here lives outside the repo and could seed it).
- Consider an inline-notes chat surface (JUN-186's larger half) building on this reference contract.
- Server-side title search for the `@` palette if the 500-most-recent fetch ever falls short; `allowSpaces` for multi-word palette queries.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. (New MCP tool is read-only over the existing notes DB; no new write or network surface.)
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None.)
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (None.)
- [x] User-facing copy follows the repo UI conventions.

## Implementation notes for reviewers

- Implementation chunks and the search-predicate fix were delegated to Codex against per-chunk contracts; every diff was independently verified and gated in-session.
- Token contract lives in `noteReferenceToken` (`src/components/agent/composer/noteReference.ts`); `serializePlainText` emits it in the leaf callback (TipTap `renderText` is bypassed there — see the comment); `buildDoc` is the inverse (rehydration), guarded off for placeholder-staged prefills.
- The transcript subqueries in `june_context_mcp.py` deliberately mirror `source_transcripts` / `latest_transcript` in `db/repositories.rs` and the branch predicate of `transcriptToText` in `NoteEditor.tsx` — keep the three in sync.

https://claude.ai/code/session_01PAXWFzPrZwWkCet8RTihgK

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785684281&installation_id=144203540&pr_number=615&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F615&signature=ad6d613f5b955eab7e91a1cdc810ccbed2675839178b2dca3233d3e2dd38fa8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->