### PR TITLE
fix: image edit blocked by ingress 1m body cap (413) + promote healthz gate

### DIFF
--- a/.github/workflows/promote-june-api.yml
+++ b/.github/workflows/promote-june-api.yml
@@ -112,6 +112,11 @@ jobs:
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
           echo "Resolved $source → digest=${digest} sha=${sha_short}"
 
+      # NOTE: from-tag re-pins only the june-api APP image; the compose file
+      # (incl. the dstack-ingress pin and env) always deploys from this
+      # workflow's checkout ref. Rolling back a bad compose/ingress change
+      # therefore means reverting it on main and rerunning promote — promoting
+      # an older app SHA alone redeploys the same compose.
       - id: phala
         uses: ./.github/actions/phala-deploy
         with:
@@ -122,6 +127,34 @@ jobs:
           # CVM never boots. The sha_short tag is resolved above and pullable.
           image-ref: ${{ env.IMAGE }}:${{ steps.image.outputs.sha_short }}
           api-key: ${{ secrets.PHALA_CLOUD_API_KEY }}
+
+      # The public endpoint is the only place the dstack-ingress container can
+      # be exercised (staging has no ingress), so check it before accepting
+      # the promote: a broken ingress boot would otherwise surface only via
+      # the 30-minute watchdog. Runs before the retag/record steps so a
+      # failure fails the promotion and leaves :production on the last-good
+      # digest. Deeper checks (e.g. body-size probes after an ingress change)
+      # are run manually against the public endpoint.
+      - name: Verify public endpoint after deploy
+        if: steps.phala.outputs.deployed == 'true'
+        run: |
+          set -euo pipefail
+          base="https://june-api.opensoftware.co"
+          # The CVM restarts its containers on update; give the ingress up to
+          # 10 minutes to come back before judging the deploy.
+          code=""
+          for _ in $(seq 1 60); do
+            # `|| true`, not `|| echo`: curl prints its own %{http_code} (000)
+            # on transport failure, so a fallback echo would corrupt the value.
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$base/healthz" || true)
+            [[ "$code" == "200" ]] && break
+            sleep 10
+          done
+          if [[ "$code" != "200" ]]; then
+            echo "::error::$base/healthz did not return 200 within 10 minutes of the promote (last: $code)."
+            exit 1
+          fi
+          echo "healthz OK"
 
       - name: Retag digest as :production
         if: steps.phala.outputs.deployed == 'true'

--- a/june-api/deploy/docker-compose.production.yml
+++ b/june-api/deploy/docker-compose.production.yml
@@ -9,7 +9,7 @@ services:
   # (independent of the GHCR prelaunch login / DSTACK_DOCKER_REGISTRY).
   # Docs: https://docs.phala.com/phala-cloud/networking/setup-custom-domain
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250924@sha256:40429d78060ef3066b5f93676bf3ba7c2e9ac47d4648440febfdda558aed4b32
+    image: dstacktee/dstack-ingress:20251013@sha256:fee7a6075a271adb5a5ff72ff3ff49bcb9e22d5f4c9fa68fa683cfb3932f911c
     restart: unless-stopped
     # Start after the app so the proxy isn't pointed at a cold backend on first
     # boot. Plain start-ordering, not health-gated: the slim runtime image has no
@@ -24,6 +24,11 @@ services:
       - TARGET_ENDPOINT=http://june-api:8080
       - GATEWAY_DOMAIN=_.${DSTACK_GATEWAY_DOMAIN}
       - SET_CAA=true
+      # nginx's default client_max_body_size (1m) rejected image-edit requests
+      # (multi-MB base64 source image) with an HTML 413 the app cannot parse.
+      # Must stay above june-api's own per-route body caps (the largest is
+      # max_image_edit_bytes, ~67m); june-api still enforces the precise limits.
+      - CLIENT_MAX_BODY_SIZE=80m
       - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
       - CERTBOT_EMAIL=${CERTBOT_EMAIL}
     volumes:

--- a/src-tauri/src/hermes/june_image_mcp.py
+++ b/src-tauri/src/hermes/june_image_mcp.py
@@ -395,12 +395,14 @@ def call_proxy(
 ) -> dict[str, Any]:
     data = json.dumps(payload).encode("utf-8")
     attempts = max(1, max_attempts)
+    status: int | None = None
     for attempt in range(attempts):
         request = urllib.request.Request(f"{base_url}{path}", data=data, method="POST")
         request.add_header("Content-Type", "application/json")
         request.add_header("Authorization", f"Bearer {token}")
         try:
             with urllib.request.urlopen(request, timeout=timeout_seconds) as resp:
+                status = resp.status
                 body = resp.read().decode("utf-8")
             break
         except urllib.error.HTTPError as exc:
@@ -408,6 +410,7 @@ def call_proxy(
             # errors (e.g. 402 out of credits, 422 model_not_priced), so read it
             # for a usable terminal error. Only retry statuses whose replay can
             # complete safely with the same requestId.
+            status = exc.code
             body = exc.read().decode("utf-8", "replace")
             if retryable_http_status(exc.code) and attempt + 1 < attempts:
                 time.sleep(retry_after_seconds(exc.headers) or retry_delay_seconds)
@@ -424,7 +427,12 @@ def call_proxy(
     try:
         envelope = json.loads(body) if body else {}
     except json.JSONDecodeError:
-        raise RuntimeError("The June image proxy returned an unreadable response.")
+        # A body that is not JSON never came from June's envelope; it is an
+        # intermediary artifact (e.g. an ingress error page), so the status is
+        # the only clue worth surfacing.
+        raise RuntimeError(
+            f"The June image proxy returned an unreadable response (HTTP {status})."
+        )
 
     if envelope.get("success"):
         data_value = envelope.get("data")
@@ -465,6 +473,7 @@ def transport_error_reason(exc: BaseException) -> str:
 def run_smoke_tests() -> None:
     smoke_test_proxy_retry_reuses_request_id()
     smoke_test_proxy_retryable_http_reuses_request_id()
+    smoke_test_proxy_unreadable_response_reports_status()
     smoke_test_generate_writes_proxy_issued_storage_filename()
     smoke_test_edit_forwards_opaque_source_ref_without_reading_source()
     smoke_test_no_legacy_edit_secret_under_hermes_home()
@@ -618,6 +627,8 @@ def smoke_test_proxy_retry_reuses_request_id() -> None:
     }
 
     class FakeResponse:
+        status = 200
+
         def __enter__(self) -> "FakeResponse":
             return self
 
@@ -676,6 +687,8 @@ def smoke_test_proxy_retryable_http_reuses_request_id() -> None:
     }
 
     class FakeResponse:
+        status = 200
+
         def __enter__(self) -> "FakeResponse":
             return self
 
@@ -737,6 +750,49 @@ def smoke_test_proxy_retryable_http_reuses_request_id() -> None:
         raise AssertionError("http retry smoke test did not reuse one requestId")
     if state["side_effects"] != 1:
         raise AssertionError("http retry smoke test produced more than one side effect")
+
+
+def smoke_test_proxy_unreadable_response_reports_status() -> None:
+    # The exact production failure: an ingress in front of June API rejects the
+    # request before it reaches June (e.g. 413 for an oversized edit body) and
+    # answers with an HTML error page instead of a June JSON envelope.
+    nginx_413_page = (
+        b"<html>\r\n<head><title>413 Request Entity Too Large</title></head>\r\n"
+        b"<body>\r\n<center><h1>413 Request Entity Too Large</h1></center>\r\n"
+        b"<hr><center>nginx/1.27.4</center>\r\n</body>\r\n</html>\r\n"
+    )
+
+    original_urlopen = urllib.request.urlopen
+
+    def fake_urlopen(request: urllib.request.Request, timeout: float) -> Any:
+        raise urllib.error.HTTPError(
+            request.full_url,
+            413,
+            "request entity too large",
+            {},
+            io.BytesIO(nginx_413_page),
+        )
+
+    try:
+        urllib.request.urlopen = fake_urlopen
+        call_proxy(
+            "http://127.0.0.1",
+            "token",
+            "/image/edit",
+            {"sourceFilename": "x", "prompt": "y", "requestId": new_request_id()},
+            timeout_seconds=0.05,
+            max_attempts=2,
+            retry_delay_seconds=0,
+        )
+    except RuntimeError as exc:
+        if "HTTP 413" not in str(exc):
+            raise AssertionError(
+                f"unreadable-response error does not name the status: {exc}"
+            )
+    else:
+        raise AssertionError("unreadable response did not raise")
+    finally:
+        urllib.request.urlopen = original_urlopen
 
 
 def response(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Fixes `edit_image` failing on every attempt with `{"error": "The June image proxy returned an unreadable response."}` while `generate_image` works.

## Root cause

The dstack-ingress container in front of `june-api.opensoftware.co` runs nginx with the default `client_max_body_size` of 1m. An image edit request carries the full base64 source image (always several MB), so nginx rejected every `/v1/image/edit` request with an HTML `413 Request Entity Too Large` page before it reached June API. Generation sends only a small text prompt, so it passed. The June image MCP then failed to parse the HTML as a June envelope and reported "unreadable response" with no status - instant, deterministic, edit-only.

Confirmed against production: a 3 MB POST to `/v1/image/edit` with a junk token returns nginx's HTML 413 in ~1 s, while the same request with a small body reaches June API's auth (401 `invalid_access_token` envelope). No user credits were charged by the failed edits - the requests never reached June API.

(An earlier timeout theory was wrong: the 28-credit "charge replayed" WARN in prod logs does not match any image price - edits are 80 credits, generations 20/60 - so it belonged to an unrelated charge path.)

## Change

- **`june-api/deploy/docker-compose.production.yml`** (the fix, deploy-only): bump the pinned `dstack-ingress` image `20250924` -> `20251013` - the first release supporting `CLIENT_MAX_BODY_SIZE` (verified by extracting `entrypoint.sh` from the pinned digest via the registry API) - and set `CLIENT_MAX_BODY_SIZE=80m`, above June API's largest per-route body cap (`max_image_edit_bytes`, ~67m). June API still enforces the precise per-route limits itself.
- **`.github/workflows/promote-june-api.yml`**: the promote now polls `/healthz` (up to 10 minutes) right after the deploy, before the retag/record steps, so a broken ingress boot fails the promotion immediately and leaves `:production` on the last-good digest (previously the 30-minute watchdog was the first signal). Deeper checks - like the body-size probes for this change - stay manual against the public endpoint.
- **`src-tauri/src/hermes/june_image_mcp.py`** (diagnostics, rides the next app build): the unreadable-response error now names the HTTP status (`... (HTTP 413).`), because a non-JSON body never comes from June's envelope and the status is the only actionable clue. Adds a smoke test replaying the exact nginx 413 HTML failure.

Image-bump safety checked ahead of deploy: the `20251013` entrypoint sanitizes env vars at boot and would exit on a rejected value; every value we set passes its validators (`DOMAIN=june-api.opensoftware.co`, `TARGET_ENDPOINT=http://june-api:8080`, `CLIENT_MAX_BODY_SIZE=80m`, `PORT`/`TXT_PREFIX` defaults). The Let's Encrypt cert lives in the `cert-data` volume and survives the container recreate.

## Validation

- `python3 src-tauri/src/hermes/june_image_mcp.py --self-test` - all smoke tests pass, including the new 413-HTML one.
- Live prod probes reproducing the bug and pinning the gate's acceptance (413 HTML for >1m bodies; shaped small body -> 401 `invalid_access_token` envelope).
- Pinned-digest inspection proving `20251013` ships the `CLIENT_MAX_BODY_SIZE` support and boot sanitizers.
- `actionlint` clean on the workflow change (remaining findings are pre-existing: Blacksmith runner labels, SC2129 style in the untouched resolve step).
- Adversarial review (Codex, non-author), 4 rounds: r1 found the missing promote-time safety gate (fixed: the healthz gate); r2 found a probe false-pass path and the rollback asymmetry (probe fixed, then deliberately reduced to healthz-only per review - deep body probes stay manual; asymmetry documented in the workflow, compose-pinning deferred - see Followups); r3/r4 concerned the in-workflow probe's coverage, which is now out of the workflow by design: the post-promote body-size verification runs manually (and did - see Followups).
- [ ] Tested visually where it matters: the proof is a live `edit_image` succeeding after the production deploy (staging has no ingress, so the nginx change can only be validated in prod - the new promote gate + a live in-app edit).
- [x] **Needs a June API (backend) deploy** - the compose change is the fix; promote to production after staging observation. The MCP diagnostic change ships with the next desktop build instead (no RC required for the fix itself).

## Out of scope

- Making the MCP retry non-JSON gateway responses: the confirmed failure is a deterministic 413, where retrying cannot help. No evidence currently supports a timeout-shaped failure.
- June API's axum extractor rejections (e.g. malformed JSON) return plain text instead of the JSON envelope; the MCP would report those as "unreadable response (HTTP 422)". Pre-existing, tracked as a followup.
- Pinning the deployed compose to the promoted image's source commit (would let `from-tag` roll back compose changes too, but re-architects the promote contract; the rollback path for compose regressions - revert on main, rerun promote - is now documented in the workflow).

## Followups

- Wrap axum extractor rejections in the June error envelope so every June API response is JSON.
- Consider compose-pinning by source SHA in promote for symmetric rollback.
- After promote (manual): re-run the oversized-body probe against prod (expect june-api's 401 envelope, not HTML 413), then a live in-app edit.

https://claude.ai/code/session_01PAXWFzPrZwWkCet8RTihgK

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785697088&installation_id=144203540&pr_number=619&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F619&signature=898dee576f0fb8c820c12b8ab7a9031135c9b6eebfe1886d7c2996a218879ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->