### PR TITLE
Harden Windows Artifact Signing workflow

### DIFF
--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -107,13 +107,22 @@ jobs:
           choco install nsis 7zip -y --no-progress
           "C:\Program Files (x86)\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+          $nugetVersion = "6.14.0"
+          $nugetExpectedSha256 = "92DBED160DDEE0F64B901E907439E021211B428E57C089ECC12FC38DCC4BD9A5"
+          $windowsSdkBuildToolsVersion = "10.0.28000.2270"
+          $artifactSigningClientVersion = "1.0.128"
+
           $nuget = Join-Path $env:RUNNER_TEMP "nuget.exe"
-          Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nuget
+          Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/v$nugetVersion/nuget.exe" -OutFile $nuget
+          $nugetActualSha256 = (Get-FileHash -LiteralPath $nuget -Algorithm SHA256).Hash.ToUpperInvariant()
+          if ($nugetActualSha256 -ne $nugetExpectedSha256) {
+            throw "nuget.exe checksum mismatch. Expected $nugetExpectedSha256, got $nugetActualSha256."
+          }
 
           $sdkRoot = Join-Path $env:RUNNER_TEMP "windows-sdk-build-tools"
-          & $nuget install Microsoft.Windows.SDK.BuildTools -x -OutputDirectory $sdkRoot
+          & $nuget install Microsoft.Windows.SDK.BuildTools -Version $windowsSdkBuildToolsVersion -x -OutputDirectory $sdkRoot
           if ($LASTEXITCODE -ne 0) {
-            throw "Failed to install Microsoft.Windows.SDK.BuildTools."
+            throw "Failed to install Microsoft.Windows.SDK.BuildTools $windowsSdkBuildToolsVersion."
           }
           $signTool = Get-ChildItem -Path $sdkRoot -Filter "signtool.exe" -Recurse -File |
             Sort-Object `
@@ -126,9 +135,9 @@ jobs:
           "WINDOWS_SIGNTOOL_PATH=$($signTool.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           $artifactClientRoot = Join-Path $env:RUNNER_TEMP "artifact-signing-client"
-          & $nuget install Microsoft.ArtifactSigning.Client -x -OutputDirectory $artifactClientRoot
+          & $nuget install Microsoft.ArtifactSigning.Client -Version $artifactSigningClientVersion -x -OutputDirectory $artifactClientRoot
           if ($LASTEXITCODE -ne 0) {
-            throw "Failed to install Microsoft.ArtifactSigning.Client."
+            throw "Failed to install Microsoft.ArtifactSigning.Client $artifactSigningClientVersion."
           }
           $dlib = Get-ChildItem -Path $artifactClientRoot -Filter "Azure.CodeSigning.Dlib.dll" -Recurse -File |
             Sort-Object `
@@ -197,12 +206,27 @@ jobs:
           } elseif ($artifactPresent.Count -eq $artifactNames.Count -and $pfxPresent.Count -eq 0) {
             "WINDOWS_SIGNING_MODE=artifact" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             "mode=artifact" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          } elseif ($pfxPresent.Count -eq 0 -and $artifactPresent.Count -eq 0) {
+            Write-Host "::error::No Windows Authenticode signing credentials are configured. Configure either WINDOWS_CERTIFICATE/WINDOWS_CERTIFICATE_PASSWORD or all Azure Artifact Signing secrets."
+            $missing = 1
           } else {
-            Write-Host "::error::Configure either WINDOWS_CERTIFICATE/WINDOWS_CERTIFICATE_PASSWORD or all Azure Artifact Signing secrets, but not a partial mix."
+            if ($pfxPresent.Count -eq $pfxNames.Count -and $artifactPresent.Count -eq $artifactNames.Count) {
+              Write-Host "::error::Both PFX signing and Azure Artifact Signing are fully configured. Configure exactly one Windows Authenticode signing mode."
+            } elseif ($pfxPresent.Count -gt 0 -and $pfxPresent.Count -lt $pfxNames.Count -and $artifactPresent.Count -eq 0) {
+              $missingPfx = @($pfxNames | Where-Object { [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_)) })
+              Write-Host "::error::PFX signing is partially configured. Missing: $($missingPfx -join ', ')."
+            } elseif ($artifactPresent.Count -gt 0 -and $artifactPresent.Count -lt $artifactNames.Count -and $pfxPresent.Count -eq 0) {
+              $missingArtifact = @($artifactNames | Where-Object { [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_)) })
+              Write-Host "::error::Azure Artifact Signing is partially configured. Missing: $($missingArtifact -join ', ')."
+            } else {
+              Write-Host "::error::Windows Authenticode signing configuration mixes PFX and Azure Artifact Signing values. Configure exactly one complete signing mode."
+            }
             foreach ($name in ($pfxNames + $artifactNames)) {
               $value = [Environment]::GetEnvironmentVariable($name)
               if ([string]::IsNullOrWhiteSpace($value)) {
                 Write-Host "::notice::$name is not set."
+              } else {
+                Write-Host "::notice::$name is set."
               }
             }
             $missing = 1

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -221,14 +221,6 @@ jobs:
             } else {
               Write-Host "::error::Windows Authenticode signing configuration mixes PFX and Azure Artifact Signing values. Configure exactly one complete signing mode."
             }
-            foreach ($name in ($pfxNames + $artifactNames)) {
-              $value = [Environment]::GetEnvironmentVariable($name)
-              if ([string]::IsNullOrWhiteSpace($value)) {
-                Write-Host "::notice::$name is not set."
-              } else {
-                Write-Host "::notice::$name is set."
-              }
-            }
             $missing = 1
           }
 

--- a/scripts/windows-sign.ps1
+++ b/scripts/windows-sign.ps1
@@ -121,7 +121,15 @@ function New-ArtifactSigningMetadata([object]$Config) {
     $metadata.CorrelationId = $correlationId
   }
 
-  $metadataPath = Join-Path $env:TEMP "artifact-signing-metadata-$([Guid]::NewGuid().ToString('N')).json"
+  $tempRoot = First-NonBlank @($env:RUNNER_TEMP, $env:TEMP)
+  if ([string]::IsNullOrWhiteSpace($tempRoot)) {
+    Fail "RUNNER_TEMP or TEMP is required to write Artifact Signing metadata."
+  }
+  if (!(Test-Path -LiteralPath $tempRoot -PathType Container)) {
+    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+  }
+
+  $metadataPath = Join-Path $tempRoot "artifact-signing-metadata-$([Guid]::NewGuid().ToString('N')).json"
   $metadata | ConvertTo-Json -Depth 4 | Set-Content -Path $metadataPath -Encoding utf8
   return $metadataPath
 }
@@ -152,13 +160,20 @@ $signtool = Find-SignTool
 
 if ($null -ne $artifactConfig) {
   $dlibPath = Find-ArtifactSigningDlib $artifactConfig.DlibPath
-  $metadataPath = New-ArtifactSigningMetadata $artifactConfig
-  $timestampUrl = First-NonBlank @($env:WINDOWS_SIGNING_TIMESTAMP_URL, "http://timestamp.acs.microsoft.com")
+  $metadataPath = $null
+  try {
+    $metadataPath = New-ArtifactSigningMetadata $artifactConfig
+    $timestampUrl = First-NonBlank @($env:WINDOWS_SIGNING_TIMESTAMP_URL, "http://timestamp.acs.microsoft.com")
 
-  Write-Host "[windows-sign] Signing $target with Azure Artifact Signing profile $($artifactConfig.ProfileName)"
-  & $signtool sign /fd SHA256 /td SHA256 /tr $timestampUrl /dlib $dlibPath /dmdf $metadataPath /d "June" $target
-  if ($LASTEXITCODE -ne 0) {
-    Fail "signtool Artifact Signing failed with exit code $LASTEXITCODE."
+    Write-Host "[windows-sign] Signing $target with Azure Artifact Signing profile $($artifactConfig.ProfileName)"
+    & $signtool sign /fd SHA256 /td SHA256 /tr $timestampUrl /dlib $dlibPath /dmdf $metadataPath /d "June" $target
+    if ($LASTEXITCODE -ne 0) {
+      Fail "signtool Artifact Signing failed with exit code $LASTEXITCODE."
+    }
+  } finally {
+    if (![string]::IsNullOrWhiteSpace($metadataPath) -and (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+      Remove-Item -LiteralPath $metadataPath -Force -ErrorAction SilentlyContinue
+    }
   }
 } else {
   if ([string]::IsNullOrWhiteSpace($certificatePathValue)) {


### PR DESCRIPTION
## Summary

- clean up Azure Artifact Signing metadata files in a `finally` block
- write signing metadata under `RUNNER_TEMP` when running in GitHub Actions
- pin the NuGet/signing toolchain versions and verify the downloaded `nuget.exe` checksum
- make Windows signing secret validation errors distinguish no credentials, partial config, mixed config, and both modes configured

## Root cause

The Azure Artifact Signing path was structurally correct, but the release workflow still had production-hardening gaps: metadata files could remain on disk after a failed signing attempt, the signing toolchain could drift because it used `latest`/unpinned package installs, and setup failures were collapsed into one generic signing-configuration error.

## References

- GitHub Actions variables reference: `RUNNER_TEMP` is the path to a temporary directory on the runner, emptied at the beginning and end of each job when permissions allow: https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
- GitHub-hosted runner reference: runner file system locations and workflow directory behavior: https://docs.github.com/en/actions/reference/github-hosted-runners-reference#file-systems
- Microsoft Artifact Signing / Trusted Signing SignTool integration uses a metadata file passed through `/dmdf`: https://learn.microsoft.com/en-us/azure/trusted-signing/how-to-signing-integrations

## Testing

- `git diff --check`
- Parsed `.github/workflows/production-desktop-windows.yml` with PyYAML
- Parsed `scripts/windows-sign.ps1` with the PowerShell parser
- Local PFX signing succeeded with a throwaway self-signed certificate
- Local fake Azure Artifact Signing failed as expected and left 0 metadata files in `RUNNER_TEMP`

`actionlint` was not available locally.

## Visual testing

Not tested visually. This is release workflow/script-only.

## June API deploy

No June API deploy needed.

## Out of scope

- proving real Azure Artifact Signing end to end with production credentials
- changing the signing mode decision between PFX and Azure
- renaming existing Artifact Signing secrets

## Followups

The Azure signing path still needs a real Windows production workflow run with the actual Azure signing account, certificate profile, OIDC federation, and production environment secrets before it can be considered fully proven.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785998763&installation_id=144203540&pr_number=645&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F645&signature=307b6f26058feae55ed7da4f03e16c9f850f9e2656828178f2e925386a8f90c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
