### PR TITLE
Add dry-run mode to Windows production release workflow

### DIFF
--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       publish:
-        description: "Upload Windows assets to the releases repo"
+        description: "Final publish: upload Windows assets and update latest.json"
         required: true
         default: false
         type: boolean

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -7,6 +7,11 @@ on:
         description: "Existing semver release to attach Windows assets to (for example 0.2.0)"
         required: true
         type: string
+      publish:
+        description: "Upload Windows assets to the releases repo"
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -375,6 +380,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish Windows release assets
+        if: inputs.publish
         shell: pwsh
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -425,11 +431,22 @@ jobs:
 
       - name: Summary
         shell: pwsh
+        env:
+          PUBLISH_RELEASE_ASSETS: ${{ inputs.publish }}
         run: |
+          $publishReleaseAssets = $env:PUBLISH_RELEASE_ASSETS -eq "true"
+          $publishStatus = if ($publishReleaseAssets) { "yes" } else { "no, dry run only" }
+          $marketingDownload = if ($publishReleaseAssets) {
+            "https://github.com/open-software-network/os-june-releases/releases/latest/download/June_x64-setup.exe"
+          } else {
+            "not updated by this dry run"
+          }
+
           @(
             "### Production Windows release",
             "- Version: ``$env:VERSION``",
             "- Release repo: ``open-software-network/os-june-releases``",
-            "- Marketing download: ``https://github.com/open-software-network/os-june-releases/releases/latest/download/June_x64-setup.exe``",
-            "- Updater platform key: ``windows-x86_64``"
+            "- Published release assets: $publishStatus",
+            "- Marketing download: ``$marketingDownload``",
+            "- Updater platform [REDACTED_SECRET]`"
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/.github/workflows/production-desktop-windows.yml
+++ b/.github/workflows/production-desktop-windows.yml
@@ -431,22 +431,12 @@ jobs:
 
       - name: Summary
         shell: pwsh
-        env:
-          PUBLISH_RELEASE_ASSETS: ${{ inputs.publish }}
         run: |
-          $publishReleaseAssets = $env:PUBLISH_RELEASE_ASSETS -eq "true"
-          $publishStatus = if ($publishReleaseAssets) { "yes" } else { "no, dry run only" }
-          $marketingDownload = if ($publishReleaseAssets) {
-            "https://github.com/open-software-network/os-june-releases/releases/latest/download/June_x64-setup.exe"
-          } else {
-            "not updated by this dry run"
-          }
-
           @(
             "### Production Windows release",
             "- Version: ``$env:VERSION``",
             "- Release repo: ``open-software-network/os-june-releases``",
-            "- Published release assets: $publishStatus",
-            "- Marketing download: ``$marketingDownload``",
-            "- Updater platform [REDACTED_SECRET]`"
+            "- Published release assets: ${{ inputs.publish && 'yes' || 'no, dry run only' }}",
+            "- Marketing download: ``${{ inputs.publish && 'https://github.com/open-software-network/os-june-releases/releases/latest/download/June_x64-setup.exe' || 'not updated by this dry run' }}``",
+            "- Windows updater platform: windows-x86_64"
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/docs/release-windows.md
+++ b/docs/release-windows.md
@@ -98,11 +98,27 @@ and initial `latest.json`. It also records the source commit in a
 commit and rebuilds the same tree, so it does not depend on the bump and can run
 as soon as promote finishes.
 
-Once promote has published `vX.Y.Z`, run:
+Once promote has published `vX.Y.Z`, first run a non-publishing dry run:
 
 ```text
-GitHub Actions -> production-desktop-windows -> Run workflow -> version X.Y.Z
+GitHub Actions -> production-desktop-windows -> Run workflow -> version X.Y.Z, publish false
 ```
+
+Dry-run mode builds, signs, verifies, and uploads the NSIS output as a workflow
+artifact, but it does not upload release assets, clobber existing assets, or
+merge `windows-x86_64` into `latest.json`. Use the dry-run artifact for signing
+and payload inspection before the final publish.
+
+After the dry run passes and the artifact has been inspected, run the final
+publish explicitly:
+
+```text
+GitHub Actions -> production-desktop-windows -> Run workflow -> version X.Y.Z, publish true
+```
+
+The `publish` input defaults to `false`, so a completed workflow run is not a
+published Windows release unless the summary says `Published release assets:
+yes`.
 
 The Windows workflow performs the release steps in order:
 
@@ -128,15 +144,15 @@ The Windows workflow performs the release steps in order:
     updater signature file exists, and inspects the NSIS payload, including the
     bundled Hermes launcher and Python runtime.
 11. Uploads the NSIS output as a workflow artifact.
-12. Uploads Windows release assets and merges `windows-x86_64` into
-    `latest.json` without removing macOS updater entries or the generated
-    release changelog.
+12. When `publish` is `true`, uploads Windows release assets and merges
+    `windows-x86_64` into `latest.json` without removing macOS updater entries
+    or the generated release changelog.
 
 ## Validation
 
-After the workflow publishes assets, download `June_x64-setup.exe` from
-`open-software-network/os-june-releases`, copy it to a clean Windows 11 VM, and
-run:
+After the workflow publishes assets with `publish` set to `true`, download
+`June_x64-setup.exe` from `open-software-network/os-june-releases`, copy it to a
+clean Windows 11 VM, and run:
 
 ```powershell
 $installer = "$env:USERPROFILE\Downloads\June_x64-setup.exe"


### PR DESCRIPTION
## Summary

- add a `publish` input to the manually dispatched Windows production workflow
- default `publish` to `false` so manual runs are dry runs unless explicitly publishing
- skip the release upload / `latest.json` mutation step unless `publish` is true
- keep the workflow artifact upload enabled so dry runs still produce downloadable NSIS outputs for inspection
- show whether release assets were published in the workflow summary

## Root cause

The Windows production workflow is manually dispatchable, but running it as-is writes to the real releases repo and uses `gh release upload --clobber`. That makes it unsafe to use for build and signing validation runs where the goal is to verify the Windows artifact/signing path without publishing or overwriting release assets.

## Testing

- `git diff --check`
- Parsed `.github/workflows/production-desktop-windows.yml` with PyYAML

## Visual testing

Not tested visually. This is release workflow-only.

## June API deploy

No June API deploy needed.

## Out of scope

- proving real Azure Artifact Signing end to end with production credentials
- changing signing credentials or signing mode selection
- changing release asset names or updater manifest shape
- skipping the stable release metadata checks; dry runs still follow the production build path until the guarded publish step

## Followups

After this lands, run the workflow with `publish: false` to validate the Windows build and signing path without uploading or clobbering release assets. Use `publish: true` only for the intentional production release publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786003404&installation_id=144203540&pr_number=647&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F647&signature=36c2ff807705c260ea45e87e8c588bb7c0b0a55d4d010c75f9f11fbbdc070a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->