### PR TITLE
Fix dictation HUD shadow clipping

### DIFF
--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -109,8 +109,8 @@ pub struct HudClientRect {
 /// don't poll from JS because WebKit throttles timers on the non-key HUD
 /// panel (and CSS :hover is unreliable there for the same reason). The
 /// stop button and the meeting prompt's corner dismiss each get a rect.
-/// (The window is sized exactly to the pill, so there's no click
-/// pass-through to manage — the whole window is interactive.)
+/// The window includes a small transparent gutter for the CSS shadow, but
+/// hover still keys off the controls themselves rather than the full frame.
 pub struct HudHoverState {
     stop_bounds: Mutex<Option<HudClientRect>>,
     last_hover: std::sync::atomic::AtomicBool,
@@ -3424,7 +3424,8 @@ fn default_hud_position(hud: &WebviewWindow, window_size: PhysicalSize<u32>) -> 
     let work_top = work_area.position.y;
     let work_center_x = work_area.position.x + work_area.size.width as i32 / 2;
 
-    // The window is exactly the pill — anchor it directly.
+    // The window is the pill plus its transparent shadow gutter. Anchor the
+    // full frame; the webview centers the pill inside it.
     let x = work_center_x - window_size.width as i32 / 2;
     let y = work_top + HUD_TOP_MARGIN;
     Some((x, y))

--- a/src/hud.ts
+++ b/src/hud.ts
@@ -112,17 +112,14 @@ const brailleWave = spinners.waverows;
 const EXIT_TRANSITION_MS = 240;
 // Matches the .hud.is-morphing fade (60ms) plus a frame of slack.
 const MORPH_FADE_MS = 80;
-// Transparent, click-through margin around the frostless HUD surface. Its
-// CSS shadow paints here and the meeting dismiss can overhang the card's
-// edge. This is the agent HUD model: transparent native window, CSS-painted
-// surface, no native vibrancy rim.
-const WINDOW_GUTTER = 16;
+// Transparent margin around the frostless HUD surface. The compact HUD shadow
+// paints here and the meeting dismiss can overhang the card's edge. Keep this
+// in sync with --shadow-hud's maximum spread in tokens.css; using the larger
+// app-card shadows here clips the overlay or forces a click-blocking window.
+const WINDOW_GUTTER = 18;
 // Gap between the error pill and the message layer that draws above/below it
 // — must match the .hud-error-layer margin in hud.css.
 const ERROR_LAYER_GAP = 8;
-// The error message layer's reveal / retract — must track the
-// .hud-error-layer grid-template-rows transition (--t-med) in hud.css.
-const ERROR_REVEAL_MS = 160;
 const MEETING_PROMPT_TIMEOUT_MS = 30_000;
 
 function invokeBestEffort(command: string, args?: Record<string, unknown>) {
@@ -399,7 +396,7 @@ function setDismissHover(isHovered: boolean) {
 // Hovering anywhere over the card (plus the overhanging X) reveals the
 // corner dismiss; hovering the record button paints its hover wash.
 function pushDismissBoundsToNative() {
-  if (!hud || hud.dataset.state !== "meeting") {
+  if (hud?.dataset.state !== "meeting") {
     invokeBestEffort("dictation_hud_set_dismiss_bounds", { rect: null });
     invokeBestEffort("dictation_hud_set_record_bounds", { rect: null });
     return;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -10,8 +10,8 @@
  * frostless CSS surface.
  *
  * The native window is transparent and slightly larger than the pill so the
- * CSS shadow can paint into its gutter. This matches the agent HUD: no native
- * vibrancy, no NSVisualEffectView rim, no inset-looking frost edge.
+ * compact HUD shadow can paint into its gutter. This matches the agent HUD:
+ * no native vibrancy, no NSVisualEffectView rim, no inset-looking frost edge.
  */
 
 :root {
@@ -83,7 +83,7 @@ body {
   padding: 4px;
   border-radius: var(--r-lg);
   background: var(--hud-bg);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-hud);
   color: var(--foreground);
   pointer-events: auto;
   /* Paced for the exit dissolve — must track EXIT_TRANSITION_MS in hud.ts
@@ -248,7 +248,7 @@ body {
   overflow: hidden;
   border-radius: var(--r-md);
   background: var(--hud-bg);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-hud);
   pointer-events: none;
   transition:
     grid-template-rows var(--t-med) var(--ease-out),

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -276,6 +276,9 @@
 
   /* Shadows ---------------------------------------------------------- */
   --shadow-sm: 0 1px 2px oklch(24% 0.002 84.59 / 5%), 0 2px 4px oklch(24% 0.002 84.59 / 3%);
+  /* Compact overlay depth: fits inside the dictation HUD's transparent
+   * native gutter, unlike --shadow-md's long card shadow. */
+  --shadow-hud: 0 1px 2px oklch(24% 0.002 84.59 / 5%), 0 4px 12px oklch(24% 0.002 84.59 / 8%);
   /* md leans ambient: faint contact, weight in the wide blurs, so lifted
    * surfaces glow softly instead of drawing a hard line under the edge. */
   --shadow-md:
@@ -382,6 +385,7 @@
   --selection-foreground: var(--foreground);
 
   --shadow-sm: 0 1px 2px oklch(0% 0 none / 24%), 0 2px 4px oklch(0% 0 none / 12%);
+  --shadow-hud: 0 1px 2px oklch(0% 0 none / 18%), 0 4px 12px oklch(0% 0 none / 28%);
   /* Same ambient bias as light md: soft contact, weight in the wide blurs. */
   --shadow-md:
     0 1px 2px oklch(0% 0 none / 12%), 0 4px 10px oklch(0% 0 none / 10%),

--- a/src/test/hud-css.test.ts
+++ b/src/test/hud-css.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import hudCss from "../styles/hud.css?raw";
+import tokensCss from "../styles/tokens.css?raw";
+
+function cssRuleFor(css: string, selector: string) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`${escaped}\\s*\\{`).exec(css);
+  if (!match) throw new Error(`Missing CSS rule for ${selector}`);
+  const openIndex = match.index + match[0].length - 1;
+  let depth = 0;
+  for (let index = openIndex; index < css.length; index += 1) {
+    if (css[index] === "{") depth += 1;
+    if (css[index] === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(openIndex + 1, index);
+    }
+  }
+  throw new Error(`Unclosed CSS rule for ${selector}`);
+}
+
+describe("dictation HUD styles", () => {
+  it("uses a compact overlay shadow that fits the HUD window gutter", () => {
+    expect(tokensCss).toContain("--shadow-hud:");
+    expect(cssRuleFor(hudCss, ".hud")).toContain("box-shadow: var(--shadow-hud);");
+    expect(cssRuleFor(hudCss, ".hud-error-layer")).toContain("box-shadow: var(--shadow-hud);");
+    expect(cssRuleFor(hudCss, ".hud")).not.toContain("box-shadow: var(--shadow-md);");
+  });
+});

--- a/src/test/hud-meeting.test.ts
+++ b/src/test/hud-meeting.test.ts
@@ -65,10 +65,10 @@ describe("meeting detection HUD", () => {
       rect: null,
     });
     // The window is resized to the measured pill (jsdom rects are zero)
-    // plus the meeting card's transparent gutter on each side.
+    // plus the meeting card's transparent shadow gutter on each side.
     expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_set_size", {
-      width: 32,
-      height: 32,
+      width: 36,
+      height: 36,
       animate: false,
     });
   });
@@ -384,7 +384,7 @@ describe("meeting detection HUD", () => {
     expect(chromeCalls()).toEqual([]);
     expect(mocks.invoke).toHaveBeenCalledWith(
       "dictation_hud_set_size",
-      expect.objectContaining({ width: 32, height: 32 }),
+      expect.objectContaining({ width: 36, height: 36 }),
     );
   });
 
@@ -550,10 +550,10 @@ describe("meeting detection HUD", () => {
     expect(mocks.invoke).toHaveBeenCalledWith("dictation_hud_preferred_error_placement");
     // The window is sized to fit the message layer mirrored above/below the
     // pill, plus the shadow gutter (jsdom rects are zero: 2 gaps tall and
-    // 2 gutters all round).
+    // 2 compact HUD gutters all round).
     expect(mocks.invoke).toHaveBeenCalledWith(
       "dictation_hud_set_size",
-      expect.objectContaining({ width: 32, height: 48 }),
+      expect.objectContaining({ width: 36, height: 52 }),
     );
   });
 


### PR DESCRIPTION
## Summary
- Add a compact `--shadow-hud` token for transient HUD overlays.
- Switch the dictation HUD pill and error reveal from `--shadow-md` to `--shadow-hud`.
- Keep the native HUD gutter small but large enough for the compact shadow, and lock the sizing expectations with focused tests.

## Root cause
The previous HUD gutter fix still used `--shadow-md`. PR #608 later changed `--shadow-md` into a much deeper layered card shadow, so the HUD inherited a larger shadow without increasing its native transparent window gutter. The result was clipped shadow edges.

## Visual testing
Yes - rendered the standalone HUD with Playwright at native HUD window dimensions and checked the captures locally:
- `.context/hud-shadow-check/listening-native-size.png`
- `.context/hud-shadow-check/error-native-size.png`

## Needs June API deploy
No.

## Tests
- `pnpm test src/test/hud-meeting.test.ts src/test/hud-css.test.ts`
- `pnpm typecheck`
- `pnpm exec biome check src/hud.ts src/styles/hud.css src/styles/tokens.css src/test/hud-meeting.test.ts src/test/hud-css.test.ts src-tauri/src/dictation.rs` (passes with pre-existing `hud.css` warnings only)

## Out of scope
- Existing repo-wide Biome warnings outside this HUD fix.
- Reworking the agent HUD shadow sizing model.

## Followups
None required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994629&installation_id=144203540&pr_number=643&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F643&signature=2edf07e8eef060b38db03b7339eb3295ec89288ce56f230d41add186fefb7ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->