### PR TITLE
Validate saved Venice API keys

### DIFF
--- a/june-api/crates/api/src/auth.rs
+++ b/june-api/crates/api/src/auth.rs
@@ -3,6 +3,7 @@ use axum::http::{HeaderMap, header};
 use june_domain::{ProviderCredentials, UserId};
 
 const VENICE_API_KEY_HEADER: &str = "x-venice-api-key";
+const VENICE_API_KEY_PREFIX: &str = "VENICE_INFERENCE_KEY_";
 
 pub(crate) async fn authenticated_user(
     state: &ApiState,
@@ -45,5 +46,53 @@ pub(crate) fn provider_credentials(headers: &HeaderMap) -> Result<ProviderCreden
         venice_api_key.as_deref(),
         validation::MAX_PROVIDER_API_KEY_CHARS,
     )?;
+    if let Some(api_key) = venice_api_key.as_deref() {
+        validate_venice_api_key(api_key)?;
+    }
     Ok(ProviderCredentials { venice_api_key })
+}
+
+fn validate_venice_api_key(api_key: &str) -> Result<(), ApiError> {
+    if !api_key.starts_with(VENICE_API_KEY_PREFIX) || api_key.chars().any(char::is_control) {
+        return Err(ApiError::bad_request("venice_api_key_invalid"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VENICE_API_KEY_HEADER, provider_credentials};
+    use axum::http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn provider_credentials_accepts_prefixed_venice_key() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            VENICE_API_KEY_HEADER,
+            HeaderValue::from_static("VENICE_INFERENCE_KEY_valid"),
+        );
+
+        let credentials = provider_credentials(&headers).expect("key should parse");
+
+        assert_eq!(
+            credentials.venice_api_key.as_deref(),
+            Some("VENICE_INFERENCE_KEY_valid")
+        );
+    }
+
+    #[test]
+    fn provider_credentials_rejects_wrong_venice_key_prefix() {
+        let mut headers = HeaderMap::new();
+        headers.insert(VENICE_API_KEY_HEADER, HeaderValue::from_static("sk_wrong"));
+
+        let error = provider_credentials(&headers).expect_err("key should fail");
+
+        assert!(matches!(
+            error,
+            crate::ApiError::BadRequest {
+                message,
+                ..
+            } if message == "venice_api_key_invalid"
+        ));
+    }
 }

--- a/june-api/crates/api/tests/http_boundary.rs
+++ b/june-api/crates/api/tests/http_boundary.rs
@@ -93,7 +93,7 @@ async fn integration_note_generate_forwards_venice_api_key_header() -> Result<()
             "transcript": "System: launch is Friday",
             "model": "text-model"
         }),
-        "vc_user_key",
+        "VENICE_INFERENCE_KEY_user",
     )?)
     .await;
 
@@ -104,7 +104,30 @@ async fn integration_note_generate_forwards_venice_api_key_header() -> Result<()
         body["data"]["content"],
         "Generated note body with user Venice key"
     );
-    assert!(!body.to_string().contains("vc_user_key"));
+    assert!(!body.to_string().contains("VENICE_INFERENCE_KEY_user"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn integration_note_generate_rejects_malformed_venice_api_key_header()
+-> Result<(), Box<dyn Error>> {
+    let response = send(json_request_with_venice_api_key(
+        "/v1/notes/generate",
+        &serde_json::json!({
+            "noteId": "note-1",
+            "promptVersion": "prompt-v1",
+            "title": "Planning",
+            "transcript": "System: launch is Friday",
+            "model": "text-model"
+        }),
+        "sk_wrong",
+    )?)
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response_json(response).await?;
+    assert_eq!(body["success"], false);
+    assert_eq!(body["message"], "venice_api_key_invalid");
     Ok(())
 }
 
@@ -661,7 +684,7 @@ async fn integration_image_edit_accepts_body_at_configured_limit() -> Result<(),
         .oneshot(raw_json_request_with_venice_api_key(
             "/v1/image/edit",
             body,
-            "vc_user_key",
+            "VENICE_INFERENCE_KEY_user",
         )?)
         .await
     {
@@ -687,7 +710,7 @@ async fn integration_image_edit_rejects_body_over_configured_limit() -> Result<(
         .oneshot(raw_json_request_with_venice_api_key(
             "/v1/image/edit",
             body,
-            "vc_user_key",
+            "VENICE_INFERENCE_KEY_user",
         )?)
         .await
     {
@@ -1190,12 +1213,13 @@ struct FakeGenerator;
 #[async_trait]
 impl Generator for FakeGenerator {
     async fn generate(&self, request: GenerationRequest) -> Result<GeneratedNote, DomainError> {
-        let content =
-            if request.provider_credentials.venice_api_key.as_deref() == Some("vc_user_key") {
-                "Generated note body with user Venice key"
-            } else {
-                "Generated note body"
-            };
+        let content = if request.provider_credentials.venice_api_key.as_deref()
+            == Some("VENICE_INFERENCE_KEY_user")
+        {
+            "Generated note body with user Venice key"
+        } else {
+            "Generated note body"
+        };
         Ok(GeneratedNote {
             content: content.to_string(),
             title_suggestion: Some("Generated title".to_string()),

--- a/june-api/crates/providers/src/venice.rs
+++ b/june-api/crates/providers/src/venice.rs
@@ -7,7 +7,10 @@ use june_domain::{
     CleanupRequest, DomainError, GeneratedNote, GenerationRequest, Generator, ProviderCredentials,
     TokenUsage, Transcriber, Transcript, TranscriptionRequest,
 };
-use reqwest::multipart::{Form, Part};
+use reqwest::{
+    StatusCode,
+    multipart::{Form, Part},
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -194,6 +197,9 @@ impl VeniceTranscriber {
             let retryable = retry::is_retryable_status(status);
             let body = response.text().await.unwrap_or_default();
             tracing::error!(%status, %url, model = %model_id, body_bytes = body.len(), retryable, "venice: non-success response");
+            if let Some(error) = user_venice_key_auth_error(status, &request.provider_credentials) {
+                return Err(UpstreamAttemptError::fatal(error));
+            }
             return Err(UpstreamAttemptError {
                 error: DomainError::UpstreamProvider,
                 retryable,
@@ -401,12 +407,11 @@ impl VeniceChat {
     ) -> Result<ChatCompletionResponse, DomainError> {
         body.messages.insert(0, ChatMessage::safety_context());
         let url = format!("{}/chat/completions", self.base_url);
-        let api_key = venice_api_key(&self.api_key, provider_credentials);
         // Bounded retry on transient failures — same rationale as the
         // transcribers: metering settles only after success, so a replay
         // can never double-charge.
         for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-            let error = match self.complete_once(&url, &body, api_key).await {
+            let error = match self.complete_once(&url, &body, provider_credentials).await {
                 Ok(parsed) => return Ok(parsed),
                 Err(error) => error,
             };
@@ -429,8 +434,9 @@ impl VeniceChat {
         &self,
         url: &str,
         body: &ChatCompletionRequest,
-        api_key: &str,
+        provider_credentials: &ProviderCredentials,
     ) -> Result<ChatCompletionResponse, UpstreamAttemptError> {
+        let api_key = venice_api_key(&self.api_key, provider_credentials);
         let response = self
             .http
             .post(url)
@@ -451,6 +457,9 @@ impl VeniceChat {
             let retryable = retry::is_retryable_status(status);
             let body_text = response.text().await.unwrap_or_default();
             tracing::error!(%status, %url, model = %body.model, body_bytes = body_text.len(), retryable, "venice: chat non-success response");
+            if let Some(error) = user_venice_key_auth_error(status, provider_credentials) {
+                return Err(UpstreamAttemptError::fatal(error));
+            }
             return Err(UpstreamAttemptError {
                 error: DomainError::UpstreamProvider,
                 retryable,
@@ -535,6 +544,9 @@ impl VeniceChat {
                 error_detail = %error_detail,
                 "venice: agent chat non-success response"
             );
+            if let Some(error) = user_venice_key_auth_error(status, provider_credentials) {
+                return Err(error);
+            }
             return Err(DomainError::UpstreamProvider);
         }
         let usage = usage_from_chat_body(&body, &content_type)?;
@@ -567,6 +579,21 @@ fn venice_api_key<'a>(configured: &'a str, credentials: &'a ProviderCredentials)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(configured)
+}
+
+pub(crate) fn user_venice_key_auth_error(
+    status: StatusCode,
+    credentials: &ProviderCredentials,
+) -> Option<DomainError> {
+    if credentials.has_venice_api_key()
+        && matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+    {
+        Some(DomainError::InvalidInput {
+            reason: "venice_api_key_rejected".to_string(),
+        })
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1121,7 +1148,7 @@ mod tests {
     use june_config::ModelType;
     use june_config::UpstreamConfig;
     use june_domain::{
-        AgentChatCompleter, AgentChatRequest, GenerationRequest, Generator, ModelId,
+        AgentChatCompleter, AgentChatRequest, DomainError, GenerationRequest, Generator, ModelId,
         ProviderCredentials,
     };
     use pretty_assertions::assert_eq;
@@ -1516,6 +1543,47 @@ mod tests {
 
         assert_eq!(completion.usage.prompt_tokens, 1);
         assert_eq!(completion.usage.completion_tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn agent_chat_reports_rejected_user_venice_key() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer VENICE_INFERENCE_KEY_bad"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "error": "Invalid API key"
+            })))
+            .mount(&server)
+            .await;
+        let agent = VeniceAgentChat::from_config(
+            http::default_client(),
+            &UpstreamConfig {
+                api_key: "shared_venice_key".to_string(),
+                base_url: server.uri(),
+            },
+        );
+
+        let error = agent
+            .complete(AgentChatRequest {
+                body: json!({
+                    "model": "text-model",
+                    "messages": [{ "role": "user", "content": "hi" }],
+                }),
+                model: ModelId("text-model".to_string()),
+                provider_credentials: ProviderCredentials {
+                    venice_api_key: Some("VENICE_INFERENCE_KEY_bad".to_string()),
+                },
+            })
+            .await
+            .expect_err("bad user key should be rejected");
+
+        assert_eq!(
+            error,
+            DomainError::InvalidInput {
+                reason: "venice_api_key_rejected".to_string()
+            }
+        );
     }
 
     #[tokio::test]

--- a/june-api/crates/providers/src/venice_augment.rs
+++ b/june-api/crates/providers/src/venice_augment.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     retry::{self, UpstreamAttemptError},
-    venice::PROVIDER_NAME,
+    venice::{PROVIDER_NAME, user_venice_key_auth_error},
 };
 use async_trait::async_trait;
 use june_config::UpstreamConfig;
@@ -61,9 +61,11 @@ impl VeniceAugment {
             url: format!("{}{}", self.base_url, endpoint.path),
             client_error_reason: endpoint.client_error_reason,
         };
-        let api_key = venice_api_key(&self.api_key, provider_credentials);
         for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-            let error = match self.post_augment_once(&endpoint, body, api_key).await {
+            let error = match self
+                .post_augment_once(&endpoint, body, provider_credentials)
+                .await
+            {
                 Ok(parsed) => return Ok(parsed),
                 Err(error) => error,
             };
@@ -81,12 +83,13 @@ impl VeniceAugment {
         &self,
         endpoint: &ResolvedAugmentEndpoint,
         body: &B,
-        api_key: &str,
+        provider_credentials: &ProviderCredentials,
     ) -> Result<T, UpstreamAttemptError>
     where
         B: Serialize,
         T: DeserializeOwned,
     {
+        let api_key = venice_api_key(&self.api_key, provider_credentials);
         let response = self
             .http
             .post(&endpoint.url)
@@ -115,6 +118,9 @@ impl VeniceAugment {
                 return Err(UpstreamAttemptError::fatal(DomainError::InvalidInput {
                     reason: endpoint.client_error_reason.to_string(),
                 }));
+            }
+            if let Some(error) = user_venice_key_auth_error(status, provider_credentials) {
+                return Err(UpstreamAttemptError::fatal(error));
             }
             return Err(UpstreamAttemptError {
                 error: DomainError::UpstreamProvider,

--- a/june-api/crates/providers/src/venice_image.rs
+++ b/june-api/crates/providers/src/venice_image.rs
@@ -8,7 +8,7 @@
 //! user-supplied Venice key for the upstream call.
 
 use crate::retry::{self, UpstreamAttemptError};
-use crate::venice::PROVIDER_NAME;
+use crate::venice::{PROVIDER_NAME, user_venice_key_auth_error};
 use async_trait::async_trait;
 use june_config::UpstreamConfig;
 use june_domain::{
@@ -50,8 +50,9 @@ impl VeniceImageGenerator {
         &self,
         url: &str,
         body: &VeniceImageRequest<'_>,
-        api_key: &str,
+        provider_credentials: &ProviderCredentials,
     ) -> Result<VeniceImageResponse, UpstreamAttemptError> {
+        let api_key = venice_api_key(&self.api_key, provider_credentials);
         let response = self
             .http
             .post(url)
@@ -80,6 +81,9 @@ impl VeniceImageGenerator {
                 return Err(UpstreamAttemptError::fatal(DomainError::InvalidInput {
                     reason: "image_generation_rejected".to_string(),
                 }));
+            }
+            if let Some(error) = user_venice_key_auth_error(status, provider_credentials) {
+                return Err(UpstreamAttemptError::fatal(error));
             }
             return Err(UpstreamAttemptError {
                 error: DomainError::UpstreamProvider,
@@ -117,7 +121,6 @@ impl ImageGenerator for VeniceImageGenerator {
             safe_mode: request.safe_mode,
         };
         let url = format!("{}/image/generate", self.base_url);
-        let api_key = venice_api_key(&self.api_key, &request.provider_credentials);
         // Bounded retry on transient failures (connection reset, 429, 5xx),
         // same as the chat and augment paths. The service settles at most one
         // June charge after this call returns; a retry can cost at most one
@@ -128,7 +131,10 @@ impl ImageGenerator for VeniceImageGenerator {
         // expiring the credit hold before settlement.
         let attempts = async {
             for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-                let error = match self.generate_once(&url, &body, api_key).await {
+                let error = match self
+                    .generate_once(&url, &body, &request.provider_credentials)
+                    .await
+                {
                     Ok(parsed) => return image_from_response(parsed, &request.model.0),
                     Err(error) => error,
                 };

--- a/june-api/crates/providers/src/venice_image_edit.rs
+++ b/june-api/crates/providers/src/venice_image_edit.rs
@@ -8,7 +8,7 @@
 //! charge) lives in the service; this provider does inference only.
 
 use crate::retry::{self, UpstreamAttemptError};
-use crate::venice::PROVIDER_NAME;
+use crate::venice::{PROVIDER_NAME, user_venice_key_auth_error};
 use async_trait::async_trait;
 use base64::Engine as _;
 use june_config::UpstreamConfig;
@@ -50,8 +50,9 @@ impl VeniceImageEditor {
         &self,
         url: &str,
         body: &VeniceImageEditBody<'_>,
-        api_key: &str,
+        provider_credentials: &ProviderCredentials,
     ) -> Result<GeneratedImage, UpstreamAttemptError> {
+        let api_key = venice_api_key(&self.api_key, provider_credentials);
         let response = self
             .http
             .post(url)
@@ -79,6 +80,9 @@ impl VeniceImageEditor {
                 return Err(UpstreamAttemptError::fatal(DomainError::InvalidInput {
                     reason: "image_edit_rejected".to_string(),
                 }));
+            }
+            if let Some(error) = user_venice_key_auth_error(status, provider_credentials) {
+                return Err(UpstreamAttemptError::fatal(error));
             }
             return Err(UpstreamAttemptError {
                 error: DomainError::UpstreamProvider,
@@ -127,14 +131,16 @@ impl ImageEditor for VeniceImageEditor {
             safe_mode: request.safe_mode,
         };
         let url = format!("{}/image/edit", self.base_url);
-        let api_key = venice_api_key(&self.api_key, &request.provider_credentials);
         // Bounded retry on transient failures, same as the generator. The
         // service charges once AFTER a successful edit, so a retry never
         // double-charges; at most one extra upstream edit if a completed
         // response was lost, bounded by UPSTREAM_ATTEMPTS.
         let attempts = async {
             for attempt in 0..retry::UPSTREAM_ATTEMPTS {
-                let error = match self.edit_once(&url, &body, api_key).await {
+                let error = match self
+                    .edit_once(&url, &body, &request.provider_credentials)
+                    .await
+                {
                     Ok(image) => return Ok(image),
                     Err(error) => error,
                 };

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -1529,6 +1529,18 @@ where
             "Your balance is too low. Upgrade to continue.",
         ));
     }
+    if envelope.message.as_deref() == Some("venice_api_key_invalid") {
+        return Err(AppError::new(
+            "venice_api_key_invalid",
+            "Your saved Venice API key is not an inference key. Open Settings and paste a key that starts with VENICE_INFERENCE_KEY_.",
+        ));
+    }
+    if envelope.message.as_deref() == Some("venice_api_key_rejected") {
+        return Err(AppError::new(
+            "venice_api_key_rejected",
+            "Venice rejected your saved API key. Open Settings and update it.",
+        ));
+    }
     let _ = path;
     let mut error = AppError::new(
         "june_request_failed",
@@ -1811,6 +1823,31 @@ mod tests {
                 .and_then(|value| value.as_u64()),
             Some(2_000)
         );
+    }
+
+    #[test]
+    fn venice_api_key_errors_are_mapped_to_user_action() {
+        let Err(invalid) = parse_response_body::<GenerateResponse>(
+            "/v1/notes/generate",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            r#"{"data":null,"success":false,"error_code":4000,"message":"venice_api_key_invalid"}"#,
+        ) else {
+            panic!("invalid Venice key should fail");
+        };
+        assert_eq!(invalid.code, "venice_api_key_invalid");
+        assert!(invalid.message.contains("VENICE_INFERENCE_KEY_"));
+
+        let Err(rejected) = parse_response_body::<GenerateResponse>(
+            "/v1/notes/generate",
+            reqwest::StatusCode::BAD_REQUEST,
+            None,
+            r#"{"data":null,"success":false,"error_code":4000,"message":"venice_api_key_rejected"}"#,
+        ) else {
+            panic!("rejected Venice key should fail");
+        };
+        assert_eq!(rejected.code, "venice_api_key_rejected");
+        assert!(rejected.message.contains("update it"));
     }
 
     #[test]

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -21,6 +21,9 @@ pub const PROVIDER_LOCAL: &str = "local";
 pub const DEFAULT_TRANSCRIPTION_MODEL: &str = "nvidia/parakeet-tdt-0.6b-v3";
 pub const DEFAULT_GENERATION_MODEL: &str = "zai-org-glm-5-2";
 pub const DEFAULT_IMAGE_MODEL: &str = "venice-sd35";
+const VENICE_API_KEY_PREFIX: &str = "VENICE_INFERENCE_KEY_";
+const VENICE_API_BASE_URL: &str = "https://api.venice.ai/api/v1";
+const VENICE_API_KEY_VERIFY_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_VENICE_API_KEY_CHARS: usize = 4_096;
 
 // Kept exported under the legacy names so existing callers compile until they
@@ -29,6 +32,7 @@ pub use PROVIDER_OPENAI as OPENAI_PROVIDER;
 pub use PROVIDER_VENICE as VENICE_PROVIDER;
 
 static MODEL_SETTINGS: OnceLock<Mutex<ProviderModelSettings>> = OnceLock::new();
+static VENICE_VERIFY_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 pub struct ProviderSettingsState {
     path: PathBuf,
@@ -491,16 +495,18 @@ pub async fn edit_image(
 }
 
 #[tauri::command]
-pub fn set_venice_api_key(
+pub async fn set_venice_api_key(
     state: State<'_, ProviderSettingsState>,
     request: SetVeniceApiKeyRequest,
 ) -> Result<ProviderModelSettingsDto, AppError> {
-    let api_key = normalize_api_key_for_save(&request.api_key).ok_or_else(|| {
+    let api_key = normalize_api_key(&request.api_key).ok_or_else(|| {
         AppError::new(
             "venice_api_key_required",
             "Enter a Venice API key before saving.",
         )
     })?;
+    validate_venice_api_key_format(&api_key)?;
+    verify_venice_api_key(&api_key).await?;
     update_settings(&state, |settings| {
         settings.venice_api_key = Some(api_key);
     })
@@ -866,9 +872,7 @@ fn normalize_api_key_option(value: Option<String>) -> Option<String> {
 
 fn normalize_api_key_for_save(value: &str) -> Option<String> {
     let value = normalize_api_key(value)?;
-    if value.chars().count() > MAX_VENICE_API_KEY_CHARS
-        || value.chars().any(|character| character.is_control())
-    {
+    if value.chars().count() > MAX_VENICE_API_KEY_CHARS || value.chars().any(char::is_control) {
         None
     } else {
         Some(value)
@@ -882,6 +886,64 @@ fn normalize_api_key(value: &str) -> Option<String> {
     } else {
         Some(value.to_string())
     }
+}
+
+fn validate_venice_api_key_format(value: &str) -> Result<(), AppError> {
+    if !value.starts_with(VENICE_API_KEY_PREFIX) {
+        return Err(AppError::new(
+            "venice_api_key_invalid",
+            "Venice API keys must start with VENICE_INFERENCE_KEY_.",
+        ));
+    }
+    if value.chars().count() > MAX_VENICE_API_KEY_CHARS
+        || value.chars().any(|character| character.is_control())
+    {
+        return Err(AppError::new(
+            "venice_api_key_invalid",
+            "Enter a valid Venice API key.",
+        ));
+    }
+    Ok(())
+}
+
+async fn verify_venice_api_key(api_key: &str) -> Result<(), AppError> {
+    let url = format!("{VENICE_API_BASE_URL}/models");
+    let response = venice_verify_http_client()
+        .get(&url)
+        .query(&[("type", "text")])
+        .bearer_auth(api_key)
+        .send()
+        .await
+        .map_err(|_| {
+            AppError::new(
+                "venice_api_key_verification_failed",
+                "Could not verify the Venice API key. Check your connection and try again.",
+            )
+        })?;
+    match response.status() {
+        reqwest::StatusCode::OK => Ok(()),
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => Err(AppError::new(
+            "venice_api_key_rejected",
+            "Venice rejected this API key. Check the key and try again.",
+        )),
+        _ => Err(AppError::new(
+            "venice_api_key_verification_failed",
+            "Could not verify the Venice API key. Try again later.",
+        )),
+    }
+}
+
+fn venice_verify_http_client() -> &'static reqwest::Client {
+    VENICE_VERIFY_HTTP_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .no_proxy()
+            .timeout(VENICE_API_KEY_VERIFY_TIMEOUT)
+            .pool_idle_timeout(Duration::from_secs(90))
+            .tcp_keepalive(Some(Duration::from_secs(30)))
+            .user_agent("os-june/0.1")
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    })
 }
 
 fn non_empty_or(value: String, fallback: &str) -> String {
@@ -1117,6 +1179,29 @@ mod tests {
         assert_eq!(sanitized.generation_provider, PROVIDER_VENICE);
         assert_eq!(sanitized.generation_model, "custom-remote-model");
         assert_eq!(sanitized.remote_generation_model, "custom-remote-model");
+    }
+
+    #[test]
+    fn venice_api_key_requires_inference_prefix() {
+        assert_eq!(
+            validate_venice_api_key_format("sk_wrong").unwrap_err().code,
+            "venice_api_key_invalid"
+        );
+        assert!(validate_venice_api_key_format("VENICE_INFERENCE_KEY_valid").is_ok());
+    }
+
+    #[test]
+    fn sanitize_settings_preserves_legacy_venice_api_key_for_actionable_error() {
+        let settings = ProviderModelSettings {
+            venice_api_key: Some("not-a-venice-inference-key".to_string()),
+            ..default_settings()
+        };
+        let sanitized = sanitize_settings(settings, &default_settings());
+
+        assert_eq!(
+            sanitized.venice_api_key.as_deref(),
+            Some("not-a-venice-inference-key")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require newly saved and user-supplied Venice API keys to use the `VENICE_INFERENCE_KEY_` prefix
- verify saved Venice keys against Venice `/models` before persisting them using a pooled Tauri HTTP client
- preserve legacy saved keys so existing users get an explicit `venice_api_key_invalid` message instead of a silent fallback
- return `venice_api_key_invalid` / `venice_api_key_rejected` instead of generic upstream failures when user-provided keys are malformed or rejected

## Tests
- `cargo test --manifest-path src-tauri/Cargo.toml venice_api_key --lib`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --all-targets --all-features --locked -- -D warnings` (from `june-api/`)
- `cargo test -p june-api --all-features --locked`
- `cargo test -p june-providers --all-features --locked -- --test-threads=1`

Note: an unconstrained local `cargo test -p june-providers --all-features --locked` hit OS file descriptor exhaustion from concurrent wiremock/JWKS tests; the same package passed serially.