### PR TITLE
Adopt shadcn shimmer recipe across text and HUD shimmers

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3429,7 +3429,7 @@ function UpdateRelaunchCard({
         </span>
         <span className="update-relaunch-copy">
           <span
-            className={relaunching ? "update-relaunch-title text-shimmer" : "update-relaunch-title"}
+            className={relaunching ? "update-relaunch-title shimmer" : "update-relaunch-title"}
           >
             {relaunching ? "Relaunching..." : "Relaunch to update"}
           </span>

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -10294,7 +10294,7 @@ function AgentChatTurnRow({
         />
         {textParts.length === 0 && nonTextParts.length === 0 ? (
           <p className="agent-assistant-empty">
-            <span className="text-shimmer">Thinking…</span>
+            <span className="text-shimmer shimmer">Thinking…</span>
           </p>
         ) : (
           // No actions on an empty/in-flight turn. There is nothing useful to
@@ -10703,7 +10703,7 @@ function AgentGeneratedImage({
     return (
       <div className="agent-generated-image" data-status="running" role="status" aria-live="polite">
         <div className="agent-generated-image-placeholder">
-          <span className="text-shimmer">Generating image…</span>
+          <span className="text-shimmer shimmer">Generating image…</span>
         </div>
       </div>
     );
@@ -10730,7 +10730,7 @@ function AgentGeneratedImage({
   const image = imageSrc ? (
     <img src={imageSrc} alt={part.prompt} draggable={false} />
   ) : part.path ? (
-    <span className="agent-generated-image-loading text-shimmer">Loading image...</span>
+    <span className="agent-generated-image-loading text-shimmer shimmer">Loading image...</span>
   ) : null;
   return (
     <figure className="agent-generated-image" data-status="complete">
@@ -11468,7 +11468,7 @@ function AgentThinkingGroup({
       onToggle={(event) => onOpenChange(event.currentTarget.open)}
     >
       <summary>
-        <span className={running ? "text-shimmer" : undefined}>
+        <span className={running ? "text-shimmer shimmer" : undefined}>
           {running ? "Thinking" : "Thought"}
         </span>
         <IconChevronDownSmall size={14} className="agent-disclosure-chevron" />
@@ -12904,14 +12904,14 @@ function ActivityIndicator({
   );
 }
 
-// Bottom-of-timeline "responding" affordance: a shimmering label, reusing the
-// same text-shimmer the recorder uses while transcribing. Lives in the timeline
-// (not the header) so it reads like the agent is actively composing the next
-// turn.
+// Bottom-of-timeline "responding" affordance: a shimmering label, painted by
+// the same shared .shimmer utility the recorder uses while transcribing. Lives
+// in the timeline (not the header) so it reads like the agent is actively
+// composing the next turn.
 function AgentThinking() {
   return (
     <div className="agent-thinking" role="status" aria-live="polite">
-      <span className="text-shimmer agent-thinking-label">Thinking…</span>
+      <span className="text-shimmer shimmer agent-thinking-label">Thinking…</span>
     </div>
   );
 }

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -373,7 +373,7 @@ export function NoteEditor({
             {showLivePreviewWaiting ? (
               <div className="transcript-processing" role="status" aria-live="polite">
                 <DotSpinner className="transcript-processing-spinner" />
-                <span className="transcript-processing-label">
+                <span className="transcript-processing-label shimmer">
                   Listening for transcript preview...
                 </span>
               </div>
@@ -785,7 +785,7 @@ function ProcessingProgressIndicator({
         <AnimatePresence initial={false} mode="popLayout">
           <motion.span
             key={status}
-            className="note-processing-roll-item"
+            className="note-processing-roll-item shimmer"
             initial={reduceMotion ? { opacity: 0 } : { y: "65%", opacity: 0, filter: "blur(5px)" }}
             animate={reduceMotion ? { opacity: 1 } : { y: "0%", opacity: 1, filter: "blur(0px)" }}
             exit={reduceMotion ? { opacity: 0 } : { y: "-65%", opacity: 0, filter: "blur(5px)" }}

--- a/src/components/notes-list/NotesList.tsx
+++ b/src/components/notes-list/NotesList.tsx
@@ -513,7 +513,12 @@ function MeetingRowContent({
         <span className="folder-note-title">{title}</span>
         <span className="folder-note-subtitle">
           {liveRecording ? <span className="note-recording-dot" aria-hidden /> : null}
-          <span data-shimmer={processing ? "true" : undefined}>{preview}</span>
+          <span
+            data-shimmer={processing ? "true" : undefined}
+            className={processing ? "shimmer" : undefined}
+          >
+            {preview}
+          </span>
         </span>
       </span>
     </>

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -267,6 +267,16 @@ body {
   --mark-shine: var(--attention-bright);
 }
 
+/* The band mirrors the shadcn shimmer geometry in shimmer.css, translated to
+ * overlay-over-mask terms: base = transparent so the mark's own color shows
+ * through, highlight = --mark-shine. Single peak at 50% with soft 50%-mix
+ * shoulders and symmetric edges — the same stop structure as the text
+ * shimmer, no plateau. The 23%/77% edges keep the band's footprint on the
+ * overlay where the old 24%/78% shoulders sat, so the "live" signal strength
+ * is unchanged; the tilt lives entirely in the gradient angle
+ * (calc(90deg + 20deg), matching shimmer.css's default --shimmer-angle).
+ * Keep in sync with .mhud-mark::before in meeting-hud.css and
+ * .hud-meeting-mark::before in hud.css. */
 .agent-hud-mark[data-status="received"]::before,
 .agent-hud-mark[data-status="starting"]::before,
 .agent-hud-mark[data-status="running"]::before,
@@ -276,15 +286,14 @@ body {
   width: 115%;
   content: "";
   background: linear-gradient(
-    100deg,
-    transparent 0%,
-    color-mix(in oklch, var(--mark-shine) 32%, transparent) 24%,
-    var(--mark-shine) 46%,
-    var(--mark-shine) 56%,
-    color-mix(in oklch, var(--mark-shine) 32%, transparent) 78%,
-    transparent 100%
+    calc(90deg + 20deg),
+    transparent 23%,
+    color-mix(in oklch, var(--mark-shine) 50%, transparent) 36.5%,
+    var(--mark-shine) 50%,
+    color-mix(in oklch, var(--mark-shine) 50%, transparent) 63.5%,
+    transparent 77%
   );
-  transform: translate3d(0, 0, 0) skewX(-16deg);
+  transform: translate3d(0, 0, 0);
   will-change: transform;
   animation: agent-hud-shimmer 1320ms linear infinite;
 }
@@ -512,10 +521,12 @@ body {
   }
 }
 
-/* A transform-only highlight pass across the masked mark. */
+/* A transform-only highlight pass across the masked mark. The band's tilt
+ * lives in the gradient angle, not a skew, so the keyframe is a pure
+ * translate. */
 @keyframes agent-hud-shimmer {
   to {
-    transform: translate3d(230%, 0, 0) skewX(-16deg);
+    transform: translate3d(230%, 0, 0);
   }
 }
 

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -539,6 +539,7 @@ body {
   }
 
   .agent-hud-mark,
+  .agent-hud-mark::before,
   .agent-hud-status {
     animation: none;
   }

--- a/src/styles/agent-hud.css
+++ b/src/styles/agent-hud.css
@@ -538,9 +538,15 @@ body {
     transition: none;
   }
 
+  /* The sweep and breathe animations are started by status-qualified selectors
+   * (.agent-hud-mark[data-status]::before, .agent-hud-status[data-status]), so
+   * plain .agent-hud-mark::before / .agent-hud-status resets lose on specificity
+   * and the motion survives. Match the attribute specificity here; this block
+   * sits later in the file, so equal specificity resolves in its favor. */
   .agent-hud-mark,
-  .agent-hud-mark::before,
-  .agent-hud-status {
+  .agent-hud-mark[data-status]::before,
+  .agent-hud-status,
+  .agent-hud-status[data-status] {
     animation: none;
   }
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,6 +1,7 @@
 @import "./tokens.css";
 @import "./fonts.css";
 @import "./dot-spinner.css";
+@import "./shimmer.css";
 
 :root {
   color: var(--foreground);
@@ -2947,10 +2948,10 @@ input:focus-visible,
    and the legend reading/percent while the real meter track renders empty
    beneath. The body structure is shared with the loaded content, and the live
    track starts from a pixel-identical empty frame before lighting up, so the
-   swap has no visible jump. The bars reuse the note-text-shimmer sweep, which
-   animates background-position on a wide gradient and so composes onto a block
-   as cleanly as it does onto text. Muted base, pill radius; sizes come from
-   spacing tokens with a small local width var. */
+   swap has no visible jump. The bars run their own background-position sweep on
+   a wide muted gradient — a block sweep, not a text-clip, so it is independent
+   of the shared .shimmer text utility (which clips to glyphs). Muted base, pill
+   radius; sizes come from spacing tokens with a small local width var. */
 .agent-usage-skeleton {
   display: inline-block;
   height: 1em;
@@ -2964,7 +2965,16 @@ input:focus-visible,
     var(--muted) 100%
   );
   background-size: 200% 100%;
-  animation: note-text-shimmer 1.6s linear infinite;
+  animation: usage-skeleton-sweep 1.6s linear infinite;
+}
+
+@keyframes usage-skeleton-sweep {
+  0% {
+    background-position: 150% 0;
+  }
+  100% {
+    background-position: -50% 0;
+  }
 }
 
 .agent-usage-skeleton-model {
@@ -8276,21 +8286,10 @@ input:focus-visible,
   color: color-mix(in oklch, var(--muted-foreground) 80%, transparent);
 }
 
+/* Pairs with the shared .shimmer utility in markup. The label just sets its
+ * base color; .shimmer sweeps the soft highlight across it at the default 2s. */
 .transcript-processing-label {
-  background: linear-gradient(
-    90deg,
-    var(--muted-foreground) 0%,
-    var(--muted-foreground) 35%,
-    var(--foreground) 50%,
-    var(--muted-foreground) 65%,
-    var(--muted-foreground) 100%
-  );
-  background-size: 200% 100%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-  -webkit-text-fill-color: transparent;
-  animation: note-text-shimmer 2s linear infinite;
+  color: var(--muted-foreground);
 }
 
 .transcript-view p {
@@ -8571,8 +8570,8 @@ input:focus-visible,
  * framer-motion slides each label up into place as the previous one lifts out,
  * blurring through the hand-off (a departure-board roll). position: relative
  * contains the leaving label once popLayout pops it out of flow; overflow clips
- * the vertical travel. Each name keeps the same left-to-right shimmer the
- * processing label has always had. */
+ * the vertical travel. Each name pairs with the shared .shimmer utility in
+ * markup for the same soft highlight the processing label carries. */
 .note-processing-roll {
   position: relative;
   flex: 0 1 auto;
@@ -8589,64 +8588,21 @@ input:focus-visible,
   line-height: 1.4em;
   white-space: nowrap;
   text-overflow: ellipsis;
-  background: linear-gradient(
-    90deg,
-    var(--muted-foreground) 0%,
-    var(--muted-foreground) 35%,
-    var(--foreground) 50%,
-    var(--muted-foreground) 65%,
-    var(--muted-foreground) 100%
-  );
-  background-size: 200% 100%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-  -webkit-text-fill-color: transparent;
-  animation: note-text-shimmer 2s linear infinite;
+  color: var(--muted-foreground);
 }
 
+/* Truncation layout plus the shimmer base color for the agent-chat working
+ * labels. Pairs with the shared .shimmer utility in markup, which owns the
+ * sweep; here we only keep the ellipsis clamp and the base color it sweeps. The
+ * agent shimmer runs quicker than the 2s default — the slower cadence read
+ * sluggish in the chat — so it sets a shorter --shimmer-duration. */
 .text-shimmer {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background: linear-gradient(
-    90deg,
-    var(--muted-foreground) 0%,
-    var(--muted-foreground) 35%,
-    var(--foreground) 50%,
-    var(--muted-foreground) 65%,
-    var(--muted-foreground) 100%
-  );
-  background-size: 200% 100%;
-  background-clip: text;
-  -webkit-background-clip: text;
-  color: transparent;
-  -webkit-text-fill-color: transparent;
-  animation: note-text-shimmer 2s linear infinite;
-}
-
-/* The agent shimmer runs quicker than the note-generating one — it read
- * sluggish in the chat. */
-.text-shimmer {
-  animation-duration: 1.2s;
-}
-
-@keyframes note-text-shimmer {
-  0% {
-    background-position: 150% 0;
-  }
-  100% {
-    background-position: -50% 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  /* framer-motion already drops the slide and blur for the stage swap (it reads
-     prefers-reduced-motion); this just rests the label's shimmer. */
-  .note-processing-roll-item {
-    animation: none;
-  }
+  color: var(--muted-foreground);
+  --shimmer-duration: 1200ms;
 }
 
 /* Count chip — how many follow-up recordings are queued behind the one
@@ -17315,30 +17271,16 @@ input:focus-visible,
 }
 
 /* Transcribing / generating / validating: sweep a highlight across the status
- * word so it reads as work-in-flight, the way the agent rows signal activity. */
+ * word so it reads as work-in-flight, the way the agent rows signal activity.
+ * Pairs with the shared .shimmer utility in markup, which owns the sweep; the
+ * status word only sets its base color and a slightly quicker cadence. */
 .folder-note-subtitle [data-shimmer="true"] {
-  background: linear-gradient(
-    100deg,
-    var(--muted-foreground) 35%,
-    var(--foreground) 50%,
-    var(--muted-foreground) 65%
-  );
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: note-status-shimmer 1.5s linear infinite;
-}
-
-@keyframes note-status-shimmer {
-  to {
-    background-position: -200% 0;
-  }
+  color: var(--muted-foreground);
+  --shimmer-duration: 1500ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .note-recording-dot,
-  .folder-note-subtitle [data-shimmer="true"] {
+  .note-recording-dot {
     animation: none;
   }
 }
@@ -18613,14 +18555,6 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-/* While relaunching, the label reuses the shared .text-shimmer sweep. That
- * utility lives earlier in this flat stylesheet, so the title's solid color
- * above would win and hide the gradient. Re-assert the transparent fill here
- * (after the title rule) so the shimmer shows through. */
-.update-relaunch-title.text-shimmer {
-  color: transparent;
-}
-
 .update-relaunch-copy > span:last-child {
   overflow: hidden;
   color: var(--muted-foreground);
@@ -18757,10 +18691,6 @@ input:focus-visible,
 
   .update-relaunch-card:hover:not(:disabled) .update-relaunch-arrow {
     transform: none;
-  }
-
-  .update-relaunch-title.text-shimmer {
-    animation: none;
   }
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -17272,8 +17272,10 @@ input:focus-visible,
 
 /* Transcribing / generating / validating: sweep a highlight across the status
  * word so it reads as work-in-flight, the way the agent rows signal activity.
- * Pairs with the shared .shimmer utility in markup, which owns the sweep; the
- * status word only sets its base color and a slightly quicker cadence. */
+ * The paint is split: markup toggles the shared .shimmer class (which owns the
+ * sweep) while processing, and this [data-shimmer] hook carries the base color
+ * and a slightly quicker cadence. Both are required — don't drop the attribute
+ * assuming the class alone suffices, or the duration override is lost. */
 .folder-note-subtitle [data-shimmer="true"] {
   color: var(--muted-foreground);
   --shimmer-duration: 1500ms;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -339,21 +339,26 @@ body {
   -webkit-mask: var(--mark) center / 10px 12px no-repeat;
 }
 
+/* The band mirrors the shadcn shimmer geometry in shimmer.css: single peak at
+ * 50%, soft 50%-mix shoulders, symmetric edges, no plateau, with the 20deg
+ * tilt carried by the gradient angle. Base = transparent so the mark's own
+ * color shows through, highlight = --mark-shine. Keep in sync with
+ * .agent-hud-mark::before in agent-hud.css and .mhud-mark::before in
+ * meeting-hud.css. */
 .hud-meeting-mark::before {
   position: absolute;
   inset: -2px auto -2px -110%;
   width: 115%;
   content: "";
   background: linear-gradient(
-    100deg,
-    transparent 0%,
-    color-mix(in oklch, var(--mark-shine) 32%, transparent) 24%,
-    var(--mark-shine) 46%,
-    var(--mark-shine) 56%,
-    color-mix(in oklch, var(--mark-shine) 32%, transparent) 78%,
-    transparent 100%
+    calc(90deg + 20deg),
+    transparent 23%,
+    color-mix(in oklch, var(--mark-shine) 50%, transparent) 36.5%,
+    var(--mark-shine) 50%,
+    color-mix(in oklch, var(--mark-shine) 50%, transparent) 63.5%,
+    transparent 77%
   );
-  transform: translate3d(0, 0, 0) skewX(-16deg);
+  transform: translate3d(0, 0, 0);
   will-change: transform;
   animation: hud-mark-shimmer 1320ms linear infinite;
 }
@@ -699,10 +704,11 @@ body {
 }
 
 /* A transform-only highlight pass across the masked mark — the agent
- * HUD's shimmer, same cadence. */
+ * HUD's shimmer, same cadence. The band's tilt lives in the gradient angle,
+ * not a skew, so the keyframe is a pure translate. */
 @keyframes hud-mark-shimmer {
   to {
-    transform: translate3d(230%, 0, 0) skewX(-16deg);
+    transform: translate3d(230%, 0, 0);
   }
 }
 

--- a/src/styles/meeting-hud.css
+++ b/src/styles/meeting-hud.css
@@ -156,24 +156,28 @@ body:active {
     opacity 120ms var(--ease-out);
 }
 
-/* Continuous shimmer: a translating highlight gradient, peak at 50%, swept
- * across the masked glyph by a transform-only keyframe. This is the live
- * recording signal. */
+/* Continuous shimmer: a translating highlight gradient, single peak at 50%,
+ * swept across the masked glyph by a transform-only keyframe. This is the
+ * live recording signal. The band mirrors the shadcn shimmer geometry in
+ * shimmer.css (soft 50%-mix shoulders, symmetric edges, no plateau, 20deg
+ * tilt carried by the gradient angle); base = transparent so the mark's own
+ * color shows through, highlight = --mark-shine. Keep in sync with
+ * .agent-hud-mark::before in agent-hud.css and .hud-meeting-mark::before in
+ * hud.css. */
 .mhud-mark::before {
   position: absolute;
   inset: -2px auto -2px -110%;
   width: 115%;
   content: "";
   background: linear-gradient(
-    100deg,
-    transparent 0%,
-    color-mix(in oklch, var(--mark-shine) 32%, transparent) 24%,
-    var(--mark-shine) 46%,
-    var(--mark-shine) 56%,
-    color-mix(in oklch, var(--mark-shine) 32%, transparent) 78%,
-    transparent 100%
+    calc(90deg + 20deg),
+    transparent 23%,
+    color-mix(in oklch, var(--mark-shine) 50%, transparent) 36.5%,
+    var(--mark-shine) 50%,
+    color-mix(in oklch, var(--mark-shine) 50%, transparent) 63.5%,
+    transparent 77%
   );
-  transform: translate3d(0, 0, 0) skewX(-16deg);
+  transform: translate3d(0, 0, 0);
   will-change: transform;
   animation: mhud-shimmer 1320ms linear infinite;
 }
@@ -189,10 +193,11 @@ body:active {
 }
 
 /* A transform-only highlight pass across the masked mark (ported from
- * agent-hud-shimmer in agent-hud.css). */
+ * agent-hud-shimmer in agent-hud.css). The band's tilt lives in the gradient
+ * angle, not a skew, so the keyframe is a pure translate. */
 @keyframes mhud-shimmer {
   to {
-    transform: translate3d(230%, 0, 0) skewX(-16deg);
+    transform: translate3d(230%, 0, 0);
   }
 }
 

--- a/src/styles/shimmer.css
+++ b/src/styles/shimmer.css
@@ -45,25 +45,37 @@
   --_spread: var(--shimmer-spread, calc(3ch + 40px));
   --_base: currentColor;
   --_highlight: var(--shimmer-color, oklch(from currentColor l c h / calc(alpha * 0.2)));
+}
 
-  background-image: var(
-    --shimmer-image,
-    linear-gradient(
-      calc(90deg + var(--shimmer-angle)),
-      var(--_base) calc(50% - var(--_spread)),
-      color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% - var(--_spread) * 0.5),
-      var(--_highlight) 50%,
-      color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% + var(--_spread) * 0.5),
-      var(--_base) calc(50% + var(--_spread))
-    )
-  );
-  background-repeat: no-repeat;
-  background-size: calc(200% + var(--_spread) * 2) 100%;
-  background-position: 0 0;
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: var(--shimmer-text-fill, transparent);
-  animation: tw-shimmer var(--shimmer-duration, 2s) linear infinite;
+/* The paint clips a gradient to the text and hides the glyph fill
+ * (-webkit-text-fill-color: transparent) so the gradient IS the text. That
+ * gradient is built from relative color syntax (oklch(from currentColor ...))
+ * and color-mix() — Level 5 color features. An older system WKWebView that
+ * rejects the gradient would still honor the transparent fill and render the
+ * label invisible. Gating the whole paint on relative-color support means
+ * unsupported engines skip it entirely and keep the element's solid `color`
+ * (no shimmer, but legible) — the graceful fallback shadcn's docs prescribe. */
+@supports (color: oklch(from red l c h)) {
+  .shimmer {
+    background-image: var(
+      --shimmer-image,
+      linear-gradient(
+        calc(90deg + var(--shimmer-angle)),
+        var(--_base) calc(50% - var(--_spread)),
+        color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% - var(--_spread) * 0.5),
+        var(--_highlight) 50%,
+        color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% + var(--_spread) * 0.5),
+        var(--_base) calc(50% + var(--_spread))
+      )
+    );
+    background-repeat: no-repeat;
+    background-size: calc(200% + var(--_spread) * 2) 100%;
+    background-position: 0 0;
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: var(--shimmer-text-fill, transparent);
+    animation: tw-shimmer var(--shimmer-duration, 2s) linear infinite;
+  }
 }
 
 /* Upstream's `@variant dark`. June's dark mode is `[data-theme="dark"]` (set by

--- a/src/styles/shimmer.css
+++ b/src/styles/shimmer.css
@@ -60,7 +60,7 @@
     background-image: var(
       --shimmer-image,
       linear-gradient(
-        calc(90deg + var(--shimmer-angle)),
+        calc(90deg + var(--shimmer-angle, 20deg)),
         var(--_base) calc(50% - var(--_spread)),
         color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% - var(--_spread) * 0.5),
         var(--_highlight) 50%,

--- a/src/styles/shimmer.css
+++ b/src/styles/shimmer.css
@@ -1,0 +1,93 @@
+/* Plain-CSS port of the `shimmer` text utility from the `shadcn` npm package
+ * (v4.13.0, its dist/tailwind.css — fetch with `pnpm dlx shadcn` to diff a
+ * newer upstream; the package is not a dependency, this file is the vendored
+ * copy). shadcn ships it as a Tailwind v4 `@utility`; this is the same recipe
+ * hand-written for June, which has no Tailwind. The variable API is kept identical to upstream so its docs
+ * apply verbatim: set `--shimmer-duration`, `--shimmer-spread`,
+ * `--shimmer-angle`, `--shimmer-color`, `--shimmer-image`, or
+ * `--shimmer-text-fill` on the element to tune a site.
+ *
+ * The paint is currentColor-based: the element must carry a real `color` (we
+ * use `var(--muted-foreground)` at the call sites) — that color is the shimmer
+ * base, and a soft wide highlight band sweeps across it. This differs from
+ * June's old hand-rolled shimmers, which set `color: transparent` and painted
+ * the color through the gradient. Any leftover `color: transparent` would make
+ * this gradient invisible.
+ *
+ * `.shimmer` is a pure paint utility: it owns only the sweep. Layout and
+ * typography (truncation, line-height, roll windows, font size) stay on the
+ * semantic class at each call site. */
+
+@property --shimmer-angle {
+  syntax: "<angle>";
+  inherits: true;
+  initial-value: 20deg;
+}
+@property --shimmer-image {
+  syntax: "*";
+  inherits: false;
+}
+@property --shimmer-text-fill {
+  syntax: "*";
+  inherits: false;
+}
+
+@keyframes tw-shimmer {
+  from {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+
+.shimmer {
+  --_spread: var(--shimmer-spread, calc(3ch + 40px));
+  --_base: currentColor;
+  --_highlight: var(--shimmer-color, oklch(from currentColor l c h / calc(alpha * 0.2)));
+
+  background-image: var(
+    --shimmer-image,
+    linear-gradient(
+      calc(90deg + var(--shimmer-angle)),
+      var(--_base) calc(50% - var(--_spread)),
+      color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% - var(--_spread) * 0.5),
+      var(--_highlight) 50%,
+      color-mix(in oklch, var(--_highlight), var(--_base) 50%) calc(50% + var(--_spread) * 0.5),
+      var(--_base) calc(50% + var(--_spread))
+    )
+  );
+  background-repeat: no-repeat;
+  background-size: calc(200% + var(--_spread) * 2) 100%;
+  background-position: 0 0;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: var(--shimmer-text-fill, transparent);
+  animation: tw-shimmer var(--shimmer-duration, 2s) linear infinite;
+}
+
+/* Upstream's `@variant dark`. June's dark mode is `[data-theme="dark"]` (set by
+ * src/lib/theme.ts — there is no `.dark` class), so scope the brighter, more
+ * opaque highlight to that attribute. This selector is more specific than the
+ * bare `.shimmer` above, so it wins regardless of source order in the flat
+ * stylesheet. */
+[data-theme="dark"] .shimmer {
+  --_highlight: var(
+    --shimmer-color,
+    oklch(from currentColor max(0.8, calc(l + 0.4)) c h / calc(alpha + 0.4))
+  );
+}
+
+/* June is LTR-only, but keeping upstream's RTL flip is harmless and preserves
+ * fidelity with the vendored recipe. */
+.shimmer:where([dir="rtl"], [dir="rtl"] *) {
+  animation-direction: reverse;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer {
+    animation: none;
+    background-image: none;
+    -webkit-text-fill-color: currentColor;
+  }
+}


### PR DESCRIPTION
## What

Replaces June's four hand-rolled text-shimmer implementations with a single vendored plain-CSS port of shadcn's `shimmer` utility, and reshapes the three HUD mark shimmers to match the same band geometry. One shimmer look across the whole app, net fewer lines.

- **New `src/styles/shimmer.css`** — faithful port of the `shimmer` utility from the `shadcn` package (v4.13.0), hand-written for June (which has no Tailwind). Keeps shadcn's variable API verbatim (`--shimmer-duration`, `--shimmer-spread`, `--shimmer-angle`, `--shimmer-color`, ...) so upstream docs apply. The band is currentColor-based with a soft wide highlight, font-relative spread (`calc(3ch + 40px)`), and a 20deg tilt; it brightens automatically in dark mode via `[data-theme="dark"]`.
- **Text sites migrated** — `.text-shimmer` (agent chat "Thinking…", image labels, relaunch title), `.transcript-processing-label` (recorder), `.note-processing-roll-item` (rolling stage names), and the notes-list `[data-shimmer]` status word now share the utility. Each site keeps its own `color` and cadence (agent 1.2s, notes list 1.5s, others 2s). Old `note-text-shimmer` / `note-status-shimmer` keyframes deleted.
- **Skeleton bars** — the usage-panel first-load bars are a block background sweep (not text-clip), so they got their own `usage-skeleton-sweep` keyframe rather than riding a text-shimmer keyframe.
- **HUD marks** — the agent, meeting, and dictation HUD logo shimmers (a highlight swept across a masked glyph) were reshaped to the shadcn band: single peak at 50%, soft 50%-mix shoulders, tilt carried by the gradient angle (`skewX` removed). Cadence (1320ms), accent colors, mask setup, and paused/reduced-motion behavior are unchanged, so the "live" signal reads the same strength.

## Why

Several independently-tuned gradients with hard 35/50/65 stops had drifted; adopting a design-system recipe unifies the look, makes future tuning a one-variable change, and tracks upstream. The `shimmer` semantics shift to currentColor-based (the element carries a real `color`, no more `color: transparent`).

## Design notes

- **Highlight polarity:** shadcn's default *fades* the text toward the surface (currentColor at 20% alpha). We kept that default; if the small muted status labels read washed out in practice, `--shimmer-color: var(--foreground)` flips it to the old *intensify* direction — a one-line escape hatch, not a fork.
- **Spread is font-relative, not width-relative** — deliberately chosen so short status labels all carry the same physical glint (one light source across the app) rather than each label sizing its band to its text length.

## Tested visually

Needs a look in-app: agent chat "Thinking…", recorder transcribing, notes-list status word, and the three HUDs (`__agentHud` / `__meetingHud` / `__dictationHud` console commands park the states). No screenshots attached yet.

## Needs a June API deploy?

No — desktop-only CSS/markup change.

## Out of scope

- The JS-driven audio-meter carrier shimmer (`src/hud.ts`) — a different mechanism, untouched.
- The `shadcn` npm package is **not** a dependency; `shimmer.css` is the vendored copy (`pnpm dlx shadcn` fetches upstream to diff a newer version).

## Followups

- If we ever shimmer a long line (e.g. a skeleton paragraph), a percentage `--shimmer-spread` at that one call site gives width-relative behavior deliberately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994575&installation_id=144203540&pr_number=642&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F642&signature=1185189b05780d7f46625db77a78f1ccae7b47e3c1b253b69912993e6d94a99f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->