### PR TITLE
Paste screenshots into the issue report dialog

### DIFF
--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -230,6 +230,7 @@ import {
   isTopUpRequiresMaxError,
   messageFromError,
 } from "../../lib/errors";
+import { clipboardImageFiles } from "../../lib/clipboard-files";
 import { withTimeout } from "../../lib/async-timeout";
 import {
   MESSAGING_PLATFORMS_LOAD_TIMEOUT_MESSAGE,
@@ -12854,91 +12855,6 @@ function formatBytes(value: number | null | undefined) {
 
 function safeText(value: unknown) {
   return typeof value === "string" ? value : "";
-}
-
-function clipboardImageFiles(data: DataTransfer | null): File[] {
-  if (!data) return [];
-  const itemFiles =
-    data.items && data.items.length
-      ? Array.from(data.items)
-          .filter((item) => item.kind === "file" && isClipboardImageType(item.type))
-          .map((item) => item.getAsFile())
-          .filter((file): file is File => Boolean(file))
-      : [];
-  if (itemFiles.length) return normalizeClipboardImageFiles(itemFiles);
-  return normalizeClipboardImageFiles(
-    Array.from(data.files ?? []).filter((file) => isClipboardImageType(file.type)),
-  );
-}
-
-function normalizeClipboardImageFiles(files: File[]): File[] {
-  if (files.length <= 1 || hasDistinctClipboardFileNames(files)) {
-    return files.map(ensureClipboardImageName);
-  }
-  const best = [...files].sort(
-    (left, right) => clipboardImageRank(right) - clipboardImageRank(left),
-  )[0];
-  return best ? [ensureClipboardImageName(best, 0)] : [];
-}
-
-function hasDistinctClipboardFileNames(files: File[]) {
-  const names = files.map((file) => file.name.trim()).filter(Boolean);
-  const stems = names.map(clipboardImageStem);
-  return (
-    names.length === files.length &&
-    new Set(names).size === files.length &&
-    new Set(stems).size === files.length
-  );
-}
-
-function ensureClipboardImageName(file: File, index: number) {
-  if (file.name.trim()) return file;
-  const suffix = index === 0 ? "" : `-${index + 1}`;
-  return new File([file], `pasted-image${suffix}.${clipboardImageExtension(file)}`, {
-    type: file.type,
-    lastModified: file.lastModified,
-  });
-}
-
-function isClipboardImageType(type: string) {
-  const mimeType = normalizedImageMimeType(type);
-  return (
-    mimeType === "image/png" ||
-    mimeType === "image/jpeg" ||
-    mimeType === "image/jpg" ||
-    mimeType === "image/tiff" ||
-    mimeType === "image/tif" ||
-    mimeType === "image/gif" ||
-    mimeType === "image/webp"
-  );
-}
-
-function clipboardImageExtension(file: File) {
-  const mimeType = normalizedImageMimeType(file.type);
-  if (mimeType === "image/jpeg" || mimeType === "image/jpg") return "jpg";
-  if (mimeType === "image/tiff" || mimeType === "image/tif") return "tiff";
-  const subtype = mimeType.startsWith("image/") ? mimeType.slice(6) : "";
-  return subtype.replace(/[^a-z0-9]/g, "") || "png";
-}
-
-function clipboardImageStem(name: string) {
-  const trimmed = name.trim().toLowerCase();
-  const dot = trimmed.lastIndexOf(".");
-  return dot > 0 ? trimmed.slice(0, dot) : trimmed;
-}
-
-function clipboardImageRank(file: File) {
-  const mimeType = normalizedImageMimeType(file.type);
-  if (mimeType === "image/png") return 50;
-  if (mimeType === "image/tiff" || mimeType === "image/tif") return 40;
-  if (mimeType === "image/webp") return 30;
-  if (mimeType === "image/jpeg" || mimeType === "image/jpg") return 20;
-  if (mimeType === "image/gif") return 10;
-  return 1;
-}
-
-function normalizedImageMimeType(type: string) {
-  return type.toLowerCase().split(";")[0];
 }
 
 function toolNames(toolset: HermesToolsetInfo) {

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -4247,6 +4247,10 @@ export function AgentWorkspace({
   }
 
   function handleComposerDrop(event: DragEvent<HTMLFormElement>) {
+    // The report dialog's JSX lives inside this form, so its events React-
+    // bubble here even though it renders in a portal; a report drop or paste
+    // must never land in the chat composer.
+    if (reportDialogOpen) return;
     event.preventDefault();
     setDropActive(false);
     const files = Array.from(event.dataTransfer.files);
@@ -4258,6 +4262,7 @@ export function AgentWorkspace({
   }
 
   function handleComposerPaste(event: ClipboardEvent<HTMLFormElement>) {
+    if (reportDialogOpen) return;
     const files = clipboardImageFiles(event.clipboardData);
     if (!files.length) return;
     event.preventDefault();

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -127,7 +127,13 @@ export function ReportDialog({
     if (sent || busy) return;
     const files = clipboardImageFiles(event.clipboardData);
     if (!files.length) return;
-    event.preventDefault();
+    // Mixed payload (e.g. a copied web-page selection carrying both text and
+    // an image): import the image but let the browser paste the text into the
+    // textarea — preventing default would silently drop the text the user
+    // meant to keep. With no meaningful text we preventDefault, which also
+    // stops screenshot tools' stray metadata from landing in the field.
+    const hasText = Boolean(event.clipboardData?.getData("text/plain")?.trim());
+    if (!hasText) event.preventDefault();
     queueFileImport(files);
   }
 

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -83,6 +83,10 @@ export function ReportDialog({
 
   function handleDragOver(event: DragEvent<HTMLDivElement>) {
     event.preventDefault();
+    // The dialog is portaled but its JSX lives inside the composer form, so
+    // React bubbles these events to the composer's own drop/paste importers
+    // behind the modal — stop them here or attachments leak into the chat.
+    event.stopPropagation();
     event.dataTransfer.dropEffect = "copy";
   }
 
@@ -104,6 +108,7 @@ export function ReportDialog({
 
   function handleDrop(event: DragEvent<HTMLDivElement>) {
     event.preventDefault();
+    event.stopPropagation();
     dragDepthRef.current = 0;
     setDropActive(false);
     const files = Array.from(event.dataTransfer.files);
@@ -118,6 +123,7 @@ export function ReportDialog({
   // files are interceptable (Finder file copies never reach clipboardData);
   // a plain text paste falls through to the textarea untouched.
   function handlePaste(event: ClipboardEvent<HTMLDivElement>) {
+    event.stopPropagation();
     if (sent || busy) return;
     const files = clipboardImageFiles(event.clipboardData);
     if (!files.length) return;

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -1,7 +1,8 @@
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconPaperclip1 } from "central-icons/IconPaperclip1";
-import { type DragEvent, useId, useMemo, useState } from "react";
+import { type ClipboardEvent, type DragEvent, useId, useMemo, useState } from "react";
 
+import { clipboardImageFiles } from "../../lib/clipboard-files";
 import { messageFromError } from "../../lib/errors";
 import { submitIssueReport } from "../../lib/tauri";
 import { DotSpinner } from "../DotSpinner";
@@ -83,6 +84,12 @@ export function ReportDialog({
     setDropActive(true);
   }
 
+  function queueFileImport(files: File[]) {
+    setError(null);
+    setDropsPending((count) => count + 1);
+    void Promise.resolve(onDropFiles(files)).finally(() => setDropsPending((count) => count - 1));
+  }
+
   function handleDrop(event: DragEvent<HTMLDivElement>) {
     event.preventDefault();
     setDropActive(false);
@@ -91,9 +98,18 @@ export function ReportDialog({
       setError("Drop files from Finder to attach them to the report.");
       return;
     }
-    setError(null);
-    setDropsPending((count) => count + 1);
-    void Promise.resolve(onDropFiles(files)).finally(() => setDropsPending((count) => count - 1));
+    queueFileImport(files);
+  }
+
+  // Pasted screenshots become attachments, same as the composer. Only image
+  // files are interceptable (Finder file copies never reach clipboardData);
+  // a plain text paste falls through to the textarea untouched.
+  function handlePaste(event: ClipboardEvent<HTMLDivElement>) {
+    if (sent || busy) return;
+    const files = clipboardImageFiles(event.clipboardData);
+    if (!files.length) return;
+    event.preventDefault();
+    queueFileImport(files);
   }
 
   async function handleSubmit() {
@@ -168,6 +184,7 @@ export function ReportDialog({
           onDragEnter={() => setDropActive(true)}
           onDragLeave={() => setDropActive(false)}
           onDrop={handleDrop}
+          onPaste={handlePaste}
         >
           <SegmentedControl
             value={category}

--- a/src/components/agent/ReportDialog.tsx
+++ b/src/components/agent/ReportDialog.tsx
@@ -1,6 +1,6 @@
 import { IconCrossSmall } from "central-icons/IconCrossSmall";
 import { IconPaperclip1 } from "central-icons/IconPaperclip1";
-import { type ClipboardEvent, type DragEvent, useId, useMemo, useState } from "react";
+import { type ClipboardEvent, type DragEvent, useId, useMemo, useRef, useState } from "react";
 
 import { clipboardImageFiles } from "../../lib/clipboard-files";
 import { messageFromError } from "../../lib/errors";
@@ -52,6 +52,9 @@ export function ReportDialog({
   onSent,
 }: ReportDialogProps) {
   const [dropActive, setDropActive] = useState(false);
+  // Enter/leave fire for every child edge crossed; only depth zero means the
+  // pointer truly left the drop zone (otherwise the overlay flickers).
+  const dragDepthRef = useRef(0);
   const [submitting, setSubmitting] = useState(false);
   // Dropped-file imports resolve in the parent, and `importingFiles` only
   // reflects them a render later — count in-flight drops here too so a fast
@@ -81,7 +84,16 @@ export function ReportDialog({
   function handleDragOver(event: DragEvent<HTMLDivElement>) {
     event.preventDefault();
     event.dataTransfer.dropEffect = "copy";
+  }
+
+  function handleDragEnter() {
+    dragDepthRef.current += 1;
     setDropActive(true);
+  }
+
+  function handleDragLeave() {
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setDropActive(false);
   }
 
   function queueFileImport(files: File[]) {
@@ -92,6 +104,7 @@ export function ReportDialog({
 
   function handleDrop(event: DragEvent<HTMLDivElement>) {
     event.preventDefault();
+    dragDepthRef.current = 0;
     setDropActive(false);
     const files = Array.from(event.dataTransfer.files);
     if (!files.length) {
@@ -181,8 +194,8 @@ export function ReportDialog({
           className="dialog-body report-dialog-drop"
           data-drop-active={dropActive || undefined}
           onDragOver={handleDragOver}
-          onDragEnter={() => setDropActive(true)}
-          onDragLeave={() => setDropActive(false)}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
           onDrop={handleDrop}
           onPaste={handlePaste}
         >

--- a/src/lib/clipboard-files.ts
+++ b/src/lib/clipboard-files.ts
@@ -1,0 +1,90 @@
+/** Image files a paste carries, extracted the way WKWebView actually
+ * delivers them: prefer DataTransferItems (screenshots), fall back to
+ * `files`, filter to image types (Finder file copies arrive as pasteboard
+ * URLs, never as Files), collapse same-image multi-representation pastes to
+ * the best one, and give nameless pastes a stable name. Shared by the chat
+ * composer and the issue report dialog. */
+export function clipboardImageFiles(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const itemFiles =
+    data.items && data.items.length
+      ? Array.from(data.items)
+          .filter((item) => item.kind === "file" && isClipboardImageType(item.type))
+          .map((item) => item.getAsFile())
+          .filter((file): file is File => Boolean(file))
+      : [];
+  if (itemFiles.length) return normalizeClipboardImageFiles(itemFiles);
+  return normalizeClipboardImageFiles(
+    Array.from(data.files ?? []).filter((file) => isClipboardImageType(file.type)),
+  );
+}
+
+function normalizeClipboardImageFiles(files: File[]): File[] {
+  if (files.length <= 1 || hasDistinctClipboardFileNames(files)) {
+    return files.map(ensureClipboardImageName);
+  }
+  const best = [...files].sort(
+    (left, right) => clipboardImageRank(right) - clipboardImageRank(left),
+  )[0];
+  return best ? [ensureClipboardImageName(best, 0)] : [];
+}
+
+function hasDistinctClipboardFileNames(files: File[]) {
+  const names = files.map((file) => file.name.trim()).filter(Boolean);
+  const stems = names.map(clipboardImageStem);
+  return (
+    names.length === files.length &&
+    new Set(names).size === files.length &&
+    new Set(stems).size === files.length
+  );
+}
+
+function ensureClipboardImageName(file: File, index: number) {
+  if (file.name.trim()) return file;
+  const suffix = index === 0 ? "" : `-${index + 1}`;
+  return new File([file], `pasted-image${suffix}.${clipboardImageExtension(file)}`, {
+    type: file.type,
+    lastModified: file.lastModified,
+  });
+}
+
+function isClipboardImageType(type: string) {
+  const mimeType = normalizedImageMimeType(type);
+  return (
+    mimeType === "image/png" ||
+    mimeType === "image/jpeg" ||
+    mimeType === "image/jpg" ||
+    mimeType === "image/tiff" ||
+    mimeType === "image/tif" ||
+    mimeType === "image/gif" ||
+    mimeType === "image/webp"
+  );
+}
+
+function clipboardImageExtension(file: File) {
+  const mimeType = normalizedImageMimeType(file.type);
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") return "jpg";
+  if (mimeType === "image/tiff" || mimeType === "image/tif") return "tiff";
+  const subtype = mimeType.startsWith("image/") ? mimeType.slice(6) : "";
+  return subtype.replace(/[^a-z0-9]/g, "") || "png";
+}
+
+function clipboardImageStem(name: string) {
+  const trimmed = name.trim().toLowerCase();
+  const dot = trimmed.lastIndexOf(".");
+  return dot > 0 ? trimmed.slice(0, dot) : trimmed;
+}
+
+function clipboardImageRank(file: File) {
+  const mimeType = normalizedImageMimeType(file.type);
+  if (mimeType === "image/png") return 50;
+  if (mimeType === "image/tiff" || mimeType === "image/tif") return 40;
+  if (mimeType === "image/webp") return 30;
+  if (mimeType === "image/jpeg" || mimeType === "image/jpg") return 20;
+  if (mimeType === "image/gif") return 10;
+  return 1;
+}
+
+function normalizedImageMimeType(type: string) {
+  return type.toLowerCase().split(";")[0];
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5581,10 +5581,27 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-.report-dialog-drop[data-drop-active="true"] {
-  border-radius: var(--r-md);
-  outline: 2px solid var(--ring-focus);
-  outline-offset: var(--sp-1);
+.report-dialog-drop {
+  position: relative;
+}
+
+/* Drag-over reads as a real drop zone: a dashed panel washes over the form
+ * with a centered instruction (pointer-events: none keeps the drop landing
+ * on the wrapper). */
+.report-dialog-drop[data-drop-active="true"]::after {
+  content: "Drop files to attach";
+  position: absolute;
+  inset: calc(-1 * var(--sp-2));
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  border: 2px dashed color-mix(in oklch, var(--muted-foreground) 45%, transparent);
+  border-radius: var(--r-lg);
+  background: color-mix(in oklch, var(--card) 92%, transparent);
+  color: var(--muted-foreground);
+  font-size: var(--fs-md);
+  font-weight: 500;
+  pointer-events: none;
 }
 
 .report-dialog-file-list {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5595,7 +5595,7 @@ input:focus-visible,
   z-index: 1;
   display: grid;
   place-items: center;
-  border: 2px dashed color-mix(in oklch, var(--muted-foreground) 45%, transparent);
+  border: 1px dashed color-mix(in oklch, var(--muted-foreground) 45%, transparent);
   border-radius: var(--r-lg);
   background: color-mix(in oklch, var(--card) 92%, transparent);
   color: var(--muted-foreground);

--- a/src/test/report-dialog.test.tsx
+++ b/src/test/report-dialog.test.tsx
@@ -176,17 +176,38 @@ describe("ReportDialog", () => {
     const textarea = screen.getByRole("textbox", { name: "Description" });
     const image = new File(["png-bytes"], "", { type: "image/png" });
 
-    fireEvent.paste(textarea, {
-      clipboardData: { items: [], files: [image] },
+    const defaultNotPrevented = fireEvent.paste(textarea, {
+      clipboardData: { items: [], files: [image], getData: () => "" },
     });
     expect(onDropFiles).toHaveBeenCalledTimes(1);
     const [pasted] = onDropFiles.mock.calls[0][0];
     expect(pasted.name).toBe("pasted-image.png");
+    // Image-only paste preventDefault's, so fireEvent returns false.
+    expect(defaultNotPrevented).toBe(false);
 
     fireEvent.paste(textarea, {
-      clipboardData: { items: [], files: [] },
+      clipboardData: { items: [], files: [], getData: () => "" },
     });
     expect(onDropFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("imports the image but keeps the text on a mixed image-and-text paste", () => {
+    const onDropFiles = vi.fn();
+    render(<Harness onDropFiles={onDropFiles} />);
+    const textarea = screen.getByRole("textbox", { name: "Description" });
+    const image = new File(["png-bytes"], "", { type: "image/png" });
+
+    const defaultNotPrevented = fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [],
+        files: [image],
+        getData: () => "Steps to reproduce",
+      },
+    });
+
+    expect(onDropFiles).toHaveBeenCalledTimes(1);
+    // The browser inserts the pasted text normally: default must not be prevented.
+    expect(defaultNotPrevented).toBe(true);
   });
 
   it("keeps drop and paste events inside the dialog", () => {
@@ -201,7 +222,9 @@ describe("ReportDialog", () => {
     const image = new File(["png"], "shot.png", { type: "image/png" });
 
     fireEvent.drop(textarea, { dataTransfer: { files: [image] } });
-    fireEvent.paste(textarea, { clipboardData: { items: [], files: [image] } });
+    fireEvent.paste(textarea, {
+      clipboardData: { items: [], files: [image], getData: () => "" },
+    });
 
     expect(outerDrop).not.toHaveBeenCalled();
     expect(outerPaste).not.toHaveBeenCalled();

--- a/src/test/report-dialog.test.tsx
+++ b/src/test/report-dialog.test.tsx
@@ -189,6 +189,24 @@ describe("ReportDialog", () => {
     expect(onDropFiles).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps drop and paste events inside the dialog", () => {
+    const outerDrop = vi.fn();
+    const outerPaste = vi.fn();
+    render(
+      <div onDrop={outerDrop} onPaste={outerPaste}>
+        <Harness />
+      </div>,
+    );
+    const textarea = screen.getByRole("textbox", { name: "Description" });
+    const image = new File(["png"], "shot.png", { type: "image/png" });
+
+    fireEvent.drop(textarea, { dataTransfer: { files: [image] } });
+    fireEvent.paste(textarea, { clipboardData: { items: [], files: [image] } });
+
+    expect(outerDrop).not.toHaveBeenCalled();
+    expect(outerPaste).not.toHaveBeenCalled();
+  });
+
   it("blocks submit while a dropped file is still importing", async () => {
     let resolveImport: () => void = () => {};
     const onDropFiles = vi.fn(

--- a/src/test/report-dialog.test.tsx
+++ b/src/test/report-dialog.test.tsx
@@ -170,6 +170,25 @@ describe("ReportDialog", () => {
     expect(onDropFiles).toHaveBeenCalledWith([file]);
   });
 
+  it("routes pasted images through the import callback and leaves text pastes alone", () => {
+    const onDropFiles = vi.fn();
+    render(<Harness onDropFiles={onDropFiles} />);
+    const textarea = screen.getByRole("textbox", { name: "Description" });
+    const image = new File(["png-bytes"], "", { type: "image/png" });
+
+    fireEvent.paste(textarea, {
+      clipboardData: { items: [], files: [image] },
+    });
+    expect(onDropFiles).toHaveBeenCalledTimes(1);
+    const [pasted] = onDropFiles.mock.calls[0][0];
+    expect(pasted.name).toBe("pasted-image.png");
+
+    fireEvent.paste(textarea, {
+      clipboardData: { items: [], files: [] },
+    });
+    expect(onDropFiles).toHaveBeenCalledTimes(1);
+  });
+
   it("blocks submit while a dropped file is still importing", async () => {
     let resolveImport: () => void = () => {};
     const onDropFiles = vi.fn(


### PR DESCRIPTION
## Summary

- Pasting an image (a CleanShot screenshot, for example) into the issue report dialog attaches it through the same import pipeline as drag and drop; text pastes fall through to the textarea untouched.
- The composer's clipboard image extraction moves to `src/lib/clipboard-files.ts` so both surfaces share one implementation (WKWebView delivers pasted screenshots as Files; Finder file copies never reach `clipboardData`, so image-only interception matches what can actually arrive).
- Drag-over now reads as a real drop zone: a gray dashed panel washes over the form with a centered "Drop files to attach" instruction, with drag depth counted so child edge-crossings do not flicker the overlay.

Follow-up to #639 (JUN-213) — both requested during design review, landed just after the merge.

## Validation

- `pnpm typecheck`, Biome, and the report-dialog + agent-workspace vitest suites green (new tests cover pasted-image routing and text-paste passthrough).
- Drop-zone state verified visually in the browser harness (drag-over screenshot reviewed).
- [x] Tested visually where it matters.
- [ ] Needs a June API (backend) deploy: no.

## Out of scope

- Pasting non-image files (they never materialize in WKWebView clipboardData).
- A permanently visible dropzone box in the resting form (the ghost Add files button, paste, and drag-over cover the affordance without the vertical cost).