### PR TITLE
Image safe mode on by default with consent dialog + agent can edit attached images (JUN-209)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -260,6 +260,15 @@ a prior image (a generated one, by filename); never starts from a blank canvas.
 Distinct from **image generation**.
 _Avoid_: image-to-image jargon, regenerate (that's a fresh **image generation**).
 
+**Safe mode** (image):
+The per-device toggle that asks Venice to blur adult content on generated and
+edited images (`safe_mode`). On by default; the user turns it off in Settings
+or via the **safe-mode consent dialog** June shows before or during a
+potentially explicit generation. Enforcement is Venice's; June's on-device
+heuristic only decides when to *offer* the dialog, never what gets generated.
+See [ADR 0008](docs/adr/0008-image-generation-and-editing-tools.md).
+_Avoid_: NSFW filter/toggle (say **safe mode**), censorship.
+
 **Credit price** (per upstream model):
 The number of OS Accounts credits June charges per unit of consumed work
 (audio seconds for transcription, tokens for generation) for a given upstream

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,8 +264,10 @@ _Avoid_: image-to-image jargon, regenerate (that's a fresh **image generation**)
 The per-device toggle that asks Venice to blur adult content on generated and
 edited images (`safe_mode`). On by default; the user turns it off in Settings
 or via the **safe-mode consent dialog** June shows before or during a
-potentially explicit generation. Enforcement is Venice's; June's on-device
-heuristic only decides when to *offer* the dialog, never what gets generated.
+potentially explicit generation. Enforcement is Venice's; the dialog gate -
+June's on-device wordlist heuristic, plus on the agent path the model's own
+`may_be_explicit` self-report in the tool call - only decides when to *offer*
+the dialog, never what gets generated, and never costs an extra call.
 See [ADR 0008](docs/adr/0008-image-generation-and-editing-tools.md).
 _Avoid_: NSFW filter/toggle (say **safe mode**), censorship.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,10 +264,13 @@ _Avoid_: image-to-image jargon, regenerate (that's a fresh **image generation**)
 The per-device toggle that asks Venice to blur adult content on generated and
 edited images (`safe_mode`). On by default; the user turns it off in Settings
 or via the **safe-mode consent dialog** June shows before or during a
-potentially explicit generation. Enforcement is Venice's; the dialog gate -
-June's on-device wordlist heuristic, plus on the agent path the model's own
-`may_be_explicit` self-report in the tool call - only decides when to *offer*
-the dialog, never what gets generated, and never costs an extra call.
+potentially explicit generation. Enforcement is Venice's; the dialog gate
+only decides when to *offer* the dialog, never what gets generated. On the
+agent path the gate is free (on-device wordlist plus the model's own
+`may_be_explicit` self-report in the tool call); on the /image path the
+wordlist short-circuits and otherwise a small metered model check classifies
+the prompt (language-agnostic, added after the English-only wordlist missed
+non-English prompts).
 See [ADR 0008](docs/adr/0008-image-generation-and-editing-tools.md).
 _Avoid_: NSFW filter/toggle (say **safe mode**), censorship.
 

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -53,9 +53,13 @@ by resolution use the default 1K tier until June exposes resolution controls.
 ## Addendum - 2026-07-06 (JUN-209: safe mode on by default + consent dialog)
 
 Supersedes the **safe_mode** bullet above: the toggle now defaults **on**.
-Image generation had not shipped to users (the UI is feature-flagged), so this
-is a plain serde-default flip with no migration marker; a settings file
-missing the field reads `true`.
+No released build has shipped the `image_safe_mode` field (it landed with
+JUN-171 days before this change), so settings files in the wild do not carry
+it and a plain serde-default flip reaches everyone; a settings file missing
+the field reads `true`. If a build with the old default does ship before
+this lands, a one-time coercion would be needed instead - any settings save
+serializes the whole struct, so such files would pin an explicit `false` the
+user never chose.
 
 With a filtering default, the user needs an explicit, informed way out.
 June adds a **safe-mode consent dialog**, gated by an on-device keyword

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -52,14 +52,17 @@ by resolution use the default 1K tier until June exposes resolution controls.
 
 ## Addendum - 2026-07-06 (JUN-209: safe mode on by default + consent dialog)
 
-Supersedes the **safe_mode** bullet above: the toggle now defaults **on**.
-No released build has shipped the `image_safe_mode` field (it landed with
-JUN-171 days before this change), so settings files in the wild do not carry
-it and a plain serde-default flip reaches everyone; a settings file missing
-the field reads `true`. If a build with the old default does ship before
-this lands, a one-time coercion would be needed instead - any settings save
-serializes the whole struct, so such files would pin an explicit `false` the
-user never chose.
+Supersedes the **safe_mode** bullet above: the toggle now defaults **on**,
+and a stored value is only honored when the user actually chose it. Any
+settings save serializes the whole struct, so files written by pre-JUN-209
+builds pin an explicit `false` the user never picked (reproduced on dev
+machines days after JUN-171 landed). A serde-default flip alone would miss
+those files, so the load path coerces: unless the persisted
+`image_safe_mode_set_by_user` marker is true, `image_safe_mode` reads `true`
+regardless of the stored value. The marker is set only by
+`set_image_safe_mode` (the Settings toggle and the consent dialog); users
+who deliberately opted out before the marker existed get flipped back on
+once and can opt out again.
 
 With a filtering default, the user needs an explicit, informed way out.
 June adds a **safe-mode consent dialog**, gated by an on-device keyword

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -50,6 +50,38 @@ the backend allowlist for generated image models; newly exposed models are price
 with the same flat ~2x convention as the original list. Models that Venice prices
 by resolution use the default 1K tier until June exposes resolution controls.
 
+## Addendum - 2026-07-06 (JUN-209: safe mode on by default + consent dialog)
+
+Supersedes the **safe_mode** bullet above: the toggle now defaults **on**.
+Image generation had not shipped to users (the UI is feature-flagged), so this
+is a plain serde-default flip with no migration marker; a settings file
+missing the field reads `true`.
+
+With a filtering default, the user needs an explicit, informed way out.
+June adds a **safe-mode consent dialog**, gated by an on-device keyword
+heuristic (`image_safety::may_request_explicit_content`) so benign prompts
+never see it:
+
+- `/image` flow: shown *before* the billable request. "Keep safe mode on"
+  proceeds (pinned `safeMode: true`); "Turn off safe mode" persists the
+  toggle off and proceeds unfiltered - that persisted toggle is the
+  remembered preference.
+- Agent tool path: the loopback proxy cannot block a tool call on user input,
+  so it emits a best-effort `image-safe-mode-consent` Tauri event and the
+  generation proceeds blurred; the dialog then offers to turn safe mode off
+  for *future* images. The tool call is never delayed, altered, or failed by
+  consent.
+- "Don't ask again" persists `image_safe_mode_prompt_dismissed`. Explicitly
+  re-enabling safe mode resets it, so re-opting into safety re-arms the
+  dialog.
+
+Trade-offs accepted: the heuristic is a conservative wordlist (misses
+euphemisms, some false positives) - acceptable because it only gates the
+dialog; Venice `safe_mode` remains the enforcement, and a false negative just
+means a blurred image with no offer. The wire shape is unchanged
+(`Option<bool>`, absent = Venice default), so older app builds are
+unaffected.
+
 ## Context
 
 JUN-129 shipped `/image <prompt>` as a client-side slash command: it creates a

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -82,13 +82,23 @@ never see it:
   re-enabling safe mode resets it, so re-opting into safety re-arms the
   dialog.
 
-The prompt check uses **no intelligence, by design**: no LLM, no classifier
-model, no Venice or June API call, no metering. It is a deterministic
-on-device wordlist + phrase match (`image_safety::may_request_explicit_content`),
-so the prompt never leaves the device for screening and the check costs
-nothing. A model-based classifier was considered and rejected: it would add
-a billable call per generation and an extra network round trip carrying the
-user's prompt, against June's privacy-by-architecture stance.
+The dialog gate costs **no extra inference and no extra charge**, but the
+two surfaces get there differently:
+
+- `/image` fast path: deterministic on-device wordlist + phrase match only
+  (`image_safety::may_request_explicit_content`) - no LLM, no classifier, no
+  Venice or June API call, no metering. A model-based check was considered
+  and rejected here: it would add a billable call per generation, and it
+  would upload the prompt for screening BEFORE the user consents - today a
+  cancelled dialog means nothing ever left the device.
+- Agent tool path: the model is already in the loop (it is the one calling
+  the tool), so it self-classifies for free via a required
+  `may_be_explicit` boolean on `generate_image`/`edit_image`. The proxy ORs
+  that self-report with the same wordlist to decide the consent event, and
+  strips the field before forwarding upstream. Self-report is filled by the
+  very model the user is steering, so it can under-report - the failure mode
+  is bounded exactly like a wordlist miss: no dialog, and Venice `safe_mode`
+  still enforces the blur.
 
 Trade-offs accepted: the heuristic is a conservative wordlist (misses
 euphemisms, some false positives) - acceptable because it only gates the

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -50,6 +50,7 @@ the backend allowlist for generated image models; newly exposed models are price
 with the same flat ~2x convention as the original list. Models that Venice prices
 by resolution use the default 1K tier until June exposes resolution controls.
 
+<<<<<<< HEAD
 ## Addendum - 2026-07-06 (JUN-209: safe mode on by default + consent dialog)
 
 Supersedes the **safe_mode** bullet above: the toggle now defaults **on**,
@@ -96,6 +97,24 @@ dialog; Venice `safe_mode` remains the enforcement, and a false negative just
 means a blurred image with no offer. The wire shape is unchanged
 (`Option<bool>`, absent = Venice default), so older app builds are
 unaffected.
+
+## Addendum - 2026-07-07 (edit sources for attached images)
+
+`edit_image` now accepts a second source kind: the plain filename of an image
+the user attached or pasted into the conversation. The Hermes runtime saves
+attachments as `upload_*.png` into the same images directory the `june_image`
+MCP uses, but the original edit contract required an HMAC-signed reference
+minted only for `june_image` tool results - so the agent could not edit
+attached images at all and fell back to vision-analyze + regenerate, which
+the SOUL forbids and which double-charges when it works.
+
+Security shape: bare filenames get NO new power. They are accepted only when
+they are a plain name (no path separators), carry a known image extension,
+and canonicalize inside the canonicalized images root (symlink escapes
+rejected), then go through the same size cap and content sniffing as signed
+references. Hermes can already read and write that directory directly, so
+this widens nothing; signed references keep their content-hash binding for
+files the tool itself issued.
 
 ## Context
 

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -50,7 +50,6 @@ the backend allowlist for generated image models; newly exposed models are price
 with the same flat ~2x convention as the original list. Models that Venice prices
 by resolution use the default 1K tier until June exposes resolution controls.
 
-<<<<<<< HEAD
 ## Addendum - 2026-07-06 (JUN-209: safe mode on by default + consent dialog)
 
 Supersedes the **safe_mode** bullet above: the toggle now defaults **on**,
@@ -109,12 +108,13 @@ attached images at all and fell back to vision-analyze + regenerate, which
 the SOUL forbids and which double-charges when it works.
 
 Security shape: bare filenames get NO new power. They are accepted only when
-they are a plain name (no path separators), carry a known image extension,
-and canonicalize inside the canonicalized images root (symlink escapes
-rejected), then go through the same size cap and content sniffing as signed
-references. Hermes can already read and write that directory directly, so
-this widens nothing; signed references keep their content-hash binding for
-files the tool itself issued.
+they are a plain name (no path separators) with the attachment prefix
+(`upload_*`), carry a known image extension, and canonicalize inside the
+canonicalized images root (symlink escapes rejected), then go through the
+same size cap and content sniffing as signed references. Hermes can already
+read and write that directory directly, so this widens nothing; tool-output
+files (`generated-image-*`) still require a signed reference, keeping their
+content-hash binding.
 
 ## Context
 

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -82,6 +82,14 @@ never see it:
   re-enabling safe mode resets it, so re-opting into safety re-arms the
   dialog.
 
+The prompt check uses **no intelligence, by design**: no LLM, no classifier
+model, no Venice or June API call, no metering. It is a deterministic
+on-device wordlist + phrase match (`image_safety::may_request_explicit_content`),
+so the prompt never leaves the device for screening and the check costs
+nothing. A model-based classifier was considered and rejected: it would add
+a billable call per generation and an extra network round trip carrying the
+user's prompt, against June's privacy-by-architecture stance.
+
 Trade-offs accepted: the heuristic is a conservative wordlist (misses
 euphemisms, some false positives) - acceptable because it only gates the
 dialog; Venice `safe_mode` remains the enforcement, and a false negative just

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -82,23 +82,32 @@ never see it:
   re-enabling safe mode resets it, so re-opting into safety re-arms the
   dialog.
 
-The dialog gate costs **no extra inference and no extra charge**, but the
-two surfaces get there differently:
+The dialog gate works differently per surface:
 
-- `/image` fast path: deterministic on-device wordlist + phrase match only
-  (`image_safety::may_request_explicit_content`) - no LLM, no classifier, no
-  Venice or June API call, no metering. A model-based check was considered
-  and rejected here: it would add a billable call per generation, and it
-  would upload the prompt for screening BEFORE the user consents - today a
-  cancelled dialog means nothing ever left the device.
-- Agent tool path: the model is already in the loop (it is the one calling
-  the tool), so it self-classifies for free via a required
-  `may_be_explicit` boolean on `generate_image`/`edit_image`. The proxy ORs
-  that self-report with the same wordlist to decide the consent event, and
-  strips the field before forwarding upstream. Self-report is filled by the
-  very model the user is steering, so it can under-report - the failure mode
-  is bounded exactly like a wordlist miss: no dialog, and Venice `safe_mode`
-  still enforces the blur.
+- Agent tool path: **free**. The model is already in the loop (it is the one
+  calling the tool), so it self-classifies via a required `may_be_explicit`
+  boolean on `generate_image`/`edit_image`. The proxy ORs that self-report
+  with the on-device wordlist to decide the consent event, and strips the
+  field before forwarding upstream. Self-report is filled by the very model
+  the user is steering, so it can under-report - the failure mode is bounded
+  exactly like a wordlist miss: no dialog, and Venice `safe_mode` still
+  enforces the blur.
+- `/image` fast path: wordlist first, then a **model check**. The on-device
+  wordlist (`image_safety::may_request_explicit_content`) short-circuits the
+  obvious cases for free; when it is silent AND safe mode is on AND the
+  consent prompt is not dismissed, June asks the user's text model whether
+  the prompt requests explicit content (a one-shot temperature-0 YES/NO
+  chat completion through the same June API path as agent session titles,
+  metered as a normal agent-chat call). Classifier failure or timeout falls
+  back to the wordlist verdict; the check can delay but never block or fail
+  a generation. Originally this surface was wordlist-only, but the wordlist
+  is English-only and a Polish prompt reproduced the systematic miss
+  (blurred result, no consent offer) - a model check is the only
+  language-agnostic gate available on a path with no model in the loop.
+  Accepted trade-offs, decided with the user: a small metered call per
+  flagged-state generation, ~1-3s added latency before the dialog, and the
+  prompt travels to June API for screening BEFORE consent whenever safe
+  mode is on (it previously left the device only on actual generation).
 
 Trade-offs accepted: the heuristic is a conservative wordlist (misses
 euphemisms, some false positives) - acceptable because it only gates the

--- a/src-tauri/src/hermes/june_image_mcp.py
+++ b/src-tauri/src/hermes/june_image_mcp.py
@@ -12,8 +12,9 @@ generation/edit is billed to the signed-in user automatically.
 Generated and edited images are written to a dedicated images directory (passed
 as the second argument) under proxy-selected storage filenames. The Rust
 loopback proxy mints opaque edit-safe source references and validates them
-before reading source bytes for edits; this MCP only forwards those references
-back to the proxy.
+before reading source bytes for edits; plain filenames of images already in
+the images directory (user attachments) are also accepted. This MCP only
+forwards those references back to the proxy.
 
 It depends only on the Python standard library so it can run inside the Hermes
 runtime venv without extra packaging.
@@ -80,14 +81,17 @@ TOOLS: list[dict[str, Any]] = [
             "Edit an existing image (image-to-image) and show the result in the "
             "conversation. Use this whenever the user asks to change, modify, "
             "adjust, refine, or reframe an image you generated, edited, or "
-            "received from this tool earlier, including reframing like wider, "
+            "received from this tool earlier, or an image the user attached or "
+            "pasted into the conversation, including reframing like wider, "
             "zoom out, bigger perspective, or closer, plus recoloring, "
             "restyling, and adding or removing elements. This transforms the "
             "image file directly: you do NOT need to see, analyze, or describe "
             "the image to edit it. "
-            "`source_filename` MUST be a filename from a previous image tool "
-            "result from this June image workspace. Bare file names and paths "
-            "copied from disk are rejected. Returns the edited image inline plus "
+            "`source_filename` MUST be one of two values: a filename from a "
+            "previous image tool result, or the plain filename of an image the "
+            "user attached to the conversation exactly as shown in its context "
+            "(for example upload_20260707_113453_1.png). Full paths and "
+            "invented names are rejected. Returns the edited image inline plus "
             "a new edit-safe `filename` you can edit again."
         ),
         "inputSchema": {
@@ -96,8 +100,9 @@ TOOLS: list[dict[str, Any]] = [
                 "source_filename": {
                     "type": "string",
                     "description": (
-                        "The edit-safe filename of the image to edit, exactly "
-                        "as returned by a prior June image tool call."
+                        "The edit-safe filename returned by a prior June image "
+                        "tool call, or the plain filename of an image the user "
+                        "attached to the conversation. Never a full path."
                     ),
                 },
                 "instruction": {

--- a/src-tauri/src/hermes/june_image_mcp.py
+++ b/src-tauri/src/hermes/june_image_mcp.py
@@ -71,8 +71,16 @@ TOOLS: list[dict[str, Any]] = [
                     "type": "string",
                     "description": "A detailed description of the image to generate.",
                 },
+                "may_be_explicit": {
+                    "type": "boolean",
+                    "description": (
+                        "True when the requested image could contain adult, sexual, or "
+                        "otherwise explicit content; false for clearly benign requests. "
+                        "Judge the request itself, not just its wording."
+                    ),
+                },
             },
-            "required": ["prompt"],
+            "required": ["prompt", "may_be_explicit"],
         },
     },
     {
@@ -109,8 +117,16 @@ TOOLS: list[dict[str, Any]] = [
                     "type": "string",
                     "description": "What to change about the image.",
                 },
+                "may_be_explicit": {
+                    "type": "boolean",
+                    "description": (
+                        "True when the requested image could contain adult, sexual, or "
+                        "otherwise explicit content; false for clearly benign requests. "
+                        "Judge the request itself, not just its wording."
+                    ),
+                },
             },
-            "required": ["source_filename", "instruction"],
+            "required": ["source_filename", "instruction", "may_be_explicit"],
         },
     },
 ]
@@ -289,7 +305,11 @@ def generate_image(
         base_url,
         token,
         "/image/generate",
-        {"prompt": prompt, "requestId": request_id},
+        {
+            "prompt": prompt,
+            "requestId": request_id,
+            "may_be_explicit": arguments.get("may_be_explicit", False),
+        },
     )
     image_base64 = str(envelope.get("imageBase64") or "")
     mime_type = str(envelope.get("mimeType") or "image/png")
@@ -328,6 +348,7 @@ def edit_image(
             "sourceFilename": source_filename,
             "prompt": instruction,
             "requestId": request_id,
+            "may_be_explicit": arguments.get("may_be_explicit", False),
         },
     )
     image_base64 = str(envelope.get("imageBase64") or "")
@@ -517,6 +538,8 @@ def smoke_test_generate_writes_proxy_issued_storage_filename() -> None:
                 raise AssertionError(f"wrong path: {path}")
             if payload.get("prompt") != "a cat":
                 raise AssertionError("generate did not send the prompt")
+            if payload.get("may_be_explicit") is not True:
+                raise AssertionError("generate did not forward may_be_explicit")
             if "image" in payload or "sourceFilename" in payload:
                 raise AssertionError("generate sent source data")
             return {
@@ -529,7 +552,12 @@ def smoke_test_generate_writes_proxy_issued_storage_filename() -> None:
 
         try:
             globals()["call_proxy"] = fake_call_proxy
-            result = generate_image("http://127.0.0.1", images_dir, "token", {"prompt": "a cat"})
+            result = generate_image(
+                "http://127.0.0.1",
+                images_dir,
+                "token",
+                {"prompt": "a cat", "may_be_explicit": True},
+            )
         finally:
             globals()["call_proxy"] = original_call_proxy
 
@@ -564,6 +592,8 @@ def smoke_test_edit_forwards_opaque_source_ref_without_reading_source() -> None:
                 raise AssertionError(f"wrong path: {path}")
             if payload.get("sourceFilename") != source_ref:
                 raise AssertionError("edit did not forward the source reference")
+            if payload.get("may_be_explicit") is not False:
+                raise AssertionError("edit did not forward may_be_explicit")
             if "image" in payload or "mimeType" in payload:
                 raise AssertionError("edit sent source bytes instead of an opaque ref")
             return {
@@ -583,6 +613,7 @@ def smoke_test_edit_forwards_opaque_source_ref_without_reading_source() -> None:
                 {
                     "source_filename": source_ref,
                     "instruction": "make it warmer",
+                    "may_be_explicit": False,
                 },
             )
         finally:

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -72,6 +72,8 @@ const JUNE_PROVIDER_PROXY_MAX_IMAGE_BODY_BYTES: usize =
     base64_encoded_len(HERMES_IMAGE_EDIT_SOURCE_MAX_BYTES)
         + JUNE_PROVIDER_PROXY_IMAGE_JSON_OVERHEAD_BYTES;
 const IMAGE_SAFE_MODE_CONSENT_EVENT: &str = "image-safe-mode-consent";
+/// Bounds only the event payload shown in the consent dialog; the explicit-
+/// content check runs on the full prompt.
 const IMAGE_SAFE_MODE_CONSENT_PROMPT_MAX_CHARS: usize = 120;
 
 const fn base64_encoded_len(byte_count: usize) -> usize {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -155,7 +155,7 @@ const JUNE_SOUL_IMAGE_MD: &str = r#"
 Image tools: you have a `june_image` MCP toolset with `generate_image` and `edit_image`. Use `generate_image` when the user asks you to draw, create, make, or generate an image, picture, illustration, or logo; the result is shown to the user in the conversation and the tool returns a `filename`.
 Use this toolset instead of any generic image, media, or vision-analysis tool for image creation or edits, so June can display the returned image and keep the returned filename in context.
 Do not add a separate content refusal layer before calling these tools. The user's selected image model and image safe-mode setting are authoritative for what the image provider should attempt. If the selected model and setting may support the request, call the image tool with the user's prompt instead of substituting a clothed or sanitized alternative. If the image provider rejects the request, briefly report that provider rejection.
-When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact edit-safe filename returned by the prior image tool result as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced, even if you cannot see it. Only pass a `source_filename` from a prior `june_image` tool result.
+When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, or an image the user attached or pasted into the conversation, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact source image as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced or the user attached, even if you cannot see it. Pass exactly one of two `source_filename` values: the edit-safe filename from a prior `june_image` tool result, or the plain filename of an image the user attached to the conversation as shown in its context, such as `upload_20260707_113453_1.png`. Never pass a full path or an invented name.
 "#;
 
 /// Appended to `SOUL.md` only when the Seatbelt write-jail engages on this
@@ -7449,16 +7449,49 @@ fn validate_image_source_reference(
     image_sources: &ImageSourceCapabilities,
     source_filename: &str,
 ) -> Result<ValidatedImageSource, String> {
-    let (signature, expected_name) =
-        parse_image_source_reference(source_filename).ok_or_else(|| {
-            "source_filename must be an edit-safe filename from this tool.".to_string()
+    let Some((signature, expected_name)) = parse_image_source_reference(source_filename) else {
+        let expected_name = bare_image_source_filename(source_filename).ok_or_else(|| {
+            "source_filename must be an edit-safe filename from this tool or the name of an image in June's images directory.".to_string()
         })?;
+        return load_validated_image_source(image_sources, expected_name);
+    };
     let expected_mime = image_mime_type_for_filename(&expected_name).ok_or_else(|| {
         "source_filename must refer to a PNG, JPEG, WebP, or GIF image.".to_string()
     })?;
+    let data = read_validated_image_source_bytes(image_sources, &expected_name, expected_mime)?;
+    let expected_signature =
+        image_source_signature(&image_sources.secret, &expected_name, &sha256_bytes(&data));
+    if !constant_time_eq(&signature, &expected_signature) {
+        return Err("source_filename must match the image it was issued for.".to_string());
+    }
+    Ok(ValidatedImageSource {
+        image_base64: BASE64_STANDARD.encode(data),
+        mime_type: expected_mime,
+    })
+}
+
+fn load_validated_image_source(
+    image_sources: &ImageSourceCapabilities,
+    expected_name: &str,
+) -> Result<ValidatedImageSource, String> {
+    let expected_mime = image_mime_type_for_filename(expected_name).ok_or_else(|| {
+        "source_filename must refer to a PNG, JPEG, WebP, or GIF image.".to_string()
+    })?;
+    let data = read_validated_image_source_bytes(image_sources, expected_name, expected_mime)?;
+    Ok(ValidatedImageSource {
+        image_base64: BASE64_STANDARD.encode(data),
+        mime_type: expected_mime,
+    })
+}
+
+fn read_validated_image_source_bytes(
+    image_sources: &ImageSourceCapabilities,
+    expected_name: &str,
+    expected_mime: &'static str,
+) -> Result<Vec<u8>, String> {
     let images_root = fs::canonicalize(&image_sources.images_dir)
         .map_err(|_| "source_filename must refer to an available June image source.".to_string())?;
-    let candidate = image_sources.images_dir.join(&expected_name);
+    let candidate = image_sources.images_dir.join(expected_name);
     let canonical = fs::canonicalize(candidate)
         .map_err(|_| "source_filename must refer to an available June image source.".to_string())?;
     if !canonical.starts_with(&images_root) {
@@ -7500,15 +7533,7 @@ fn validate_image_source_reference(
             "source_filename must refer to a real PNG, JPEG, WebP, or GIF image.".to_string(),
         );
     }
-    let expected_signature =
-        image_source_signature(&image_sources.secret, &expected_name, &sha256_bytes(&data));
-    if !constant_time_eq(&signature, &expected_signature) {
-        return Err("source_filename must match the image it was issued for.".to_string());
-    }
-    Ok(ValidatedImageSource {
-        image_base64: BASE64_STANDARD.encode(data),
-        mime_type: expected_mime,
-    })
+    Ok(data)
 }
 
 fn mint_image_source_reference(
@@ -7580,6 +7605,14 @@ fn parse_image_source_reference(reference: &str) -> Option<(String, String)> {
     }
     let expected_name = format!("{stem}{extension}");
     Some((signature.to_ascii_lowercase(), expected_name))
+}
+
+fn bare_image_source_filename(source_filename: &str) -> Option<&str> {
+    let name = bare_filename(source_filename.trim())?;
+    if matches!(name, "." | "..") || image_mime_type_for_filename(name).is_none() {
+        return None;
+    }
+    Some(name)
 }
 
 fn generated_image_storage_filename(mime_type: &str) -> String {
@@ -8428,6 +8461,71 @@ mod tests {
     }
 
     #[test]
+    fn bare_image_source_filename_validates_from_images_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let images_dir = temp.path().join("images");
+        let source_path = images_dir.join("upload_x.png");
+        let bytes = test_png_bytes(b"attachment");
+        write_test_png(&source_path, b"attachment");
+        let image_sources = test_image_sources(images_dir, [7u8; 32]);
+
+        let validated = validate_image_source_reference(&image_sources, "upload_x.png")
+            .expect("bare attachment filename validates");
+
+        assert_eq!(validated.mime_type, "image/png");
+        assert_eq!(
+            BASE64_STANDARD
+                .decode(validated.image_base64.as_bytes())
+                .expect("decode validated image"),
+            bytes
+        );
+    }
+
+    #[test]
+    fn bare_image_source_filename_rejects_unsafe_names() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let images_dir = temp.path().join("images");
+        fs::create_dir_all(&images_dir).expect("images dir");
+        write_test_png(&images_dir.join("upload_x.png"), b"attachment");
+        fs::write(images_dir.join("upload_x.txt"), b"not an image").expect("write txt");
+        fs::create_dir(images_dir.join("directory.png")).expect("image directory");
+        let image_sources = test_image_sources(images_dir, [7u8; 32]);
+        let absolute = temp.path().join("upload_x.png");
+
+        for source_filename in [
+            "../escape.png",
+            "sub/dir.png",
+            absolute.to_str().expect("absolute path"),
+            "upload_x.txt",
+            "missing.png",
+            "directory.png",
+        ] {
+            assert!(
+                validate_image_source_reference(&image_sources, source_filename).is_err(),
+                "{source_filename} must be rejected",
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bare_image_source_filename_rejects_symlink_escape() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let images_dir = temp.path().join("images");
+        fs::create_dir_all(&images_dir).expect("images dir");
+        let outside = temp.path().join("outside.png");
+        write_test_png(&outside, b"outside");
+        std::os::unix::fs::symlink(&outside, images_dir.join("upload_x.png"))
+            .expect("image symlink");
+        let image_sources = test_image_sources(images_dir, [7u8; 32]);
+
+        let error = validate_image_source_reference(&image_sources, "upload_x.png")
+            .expect_err("symlink escape must be rejected");
+
+        assert!(error.contains("available June image source"));
+    }
+
+    #[test]
     fn image_source_signing_secret_stays_outside_hermes_home() {
         let temp = tempfile::tempdir().expect("tempdir");
         let app_data_dir = temp.path().join("June");
@@ -9224,6 +9322,16 @@ mcp_servers:
         assert!(soul.contains("selected image model and image safe-mode setting are authoritative"));
         assert!(soul.contains("call the image tool with the user's prompt"));
         assert!(soul.contains("provider rejects the request"));
+        assert!(soul.contains("an image the user attached or pasted into the conversation"));
+        assert!(soul.contains("the edit-safe filename from a prior `june_image` tool result"));
+        assert!(
+            soul.contains("the plain filename of an image the user attached to the conversation")
+        );
+        assert!(soul.contains("upload_20260707_113453_1.png"));
+        assert!(soul.contains("Never pass a full path or an invented name"));
+        assert!(
+            !soul.contains("Only pass a `source_filename` from a prior `june_image` tool result")
+        );
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -4,7 +4,7 @@ use rand::{distributions::Alphanumeric, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     fs::{self, OpenOptions},
     io::{self, Read, Seek, SeekFrom, Write},
     net::TcpListener,
@@ -333,6 +333,10 @@ struct ProviderProxyState {
     token: String,
     image_sources: ImageSourceCapabilities,
     app: Option<AppHandle>,
+    /// Safe-mode values already injected, keyed by requestId, so an MCP retry
+    /// of the same request replays the same shape even if the user flipped
+    /// the toggle in between (June API bills a changed shape as a new call).
+    image_safe_mode_pins: Arc<Mutex<VecDeque<(String, bool)>>>,
 }
 
 #[derive(Clone, Serialize)]
@@ -6804,6 +6808,7 @@ async fn start_june_provider_proxy(
             token,
             image_sources,
             app,
+            image_safe_mode_pins: Arc::new(Mutex::new(VecDeque::new())),
         }),
         shutdown_rx,
     ));
@@ -6930,7 +6935,7 @@ async fn handle_june_provider_connection(
                 .unwrap_or_else(|_| serde_json::json!({}));
             let image_self_report = strip_image_explicit_self_report(&mut body);
             ensure_image_generation_model(&mut body);
-            ensure_image_safe_mode(&mut body);
+            ensure_image_safe_mode(&mut body, &state.image_safe_mode_pins);
             if should_offer_safe_mode_consent(
                 &body,
                 crate::providers::image_safe_mode_prompt_dismissed(),
@@ -6966,7 +6971,7 @@ async fn handle_june_provider_connection(
                 .await?;
                 return Ok(());
             }
-            ensure_image_safe_mode(&mut body);
+            ensure_image_safe_mode(&mut body, &state.image_safe_mode_pins);
             if should_offer_safe_mode_consent(
                 &body,
                 crate::providers::image_safe_mode_prompt_dismissed(),
@@ -7754,17 +7759,48 @@ fn ensure_image_generation_model(body: &mut serde_json::Value) {
 /// Injects the on-device image safe-mode setting when the request omits it, so
 /// MCP-driven generation/editing honors the user's Settings toggle (the MCP
 /// never sends `safeMode`). Uses the camelCase key June API expects.
-fn ensure_image_safe_mode(body: &mut serde_json::Value) {
+///
+/// The injected value is pinned per `requestId`: the MCP retries 429/503/504
+/// by re-posting the same `requestId`, and June API hashes `safe_mode` into
+/// the replay-ledger key - if the user flips the toggle between attempts (the
+/// consent dialog makes this race easy), an unpinned retry would change shape
+/// and settle as a second billable generation instead of a replay.
+fn ensure_image_safe_mode(body: &mut serde_json::Value, pins: &Mutex<VecDeque<(String, bool)>>) {
     let Some(object) = body.as_object_mut() else {
         return;
     };
-    if !object.contains_key("safeMode") {
-        object.insert(
-            "safeMode".to_string(),
-            serde_json::Value::Bool(crate::providers::image_safe_mode()),
-        );
+    if object.contains_key("safeMode") {
+        return;
     }
+    let request_id = object
+        .get("requestId")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let safe_mode = match (request_id, pins.lock()) {
+        (Some(id), Ok(mut pins)) => {
+            if let Some((_, pinned)) = pins.iter().find(|(pinned_id, _)| *pinned_id == id) {
+                *pinned
+            } else {
+                let current = crate::providers::image_safe_mode();
+                if pins.len() >= IMAGE_SAFE_MODE_PIN_CAP {
+                    pins.pop_front();
+                }
+                pins.push_back((id, current));
+                current
+            }
+        }
+        // No requestId to key on (or a poisoned lock): fall back to the live
+        // setting, matching the pre-pinning behavior.
+        _ => crate::providers::image_safe_mode(),
+    };
+    object.insert("safeMode".to_string(), serde_json::Value::Bool(safe_mode));
 }
+
+/// Retries arrive within seconds of the first attempt, so a small ring of
+/// recent request ids is enough to keep every plausible replay stable.
+const IMAGE_SAFE_MODE_PIN_CAP: usize = 64;
 
 /// Reads and removes the MCP-only explicit-content self-report before the
 /// request shape reaches June API. Accepts the snake_case schema field and a
@@ -8474,6 +8510,77 @@ mod tests {
             truncate_image_safe_mode_consent_prompt(&prompt, 120),
             "é".repeat(120)
         );
+    }
+
+    #[test]
+    fn ensure_image_safe_mode_replays_pinned_value_over_live_setting() {
+        // Default settings have safe mode ON; the pin says this request first
+        // ran with it OFF, so a retry must replay OFF or June API's replay
+        // ledger sees a new shape and bills a second generation.
+        let pins = Mutex::new(VecDeque::from([("req-1".to_string(), false)]));
+        let mut body = serde_json::json!({ "requestId": "req-1", "prompt": "a cat" });
+
+        ensure_image_safe_mode(&mut body, &pins);
+
+        assert_eq!(body.get("safeMode"), Some(&serde_json::Value::Bool(false)));
+    }
+
+    #[test]
+    fn ensure_image_safe_mode_pins_first_injection_for_request_id() {
+        let pins = Mutex::new(VecDeque::new());
+        let mut body = serde_json::json!({ "requestId": "req-2", "prompt": "a cat" });
+
+        ensure_image_safe_mode(&mut body, &pins);
+
+        let injected = body
+            .get("safeMode")
+            .and_then(serde_json::Value::as_bool)
+            .expect("safeMode injected");
+        assert_eq!(
+            pins.lock().unwrap().back(),
+            Some(&("req-2".to_string(), injected))
+        );
+    }
+
+    #[test]
+    fn ensure_image_safe_mode_respects_explicit_value_without_pinning() {
+        let pins = Mutex::new(VecDeque::new());
+        let mut body =
+            serde_json::json!({ "requestId": "req-3", "prompt": "a cat", "safeMode": false });
+
+        ensure_image_safe_mode(&mut body, &pins);
+
+        assert_eq!(body.get("safeMode"), Some(&serde_json::Value::Bool(false)));
+        assert!(pins.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn ensure_image_safe_mode_without_request_id_skips_pinning() {
+        let pins = Mutex::new(VecDeque::new());
+        let mut body = serde_json::json!({ "prompt": "a cat" });
+
+        ensure_image_safe_mode(&mut body, &pins);
+
+        assert!(body
+            .get("safeMode")
+            .and_then(serde_json::Value::as_bool)
+            .is_some());
+        assert!(pins.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn ensure_image_safe_mode_pin_ring_evicts_oldest() {
+        let pins = Mutex::new(VecDeque::from_iter(
+            (0..IMAGE_SAFE_MODE_PIN_CAP).map(|index| (format!("req-{index}"), false)),
+        ));
+        let mut body = serde_json::json!({ "requestId": "req-new", "prompt": "a cat" });
+
+        ensure_image_safe_mode(&mut body, &pins);
+
+        let pins = pins.lock().unwrap();
+        assert_eq!(pins.len(), IMAGE_SAFE_MODE_PIN_CAP);
+        assert!(pins.iter().all(|(id, _)| id != "req-0"));
+        assert_eq!(pins.back().map(|(id, _)| id.as_str()), Some("req-new"));
     }
 
     fn test_png_bytes(label: &[u8]) -> Vec<u8> {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -16,7 +16,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::oneshot,
@@ -71,6 +71,8 @@ const JUNE_PROVIDER_PROXY_IMAGE_JSON_OVERHEAD_BYTES: usize = 16 * 1024;
 const JUNE_PROVIDER_PROXY_MAX_IMAGE_BODY_BYTES: usize =
     base64_encoded_len(HERMES_IMAGE_EDIT_SOURCE_MAX_BYTES)
         + JUNE_PROVIDER_PROXY_IMAGE_JSON_OVERHEAD_BYTES;
+const IMAGE_SAFE_MODE_CONSENT_EVENT: &str = "image-safe-mode-consent";
+const IMAGE_SAFE_MODE_CONSENT_PROMPT_MAX_CHARS: usize = 120;
 
 const fn base64_encoded_len(byte_count: usize) -> usize {
     byte_count.div_ceil(3) * 4
@@ -327,6 +329,14 @@ struct SharedProviderProxy {
 struct ProviderProxyState {
     token: String,
     image_sources: ImageSourceCapabilities,
+    app: Option<AppHandle>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ImageSafeModeConsentPayload {
+    source: &'static str,
+    prompt: String,
 }
 
 #[derive(Clone)]
@@ -1018,7 +1028,8 @@ async fn ensure_provider_proxy(
         images_dir: hermes_home.join(JUNE_IMAGE_MCP_IMAGES_DIR_NAME),
         secret: load_or_create_image_source_capability_secret(&app_data_dir)?,
     };
-    let started = start_june_provider_proxy(token.clone(), image_sources).await?;
+    let started =
+        start_june_provider_proxy(token.clone(), image_sources, Some(app.clone())).await?;
     let mut guard = bridge
         .provider_proxy
         .lock()
@@ -6770,6 +6781,7 @@ fn yaml_string(value: &str) -> String {
 async fn start_june_provider_proxy(
     token: String,
     image_sources: ImageSourceCapabilities,
+    app: Option<AppHandle>,
 ) -> Result<RunningJuneProviderProxy, AppError> {
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .map_err(|error| AppError::new("june_provider_proxy_failed", error.to_string()))?;
@@ -6788,6 +6800,7 @@ async fn start_june_provider_proxy(
         Arc::new(ProviderProxyState {
             token,
             image_sources,
+            app,
         }),
         shutdown_rx,
     ));
@@ -6914,6 +6927,12 @@ async fn handle_june_provider_connection(
                 .unwrap_or_else(|_| serde_json::json!({}));
             ensure_image_generation_model(&mut body);
             ensure_image_safe_mode(&mut body);
+            if should_offer_safe_mode_consent(
+                &body,
+                crate::providers::image_safe_mode_prompt_dismissed(),
+            ) {
+                emit_image_safe_mode_consent(&state, &body);
+            }
             forward_image_tool(
                 &mut stream,
                 "/v1/image/generate",
@@ -6942,6 +6961,12 @@ async fn handle_june_provider_connection(
                 return Ok(());
             }
             ensure_image_safe_mode(&mut body);
+            if should_offer_safe_mode_consent(
+                &body,
+                crate::providers::image_safe_mode_prompt_dismissed(),
+            ) {
+                emit_image_safe_mode_consent(&state, &body);
+            }
             forward_image_tool(&mut stream, "/v1/image/edit", &body, &state.image_sources).await?;
         }
         _ => {
@@ -7694,6 +7719,52 @@ fn ensure_image_safe_mode(body: &mut serde_json::Value) {
     }
 }
 
+/// Consent event fires only when this generation runs with safe mode on,
+/// the user hasn't dismissed the prompt, and the text looks explicit.
+fn should_offer_safe_mode_consent(body: &serde_json::Value, prompt_dismissed: bool) -> bool {
+    let safe_mode = body
+        .get("safeMode")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if !safe_mode || prompt_dismissed {
+        return false;
+    }
+    let Some(prompt) = image_safe_mode_consent_text(body) else {
+        return false;
+    };
+    crate::image_safety::may_request_explicit_content(prompt)
+}
+
+fn image_safe_mode_consent_text(body: &serde_json::Value) -> Option<&str> {
+    body.get("prompt")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+}
+
+fn emit_image_safe_mode_consent(state: &ProviderProxyState, body: &serde_json::Value) {
+    let Some(app) = state.app.as_ref() else {
+        return;
+    };
+    let Some(prompt) = image_safe_mode_consent_text(body) else {
+        return;
+    };
+    let _ = app.emit(
+        IMAGE_SAFE_MODE_CONSENT_EVENT,
+        ImageSafeModeConsentPayload {
+            source: "agent",
+            prompt: truncate_image_safe_mode_consent_prompt(
+                prompt,
+                IMAGE_SAFE_MODE_CONSENT_PROMPT_MAX_CHARS,
+            ),
+        },
+    );
+}
+
+fn truncate_image_safe_mode_consent_prompt(prompt: &str, max_chars: usize) -> String {
+    prompt.chars().take(max_chars).collect()
+}
+
 async fn write_raw_response(
     stream: &mut tokio::net::TcpStream,
     status: u16,
@@ -8231,6 +8302,66 @@ mod tests {
         let image_message = provider_proxy_body_too_large_message("/v1/image/edit");
         assert!(image_message.contains("image_request_too_large"));
         assert!(!image_message.contains("maximum context length"));
+    }
+
+    #[test]
+    fn offers_safe_mode_consent_for_explicit_safe_mode_prompt() {
+        let body = serde_json::json!({
+            "safeMode": true,
+            "prompt": "portrait of a nude figure",
+        });
+
+        assert!(should_offer_safe_mode_consent(&body, false));
+    }
+
+    #[test]
+    fn skips_safe_mode_consent_when_safe_mode_is_off() {
+        let body = serde_json::json!({
+            "safeMode": false,
+            "prompt": "portrait of a nude figure",
+        });
+
+        assert!(!should_offer_safe_mode_consent(&body, false));
+    }
+
+    #[test]
+    fn skips_safe_mode_consent_when_prompt_was_dismissed() {
+        let body = serde_json::json!({
+            "safeMode": true,
+            "prompt": "portrait of a nude figure",
+        });
+
+        assert!(!should_offer_safe_mode_consent(&body, true));
+    }
+
+    #[test]
+    fn skips_safe_mode_consent_for_benign_prompt() {
+        let body = serde_json::json!({
+            "safeMode": true,
+            "prompt": "sunset over Sussex",
+        });
+
+        assert!(!should_offer_safe_mode_consent(&body, false));
+    }
+
+    #[test]
+    fn skips_safe_mode_consent_when_prompt_is_missing() {
+        let body = serde_json::json!({
+            "safeMode": true,
+            "instruction": "portrait of a nude figure",
+        });
+
+        assert!(!should_offer_safe_mode_consent(&body, false));
+    }
+
+    #[test]
+    fn truncates_safe_mode_consent_prompt_on_char_boundary() {
+        let prompt = "é".repeat(121);
+
+        assert_eq!(
+            truncate_image_safe_mode_consent_prompt(&prompt, 120),
+            "é".repeat(120)
+        );
     }
 
     fn test_png_bytes(label: &[u8]) -> Vec<u8> {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -7607,9 +7607,16 @@ fn parse_image_source_reference(reference: &str) -> Option<(String, String)> {
     Some((signature.to_ascii_lowercase(), expected_name))
 }
 
+/// Hermes saves conversation attachments into the images dir under this
+/// prefix. Bare (unsigned) edit sources are limited to it so tool-produced
+/// files keep the signed reference's content-hash binding.
+const IMAGE_ATTACHMENT_FILENAME_PREFIX: &str = "upload_";
+
 fn bare_image_source_filename(source_filename: &str) -> Option<&str> {
     let name = bare_filename(source_filename.trim())?;
-    if matches!(name, "." | "..") || image_mime_type_for_filename(name).is_none() {
+    if !name.starts_with(IMAGE_ATTACHMENT_FILENAME_PREFIX)
+        || image_mime_type_for_filename(name).is_none()
+    {
         return None;
     }
     Some(name)
@@ -8488,17 +8495,21 @@ mod tests {
         fs::create_dir_all(&images_dir).expect("images dir");
         write_test_png(&images_dir.join("upload_x.png"), b"attachment");
         fs::write(images_dir.join("upload_x.txt"), b"not an image").expect("write txt");
-        fs::create_dir(images_dir.join("directory.png")).expect("image directory");
+        fs::create_dir(images_dir.join("upload_dir.png")).expect("image directory");
+        // A real tool-output file: bare names must NOT reach it - tool results
+        // keep the signed reference's content-hash binding.
+        write_test_png(&images_dir.join("generated-image-x.png"), b"tool output");
         let image_sources = test_image_sources(images_dir, [7u8; 32]);
         let absolute = temp.path().join("upload_x.png");
 
         for source_filename in [
-            "../escape.png",
-            "sub/dir.png",
+            "../upload_x.png",
+            "sub/upload_x.png",
             absolute.to_str().expect("absolute path"),
             "upload_x.txt",
-            "missing.png",
-            "directory.png",
+            "upload_missing.png",
+            "upload_dir.png",
+            "generated-image-x.png",
         ] {
             assert!(
                 validate_image_source_reference(&image_sources, source_filename).is_err(),

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -155,6 +155,7 @@ const JUNE_SOUL_IMAGE_MD: &str = r#"
 Image tools: you have a `june_image` MCP toolset with `generate_image` and `edit_image`. Use `generate_image` when the user asks you to draw, create, make, or generate an image, picture, illustration, or logo; the result is shown to the user in the conversation and the tool returns a `filename`.
 Use this toolset instead of any generic image, media, or vision-analysis tool for image creation or edits, so June can display the returned image and keep the returned filename in context.
 Do not add a separate content refusal layer before calling these tools. The user's selected image model and image safe-mode setting are authoritative for what the image provider should attempt. If the selected model and setting may support the request, call the image tool with the user's prompt instead of substituting a clothed or sanitized alternative. If the image provider rejects the request, briefly report that provider rejection.
+Set `may_be_explicit` honestly on every `generate_image` or `edit_image` call, judging whether the requested image could contain adult, sexual, or otherwise explicit content from the request itself rather than only its wording.
 When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, or an image the user attached or pasted into the conversation, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact source image as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced or the user attached, even if you cannot see it. Pass exactly one of two `source_filename` values: the edit-safe filename from a prior `june_image` tool result, or the plain filename of an image the user attached to the conversation as shown in its context, such as `upload_20260707_113453_1.png`. Never pass a full path or an invented name.
 "#;
 
@@ -6927,11 +6928,13 @@ async fn handle_june_provider_connection(
             // safe_mode likewise comes from the on-device setting.
             let mut body = serde_json::from_slice::<serde_json::Value>(&request.body)
                 .unwrap_or_else(|_| serde_json::json!({}));
+            let image_self_report = strip_image_explicit_self_report(&mut body);
             ensure_image_generation_model(&mut body);
             ensure_image_safe_mode(&mut body);
             if should_offer_safe_mode_consent(
                 &body,
                 crate::providers::image_safe_mode_prompt_dismissed(),
+                image_self_report,
             ) {
                 emit_image_safe_mode_consent(&state, &body);
             }
@@ -6950,6 +6953,7 @@ async fn handle_june_provider_connection(
             // it here, where the signing key is outside Hermes home.
             let mut body = serde_json::from_slice::<serde_json::Value>(&request.body)
                 .unwrap_or_else(|_| serde_json::json!({}));
+            let image_self_report = strip_image_explicit_self_report(&mut body);
             if let Err(message) = prepare_image_edit_request(&mut body, &state.image_sources) {
                 write_json_response(
                     &mut stream,
@@ -6966,6 +6970,7 @@ async fn handle_june_provider_connection(
             if should_offer_safe_mode_consent(
                 &body,
                 crate::providers::image_safe_mode_prompt_dismissed(),
+                image_self_report,
             ) {
                 emit_image_safe_mode_consent(&state, &body);
             }
@@ -7761,9 +7766,32 @@ fn ensure_image_safe_mode(body: &mut serde_json::Value) {
     }
 }
 
+/// Reads and removes the MCP-only explicit-content self-report before the
+/// request shape reaches June API. Accepts the snake_case schema field and a
+/// camelCase alias defensively; malformed values are stripped but ignored.
+fn strip_image_explicit_self_report(body: &mut serde_json::Value) -> bool {
+    let Some(object) = body.as_object_mut() else {
+        return false;
+    };
+    let snake_case = object
+        .remove("may_be_explicit")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    let camel_case = object
+        .remove("mayBeExplicit")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    snake_case || camel_case
+}
+
 /// Consent event fires only when this generation runs with safe mode on,
-/// the user hasn't dismissed the prompt, and the text looks explicit.
-fn should_offer_safe_mode_consent(body: &serde_json::Value, prompt_dismissed: bool) -> bool {
+/// the user hasn't dismissed the prompt, and the text or MCP self-report
+/// indicates the request may be explicit.
+fn should_offer_safe_mode_consent(
+    body: &serde_json::Value,
+    prompt_dismissed: bool,
+    self_report: bool,
+) -> bool {
     let safe_mode = body
         .get("safeMode")
         .and_then(serde_json::Value::as_bool)
@@ -7771,10 +7799,10 @@ fn should_offer_safe_mode_consent(body: &serde_json::Value, prompt_dismissed: bo
     if !safe_mode || prompt_dismissed {
         return false;
     }
-    let Some(prompt) = image_safe_mode_consent_text(body) else {
-        return false;
-    };
-    crate::image_safety::may_request_explicit_content(prompt)
+    let wordlist_report = image_safe_mode_consent_text(body)
+        .map(crate::image_safety::may_request_explicit_content)
+        .unwrap_or(false);
+    wordlist_report || self_report
 }
 
 fn image_safe_mode_consent_text(body: &serde_json::Value) -> Option<&str> {
@@ -8347,43 +8375,53 @@ mod tests {
     }
 
     #[test]
-    fn offers_safe_mode_consent_for_explicit_safe_mode_prompt() {
+    fn offers_safe_mode_consent_for_self_reported_explicit_safe_mode_prompt() {
+        let body = serde_json::json!({
+            "safeMode": true,
+            "prompt": "portrait in soft window light",
+        });
+
+        assert!(should_offer_safe_mode_consent(&body, false, true));
+    }
+
+    #[test]
+    fn offers_safe_mode_consent_for_wordlist_flagged_prompt_when_model_under_reports() {
         let body = serde_json::json!({
             "safeMode": true,
             "prompt": "portrait of a nude figure",
         });
 
-        assert!(should_offer_safe_mode_consent(&body, false));
+        assert!(should_offer_safe_mode_consent(&body, false, false));
     }
 
     #[test]
-    fn skips_safe_mode_consent_when_safe_mode_is_off() {
-        let body = serde_json::json!({
-            "safeMode": false,
-            "prompt": "portrait of a nude figure",
-        });
-
-        assert!(!should_offer_safe_mode_consent(&body, false));
-    }
-
-    #[test]
-    fn skips_safe_mode_consent_when_prompt_was_dismissed() {
-        let body = serde_json::json!({
-            "safeMode": true,
-            "prompt": "portrait of a nude figure",
-        });
-
-        assert!(!should_offer_safe_mode_consent(&body, true));
-    }
-
-    #[test]
-    fn skips_safe_mode_consent_for_benign_prompt() {
+    fn skips_safe_mode_consent_when_wordlist_and_self_report_are_benign() {
         let body = serde_json::json!({
             "safeMode": true,
             "prompt": "sunset over Sussex",
         });
 
-        assert!(!should_offer_safe_mode_consent(&body, false));
+        assert!(!should_offer_safe_mode_consent(&body, false, false));
+    }
+
+    #[test]
+    fn skips_safe_mode_consent_when_safe_mode_is_off_even_with_self_report() {
+        let body = serde_json::json!({
+            "safeMode": false,
+            "prompt": "portrait of a nude figure",
+        });
+
+        assert!(!should_offer_safe_mode_consent(&body, false, true));
+    }
+
+    #[test]
+    fn skips_safe_mode_consent_when_prompt_was_dismissed_even_with_self_report() {
+        let body = serde_json::json!({
+            "safeMode": true,
+            "prompt": "portrait of a nude figure",
+        });
+
+        assert!(!should_offer_safe_mode_consent(&body, true, true));
     }
 
     #[test]
@@ -8393,7 +8431,39 @@ mod tests {
             "instruction": "portrait of a nude figure",
         });
 
-        assert!(!should_offer_safe_mode_consent(&body, false));
+        assert!(!should_offer_safe_mode_consent(&body, false, false));
+    }
+
+    #[test]
+    fn strips_image_explicit_self_report_fields_from_forwarded_body() {
+        let mut body = serde_json::json!({
+            "prompt": "sunset over Sussex",
+            "may_be_explicit": false,
+            "mayBeExplicit": true,
+        });
+
+        assert!(strip_image_explicit_self_report(&mut body));
+        assert_eq!(body.get("may_be_explicit"), None);
+        assert_eq!(body.get("mayBeExplicit"), None);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "prompt": "sunset over Sussex",
+            })
+        );
+    }
+
+    #[test]
+    fn strips_malformed_image_explicit_self_report_as_false() {
+        let mut body = serde_json::json!({
+            "prompt": "sunset over Sussex",
+            "may_be_explicit": "true",
+            "mayBeExplicit": "false",
+        });
+
+        assert!(!strip_image_explicit_self_report(&mut body));
+        assert_eq!(body.get("may_be_explicit"), None);
+        assert_eq!(body.get("mayBeExplicit"), None);
     }
 
     #[test]
@@ -9332,6 +9402,8 @@ mcp_servers:
         assert!(soul.contains("Do not add a separate content refusal layer"));
         assert!(soul.contains("selected image model and image safe-mode setting are authoritative"));
         assert!(soul.contains("call the image tool with the user's prompt"));
+        assert!(soul.contains("Set `may_be_explicit` honestly"));
+        assert!(soul.contains("judging whether the requested image could contain adult"));
         assert!(soul.contains("provider rejects the request"));
         assert!(soul.contains("an image the user attached or pasted into the conversation"));
         assert!(soul.contains("the edit-safe filename from a prior `june_image` tool result"));

--- a/src-tauri/src/image_safety.rs
+++ b/src-tauri/src/image_safety.rs
@@ -1,0 +1,127 @@
+use serde::{Deserialize, Serialize};
+
+const EXPLICIT_TERMS: &[&str] = &[
+    "bdsm",
+    "bottomless",
+    "erotic",
+    "erotica",
+    "explicit",
+    "fetish",
+    "genitals",
+    "hentai",
+    "naked",
+    "nipples",
+    "nsfw",
+    "nude",
+    "nudes",
+    "porn",
+    "porno",
+    "pornographic",
+    "sex",
+    "sexual",
+    "sexy",
+    "stripping",
+    "striptease",
+    "topless",
+    "undressed",
+    "undressing",
+    "xxx",
+];
+
+const EXPLICIT_PHRASES: &[&[&str]] = &[
+    &["no", "clothes"],
+    &["take", "off", "her", "clothes"],
+    &["take", "off", "his", "clothes"],
+    &["take", "off", "their", "clothes"],
+    &["without", "clothes"],
+];
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagePromptScreenRequest {
+    pub prompt: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagePromptScreenResponse {
+    pub may_be_explicit: bool,
+}
+
+/// True when an image prompt plausibly requests explicit (adult) content, so
+/// callers can offer the safe-mode consent dialog before generating.
+pub fn may_request_explicit_content(prompt: &str) -> bool {
+    let normalized = prompt.to_lowercase();
+    let tokens: Vec<&str> = normalized
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+
+    tokens
+        .iter()
+        .any(|token| EXPLICIT_TERMS.binary_search(token).is_ok())
+        || EXPLICIT_PHRASES
+            .iter()
+            .any(|phrase| contains_token_sequence(&tokens, phrase))
+}
+
+#[tauri::command]
+pub fn image_prompt_may_be_explicit(
+    request: ImagePromptScreenRequest,
+) -> ImagePromptScreenResponse {
+    ImagePromptScreenResponse {
+        may_be_explicit: may_request_explicit_content(&request.prompt),
+    }
+}
+
+fn contains_token_sequence(tokens: &[&str], sequence: &[&str]) -> bool {
+    !sequence.is_empty()
+        && tokens
+            .windows(sequence.len())
+            .any(|window| window == sequence)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::may_request_explicit_content;
+
+    #[test]
+    fn detects_plain_term() {
+        assert!(may_request_explicit_content("portrait of a nude figure"));
+    }
+
+    #[test]
+    fn detects_uppercase_term() {
+        assert!(may_request_explicit_content("NSFW illustration"));
+    }
+
+    #[test]
+    fn detects_term_with_punctuation() {
+        assert!(may_request_explicit_content("nude!"));
+    }
+
+    #[test]
+    fn detects_phrase() {
+        assert!(may_request_explicit_content("portrait without clothes"));
+    }
+
+    #[test]
+    fn ignores_sussex_substring_trap() {
+        assert!(!may_request_explicit_content("sunset over Sussex"));
+    }
+
+    #[test]
+    fn ignores_sextant_substring_trap() {
+        assert!(!may_request_explicit_content("sextant on a ship's deck"));
+    }
+
+    #[test]
+    fn ignores_sexagenarian_substring_trap() {
+        assert!(!may_request_explicit_content("a sexagenarian chess player"));
+    }
+
+    #[test]
+    fn ignores_empty_string() {
+        assert!(!may_request_explicit_content(""));
+    }
+}

--- a/src-tauri/src/image_safety.rs
+++ b/src-tauri/src/image_safety.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+// Deliberately conservative (ADR 0008 addendum, JUN-209): this list only
+// gates the safe-mode consent dialog, never what gets generated - Venice
+// `safe_mode` is the enforcement. Keep terms unambiguous; euphemisms are an
+// accepted miss, and broadening the list mostly buys false-positive dialogs.
 const EXPLICIT_TERMS: &[&str] = &[
     "bdsm",
     "bottomless",

--- a/src-tauri/src/image_safety.rs
+++ b/src-tauri/src/image_safety.rs
@@ -1,4 +1,7 @@
+use crate::domain::types::AppError;
 use serde::{Deserialize, Serialize};
+use std::{future::Future, time::Duration};
+use tokio::time::timeout;
 
 // Deliberately conservative (ADR 0008 addendum, JUN-209): this list only
 // gates the safe-mode consent dialog, never what gets generated - Venice
@@ -70,12 +73,33 @@ pub fn may_request_explicit_content(prompt: &str) -> bool {
 }
 
 #[tauri::command]
-pub fn image_prompt_may_be_explicit(
+pub async fn image_prompt_may_be_explicit(
     request: ImagePromptScreenRequest,
 ) -> ImagePromptScreenResponse {
-    ImagePromptScreenResponse {
-        may_be_explicit: may_request_explicit_content(&request.prompt),
+    screen_image_prompt(&request.prompt, |prompt| async move {
+        crate::june_api::classify_image_prompt_explicit(&prompt).await
+    })
+    .await
+}
+
+async fn screen_image_prompt<F, Fut>(prompt: &str, classify: F) -> ImagePromptScreenResponse
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<bool, AppError>>,
+{
+    if may_request_explicit_content(prompt) {
+        return ImagePromptScreenResponse {
+            may_be_explicit: true,
+        };
     }
+
+    let may_be_explicit = match timeout(Duration::from_secs(8), classify(prompt.to_string())).await
+    {
+        Ok(Ok(verdict)) => verdict,
+        Ok(Err(_)) | Err(_) => false,
+    };
+
+    ImagePromptScreenResponse { may_be_explicit }
 }
 
 fn contains_token_sequence(tokens: &[&str], sequence: &[&str]) -> bool {
@@ -87,7 +111,12 @@ fn contains_token_sequence(tokens: &[&str], sequence: &[&str]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::may_request_explicit_content;
+    use super::{may_request_explicit_content, screen_image_prompt};
+    use crate::domain::types::AppError;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     #[test]
     fn detects_plain_term() {
@@ -127,5 +156,44 @@ mod tests {
     #[test]
     fn ignores_empty_string() {
         assert!(!may_request_explicit_content(""));
+    }
+
+    #[tokio::test]
+    async fn wordlist_hit_skips_classifier() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_for_classifier = Arc::clone(&called);
+
+        let response = screen_image_prompt("portrait of a nude figure", move |_| async move {
+            called_for_classifier.store(true, Ordering::SeqCst);
+            Ok(false)
+        })
+        .await;
+
+        assert!(response.may_be_explicit);
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn classifier_true_propagates() {
+        let response = screen_image_prompt("portret bez ubrania", |_| async { Ok(true) }).await;
+
+        assert!(response.may_be_explicit);
+    }
+
+    #[tokio::test]
+    async fn classifier_false_propagates() {
+        let response = screen_image_prompt("a red bicycle", |_| async { Ok(false) }).await;
+
+        assert!(!response.may_be_explicit);
+    }
+
+    #[tokio::test]
+    async fn classifier_error_falls_back_to_false() {
+        let response = screen_image_prompt("portret bez ubrania", |_| async {
+            Err(AppError::new("classifier_failed", "classifier failed"))
+        })
+        .await;
+
+        assert!(!response.may_be_explicit);
     }
 }

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -986,6 +986,75 @@ pub async fn suggest_agent_session_title(prompt: &str) -> Result<String, AppErro
     })
 }
 
+/// One-shot YES/NO classification: does this image prompt request explicit
+/// (adult) content? Language-agnostic - this backs the /image consent gate
+/// where no model is otherwise in the loop. Metered like any agent chat.
+pub async fn classify_image_prompt_explicit(prompt: &str) -> Result<bool, AppError> {
+    if prompt.trim().is_empty() {
+        return Err(AppError::new(
+            "image_prompt_classification_empty",
+            "Cannot classify an empty image prompt.",
+        ));
+    }
+    let response = proxy_agent_chat_completions(serde_json::json!({
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a strict content classifier for an image generator. The user message is an image-generation prompt, in any language. Answer with exactly one word: YES if it requests adult, sexual, nude, or otherwise explicit content; NO otherwise. Answer NO when the request is ambiguous or benign."
+            },
+            {
+                "role": "user",
+                "content": prompt
+            }
+        ],
+        "temperature": 0,
+        // Sized for reasoning models: hidden thinking spends from the same
+        // budget as the one-word answer, and a cap hit mid-think yields no
+        // classification at all.
+        "max_tokens": 500
+    }))
+    .await?;
+    if !(200..300).contains(&response.status) {
+        return Err(AppError::new(
+            "image_prompt_classification_failed",
+            format!(
+                "Image prompt classification returned status {}.",
+                response.status
+            ),
+        ));
+    }
+    let body = response.collect_body().await?;
+    let value: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|error| AppError::new("image_prompt_classification_invalid", error.to_string()))?;
+    let text = extract_chat_completion_text(&value).ok_or_else(|| {
+        AppError::new(
+            "image_prompt_classification_invalid",
+            "Image prompt classification did not return text.",
+        )
+    })?;
+    parse_explicit_classification(&text).ok_or_else(|| {
+        AppError::new(
+            "image_prompt_classification_invalid",
+            "Image prompt classification did not return YES or NO.",
+        )
+    })
+}
+
+fn parse_explicit_classification(text: &str) -> Option<bool> {
+    let text = text
+        .trim()
+        .trim_matches(|character: char| !character.is_alphanumeric())
+        .trim();
+    let lower = text.to_ascii_lowercase();
+    if lower.starts_with("yes") {
+        Some(true)
+    } else if lower.starts_with("no") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
 // Matches the server's per-attachment cap; bigger files are listed by name
 // in the report but their bytes stay local.
 const ISSUE_ATTACHMENT_MAX_BYTES: usize = 10 * 1024 * 1024;
@@ -1785,6 +1854,17 @@ mod tests {
             Some("Create a quarterly planning briefing with follow")
         );
         assert_eq!(clean_agent_session_title("   "), None);
+    }
+
+    #[test]
+    fn parses_explicit_classification_yes_no_answers() {
+        assert_eq!(parse_explicit_classification("YES"), Some(true));
+        assert_eq!(parse_explicit_classification("no."), Some(false));
+        assert_eq!(parse_explicit_classification("  Yes\n"), Some(true));
+        assert_eq!(parse_explicit_classification("**NO**"), Some(false));
+        assert_eq!(parse_explicit_classification("maybe"), None);
+        assert_eq!(parse_explicit_classification(""), None);
+        assert_eq!(parse_explicit_classification("The answer is yes."), None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -255,6 +255,7 @@ pub fn run() {
             providers::set_venice_api_key,
             providers::clear_venice_api_key,
             providers::set_image_safe_mode,
+            providers::set_image_safe_mode_prompt_dismissed,
             providers::generate_image,
             providers::edit_image,
             providers::save_local_generation_settings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod db;
 pub mod dictation;
 pub mod domain;
 pub mod hermes_bridge;
+pub mod image_safety;
 pub mod june_api;
 pub mod macos_menu_icons;
 pub mod meeting_detection;
@@ -256,6 +257,7 @@ pub fn run() {
             providers::clear_venice_api_key,
             providers::set_image_safe_mode,
             providers::set_image_safe_mode_prompt_dismissed,
+            image_safety::image_prompt_may_be_explicit,
             providers::generate_image,
             providers::edit_image,
             providers::save_local_generation_settings,

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -61,11 +61,17 @@ pub struct ProviderModelSettings {
     #[serde(default)]
     pub local_generation: LocalGenerationSettings,
     /// When true, Venice `safe_mode` blurs adult content on generated/edited
-    /// images. June defaults it OFF (privacy-first: no server-side censoring of
-    /// the user's own image work); the user opts in via Settings. Defaulted so
-    /// settings files predating this field still deserialize (to `false`).
-    #[serde(default)]
+    /// images. June defaults it ON; the user opts out via Settings or the
+    /// generation-time consent dialog. Defaulted so settings files predating
+    /// this field still deserialize to the current default.
+    #[serde(default = "default_image_safe_mode")]
     pub image_safe_mode: bool,
+    /// When true, the user chose "don't ask again" on the safe-mode consent
+    /// dialog: June stops offering to turn safe mode off before
+    /// potentially-explicit generations. Reset to false whenever safe mode is
+    /// explicitly re-enabled, so re-opting into safety re-arms the prompt.
+    #[serde(default)]
+    pub image_safe_mode_prompt_dismissed: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -92,6 +98,7 @@ pub struct ProviderModelSettingsDto {
     pub venice_api_key_configured: bool,
     pub local_generation: LocalGenerationSettings,
     pub image_safe_mode: bool,
+    pub image_safe_mode_prompt_dismissed: bool,
 }
 
 impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
@@ -109,6 +116,7 @@ impl From<&ProviderModelSettings> for ProviderModelSettingsDto {
                 .is_some_and(|value| !value.trim().is_empty()),
             local_generation: settings.local_generation.clone(),
             image_safe_mode: settings.image_safe_mode,
+            image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
         }
     }
 }
@@ -275,9 +283,9 @@ pub fn venice_api_key() -> Option<String> {
     current_settings().venice_api_key
 }
 
-/// Whether Venice safe mode is on for image generation/editing. `false` (the
-/// default) means June sends `safe_mode: false` so it never server-side-censors
-/// the user's own image work; the user can turn it on in Settings.
+/// Whether Venice safe mode is on for image generation/editing. The default is
+/// `true`, so June asks Venice to blur adult content unless the user opts out
+/// via Settings or the generation-time consent dialog.
 pub fn image_safe_mode() -> bool {
     current_settings().image_safe_mode
 }
@@ -381,16 +389,50 @@ pub struct SetImageSafeModeRequest {
     pub enabled: bool,
 }
 
-/// Persists the image safe-mode toggle. Off by default (privacy-first); the
-/// value flows into every image generation/edit request from the loopback proxy
-/// and the fast path.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SetImageSafeModePromptDismissedRequest {
+    pub dismissed: bool,
+}
+
+/// Persists the image safe-mode toggle. On by default; the user can opt out
+/// via Settings or the generation-time consent dialog. The value flows into
+/// every image generation/edit request from the loopback proxy and the fast
+/// path.
 #[tauri::command]
 pub fn set_image_safe_mode(
     state: State<'_, ProviderSettingsState>,
     request: SetImageSafeModeRequest,
 ) -> Result<ProviderModelSettingsDto, AppError> {
-    update_settings(&state, |settings| {
+    set_image_safe_mode_impl(&state, request)
+}
+
+fn set_image_safe_mode_impl(
+    state: &ProviderSettingsState,
+    request: SetImageSafeModeRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    update_settings(state, |settings| {
         settings.image_safe_mode = request.enabled;
+        if request.enabled {
+            settings.image_safe_mode_prompt_dismissed = false;
+        }
+    })
+}
+
+#[tauri::command]
+pub fn set_image_safe_mode_prompt_dismissed(
+    state: State<'_, ProviderSettingsState>,
+    request: SetImageSafeModePromptDismissedRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    set_image_safe_mode_prompt_dismissed_impl(&state, request)
+}
+
+fn set_image_safe_mode_prompt_dismissed_impl(
+    state: &ProviderSettingsState,
+    request: SetImageSafeModePromptDismissedRequest,
+) -> Result<ProviderModelSettingsDto, AppError> {
+    update_settings(state, |settings| {
+        settings.image_safe_mode_prompt_dismissed = request.dismissed;
     })
 }
 
@@ -775,7 +817,8 @@ fn default_settings() -> ProviderModelSettings {
         image_model: DEFAULT_IMAGE_MODEL.to_string(),
         venice_api_key: None,
         local_generation: LocalGenerationSettings::default(),
-        image_safe_mode: false,
+        image_safe_mode: true,
+        image_safe_mode_prompt_dismissed: false,
     }
 }
 
@@ -797,6 +840,10 @@ fn default_generation_model() -> String {
 
 fn default_image_model() -> String {
     DEFAULT_IMAGE_MODEL.to_string()
+}
+
+fn default_image_safe_mode() -> bool {
+    true
 }
 
 fn provider_settings_path(app: &AppHandle) -> Option<PathBuf> {
@@ -863,6 +910,7 @@ fn sanitize_settings(
         venice_api_key: normalize_api_key_option(settings.venice_api_key),
         local_generation,
         image_safe_mode: settings.image_safe_mode,
+        image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
     }
 }
 
@@ -1152,6 +1200,28 @@ mod tests {
     }
 
     #[test]
+    fn default_settings_enable_image_safe_mode_without_prompt_dismissal() {
+        let settings = default_settings();
+
+        assert!(settings.image_safe_mode);
+        assert!(!settings.image_safe_mode_prompt_dismissed);
+    }
+
+    #[test]
+    fn provider_settings_deserialize_defaults_missing_image_safe_mode_fields() {
+        let settings: ProviderModelSettings = serde_json::from_value(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35"
+        }))
+        .unwrap();
+
+        assert!(settings.image_safe_mode);
+        assert!(!settings.image_safe_mode_prompt_dismissed);
+    }
+
+    #[test]
     fn venice_models_response_serializes_canonical_mode() {
         let response = VeniceModelsResponse {
             mode: ModelMode::Transcription,
@@ -1341,6 +1411,42 @@ mod tests {
     }
 
     static NEXT_TEST_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    #[test]
+    fn set_image_safe_mode_true_resets_dismissed_prompt() {
+        let state = test_state();
+        {
+            let mut settings = state.settings.lock().unwrap();
+            settings.image_safe_mode = false;
+            settings.image_safe_mode_prompt_dismissed = true;
+        }
+
+        let updated =
+            set_image_safe_mode_impl(&state, SetImageSafeModeRequest { enabled: true }).unwrap();
+
+        assert!(updated.image_safe_mode);
+        assert!(!updated.image_safe_mode_prompt_dismissed);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(saved.image_safe_mode);
+        assert!(!saved.image_safe_mode_prompt_dismissed);
+    }
+
+    #[test]
+    fn set_image_safe_mode_prompt_dismissed_persists_flag() {
+        let state = test_state();
+
+        let updated = set_image_safe_mode_prompt_dismissed_impl(
+            &state,
+            SetImageSafeModePromptDismissedRequest { dismissed: true },
+        )
+        .unwrap();
+
+        assert!(updated.image_safe_mode_prompt_dismissed);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(saved.image_safe_mode_prompt_dismissed);
+    }
 
     #[test]
     fn save_local_generation_settings_persists_without_activating() {

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -72,6 +72,13 @@ pub struct ProviderModelSettings {
     /// explicitly re-enabled, so re-opting into safety re-arms the prompt.
     #[serde(default)]
     pub image_safe_mode_prompt_dismissed: bool,
+    /// True once the user explicitly chose a safe-mode value (Settings toggle
+    /// or the consent dialog, both of which land in `set_image_safe_mode`).
+    /// Without it, a stored `image_safe_mode` is ignored on load and safe
+    /// mode reads its default (on) - files written by pre-JUN-209 builds
+    /// carry an incidental `false` the user never picked.
+    #[serde(default)]
+    pub image_safe_mode_set_by_user: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -417,6 +424,7 @@ fn set_image_safe_mode_impl(
 ) -> Result<ProviderModelSettingsDto, AppError> {
     update_settings(state, |settings| {
         settings.image_safe_mode = request.enabled;
+        settings.image_safe_mode_set_by_user = true;
         if request.enabled {
             settings.image_safe_mode_prompt_dismissed = false;
         }
@@ -823,6 +831,7 @@ fn default_settings() -> ProviderModelSettings {
         local_generation: LocalGenerationSettings::default(),
         image_safe_mode: true,
         image_safe_mode_prompt_dismissed: false,
+        image_safe_mode_set_by_user: false,
     }
 }
 
@@ -900,6 +909,12 @@ fn sanitize_settings(
         configured
     };
 
+    let image_safe_mode = if settings.image_safe_mode_set_by_user {
+        settings.image_safe_mode
+    } else {
+        true
+    };
+
     ProviderModelSettings {
         transcription_provider: transcription_provider_for_model(&transcription_model).to_string(),
         generation_provider: if local_active {
@@ -913,8 +928,9 @@ fn sanitize_settings(
         image_model: non_empty_or(settings.image_model, &defaults.image_model),
         venice_api_key: normalize_api_key_option(settings.venice_api_key),
         local_generation,
-        image_safe_mode: settings.image_safe_mode,
+        image_safe_mode,
         image_safe_mode_prompt_dismissed: settings.image_safe_mode_prompt_dismissed,
+        image_safe_mode_set_by_user: settings.image_safe_mode_set_by_user,
     }
 }
 
@@ -1209,20 +1225,56 @@ mod tests {
 
         assert!(settings.image_safe_mode);
         assert!(!settings.image_safe_mode_prompt_dismissed);
+        assert!(!settings.image_safe_mode_set_by_user);
     }
 
     #[test]
     fn provider_settings_deserialize_defaults_missing_image_safe_mode_fields() {
-        let settings: ProviderModelSettings = serde_json::from_value(serde_json::json!({
+        let settings = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
             "transcriptionProvider": "venice",
             "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
             "generationModel": "zai-org-glm-5-2",
             "imageModel": "venice-sd35"
         }))
         .unwrap();
+        let settings = sanitize_settings(settings, &default_settings());
 
         assert!(settings.image_safe_mode);
         assert!(!settings.image_safe_mode_prompt_dismissed);
+        assert!(!settings.image_safe_mode_set_by_user);
+    }
+
+    #[test]
+    fn provider_settings_coerces_legacy_image_safe_mode_false_without_user_marker() {
+        let settings = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35",
+            "imageSafeMode": false
+        }))
+        .unwrap();
+        let settings = sanitize_settings(settings, &default_settings());
+
+        assert!(settings.image_safe_mode);
+        assert!(!settings.image_safe_mode_set_by_user);
+    }
+
+    #[test]
+    fn provider_settings_preserves_image_safe_mode_false_with_user_marker() {
+        let settings = serde_json::from_value::<ProviderModelSettings>(serde_json::json!({
+            "transcriptionProvider": "venice",
+            "transcriptionModel": "nvidia/parakeet-tdt-0.6b-v3",
+            "generationModel": "zai-org-glm-5-2",
+            "imageModel": "venice-sd35",
+            "imageSafeMode": false,
+            "imageSafeModeSetByUser": true
+        }))
+        .unwrap();
+        let settings = sanitize_settings(settings, &default_settings());
+
+        assert!(!settings.image_safe_mode);
+        assert!(settings.image_safe_mode_set_by_user);
     }
 
     #[test]
@@ -1434,11 +1486,34 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
         assert!(saved.image_safe_mode);
         assert!(!saved.image_safe_mode_prompt_dismissed);
+        assert!(saved.image_safe_mode_set_by_user);
     }
 
     #[test]
-    fn set_image_safe_mode_prompt_dismissed_persists_flag() {
+    fn set_image_safe_mode_false_persists_user_marker_and_reloads_false() {
         let state = test_state();
+
+        let updated =
+            set_image_safe_mode_impl(&state, SetImageSafeModeRequest { enabled: false }).unwrap();
+
+        assert!(!updated.image_safe_mode);
+        let saved: ProviderModelSettings =
+            serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
+        assert!(!saved.image_safe_mode);
+        assert!(saved.image_safe_mode_set_by_user);
+
+        let reloaded = sanitize_settings(saved, &default_settings());
+        assert!(!reloaded.image_safe_mode);
+        assert!(reloaded.image_safe_mode_set_by_user);
+    }
+
+    #[test]
+    fn set_image_safe_mode_prompt_dismissed_persists_flag_without_touching_user_marker() {
+        let state = test_state();
+        {
+            let mut settings = state.settings.lock().unwrap();
+            settings.image_safe_mode_set_by_user = true;
+        }
 
         let updated = set_image_safe_mode_prompt_dismissed_impl(
             &state,
@@ -1450,6 +1525,7 @@ mod tests {
         let saved: ProviderModelSettings =
             serde_json::from_str(&fs::read_to_string(&state.path).unwrap()).unwrap();
         assert!(saved.image_safe_mode_prompt_dismissed);
+        assert!(saved.image_safe_mode_set_by_user);
     }
 
     #[test]

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -290,6 +290,10 @@ pub fn image_safe_mode() -> bool {
     current_settings().image_safe_mode
 }
 
+pub fn image_safe_mode_prompt_dismissed() -> bool {
+    current_settings().image_safe_mode_prompt_dismissed
+}
+
 /// Context window (tokens) of the configured generation model, looked up in
 /// the backend's model catalog and cached per model id. The agent provider
 /// proxy advertises it on `/v1/models` so Hermes sizes its history to the

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -823,6 +823,11 @@ type ImageSafeModeConsentRequest = {
   resolve: (choice: ImageSafeModeConsentChoice) => void;
 };
 
+type ImageSafeModeConsentEventPayload = {
+  source?: string;
+  prompt?: string;
+};
+
 export function agentWorkspaceErrorStateForMessage(
   message: string,
   sessionId: string | null,
@@ -1714,6 +1719,7 @@ export function AgentWorkspace({
   );
   const [imageSafeModeConsentRequest, setImageSafeModeConsentRequest] =
     useState<ImageSafeModeConsentRequest | null>(null);
+  const imageSafeModeConsentRequestRef = useRef<ImageSafeModeConsentRequest | null>(null);
   const composerSizeProceedSignatureRef = useRef<string | null>(null);
   const composerSizeProceedInputSignatureRef = useRef<string | null>(null);
   // Honest result of the last model switch (feature 10): scoped to the session
@@ -3530,7 +3536,7 @@ export function AgentWorkspace({
   useEffect(() => {
     let disposed = false;
     const unlisteners: Array<() => void> = [];
-    const installListener = async (eventName: string) => {
+    const installFileDropListener = async (eventName: string) => {
       const unlisten = await listen<TauriFileDropPayload>(eventName, (event) => {
         const paths = event.payload?.paths ?? [];
         if (paths.length) {
@@ -3543,8 +3549,22 @@ export function AgentWorkspace({
       }
       unlisteners.push(unlisten);
     };
-    void installListener("tauri://drag-drop");
-    void installListener("tauri://file-drop");
+    const installImageSafeModeConsentListener = async () => {
+      const unlisten = await listen<ImageSafeModeConsentEventPayload>(
+        "image-safe-mode-consent",
+        (event) => {
+          void handleAgentImageSafeModeConsentEvent(event.payload);
+        },
+      );
+      if (disposed) {
+        unlisten();
+        return;
+      }
+      unlisteners.push(unlisten);
+    };
+    void installFileDropListener("tauri://drag-drop");
+    void installFileDropListener("tauri://file-drop");
+    void installImageSafeModeConsentListener();
     return () => {
       disposed = true;
       for (const unlisten of unlisteners) unlisten();
@@ -3820,15 +3840,47 @@ export function AgentWorkspace({
     variant: "slash" | "agent",
   ): Promise<ImageSafeModeConsentChoice> {
     return new Promise((resolve) => {
-      setImageSafeModeConsentRequest({ variant, resolve });
+      const request = { variant, resolve };
+      imageSafeModeConsentRequestRef.current = request;
+      setImageSafeModeConsentRequest(request);
     });
   }
 
   function resolveImageSafeModeConsent(choice: ImageSafeModeConsentChoice) {
-    const request = imageSafeModeConsentRequest;
+    const request = imageSafeModeConsentRequestRef.current;
     if (!request) return;
+    imageSafeModeConsentRequestRef.current = null;
     setImageSafeModeConsentRequest(null);
     request.resolve(choice);
+  }
+
+  async function handleAgentImageSafeModeConsentEvent(payload?: ImageSafeModeConsentEventPayload) {
+    if (payload?.source !== "agent") return;
+    if (imageSafeModeConsentRequestRef.current) return;
+
+    let settings: ProviderModelSettingsDto | undefined;
+    try {
+      settings = (await providerModelSettings()).settings;
+    } catch {
+      return;
+    }
+    if (!settings.imageSafeMode || settings.imageSafeModePromptDismissed) return;
+    if (imageSafeModeConsentRequestRef.current) return;
+
+    const choice = await requestImageSafeModeConsent("agent");
+    if (choice.action === "dismiss") return;
+    if (choice.action === "keep") {
+      if (choice.dontAskAgain) void setImageSafeModePromptDismissed(true);
+      return;
+    }
+
+    try {
+      await setImageSafeMode(false);
+    } catch (err) {
+      setError(messageFromError(err));
+      return;
+    }
+    if (choice.dontAskAgain) void setImageSafeModePromptDismissed(true);
   }
 
   // `/image <prompt>` renders the generated image inline in the chat as an

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -105,7 +105,10 @@ import {
   osAccountsUpgrade,
   providerModelSettings,
   retryAgentTask,
+  imagePromptMayBeExplicit,
   setHermesAgentCliAccess,
+  setImageSafeMode,
+  setImageSafeModePromptDismissed,
   setLocalGenerationEnabled,
   setVeniceModel,
   startHermesBridge,
@@ -258,6 +261,7 @@ import {
 } from "../../lib/agent-composer-slash-commands";
 import { generateChatImage, newImageRequestId } from "../../lib/chat-image-generation";
 import { IMAGE_GENERATION_ENABLED } from "../../lib/feature-flags";
+import { ImageSafeModeConsentDialog } from "./ImageSafeModeConsentDialog";
 import {
   ComposerEditor,
   type ComposerEditorHandle,
@@ -807,6 +811,16 @@ type AgentWorkspaceErrorOptions = {
 type AgentWorkspaceNotice = {
   message: string;
   sessionId: string | null;
+};
+
+type ImageSafeModeConsentChoice =
+  | { action: "keep"; dontAskAgain: boolean }
+  | { action: "turnOff"; dontAskAgain: boolean }
+  | { action: "dismiss" };
+
+type ImageSafeModeConsentRequest = {
+  variant: "slash" | "agent";
+  resolve: (choice: ImageSafeModeConsentChoice) => void;
 };
 
 export function agentWorkspaceErrorStateForMessage(
@@ -1698,6 +1712,8 @@ export function AgentWorkspace({
   const [composerSizeWarning, setComposerSizeWarning] = useState<ComposerInputSizeWarning | null>(
     null,
   );
+  const [imageSafeModeConsentRequest, setImageSafeModeConsentRequest] =
+    useState<ImageSafeModeConsentRequest | null>(null);
   const composerSizeProceedSignatureRef = useRef<string | null>(null);
   const composerSizeProceedInputSignatureRef = useRef<string | null>(null);
   // Honest result of the last model switch (feature 10): scoped to the session
@@ -3800,6 +3816,21 @@ export function AgentWorkspace({
     });
   }
 
+  function requestImageSafeModeConsent(
+    variant: "slash" | "agent",
+  ): Promise<ImageSafeModeConsentChoice> {
+    return new Promise((resolve) => {
+      setImageSafeModeConsentRequest({ variant, resolve });
+    });
+  }
+
+  function resolveImageSafeModeConsent(choice: ImageSafeModeConsentChoice) {
+    const request = imageSafeModeConsentRequest;
+    if (!request) return;
+    setImageSafeModeConsentRequest(null);
+    request.resolve(choice);
+  }
+
   // `/image <prompt>` renders the generated image inline in the chat as an
   // assistant turn (loader -> image, with view + download), NOT as a composer
   // attachment chip. It creates/uses a real session and the prompt becomes a
@@ -3815,6 +3846,58 @@ export function AgentWorkspace({
       return;
     }
 
+    // Busy-gate the consent + generation flow before any async IPC. This keeps
+    // a second /image submission from starting while the prompt screen or
+    // dialog is pending, but still lets dismiss leave the draft untouched.
+    setImportingFiles(true);
+
+    // Pin the image model and safe mode before the paid turn starts: June API's
+    // replay ledger hashes them into the requestId's key, so a retry after a
+    // settings change must send the values this turn started with or it becomes
+    // a second charge. If the settings read fails, leave them unpinned (server
+    // resolves live, matching the pre-pinning behavior) and skip consent.
+    let settings: ProviderModelSettingsDto | undefined;
+    let pinnedModel: string | undefined;
+    let pinnedSafeMode: boolean | undefined;
+    try {
+      const settingsResponse = await providerModelSettings();
+      settings = settingsResponse.settings;
+      pinnedModel = settings.imageModel || undefined;
+      pinnedSafeMode = settings.imageSafeMode;
+    } catch {
+      // Non-fatal: generation proceeds with server-resolved settings.
+    }
+
+    if (settings?.imageSafeMode && !settings.imageSafeModePromptDismissed) {
+      let mayBeExplicit = false;
+      try {
+        mayBeExplicit = await imagePromptMayBeExplicit(prompt);
+      } catch {
+        mayBeExplicit = false;
+      }
+      if (mayBeExplicit) {
+        const choice = await requestImageSafeModeConsent("slash");
+        if (choice.action === "dismiss") {
+          setImportingFiles(false);
+          return;
+        }
+        if (choice.action === "keep") {
+          if (choice.dontAskAgain) void setImageSafeModePromptDismissed(true);
+          pinnedSafeMode = true;
+        } else {
+          try {
+            await setImageSafeMode(false);
+          } catch (err) {
+            setImportingFiles(false);
+            setError(messageFromError(err));
+            return;
+          }
+          if (choice.dontAskAgain) void setImageSafeModePromptDismissed(true);
+          pinnedSafeMode = false;
+        }
+      }
+    }
+
     // The prompt is about to become a user turn — clear the draft up front and,
     // on a fresh session, play the hero teardown so the conversation view takes
     // over while the session is created.
@@ -3822,11 +3905,9 @@ export function AgentWorkspace({
     if (heroMode) setHeroLeaving(true);
     clearComposerCommandDraft(commandText);
     setError(null);
-    // Busy-gate the WHOLE flow (session create + generation) via the same
-    // importingFiles flag submit() and the send button already check, so a
-    // second Enter or /image can't launch another billable generation while this
-    // one is in flight. generatingImage only tailors the placeholder copy.
-    setImportingFiles(true);
+    // importingFiles already busy-gates the WHOLE flow (consent + session
+    // create + generation) via the same flag submit() and the send button check.
+    // generatingImage only tailors the placeholder copy once generation starts.
     setGeneratingImage(true);
 
     let targetSessionId: string | undefined;
@@ -3859,21 +3940,6 @@ export function AgentWorkspace({
     const createdAt = new Date(turnStartedAt).toISOString();
     const imageCreatedAt = new Date(turnStartedAt + 1).toISOString();
     const requestId = newImageRequestId();
-    // Pin the image model and safe mode NOW: June API's replay ledger hashes
-    // them into the requestId's key, so a retry after a settings change must
-    // send the values this turn started with or it becomes a second charge.
-    // If the settings read fails, leave them unpinned (server resolves live,
-    // matching the pre-pinning behavior).
-    let pinnedModel: string | undefined;
-    let pinnedSafeMode: boolean | undefined;
-    try {
-      const settingsResponse = await providerModelSettings();
-      pinnedModel = settingsResponse.settings.imageModel || undefined;
-      pinnedSafeMode = settingsResponse.settings.imageSafeMode;
-    } catch {
-      // Non-fatal: generation proceeds with server-resolved settings.
-    }
-
     setImageTurnsBySession((current) => ({
       ...current,
       [sessionId]: [
@@ -8187,6 +8253,18 @@ export function AgentWorkspace({
           ) : null}
         </>
       )}
+      {imageSafeModeConsentRequest ? (
+        <ImageSafeModeConsentDialog
+          variant={imageSafeModeConsentRequest.variant}
+          onKeepSafeMode={(dontAskAgain) =>
+            resolveImageSafeModeConsent({ action: "keep", dontAskAgain })
+          }
+          onTurnOffSafeMode={(dontAskAgain) =>
+            resolveImageSafeModeConsent({ action: "turnOff", dontAskAgain })
+          }
+          onDismiss={() => resolveImageSafeModeConsent({ action: "dismiss" })}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/components/agent/ImageSafeModeConsentDialog.tsx
+++ b/src/components/agent/ImageSafeModeConsentDialog.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Dialog } from "../ui/Dialog";
+
+export type ImageSafeModeConsentDialogProps = {
+  /** "slash" = pre-generation (/image); "agent" = non-blocking, generation already running. */
+  variant: "slash" | "agent";
+  onKeepSafeMode: (dontAskAgain: boolean) => void;
+  onTurnOffSafeMode: (dontAskAgain: boolean) => void;
+  /** Close/Escape/backdrop. Slash flow treats this as cancel-generation. */
+  onDismiss: () => void;
+};
+
+export function ImageSafeModeConsentDialog({
+  variant,
+  onKeepSafeMode,
+  onTurnOffSafeMode,
+  onDismiss,
+}: ImageSafeModeConsentDialogProps) {
+  const [dontAskAgain, setDontAskAgain] = useState(false);
+  const body =
+    variant === "slash"
+      ? "This prompt may include adult content, which safe mode blurs. Generate with safe mode on, or turn it off? You can change this anytime in Settings."
+      : "June is generating an image that may include adult content, so it will be blurred. Keep safe mode on for future images, or turn it off? You can change this anytime in Settings.";
+
+  return (
+    <Dialog
+      open
+      onClose={onDismiss}
+      title="Safe mode is on"
+      description={body}
+      initialFocusSelector="[data-image-safe-mode-primary]"
+      footer={
+        <>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => onTurnOffSafeMode(dontAskAgain)}
+          >
+            Turn off safe mode
+          </button>
+          <button
+            type="button"
+            className="primary-action"
+            data-image-safe-mode-primary
+            onClick={() => onKeepSafeMode(dontAskAgain)}
+          >
+            Keep safe mode on
+          </button>
+        </>
+      }
+    >
+      <label className="image-safe-mode-consent-checkbox">
+        <input
+          type="checkbox"
+          checked={dontAskAgain}
+          onChange={(event) => setDontAskAgain(event.currentTarget.checked)}
+        />
+        <span>Don't ask again</span>
+      </label>
+    </Dialog>
+  );
+}

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -210,8 +210,9 @@ const DEFAULT_PROVIDER_MODELS: ProviderModelSettingsDto = {
     modelId: "",
     apiKey: "",
   },
-  // Off by default (privacy-first), matching the Rust providers default.
-  imageSafeMode: false,
+  // On by default, matching the Rust providers default.
+  imageSafeMode: true,
+  imageSafeModePromptDismissed: false,
 };
 
 const MIC_TEST_DURATION_SECONDS = 5;
@@ -1758,7 +1759,7 @@ export function AppSettings({
                       <div className="settings-row-info">
                         <h3 className="settings-row-title">Safe mode</h3>
                         <p className="settings-row-description">
-                          Blur adult content in generated and edited images. Off by default; your
+                          Blur adult content in generated and edited images. On by default; your
                           image work stays private either way.
                         </p>
                       </div>

--- a/src/components/settings/AppSettings.tsx
+++ b/src/components/settings/AppSettings.tsx
@@ -1565,6 +1565,15 @@ export function AppSettings({
                     options={generationOptions}
                     onOpen={() => openModelPicker("generation")}
                   />
+                  {IMAGE_GENERATION_ENABLED ? (
+                    <ModelRow
+                      title="Image"
+                      description="Used when you generate an image from chat."
+                      value={providerSettings.imageModel}
+                      options={imageOptions}
+                      onOpen={() => openModelPicker("image")}
+                    />
+                  ) : null}
                   <button
                     type="button"
                     className="settings-row settings-more-options-trigger"
@@ -1583,14 +1592,34 @@ export function AppSettings({
                     />
                   </button>
                   {showMoreModelOptions ? (
-                    <VeniceApiKeyRow
-                      id="models-more-options"
-                      configured={providerSettings.veniceApiKeyConfigured}
-                      value={veniceApiKeyDraft}
-                      onValueChange={setVeniceApiKeyDraft}
-                      onSave={() => void saveVeniceApiKey()}
-                      onRemove={() => void removeVeniceApiKey()}
-                    />
+                    <>
+                      <VeniceApiKeyRow
+                        id="models-more-options"
+                        configured={providerSettings.veniceApiKeyConfigured}
+                        value={veniceApiKeyDraft}
+                        onValueChange={setVeniceApiKeyDraft}
+                        onSave={() => void saveVeniceApiKey()}
+                        onRemove={() => void removeVeniceApiKey()}
+                      />
+                      {IMAGE_GENERATION_ENABLED ? (
+                        <div className="settings-row">
+                          <div className="settings-row-info">
+                            <h3 className="settings-row-title">Safe mode</h3>
+                            <p className="settings-row-description">
+                              Blur adult content in generated and edited images. On by default; your
+                              image work stays private either way.
+                            </p>
+                          </div>
+                          <div className="settings-row-control">
+                            <Switch
+                              checked={providerSettings.imageSafeMode}
+                              aria-label="Blur adult content in images"
+                              onCheckedChange={toggleImageSafeMode}
+                            />
+                          </div>
+                        </div>
+                      ) : null}
+                    </>
                   ) : null}
                 </div>
               </div>
@@ -1731,44 +1760,6 @@ export function AppSettings({
                             </button>
                           </div>
                         ) : null}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </section>
-            ) : null}
-
-            {IMAGE_GENERATION_ENABLED ? (
-              <section className="settings-group" aria-labelledby="image-generation-heading">
-                <h2 id="image-generation-heading" className="settings-group-heading">
-                  Image generation
-                </h2>
-                <p className="settings-group-description">
-                  Choose the model June uses when you ask it to generate an image.
-                </p>
-                <div className="settings-card">
-                  <div className="settings-rows">
-                    <ModelRow
-                      title="Image"
-                      description="Used when you generate an image from chat."
-                      value={providerSettings.imageModel}
-                      options={imageOptions}
-                      onOpen={() => openModelPicker("image")}
-                    />
-                    <div className="settings-row">
-                      <div className="settings-row-info">
-                        <h3 className="settings-row-title">Safe mode</h3>
-                        <p className="settings-row-description">
-                          Blur adult content in generated and edited images. On by default; your
-                          image work stays private either way.
-                        </p>
-                      </div>
-                      <div className="settings-row-control">
-                        <Switch
-                          checked={providerSettings.imageSafeMode}
-                          aria-label="Blur adult content in images"
-                          onCheckedChange={toggleImageSafeMode}
-                        />
                       </div>
                     </div>
                   </div>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -183,9 +183,11 @@ export type ProviderModelSettingsDto = {
   imageModel: string;
   veniceApiKeyConfigured: boolean;
   localGeneration: LocalGenerationSettingsDto;
-  /** Venice safe mode for image generation/editing (blurs adult content). Off
-   * by default (privacy-first); the user opts in via Settings. */
+  /** Venice safe mode for image generation/editing (blurs adult content). On
+   * by default; the user opts out via Settings or the consent dialog. */
   imageSafeMode: boolean;
+  /** Whether the user chose "don't ask again" on the safe-mode consent dialog. */
+  imageSafeModePromptDismissed: boolean;
 };
 
 export type LocalGenerationSettingsDto = {
@@ -1621,11 +1623,17 @@ export async function clearVeniceApiKey() {
   return invoke<ProviderModelSettingsDto>("clear_venice_api_key");
 }
 
-// Toggles Venice safe mode for image generation/editing. Off by default; when
+// Toggles Venice safe mode for image generation/editing. On by default; when
 // on, Venice blurs adult content.
 export async function setImageSafeMode(enabled: boolean) {
   return invoke<ProviderModelSettingsDto>("set_image_safe_mode", {
     request: { enabled },
+  });
+}
+
+export async function setImageSafeModePromptDismissed(dismissed: boolean) {
+  return invoke<ProviderModelSettingsDto>("set_image_safe_mode_prompt_dismissed", {
+    request: { dismissed },
   });
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -203,6 +203,10 @@ export type GeneratedImageDto = {
   provider: string;
 };
 
+export type ImagePromptScreenResponse = {
+  mayBeExplicit: boolean;
+};
+
 export type ProviderModelSettingsResponse = {
   settings: ProviderModelSettingsDto;
 };
@@ -1635,6 +1639,14 @@ export async function setImageSafeModePromptDismissed(dismissed: boolean) {
   return invoke<ProviderModelSettingsDto>("set_image_safe_mode_prompt_dismissed", {
     request: { dismissed },
   });
+}
+
+/** Runs an on-device heuristic that gates only the safe-mode consent dialog. */
+export async function imagePromptMayBeExplicit(prompt: string): Promise<boolean> {
+  const response = await invoke<ImagePromptScreenResponse>("image_prompt_may_be_explicit", {
+    request: { prompt },
+  });
+  return response.mayBeExplicit;
 }
 
 // Generates an image from a prompt via the June API. `model` is optional; the

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1641,7 +1641,7 @@ export async function setImageSafeModePromptDismissed(dismissed: boolean) {
   });
 }
 
-/** Runs an on-device heuristic that gates only the safe-mode consent dialog. */
+/** Screens an image prompt for the safe-mode consent dialog. */
 export async function imagePromptMayBeExplicit(prompt: string): Promise<boolean> {
   const response = await invoke<ImagePromptScreenResponse>("image_prompt_may_be_explicit", {
     request: { prompt },

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -18626,6 +18626,22 @@ input:focus-visible,
   gap: var(--sp-3);
 }
 
+.image-safe-mode-consent-checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  color: var(--foreground);
+  font-size: var(--fs-md);
+  cursor: pointer;
+}
+
+.image-safe-mode-consent-checkbox input {
+  width: var(--sp-4);
+  height: var(--sp-4);
+  margin: 0;
+  accent-color: var(--primary);
+}
+
 .update-popover {
   width: 100%;
   min-width: 0;

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -7102,6 +7102,7 @@ describe("AgentWorkspace", () => {
         generationModel: "zai-org-glm-5-2",
         imageModel: "venice-sd35",
         imageSafeMode: false,
+        imageSafeModePromptDismissed: false,
       },
     });
     mocks.generateImage.mockRejectedValueOnce(new Error("gateway timeout")).mockResolvedValueOnce({
@@ -7138,6 +7139,7 @@ describe("AgentWorkspace", () => {
         generationModel: "zai-org-glm-5-2",
         imageModel: "flux-2-pro",
         imageSafeMode: true,
+        imageSafeModePromptDismissed: false,
       },
     });
 
@@ -7224,6 +7226,7 @@ describe("AgentWorkspace", () => {
         generationModel: "zai-org-glm-5-2",
         imageModel: "venice-sd35",
         imageSafeMode: false,
+        imageSafeModePromptDismissed: false,
       },
     });
     // The paid request never settles client-side - the app "exits" while the

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -84,13 +84,11 @@ const mocks = vi.hoisted(() => ({
     connect: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
   }>,
-  eventHandlers: new Map<string, (event: { payload?: { paths?: string[] } }) => void>(),
-  listen: vi.fn(
-    async (eventName: string, handler: (event: { payload?: { paths?: string[] } }) => void) => {
-      mocks.eventHandlers.set(eventName, handler);
-      return () => mocks.eventHandlers.delete(eventName);
-    },
-  ),
+  eventHandlers: new Map<string, (event: { payload?: unknown }) => unknown>(),
+  listen: vi.fn(async (eventName: string, handler: (event: { payload?: unknown }) => unknown) => {
+    mocks.eventHandlers.set(eventName, handler);
+    return () => mocks.eventHandlers.delete(eventName);
+  }),
 }));
 
 vi.mock("../lib/tauri", () => ({
@@ -242,6 +240,14 @@ function mockImageGenerationSuccess() {
     rootLabel: "Workspace",
     size: 5,
     previewDataUrl: "data:image/png;base64,preview",
+  });
+}
+
+async function emitImageSafeModeConsent(prompt = "paint a nude portrait") {
+  const handler = mocks.eventHandlers.get("image-safe-mode-consent");
+  expect(handler).toBeDefined();
+  await act(async () => {
+    await handler?.({ payload: { source: "agent", prompt } });
   });
 }
 
@@ -7224,7 +7230,7 @@ describe("AgentWorkspace", () => {
     await user.type(await screen.findByRole("textbox"), "/image a red bicycle");
     fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
 
-    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    await screen.findByRole("dialog", { name: "Safe mode is on" });
     await user.keyboard("{Escape}");
 
     await waitFor(() =>
@@ -7233,6 +7239,99 @@ describe("AgentWorkspace", () => {
     expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
     expect(mocks.generateImage).not.toHaveBeenCalled();
     expect(await screen.findByRole("textbox")).toHaveTextContent("/image a red bicycle");
+  });
+
+  it("shows safe-mode consent when the agent image event arrives", async () => {
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await emitImageSafeModeConsent();
+
+    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    expect(
+      within(dialog).getByText(/June is generating an image that may include adult content/i),
+    ).toBeInTheDocument();
+  });
+
+  it("drops duplicate agent safe-mode consent events while the dialog is open", async () => {
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await emitImageSafeModeConsent("first prompt");
+    await screen.findByRole("dialog", { name: "Safe mode is on" });
+    mocks.providerModelSettings.mockClear();
+
+    await emitImageSafeModeConsent("second prompt");
+
+    expect(screen.getAllByRole("dialog", { name: "Safe mode is on" })).toHaveLength(1);
+    expect(mocks.providerModelSettings).not.toHaveBeenCalled();
+  });
+
+  it("keeps safe mode on for an agent image event and persists don't ask again", async () => {
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await emitImageSafeModeConsent();
+    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    await user.click(within(dialog).getByRole("checkbox", { name: "Don't ask again" }));
+    await user.click(within(dialog).getByRole("button", { name: "Keep safe mode on" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Safe mode is on" })).not.toBeInTheDocument(),
+    );
+    expect(mocks.setImageSafeModePromptDismissed).toHaveBeenCalledWith(true);
+    expect(mocks.setImageSafeMode).not.toHaveBeenCalled();
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+  });
+
+  it("turns safe mode off for an agent image event and persists don't ask again", async () => {
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await emitImageSafeModeConsent();
+    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    await user.click(within(dialog).getByRole("checkbox", { name: "Don't ask again" }));
+    await user.click(within(dialog).getByRole("button", { name: "Turn off safe mode" }));
+
+    await waitFor(() => expect(mocks.setImageSafeMode).toHaveBeenCalledWith(false));
+    expect(mocks.setImageSafeModePromptDismissed).toHaveBeenCalledWith(true);
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+  });
+
+  it("dismisses agent safe-mode consent without persisting a choice", async () => {
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await emitImageSafeModeConsent();
+    await screen.findByRole("dialog", { name: "Safe mode is on" });
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Safe mode is on" })).not.toBeInTheDocument(),
+    );
+    expect(mocks.setImageSafeMode).not.toHaveBeenCalled();
+    expect(mocks.setImageSafeModePromptDismissed).not.toHaveBeenCalled();
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+  });
+
+  it("drops stale agent safe-mode consent events when safe mode is already off", async () => {
+    mockImageSettings({ imageSafeMode: false, imageSafeModePromptDismissed: false });
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    await emitImageSafeModeConsent();
+
+    expect(screen.queryByRole("dialog", { name: "Safe mode is on" })).not.toBeInTheDocument();
+    expect(mocks.setImageSafeMode).not.toHaveBeenCalled();
+    expect(mocks.setImageSafeModePromptDismissed).not.toHaveBeenCalled();
   });
 
   it("reuses the failed /image request id when the user retries the same turn", async () => {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -50,12 +50,15 @@ const mocks = vi.hoisted(() => ({
   hermesBridgeSkills: vi.fn(),
   hermesBridgeStatus: vi.fn(),
   hermesBridgeToolsets: vi.fn(),
+  imagePromptMayBeExplicit: vi.fn(),
   importHermesBridgeFile: vi.fn(),
   importHermesBridgeFileBytes: vi.fn(),
   listVeniceModels: vi.fn(),
   listAgentTasks: vi.fn(),
   downloadHermesBridgeFile: vi.fn(),
   osAccountsUpgrade: vi.fn(),
+  setImageSafeMode: vi.fn(),
+  setImageSafeModePromptDismissed: vi.fn(),
   setVeniceModel: vi.fn(),
   setLocalGenerationEnabled: vi.fn(),
   providerModelSettings: vi.fn(),
@@ -111,6 +114,7 @@ vi.mock("../lib/tauri", () => ({
   hermesBridgeSkills: mocks.hermesBridgeSkills,
   hermesBridgeStatus: mocks.hermesBridgeStatus,
   hermesBridgeToolsets: mocks.hermesBridgeToolsets,
+  imagePromptMayBeExplicit: mocks.imagePromptMayBeExplicit,
   importHermesBridgeFile: mocks.importHermesBridgeFile,
   importHermesBridgeFileBytes: mocks.importHermesBridgeFileBytes,
   listVeniceModels: mocks.listVeniceModels,
@@ -120,6 +124,8 @@ vi.mock("../lib/tauri", () => ({
   providerModelSettings: mocks.providerModelSettings,
   retryAgentTask: mocks.retryAgentTask,
   setHermesAgentCliAccess: mocks.setHermesAgentCliAccess,
+  setImageSafeMode: mocks.setImageSafeMode,
+  setImageSafeModePromptDismissed: mocks.setImageSafeModePromptDismissed,
   setLocalGenerationEnabled: mocks.setLocalGenerationEnabled,
   setVeniceModel: mocks.setVeniceModel,
   saveAgentAssistantMessage: mocks.saveAgentAssistantMessage,
@@ -202,6 +208,43 @@ function seedLegacyExistingSessionReportDraft() {
   });
 }
 
+function mockImageSettings({
+  imageSafeMode,
+  imageSafeModePromptDismissed,
+  imageModel = "venice-sd35",
+}: {
+  imageSafeMode: boolean;
+  imageSafeModePromptDismissed: boolean;
+  imageModel?: string;
+}) {
+  mocks.providerModelSettings.mockResolvedValue({
+    settings: {
+      transcriptionProvider: "venice",
+      transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+      generationModel: "zai-org-glm-5-2",
+      imageModel,
+      imageSafeMode,
+      imageSafeModePromptDismissed,
+    },
+  });
+}
+
+function mockImageGenerationSuccess() {
+  mocks.generateImage.mockResolvedValueOnce({
+    imageBase64: "aGVsbG8=",
+    mimeType: "image/png",
+    model: "venice-sd35",
+    provider: "venice",
+  });
+  mocks.importHermesBridgeFileBytes.mockResolvedValueOnce({
+    name: "generated-image.png",
+    path: "/Users/alex/Library/Application Support/co.opensoftware.june/hermes/workspace/uploads/generated-image.png",
+    rootLabel: "Workspace",
+    size: 5,
+    previewDataUrl: "data:image/png;base64,preview",
+  });
+}
+
 function mockGlmCapabilities(capabilities: string[]) {
   mocks.listVeniceModels.mockResolvedValue({
     mode: "generation",
@@ -260,6 +303,21 @@ describe("AgentWorkspace", () => {
         transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
         generationModel: "zai-org-glm-5-2",
       },
+    });
+    mocks.imagePromptMayBeExplicit.mockResolvedValue(false);
+    mocks.setImageSafeMode.mockResolvedValue({
+      transcriptionProvider: "venice",
+      transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+      generationModel: "zai-org-glm-5-2",
+      imageSafeMode: false,
+      imageSafeModePromptDismissed: false,
+    });
+    mocks.setImageSafeModePromptDismissed.mockResolvedValue({
+      transcriptionProvider: "venice",
+      transcriptionModel: "nvidia/parakeet-tdt-0.6b-v3",
+      generationModel: "zai-org-glm-5-2",
+      imageSafeMode: true,
+      imageSafeModePromptDismissed: true,
     });
     mocks.listVeniceModels.mockResolvedValue({
       mode: "generation",
@@ -7049,6 +7107,132 @@ describe("AgentWorkspace", () => {
       expect.stringMatching(/^generated-image-\d+\.png$/),
       expect.any(Uint8Array),
     );
+  });
+
+  it.each([
+    {
+      name: "safe mode off",
+      settings: { imageSafeMode: false, imageSafeModePromptDismissed: false },
+      heuristic: true,
+    },
+    {
+      name: "prompt dismissed",
+      settings: { imageSafeMode: true, imageSafeModePromptDismissed: true },
+      heuristic: true,
+    },
+    {
+      name: "heuristic false",
+      settings: { imageSafeMode: true, imageSafeModePromptDismissed: false },
+      heuristic: false,
+    },
+    {
+      name: "settings read fails",
+      settings: null,
+      heuristic: true,
+    },
+  ])("skips the safe-mode consent dialog when %s", async ({ settings, heuristic }) => {
+    mockGlmCapabilities(["functionCalling", "supportsVision"]);
+    if (settings) {
+      mockImageSettings(settings);
+    }
+    mocks.imagePromptMayBeExplicit.mockResolvedValue(heuristic);
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+
+    if (!settings) {
+      mocks.providerModelSettings.mockRejectedValueOnce(new Error("settings unavailable"));
+    }
+    mocks.imagePromptMayBeExplicit.mockClear();
+    mockImageGenerationSuccess();
+
+    await user.type(await screen.findByRole("textbox"), "/image a red bicycle");
+    fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
+
+    await screen.findByRole("img", { name: "a red bicycle" });
+    expect(screen.queryByRole("dialog", { name: "Safe mode is on" })).not.toBeInTheDocument();
+    expect(mocks.generateImage).toHaveBeenCalledTimes(1);
+    if (settings?.imageSafeMode && !settings.imageSafeModePromptDismissed) {
+      expect(mocks.imagePromptMayBeExplicit).toHaveBeenCalledWith("a red bicycle");
+    } else {
+      expect(mocks.imagePromptMayBeExplicit).not.toHaveBeenCalled();
+    }
+  });
+
+  it("keeps safe mode on for an explicit /image prompt and persists don't ask again", async () => {
+    mockGlmCapabilities(["functionCalling", "supportsVision"]);
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    mocks.imagePromptMayBeExplicit.mockResolvedValue(true);
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    mockImageGenerationSuccess();
+
+    await user.type(await screen.findByRole("textbox"), "/image a red bicycle");
+    fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
+
+    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    expect(within(dialog).getByRole("button", { name: "Keep safe mode on" })).toHaveFocus();
+    await user.click(within(dialog).getByRole("checkbox", { name: "Don't ask again" }));
+    await user.click(within(dialog).getByRole("button", { name: "Keep safe mode on" }));
+
+    await screen.findByRole("img", { name: "a red bicycle" });
+    expect(mocks.setImageSafeModePromptDismissed).toHaveBeenCalledWith(true);
+    expect(mocks.setImageSafeMode).not.toHaveBeenCalled();
+    expect(mocks.generateImage).toHaveBeenCalledWith(
+      "a red bicycle",
+      "venice-sd35",
+      expect.any(String),
+      true,
+    );
+  });
+
+  it("turns safe mode off for an explicit /image prompt and pins generation off", async () => {
+    mockGlmCapabilities(["functionCalling", "supportsVision"]);
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    mocks.imagePromptMayBeExplicit.mockResolvedValue(true);
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    mockImageGenerationSuccess();
+
+    await user.type(await screen.findByRole("textbox"), "/image a red bicycle");
+    fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
+
+    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    await user.click(within(dialog).getByRole("button", { name: "Turn off safe mode" }));
+
+    await screen.findByRole("img", { name: "a red bicycle" });
+    expect(mocks.setImageSafeMode).toHaveBeenCalledWith(false);
+    expect(mocks.generateImage).toHaveBeenCalledWith(
+      "a red bicycle",
+      "venice-sd35",
+      expect.any(String),
+      false,
+    );
+  });
+
+  it("dismisses safe-mode consent without creating an /image session or clearing the draft", async () => {
+    mockGlmCapabilities(["functionCalling", "supportsVision"]);
+    mockImageSettings({ imageSafeMode: true, imageSafeModePromptDismissed: false });
+    mocks.imagePromptMayBeExplicit.mockResolvedValue(true);
+    const user = userEvent.setup();
+    render(<AgentWorkspace />);
+    expect(await screen.findByText("Existing session")).toBeInTheDocument();
+    mocks.gatewayRequest.mockClear();
+
+    await user.type(await screen.findByRole("textbox"), "/image a red bicycle");
+    fireEvent.submit(document.querySelector(".agent-composer") as HTMLFormElement);
+
+    const dialog = await screen.findByRole("dialog", { name: "Safe mode is on" });
+    await user.keyboard("{Escape}");
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Safe mode is on" })).not.toBeInTheDocument(),
+    );
+    expect(mocks.gatewayRequest).not.toHaveBeenCalledWith("session.create", expect.anything());
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+    expect(await screen.findByRole("textbox")).toHaveTextContent("/image a red bicycle");
   });
 
   it("reuses the failed /image request id when the user retries the same turn", async () => {

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -18,6 +18,8 @@ const mocks = vi.hoisted(() => ({
   setVeniceModel: vi.fn(),
   setVeniceApiKey: vi.fn(),
   clearVeniceApiKey: vi.fn(),
+  setImageSafeMode: vi.fn(),
+  setImageSafeModePromptDismissed: vi.fn(),
   saveLocalGenerationSettings: vi.fn(),
   setLocalGenerationEnabled: vi.fn(),
   probeLocalGenerationEndpoint: vi.fn(),
@@ -79,6 +81,8 @@ vi.mock("../lib/tauri", () => ({
   setVeniceModel: mocks.setVeniceModel,
   setVeniceApiKey: mocks.setVeniceApiKey,
   clearVeniceApiKey: mocks.clearVeniceApiKey,
+  setImageSafeMode: mocks.setImageSafeMode,
+  setImageSafeModePromptDismissed: mocks.setImageSafeModePromptDismissed,
   saveLocalGenerationSettings: mocks.saveLocalGenerationSettings,
   setLocalGenerationEnabled: mocks.setLocalGenerationEnabled,
   probeLocalGenerationEndpoint: mocks.probeLocalGenerationEndpoint,
@@ -185,6 +189,8 @@ function buildProviderSettings() {
       modelId: localState.modelId,
       apiKey: localState.apiKey,
     },
+    imageSafeMode: true,
+    imageSafeModePromptDismissed: false,
   };
 }
 
@@ -249,6 +255,8 @@ describe("AppSettings", () => {
           modelId: "",
           apiKey: "",
         },
+        imageSafeMode: true,
+        imageSafeModePromptDismissed: false,
       },
     });
     mocks.listVeniceModels.mockImplementation(async (mode) => ({
@@ -391,6 +399,8 @@ describe("AppSettings", () => {
         modelId: localState.modelId,
         apiKey: localState.apiKey,
       },
+      imageSafeMode: true,
+      imageSafeModePromptDismissed: false,
     }));
     mocks.setVeniceApiKey.mockResolvedValue({
       ...buildProviderSettings(),

--- a/src/test/app-settings.test.tsx
+++ b/src/test/app-settings.test.tsx
@@ -402,6 +402,10 @@ describe("AppSettings", () => {
       imageSafeMode: true,
       imageSafeModePromptDismissed: false,
     }));
+    mocks.setImageSafeMode.mockImplementation(async (enabled: boolean) => ({
+      ...buildProviderSettings(),
+      imageSafeMode: enabled,
+    }));
     mocks.setVeniceApiKey.mockResolvedValue({
       ...buildProviderSettings(),
       veniceApiKeyConfigured: true,
@@ -2603,7 +2607,7 @@ describe("AppSettings", () => {
     expect(mocks.setVeniceModel).toHaveBeenCalledWith("generation", "zai-org-glm-5-1");
   });
 
-  it("shows the image generation section and saves the default image model", async () => {
+  it("shows the image model in AI models and saves the default image model", async () => {
     const user = userEvent.setup();
     render(
       <AppSettings
@@ -2620,9 +2624,16 @@ describe("AppSettings", () => {
 
     await user.click(await screen.findByRole("tab", { name: "Models" }));
 
-    // The section renders and the saved default is shown.
-    expect(screen.getByRole("heading", { name: "Image generation" })).toBeInTheDocument();
-    expect(screen.getByText("Venice SD3.5")).toBeInTheDocument();
+    const modelsSection = screen.getByRole("heading", { name: "AI models" }).closest("section");
+    expect(modelsSection).not.toBeNull();
+    expect(screen.queryByRole("heading", { name: "Image generation" })).not.toBeInTheDocument();
+    expect(
+      within(modelsSection as HTMLElement).getByRole("button", { name: "Change image model" }),
+    ).toBeInTheDocument();
+    expect(within(modelsSection as HTMLElement).getByText("Venice SD3.5")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: "Blur adult content in images" }),
+    ).not.toBeInTheDocument();
 
     // The picker opens with the curated image options (no backend fetch).
     await user.click(screen.getByRole("button", { name: "Change image model" }));
@@ -2652,6 +2663,41 @@ describe("AppSettings", () => {
     await waitFor(() =>
       expect(screen.queryByRole("option", { name: /FLUX 2 Pro/ })).not.toBeInTheDocument(),
     );
+  });
+
+  it("keeps image Safe mode behind More options and toggles it once expanded", async () => {
+    const user = userEvent.setup();
+    render(
+      <AppSettings
+        account={signedInAccount}
+        accountLoading={false}
+        sourceMode="microphoneOnly"
+        checkingSourceReadiness={false}
+        onAccountChanged={vi.fn()}
+        onAccountRefresh={vi.fn()}
+        onSourceModeChange={vi.fn()}
+        onEnableSystemAudio={vi.fn()}
+      />,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Models" }));
+
+    expect(screen.getByRole("button", { name: "Change image model" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: "Blur adult content in images" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /More options/ }));
+
+    const safeModeSwitch = await screen.findByRole("switch", {
+      name: "Blur adult content in images",
+    });
+    expect(safeModeSwitch).toHaveAttribute("aria-checked", "true");
+
+    await user.click(safeModeSwitch);
+
+    expect(mocks.setImageSafeMode).toHaveBeenCalledWith(false);
+    expect(await screen.findByText("Safe mode off: images are not filtered.")).toBeInTheDocument();
   });
 
   it("blocks selecting a text model that cannot use tools", async () => {


### PR DESCRIPTION
## Summary

Closes JUN-209.

- Image safe mode (`image_safe_mode`) now defaults **on**: fresh installs and
  settings files missing the field ask Venice to blur adult content on
  generated/edited images unless the user opts out.
- New safe-mode consent dialog, gated by an on-device keyword heuristic
  (`image_safety::may_request_explicit_content`) so benign prompts never see
  it:
  - `/image` flow: shown before the billable request; "Turn off safe mode"
    persists the toggle off (the remembered preference) and generates
    unfiltered; "Keep safe mode on" proceeds blurred; Escape/close cancels
    without charging and keeps the composer draft.
  - Agent tool path: the loopback proxy emits a best-effort
    `image-safe-mode-consent` Tauri event and the generation proceeds
    blurred; the dialog offers to turn safe mode off for future images. The
    agent's tool call is never delayed, altered, or failed by consent.
  - "Don't ask again" persists `image_safe_mode_prompt_dismissed`;
    explicitly re-enabling safe mode resets it.
  - Agent-path gate = wordlist OR model self-report: both image tools now
    require a `may_be_explicit` boolean the calling model fills (zero extra
    inference/charge - it is already in the loop); the proxy ORs it with the
    wordlist and strips the field before forwarding so it never reaches June
    API's billed request shape. Under-reporting degrades to exactly a
    wordlist miss: no dialog, blur still enforced. /image stays
    wordlist-only on purpose (an AI check there = a new billable call and
    uploads the prompt before consent).
- ADR 0008 dated addendum supersedes the "default off" bullet; CONTEXT.md
  gains the "Safe mode (image)" glossary term.

Also folded in (was PR #649, consolidated here so the whole image flow ships
and tests together): **the agent can now edit attached images.**
`edit_image` sources were HMAC-signed references minted only for
`june_image` tool results, so an attached/pasted image (saved by Hermes as
`hermes/images/upload_*.png`) could not be edited at all - the agent fell
back to a vision-analyze + regenerate detour that the SOUL forbids and that
double-charges. Now `validate_image_source_reference` also accepts a bare
filename IFF it is a plain name with the `upload_*` attachment prefix and a
known image extension that canonicalizes inside the images root (symlink
escapes rejected), sharing the signed path's size cap and content sniffing;
tool-output files (`generated-image-*`) still require signed references
with their content-hash binding. SOUL + the `edit_image` MCP schema updated
to route attached-image follow-ups to `edit_image` with the attachment's
plain filename, keeping the "never see/analyze first" rule. Bot-review
rounds on #649 (2 Greptile P1s refuted - one withdrawn by Greptile; 2 Codex
P2s accepted and fixed) carried over; see #649 for the threads.

Security-sensitive note: this changes content-safety defaults - the default
gets stricter (today every user silently sends `safe_mode: false`); turning
filtering off now requires an explicit user choice, made once and persisted.

## Validation

- `make verify` green (Biome, typecheck, vitest 131 files / 2111 passed / 0
  failed, cargo fmt/clippy/test for both crates).
- New unit coverage: Rust settings defaults + legacy-JSON deserialization +
  re-arming rule; heuristic wordlist/phrases incl. substring traps
  (sussex/sextant); bridge consent decision + multibyte truncation; frontend
  gating, keep/turn-off/dismiss, draft retention, agent-event races and
  stale-event drops.
- Visual walkthrough (Vite + Chrome DevTools, component-scoped preview):
  both dialog variants render with correct copy, initial focus on "Keep safe
  mode on", checkbox and all three choice paths verified; no console errors.
  Screenshots: uploaded to os-platform (org access) and linked in a PR
  comment; also attached on JUN-209.
- Review battery (all axes on Codex, single-harness convention): standards
  clean; spec and adversarial findings dispositioned below.

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording).
- [ ] Needs a June API (backend) deploy before it works end to end.

No backend deploy needed: June API already accepts `safe_mode: Option<bool>`;
the wire shape is unchanged and older app builds are unaffected.

## Out of scope

- Blocking the agent's image tool call on consent. Deliberate: the proxy
  cannot hang a tool call on user input, so an agent-initiated flagged
  generation is billed once with safe mode on even if the user then opts
  out. Accepted trade-off, documented in the ADR addendum.
- Retry/regeneration of the in-flight agent image from the consent dialog.
- Migration marker for stored `imageSafeMode: false`. Deliberate: no released
  build has shipped the field (landed with JUN-171 days ago), so settings
  files in the wild lack it and the serde-default flip reaches everyone.
  **Reviewer attention**: if a release went out with the old default after
  JUN-171 merged, this assumption breaks and a one-time coercion is needed.

## Followups

- Pre-existing (unchanged from origin/main): if the pre-generation settings
  read fails, `/image` proceeds unpinned and a retry after a settings change
  can replay a different shape. Carried over verbatim; flagged by the spec
  review axis, dispositioned as pre-existing parity.
- Consider surfacing "this image was blurred by safe mode" on the generated
  result itself (provider response does not currently expose whether
  blurring was applied).
- Per-session scoping of the shared images directory (raised on #649): a
  bare `upload_*` basename can name another conversation's attachment. Not a
  new capability (Hermes's file tools already read hermes home; the sandbox
  is a write jail), but per-session scoping would harden both the direct
  reads and the edit path.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None.)
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (No backend changes.)
- [x] User-facing copy follows the repo UI conventions.

https://claude.ai/code/session_01JnMdSpy1rc91pEABcEKMd5
