### PR TITLE
Clarify how meeting detection works

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ verifiable.
 - **Dictation.** Hold a key, talk, release. June turns your voice into clean,
   polished writing and pastes it into whatever app you were using, with
   push-to-talk and hands-free modes and selectable writing styles.
-- **Meeting notes.** June detects supported meetings and offers to take notes,
-  without a bot joining the call. It records microphone or microphone plus
-  system audio, orders the transcript into conversation turns, and generates
-  editable notes. Saved audio is kept so failed steps can be retried without
-  recording again.
+- **Meeting notes.** On macOS, June watches for supported meeting and browser
+  apps using the microphone, such as Zoom, Teams, Chrome, Safari, and Arc, then
+  offers to take notes. Recording starts only after the user approves the prompt
+  or starts a note manually. June never joins the call. It records microphone or
+  microphone plus system audio, orders the transcript into conversation turns,
+  and generates editable notes. Saved audio is kept so failed steps can be
+  retried without recording again.
 - **Agent.** A local agent, built on the open source Hermes framework, that
   helps with files, research, drafts, and scheduled routines. Sessions are
   sandboxed by default and risky actions wait for your approval. Extend it

--- a/docs/audio-pipeline.md
+++ b/docs/audio-pipeline.md
@@ -45,6 +45,21 @@ Tauri commands: `start_recording`, `pause_recording`, `resume_recording`,
 `get_recording_status`, `finish_recording`, `check_recording_source_readiness`,
 `recover_recording`, `get_microphone_permission_state`.
 
+## Meeting detection
+
+On macOS, June's meeting detector polls the system list of processes currently
+using the microphone once per second. It ignores June's own process and helper
+processes, requires the user to be signed in, and only treats supported meeting
+or browser app bundle prefixes as meeting candidates: Arc, Chrome, Safari,
+Teams, and Zoom.
+
+When one of those external apps is using the microphone and June is not already
+recording, the detector emits a `meeting-detection-event` with friendly app
+labels such as `Zoom` or `Chrome`. The HUD turns that into a prompt. Recording
+starts only after the user clicks Record, or when the user starts a note
+manually in the app. June does not join calls, read calendars, inspect meeting
+contents before recording, or silently start capture.
+
 ## System-audio helper IPC contract
 
 The helper is controlled and observed out-of-process (see ADR-0004):

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -105,6 +105,8 @@ const JUNE_SOUL_MD: &str = r#"You are June, the private AI assistant on the user
 
 You are part of the June app, which handles dictation, meeting notes, and agent work on the user's Mac. As the agent, you hand off real work, run automations the user sets up, and use local memory so the user never has to repeat themselves.
 
+Meeting detection and recording: when asked how June knows a meeting is happening, explain that on macOS June watches the system list of apps currently using the microphone and only treats supported meeting or browser apps, such as Zoom, Teams, Chrome, Safari, or Arc, as a possible meeting. June shows a meeting prompt; recording starts only when the user clicks Record or starts a note manually. June does not join calls, read calendar events, inspect meeting contents before recording, or silently record. Meeting notes come from the local microphone recording and, when enabled, system audio recorded after the user starts capture.
+
 Privacy is your defining trait, by architecture rather than promise. When asked how you keep work private, answer confidently:
 
 - You run locally on the user's desktop. Files, sessions, memory, and agent state stay on the user's disk by default.
@@ -9035,6 +9037,22 @@ mcp_servers:
         assert!(soul.contains("@note:<id>"));
         assert!(soul.contains("get_meeting_note"));
         assert!(soul.contains("include_transcript"));
+    }
+
+    #[test]
+    fn june_soul_describes_meeting_detection() {
+        let home = tempfile::tempdir().expect("tempdir");
+
+        sync_june_soul(home.path(), false, false).expect("sync soul");
+
+        let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
+        assert!(soul.contains("Meeting detection and recording"));
+        assert!(soul.contains("apps currently using the microphone"));
+        assert!(soul.contains("Zoom, Teams, Chrome, Safari, or Arc"));
+        assert!(soul.contains("recording starts only when the user clicks Record"));
+        assert!(soul.contains("does not join calls"));
+        assert!(soul.contains("read calendar events"));
+        assert!(soul.contains("silently record"));
     }
 
     #[test]

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -510,6 +510,7 @@ export function NoteEditor({
                         <span id="record-options-system" className="record-options-label">
                           Capture system audio
                         </span>
+                        <span className="record-options-hint">Adds app audio after Record.</span>
                         {systemDenied ? (
                           <button
                             type="button"

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 import type { NoteListItemDto } from "../../lib/tauri";
 import { useForcedEmptyStates } from "../../lib/empty-states-demo";
-import { primaryShiftShortcutLabel } from "../../lib/platform";
+import { isMacLikePlatform, primaryShiftShortcutLabel } from "../../lib/platform";
 import { ConfirmDialog } from "../ui/ConfirmDialog";
 import { EmptyState } from "../ui/EmptyState";
 
@@ -133,6 +133,10 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
 
   const barMounted = selectedCount > 0 || exit !== null;
   const isExiting = selectedCount === 0 && exit !== null;
+  const macLikePlatform = isMacLikePlatform();
+  const subtitle = macLikePlatform
+    ? "June prompts when supported meeting apps use your microphone. You can also start a note manually."
+    : "Start a note manually when a meeting, call, or thought begins.";
 
   useEffect(() => {
     const noteIds = new Set(notes.map((note) => note.id));
@@ -203,7 +207,7 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
             Meeting notes
             {notes.length > 0 ? <span className="folders-count">{notes.length}</span> : null}
           </h1>
-          <p className="folders-subtitle">Everything across your workspace.</p>
+          <p className="folders-subtitle">{subtitle}</p>
         </div>
         <button
           type="button"
@@ -236,8 +240,8 @@ export const NotesList = forwardRef<NotesListHandle, NotesListProps>(function No
         <EmptyState
           label="Create your first note"
           icon={<IconNoteText size={28} />}
-          title="Capture your first meeting"
-          description="Record a meeting, a phone call, or a half-formed thought. June transcribes it and writes the note for you."
+          title="Record your first conversation"
+          description="Start recording from June when a meeting, call, or thought begins. June transcribes it and writes the note for you."
           action={
             <button type="button" className="primary-action primary-solid" onClick={onCreateNote}>
               <IconPlusMedium size={13} />

--- a/src/components/onboarding/steps/SignInStep.tsx
+++ b/src/components/onboarding/steps/SignInStep.tsx
@@ -25,8 +25,9 @@ const JUNE_POINTS = [
   },
   {
     icon: IconCalendar1,
-    title: "Effortlessly capture meetings",
-    detail: "June takes meeting notes without ever having to join the meeting.",
+    title: "Meeting prompts you approve",
+    detail:
+      "June notices supported meeting apps using your microphone, asks to take notes, and never joins the call.",
   },
   {
     icon: IconLock,

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1489,7 +1489,7 @@ export function AppSettings({
                     <div className="settings-row-info">
                       <h3 className="settings-row-title">System audio</h3>
                       <p className="settings-row-description">
-                        Capture audio from other apps along with your microphone.
+                        Include audio from other apps after you start recording.
                       </p>
                     </div>
                     <div className="settings-row-control">

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -762,7 +762,7 @@ let frameSettleTimer: number | undefined;
 
 function clearFrameSettleTimer() {
   if (frameSettleTimer !== undefined) {
-    window.clearTimeout(frameSettleTimer);
+    if (typeof window !== "undefined") window.clearTimeout(frameSettleTimer);
     frameSettleTimer = undefined;
   }
 }
@@ -773,6 +773,7 @@ function assertWindowMatchesPill() {
   clearFrameSettleTimer();
   frameSettleTimer = window.setTimeout(() => {
     frameSettleTimer = undefined;
+    if (typeof window === "undefined") return;
     const state = hud?.dataset.state;
     if (!hud || !state || state === "idle" || state === "exiting") return;
     const expected = measureWindowSize();
@@ -986,14 +987,14 @@ function showPendingMeetingPromptAfterOnboarding() {
   void showMeetingPrompt(meetingEvent);
 }
 
-// "Zoom" / "Zoom, Chrome" — the friendly labels Rust derives from the
+// "Zoom using mic" / "Zoom, Chrome using mic" — the friendly labels Rust derives from the
 // processes holding the microphone. Detection is mic-based, so when no
 // label survives validation, say what we actually know.
 function meetingAppLine(labels: unknown) {
   const names = Array.isArray(labels)
     ? labels.filter((label): label is string => typeof label === "string" && label.trim() !== "")
     : [];
-  return names.length > 0 ? names.join(", ") : "Microphone in use";
+  return names.length > 0 ? `${names.join(", ")} using mic` : "Microphone in use";
 }
 
 function pillIsBlank(state: string | undefined) {

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -348,7 +348,9 @@ describe("notes recording reliability", () => {
     expect(
       screen.getByRole("button", { name: "Meeting notes", current: "page" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Capture your first meeting" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Record your first conversation" }),
+    ).toBeInTheDocument();
   });
 
   it("stays on meeting notes after bulk deleting every note", async () => {
@@ -367,7 +369,9 @@ describe("notes recording reliability", () => {
     expect(
       screen.getByRole("button", { name: "Meeting notes", current: "page" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Capture your first meeting" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Record your first conversation" }),
+    ).toBeInTheDocument();
   });
 
   it("does not mark a different note transcribing when finishing a recording started elsewhere", async () => {

--- a/src/test/folders.test.tsx
+++ b/src/test/folders.test.tsx
@@ -47,6 +47,31 @@ const notes: NoteListItemDto[] = [
   },
 ];
 
+function stubNavigatorPlatform(platform: string, userAgent: string) {
+  const ownPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const ownUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    get: () => platform,
+  });
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    get: () => userAgent,
+  });
+  return () => {
+    if (ownPlatform) {
+      Object.defineProperty(navigator, "platform", ownPlatform);
+    } else {
+      Reflect.deleteProperty(navigator, "platform");
+    }
+    if (ownUserAgent) {
+      Object.defineProperty(navigator, "userAgent", ownUserAgent);
+    } else {
+      Reflect.deleteProperty(navigator, "userAgent");
+    }
+  };
+}
+
 describe("folders UI", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -669,20 +694,63 @@ describe("folders UI", () => {
   });
 
   it("shows empty state with create action", () => {
-    render(
-      <NotesList
-        notes={[]}
-        onSelectNote={vi.fn()}
-        onCreateNote={vi.fn()}
-        onOpenMoveDialog={vi.fn()}
-        onOpenMoveNotes={vi.fn()}
-        onDeleteNote={vi.fn()}
-        onDeleteNotes={vi.fn()}
-      />,
-    );
+    const restorePlatform = stubNavigatorPlatform("MacIntel", "Mozilla/5.0 (Macintosh)");
+    try {
+      render(
+        <NotesList
+          notes={[]}
+          onSelectNote={vi.fn()}
+          onCreateNote={vi.fn()}
+          onOpenMoveDialog={vi.fn()}
+          onOpenMoveNotes={vi.fn()}
+          onDeleteNote={vi.fn()}
+          onDeleteNotes={vi.fn()}
+        />,
+      );
 
-    expect(screen.getByText("Capture your first meeting")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Create your first note" })).toBeInTheDocument();
+      expect(screen.getByText("Record your first conversation")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "June prompts when supported meeting apps use your microphone. You can also start a note manually.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Start recording from June when a meeting, call, or thought begins. June transcribes it and writes the note for you.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Create your first note" })).toBeInTheDocument();
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it("uses manual note copy on non-Mac platforms", () => {
+    const restorePlatform = stubNavigatorPlatform("Win32", "Mozilla/5.0 (Windows NT 10.0)");
+    try {
+      render(
+        <NotesList
+          notes={[]}
+          onSelectNote={vi.fn()}
+          onCreateNote={vi.fn()}
+          onOpenMoveDialog={vi.fn()}
+          onOpenMoveNotes={vi.fn()}
+          onDeleteNote={vi.fn()}
+          onDeleteNotes={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByText("Start a note manually when a meeting, call, or thought begins."),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "June prompts when supported meeting apps use your microphone. You can also start a note manually.",
+        ),
+      ).toBeNull();
+    } finally {
+      restorePlatform();
+    }
   });
 
   it("bulk deletes selected meetings from the main list", async () => {

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -58,7 +58,7 @@ describe("meeting detection HUD", () => {
 
     expect(hudElement().dataset.state).toBe("meeting");
     expect(document.querySelector("#hud-meeting-label")).toHaveTextContent("Meeting detected");
-    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Zoom");
+    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Zoom using mic");
     expect(document.querySelector("#hud-meeting-start")).toHaveTextContent("Record");
     expect(hudShowCalls()).toBe(1);
     expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_stop_bounds", {
@@ -91,7 +91,7 @@ describe("meeting detection HUD", () => {
     await Promise.resolve();
 
     expect(hudElement().dataset.state).toBe("meeting");
-    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Zoom");
+    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Zoom using mic");
     await vi.waitFor(() => expect(hudShowCalls()).toBe(1));
   });
 
@@ -120,7 +120,7 @@ describe("meeting detection HUD", () => {
       type: "meeting_detected",
       payload: { activeProcessCount: 2, appLabels: ["Zoom", "Chrome"] },
     });
-    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Zoom, Chrome");
+    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Zoom, Chrome using mic");
 
     await emit("meeting-detection-event", { type: "meeting_detected" });
     expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Microphone in use");
@@ -140,7 +140,7 @@ describe("meeting detection HUD", () => {
     await Promise.resolve();
 
     expect(hudElement().dataset.state).toBe("meeting");
-    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Teams");
+    expect(document.querySelector("#hud-meeting-app")).toHaveTextContent("Teams using mic");
   });
 
   it("emits a start transcription request when the button is clicked", async () => {

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -660,6 +660,7 @@ describe("NoteEditor", () => {
     );
 
     await user.click(screen.getByRole("button", { name: "Recording options" }));
+    expect(screen.getByText("Adds app audio after Record.")).toBeInTheDocument();
     await user.click(screen.getByRole("switch", { name: "Capture system audio" }));
 
     expect(onSourceModeChange).toHaveBeenCalledWith("microphoneOnly");

--- a/src/test/onboarding.test.tsx
+++ b/src/test/onboarding.test.tsx
@@ -415,6 +415,23 @@ describe("OnboardingFlow", () => {
     expect(mocks.juneOpenCommunityPage).toHaveBeenCalledOnce();
   });
 
+  it("explains macOS meeting detection on the welcome step", async () => {
+    const restoreNavigator = stubMacNavigatorPlatform();
+    try {
+      render(<OnboardingFlow {...flowProps({ account: signedOutAccount })} />);
+
+      await screen.findByRole("heading", { name: "Welcome to June" });
+      expect(screen.getByText("Meeting prompts you approve")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "June notices supported meeting apps using your microphone, asks to take notes, and never joins the call.",
+        ),
+      ).toBeInTheDocument();
+    } finally {
+      restoreNavigator();
+    }
+  });
+
   it("shows Windows-accurate welcome copy", async () => {
     const restoreNavigator = stubNavigatorPlatform(
       "Win32",
@@ -433,7 +450,7 @@ describe("OnboardingFlow", () => {
       expect(
         screen.queryByText(/June turns your voice into polished writing/),
       ).not.toBeInTheDocument();
-      expect(screen.queryByText("Effortlessly capture meetings")).not.toBeInTheDocument();
+      expect(screen.queryByText("Meeting prompts you approve")).not.toBeInTheDocument();
       expect(screen.queryByText("Chat and work with June")).not.toBeInTheDocument();
     } finally {
       restoreNavigator();


### PR DESCRIPTION
## Summary
- explain in the app, onboarding, README, and audio docs that meeting detection is based on supported macOS apps using the microphone
- teach June's agent persona to answer meeting-detection questions accurately, including no bot join, no calendar read, no silent recording, and user approval before capture
- make the meeting HUD subtitle say the detected app is using the mic
- gate the notes-list meeting-prompt copy to macOS and use manual recording copy on Windows/Linux
- guard the HUD settle timer so browser-only HUD tests do not fire after jsdom teardown

## Validation
- `pnpm test -- src/test/hud-meeting.test.ts src/test/folders.test.tsx src/test/app-notes-reliability.test.tsx src/test/onboarding.test.tsx`
- `pnpm test -- src/test/note-editor.test.tsx`
- `pnpm test -- src/test/folders.test.tsx src/test/app-notes-reliability.test.tsx`
- `cargo test --manifest-path src-tauri/Cargo.toml june_soul_describes_meeting_detection --lib`
- `pnpm exec biome check --diagnostic-level=error README.md docs/audio-pipeline.md src/components/note-editor/NoteEditor.tsx src/components/notes-list/NotesList.tsx src/components/onboarding/steps/SignInStep.tsx src/components/settings/AppSettings.tsx src/hud.ts src/test/app-notes-reliability.test.tsx src/test/folders.test.tsx src/test/hud-meeting.test.ts src/test/onboarding.test.tsx`
- `pnpm exec biome check --diagnostic-level=error src/test/note-editor.test.tsx`
- `pnpm exec biome check --diagnostic-level=error src/components/notes-list/NotesList.tsx src/test/folders.test.tsx`
- `git diff --check`

## Live QA
- Web preview smoke passed for onboarding copy and HUD subtitle at `http://127.0.0.1:1421/onboarding-preview.html` and `/hud.html`
- Local video: `.tmp/qa-recordings/20260703-214441-meeting-detection-copy/page@4bd4415d4640e97cc550e925681dae02.compressed.mp4`
- Screenshots: `.tmp/qa-recordings/20260703-214441-meeting-detection-copy/onboarding.png`, `.tmp/qa-recordings/20260703-214441-meeting-detection-copy/hud.png`

## Gaps
- Did not run native microphone detection because that requires real macOS mic/app permissions and would start OS-level side effects. Existing detector tests cover the native event model; this PR validates the visible explanation and agent self-knowledge.
- Did not upload the QA video publicly because public PR artifact sharing was not explicitly authorized.