### PR TITLE
fix(dev): ignore Rust target dirs in Vite watcher on Windows

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1421,
     strictPort: true,
+    // Vite's file watcher must not descend into the Rust build-output dirs.
+    // On Windows, cargo locks `.exe`/pdb files in `target/` while linking, and
+    // `fs.watch` throws EBUSY on locked files. An unhandled watcher error
+    // crashes Vite and tears down `tauri dev` mid-compile. macOS's FSEvents
+    // watcher doesn't hit this, so the gap only shows on Windows.
+    watch: {
+      ignored: ["**/src-tauri/target/**", "**/june-api/target/**"],
+    },
   },
   envPrefix: ["VITE_", "TAURI_"],
   build: {


### PR DESCRIPTION
## Summary
- Adds an explicit `server.watch.ignored` list in `vite.config.ts` for the Rust build-output dirs (`src-tauri/target/**`, `june-api/target/**`).
- Fixes `pnpm tauri:dev` crashing mid-compile on Windows.

## Root cause
On Windows, cargo locks `.exe`/pdb files in `target/` while linking. Vite default `fs.watch` watcher descends into those dirs and throws `EBUSY` on the locked files; the unhandled watcher error crashes Vite and tears down `tauri dev` mid-compile.

macOS uses FSEvents and does not hit this, so the gap only surfaces on Windows. The `windows-rust` CI job does a one-shot `tauri-build.mjs --debug --no-sign` bundle (no dev server, no file watcher), so it never exercises this path either. That is why this slipped through despite Windows being a supported build target.

## Validation
- [x] Tested locally on Windows 11: `pnpm tauri:dev` no longer crashes during cargo relinks; the dev server stays up and the native app reaches a working state (chat flows end to end).
- [x] No June API (backend) deploy needed. This is a frontend dev-server config change only; it has no effect on shipped binaries or runtime behavior.

Not tested visually (no UI change). The change is a dev-tooling fix.

## Out of scope
- Does not change macOS or Linux dev behavior beyond sparing the watcher some noise on those platforms too (harmless).
- Does not address the separate, larger issue where June managed Hermes runtime installer fails on some Windows hosts because `Get-FileHash` is not recognized under `-NoProfile -NonInteractive` PowerShell. That will be a separate draft PR.
- Does not change the `windows-rust` CI job. A followup could add a dev-mode smoke step to that job so this class of regression is caught in CI, but that is intentionally left for later.

## Followups
- Separate draft PR: managed Hermes installer `Get-FileHash` failure on Windows (workaround documented; proposed fix behind it).
- Consider adding a Windows dev-mode smoke step to `desktop.yml` so dev-server regressions are caught in CI, not just bundle builds.

## Security and release checklist
- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] No security-sensitive changes.
- [x] No workflow action references changed.
- [x] No desktop signing, updater, entitlement, capability, or release changes. Dev-server config only.
- [x] No backend auth, billing, metering, CORS, rate limit, or logging changes.
- [x] No user-facing copy changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785919313&installation_id=144203540&pr_number=624&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F624&signature=8c9faf082b62f95900cc6bd2d9afd365c336ecbcb19b48f522b818807ec48af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->