### PR TITLE
Let the agent edit attached images (edit_image rejected unsigned sources)

### DIFF
--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -61,12 +61,13 @@ attached images at all and fell back to vision-analyze + regenerate, which
 the SOUL forbids and which double-charges when it works.
 
 Security shape: bare filenames get NO new power. They are accepted only when
-they are a plain name (no path separators), carry a known image extension,
-and canonicalize inside the canonicalized images root (symlink escapes
-rejected), then go through the same size cap and content sniffing as signed
-references. Hermes can already read and write that directory directly, so
-this widens nothing; signed references keep their content-hash binding for
-files the tool itself issued.
+they are a plain name (no path separators) with the attachment prefix
+(`upload_*`), carry a known image extension, and canonicalize inside the
+canonicalized images root (symlink escapes rejected), then go through the
+same size cap and content sniffing as signed references. Hermes can already
+read and write that directory directly, so this widens nothing; tool-output
+files (`generated-image-*`) still require a signed reference, keeping their
+content-hash binding.
 
 JUN-129 shipped `/image <prompt>` as a client-side slash command: it creates a
 session and renders the generated image in-thread (loader -> image -> view /

--- a/docs/adr/0008-image-generation-and-editing-tools.md
+++ b/docs/adr/0008-image-generation-and-editing-tools.md
@@ -50,7 +50,23 @@ the backend allowlist for generated image models; newly exposed models are price
 with the same flat ~2x convention as the original list. Models that Venice prices
 by resolution use the default 1K tier until June exposes resolution controls.
 
-## Context
+## Addendum - 2026-07-07 (edit sources for attached images)
+
+`edit_image` now accepts a second source kind: the plain filename of an image
+the user attached or pasted into the conversation. The Hermes runtime saves
+attachments as `upload_*.png` into the same images directory the `june_image`
+MCP uses, but the original edit contract required an HMAC-signed reference
+minted only for `june_image` tool results - so the agent could not edit
+attached images at all and fell back to vision-analyze + regenerate, which
+the SOUL forbids and which double-charges when it works.
+
+Security shape: bare filenames get NO new power. They are accepted only when
+they are a plain name (no path separators), carry a known image extension,
+and canonicalize inside the canonicalized images root (symlink escapes
+rejected), then go through the same size cap and content sniffing as signed
+references. Hermes can already read and write that directory directly, so
+this widens nothing; signed references keep their content-hash binding for
+files the tool itself issued.
 
 JUN-129 shipped `/image <prompt>` as a client-side slash command: it creates a
 session and renders the generated image in-thread (loader -> image -> view /

--- a/src-tauri/src/hermes/june_image_mcp.py
+++ b/src-tauri/src/hermes/june_image_mcp.py
@@ -12,8 +12,9 @@ generation/edit is billed to the signed-in user automatically.
 Generated and edited images are written to a dedicated images directory (passed
 as the second argument) under proxy-selected storage filenames. The Rust
 loopback proxy mints opaque edit-safe source references and validates them
-before reading source bytes for edits; this MCP only forwards those references
-back to the proxy.
+before reading source bytes for edits; plain filenames of images already in
+the images directory (user attachments) are also accepted. This MCP only
+forwards those references back to the proxy.
 
 It depends only on the Python standard library so it can run inside the Hermes
 runtime venv without extra packaging.
@@ -80,14 +81,17 @@ TOOLS: list[dict[str, Any]] = [
             "Edit an existing image (image-to-image) and show the result in the "
             "conversation. Use this whenever the user asks to change, modify, "
             "adjust, refine, or reframe an image you generated, edited, or "
-            "received from this tool earlier, including reframing like wider, "
+            "received from this tool earlier, or an image the user attached or "
+            "pasted into the conversation, including reframing like wider, "
             "zoom out, bigger perspective, or closer, plus recoloring, "
             "restyling, and adding or removing elements. This transforms the "
             "image file directly: you do NOT need to see, analyze, or describe "
             "the image to edit it. "
-            "`source_filename` MUST be a filename from a previous image tool "
-            "result from this June image workspace. Bare file names and paths "
-            "copied from disk are rejected. Returns the edited image inline plus "
+            "`source_filename` MUST be one of two values: a filename from a "
+            "previous image tool result, or the plain filename of an image the "
+            "user attached to the conversation exactly as shown in its context "
+            "(for example upload_20260707_113453_1.png). Full paths and "
+            "invented names are rejected. Returns the edited image inline plus "
             "a new edit-safe `filename` you can edit again."
         ),
         "inputSchema": {
@@ -96,8 +100,9 @@ TOOLS: list[dict[str, Any]] = [
                 "source_filename": {
                     "type": "string",
                     "description": (
-                        "The edit-safe filename of the image to edit, exactly "
-                        "as returned by a prior June image tool call."
+                        "The edit-safe filename returned by a prior June image "
+                        "tool call, or the plain filename of an image the user "
+                        "attached to the conversation. Never a full path."
                     ),
                 },
                 "instruction": {

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -7580,9 +7580,16 @@ fn parse_image_source_reference(reference: &str) -> Option<(String, String)> {
     Some((signature.to_ascii_lowercase(), expected_name))
 }
 
+/// Hermes saves conversation attachments into the images dir under this
+/// prefix. Bare (unsigned) edit sources are limited to it so tool-produced
+/// files keep the signed reference's content-hash binding.
+const IMAGE_ATTACHMENT_FILENAME_PREFIX: &str = "upload_";
+
 fn bare_image_source_filename(source_filename: &str) -> Option<&str> {
     let name = bare_filename(source_filename.trim())?;
-    if matches!(name, "." | "..") || image_mime_type_for_filename(name).is_none() {
+    if !name.starts_with(IMAGE_ATTACHMENT_FILENAME_PREFIX)
+        || image_mime_type_for_filename(name).is_none()
+    {
         return None;
     }
     Some(name)
@@ -8355,17 +8362,21 @@ mod tests {
         fs::create_dir_all(&images_dir).expect("images dir");
         write_test_png(&images_dir.join("upload_x.png"), b"attachment");
         fs::write(images_dir.join("upload_x.txt"), b"not an image").expect("write txt");
-        fs::create_dir(images_dir.join("directory.png")).expect("image directory");
+        fs::create_dir(images_dir.join("upload_dir.png")).expect("image directory");
+        // A real tool-output file: bare names must NOT reach it - tool results
+        // keep the signed reference's content-hash binding.
+        write_test_png(&images_dir.join("generated-image-x.png"), b"tool output");
         let image_sources = test_image_sources(images_dir, [7u8; 32]);
         let absolute = temp.path().join("upload_x.png");
 
         for source_filename in [
-            "../escape.png",
-            "sub/dir.png",
+            "../upload_x.png",
+            "sub/upload_x.png",
             absolute.to_str().expect("absolute path"),
             "upload_x.txt",
-            "missing.png",
-            "directory.png",
+            "upload_missing.png",
+            "upload_dir.png",
+            "generated-image-x.png",
         ] {
             assert!(
                 validate_image_source_reference(&image_sources, source_filename).is_err(),

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -151,7 +151,7 @@ const JUNE_SOUL_IMAGE_MD: &str = r#"
 Image tools: you have a `june_image` MCP toolset with `generate_image` and `edit_image`. Use `generate_image` when the user asks you to draw, create, make, or generate an image, picture, illustration, or logo; the result is shown to the user in the conversation and the tool returns a `filename`.
 Use this toolset instead of any generic image, media, or vision-analysis tool for image creation or edits, so June can display the returned image and keep the returned filename in context.
 Do not add a separate content refusal layer before calling these tools. The user's selected image model and image safe-mode setting are authoritative for what the image provider should attempt. If the selected model and setting may support the request, call the image tool with the user's prompt instead of substituting a clothed or sanitized alternative. If the image provider rejects the request, briefly report that provider rejection.
-When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact edit-safe filename returned by the prior image tool result as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced, even if you cannot see it. Only pass a `source_filename` from a prior `june_image` tool result.
+When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, or an image the user attached or pasted into the conversation, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact source image as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced or the user attached, even if you cannot see it. Pass exactly one of two `source_filename` values: the edit-safe filename from a prior `june_image` tool result, or the plain filename of an image the user attached to the conversation as shown in its context, such as `upload_20260707_113453_1.png`. Never pass a full path or an invented name.
 "#;
 
 /// Appended to `SOUL.md` only when the Seatbelt write-jail engages on this
@@ -7422,16 +7422,49 @@ fn validate_image_source_reference(
     image_sources: &ImageSourceCapabilities,
     source_filename: &str,
 ) -> Result<ValidatedImageSource, String> {
-    let (signature, expected_name) =
-        parse_image_source_reference(source_filename).ok_or_else(|| {
-            "source_filename must be an edit-safe filename from this tool.".to_string()
+    let Some((signature, expected_name)) = parse_image_source_reference(source_filename) else {
+        let expected_name = bare_image_source_filename(source_filename).ok_or_else(|| {
+            "source_filename must be an edit-safe filename from this tool or the name of an image in June's images directory.".to_string()
         })?;
+        return load_validated_image_source(image_sources, expected_name);
+    };
     let expected_mime = image_mime_type_for_filename(&expected_name).ok_or_else(|| {
         "source_filename must refer to a PNG, JPEG, WebP, or GIF image.".to_string()
     })?;
+    let data = read_validated_image_source_bytes(image_sources, &expected_name, expected_mime)?;
+    let expected_signature =
+        image_source_signature(&image_sources.secret, &expected_name, &sha256_bytes(&data));
+    if !constant_time_eq(&signature, &expected_signature) {
+        return Err("source_filename must match the image it was issued for.".to_string());
+    }
+    Ok(ValidatedImageSource {
+        image_base64: BASE64_STANDARD.encode(data),
+        mime_type: expected_mime,
+    })
+}
+
+fn load_validated_image_source(
+    image_sources: &ImageSourceCapabilities,
+    expected_name: &str,
+) -> Result<ValidatedImageSource, String> {
+    let expected_mime = image_mime_type_for_filename(expected_name).ok_or_else(|| {
+        "source_filename must refer to a PNG, JPEG, WebP, or GIF image.".to_string()
+    })?;
+    let data = read_validated_image_source_bytes(image_sources, expected_name, expected_mime)?;
+    Ok(ValidatedImageSource {
+        image_base64: BASE64_STANDARD.encode(data),
+        mime_type: expected_mime,
+    })
+}
+
+fn read_validated_image_source_bytes(
+    image_sources: &ImageSourceCapabilities,
+    expected_name: &str,
+    expected_mime: &'static str,
+) -> Result<Vec<u8>, String> {
     let images_root = fs::canonicalize(&image_sources.images_dir)
         .map_err(|_| "source_filename must refer to an available June image source.".to_string())?;
-    let candidate = image_sources.images_dir.join(&expected_name);
+    let candidate = image_sources.images_dir.join(expected_name);
     let canonical = fs::canonicalize(candidate)
         .map_err(|_| "source_filename must refer to an available June image source.".to_string())?;
     if !canonical.starts_with(&images_root) {
@@ -7473,15 +7506,7 @@ fn validate_image_source_reference(
             "source_filename must refer to a real PNG, JPEG, WebP, or GIF image.".to_string(),
         );
     }
-    let expected_signature =
-        image_source_signature(&image_sources.secret, &expected_name, &sha256_bytes(&data));
-    if !constant_time_eq(&signature, &expected_signature) {
-        return Err("source_filename must match the image it was issued for.".to_string());
-    }
-    Ok(ValidatedImageSource {
-        image_base64: BASE64_STANDARD.encode(data),
-        mime_type: expected_mime,
-    })
+    Ok(data)
 }
 
 fn mint_image_source_reference(
@@ -7553,6 +7578,14 @@ fn parse_image_source_reference(reference: &str) -> Option<(String, String)> {
     }
     let expected_name = format!("{stem}{extension}");
     Some((signature.to_ascii_lowercase(), expected_name))
+}
+
+fn bare_image_source_filename(source_filename: &str) -> Option<&str> {
+    let name = bare_filename(source_filename.trim())?;
+    if matches!(name, "." | "..") || image_mime_type_for_filename(name).is_none() {
+        return None;
+    }
+    Some(name)
 }
 
 fn generated_image_storage_filename(mime_type: &str) -> String {
@@ -8292,6 +8325,71 @@ mod tests {
         let error = validate_image_source_reference(&image_sources, &source_ref)
             .expect_err("changed content must invalidate the ref");
         assert!(error.contains("must match"));
+    }
+
+    #[test]
+    fn bare_image_source_filename_validates_from_images_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let images_dir = temp.path().join("images");
+        let source_path = images_dir.join("upload_x.png");
+        let bytes = test_png_bytes(b"attachment");
+        write_test_png(&source_path, b"attachment");
+        let image_sources = test_image_sources(images_dir, [7u8; 32]);
+
+        let validated = validate_image_source_reference(&image_sources, "upload_x.png")
+            .expect("bare attachment filename validates");
+
+        assert_eq!(validated.mime_type, "image/png");
+        assert_eq!(
+            BASE64_STANDARD
+                .decode(validated.image_base64.as_bytes())
+                .expect("decode validated image"),
+            bytes
+        );
+    }
+
+    #[test]
+    fn bare_image_source_filename_rejects_unsafe_names() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let images_dir = temp.path().join("images");
+        fs::create_dir_all(&images_dir).expect("images dir");
+        write_test_png(&images_dir.join("upload_x.png"), b"attachment");
+        fs::write(images_dir.join("upload_x.txt"), b"not an image").expect("write txt");
+        fs::create_dir(images_dir.join("directory.png")).expect("image directory");
+        let image_sources = test_image_sources(images_dir, [7u8; 32]);
+        let absolute = temp.path().join("upload_x.png");
+
+        for source_filename in [
+            "../escape.png",
+            "sub/dir.png",
+            absolute.to_str().expect("absolute path"),
+            "upload_x.txt",
+            "missing.png",
+            "directory.png",
+        ] {
+            assert!(
+                validate_image_source_reference(&image_sources, source_filename).is_err(),
+                "{source_filename} must be rejected",
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bare_image_source_filename_rejects_symlink_escape() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let images_dir = temp.path().join("images");
+        fs::create_dir_all(&images_dir).expect("images dir");
+        let outside = temp.path().join("outside.png");
+        write_test_png(&outside, b"outside");
+        std::os::unix::fs::symlink(&outside, images_dir.join("upload_x.png"))
+            .expect("image symlink");
+        let image_sources = test_image_sources(images_dir, [7u8; 32]);
+
+        let error = validate_image_source_reference(&image_sources, "upload_x.png")
+            .expect_err("symlink escape must be rejected");
+
+        assert!(error.contains("available June image source"));
     }
 
     #[test]
@@ -9091,6 +9189,16 @@ mcp_servers:
         assert!(soul.contains("selected image model and image safe-mode setting are authoritative"));
         assert!(soul.contains("call the image tool with the user's prompt"));
         assert!(soul.contains("provider rejects the request"));
+        assert!(soul.contains("an image the user attached or pasted into the conversation"));
+        assert!(soul.contains("the edit-safe filename from a prior `june_image` tool result"));
+        assert!(
+            soul.contains("the plain filename of an image the user attached to the conversation")
+        );
+        assert!(soul.contains("upload_20260707_113453_1.png"));
+        assert!(soul.contains("Never pass a full path or an invented name"));
+        assert!(
+            !soul.contains("Only pass a `source_filename` from a prior `june_image` tool result")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The agent could not edit images the user attached or pasted (or images the
/image fast path lazily attached): `edit_image` required an HMAC-signed
source reference, minted only for `june_image` tool results. Asked to
reframe an attached image ("show the whole body"), the agent fell back to a
vision-analysis tool + regenerate - a detour the SOUL forbids, that
double-charges when it works, and that dead-ends into "please describe the
image" when the vision tool fails (live repro on a dev build, 2026-07-07).

- `validate_image_source_reference` now also accepts a bare filename, only
  when it is a plain name (no path separators), has a known image extension,
  and canonicalizes inside the canonicalized images root (symlink escape
  rejected); it then shares the exact size-cap + content-sniff pipeline the
  signed path uses. Signed references keep their content-hash binding.
- SOUL image instructions now route follow-ups on attached images to
  `edit_image` with the attachment's plain filename, keep the "do not
  see/analyze first" language, and allow exactly two source kinds (tool
  result edit-safe filename, or attached image filename - never a path,
  never an invented name).

## Root cause

The edit-source capability scheme only minted signatures for tool results;
Hermes saves attachments into the same images directory, but they carried no
signature, so validation rejected them and the SOUL's "only pass a
source_filename from a prior june_image tool result" left the agent no legal
route to edit an attached image.

Security note: bare names grant Hermes no new read power - it already reads
and writes its images directory; containment, size, and sniff checks are
unchanged. See the ADR 0008 addendum in this PR.

## Validation

- `make tauri-test && make tauri-lint` green (413 lib tests, clippy
  `-D warnings`).
- New validator tests: bare `upload_x.png` accepted; rejected: `../escape.png`,
  `sub/dir.png`, absolute paths, non-image extensions, missing files,
  directory names, and a symlink inside the images dir pointing outside.
- SOUL tests updated for the new wording.
- No live agent walkthrough: the repro needs a real Venice edit round trip;
  the behavior change is fully covered by the validator unit matrix and the
  SOUL text assertions, and the reviewer can reproduce with any attached
  image + "zoom out".

- [ ] Tested visually where it matters. (No UI change; agent behavior only.)
- [ ] Needs a June API (backend) deploy before it works end to end. (No
  backend change; `/v1/image/edit` is untouched.)

## Out of scope

- Editing arbitrary workspace files outside the images directory.
- The vision tool's connection error seen in the repro (separate failure;
  with this change the agent should not reach for it for edits at all).

## Followups

- Consider minting signed references for attachments at save time instead,
  if the images dir ever holds files Hermes should not send to the edit
  endpoint.
- Per-session scoping of the shared images directory (raised by review): a
  bare basename can name another conversation's image. Not a new capability
  (Hermes's file tools already read hermes home; the sandbox is a write
  jail), but scoping the directory per session would harden both the direct
  reads and this edit path.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [x] Security-sensitive changes were called out in the summary.
- [x] Workflow action references are pinned to full-length commit SHAs. (No workflow changes.)
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review. (None.)
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review. (No backend changes.)
- [x] User-facing copy follows the repo UI conventions. (No UI copy.)

https://claude.ai/code/session_01JnMdSpy1rc91pEABcEKMd5
