### PR TITLE
fix: resolve me/@me in os-platform assignee/creator filters

### DIFF
--- a/.agents/skills/os-platform/SKILL.md
+++ b/.agents/skills/os-platform/SKILL.md
@@ -14,6 +14,7 @@ Run commands from this skill directory:
 ```bash
 python3 scripts/os_platform.py status
 python3 scripts/os_platform.py issues list open-software --q "wallet" --limit 10
+python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo
 python3 scripts/os_platform.py issues show open-software 123
 python3 scripts/os_platform.py issues take open-software 123 --yes
@@ -45,7 +46,7 @@ Use the user prompt first, then `os-platform.json`, then ask the user for missin
 
 If the user asks for issues and omits org, read `os-platform.json`; if it has `org`, use it. If no org is available, ask the user which org to use before running the script.
 
-When the user asks for issues to work on, prioritize todo issues assigned to the user or with no assignee before other todo issues. If the user identity is unclear, prefer unassigned todo issues and ask which user handle to use for assigned work.
+When the user asks for their own tasks or issues assigned to them, pass `--assignee me` (the script resolves `me`/`@me` to the authenticated API user via `GET /v1/users/me`, so no handle lookup is needed). When the user asks for issues to work on generally, prioritize todo issues assigned to the user or with no assignee before other todo issues. If the user identity is unclear, prefer unassigned todo issues.
 
 ## Specific Issue Triage
 

--- a/.agents/skills/os-platform/references/api-map.md
+++ b/.agents/skills/os-platform/references/api-map.md
@@ -53,16 +53,19 @@ Use `real_paths` and `fixture_paths` from that response to decide whether a resu
 - `--status`
 - `--type`
 - `--priority`
-- `--assignee`
-- `--creator`
+- `--assignee` (accepts `me`/`@me`, resolved to the authenticated user's public id via `GET /v1/users/me`; `none` means unassigned)
+- `--creator` (also accepts `me`/`@me`)
 - `--project`
 - `--labels`
 - `--q`
+
+The `me`/`@me` sentinel is resolved locally before the request: the script calls `GET /v1/users/me` once when the token is present and substitutes the returned `public_id`. Any token in a CSV is resolved (e.g. `--assignee alice,me`).
 
 Examples:
 
 ```bash
 python3 scripts/os_platform.py issues list open-software --status todo,in_progress --priority high,urgent
+python3 scripts/os_platform.py issues list open-software --assignee me --status todo,in_progress
 python3 scripts/os_platform.py issues list open-software --project os-forge --q "wallet"
 python3 scripts/os_platform.py issues search open-software "wallet bug" --status todo --assignee none
 python3 scripts/os_platform.py issues take open-software 123 --yes

--- a/.agents/skills/os-platform/scripts/os_platform.py
+++ b/.agents/skills/os-platform/scripts/os_platform.py
@@ -24,6 +24,7 @@ CONFIG_FILE_NAME = "os-platform.json"
 API_KEY_ENV = "OS_PLATFORM_API_KEY"
 BASE_URL_ENV = "OS_PLATFORM_API_BASE_URL"
 WORD_RE = re.compile(r"[a-z0-9]+")
+ME_TOKENS = {"me", "@me"}
 
 COMPACT_KEYS = {
     "id",
@@ -562,8 +563,8 @@ def add_issue_filters(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--status", help="CSV statuses: todo,in_progress,in_review,completed,cancelled.")
     parser.add_argument("--type", help="CSV issue types: feature,bug,improvement,design,docs,refactor,other.")
     parser.add_argument("--priority", help="CSV priorities: none,low,med,high,urgent.")
-    parser.add_argument("--assignee", help="CSV user refs or none.")
-    parser.add_argument("--creator", help="CSV user refs.")
+    parser.add_argument("--assignee", help="CSV user refs, me/@me for yourself, or none.")
+    parser.add_argument("--creator", help="CSV user refs, or me/@me for yourself.")
     parser.add_argument("--labels", help="CSV label slugs.")
     parser.add_argument("--q", help="Search issue title or external id.")
     parser.add_argument("--sort", help="created, created_asc, priority, reward, or status_grouped.")
@@ -678,6 +679,40 @@ def assign_issue_to_current_user(
         body=body,
     )
     return unwrap_envelope(payload)
+
+
+def csv_has_me_token(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return any(part.strip().lower() in ME_TOKENS for part in value.split(","))
+
+
+def resolve_me_tokens(value: str, public_id: str) -> str:
+    parts = [part.strip() for part in value.split(",")]
+    resolved = [public_id if part.lower() in ME_TOKENS else part for part in parts if part]
+    return ",".join(resolved)
+
+
+def resolve_self_refs(
+    args: argparse.Namespace,
+    *,
+    base_url: str,
+    api_key: str,
+    timeout: int,
+    request: Any = request_json,
+) -> None:
+    """Replace a ``me``/``@me`` sentinel in --assignee/--creator with the caller's public id."""
+    fields = [name for name in ("assignee", "creator") if csv_has_me_token(getattr(args, name, None))]
+    if not fields:
+        return
+    public_id = current_user_public_id(
+        base_url=base_url,
+        api_key=api_key,
+        timeout=timeout,
+        request=request,
+    )
+    for name in fields:
+        setattr(args, name, resolve_me_tokens(getattr(args, name), public_id))
 
 
 def command_to_request(args: argparse.Namespace) -> tuple[str, str, dict[str, Any]]:
@@ -855,6 +890,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     api_key = require_api_key(getattr(args, "api_key", None))
     base_url = normalize_base_url(args.base_url)
     try:
+        if args.resource == "issues" and getattr(args, "action", None) in {"list", "search"}:
+            resolve_self_refs(args, base_url=base_url, api_key=api_key, timeout=args.timeout)
+
         if args.resource == "issues" and args.action == "take":
             data = take_issue(
                 args.org,

--- a/.agents/skills/os-platform/scripts/test_os_platform.py
+++ b/.agents/skills/os-platform/scripts/test_os_platform.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Tests for the `me` self-reference resolution in os_platform.py."""
+
+import argparse
+import unittest
+
+import os_platform
+
+
+class ResolveMeTokensTest(unittest.TestCase):
+    def test_replaces_me_case_insensitively(self):
+        self.assertEqual(os_platform.resolve_me_tokens("me", "usr_1"), "usr_1")
+        self.assertEqual(os_platform.resolve_me_tokens("ME", "usr_1"), "usr_1")
+        self.assertEqual(os_platform.resolve_me_tokens("@me", "usr_1"), "usr_1")
+
+    def test_leaves_other_refs_and_none_untouched(self):
+        self.assertEqual(os_platform.resolve_me_tokens("none", "usr_1"), "none")
+        self.assertEqual(os_platform.resolve_me_tokens("alice,me", "usr_1"), "alice,usr_1")
+        self.assertEqual(os_platform.resolve_me_tokens("alice,bob", "usr_1"), "alice,bob")
+
+    def test_detects_me_token(self):
+        self.assertTrue(os_platform.csv_has_me_token("me"))
+        self.assertTrue(os_platform.csv_has_me_token("alice, @me"))
+        self.assertFalse(os_platform.csv_has_me_token("alice,bob"))
+        self.assertFalse(os_platform.csv_has_me_token(None))
+        self.assertFalse(os_platform.csv_has_me_token("none"))
+
+
+class ResolveSelfRefsTest(unittest.TestCase):
+    def _stub_request(self):
+        calls = []
+
+        def request(method, path, **_kwargs):
+            calls.append((method, path))
+            return {"success": True, "data": {"public_id": "usr_me", "handle": "caller"}}
+
+        return request, calls
+
+    def test_resolves_assignee_and_creator_with_single_lookup(self):
+        args = argparse.Namespace(assignee="me", creator="@me")
+        request, calls = self._stub_request()
+        os_platform.resolve_self_refs(
+            args, base_url="https://x", api_key="k", timeout=5, request=request
+        )
+        self.assertEqual(args.assignee, "usr_me")
+        self.assertEqual(args.creator, "usr_me")
+        self.assertEqual(calls, [("GET", "/v1/users/me")])
+
+    def test_no_lookup_when_no_me_token(self):
+        args = argparse.Namespace(assignee="alice", creator=None)
+        request, calls = self._stub_request()
+        os_platform.resolve_self_refs(
+            args, base_url="https://x", api_key="k", timeout=5, request=request
+        )
+        self.assertEqual(args.assignee, "alice")
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- The os-platform skill's `--assignee`/`--creator` filters require a concrete user ref (a `usr_...` public id or handle). Agents (and users) naturally reach for `--assignee me`, which the API treats as a literal ref and silently returns an empty list — so "show my assigned tasks" quietly returned nothing.
- This adds a `me`/`@me` sentinel that the script resolves locally to the authenticated caller's `public_id` (via the `GET /v1/users/me` call the skill already uses for `issues take`), then passes to the existing filter. Works in a CSV too (`--assignee alice,me`).
- Docs (SKILL.md, api-map.md) and `--help` updated so the shortcut is discoverable; new stdlib unit tests cover the resolution.

## Root cause

`--assignee me` was sent verbatim to `GET /v1/orgs/{org}/bounties?assignee=me`. There is no server-side `me` alias, so it matched no user and returned an empty `items` list with no error — indistinguishable from "you have no assigned issues".

## Validation

- `python3 -m unittest test_os_platform -v` — 5 passing (pure-function resolution + `resolve_self_refs` with a stubbed request asserting a single `/v1/users/me` lookup, and none when no `me` token is present).
- Live: `issues list june --assignee me --status todo,in_progress,in_review` now returns the 15 assigned issues; `@me` alias verified; unrelated lists make no extra `/v1/users/me` call (fetched lazily only when the token is present).

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording). <!-- N/A: CLI skill, no UI -->
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- No: client-side only, uses existing endpoints -->

## Out of scope

- No new mutation commands or subcommands (e.g. a dedicated `issues mine`); the sentinel reuses existing filters and the read-only surface is unchanged.
- No change to how `none` (unassigned) is handled.

## Followups

- Could extend the same `me` resolution to a `contributors show <org> me` shortcut if useful; deferred as unneeded for now.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary. <!-- none; read-only helper, no new writes -->
- [x] Workflow action references are pinned to full-length commit SHAs. <!-- N/A -->
- [x] Desktop signing, updater, entitlement, capability, or release changes have owner review. <!-- N/A -->
- [x] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. <!-- N/A -->
- [x] User-facing copy follows the repo UI conventions.

https://claude.ai/code/session_01Y6jAsYLmsZ8arat3uxsMNp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785916111&installation_id=144203540&pr_number=623&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F623&signature=bbc746c4ff4748bfba460176ea9c6edcd06c98c07571b1e59c1ecdb76069c601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->