### PR TITLE
fix: image metering budget fits the OS Accounts hold cap end to end

### DIFF
--- a/june-api/crates/app/src/main.rs
+++ b/june-api/crates/app/src/main.rs
@@ -172,8 +172,20 @@ fn build_router(
     }));
     let image = Arc::new(ImageService::new(ImageServiceDeps {
         os_accounts: os_accounts.clone(),
-        generator: build_image_generator(clients.image, &config.upstreams.venice),
-        editor: build_image_editor(clients.image, &config.upstreams.venice),
+        generator: build_image_generator(
+            clients.image,
+            &config.upstreams.venice,
+            Duration::from_secs(image_client_timeout_secs(
+                config.server.request_timeout_secs,
+            )),
+        ),
+        editor: build_image_editor(
+            clients.image,
+            &config.upstreams.venice,
+            Duration::from_secs(image_client_timeout_secs(
+                config.server.request_timeout_secs,
+            )),
+        ),
         pricing: config
             .image_pricing
             .iter()
@@ -238,20 +250,24 @@ struct HttpClients<'a> {
 fn build_image_generator(
     upstream_http: &reqwest::Client,
     venice: &june_config::UpstreamConfig,
+    leg_budget: Duration,
 ) -> Arc<dyn june_domain::ImageGenerator> {
     Arc::new(VeniceImageGenerator::from_config(
         upstream_http.clone(),
         venice,
+        leg_budget,
     ))
 }
 
 fn build_image_editor(
     upstream_http: &reqwest::Client,
     venice: &june_config::UpstreamConfig,
+    leg_budget: Duration,
 ) -> Arc<dyn june_domain::ImageEditor> {
     Arc::new(VeniceImageEditor::from_config(
         upstream_http.clone(),
         venice,
+        leg_budget,
     ))
 }
 

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -16,20 +16,40 @@ pub const OPENAI_API_KEY_PLACEHOLDER: &str = "sk_REPLACE_ME";
 pub const VENICE_API_KEY_PLACEHOLDER: &str = "VENICE_API_KEY_REPLACE_ME";
 pub const IMAGE_EDIT_SOURCE_MAX_BYTES: usize = 50 * 1024 * 1024;
 pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 600;
-pub const IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS: u64 = 30;
-pub const DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS: u64 =
-    DEFAULT_REQUEST_TIMEOUT_SECS - IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS;
-pub const IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS: u64 = 30;
 /// OS Accounts rejects `/authorize` holds outside 1..=600 seconds as
 /// `invalid_ttl` (envelope code 4201). Keep in sync with
 /// `MAX_HOLD_TTL_SECONDS` in os-accounts `api/crates/services/src/grants.rs`.
 pub const OS_ACCOUNTS_MAX_HOLD_TTL_SECS: u64 = 600;
-/// The hold must outlive the image *client* timeout plus the settlement
-/// margin — not the whole route timeout: route timeout + margin (630) is past
-/// the OS Accounts cap and every image authorize was rejected `invalid_ttl`
-/// in production. 570 + 30 lands exactly on the 600-second cap.
+/// Budget reserved between the image client call ending and the hold
+/// expiring, sized to the WORST-CASE charge path, not a nominal grace:
+/// settling can spend `CHARGE_RETRY_ATTEMPTS` HTTP calls at the 60-second
+/// client timeout plus backoff (~121s) before giving up. Keep in sync with
+/// `CHARGE_RETRY_ATTEMPTS` / `CHARGE_RETRY_BACKOFF` (`os_accounts.rs`) and the
+/// default HTTP client timeout (`http.rs`) in june-providers — a contract test
+/// there pins this margin above that budget.
+pub const IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS: u64 = 150;
+/// Budget reserved before generation for the OS Accounts authorize call —
+/// it runs on the same 60-second default HTTP client (pinned by the same
+/// june-providers contract test as the settlement budget). The route's
+/// `TimeoutLayer` bounds authorize + generate + settle together, so the
+/// image client window must leave room for both metering legs.
+pub const OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS: u64 = 60;
+pub const DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS: u64 = DEFAULT_REQUEST_TIMEOUT_SECS
+    - OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS
+    - IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS;
+/// The hold is minted after authorize returns and must cover generation
+/// plus settlement: 390 + 150 = 540, inside the 600-second platform cap.
+/// Anchoring on the route timeout instead produced 630, past the cap, and
+/// every image authorize was rejected `invalid_ttl` (4201) in production.
 pub const DEFAULT_IMAGE_HOLD_TTL_SECS: u64 =
-    DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS;
+    DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS + IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS;
+// The full route budget must fit its three legs.
+const _: () = assert!(
+    OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS
+        + DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS
+        + IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS
+        <= DEFAULT_REQUEST_TIMEOUT_SECS
+);
 // Compile-time regression pin: a default past the cap fails every image
 // authorize as invalid_ttl (4201) in production.
 const _: () = assert!(DEFAULT_IMAGE_HOLD_TTL_SECS <= OS_ACCOUNTS_MAX_HOLD_TTL_SECS);
@@ -42,7 +62,9 @@ const fn base64_encoded_len(byte_count: usize) -> usize {
 }
 
 pub const fn image_client_timeout_secs(route_timeout_secs: u64) -> u64 {
-    route_timeout_secs - IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS
+    route_timeout_secs
+        - OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS
+        - IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -830,19 +852,21 @@ fn validate_request_limits(config: &AppConfig) -> Result<(), ConfigError> {
 
 fn validate_image_hold_ttl(config: &AppConfig) -> Result<(), ConfigError> {
     // The hold has to cover the image *client* timeout (route timeout minus
-    // the settlement margin) plus the hold margin. Anchoring on the route
-    // timeout instead demanded 630s, which OS Accounts rejects (see
-    // OS_ACCOUNTS_MAX_HOLD_TTL_SECS). Saturating math keeps this safe even
-    // when the route timeout is itself invalid (rejected by the margin check).
+    // the settlement budget) plus that same settlement budget for the charge
+    // path. Anchoring on the route timeout plus a margin demanded 630s, which
+    // OS Accounts rejects (see OS_ACCOUNTS_MAX_HOLD_TTL_SECS). Saturating
+    // math keeps this safe even when the route timeout is itself invalid
+    // (rejected by the margin check).
     let minimum = config
         .server
         .request_timeout_secs
+        .saturating_sub(OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS)
         .saturating_sub(IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS)
-        .saturating_add(IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS);
+        .saturating_add(IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS);
     if config.os_accounts.authorize_hold_ttl_image_secs < minimum {
         return Err(ConfigError::InvalidRequired {
             field: "os_accounts.authorize_hold_ttl_image_secs",
-            reason: "must cover the image client timeout plus the hold margin",
+            reason: "must cover the image client timeout plus the settlement budget",
         });
     }
     Ok(())
@@ -892,10 +916,12 @@ fn validate_hold_ttl_bounds(config: &AppConfig) -> Result<(), ConfigError> {
 }
 
 fn validate_image_timeout_margin(config: &AppConfig) -> Result<(), ConfigError> {
-    if config.server.request_timeout_secs <= IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS {
+    if config.server.request_timeout_secs
+        <= OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS + IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS
+    {
         return Err(ConfigError::InvalidRequired {
             field: "server.request_timeout_secs",
-            reason: "must be > image settlement margin",
+            reason: "must exceed the authorize budget plus the image settlement margin",
         });
     }
     Ok(())
@@ -1025,9 +1051,9 @@ mod tests {
     use super::{
         AppConfig, ConfigError, DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS, DEFAULT_IMAGE_HOLD_TTL_SECS,
         DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_REQUEST_TIMEOUT_SECS, IMAGE_EDIT_SOURCE_MAX_BYTES,
-        IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS, IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS, ModelPriceConfig,
-        ModelProvider, ModelType, OPENAI_API_KEY_PLACEHOLDERS,
-        OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_MAX_HOLD_TTL_SECS, PriceUnit,
+        IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS, ModelPriceConfig, ModelProvider, ModelType,
+        OPENAI_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS,
+        OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS, OS_ACCOUNTS_MAX_HOLD_TTL_SECS, PriceUnit,
         VENICE_API_KEY_PLACEHOLDERS, image_client_timeout_secs, validate,
     };
     use pretty_assertions::assert_eq;
@@ -1281,7 +1307,7 @@ mod tests {
         assert_eq!(
             config.os_accounts.authorize_hold_ttl_image_secs,
             image_client_timeout_secs(config.server.request_timeout_secs)
-                + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS
+                + IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS
         );
         assert_eq!(
             config.os_accounts.authorize_hold_ttl_image_secs,
@@ -1346,9 +1372,9 @@ mod tests {
     #[test]
     fn validate_rejects_image_route_timeout_without_settlement_margin() {
         let mut config = valid_config();
-        config.server.request_timeout_secs = IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS;
-        config.os_accounts.authorize_hold_ttl_image_secs =
-            config.server.request_timeout_secs + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS;
+        config.server.request_timeout_secs =
+            OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS + IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS;
+        config.os_accounts.authorize_hold_ttl_image_secs = DEFAULT_IMAGE_HOLD_TTL_SECS;
 
         let result = validate(&config);
 

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -20,8 +20,19 @@ pub const IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS: u64 = 30;
 pub const DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS: u64 =
     DEFAULT_REQUEST_TIMEOUT_SECS - IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS;
 pub const IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS: u64 = 30;
+/// OS Accounts rejects `/authorize` holds outside 1..=600 seconds as
+/// `invalid_ttl` (envelope code 4201). Keep in sync with
+/// `MAX_HOLD_TTL_SECONDS` in os-accounts `api/crates/services/src/grants.rs`.
+pub const OS_ACCOUNTS_MAX_HOLD_TTL_SECS: u64 = 600;
+/// The hold must outlive the image *client* timeout plus the settlement
+/// margin — not the whole route timeout: route timeout + margin (630) is past
+/// the OS Accounts cap and every image authorize was rejected `invalid_ttl`
+/// in production. 570 + 30 lands exactly on the 600-second cap.
 pub const DEFAULT_IMAGE_HOLD_TTL_SECS: u64 =
-    DEFAULT_REQUEST_TIMEOUT_SECS + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS;
+    DEFAULT_IMAGE_CLIENT_TIMEOUT_SECS + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS;
+// Compile-time regression pin: a default past the cap fails every image
+// authorize as invalid_ttl (4201) in production.
+const _: () = assert!(DEFAULT_IMAGE_HOLD_TTL_SECS <= OS_ACCOUNTS_MAX_HOLD_TTL_SECS);
 const IMAGE_EDIT_JSON_OVERHEAD_BYTES: usize = 16 * 1024;
 pub const DEFAULT_MAX_IMAGE_EDIT_BYTES: usize =
     base64_encoded_len(IMAGE_EDIT_SOURCE_MAX_BYTES) + IMAGE_EDIT_JSON_OVERHEAD_BYTES;
@@ -813,19 +824,69 @@ fn validate_request_limits(config: &AppConfig) -> Result<(), ConfigError> {
         config.server.max_image_edit_bytes,
     )?;
     validate_image_hold_ttl(config)?;
+    validate_hold_ttl_bounds(config)?;
     Ok(())
 }
 
 fn validate_image_hold_ttl(config: &AppConfig) -> Result<(), ConfigError> {
+    // The hold has to cover the image *client* timeout (route timeout minus
+    // the settlement margin) plus the hold margin. Anchoring on the route
+    // timeout instead demanded 630s, which OS Accounts rejects (see
+    // OS_ACCOUNTS_MAX_HOLD_TTL_SECS). Saturating math keeps this safe even
+    // when the route timeout is itself invalid (rejected by the margin check).
     let minimum = config
         .server
         .request_timeout_secs
+        .saturating_sub(IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS)
         .saturating_add(IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS);
     if config.os_accounts.authorize_hold_ttl_image_secs < minimum {
         return Err(ConfigError::InvalidRequired {
             field: "os_accounts.authorize_hold_ttl_image_secs",
-            reason: "must be >= server.request_timeout_secs + image hold margin",
+            reason: "must cover the image client timeout plus the hold margin",
         });
+    }
+    Ok(())
+}
+
+/// Every authorize hold TTL must fit the OS Accounts platform bounds; a value
+/// past the cap is rejected `invalid_ttl` on every request, which surfaces to
+/// users as `metering_provider_failed` and disables the whole action.
+fn validate_hold_ttl_bounds(config: &AppConfig) -> Result<(), ConfigError> {
+    let ttls: [(&'static str, u64); 6] = [
+        (
+            "os_accounts.authorize_hold_ttl_note_transcribe_secs",
+            config.os_accounts.authorize_hold_ttl_note_transcribe_secs,
+        ),
+        (
+            "os_accounts.authorize_hold_ttl_note_generate_secs",
+            config.os_accounts.authorize_hold_ttl_note_generate_secs,
+        ),
+        (
+            "os_accounts.authorize_hold_ttl_dictate_transcribe_secs",
+            config
+                .os_accounts
+                .authorize_hold_ttl_dictate_transcribe_secs,
+        ),
+        (
+            "os_accounts.authorize_hold_ttl_dictate_cleanup_secs",
+            config.os_accounts.authorize_hold_ttl_dictate_cleanup_secs,
+        ),
+        (
+            "os_accounts.authorize_hold_ttl_web_secs",
+            config.os_accounts.authorize_hold_ttl_web_secs,
+        ),
+        (
+            "os_accounts.authorize_hold_ttl_image_secs",
+            config.os_accounts.authorize_hold_ttl_image_secs,
+        ),
+    ];
+    for (field, value) in ttls {
+        if !(1..=OS_ACCOUNTS_MAX_HOLD_TTL_SECS).contains(&value) {
+            return Err(ConfigError::InvalidRequired {
+                field,
+                reason: "must be within the OS Accounts hold TTL bounds (1..=600 seconds)",
+            });
+        }
     }
     Ok(())
 }
@@ -966,8 +1027,8 @@ mod tests {
         DEFAULT_MAX_IMAGE_EDIT_BYTES, DEFAULT_REQUEST_TIMEOUT_SECS, IMAGE_EDIT_SOURCE_MAX_BYTES,
         IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS, IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS, ModelPriceConfig,
         ModelProvider, ModelType, OPENAI_API_KEY_PLACEHOLDERS,
-        OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, PriceUnit, VENICE_API_KEY_PLACEHOLDERS,
-        image_client_timeout_secs, validate,
+        OS_ACCOUNTS_APP_API_KEY_PLACEHOLDERS, OS_ACCOUNTS_MAX_HOLD_TTL_SECS, PriceUnit,
+        VENICE_API_KEY_PLACEHOLDERS, image_client_timeout_secs, validate,
     };
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
@@ -1215,16 +1276,58 @@ mod tests {
     }
 
     #[test]
-    fn default_image_hold_ttl_tracks_request_timeout_with_margin() {
+    fn default_image_hold_ttl_covers_client_timeout_within_platform_cap() {
         let config = AppConfig::default();
         assert_eq!(
             config.os_accounts.authorize_hold_ttl_image_secs,
-            config.server.request_timeout_secs + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS
+            image_client_timeout_secs(config.server.request_timeout_secs)
+                + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS
         );
         assert_eq!(
             config.os_accounts.authorize_hold_ttl_image_secs,
             DEFAULT_IMAGE_HOLD_TTL_SECS
         );
+        // The <= OS_ACCOUNTS_MAX_HOLD_TTL_SECS regression pin lives as a
+        // compile-time const assertion next to the constant itself.
+    }
+
+    #[test]
+    fn validate_rejects_image_hold_ttl_above_os_accounts_cap() {
+        let mut config = valid_config();
+        config.os_accounts.authorize_hold_ttl_image_secs = OS_ACCOUNTS_MAX_HOLD_TTL_SECS + 30;
+
+        let result = validate(&config);
+
+        assert!(matches!(
+            result,
+            Err(ConfigError::InvalidRequired {
+                field: "os_accounts.authorize_hold_ttl_image_secs",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_any_hold_ttl_outside_platform_bounds() {
+        let mut config = valid_config();
+        config.os_accounts.authorize_hold_ttl_web_secs = OS_ACCOUNTS_MAX_HOLD_TTL_SECS + 1;
+        assert!(matches!(
+            validate(&config),
+            Err(ConfigError::InvalidRequired {
+                field: "os_accounts.authorize_hold_ttl_web_secs",
+                ..
+            })
+        ));
+
+        let mut config = valid_config();
+        config.os_accounts.authorize_hold_ttl_dictate_cleanup_secs = 0;
+        assert!(matches!(
+            validate(&config),
+            Err(ConfigError::InvalidRequired {
+                field: "os_accounts.authorize_hold_ttl_dictate_cleanup_secs",
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -1259,7 +1362,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_image_hold_ttl_below_request_timeout_margin() {
+    fn validate_rejects_image_hold_ttl_below_client_timeout_margin() {
         let mut config = valid_config();
         config.server.request_timeout_secs = DEFAULT_REQUEST_TIMEOUT_SECS;
         config.os_accounts.authorize_hold_ttl_image_secs = 60;

--- a/june-api/crates/providers/src/http.rs
+++ b/june-api/crates/providers/src/http.rs
@@ -1,7 +1,8 @@
 use reqwest::Client;
 use std::time::Duration;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_mins(1);
+pub(crate) const DEFAULT_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(DEFAULT_TIMEOUT_SECS);
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub fn default_client() -> Client {

--- a/june-api/crates/providers/src/os_accounts.rs
+++ b/june-api/crates/providers/src/os_accounts.rs
@@ -14,6 +14,33 @@ const ERR_INSUFFICIENT_CREDITS: i64 = 4301;
 const ERR_IDEMPOTENCY_KEY_COLLISION: i64 = 4001;
 const CHARGE_RETRY_ATTEMPTS: u32 = 2;
 const CHARGE_RETRY_BACKOFF: Duration = Duration::from_millis(250);
+// Compile-time budget contracts with june-config's image route arithmetic.
+//
+// The image hold TTL reserves `IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS` for the
+// charge path after generation. If the worst-case charge budget (every retry
+// spending the full HTTP timeout plus backoff) outgrew that margin, a
+// max-length generation would settle against an expired hold: June pays the
+// upstream and the user sees `metering_provider_failed`.
+const _: () = assert!(
+    (CHARGE_RETRY_ATTEMPTS as u64) * crate::http::DEFAULT_TIMEOUT_SECS
+        + ((CHARGE_RETRY_ATTEMPTS - 1) as u64) * next_second(CHARGE_RETRY_BACKOFF)
+        <= june_config::IMAGE_SETTLEMENT_TIMEOUT_MARGIN_SECS
+);
+// The authorize leg runs on the same default HTTP client; the image route
+// reserves this budget ahead of the generation window.
+const _: () = assert!(
+    crate::http::DEFAULT_TIMEOUT_SECS <= june_config::OS_ACCOUNTS_AUTHORIZE_TIMEOUT_BUDGET_SECS
+);
+
+/// Backoff rounded up to a whole second for the const budget arithmetic.
+const fn next_second(duration: std::time::Duration) -> u64 {
+    let secs = duration.as_secs();
+    if duration.subsec_nanos() > 0 {
+        secs + 1
+    } else {
+        secs
+    }
+}
 
 pub struct OsAccountsHttpClient {
     http: reqwest::Client,

--- a/june-api/crates/providers/src/venice_image.rs
+++ b/june-api/crates/providers/src/venice_image.rs
@@ -27,14 +27,22 @@ pub struct VeniceImageGenerator {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
+    /// End-to-end budget for the whole generate leg INCLUDING retries; the
+    /// hold TTL and route timeout arithmetic assume this bound (config lib.rs).
+    leg_budget: std::time::Duration,
 }
 
 impl VeniceImageGenerator {
-    pub fn from_config(http: reqwest::Client, config: &UpstreamConfig) -> Self {
+    pub fn from_config(
+        http: reqwest::Client,
+        config: &UpstreamConfig,
+        leg_budget: std::time::Duration,
+    ) -> Self {
         Self {
             http,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            leg_budget,
         }
     }
 
@@ -113,20 +121,33 @@ impl ImageGenerator for VeniceImageGenerator {
         // Bounded retry on transient failures (connection reset, 429, 5xx),
         // same as the chat and augment paths. The service settles at most one
         // June charge after this call returns; a retry can cost at most one
-        // extra upstream generation if a completed response was lost.
-        for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-            let error = match self.generate_once(&url, &body, api_key).await {
-                Ok(parsed) => return image_from_response(parsed, &request.model.0),
-                Err(error) => error,
-            };
-            if error.retryable && attempt + 1 < retry::UPSTREAM_ATTEMPTS {
-                tracing::warn!(%url, model = %request.model.0, attempt, "venice image: transient failure, retrying");
-                tokio::time::sleep(retry::UPSTREAM_RETRY_BACKOFF).await;
-                continue;
+        // extra upstream generation if a completed response was lost. The
+        // whole loop runs under one end-to-end deadline: per-attempt HTTP
+        // timeouts alone would let retries spend attempts x budget, breaking
+        // the authorize + generate + settle <= route/hold arithmetic and
+        // expiring the credit hold before settlement.
+        let attempts = async {
+            for attempt in 0..retry::UPSTREAM_ATTEMPTS {
+                let error = match self.generate_once(&url, &body, api_key).await {
+                    Ok(parsed) => return image_from_response(parsed, &request.model.0),
+                    Err(error) => error,
+                };
+                if error.retryable && attempt + 1 < retry::UPSTREAM_ATTEMPTS {
+                    tracing::warn!(%url, model = %request.model.0, attempt, "venice image: transient failure, retrying");
+                    tokio::time::sleep(retry::UPSTREAM_RETRY_BACKOFF).await;
+                    continue;
+                }
+                return Err(error.error);
             }
-            return Err(error.error);
+            Err(DomainError::UpstreamProvider)
+        };
+        match tokio::time::timeout(self.leg_budget, attempts).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                tracing::error!(%url, model = %request.model.0, "venice image: generate leg budget exhausted");
+                Err(DomainError::UpstreamProvider)
+            }
         }
-        Err(DomainError::UpstreamProvider)
     }
 }
 
@@ -201,6 +222,7 @@ mod tests {
                 api_key: "venice_key".to_string(),
                 base_url: server.uri(),
             },
+            std::time::Duration::from_secs(5),
         )
     }
 

--- a/june-api/crates/providers/src/venice_image_edit.rs
+++ b/june-api/crates/providers/src/venice_image_edit.rs
@@ -27,14 +27,22 @@ pub struct VeniceImageEditor {
     http: reqwest::Client,
     api_key: String,
     base_url: String,
+    /// End-to-end budget for the whole edit leg INCLUDING retries (see
+    /// `VeniceImageGenerator::leg_budget`).
+    leg_budget: std::time::Duration,
 }
 
 impl VeniceImageEditor {
-    pub fn from_config(http: reqwest::Client, config: &UpstreamConfig) -> Self {
+    pub fn from_config(
+        http: reqwest::Client,
+        config: &UpstreamConfig,
+        leg_budget: std::time::Duration,
+    ) -> Self {
         Self {
             http,
             api_key: config.api_key.clone(),
             base_url: config.base_url.trim_end_matches('/').to_string(),
+            leg_budget,
         }
     }
 
@@ -124,19 +132,28 @@ impl ImageEditor for VeniceImageEditor {
         // service charges once AFTER a successful edit, so a retry never
         // double-charges; at most one extra upstream edit if a completed
         // response was lost, bounded by UPSTREAM_ATTEMPTS.
-        for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-            let error = match self.edit_once(&url, &body, api_key).await {
-                Ok(image) => return Ok(image),
-                Err(error) => error,
-            };
-            if error.retryable && attempt + 1 < retry::UPSTREAM_ATTEMPTS {
-                tracing::warn!(%url, model = %request.model.0, attempt, "venice image edit: transient failure, retrying");
-                tokio::time::sleep(retry::UPSTREAM_RETRY_BACKOFF).await;
-                continue;
+        let attempts = async {
+            for attempt in 0..retry::UPSTREAM_ATTEMPTS {
+                let error = match self.edit_once(&url, &body, api_key).await {
+                    Ok(image) => return Ok(image),
+                    Err(error) => error,
+                };
+                if error.retryable && attempt + 1 < retry::UPSTREAM_ATTEMPTS {
+                    tracing::warn!(%url, model = %request.model.0, attempt, "venice image edit: transient failure, retrying");
+                    tokio::time::sleep(retry::UPSTREAM_RETRY_BACKOFF).await;
+                    continue;
+                }
+                return Err(error.error);
             }
-            return Err(error.error);
+            Err(DomainError::UpstreamProvider)
+        };
+        match tokio::time::timeout(self.leg_budget, attempts).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                tracing::error!(%url, model = %request.model.0, "venice image edit: edit leg budget exhausted");
+                Err(DomainError::UpstreamProvider)
+            }
         }
-        Err(DomainError::UpstreamProvider)
     }
 }
 
@@ -178,6 +195,7 @@ mod tests {
                 api_key: "test-key".to_string(),
                 base_url: base_url.to_string(),
             },
+            std::time::Duration::from_secs(5),
         )
     }
 

--- a/june-api/crates/services/src/image.rs
+++ b/june-api/crates/services/src/image.rs
@@ -1149,9 +1149,7 @@ mod tests {
         ImageEditParams, ImageGenerateParams, ImageModelPrice, ImageService, ImageServiceDeps,
     };
     use async_trait::async_trait;
-    use june_config::{
-        DEFAULT_REQUEST_TIMEOUT_SECS, IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS, ModelProvider,
-    };
+    use june_config::{DEFAULT_IMAGE_HOLD_TTL_SECS, ModelProvider};
     use june_domain::{
         Authorization, AuthorizeRequest, ChargeRequest, DomainError, GeneratedImage,
         ImageEditRequest, ImageEditor, ImageGenerationRequest, ImageGenerator, OsAccountsClient,
@@ -1842,7 +1840,7 @@ mod tests {
             Arc::new(TtlExpiringOsAccounts::new(clock.clone())),
             Arc::new(DelayedGenerator::new(clock, delayed_past_old_hold)),
             Arc::new(FixedEditor),
-            DEFAULT_REQUEST_TIMEOUT_SECS + IMAGE_HOLD_TTL_TIMEOUT_MARGIN_SECS,
+            DEFAULT_IMAGE_HOLD_TTL_SECS,
         );
 
         let output = service


### PR DESCRIPTION
## Summary

Fixes image generation failing in production with `metering_provider_failed` on every request.

## Root cause

`DEFAULT_IMAGE_HOLD_TTL_SECS` anchored the credit-hold TTL on the image *route* timeout plus a margin (600 + 30 = 630 s). OS Accounts bounds `/authorize` holds to 1..=600 s (`MAX_HOLD_TTL_SECONDS` in os-accounts `grants.rs`), so it rejected every image authorize as `422 invalid_ttl` (envelope code 4201; the 71-byte error body in prod logs matches that message exactly), which june-api maps to `metering_provider_failed`. Only the image path uses this TTL - chat/web/dictation send 30-300 s holds - so images failed immediately and deterministically while everything else worked. june-api's own boot validation *required* >= 630 (also anchored on the route timeout), so no env override could mitigate: <= 600 failed boot, >= 630 failed OS Accounts.

It escaped tests because june-api's OS Accounts fake does not enforce the platform's TTL bounds - a cross-repo contract with no test on either side of the seam.

## Change

The image metering budget is now closed end to end (three further leaks found by the adversarial review loop and fixed in the same change):

- **Route budget fits its three legs**: authorize (60 s, the OS Accounts HTTP client timeout) + generation leg (390 s) + settlement (150 s, sized to the worst-case charge path of 2 x 60 s retries + backoff) = the 600 s route timeout.
- **The generation leg is a true end-to-end deadline**: both Venice image providers run their whole retry loop under one `tokio::time::timeout`, so upstream retries can no longer multiply the leg past its budget.
- **The hold covers generation + settlement** (540 s), inside the platform cap. `OS_ACCOUNTS_MAX_HOLD_TTL_SECS = 600` with a keep-in-sync comment.
- **Enforced by construction**: compile-time `const` guards pin the default arithmetic (hold <= cap; legs <= route; charge retry budget <= settlement margin; authorize budget >= HTTP timeout), and boot-time `validate_hold_ttl_bounds` bounds **all six** authorize hold TTLs to the platform's 1..=600 for configured values too.

## Validation

- `cargo test` (june-api workspace, pinned toolchain): 279 passed / 0 failed, including new tests (default arithmetic, 630 rejected at boot, per-field TTL bounds).
- `cargo clippy` 0 warnings, `cargo fmt --check` clean.
- Adversarial review loop (Codex, non-author): 4 rounds; rounds 1-3 each surfaced a real budget leak (settlement margin, authorize leg, retry amplification), all fixed with guards; round 4 verdict approve.

- [ ] Tested visually where it matters. (No UI surface; the visual proof is image generation working on the next deployed build - see Followups.)
- [x] **Needs a June API (backend) deploy before it works end to end.** This is the entire fix: build a new image and promote to production.

## Out of scope

- OS Accounts-side changes (e.g. exporting the bound in its client contract or an accept-and-clamp) - follow-up issue.
- The desktop app - no change needed; the RC only needs the backend deployed.

## Followups

- File an os-accounts issue: expose the hold-TTL bounds in the documented contract table (the 1..=600 bound currently lives in a code comment in the integration skill) and consider a fake/test harness consumers can run against.
- After deploy: verify with a live image generation on the rc channel.

https://claude.ai/code/session_01PAXWFzPrZwWkCet8RTihgK

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785691807&installation_id=144203540&pr_number=618&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F618&signature=a284f4dff6c7981e8844d0231d51ecd7b2a1e1d7fdfc86b0125a6c5cdea95e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->