### PR TITLE
fix(windows): avoid Get-FileHash in managed runtime installer

### DIFF
--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -5713,7 +5713,15 @@ if (!(Test-Path (Join-Path $installDir "pyproject.toml"))) {
   try {
     $archive = Join-Path $tmpDir "hermes-agent.tar.gz"
     Invoke-WebRequest -Uri $sourceTarballUrl -OutFile $archive
-    $actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $archive).Hash.ToLowerInvariant()
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $stream = [System.IO.File]::OpenRead($archive)
+    try {
+      $hashBytes = $sha256.ComputeHash($stream)
+      $actualSha256 = ([System.BitConverter]::ToString($hashBytes) -replace '-', '').ToLowerInvariant()
+    } finally {
+      $stream.Dispose()
+      $sha256.Dispose()
+    }
     if ($actualSha256 -ne $sourceTarballSha256) {
       throw "Hermes source archive checksum mismatch. Expected $sourceTarballSha256, got $actualSha256."
     }


### PR DESCRIPTION
## Summary

- replace the Windows managed runtime installer checksum step with inline .NET SHA256 hashing instead of `Get-FileHash`
- keep the existing download, checksum comparison, unpack, and install flow unchanged otherwise
- document the Windows host failure mode and ask reviewers to weigh the chosen fix against a `pwsh.exe`-first fallback approach before undrafting

## Root cause

The Windows managed runtime installer is spawned with `powershell.exe -NoProfile -NonInteractive`. On the affected Windows 11 host, that session did not auto-load the module that provides `Get-FileHash`, so the checksum step failed before the runtime could be unpacked and installed. The installer log showed:

```text
Get-FileHash : The term 'Get-FileHash' is not recognized as the name of a cmdlet, function, script file, or operable program.
At line:61 char:22
+     $actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $archive).H ...
+                      ~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Get-FileHash:String) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : CommandNotFoundException
```

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml`
- compared the installer failure log against the embedded PowerShell script and replaced only the checksum implementation
- not tested visually (no UI change)
- not yet tested on a Windows CI runner

- [ ] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end. <!-- check if yes; say which change -->

## Out of scope

- switching the installer process to prefer `pwsh.exe` with fallback to `powershell.exe`
- adding a Windows dev-mode smoke step to `.github/workflows/desktop.yml`
- changing the user workaround or any local Hermes environment variables

## Followups

- reviewers should weigh whether keeping the inline .NET SHA256 approach is preferable to probing `pwsh.exe` first and falling back to `powershell.exe`
- consider adding a Windows dev-mode smoke step to catch installer and dev-environment regressions in CI; see PR #624 for the related workflow followup

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785920005&installation_id=144203540&pr_number=625&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F625&signature=098a670a5264ca1163d1adc24ab91c473f03d4520122f3893c50e7b55c1e0876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->