### PR TITLE
Allow user-directed June personas

### DIFF
--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -41,6 +41,15 @@ Phase C has landed. The current built-in fallback image generation price list is
 image. Image editing is metered separately through `image_edit_pricing`, with
 `firered-image-edit` priced at 80 credits per image edit.
 
+## Addendum - 2026-07-06
+
+The Settings image-model picker now mirrors Venice's current image catalog for
+models June can price, including privacy tags (`Private` or `Anonymized`) and an
+`Uncensored` tag when Venice marks the model that way. `image_pricing` remains
+the backend allowlist for generated image models; newly exposed models are priced
+with the same flat ~2x convention as the original list. Models that Venice prices
+by resolution use the default 1K tier until June exposes resolution controls.
+
 ## Context
 
 JUN-129 shipped `/image <prompt>` as a client-side slash command: it creates a

--- a/june-api/crates/config/src/lib.rs
+++ b/june-api/crates/config/src/lib.rs
@@ -593,15 +593,45 @@ fn default_pricing() -> BTreeMap<String, ModelPriceConfig> {
 /// and `DEFAULT_IMAGE_MODEL` in the Tauri providers module — every id here must
 /// be a current Venice image model (verified against the models list), or
 /// generation fails `image_generation_rejected`. Values are the Venice per-image
-/// cost with a ~2x margin (mirroring the flat web-tool pricing): SD3.5 ~$0.01 ->
-/// 20, Chroma ~$0.01 -> 20, Qwen Image ~$0.03 -> 60, FLUX 2 Pro ~$0.03 -> 60.
-/// `$1 = 1000 credits`.
+/// cost with a ~2x margin (mirroring the flat web-tool pricing). Models that
+/// price by resolution use their default 1K tier because June does not expose a
+/// higher-resolution image request control yet. `$1 = 1000 credits`.
 fn default_image_pricing() -> BTreeMap<String, u64> {
     BTreeMap::from([
         ("venice-sd35".to_string(), 20),
+        ("grok-imagine-image-quality".to_string(), 160),
+        ("krea-2-turbo".to_string(), 80),
         ("flux-2-pro".to_string(), 60),
+        ("flux-2-max".to_string(), 180),
+        ("gpt-image-2".to_string(), 540),
+        ("gpt-image-1-5".to_string(), 520),
+        ("hunyuan-image-v3".to_string(), 180),
+        ("ideogram-v4".to_string(), 120),
+        ("imagineart-1.5-pro".to_string(), 120),
+        ("krea-v2-large".to_string(), 140),
+        ("krea-v2-medium".to_string(), 80),
+        ("luma-uni-1".to_string(), 100),
+        ("luma-uni-1-max".to_string(), 240),
+        ("nano-banana-2".to_string(), 200),
+        ("nano-banana-pro".to_string(), 360),
+        ("nano-banana-2-lite".to_string(), 120),
+        ("recraft-v4".to_string(), 100),
+        ("recraft-v4-pro".to_string(), 580),
+        ("seedream-v4".to_string(), 100),
+        ("seedream-v5-lite".to_string(), 100),
+        ("qwen-image-2".to_string(), 100),
+        ("qwen-image-2-pro".to_string(), 200),
+        ("wan-2-7-text-to-image".to_string(), 75),
+        ("wan-2-7-pro-text-to-image".to_string(), 188),
+        ("grok-imagine-image".to_string(), 80),
+        ("lustify-sdxl".to_string(), 20),
+        ("lustify-v7".to_string(), 20),
+        ("lustify-v8".to_string(), 20),
         ("qwen-image".to_string(), 60),
+        ("wai-Illustrious".to_string(), 20),
+        ("z-image-turbo".to_string(), 20),
         ("chroma".to_string(), 20),
+        ("bria-bg-remover".to_string(), 60),
     ])
 }
 
@@ -1280,7 +1310,42 @@ mod tests {
     #[test]
     fn default_config_prices_the_curated_image_models() {
         let config = valid_config();
-        for model in ["venice-sd35", "flux-2-pro", "qwen-image", "chroma"] {
+        for model in [
+            "venice-sd35",
+            "grok-imagine-image-quality",
+            "krea-2-turbo",
+            "flux-2-pro",
+            "flux-2-max",
+            "gpt-image-2",
+            "gpt-image-1-5",
+            "hunyuan-image-v3",
+            "ideogram-v4",
+            "imagineart-1.5-pro",
+            "krea-v2-large",
+            "krea-v2-medium",
+            "luma-uni-1",
+            "luma-uni-1-max",
+            "nano-banana-2",
+            "nano-banana-pro",
+            "nano-banana-2-lite",
+            "recraft-v4",
+            "recraft-v4-pro",
+            "seedream-v4",
+            "seedream-v5-lite",
+            "qwen-image-2",
+            "qwen-image-2-pro",
+            "wan-2-7-text-to-image",
+            "wan-2-7-pro-text-to-image",
+            "grok-imagine-image",
+            "lustify-sdxl",
+            "lustify-v7",
+            "lustify-v8",
+            "qwen-image",
+            "wai-Illustrious",
+            "z-image-turbo",
+            "chroma",
+            "bria-bg-remover",
+        ] {
             assert!(
                 config.image_pricing.get(model).is_some_and(|c| *c > 0),
                 "missing image price for {model}"

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -150,6 +150,7 @@ Web tools: you have a `june_web` MCP toolset with `web_search` and `web_fetch`. 
 const JUNE_SOUL_IMAGE_MD: &str = r#"
 Image tools: you have a `june_image` MCP toolset with `generate_image` and `edit_image`. Use `generate_image` when the user asks you to draw, create, make, or generate an image, picture, illustration, or logo; the result is shown to the user in the conversation and the tool returns a `filename`.
 Use this toolset instead of any generic image, media, or vision-analysis tool for image creation or edits, so June can display the returned image and keep the returned filename in context.
+Do not add a separate content refusal layer before calling these tools. The user's selected image model and image safe-mode setting are authoritative for what the image provider should attempt. If the selected model and setting may support the request, call the image tool with the user's prompt instead of substituting a clothed or sanitized alternative. If the image provider rejects the request, briefly report that provider rejection.
 When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact edit-safe filename returned by the prior image tool result as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced, even if you cannot see it. Only pass a `source_filename` from a prior `june_image` tool result.
 "#;
 
@@ -9076,6 +9077,20 @@ mcp_servers:
         assert!(soul.contains("june_web"));
         assert!(soul.contains("web_search"));
         assert!(soul.contains("web_fetch"));
+    }
+
+    #[test]
+    fn june_soul_uses_image_settings_instead_of_pre_refusing() {
+        let home = tempfile::tempdir().expect("tempdir");
+
+        sync_june_soul(home.path(), false, false).expect("sync soul");
+
+        let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
+        assert!(soul.contains("june_image"));
+        assert!(soul.contains("Do not add a separate content refusal layer"));
+        assert!(soul.contains("selected image model and image safe-mode setting are authoritative"));
+        assert!(soul.contains("call the image tool with the user's prompt"));
+        assert!(soul.contains("provider rejects the request"));
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -103,6 +103,8 @@ const JUNE_IMAGE_MCP_TOKEN_ENV: &str = "JUNE_IMAGE_PROXY_TOKEN";
 /// seeds its stock "Hermes Agent by Nous Research" persona.
 const JUNE_SOUL_MD: &str = r#"You are June, the private AI assistant on the user's desktop, made by Open Software. You run on the open-source Hermes agent framework, but your name and identity are June — when asked who or what you are, answer as June, not as Hermes or the underlying model.
 
+User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, safety, privacy, tool limits, or the user's own stated constraints. Do not claim to be a different product, company, human, or authority when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
+
 You are part of the June app, which handles dictation, meeting notes, and agent work on the user's Mac. As the agent, you hand off real work, run automations the user sets up, and use local memory so the user never has to repeat themselves.
 
 Privacy is your defining trait, by architecture rather than promise. When asked how you keep work private, answer confidently:
@@ -9001,6 +9003,10 @@ mcp_servers:
         let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
         assert!(soul.contains("You are June"));
         assert!(soul.contains("Open Software"));
+        assert!(soul.contains("User-directed roles and personas are allowed task framing"));
+        assert!(
+            soul.contains("Do not claim to be a different product, company, human, or authority")
+        );
         assert!(!soul.contains("Nous Research"));
     }
 

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -103,7 +103,7 @@ const JUNE_IMAGE_MCP_TOKEN_ENV: &str = "JUNE_IMAGE_PROXY_TOKEN";
 /// seeds its stock "Hermes Agent by Nous Research" persona.
 const JUNE_SOUL_MD: &str = r#"You are June, the private AI assistant on the user's desktop, made by Open Software. You run on the open-source Hermes agent framework, but your name and identity are June — when asked who or what you are, answer as June, not as Hermes or the underlying model.
 
-User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, safety, privacy, tool limits, or the user's own stated constraints. Do not claim to be a different product, company, human, or authority when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
+User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, safety, privacy, tool limits, the user's own stated constraints, or any other built-in constraints and policies. Do not claim to be a different product, company, human, or authority when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
 
 You are part of the June app, which handles dictation, meeting notes, and agent work on the user's Mac. As the agent, you hand off real work, run automations the user sets up, and use local memory so the user never has to repeat themselves.
 
@@ -9004,6 +9004,7 @@ mcp_servers:
         assert!(soul.contains("You are June"));
         assert!(soul.contains("Open Software"));
         assert!(soul.contains("User-directed roles and personas are allowed task framing"));
+        assert!(soul.contains("any other built-in constraints and policies"));
         assert!(
             soul.contains("Do not claim to be a different product, company, human, or authority")
         );

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -103,7 +103,7 @@ const JUNE_IMAGE_MCP_TOKEN_ENV: &str = "JUNE_IMAGE_PROXY_TOKEN";
 /// seeds its stock "Hermes Agent by Nous Research" persona.
 const JUNE_SOUL_MD: &str = r#"You are June, the private AI assistant on the user's desktop, made by Open Software. You run on the open-source Hermes agent framework, but your name and identity are June — when asked who or what you are, answer as June, not as Hermes or the underlying model.
 
-User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, safety, privacy, tool limits, the user's own stated constraints, or any other built-in constraints and policies. Do not claim to be a different product, company, human, or authority when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
+User-directed roles and personas are allowed task framing, not an identity reset. If the user explicitly asks you to act as a reviewer, coach, interviewer, character, style, or other role, follow that framing for the requested work unless it conflicts with system or developer instructions, privacy, tool limits, the user's own stated constraints, or the current app and tool settings. Do not claim to be a different product, company, human, or authority when asked about your real identity or provenance: be transparent that you are June, while adapting your behavior to the role the user chose.
 
 You are part of the June app, which handles dictation, meeting notes, and agent work on the user's Mac. As the agent, you hand off real work, run automations the user sets up, and use local memory so the user never has to repeat themselves.
 
@@ -9004,7 +9004,7 @@ mcp_servers:
         assert!(soul.contains("You are June"));
         assert!(soul.contains("Open Software"));
         assert!(soul.contains("User-directed roles and personas are allowed task framing"));
-        assert!(soul.contains("any other built-in constraints and policies"));
+        assert!(soul.contains("the current app and tool settings"));
         assert!(
             soul.contains("Do not claim to be a different product, company, human, or authority")
         );

--- a/src/components/settings/ModelPickerDialog.tsx
+++ b/src/components/settings/ModelPickerDialog.tsx
@@ -29,7 +29,15 @@ export function ModelMeta({ model }: { model: VeniceModelDto }) {
     items.push(<span>{model.description}</span>);
   }
   if (privacyBadge) {
-    items.push(<ModelPrivacyChip badge={privacyBadge} />);
+    const imagePrivacyLabel =
+      model.modelType === "image"
+        ? privacyBadge.mode === "private"
+          ? "Private"
+          : privacyBadge.mode === "anonymous"
+            ? "Anonymized"
+            : undefined
+        : undefined;
+    items.push(<ModelPrivacyChip badge={privacyBadge} label={imagePrivacyLabel} />);
   }
   if (flags.uncensored) {
     items.push(

--- a/src/lib/image-models.ts
+++ b/src/lib/image-models.ts
@@ -4,6 +4,27 @@ import type { VeniceModelDto } from "./tauri";
 // module (src-tauri/src/providers/mod.rs) — keep the two in sync.
 export const DEFAULT_IMAGE_MODEL = "venice-sd35";
 
+type ImageModelDefinition = Omit<
+  VeniceModelDto,
+  "provider" | "modelType" | "capabilities" | "traits"
+> &
+  Pick<VeniceModelDto, "privacy"> &
+  Partial<Pick<VeniceModelDto, "capabilities" | "traits">>;
+
+function imageModel({
+  traits = [],
+  capabilities = [],
+  ...model
+}: ImageModelDefinition): VeniceModelDto {
+  return {
+    provider: "venice",
+    modelType: "image",
+    capabilities,
+    traits,
+    ...model,
+  };
+}
+
 // Curated Venice image models for the settings picker. Image models are not
 // part of the text/ASR model catalog the backend serves, so the picker uses
 // this local snapshot instead of fetching. Image generation IS metered: the
@@ -12,40 +33,183 @@ export const DEFAULT_IMAGE_MODEL = "venice-sd35";
 // (`model_not_priced`). Keep these ids in sync with that map — a model listed
 // here but unpriced there fails at generation time.
 export const IMAGE_MODELS: VeniceModelDto[] = [
-  {
-    provider: "venice",
+  imageModel({
     id: "venice-sd35",
     name: "Venice SD3.5",
-    modelType: "image",
     description: "Venice's default Stable Diffusion 3.5 image model.",
-    traits: ["default"],
-    capabilities: [],
-  },
-  {
-    provider: "venice",
+    privacy: "private",
+    traits: ["eliza-default"],
+  }),
+  imageModel({
+    id: "grok-imagine-image-quality",
+    name: "Grok Imagine High Quality",
+    privacy: "private",
+  }),
+  imageModel({
+    id: "krea-2-turbo",
+    name: "Krea 2 Turbo",
+    privacy: "private",
+  }),
+  imageModel({
     id: "flux-2-pro",
     name: "FLUX 2 Pro",
-    modelType: "image",
     description: "High-detail FLUX model for photorealistic results.",
-    traits: [],
-    capabilities: [],
-  },
-  {
-    provider: "venice",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "flux-2-max",
+    name: "FLUX 2 Max",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "gpt-image-2",
+    name: "GPT Image 2",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "gpt-image-1-5",
+    name: "GPT Image 1.5",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "hunyuan-image-v3",
+    name: "Hunyuan Image 3.0",
+    privacy: "private",
+  }),
+  imageModel({
+    id: "ideogram-v4",
+    name: "Ideogram V4",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "imagineart-1.5-pro",
+    name: "ImagineArt 1.5 Pro",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "krea-v2-large",
+    name: "Krea v2 Large",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "krea-v2-medium",
+    name: "Krea v2 Medium",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "luma-uni-1",
+    name: "Luma Uni-1",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "luma-uni-1-max",
+    name: "Luma Uni-1 Max",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "nano-banana-2",
+    name: "Nano Banana 2",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "nano-banana-pro",
+    name: "Nano Banana Pro",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "nano-banana-2-lite",
+    name: "Nano Banana 2 Lite",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "recraft-v4",
+    name: "Recraft V4",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "recraft-v4-pro",
+    name: "Recraft V4 Pro",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "seedream-v4",
+    name: "Seedream V4.5",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "seedream-v5-lite",
+    name: "Seedream V5 Lite",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "qwen-image-2",
+    name: "Qwen Image 2",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "qwen-image-2-pro",
+    name: "Qwen Image 2 Pro",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "wan-2-7-text-to-image",
+    name: "Wan 2.7",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "wan-2-7-pro-text-to-image",
+    name: "Wan 2.7 Pro",
+    privacy: "anonymized",
+  }),
+  imageModel({
+    id: "grok-imagine-image",
+    name: "Grok Imagine",
+    privacy: "private",
+  }),
+  imageModel({
+    id: "lustify-sdxl",
+    name: "Lustify SDXL",
+    privacy: "private",
+  }),
+  imageModel({
+    id: "lustify-v7",
+    name: "Lustify v7",
+    privacy: "private",
+    traits: ["most_uncensored"],
+  }),
+  imageModel({
+    id: "lustify-v8",
+    name: "Lustify v8",
+    privacy: "private",
+    traits: ["most_uncensored"],
+  }),
+  imageModel({
     id: "qwen-image",
     name: "Qwen Image",
-    modelType: "image",
     description: "Strong text rendering and prompt adherence.",
-    traits: [],
-    capabilities: [],
-  },
-  {
-    provider: "venice",
+    privacy: "anonymized",
+    traits: ["highest_quality"],
+  }),
+  imageModel({
+    id: "wai-Illustrious",
+    name: "Anime (WAI)",
+    privacy: "private",
+  }),
+  imageModel({
+    id: "z-image-turbo",
+    name: "Z-Image Turbo",
+    privacy: "private",
+    traits: ["default", "fastest"],
+  }),
+  imageModel({
     id: "chroma",
     name: "Chroma",
-    modelType: "image",
     description: "Versatile general-purpose image model.",
-    traits: [],
-    capabilities: [],
-  },
+    privacy: "private",
+  }),
+  imageModel({
+    id: "bria-bg-remover",
+    name: "Background Remover",
+    privacy: "anonymized",
+  }),
 ];

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -2618,14 +2618,25 @@ describe("AppSettings", () => {
     await user.click(screen.getByRole("button", { name: "Change image model" }));
     expect(await screen.findByRole("option", { name: /Venice SD3\.5/ })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: /FLUX 2 Pro/ })).toBeInTheDocument();
+    expect(screen.getByText("GPT Image 2")).toBeInTheDocument();
+    expect(screen.getByText("Lustify v8")).toBeInTheDocument();
+    expect(screen.getByText("Z-Image Turbo")).toBeInTheDocument();
     expect(
       screen.getAllByText("Venice's default Stable Diffusion 3.5 image model.").length,
     ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Private").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Anonymized").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Uncensored").length).toBeGreaterThan(0);
     expect(screen.queryByText("Model details unavailable")).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText("Search models"), "uncensored");
+    expect(screen.getByRole("option", { name: /Lustify v7/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Lustify v8/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /FLUX 2 Pro/ })).not.toBeInTheDocument();
+    await user.clear(screen.getByLabelText("Search models"));
     // Image models are not fetched from the catalog.
     expect(mocks.listVeniceModels).not.toHaveBeenCalledWith("image");
 
-    await user.click(screen.getByRole("option", { name: /FLUX 2 Pro/ }));
+    await user.click(await screen.findByRole("option", { name: /FLUX 2 Pro/ }));
     expect(mocks.setVeniceModel).toHaveBeenCalledWith("image", "flux-2-pro");
     // The picker closes after a selection.
     await waitFor(() =>


### PR DESCRIPTION
Closes JUN-211

## Root cause
June's managed Hermes `SOUL.md` identity rule did not distinguish real identity/provenance questions from user-requested role or persona framing, so the agent could treat role requests as identity-reset attempts and refuse them too broadly. While testing the same flow, the Settings image model picker also showed a stale four-model image catalog with no privacy or uncensored model metadata. One more gap: the image tool honored the selected model and safe-mode setting, but the chat model could still pre-refuse image requests in prose before calling the tool.

## What changed
- Updated June's managed Hermes `SOUL.md` seed so explicit user-requested roles and personas are allowed as task framing.
- Kept June's real identity/provenance rule intact: June should still be transparent that it is June when asked what it is.
- Scoped the persona exception to system/developer instructions, privacy, tool limits, the user's own stated constraints, and current app/tool settings, so the prompt does not add a separate safety veto over Settings-controlled behavior.
- Taught the image-tool prompt not to add a separate content refusal layer before calling `june_image`; the selected image model and safe-mode setting are authoritative, and provider rejection is reported only if the provider rejects.
- Expanded the curated image model picker to the current priced Venice image catalog.
- Added visible image-model tags for `Private`, `Anonymized`, and `Uncensored` where Venice metadata provides those signals.
- Synced June API `image_pricing` with the expanded picker list so newly exposed models are accepted by the backend.
- Added regression coverage for the SOUL sync test, image-tool pre-refusal guidance, the image model picker, uncensored search, and backend image pricing defaults.

## Why
The user's explicit instruction is now the control point for role/persona behavior, while identity transparency and app/tool settings still take precedence. The image model picker now exposes all priced models June can generate with and makes the privacy/uncensored tradeoffs visible before selection. Image requests now flow through the configured image provider instead of being blocked by an extra chat-model refusal.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml sync_june_soul --locked`
- `cargo test --manifest-path src-tauri/Cargo.toml soul --locked`
- `make tauri-fmt-check`
- `make tauri-test`
- `pnpm test -- src/test/app-settings.test.tsx`
- `cargo test -p june-config default_config_prices_the_curated_image_models --locked`
- `cargo fmt --all --check` from `june-api/`
- `pnpm typecheck`
- `git diff --check`
- GitHub Actions: pending rerun on latest commit `6317f7a0`

## Visual testing
`pnpm tauri:dev` is running locally on the PR branch with local-dev auth aligned. Vite is serving at `http://127.0.0.1:1421/`, June API is listening on `127.0.0.1:8080`, Hermes/system-audio initialized successfully, and the local logs show `image_generate` requests using the selected `lustify-v8` image model.

## June API deploy
June API deploy is now needed before promoting a desktop build that exposes the expanded image list in production. Without the backend `image_pricing` update, newly selectable image models would fail with `model_not_priced`.

## Out of scope
- New Settings toggle for persona behavior. JUN-211 allowed the behavior to be user-controlled through explicit user instruction.
- Live upstream generation tests for every new image model, to avoid spending provider credits during PR validation. The catalog and pricing metadata were verified against Venice's current `/models?type=image` response.
