### PR TITLE
docs(release): fix Windows installed executable path

### DIFF
--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -102,8 +102,11 @@ run:
 $installer = "$env:USERPROFILE\Downloads\June_x64-setup.exe"
 Get-AuthenticodeSignature $installer | Format-List
 Start-Process -FilePath $installer -ArgumentList "/S" -Wait
-Start-Process "$env:LOCALAPPDATA\June\June.exe"
+Start-Process "$env:LOCALAPPDATA\June\os-june.exe"
 ```
+
+The installed app is branded as June, but the current Windows binary on disk is
+`os-june.exe` under `$env:LOCALAPPDATA\June`.
 
 Confirm the signature status is `Valid`, the publisher is Open Software Network,
 the app launches as June, the sign-in copy mentions recording and notes without


### PR DESCRIPTION
## Summary

- correct the Windows release validation command to launch `os-june.exe`
- note that the app is branded as June while the installed Windows binary on disk is currently `os-june.exe`

## Root cause

The Windows release runbook assumed the installed executable name matched the product name (`June.exe`), but the installer currently installs `os-june.exe` under `%LOCALAPPDATA%\June`.

## Validation

- reviewed `docs/release-windows.md` against the local installer build/install findings captured in `C:\Users\jimmy\AppData\Local\Temp\os-june-handoff-2026-07-06-windows-installer.md`
- repo search confirmed no other `June.exe` references remained under `docs`, `src`, `.github`, or `specs`

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).

<img width="3200" height="1828" alt="image" src="https://github.com/user-attachments/assets/21305048-16a7-406c-8d7f-1b71ab51a4d4" />


## Out of scope

- renaming the installed Windows binary
- adding a Windows installer smoke test to CI or release workflows
- hardening local Windows Hermes bundling reproducibility
- RC/stable release workflow changes and ADR updates

## Followups

- consider adding a Windows installer smoke test that installs silently and launches the installed app once
- decide separately whether the installed Windows binary should remain `os-june.exe` or be renamed to match the June product name

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785931456&installation_id=144203540&pr_number=626&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F626&signature=322c6f6efb42d91def4ae24761edc9e6c60f03b22e3a046eaaef0949b2f5ba9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->