### PR TITLE
Recording and dictation reliability batch + agent recorder tool (JUN-190/191/192/193/195/196/221)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -222,7 +222,7 @@ is UI; the reference is the token).
 **Skill / Toolset / MCP server**:
 A Skill is a bundled/installed capability pack; a Toolset is a togglable tool
 group; an MCP server is an external tool provider (June ships `june_context`,
-`june_web`, and `june_image`).
+`june_web`, `june_image`, and `june_recorder`).
 _Avoid_: using "tool" for all three.
 
 **Admin surface**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -374,10 +374,13 @@ _Avoid_: pet (legacy name — survives only in an old storage key), overlay
 
 **Permission**:
 A macOS TCC grant June needs — microphone, accessibility, or screen/system
-audio recording. System-audio permission is probe-driven (there is no
-query-only macOS API); the dictation helper is the authoritative source for
-mic + accessibility state.
-_Avoid_: entitlement (that is the code-signing sense).
+audio recording. TCC grants are bundle-scoped, so the authoritative source is
+the bundle that captures: the dictation helper for dictation mic +
+accessibility state, the main app's own `AVCaptureDevice` authorization for
+note-recording mic state (the helper's grant never covers the main app).
+System-audio permission is probe-driven (there is no query-only macOS API).
+_Avoid_: entitlement (that is the code-signing sense), treating one bundle's
+mic grant as covering the other.
 
 ## Flagged ambiguities
 

--- a/docs/adr/0013-agent-recorder-tool-via-frontend-event.md
+++ b/docs/adr/0013-agent-recorder-tool-via-frontend-event.md
@@ -1,0 +1,53 @@
+# ADR 0013: Agent recorder tool via frontend event
+
+Date: 2026-07-07
+Status: accepted
+
+## Context
+
+June's agent could search notes and use web or image tools, but it had no way
+to start or stop a meeting recording when the user explicitly asked it to do so
+(JUN-193). The native shell already exposes recording commands for the UI, and
+the frontend owns the visible recorder state: creating a note, showing the
+recorder bar, showing sidebar or floating recorder presence, and cleaning up a
+fresh note if recording startup fails.
+
+Starting capture directly from Rust would bypass that frontend state. The
+recording could be active without the user seeing the recorder bar or the note
+that owns the session, and the direct path would duplicate self-healing logic
+that already exists in the UI.
+
+## Decision
+
+June ships a fourth built-in MCP server, `june_recorder`, for agent recording
+control. Its tools call the existing loopback provider proxy with a bearer token
+from `JUNE_RECORDER_PROXY_TOKEN`.
+
+For start and stop actions, the proxy does not start or finish capture itself.
+It creates a request id, emits `june://agent-recorder-request` to the main
+webview, and waits up to 15 seconds for the frontend to resolve the request via
+`resolve_agent_recorder_request`. The frontend services the event through the
+same note creation, visible recording, stop, and processing paths used by the
+normal UI.
+
+`recording_status` is read directly from Rust-side active capture state because
+it does not mutate recording state or affect visibility.
+
+## Alternatives
+
+- Start capture directly in Rust. Rejected because it could create an invisible
+  recording, duplicate frontend-owned state transitions, and skip the tested
+  cleanup path for a freshly created note.
+- Leave the agent without a recording tool. Rejected because JUN-193 requires
+  the agent to handle explicit user requests to start and stop recording.
+
+## Consequences
+
+- Agent-initiated recordings are visible in the same recorder bar and recorder
+  presence surfaces as user-initiated recordings.
+- The main webview must be alive and able to answer the event for start or stop
+  actions to succeed.
+- Start and stop actions can fail with a structured timeout after 15 seconds if
+  the frontend does not acknowledge the request.
+- The tool remains local. Starting or stopping a recording does not authorize,
+  charge, or call June API.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2896,6 +2896,7 @@ version = "0.0.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "block2",
  "chrono",
  "cpal",
  "dotenvy",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ zeroize = { version = "1", features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { version = "3", features = ["apple-native"] }
+block2 = "0.6"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", default-features = false, features = [
     "std",

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -13,6 +13,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=OS_ACCOUNTS_API_URL");
     println!("cargo:rerun-if-env-changed=OS_ACCOUNTS_CLIENT_ID");
     println!("cargo:rerun-if-env-changed=JUNE_API_URL");
+    if std::env::var("CARGO_CFG_TARGET_OS").ok().as_deref() == Some("macos") {
+        println!("cargo:rustc-link-lib=framework=AVFoundation");
+    }
     clean_legacy_helper_bundles();
     build_system_audio_helper();
     build_dictation_helper();

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1499,6 +1499,16 @@ final class DictationController {
     }
 
     func stop() {
+        // A stop that lands while a start is still waiting on the permission
+        // prompt cancels that start (a grazed push-to-talk key, or the prompt
+        // never calling back); erroring not_listening here would wedge the
+        // pending flag until a helper restart.
+        if startPending && !isListening {
+            dictationStartGeneration += 1
+            startPending = false
+            emit("recording_discarded", ["reason": "start_cancelled"])
+            return
+        }
         guard isListening, recordingPurpose == .dictation else {
             emit("error", ["code": "not_listening", "message": "Dictation is not listening."])
             return

--- a/src-tauri/native/mac-dictation-helper/main.swift
+++ b/src-tauri/native/mac-dictation-helper/main.swift
@@ -1429,10 +1429,11 @@ final class DictationController {
     private var preferredMicrophoneName: String?
     private var isListening = false
     private var isFinalizing = false
+    private var startPending = false
     private var maxObservedAudioLevel: Float = 0
 
     var listening: Bool {
-        isListening || isFinalizing
+        isListening || isFinalizing || startPending
     }
 
     func emitDiagnostics() {
@@ -1467,11 +1468,15 @@ final class DictationController {
     private var dictationStartGeneration = 0
 
     func start() {
+        if startPending {
+            return
+        }
         guard !listening else {
             emit("error", ["code": "already_listening", "message": "Dictation is already listening."])
             return
         }
 
+        startPending = true
         dictationStartGeneration += 1
         let generation = dictationStartGeneration
         AVCaptureDevice.requestAccess(for: .audio) { [weak self] microphoneAllowed in
@@ -1482,6 +1487,7 @@ final class DictationController {
                 guard let self, self.dictationStartGeneration == generation else {
                     return
                 }
+                self.startPending = false
                 guard microphoneAllowed else {
                     emit("error", ["code": "microphone_permission_missing", "message": "Microphone permission is required."])
                     emit("permission_status", permissionPayload())
@@ -1499,6 +1505,16 @@ final class DictationController {
         }
 
         stopActiveRecording()
+    }
+
+    func toggle(shortcut: String) {
+        if isListening {
+            emit("hotkey_trigger", ["action": "stop", "shortcut": shortcut])
+            stop()
+        } else if !isFinalizing && !startPending {
+            emit("hotkey_trigger", ["action": "start", "shortcut": shortcut])
+            start()
+        }
     }
 
     func startMicTest(durationSeconds: Double) {
@@ -1543,6 +1559,7 @@ final class DictationController {
         // Cancel any start still waiting on the permission prompt — the
         // graze is over, so a later grant must not open the microphone.
         dictationStartGeneration += 1
+        startPending = false
         // The HUD shows on listening_started, so a discard that interrupts a
         // live recording (a grazed push-to-talk key, a signed-out session)
         // must announce itself or the HUD stays stuck on "Listening".
@@ -1884,6 +1901,7 @@ final class DictationController {
     private func resetRecordingState(keepRecordingFile: Bool = false) {
         isListening = false
         isFinalizing = false
+        startPending = false
         maxObservedAudioLevel = 0
         recordingStartedAt = 0
         micTestStopWorkItem?.cancel()
@@ -2076,13 +2094,7 @@ func handleCommandLine(_ line: String) {
     case "toggle_listening":
         let shortcut = command?["shortcut"] as? String ?? "hotkey"
         runOnMain {
-            if dictation.listening {
-                emit("hotkey_trigger", ["action": "stop", "shortcut": shortcut])
-                dictation.stop()
-            } else {
-                emit("hotkey_trigger", ["action": "start", "shortcut": shortcut])
-                dictation.start()
-            }
+            dictation.toggle(shortcut: shortcut)
         }
     case "paste_text":
         let text = command?["text"] as? String ?? ""

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -198,6 +198,44 @@ fn microphone_authorization_status() -> MicrophoneAuthorizationStatus {
     }
 }
 
+/// TCC microphone grants are bundle-scoped: onboarding prompts through the
+/// dictation helper (`co.opensoftware.june.dictation-helper`), whose grant
+/// never covers the main app bundle. The main app must trigger its own TCC
+/// prompt before capture, or a fresh install records only zeros.
+#[cfg(target_os = "macos")]
+pub fn request_microphone_permission_blocking() -> (String, Option<String>) {
+    use objc2::{msg_send, runtime::AnyClass};
+    use objc2_foundation::NSString;
+
+    if microphone_authorization_status() != MicrophoneAuthorizationStatus::NotDetermined {
+        return microphone_permission_state();
+    }
+    let Some(device_class) = AnyClass::get(c"AVCaptureDevice") else {
+        return microphone_permission_state();
+    };
+    let (sender, receiver) = std::sync::mpsc::channel::<bool>();
+    let handler = block2::RcBlock::new(move |granted: objc2::runtime::Bool| {
+        let _ = sender.send(granted.as_bool());
+    });
+    let media_type = NSString::from_str("soun");
+    let _: () = unsafe {
+        msg_send![
+            device_class,
+            requestAccessForMediaType: &*media_type,
+            completionHandler: &*handler
+        ]
+    };
+    // The prompt has no OS-side timeout; a user who walks away must not hang
+    // the start command forever.
+    match receiver.recv_timeout(std::time::Duration::from_secs(120)) {
+        Ok(_) => microphone_permission_state(),
+        Err(_) => (
+            "not_determined".to_string(),
+            Some("Approve the macOS microphone prompt, then try again.".to_string()),
+        ),
+    }
+}
+
 pub fn microphone_device_available() -> bool {
     cpal::default_host().default_input_device().is_some()
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -28,6 +28,8 @@ use std::{
 use uuid::Uuid;
 
 pub const DEFAULT_SILENCE_THRESHOLD: f32 = 0.012;
+// Healthy devices open quickly; this bounds CPAL/CoreAudio hangs during device handoff.
+pub const CAPTURE_START_TIMEOUT: Duration = Duration::from_secs(10);
 const RECOVERY_SNAPSHOT_INTERVAL_MS: i64 = 500;
 const MICROPHONE_STALL_THRESHOLD: Duration = Duration::from_secs(3);
 const MICROPHONE_STREAM_WARNING_MESSAGE: &str =
@@ -265,14 +267,29 @@ pub fn start_capture(
     note_id: String,
     source_mode: RecordingSourceMode,
 ) -> Result<StartedRecording, AppError> {
-    let mut active = ACTIVE_RECORDING
-        .lock()
-        .map_err(|_| AppError::new("recording_lock_failed", "Recording state is unavailable."))?;
-    if active.is_some() {
-        return Err(AppError::new(
-            "recording_already_active",
-            "A previous recording is still active. June attempted to save it locally; please try again.",
-        ));
+    start_capture_with_cancel(
+        app,
+        paths,
+        note_id,
+        source_mode,
+        Arc::new(AtomicBool::new(false)),
+    )
+}
+
+pub fn start_capture_with_cancel(
+    app: tauri::AppHandle,
+    paths: &AppPaths,
+    note_id: String,
+    source_mode: RecordingSourceMode,
+    abandoned: Arc<AtomicBool>,
+) -> Result<StartedRecording, AppError> {
+    {
+        let active = ACTIVE_RECORDING.lock().map_err(|_| {
+            AppError::new("recording_lock_failed", "Recording state is unavailable.")
+        })?;
+        if active.is_some() {
+            return Err(recording_already_active_error());
+        }
     }
 
     let host = cpal::default_host();
@@ -459,9 +476,33 @@ pub fn start_capture(
         None
     };
     let live_preview_enabled = live_preview.is_some() || system_live_preview.is_some();
+    if abandoned.load(Ordering::Acquire) {
+        cleanup_abandoned_capture(
+            writer,
+            partial_path,
+            system_partial_path,
+            live_preview,
+            system_live_preview,
+            system_capture,
+            None,
+        );
+        return Err(capture_start_timeout_error());
+    }
     stream
         .play()
         .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
+    if abandoned.load(Ordering::Acquire) {
+        cleanup_abandoned_capture(
+            writer,
+            partial_path,
+            system_partial_path,
+            live_preview,
+            system_live_preview,
+            system_capture,
+            Some(stream),
+        );
+        return Err(capture_start_timeout_error());
+    }
     let started = Instant::now();
     let status = RecordingStatusDto {
         session_id: session_id.clone(),
@@ -489,6 +530,33 @@ pub fn start_capture(
         ),
         warnings: Vec::new(),
     };
+    let mut active = ACTIVE_RECORDING
+        .lock()
+        .map_err(|_| AppError::new("recording_lock_failed", "Recording state is unavailable."))?;
+    if abandoned.load(Ordering::Acquire) {
+        cleanup_abandoned_capture(
+            writer,
+            partial_path,
+            system_partial_path,
+            live_preview,
+            system_live_preview,
+            system_capture,
+            Some(stream),
+        );
+        return Err(capture_start_timeout_error());
+    }
+    if active.is_some() {
+        cleanup_abandoned_capture(
+            writer,
+            partial_path,
+            system_partial_path,
+            live_preview,
+            system_live_preview,
+            system_capture,
+            Some(stream),
+        );
+        return Err(recording_already_active_error());
+    }
 
     *active = Some(ActiveRecording {
         session_id: session_id.clone(),
@@ -526,6 +594,48 @@ pub fn start_capture(
         device_label,
         status,
     })
+}
+
+pub fn capture_start_timeout_error() -> AppError {
+    AppError::new(
+        "capture_start_timeout",
+        "Could not start the microphone. Try again, or check the selected input device.",
+    )
+}
+
+fn recording_already_active_error() -> AppError {
+    AppError::new(
+        "recording_already_active",
+        "A previous recording is still active. June attempted to save it locally; please try again.",
+    )
+}
+
+fn cleanup_abandoned_capture(
+    writer: Arc<Mutex<Option<WavWriter<BufWriter<File>>>>>,
+    partial_path: PathBuf,
+    system_partial_path: Option<PathBuf>,
+    live_preview: Option<LivePreviewController>,
+    system_live_preview: Option<SystemLivePreviewController>,
+    system_capture: Option<SystemAudioCapture>,
+    stream: Option<cpal::Stream>,
+) {
+    drop(stream);
+    if let Some(live_preview) = live_preview {
+        live_preview.cancel();
+    }
+    if let Some(system_live_preview) = system_live_preview {
+        system_live_preview.cancel();
+    }
+    if let Some(system_capture) = system_capture {
+        let _ = system_capture.stop();
+    }
+    if let Ok(mut writer_guard) = writer.lock() {
+        let _ = writer_guard.take();
+    }
+    let _ = std::fs::remove_file(partial_path);
+    if let Some(system_partial_path) = system_partial_path {
+        let _ = std::fs::remove_file(system_partial_path);
+    }
 }
 
 /// Ducks or restores the active recording's microphone channel. While ducked

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -30,6 +30,9 @@ use uuid::Uuid;
 pub const DEFAULT_SILENCE_THRESHOLD: f32 = 0.012;
 // Healthy devices open quickly; this bounds CPAL/CoreAudio hangs during device handoff.
 pub const CAPTURE_START_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long a first-run start waits on the macOS microphone prompt; the
+/// agent recorder lease budgets against it.
+pub const MICROPHONE_PROMPT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Start handshake between the capture builder and its timeout watchdog.
 /// The builder commits `Published` in the same critical section that
@@ -250,7 +253,7 @@ pub fn request_microphone_permission_blocking() -> (String, Option<String>) {
     };
     // The prompt has no OS-side timeout; a user who walks away must not hang
     // the start command forever.
-    match receiver.recv_timeout(std::time::Duration::from_secs(120)) {
+    match receiver.recv_timeout(MICROPHONE_PROMPT_TIMEOUT) {
         Ok(_) => microphone_permission_state(),
         Err(_) => (
             "not_determined".to_string(),

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -30,6 +30,27 @@ use uuid::Uuid;
 pub const DEFAULT_SILENCE_THRESHOLD: f32 = 0.012;
 // Healthy devices open quickly; this bounds CPAL/CoreAudio hangs during device handoff.
 pub const CAPTURE_START_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Start handshake between the capture builder and its timeout watchdog.
+/// The builder commits `Published` in the same critical section that
+/// publishes `ACTIVE_RECORDING`, so the watchdog can never declare a timeout
+/// for a capture that is (or is about to be) active — it either abandons a
+/// still-pending build or accepts a published one as success.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureStartState {
+    Pending,
+    Published,
+    Abandoned,
+}
+
+pub type CaptureStartHandshake = Mutex<CaptureStartState>;
+
+fn capture_start_abandoned(handshake: &CaptureStartHandshake) -> bool {
+    handshake
+        .lock()
+        .map(|state| *state == CaptureStartState::Abandoned)
+        .unwrap_or(false)
+}
 const RECOVERY_SNAPSHOT_INTERVAL_MS: i64 = 500;
 const MICROPHONE_STALL_THRESHOLD: Duration = Duration::from_secs(3);
 const MICROPHONE_STREAM_WARNING_MESSAGE: &str =
@@ -272,7 +293,7 @@ pub fn start_capture(
         paths,
         note_id,
         source_mode,
-        Arc::new(AtomicBool::new(false)),
+        Arc::new(Mutex::new(CaptureStartState::Pending)),
     )
 }
 
@@ -281,7 +302,7 @@ pub fn start_capture_with_cancel(
     paths: &AppPaths,
     note_id: String,
     source_mode: RecordingSourceMode,
-    abandoned: Arc<AtomicBool>,
+    handshake: Arc<CaptureStartHandshake>,
 ) -> Result<StartedRecording, AppError> {
     {
         let active = ACTIVE_RECORDING.lock().map_err(|_| {
@@ -476,7 +497,7 @@ pub fn start_capture_with_cancel(
         None
     };
     let live_preview_enabled = live_preview.is_some() || system_live_preview.is_some();
-    if abandoned.load(Ordering::Acquire) {
+    if capture_start_abandoned(&handshake) {
         cleanup_abandoned_capture(
             writer,
             partial_path,
@@ -491,7 +512,7 @@ pub fn start_capture_with_cancel(
     stream
         .play()
         .map_err(|error| AppError::new("audio_writer_failed", error.to_string()))?;
-    if abandoned.load(Ordering::Acquire) {
+    if capture_start_abandoned(&handshake) {
         cleanup_abandoned_capture(
             writer,
             partial_path,
@@ -533,29 +554,53 @@ pub fn start_capture_with_cancel(
     let mut active = ACTIVE_RECORDING
         .lock()
         .map_err(|_| AppError::new("recording_lock_failed", "Recording state is unavailable."))?;
-    if abandoned.load(Ordering::Acquire) {
-        cleanup_abandoned_capture(
-            writer,
-            partial_path,
-            system_partial_path,
-            live_preview,
-            system_live_preview,
-            system_capture,
-            Some(stream),
-        );
-        return Err(capture_start_timeout_error());
-    }
-    if active.is_some() {
-        cleanup_abandoned_capture(
-            writer,
-            partial_path,
-            system_partial_path,
-            live_preview,
-            system_live_preview,
-            system_capture,
-            Some(stream),
-        );
-        return Err(recording_already_active_error());
+    // Commit-or-abandon happens atomically with the publish below (lock
+    // order: ACTIVE_RECORDING, then the handshake; the watchdog only ever
+    // takes the handshake). Past this block the watchdog treats the build as
+    // successfully published and returns it as success.
+    {
+        let Ok(mut state) = handshake.lock() else {
+            cleanup_abandoned_capture(
+                writer,
+                partial_path,
+                system_partial_path,
+                live_preview,
+                system_live_preview,
+                system_capture,
+                Some(stream),
+            );
+            return Err(AppError::new(
+                "recording_lock_failed",
+                "Recording state is unavailable.",
+            ));
+        };
+        if *state == CaptureStartState::Abandoned {
+            drop(state);
+            cleanup_abandoned_capture(
+                writer,
+                partial_path,
+                system_partial_path,
+                live_preview,
+                system_live_preview,
+                system_capture,
+                Some(stream),
+            );
+            return Err(capture_start_timeout_error());
+        }
+        if active.is_some() {
+            drop(state);
+            cleanup_abandoned_capture(
+                writer,
+                partial_path,
+                system_partial_path,
+                live_preview,
+                system_live_preview,
+                system_capture,
+                Some(stream),
+            );
+            return Err(recording_already_active_error());
+        }
+        *state = CaptureStartState::Published;
     }
 
     *active = Some(ActiveRecording {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -130,12 +130,80 @@ struct CaptureStats {
 }
 
 pub fn microphone_permission_state() -> (String, Option<String>) {
+    microphone_permission_state_from_authorization(microphone_authorization_status())
+}
+
+fn microphone_permission_state_from_authorization(
+    status: MicrophoneAuthorizationStatus,
+) -> (String, Option<String>) {
+    match status {
+        MicrophoneAuthorizationStatus::Granted => ("granted".to_string(), None),
+        MicrophoneAuthorizationStatus::Denied => {
+            ("denied".to_string(), Some(microphone_permission_hint()))
+        }
+        MicrophoneAuthorizationStatus::Restricted => {
+            ("restricted".to_string(), Some(microphone_permission_hint()))
+        }
+        MicrophoneAuthorizationStatus::NotDetermined => (
+            "not_determined".to_string(),
+            Some(microphone_permission_hint()),
+        ),
+        MicrophoneAuthorizationStatus::Unknown => {
+            ("unknown".to_string(), Some(microphone_permission_hint()))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MicrophoneAuthorizationStatus {
+    Granted,
+    Denied,
+    Restricted,
+    NotDetermined,
+    Unknown,
+}
+
+#[cfg(target_os = "macos")]
+fn microphone_authorization_status() -> MicrophoneAuthorizationStatus {
+    macos_microphone_authorization_status().unwrap_or(MicrophoneAuthorizationStatus::Unknown)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_microphone_authorization_status() -> Option<MicrophoneAuthorizationStatus> {
+    use objc2::{msg_send, runtime::AnyClass};
+    use objc2_foundation::NSString;
+
+    let device_class = AnyClass::get(c"AVCaptureDevice")?;
+    // AVMediaTypeAudio's raw value is "soun"; this matches
+    // AVCaptureDevice.authorizationStatus(for: .audio) in the dictation helper.
+    let media_type = NSString::from_str("soun");
+    let raw_status: isize =
+        unsafe { msg_send![device_class, authorizationStatusForMediaType: &*media_type] };
+    Some(match raw_status {
+        0 => MicrophoneAuthorizationStatus::NotDetermined,
+        1 => MicrophoneAuthorizationStatus::Restricted,
+        2 => MicrophoneAuthorizationStatus::Denied,
+        3 => MicrophoneAuthorizationStatus::Granted,
+        _ => MicrophoneAuthorizationStatus::Unknown,
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn microphone_authorization_status() -> MicrophoneAuthorizationStatus {
     let host = cpal::default_host();
     if host.default_input_device().is_some() {
-        ("granted".to_string(), None)
+        MicrophoneAuthorizationStatus::Granted
     } else {
-        ("denied".to_string(), Some(microphone_permission_hint()))
+        MicrophoneAuthorizationStatus::Denied
     }
+}
+
+pub fn microphone_device_available() -> bool {
+    cpal::default_host().default_input_device().is_some()
+}
+
+pub fn microphone_device_hint() -> String {
+    "No microphone input device is available.".to_string()
 }
 
 fn microphone_permission_hint() -> String {
@@ -970,6 +1038,48 @@ fn source_warnings(
 mod tests {
     use super::*;
 
+    #[test]
+    fn microphone_permission_mapping_reports_granted_only_for_authorized() {
+        let (state, hint) =
+            microphone_permission_state_from_authorization(MicrophoneAuthorizationStatus::Granted);
+
+        assert_eq!(state, "granted");
+        assert_eq!(hint, None);
+    }
+
+    #[test]
+    fn microphone_permission_mapping_reports_denied_or_restricted_as_not_granted() {
+        let (denied_state, denied_hint) =
+            microphone_permission_state_from_authorization(MicrophoneAuthorizationStatus::Denied);
+        let (restricted_state, restricted_hint) = microphone_permission_state_from_authorization(
+            MicrophoneAuthorizationStatus::Restricted,
+        );
+
+        assert_eq!(denied_state, "denied");
+        assert!(denied_hint.is_some());
+        assert_eq!(restricted_state, "restricted");
+        assert!(restricted_hint.is_some());
+    }
+
+    #[test]
+    fn microphone_permission_mapping_keeps_not_determined_not_ready() {
+        let (state, hint) = microphone_permission_state_from_authorization(
+            MicrophoneAuthorizationStatus::NotDetermined,
+        );
+
+        assert_eq!(state, "not_determined");
+        assert!(hint.is_some());
+    }
+
+    #[test]
+    fn microphone_permission_mapping_keeps_unknown_not_ready() {
+        let (state, hint) =
+            microphone_permission_state_from_authorization(MicrophoneAuthorizationStatus::Unknown);
+
+        assert_eq!(state, "unknown");
+        assert!(hint.is_some());
+    }
+
     fn test_writer(dir: &tempfile::TempDir) -> Arc<Mutex<Option<WavWriter<BufWriter<File>>>>> {
         let writer = WavWriter::create(
             dir.path().join("mic.wav"),
@@ -1188,5 +1298,16 @@ mod tests {
             issue_state(None, Some(stale_callback), RecordingState::Paused),
             None
         );
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod avfoundation_link_tests {
+    // If AVFoundation stops being linked, AnyClass::get returns None and
+    // readiness silently degrades to "unknown" (never granted) — this probe
+    // turns that silent degradation into a test failure.
+    #[test]
+    fn avcapturedevice_class_resolves() {
+        assert!(super::macos_microphone_authorization_status().is_some());
     }
 }

--- a/src-tauri/src/audio/system_macos.rs
+++ b/src-tauri/src/audio/system_macos.rs
@@ -184,6 +184,10 @@ impl SystemAudioCapture {
     }
 }
 
+/// Upper bound on the helper's CoreAudio capture probe (readiness checks
+/// wait on this); the agent recorder lease budgets against it.
+pub const SYSTEM_AUDIO_PERMISSION_PROBE_TIMEOUT: Duration = Duration::from_secs(75);
+
 fn apply_helper_status(stats: &mut SystemAudioStats, status: &HelperStatus) {
     if let Some(level) = status.level {
         stats.max_level = stats.max_level.max(status.max_level.unwrap_or(level));
@@ -305,7 +309,7 @@ pub fn helper_permission_check() -> Result<(), AppError> {
     let status = wait_for_status(
         &status_path,
         Some(&log_path),
-        Duration::from_secs(75),
+        SYSTEM_AUDIO_PERMISSION_PROBE_TIMEOUT,
         &["ready", "level", "error"],
         "System audio helper could not start a usable CoreAudio capture. Grant System Audio Recording permission if macOS prompts for it, then try again. The terminal helper log shows the last completed CoreAudio step.",
     );

--- a/src-tauri/src/audio/validation.rs
+++ b/src-tauri/src/audio/validation.rs
@@ -11,6 +11,7 @@ pub const MIN_RECORDING_MS: i64 = 1_000;
 const MIN_POSITIVE_DURATION_DRIFT_MS: i64 = 60_000;
 const MAX_POSITIVE_DURATION_DRIFT_MS: i64 = 10 * 60_000;
 const POSITIVE_DURATION_DRIFT_RATIO_DENOMINATOR: i64 = 4;
+const SILENT_PEAK_AMPLITUDE_MAX: f32 = f32::EPSILON;
 
 #[derive(Debug, Clone, Copy)]
 pub struct AudioValidationConfig {
@@ -47,6 +48,7 @@ pub fn validate_audio_artifact(
         actual_duration_ms: 0,
         duration_within_tolerance: false,
         non_silent_signal: false,
+        recorded_silence: false,
         peak_amplitude: 0.0,
         rms_amplitude: 0.0,
         warnings: Vec::new(),
@@ -107,7 +109,13 @@ pub fn validate_audio_artifact(
     if samples > 0 {
         result.rms_amplitude = (sum_square / samples as f64).sqrt() as f32;
     }
-    result.non_silent_signal = samples > 0;
+    result.non_silent_signal = result.peak_amplitude > SILENT_PEAK_AMPLITUDE_MAX;
+    result.recorded_silence = samples > 0 && !result.non_silent_signal;
+    if result.recorded_silence {
+        result
+            .warnings
+            .push("audio contains only silence".to_string());
+    }
 
     Ok(result)
 }
@@ -546,6 +554,58 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("not readable WAV")));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn flags_structurally_valid_silent_wav_without_failing_validation() {
+        let dir = std::env::temp_dir().join(format!("os-june-silent-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("microphone.wav");
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&path, spec).unwrap();
+        for _ in 0..16_000 {
+            writer.write_sample(0_i16).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let result = validate_audio_artifact(&path, 1_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert!(result.readable_audio);
+        assert!(result.non_zero_size);
+        assert!(!result.non_silent_signal);
+        assert!(result.recorded_silence);
+        assert_eq!(result.peak_amplitude, 0.0);
+        assert_eq!(result.rms_amplitude, 0.0);
+        assert!(source_audio_passes_validation(
+            RecordingSource::Microphone,
+            &result
+        ));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn does_not_flag_normal_wav_as_silent() {
+        let dir = std::env::temp_dir().join(format!("os-june-silent-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("microphone.wav");
+        write_wav(&path, 1_000);
+
+        let result = validate_audio_artifact(&path, 1_000, AudioValidationConfig::default())
+            .expect("validation should run");
+
+        assert!(result.non_silent_signal);
+        assert!(!result.recorded_silence);
+        assert!(result.peak_amplitude > 0.0);
+        assert!(result.rms_amplitude > 0.0);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,7 +5,8 @@ use crate::{
             capture_start_timeout_error, capture_status_for_recovery, finish_active_capture,
             finish_capture, is_capture_active, microphone_device_available, microphone_device_hint,
             microphone_permission_state, pause_capture, resume_capture, start_capture_with_cancel,
-            CaptureRecoverySnapshot, StartedRecording, CAPTURE_START_TIMEOUT,
+            CaptureRecoverySnapshot, CaptureStartHandshake, CaptureStartState, StartedRecording,
+            CAPTURE_START_TIMEOUT,
         },
         recovery::scan_recoverable_recordings,
         validation::{
@@ -48,10 +49,7 @@ use sqlx_sqlite::SqlitePool;
 use sqlx_sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    mpsc, Arc, Mutex, OnceLock,
-};
+use std::sync::{mpsc, Arc, Mutex, OnceLock};
 use std::{
     path::{Path, PathBuf},
     time::{Duration, Instant},
@@ -927,7 +925,7 @@ pub async fn start_recording(
 
 async fn start_capture_with_timeout<F>(start_capture: F) -> Result<StartedRecording, AppError>
 where
-    F: FnOnce(Arc<AtomicBool>) -> Result<StartedRecording, AppError> + Send + 'static,
+    F: FnOnce(Arc<CaptureStartHandshake>) -> Result<StartedRecording, AppError> + Send + 'static,
 {
     start_capture_with_timeout_and_cleanup(
         start_capture,
@@ -950,16 +948,16 @@ async fn start_capture_with_timeout_and_cleanup<F, C>(
     timeout: Duration,
 ) -> Result<StartedRecording, AppError>
 where
-    F: FnOnce(Arc<AtomicBool>) -> Result<StartedRecording, AppError> + Send + 'static,
+    F: FnOnce(Arc<CaptureStartHandshake>) -> Result<StartedRecording, AppError> + Send + 'static,
     C: FnOnce(&StartedRecording) + Send + 'static,
 {
-    let abandoned = Arc::new(AtomicBool::new(false));
-    let worker_abandoned = Arc::clone(&abandoned);
+    let handshake = Arc::new(Mutex::new(CaptureStartState::Pending));
+    let worker_handshake = Arc::clone(&handshake);
     let (sender, receiver) = mpsc::channel();
     let thread = std::thread::Builder::new()
         .name("capture-start".to_string())
         .spawn(move || {
-            let result = start_capture(worker_abandoned);
+            let result = start_capture(worker_handshake);
             match result {
                 Ok(started) => {
                     if let Err(mpsc::SendError(Ok(started))) = sender.send(Ok(started)) {
@@ -974,20 +972,44 @@ where
         .map_err(|error| AppError::new("recording_start_failed", error.to_string()))?;
     drop(thread);
 
-    match tokio::task::spawn_blocking(move || receiver.recv_timeout(timeout))
-        .await
-        .map_err(|error| AppError::new("recording_start_failed", error.to_string()))?
-    {
-        Ok(result) => result,
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            abandoned.store(true, Ordering::Release);
-            Err(capture_start_timeout_error())
+    tokio::task::spawn_blocking(move || {
+        match receiver.recv_timeout(timeout) {
+            Ok(result) => result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Abandon only a build that has not committed. If the builder
+                // already published (it won the race by a hair), its capture
+                // is live: take the in-flight result as success instead of
+                // stranding an active recording behind a timeout error.
+                let published = handshake
+                    .lock()
+                    .map(|mut state| {
+                        if *state == CaptureStartState::Published {
+                            true
+                        } else {
+                            *state = CaptureStartState::Abandoned;
+                            false
+                        }
+                    })
+                    .unwrap_or(false);
+                if published {
+                    receiver.recv().unwrap_or_else(|_| {
+                        Err(AppError::new(
+                            "recording_start_failed",
+                            "Recording start failed before reporting a result.",
+                        ))
+                    })
+                } else {
+                    Err(capture_start_timeout_error())
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => Err(AppError::new(
+                "recording_start_failed",
+                "Recording start failed before reporting a result.",
+            )),
         }
-        Err(mpsc::RecvTimeoutError::Disconnected) => Err(AppError::new(
-            "recording_start_failed",
-            "Recording start failed before reporting a result.",
-        )),
-    }
+    })
+    .await
+    .map_err(|error| AppError::new("recording_start_failed", error.to_string()))?
 }
 
 #[tauri::command]
@@ -2112,7 +2134,7 @@ mod tests {
         start_capture_with_timeout_and_cleanup,
     };
     use crate::{
-        audio::capture::{is_capture_active, StartedRecording, StartedSource},
+        audio::capture::{is_capture_active, CaptureStartState, StartedRecording, StartedSource},
         domain::types::{
             AppError, AudioLevelDto, RecordingSource, RecordingSourceMode, RecordingState,
             RecordingStatusDto, SourceReadinessDto,
@@ -2184,6 +2206,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn capture_published_just_before_timeout_is_returned_as_success() {
+        let result = start_capture_with_timeout_and_cleanup(
+            move |handshake| {
+                // Commit the publish (as the real builder does under the
+                // ACTIVE_RECORDING lock), then outlive the watchdog timeout
+                // before reporting: the watchdog must accept this capture as
+                // success rather than strand a live recording behind a
+                // timeout error.
+                *handshake.lock().expect("handshake lock") = CaptureStartState::Published;
+                std::thread::sleep(Duration::from_millis(60));
+                Ok(fake_started_recording("published-session"))
+            },
+            move |_| panic!("published capture must not be torn down as late success"),
+            Duration::from_millis(20),
+        )
+        .await;
+
+        let started = result.expect("published capture is a success, not a timeout");
+        assert_eq!(started.session_id, "published-session");
+    }
+
+    #[tokio::test]
     async fn capture_start_timeout_returns_timeout_without_registering_active_capture() {
         let builder_saw_abandoned = Arc::new(AtomicBool::new(false));
         let registered = Arc::new(AtomicBool::new(false));
@@ -2194,11 +2238,11 @@ mod tests {
 
         let result = start_capture_with_timeout_and_cleanup(
             move |abandoned| {
-                while !abandoned.load(Ordering::Acquire) {
+                while *abandoned.lock().expect("handshake lock") != CaptureStartState::Abandoned {
                     std::thread::sleep(Duration::from_millis(2));
                 }
                 builder_saw_abandoned_for_thread.store(true, Ordering::Release);
-                if !abandoned.load(Ordering::Acquire) {
+                if *abandoned.lock().expect("handshake lock") != CaptureStartState::Abandoned {
                     registered_for_thread.store(true, Ordering::Release);
                     return Ok(fake_started_recording("late-session"));
                 }
@@ -2234,7 +2278,7 @@ mod tests {
             move |abandoned| {
                 // Return only after the timeout has demonstrably fired; a
                 // fixed sleep races the timeout under machine load.
-                while !abandoned.load(Ordering::Acquire) {
+                while *abandoned.lock().expect("handshake lock") != CaptureStartState::Abandoned {
                     std::thread::sleep(Duration::from_millis(2));
                 }
                 let started = fake_started_recording("late-session");

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,9 +2,10 @@ use crate::{
     app_paths::AppPaths,
     audio::{
         capture::{
-            capture_status_for_recovery, finish_active_capture, finish_capture, is_capture_active,
-            microphone_device_available, microphone_device_hint, microphone_permission_state,
-            pause_capture, resume_capture, start_capture, CaptureRecoverySnapshot,
+            capture_start_timeout_error, capture_status_for_recovery, finish_active_capture,
+            finish_capture, is_capture_active, microphone_device_available, microphone_device_hint,
+            microphone_permission_state, pause_capture, resume_capture, start_capture_with_cancel,
+            CaptureRecoverySnapshot, StartedRecording, CAPTURE_START_TIMEOUT,
         },
         recovery::scan_recoverable_recordings,
         validation::{
@@ -47,7 +48,10 @@ use sqlx_sqlite::SqlitePool;
 use sqlx_sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc, Mutex, OnceLock,
+};
 use std::{
     path::{Path, PathBuf},
     time::{Duration, Instant},
@@ -881,11 +885,10 @@ pub async fn start_recording(
     finish_active_capture_before_start(&repos).await?;
     let capture_paths = paths.clone();
     let capture_note_id = note.id.clone();
-    let started = tokio::task::spawn_blocking(move || {
-        start_capture(app, &capture_paths, capture_note_id, source_mode)
+    let started = start_capture_with_timeout(move |abandoned| {
+        start_capture_with_cancel(app, &capture_paths, capture_note_id, source_mode, abandoned)
     })
-    .await
-    .map_err(|error| AppError::new("recording_start_failed", error.to_string()))??;
+    .await?;
     repos
         .create_recording_session(
             &note.id,
@@ -920,6 +923,71 @@ pub async fn start_recording(
         sources: started.status.sources,
         warnings: Vec::new(),
     })
+}
+
+async fn start_capture_with_timeout<F>(start_capture: F) -> Result<StartedRecording, AppError>
+where
+    F: FnOnce(Arc<AtomicBool>) -> Result<StartedRecording, AppError> + Send + 'static,
+{
+    start_capture_with_timeout_and_cleanup(
+        start_capture,
+        |started| {
+            if let Err(error) = finish_capture(&started.session_id) {
+                eprintln!(
+                    "failed to tear down abandoned recording {} after start timeout: {}",
+                    started.session_id, error.message
+                );
+            }
+        },
+        CAPTURE_START_TIMEOUT,
+    )
+    .await
+}
+
+async fn start_capture_with_timeout_and_cleanup<F, C>(
+    start_capture: F,
+    cleanup_late_success: C,
+    timeout: Duration,
+) -> Result<StartedRecording, AppError>
+where
+    F: FnOnce(Arc<AtomicBool>) -> Result<StartedRecording, AppError> + Send + 'static,
+    C: FnOnce(&StartedRecording) + Send + 'static,
+{
+    let abandoned = Arc::new(AtomicBool::new(false));
+    let worker_abandoned = Arc::clone(&abandoned);
+    let (sender, receiver) = mpsc::channel();
+    let thread = std::thread::Builder::new()
+        .name("capture-start".to_string())
+        .spawn(move || {
+            let result = start_capture(worker_abandoned);
+            match result {
+                Ok(started) => {
+                    if let Err(mpsc::SendError(Ok(started))) = sender.send(Ok(started)) {
+                        cleanup_late_success(&started);
+                    }
+                }
+                Err(error) => {
+                    let _ = sender.send(Err(error));
+                }
+            }
+        })
+        .map_err(|error| AppError::new("recording_start_failed", error.to_string()))?;
+    drop(thread);
+
+    match tokio::task::spawn_blocking(move || receiver.recv_timeout(timeout))
+        .await
+        .map_err(|error| AppError::new("recording_start_failed", error.to_string()))?
+    {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            abandoned.store(true, Ordering::Release);
+            Err(capture_start_timeout_error())
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(AppError::new(
+            "recording_start_failed",
+            "Recording start failed before reporting a result.",
+        )),
+    }
 }
 
 #[tauri::command]
@@ -2034,10 +2102,25 @@ fn app_paths(app: &AppHandle) -> Result<AppPaths, AppError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_system_audio_permission_probe_result, recovery_validation_expected_duration_ms,
-        should_probe_system_audio_permission,
+        apply_system_audio_permission_probe_result, capture_start_timeout_error,
+        recovery_validation_expected_duration_ms, should_probe_system_audio_permission,
+        start_capture_with_timeout_and_cleanup,
     };
-    use crate::domain::types::{AppError, RecordingSource, SourceReadinessDto};
+    use crate::{
+        audio::capture::{is_capture_active, StartedRecording, StartedSource},
+        domain::types::{
+            AppError, AudioLevelDto, RecordingSource, RecordingSourceMode, RecordingState,
+            RecordingStatusDto, SourceReadinessDto,
+        },
+    };
+    use std::{
+        path::PathBuf,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, Mutex,
+        },
+        time::Duration,
+    };
 
     #[test]
     fn skips_system_audio_permission_probe_while_capture_is_active() {
@@ -2093,6 +2176,85 @@ mod tests {
             readiness.message.as_deref(),
             Some("Failed to create audio format for system tap.")
         );
+    }
+
+    #[tokio::test]
+    async fn capture_start_timeout_returns_timeout_without_registering_active_capture() {
+        let builder_saw_abandoned = Arc::new(AtomicBool::new(false));
+        let registered = Arc::new(AtomicBool::new(false));
+        let cleanup_called = Arc::new(AtomicBool::new(false));
+        let builder_saw_abandoned_for_thread = Arc::clone(&builder_saw_abandoned);
+        let registered_for_thread = Arc::clone(&registered);
+        let cleanup_called_for_thread = Arc::clone(&cleanup_called);
+
+        let result = start_capture_with_timeout_and_cleanup(
+            move |abandoned| {
+                while !abandoned.load(Ordering::Acquire) {
+                    std::thread::sleep(Duration::from_millis(2));
+                }
+                builder_saw_abandoned_for_thread.store(true, Ordering::Release);
+                if !abandoned.load(Ordering::Acquire) {
+                    registered_for_thread.store(true, Ordering::Release);
+                    return Ok(fake_started_recording("late-session"));
+                }
+                Err(capture_start_timeout_error())
+            },
+            move |_| {
+                cleanup_called_for_thread.store(true, Ordering::Release);
+            },
+            Duration::from_millis(20),
+        )
+        .await;
+
+        let error = match result {
+            Ok(_) => panic!("start should time out"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code, "capture_start_timeout");
+        wait_until(|| builder_saw_abandoned.load(Ordering::Acquire));
+        assert!(!registered.load(Ordering::Acquire));
+        assert!(!cleanup_called.load(Ordering::Acquire));
+        assert!(!is_capture_active());
+    }
+
+    #[tokio::test]
+    async fn late_capture_start_success_is_cleaned_up_after_timeout() {
+        let active_session = Arc::new(Mutex::new(None::<String>));
+        let cleanup_called = Arc::new(AtomicBool::new(false));
+        let active_session_for_builder = Arc::clone(&active_session);
+        let active_session_for_cleanup = Arc::clone(&active_session);
+        let cleanup_called_for_thread = Arc::clone(&cleanup_called);
+
+        let result = start_capture_with_timeout_and_cleanup(
+            move |_abandoned| {
+                std::thread::sleep(Duration::from_millis(60));
+                let started = fake_started_recording("late-session");
+                *active_session_for_builder
+                    .lock()
+                    .expect("active session lock") = Some(started.session_id.clone());
+                Ok(started)
+            },
+            move |started| {
+                let mut active = active_session_for_cleanup
+                    .lock()
+                    .expect("active session lock");
+                if active.as_deref() == Some(started.session_id.as_str()) {
+                    *active = None;
+                }
+                cleanup_called_for_thread.store(true, Ordering::Release);
+            },
+            Duration::from_millis(20),
+        )
+        .await;
+
+        let error = match result {
+            Ok(_) => panic!("start should time out"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code, "capture_start_timeout");
+        wait_until(|| cleanup_called.load(Ordering::Acquire));
+        assert_eq!(*active_session.lock().expect("active session lock"), None);
+        assert!(!is_capture_active());
     }
 
     #[test]
@@ -2219,5 +2381,44 @@ mod tests {
         writer.flush().expect("flush");
         std::mem::forget(writer);
         (dir, path)
+    }
+
+    fn fake_started_recording(session_id: &str) -> StartedRecording {
+        StartedRecording {
+            session_id: session_id.to_string(),
+            note_id: "note-1".to_string(),
+            source_mode: RecordingSourceMode::MicrophoneOnly,
+            partial_path: PathBuf::from("microphone.partial.wav"),
+            final_path: PathBuf::from("microphone.wav"),
+            sources: vec![StartedSource {
+                source: RecordingSource::Microphone,
+                partial_path: PathBuf::from("microphone.partial.wav"),
+                final_path: PathBuf::from("microphone.wav"),
+            }],
+            device_label: Some("Test microphone".to_string()),
+            status: RecordingStatusDto {
+                session_id: session_id.to_string(),
+                note_id: Some("note-1".to_string()),
+                source_mode: RecordingSourceMode::MicrophoneOnly,
+                state: RecordingState::Recording,
+                elapsed_ms: 0,
+                level: AudioLevelDto::default(),
+                silence_warning: false,
+                bytes_written: 0,
+                live_preview_enabled: false,
+                sources: Vec::new(),
+                warnings: Vec::new(),
+            },
+        }
+    }
+
+    fn wait_until(condition: impl Fn() -> bool) {
+        for _ in 0..50 {
+            if condition() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(condition());
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1106,6 +1106,7 @@ async fn finish_recording_session(
                     artifact.id.clone(),
                     source.source.as_db().to_string(),
                     source.final_path.clone(),
+                    validation.recorded_silence,
                 ));
             }
         }
@@ -1129,6 +1130,7 @@ async fn finish_recording_session(
             actual_duration_ms: Some(validation.actual_duration_ms),
             duration_within_tolerance: validation.duration_within_tolerance,
             non_silent_signal: validation.non_silent_signal,
+            recorded_silence: validation.recorded_silence,
             peak_amplitude: Some(validation.peak_amplitude),
             rms_amplitude: Some(validation.rms_amplitude),
             warnings: validation.warnings.clone(),
@@ -1148,6 +1150,7 @@ async fn finish_recording_session(
             actual_duration_ms: 0,
             duration_within_tolerance: false,
             non_silent_signal: false,
+            recorded_silence: false,
             peak_amplitude: 0.0,
             rms_amplitude: 0.0,
             warnings: vec!["No microphone validation was available.".to_string()],
@@ -1252,7 +1255,7 @@ async fn finish_recording_session(
         let result = if valid_sources.len() == 1
             && task_source_mode == RecordingSourceMode::MicrophoneOnly
         {
-            let (artifact_id, _source, path) = valid_sources
+            let (artifact_id, _source, path, _recorded_silence) = valid_sources
                 .into_iter()
                 .next()
                 .expect("valid source was checked before starting processing");
@@ -1447,7 +1450,7 @@ pub async fn retry_processing(
                 RecordingSourceMode::MicrophonePlusSystem,
                 sources
                     .into_iter()
-                    .map(|(id, source, path, _session_id)| (id, source, path))
+                    .map(|(id, source, path, _session_id)| (id, source, path, false))
                     .collect(),
                 title,
                 existing_generated_note,
@@ -1571,7 +1574,12 @@ pub async fn recover_recording(
                 )
                 .await?;
             if valid {
-                valid_sources.push((artifact.id, artifact.source, path));
+                valid_sources.push((
+                    artifact.id,
+                    artifact.source,
+                    path,
+                    validation.recorded_silence,
+                ));
             }
         }
         if valid_sources.is_empty() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,8 +3,8 @@ use crate::{
     audio::{
         capture::{
             capture_status_for_recovery, finish_active_capture, finish_capture, is_capture_active,
-            microphone_permission_state, pause_capture, resume_capture, start_capture,
-            CaptureRecoverySnapshot,
+            microphone_device_available, microphone_device_hint, microphone_permission_state,
+            pause_capture, resume_capture, start_capture, CaptureRecoverySnapshot,
         },
         recovery::scan_recoverable_recordings,
         validation::{
@@ -1281,18 +1281,25 @@ async fn finish_recording_session(
 
 fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSourceReadinessDto {
     let (microphone_state, microphone_hint) = microphone_permission_state();
-    let microphone_ready = microphone_state == "granted";
+    let microphone_permission_granted = microphone_state == "granted";
+    let microphone_device_available = microphone_device_available();
+    let microphone_ready = microphone_permission_granted && microphone_device_available;
+    let microphone_message = if microphone_permission_granted && !microphone_device_available {
+        Some(microphone_device_hint())
+    } else {
+        microphone_hint.clone()
+    };
     let mut sources = vec![SourceReadinessDto {
         source: RecordingSource::Microphone,
         required: true,
         ready: microphone_ready,
         permission_state: microphone_state.clone(),
-        device_available: microphone_ready,
+        device_available: microphone_device_available,
         capture_available: microphone_ready,
-        recovery_action: microphone_hint
-            .as_ref()
-            .map(|_| "openMicrophoneSettings".to_string()),
-        message: microphone_hint,
+        recovery_action: microphone_message.as_ref().and_then(|_| {
+            (!microphone_permission_granted).then(|| "openMicrophoneSettings".to_string())
+        }),
+        message: microphone_message,
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {
         let mut system = crate::audio::system_macos::system_audio_readiness();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -856,6 +856,28 @@ pub async fn start_recording(
             .unwrap_or_else(|| "The selected recording sources are not ready.".to_string());
         return Err(AppError::new("source_not_ready", message));
     }
+    // First capture on a fresh install: the main app must own its TCC mic
+    // prompt (the dictation helper's grant is a different bundle). Resolve
+    // `not_determined` here, before the stream opens, so a denial is a clear
+    // error instead of a recording full of zeros.
+    #[cfg(target_os = "macos")]
+    {
+        let (permission_state, permission_hint) = tokio::task::spawn_blocking(
+            crate::audio::capture::request_microphone_permission_blocking,
+        )
+        .await
+        .map_err(|error| AppError::new("readiness_check_failed", error.to_string()))?;
+        if matches!(
+            permission_state.as_str(),
+            "denied" | "restricted" | "not_determined"
+        ) {
+            return Err(AppError::new(
+                "microphone_permission_missing",
+                permission_hint
+                    .unwrap_or_else(|| "Microphone permission is required to record.".to_string()),
+            ));
+        }
+    }
     finish_active_capture_before_start(&repos).await?;
     let capture_paths = paths.clone();
     let capture_note_id = note.id.clone();
@@ -1281,13 +1303,21 @@ async fn finish_recording_session(
 
 fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSourceReadinessDto {
     let (microphone_state, microphone_hint) = microphone_permission_state();
-    let microphone_permission_granted = microphone_state == "granted";
+    // TCC grants are bundle-scoped, so the dictation helper's grant never
+    // covers the main app. `not_determined` (and the defensive `unknown`)
+    // must stay startable: the start path triggers the main app's own TCC
+    // prompt, and blocking here would leave a fresh install with no way to
+    // ever produce that prompt.
+    let microphone_permission_blocked =
+        matches!(microphone_state.as_str(), "denied" | "restricted");
     let microphone_device_available = microphone_device_available();
-    let microphone_ready = microphone_permission_granted && microphone_device_available;
-    let microphone_message = if microphone_permission_granted && !microphone_device_available {
+    let microphone_ready = !microphone_permission_blocked && microphone_device_available;
+    let microphone_message = if microphone_permission_blocked {
+        microphone_hint.clone()
+    } else if !microphone_device_available {
         Some(microphone_device_hint())
     } else {
-        microphone_hint.clone()
+        None
     };
     let mut sources = vec![SourceReadinessDto {
         source: RecordingSource::Microphone,
@@ -1296,9 +1326,8 @@ fn recording_source_readiness(source_mode: RecordingSourceMode) -> RecordingSour
         permission_state: microphone_state.clone(),
         device_available: microphone_device_available,
         capture_available: microphone_ready,
-        recovery_action: microphone_message.as_ref().and_then(|_| {
-            (!microphone_permission_granted).then(|| "openMicrophoneSettings".to_string())
-        }),
+        recovery_action: microphone_permission_blocked
+            .then(|| "openMicrophoneSettings".to_string()),
         message: microphone_message,
     }];
     if source_mode == RecordingSourceMode::MicrophonePlusSystem {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1323,7 +1323,7 @@ async fn finish_recording_session(
         let result = if valid_sources.len() == 1
             && task_source_mode == RecordingSourceMode::MicrophoneOnly
         {
-            let (artifact_id, _source, path, _recorded_silence) = valid_sources
+            let (artifact_id, _source, path, recorded_silence) = valid_sources
                 .into_iter()
                 .next()
                 .expect("valid source was checked before starting processing");
@@ -1336,6 +1336,7 @@ async fn finish_recording_session(
                 title,
                 existing_generated_note,
                 manual_notes,
+                recorded_silence,
             )
             .await
         } else {
@@ -1491,7 +1492,7 @@ pub async fn retry_processing(
         let existing_generated_note = note.generated_content.clone();
         let manual_notes = manual_notes_for_generation(&note);
         let result = if sources.len() == 1 {
-            let (audio_artifact_id, _source, audio_path, session_id) = sources
+            let (audio_artifact_id, _source, audio_path, session_id, recorded_silence) = sources
                 .into_iter()
                 .next()
                 .expect("retry sources were checked before starting processing");
@@ -1504,12 +1505,13 @@ pub async fn retry_processing(
                 title,
                 existing_generated_note,
                 manual_notes,
+                recorded_silence,
             )
             .await
         } else {
             let session_id = sources
                 .first()
-                .map(|(_id, _source, _path, session_id)| session_id.clone())
+                .map(|(_id, _source, _path, session_id, _recorded_silence)| session_id.clone())
                 .unwrap_or_default();
             process_saved_source_audio(
                 &task_repos,
@@ -1518,7 +1520,9 @@ pub async fn retry_processing(
                 RecordingSourceMode::MicrophonePlusSystem,
                 sources
                     .into_iter()
-                    .map(|(id, source, path, _session_id)| (id, source, path, false))
+                    .map(|(id, source, path, _session_id, recorded_silence)| {
+                        (id, source, path, recorded_silence)
+                    })
                     .collect(),
                 title,
                 existing_generated_note,
@@ -1540,16 +1544,16 @@ async fn retry_audio_sources(
     repos: &Repositories,
     paths: &AppPaths,
     note_id: &str,
-) -> Result<Vec<(String, String, PathBuf, String)>, AppError> {
+) -> Result<Vec<(String, String, PathBuf, String, bool)>, AppError> {
     let sources = repos
         .latest_valid_audio_artifact_paths(note_id)
         .await?
         .into_iter()
-        .filter_map(|(id, source, path, session_id)| {
+        .filter_map(|(id, source, path, session_id, recorded_silence)| {
             paths
                 .contained_recording_file(path)
                 .ok()
-                .map(|path| (id, source, path, session_id))
+                .map(|path| (id, source, path, session_id, recorded_silence))
         })
         .collect::<Vec<_>>();
     if sources.is_empty() {
@@ -1747,6 +1751,7 @@ pub async fn recover_recording(
         note.title,
         existing_generated_note,
         manual_notes,
+        validation.recorded_silence,
     )
     .await
 }
@@ -2226,8 +2231,12 @@ mod tests {
         let cleanup_called_for_thread = Arc::clone(&cleanup_called);
 
         let result = start_capture_with_timeout_and_cleanup(
-            move |_abandoned| {
-                std::thread::sleep(Duration::from_millis(60));
+            move |abandoned| {
+                // Return only after the timeout has demonstrably fired; a
+                // fixed sleep races the timeout under machine load.
+                while !abandoned.load(Ordering::Acquire) {
+                    std::thread::sleep(Duration::from_millis(2));
+                }
                 let started = fake_started_recording("late-session");
                 *active_session_for_builder
                     .lock()

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1,9 +1,9 @@
 use crate::domain::types::{
     AgentMessageDto, AgentMessageRole, AgentSafetyProfile, AgentTaskDto, AgentTaskListResponse,
     AgentTaskStatus, AgentToolEventDto, AgentToolEventStatus, AppError, AudioArtifactDto,
-    DictationHistoryItemDto, DictionaryEntryDto, FolderDto, ListDictationHistoryResponse,
-    ListNotesResponse, NoteDto, NoteListItemDto, ProcessingStatus, RecordingSourceMode,
-    RecordingState, SessionFolderDto, TranscriptCoverageDto, TranscriptDto,
+    AudioValidationDto, DictationHistoryItemDto, DictionaryEntryDto, FolderDto,
+    ListDictationHistoryResponse, ListNotesResponse, NoteDto, NoteListItemDto, ProcessingStatus,
+    RecordingSourceMode, RecordingState, SessionFolderDto, TranscriptCoverageDto, TranscriptDto,
 };
 use chrono::{Duration, SecondsFormat, Utc};
 use sqlx::query::query;
@@ -1807,6 +1807,7 @@ impl Repositories {
             language: row.get("language"),
             status: row.get("status"),
             last_error: row.get("last_error"),
+            recorded_silence: false,
         }))
     }
 
@@ -1815,8 +1816,10 @@ impl Repositories {
         note_id: &str,
     ) -> Result<Vec<TranscriptDto>, sqlx::error::Error> {
         let rows = query(
-            "SELECT t.id, t.text, t.source_mode, t.source, t.start_ms, t.end_ms, t.turn_index, t.language, t.status, t.last_error
+            "SELECT t.id, t.text, t.source_mode, t.source, t.start_ms, t.end_ms, t.turn_index, t.language, t.status, t.last_error,
+                    aa.validation_summary
              FROM transcripts t
+             LEFT JOIN audio_artifacts aa ON aa.id = t.audio_artifact_id
              LEFT JOIN recording_sessions rs ON rs.id = t.recording_session_id
              WHERE t.note_id = ?
                AND t.recording_session_id IS NOT NULL
@@ -1846,6 +1849,10 @@ impl Repositories {
                 language: row.get("language"),
                 status: row.get("status"),
                 last_error: row.get("last_error"),
+                recorded_silence: validation_summary_recorded_silence(
+                    row.get::<Option<String>, _>("validation_summary")
+                        .as_deref(),
+                ),
             })
             .collect())
     }
@@ -1953,6 +1960,7 @@ impl Repositories {
                 language: row.get("language"),
                 status: row.get("status"),
                 last_error: row.get("last_error"),
+                recorded_silence: false,
             })
             .collect())
     }
@@ -1976,6 +1984,7 @@ impl Repositories {
             language,
             status: "succeeded".to_string(),
             last_error: None,
+            recorded_silence: false,
         };
         let now = timestamp();
         query(
@@ -2022,6 +2031,7 @@ impl Repositories {
             language,
             status: "succeeded".to_string(),
             last_error: None,
+            recorded_silence: false,
         };
         let now = timestamp();
         query(
@@ -2114,6 +2124,7 @@ impl Repositories {
             language,
             status: "succeeded".to_string(),
             last_error: None,
+            recorded_silence: false,
         })
     }
 
@@ -2142,6 +2153,7 @@ impl Repositories {
             language: None,
             status: "failed".to_string(),
             last_error: Some(last_error.to_string()),
+            recorded_silence: false,
         };
         let now = timestamp();
         query(
@@ -2231,6 +2243,7 @@ impl Repositories {
             language: None,
             status: "failed".to_string(),
             last_error: Some(last_error.to_string()),
+            recorded_silence: false,
         })
     }
 
@@ -2757,4 +2770,11 @@ fn preview_for(title: &str, content: &str) -> String {
         content
     };
     source.chars().take(140).collect()
+}
+
+fn validation_summary_recorded_silence(summary: Option<&str>) -> bool {
+    summary
+        .and_then(|summary| serde_json::from_str::<AudioValidationDto>(summary).ok())
+        .map(|validation| validation.recorded_silence)
+        .unwrap_or(false)
 }

--- a/src-tauri/src/db/repositories.rs
+++ b/src-tauri/src/db/repositories.rs
@@ -1715,7 +1715,7 @@ impl Repositories {
     pub async fn latest_valid_audio_artifact_paths(
         &self,
         note_id: &str,
-    ) -> Result<Vec<(String, String, String, String)>, sqlx::error::Error> {
+    ) -> Result<Vec<(String, String, String, String, bool)>, sqlx::error::Error> {
         let session = query(
             "SELECT recording_session_id
              FROM audio_artifacts
@@ -1731,7 +1731,7 @@ impl Repositories {
         };
         let session_id: String = session.get("recording_session_id");
         let rows = query(
-            "SELECT id, source, path, recording_session_id
+            "SELECT id, source, path, recording_session_id, validation_summary
              FROM audio_artifacts
              WHERE note_id = ? AND recording_session_id = ? AND status = 'valid'
              ORDER BY CASE source WHEN 'microphone' THEN 0 WHEN 'system' THEN 1 ELSE 2 END",
@@ -1748,6 +1748,10 @@ impl Repositories {
                     row.get("source"),
                     row.get("path"),
                     row.get("recording_session_id"),
+                    validation_summary_recorded_silence(
+                        row.get::<Option<String>, _>("validation_summary")
+                            .as_deref(),
+                    ),
                 )
             })
             .collect())

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -419,12 +419,16 @@ pub struct DictationSettingsResponse {
 /// transcribing a fraction of a second of noise. Mirrors the helper's old
 /// holdThreshold, which used to absorb these by delaying the start.
 const PUSH_TO_TALK_MIN_HOLD: Duration = Duration::from_millis(160);
+const TOGGLE_SHORTCUT_DEBOUNCE: Duration = Duration::from_millis(275);
 
 #[derive(Debug, Default)]
 struct ShortcutActivationController {
     active_mode: Option<DictationShortcutKind>,
     push_to_talk_is_down: bool,
     push_started_at: Option<Instant>,
+    toggle_command_in_flight: bool,
+    last_toggle_command_at: Option<Instant>,
+    helper_is_finalizing: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -479,23 +483,55 @@ impl ShortcutActivationController {
             }
             (DictationShortcutKind::Toggle, ShortcutKeyEdge::Down) => match self.active_mode {
                 Some(DictationShortcutKind::PushToTalk) => None,
-                Some(DictationShortcutKind::Toggle) => {
+                Some(DictationShortcutKind::Toggle) if self.can_send_toggle_command(now) => {
                     self.active_mode = None;
+                    self.mark_toggle_command_sent(now);
                     Some(DictationCommand::ToggleListening)
                 }
-                None => {
+                Some(DictationShortcutKind::Toggle) => None,
+                None if self.can_send_toggle_command(now) => {
                     self.active_mode = Some(DictationShortcutKind::Toggle);
+                    self.mark_toggle_command_sent(now);
                     Some(DictationCommand::ToggleListening)
                 }
+                None => None,
             },
             (DictationShortcutKind::Toggle, ShortcutKeyEdge::Up) => None,
         }
+    }
+
+    fn can_send_toggle_command(&self, now: Instant) -> bool {
+        !self.toggle_command_in_flight
+            && !self.helper_is_finalizing
+            && self.last_toggle_command_at.map_or(true, |last| {
+                now.duration_since(last) >= TOGGLE_SHORTCUT_DEBOUNCE
+            })
+    }
+
+    fn mark_toggle_command_sent(&mut self, now: Instant) {
+        self.toggle_command_in_flight = true;
+        self.last_toggle_command_at = Some(now);
+    }
+
+    fn acknowledge_toggle_command(&mut self) {
+        self.toggle_command_in_flight = false;
+    }
+
+    fn mark_helper_finalizing(&mut self) {
+        self.helper_is_finalizing = true;
+    }
+
+    fn clear_helper_finalizing(&mut self) {
+        self.helper_is_finalizing = false;
     }
 
     fn reset(&mut self) {
         self.active_mode = None;
         self.push_to_talk_is_down = false;
         self.push_started_at = None;
+        self.toggle_command_in_flight = false;
+        self.last_toggle_command_at = None;
+        self.helper_is_finalizing = false;
     }
 }
 
@@ -1611,6 +1647,26 @@ fn reset_shortcut_activation(app: &AppHandle) {
     }
 }
 
+fn acknowledge_shortcut_toggle(app: &AppHandle) {
+    if let Some(state) = app.try_state::<ShortcutActivationState>() {
+        if let Ok(mut controller) = state.controller.lock() {
+            controller.acknowledge_toggle_command();
+        }
+    }
+}
+
+fn update_shortcut_helper_finalizing(app: &AppHandle, finalizing: bool) {
+    if let Some(state) = app.try_state::<ShortcutActivationState>() {
+        if let Ok(mut controller) = state.controller.lock() {
+            if finalizing {
+                controller.mark_helper_finalizing();
+            } else {
+                controller.clear_helper_finalizing();
+            }
+        }
+    }
+}
+
 fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_label: &str) {
     // The start path needs a signed-in OS Accounts session for the
     // transcription that follows, but the token check must not sit between
@@ -1624,7 +1680,10 @@ fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_l
     // before. ToggleListening can also start, but we can't tell
     // start-from-stop without extra state; transcribe_recording_ready acts
     // as the backstop there.
-    forward_dictation_command(app, command, shortcut_label);
+    let forwarded = forward_dictation_command(app, command, shortcut_label);
+    if !forwarded && matches!(command, DictationCommand::ToggleListening) {
+        reset_shortcut_activation(app);
+    }
     if matches!(command, DictationCommand::StartListening) {
         let app = app.clone();
         let label = shortcut_label.to_string();
@@ -1646,7 +1705,11 @@ fn send_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_l
     }
 }
 
-fn forward_dictation_command(app: &AppHandle, command: DictationCommand, shortcut_label: &str) {
+fn forward_dictation_command(
+    app: &AppHandle,
+    command: DictationCommand,
+    shortcut_label: &str,
+) -> bool {
     let Some(state) = app.try_state::<HelperState>() else {
         emit_dictation_event_value(
             app,
@@ -1655,12 +1718,14 @@ fn forward_dictation_command(app: &AppHandle, command: DictationCommand, shortcu
                 "Dictation helper process is not running.",
             )),
         );
-        return;
+        return false;
     };
 
     if let Err(error) = send_helper_command(&state, command.helper_command(shortcut_label)) {
         emit_dictation_event_value(app, app_error_event(error));
+        return false;
     }
+    true
 }
 
 /// Instant (millis since the Unix epoch) of the last signed-out prompt.
@@ -2225,6 +2290,25 @@ fn handle_helper_event_line(app: &AppHandle, line: String) {
         .and_then(serde_json::Value::as_str);
 
     handle_shortcut_key_event(app, event_type, event.as_ref());
+    if matches!(
+        event_type,
+        Some(
+            "listening_started"
+                | "finalizing_transcript"
+                | "recording_discarded"
+                | "final_transcript"
+                | "error"
+        )
+    ) {
+        acknowledge_shortcut_toggle(app);
+    }
+    match event_type {
+        Some("finalizing_transcript") => update_shortcut_helper_finalizing(app, true),
+        Some("listening_started" | "recording_discarded" | "final_transcript" | "error") => {
+            update_shortcut_helper_finalizing(app, false);
+        }
+        _ => {}
+    }
 
     if matches!(event_type, Some("recording_ready")) {
         if let Some(event) = event.as_ref() {
@@ -4252,9 +4336,143 @@ mod tests {
             controller.handle_edge(ShortcutKeyEdge::Up, DictationShortcutKind::Toggle, now),
             None
         );
+        controller.acknowledge_toggle_command();
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE
+            ),
+            Some(DictationCommand::ToggleListening)
+        );
+    }
+
+    #[test]
+    fn rapid_toggle_edges_send_one_command_until_acknowledged() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        let commands = [
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
+            controller.handle_edge(
+                ShortcutKeyEdge::Up,
+                DictationShortcutKind::Toggle,
+                now + Duration::from_millis(20),
+            ),
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + Duration::from_millis(100),
+            ),
+            controller.handle_edge(
+                ShortcutKeyEdge::Up,
+                DictationShortcutKind::Toggle,
+                now + Duration::from_millis(120),
+            ),
+        ];
+
+        assert_eq!(
+            commands
+                .into_iter()
+                .flatten()
+                .filter(|command| *command == DictationCommand::ToggleListening)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn acknowledged_toggle_still_respects_debounce_window() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
         assert_eq!(
             controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
             Some(DictationCommand::ToggleListening)
+        );
+        controller.acknowledge_toggle_command();
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE - Duration::from_millis(1)
+            ),
+            None
+        );
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE
+            ),
+            Some(DictationCommand::ToggleListening)
+        );
+    }
+
+    #[test]
+    fn toggle_during_helper_finalizing_is_dropped_without_parity_flip() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
+            Some(DictationCommand::ToggleListening)
+        );
+        controller.acknowledge_toggle_command();
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE
+            ),
+            Some(DictationCommand::ToggleListening)
+        );
+        controller.acknowledge_toggle_command();
+        controller.mark_helper_finalizing();
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE + Duration::from_secs(1)
+            ),
+            None
+        );
+        controller.clear_helper_finalizing();
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE + Duration::from_secs(2)
+            ),
+            Some(DictationCommand::ToggleListening)
+        );
+    }
+
+    #[test]
+    fn toggle_gate_never_drops_push_to_talk_release() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::PushToTalk,
+                now
+            ),
+            Some(DictationCommand::StartListening)
+        );
+        controller.toggle_command_in_flight = true;
+        controller.last_toggle_command_at = Some(now);
+
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Up,
+                DictationShortcutKind::PushToTalk,
+                now + PUSH_TO_TALK_MIN_HOLD
+            ),
+            Some(DictationCommand::StopAndPaste)
         );
     }
 

--- a/src-tauri/src/dictation.rs
+++ b/src-tauri/src/dictation.rs
@@ -420,6 +420,14 @@ pub struct DictationSettingsResponse {
 /// holdThreshold, which used to absorb these by delaying the start.
 const PUSH_TO_TALK_MIN_HOLD: Duration = Duration::from_millis(160);
 const TOGGLE_SHORTCUT_DEBOUNCE: Duration = Duration::from_millis(275);
+/// A toggle ack normally arrives within milliseconds; if the helper dies (or
+/// a permission prompt never calls back) no ack event ever comes, and an
+/// unexpiring in-flight flag would wedge the shortcut until app restart.
+const TOGGLE_ACK_EXPIRY: Duration = Duration::from_secs(8);
+/// Finalizing normally resolves in a few seconds (one dictation round-trip);
+/// a helper that dies mid-finalize emits no terminal event, so the
+/// suppression must expire rather than wedge the shortcut.
+const FINALIZING_SUPPRESSION_EXPIRY: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Default)]
 struct ShortcutActivationController {
@@ -428,7 +436,7 @@ struct ShortcutActivationController {
     push_started_at: Option<Instant>,
     toggle_command_in_flight: bool,
     last_toggle_command_at: Option<Instant>,
-    helper_is_finalizing: bool,
+    helper_finalizing_since: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -501,8 +509,15 @@ impl ShortcutActivationController {
     }
 
     fn can_send_toggle_command(&self, now: Instant) -> bool {
-        !self.toggle_command_in_flight
-            && !self.helper_is_finalizing
+        let in_flight = self.toggle_command_in_flight
+            && self
+                .last_toggle_command_at
+                .map_or(true, |last| now.duration_since(last) < TOGGLE_ACK_EXPIRY);
+        let finalizing = self
+            .helper_finalizing_since
+            .is_some_and(|since| now.duration_since(since) < FINALIZING_SUPPRESSION_EXPIRY);
+        !in_flight
+            && !finalizing
             && self.last_toggle_command_at.map_or(true, |last| {
                 now.duration_since(last) >= TOGGLE_SHORTCUT_DEBOUNCE
             })
@@ -518,11 +533,11 @@ impl ShortcutActivationController {
     }
 
     fn mark_helper_finalizing(&mut self) {
-        self.helper_is_finalizing = true;
+        self.helper_finalizing_since = Some(Instant::now());
     }
 
     fn clear_helper_finalizing(&mut self) {
-        self.helper_is_finalizing = false;
+        self.helper_finalizing_since = None;
     }
 
     fn reset(&mut self) {
@@ -531,7 +546,7 @@ impl ShortcutActivationController {
         self.push_started_at = None;
         self.toggle_command_in_flight = false;
         self.last_toggle_command_at = None;
-        self.helper_is_finalizing = false;
+        self.helper_finalizing_since = None;
     }
 }
 
@@ -4406,6 +4421,45 @@ mod tests {
                 DictationShortcutKind::Toggle,
                 now + TOGGLE_SHORTCUT_DEBOUNCE
             ),
+            Some(DictationCommand::ToggleListening)
+        );
+    }
+
+    #[test]
+    fn unacknowledged_toggle_expires_instead_of_wedging_the_shortcut() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
+            Some(DictationCommand::ToggleListening)
+        );
+        // No ack ever arrives (helper died / permission prompt never called
+        // back). Within the expiry the toggle stays suppressed...
+        assert_eq!(
+            controller.handle_edge(
+                ShortcutKeyEdge::Down,
+                DictationShortcutKind::Toggle,
+                now + TOGGLE_SHORTCUT_DEBOUNCE
+            ),
+            None
+        );
+        // ...and past the expiry the shortcut recovers on its own.
+        controller.last_toggle_command_at = Some(now - TOGGLE_ACK_EXPIRY);
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
+            Some(DictationCommand::ToggleListening)
+        );
+    }
+
+    #[test]
+    fn stuck_finalizing_suppression_expires_instead_of_wedging_the_shortcut() {
+        let mut controller = ShortcutActivationController::default();
+        let now = Instant::now();
+
+        controller.helper_finalizing_since = Some(now - FINALIZING_SUPPRESSION_EXPIRY);
+        assert_eq!(
+            controller.handle_edge(ShortcutKeyEdge::Down, DictationShortcutKind::Toggle, now),
             Some(DictationCommand::ToggleListening)
         );
     }

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -53,10 +53,13 @@ pub struct SourceTranscriptInput {
     pub text: String,
     pub valid: bool,
     pub warning: Option<String>,
+    pub recorded_silence: bool,
     pub start_ms: Option<i64>,
     pub end_ms: Option<i64>,
     pub turn_index: Option<i64>,
 }
+
+pub type SourceAudioForProcessing = (String, String, PathBuf, bool);
 
 pub fn valid_sources_for_processing(
     sources: Vec<SourceTranscriptInput>,
@@ -76,6 +79,7 @@ fn source_transcript_input_from_row(row: &TranscriptDto) -> SourceTranscriptInpu
         text: row.text.clone(),
         valid: row.status == "succeeded" && !row.text.trim().is_empty(),
         warning: row.last_error.clone(),
+        recorded_silence: row.recorded_silence,
         start_ms: row.start_ms,
         end_ms: row.end_ms,
         turn_index: row.turn_index,
@@ -398,7 +402,7 @@ pub async fn process_saved_source_audio(
     note_id: &str,
     session_id: &str,
     source_mode: RecordingSourceMode,
-    sources: Vec<(String, String, PathBuf)>,
+    sources: Vec<SourceAudioForProcessing>,
     title: String,
     existing_generated_note: Option<String>,
     manual_notes: Option<String>,
@@ -434,11 +438,13 @@ pub async fn process_saved_source_audio(
     }
     let detection_sources = sources
         .iter()
-        .map(|(artifact_id, source, audio_path)| DetectionSource {
-            artifact_id: artifact_id.clone(),
-            source: source.clone(),
-            path: audio_path.clone(),
-        })
+        .map(
+            |(artifact_id, source, audio_path, _recorded_silence)| DetectionSource {
+                artifact_id: artifact_id.clone(),
+                source: source.clone(),
+                path: audio_path.clone(),
+            },
+        )
         .collect::<Vec<_>>();
     // Detection now carries real DSP (GCC-PHAT probes, adaptive
     // cancellation passes over full recordings) — CPU-bound for minutes on
@@ -539,6 +545,7 @@ pub async fn process_saved_source_audio(
                         text: existing.text.clone(),
                         valid: existing.status == "succeeded" && !existing.text.trim().is_empty(),
                         warning: None,
+                        recorded_silence: existing.recorded_silence,
                         start_ms: existing.start_ms.or(Some(turn.start_ms)),
                         end_ms: existing.end_ms.or(Some(turn.end_ms)),
                         turn_index: existing.turn_index.or(Some(turn.turn_index)),
@@ -572,6 +579,7 @@ pub async fn process_saved_source_audio(
                 turn.turn_index, turn.source, turn.start_ms, turn.end_ms
             )),
         )?;
+        let recorded_silence = source_recorded_silence(&sources, &turn.artifact_id);
         transcription_jobs.push(TurnTranscriptionJob {
             echo_trimmed: echo_rejection
                 .trimmed_artifact_ids
@@ -581,6 +589,7 @@ pub async fn process_saved_source_audio(
             audio_path,
             temp_dir: segment_dir.clone(),
             source_path: source_audio_path,
+            recorded_silence,
             covers_full_source,
             source_fallback: false,
             start_ms: turn.start_ms,
@@ -943,14 +952,14 @@ async fn persist_microphone_only_transcript_coverage(
 }
 
 fn compute_transcript_coverage(
-    sources: &[(String, String, PathBuf)],
+    sources: &[SourceAudioForProcessing],
     detected_turns: &[AudioTurn],
     persisted_transcripts: &[TranscriptDto],
     failed_transcripts: &[FailedTranscriptCandidate],
 ) -> TranscriptCoverageCheckpoint {
     let mut source_entries = sources
         .iter()
-        .map(|(_artifact_id, source, source_path)| {
+        .map(|(_artifact_id, source, source_path, _recorded_silence)| {
             let source_detected_turns = detected_turns
                 .iter()
                 .filter(|turn| turn.source == *source)
@@ -1130,6 +1139,7 @@ struct TurnTranscriptionJob {
     audio_path: PathBuf,
     temp_dir: PathBuf,
     source_path: PathBuf,
+    recorded_silence: bool,
     covers_full_source: bool,
     source_fallback: bool,
     /// The source lost audio to echo trimming; full-source fallbacks must
@@ -1219,6 +1229,9 @@ async fn transcribe_prepared_audio(
     if audio_paths.len() == 1 {
         let audio_path = audio_paths.into_iter().next().unwrap_or(request.audio_path);
         let duration_ms = source_wav_duration_ms(&audio_path).unwrap_or_default();
+        if crate::audio::turns::source_is_effectively_silent(&audio_path) {
+            return Err(AppError::new("no_speech", "no_speech"));
+        }
         let transcript = transcribe_with_transient_retries(
             &transcriber,
             TranscriptionRequest {
@@ -1322,6 +1335,7 @@ async fn transcribe_prepared_audio(
             text: text.clone(),
             valid: !text.is_empty(),
             warning: None,
+            recorded_silence: false,
             start_ms: request.start_ms,
             end_ms: request.end_ms,
             turn_index: request.turn_index,
@@ -1636,12 +1650,18 @@ async fn transcribe_one_turn_job(
     {
         Ok(transcription) => transcription,
         Err(error) => {
-            let warning = user_facing_transcription_failure_message(&error.code, &error.message);
+            let warning = user_facing_transcription_failure_message(
+                &error.code,
+                &error.message,
+                job.recorded_silence,
+                job.source.as_str(),
+            );
             let input = SourceTranscriptInput {
                 source: job.source,
                 text: String::new(),
                 valid: false,
                 warning: Some(warning),
+                recorded_silence: job.recorded_silence,
                 start_ms: Some(job.start_ms),
                 end_ms: Some(job.end_ms),
                 turn_index: Some(job.turn_index),
@@ -1663,6 +1683,7 @@ async fn transcribe_one_turn_job(
         text: transcript.text,
         valid: true,
         warning: None,
+        recorded_silence: false,
         start_ms: Some(job.start_ms),
         end_ms: Some(job.end_ms),
         turn_index: Some(job.turn_index),
@@ -1787,6 +1808,7 @@ fn full_source_fallback_job(jobs: &[TurnTranscriptionJob]) -> Option<TurnTranscr
         audio_path: first.source_path.clone(),
         temp_dir: first.temp_dir.clone(),
         source_path: first.source_path.clone(),
+        recorded_silence: first.recorded_silence,
         covers_full_source: true,
         source_fallback: true,
         start_ms: 0,
@@ -1896,14 +1918,14 @@ struct DroppedSource {
 }
 
 struct SilentSystemDropOutcome {
-    kept: Vec<(String, String, PathBuf)>,
+    kept: Vec<SourceAudioForProcessing>,
     dropped: Vec<DroppedSource>,
 }
 
 #[cfg(test)]
 fn drop_silent_system_sources(
-    sources: Vec<(String, String, PathBuf)>,
-) -> Vec<(String, String, PathBuf)> {
+    sources: Vec<SourceAudioForProcessing>,
+) -> Vec<SourceAudioForProcessing> {
     partition_silent_system_sources(sources).kept
 }
 
@@ -1916,11 +1938,11 @@ fn drop_silent_system_sources(
 /// would strand quiet-but-real tracks before the full-source fallback ever runs,
 /// transcribing mic-only.
 fn partition_silent_system_sources(
-    sources: Vec<(String, String, PathBuf)>,
+    sources: Vec<SourceAudioForProcessing>,
 ) -> SilentSystemDropOutcome {
     let has_other_source = sources
         .iter()
-        .any(|(_, source, _)| source.as_str() != "system");
+        .any(|(_, source, _, _)| source.as_str() != "system");
     if !has_other_source {
         return SilentSystemDropOutcome {
             kept: sources,
@@ -1929,7 +1951,7 @@ fn partition_silent_system_sources(
     }
     let mut kept = Vec::new();
     let mut dropped = Vec::new();
-    for (artifact_id, source, path) in sources {
+    for (artifact_id, source, path, recorded_silence) in sources {
         // Decode once: `source_max_rms` is `None` when the file can't be read,
         // which must mean "keep" (matching the old read-failure semantics).
         let max_rms = if source.as_str() == "system" {
@@ -1952,18 +1974,18 @@ fn partition_silent_system_sources(
                 max_rms,
             });
         } else {
-            kept.push((artifact_id, source, path));
+            kept.push((artifact_id, source, path, recorded_silence));
         }
     }
     SilentSystemDropOutcome { kept, dropped }
 }
 
 fn add_full_source_turns_for_missing_sources(
-    sources: &[(String, String, PathBuf)],
+    sources: &[SourceAudioForProcessing],
     mut turns: Vec<AudioTurn>,
     echo_rejection: &EchoRejectionReport,
 ) -> Vec<AudioTurn> {
-    for (artifact_id, source, audio_path) in sources {
+    for (artifact_id, source, audio_path, _recorded_silence) in sources {
         let has_source_turn = turns
             .iter()
             .any(|turn| turn.artifact_id == *artifact_id && turn.source == *source);
@@ -1995,6 +2017,14 @@ fn add_full_source_turns_for_missing_sources(
     turns
 }
 
+fn source_recorded_silence(sources: &[SourceAudioForProcessing], artifact_id: &str) -> bool {
+    sources
+        .iter()
+        .find(|(source_artifact_id, _, _, _)| source_artifact_id == artifact_id)
+        .map(|(_, _, _, recorded_silence)| *recorded_silence)
+        .unwrap_or(false)
+}
+
 /// Whether a failed source should be persisted as a visible per-source error.
 /// A silent system-audio track (no_speech) is expected when the user only
 /// speaks into the mic, so we drop it once any source produced a usable
@@ -2019,13 +2049,24 @@ fn is_no_speech_error(error: &AppError) -> bool {
     is_no_speech_message(&error.code) || is_no_speech_message(&error.message)
 }
 
-fn user_facing_transcription_failure_message(code: &str, message: &str) -> String {
+fn user_facing_transcription_failure_message(
+    code: &str,
+    message: &str,
+    recorded_silence: bool,
+    source: &str,
+) -> String {
     let normalized_code = code.trim().to_ascii_lowercase();
     let normalized_message = message.trim().to_ascii_lowercase();
     if normalized_code == "no_speech"
         || normalized_message == "no_speech"
         || normalized_message.contains("no speech")
     {
+        if recorded_silence {
+            if source == "system" {
+                return "The system audio recorded silence for the whole session. Check that audio was playing and that system audio capture is enabled.".to_string();
+            }
+            return "The microphone recorded silence for the whole session. Check that the right microphone is selected in Settings and that macOS input volume is up.".to_string();
+        }
         return "No speech detected. Try speaking louder or moving closer to the microphone."
             .to_string();
     }
@@ -2233,11 +2274,13 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             ),
             (
                 "system-artifact".to_string(),
                 "system".to_string(),
                 system_path.clone(),
+                false,
             ),
         ];
         let detected_mic_turn = AudioTurn {
@@ -2279,11 +2322,13 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             ),
             (
                 "system-artifact".to_string(),
                 "system".to_string(),
                 system_path.clone(),
+                false,
             ),
         ];
         let turns = vec![
@@ -2330,6 +2375,7 @@ mod tests {
             "mic-artifact".to_string(),
             "microphone".to_string(),
             mic_path,
+            false,
         )];
         let report = EchoRejectionReport {
             detected_turn_artifact_ids: vec!["mic-artifact".to_string()],
@@ -2383,11 +2429,13 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             ),
             (
                 "system-artifact".to_string(),
                 "system".to_string(),
                 system_path.clone(),
+                false,
             ),
         ];
 
@@ -2855,20 +2903,38 @@ mod tests {
     #[test]
     fn transcription_failure_messages_hide_provider_codes() {
         assert_eq!(
-            user_facing_transcription_failure_message("june_request_failed", "no_speech"),
+            user_facing_transcription_failure_message(
+                "june_request_failed",
+                "no_speech",
+                false,
+                "microphone"
+            ),
             "No speech detected. Try speaking louder or moving closer to the microphone."
         );
         assert_eq!(
             user_facing_transcription_failure_message(
                 "june_request_failed",
-                "upstream_provider_failed"
+                "no_speech",
+                true,
+                "microphone",
+            ),
+            "The microphone recorded silence for the whole session. Check that the right microphone is selected in Settings and that macOS input volume is up."
+        );
+        assert_eq!(
+            user_facing_transcription_failure_message(
+                "june_request_failed",
+                "upstream_provider_failed",
+                true,
+                "microphone",
             ),
             "The transcription provider could not process this audio."
         );
         assert_eq!(
             user_facing_transcription_failure_message(
                 "june_request_failed",
-                "metering_provider_failed"
+                "metering_provider_failed",
+                true,
+                "microphone",
             ),
             "Billing is temporarily unavailable. Please try again in a moment."
         );
@@ -2882,6 +2948,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             )],
             &[
                 test_audio_turn("mic-artifact", "microphone", mic_path.clone(), 0, 0, 50_000),
@@ -2910,6 +2977,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             )],
             &[test_audio_turn(
                 "mic-artifact",
@@ -2941,6 +3009,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             )],
             &[test_audio_turn(
                 "mic-artifact",
@@ -2982,6 +3051,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             )],
             &[test_audio_turn(
                 "mic-artifact",
@@ -3021,6 +3091,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             )],
             &[test_audio_turn(
                 "mic-artifact",
@@ -3049,6 +3120,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 missing_path.clone(),
+                false,
             )],
             &[test_audio_turn(
                 "mic-artifact",
@@ -3075,6 +3147,7 @@ mod tests {
                 "mic-artifact".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             )],
             &[test_audio_turn(
                 "mic-artifact",
@@ -3222,6 +3295,7 @@ mod tests {
                     warning: Some(
                         "The transcription provider could not process this audio.".to_string(),
                     ),
+                    recorded_silence: false,
                     start_ms: Some(0),
                     end_ms: Some(0),
                     turn_index: Some(0),
@@ -3237,6 +3311,7 @@ mod tests {
                         "No speech detected. Try speaking louder or moving closer to the microphone."
                             .to_string(),
                     ),
+                    recorded_silence: false,
                     start_ms: Some(0),
                     end_ms: Some(0),
                     turn_index: Some(1),
@@ -3505,6 +3580,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn single_chunk_silent_audio_is_skipped_before_reaching_the_transcriber() {
+        let dir = std::env::temp_dir().join(format!(
+            "os-june-single-chunk-silentskip-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let audio_path = dir.join("turn.wav");
+        write_segmented_wav(&audio_path, 16_000, &[(16_000, 0)]);
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let transcriber = {
+            let calls = Arc::clone(&calls);
+            Arc::new(move |_request: TranscriptionRequest| {
+                let calls = Arc::clone(&calls);
+                Box::pin(async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(TranscriptionProviderResult {
+                        text: "should not be called".to_string(),
+                        language: None,
+                        provider: "test".to_string(),
+                    })
+                }) as TranscriptionFuture
+            }) as TurnTranscriber
+        };
+
+        let error = transcribe_prepared_audio(
+            transcriber,
+            TranscribePreparedAudioRequest {
+                provider: "test".to_string(),
+                audio_path,
+                temp_dir: dir.clone(),
+                chunk_stem: "turn-0".to_string(),
+                title: "Meeting".to_string(),
+                base_context: None,
+                operation_id: "turn-0".to_string(),
+                source: "microphone".to_string(),
+                start_ms: Some(0),
+                end_ms: Some(1_000),
+                turn_index: Some(0),
+            },
+        )
+        .await
+        .expect_err("silent single-chunk audio should report no speech");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(is_no_speech_error(&error));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
     async fn silent_chunks_are_skipped_before_reaching_the_transcriber() {
         // 62s: loud 0-30s, silent 30-60s, loud 60-62s -> chunks 0 and 2 audible,
         // chunk 1 silent. The silent chunk must never reach the API (no credit
@@ -3605,8 +3730,9 @@ mod tests {
                 "mic".to_string(),
                 "microphone".to_string(),
                 mic_path.clone(),
+                false,
             ),
-            ("sys".to_string(), "system".to_string(), system_path),
+            ("sys".to_string(), "system".to_string(), system_path, true),
         ]);
 
         assert_eq!(kept.len(), 1);
@@ -3627,6 +3753,7 @@ mod tests {
             "sys".to_string(),
             "system".to_string(),
             system_path,
+            true,
         )]);
 
         // System-only capture of silence must survive so its "no speech"
@@ -3652,8 +3779,13 @@ mod tests {
         write_test_wav(&system_path, &quiet);
 
         let kept = drop_silent_system_sources(vec![
-            ("mic".to_string(), "microphone".to_string(), mic_path),
-            ("sys".to_string(), "system".to_string(), system_path.clone()),
+            ("mic".to_string(), "microphone".to_string(), mic_path, false),
+            (
+                "sys".to_string(),
+                "system".to_string(),
+                system_path.clone(),
+                false,
+            ),
         ]);
 
         assert_eq!(kept.len(), 2);
@@ -3677,8 +3809,8 @@ mod tests {
         write_test_wav(&system_path, &[15_000, -16_000, 14_000]);
 
         let kept = drop_silent_system_sources(vec![
-            ("mic".to_string(), "microphone".to_string(), mic_path),
-            ("sys".to_string(), "system".to_string(), system_path),
+            ("mic".to_string(), "microphone".to_string(), mic_path, false),
+            ("sys".to_string(), "system".to_string(), system_path, false),
         ]);
 
         assert_eq!(kept.len(), 2);
@@ -3693,6 +3825,7 @@ mod tests {
             audio_path: PathBuf::from(path),
             temp_dir: std::env::temp_dir(),
             source_path: PathBuf::from(path),
+            recorded_silence: false,
             covers_full_source: true,
             source_fallback: false,
             echo_trimmed: false,
@@ -3763,6 +3896,7 @@ mod tests {
             language: None,
             status: "succeeded".to_string(),
             last_error: None,
+            recorded_silence: false,
         }
     }
 
@@ -3774,6 +3908,7 @@ mod tests {
                 text: String::new(),
                 valid: false,
                 warning: Some(warning.to_string()),
+                recorded_silence: false,
                 start_ms: Some(turn_index * 1_000),
                 end_ms: Some(turn_index * 1_000 + 500),
                 turn_index: Some(turn_index),

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -289,7 +289,7 @@ pub async fn process_saved_audio(
     let transcription_provider = crate::providers::configured_transcription_provider();
     let dictionary_entries = repos.list_dictionary_entries().await?;
     let dictionary_context = build_dictionary_context(&dictionary_entries);
-    let transcript = match transcribe_prepared_audio(
+    let transcription = match transcribe_prepared_audio(
         default_turn_transcriber(),
         TranscribePreparedAudioRequest {
             provider: transcription_provider.clone(),
@@ -307,7 +307,7 @@ pub async fn process_saved_audio(
     )
     .await
     {
-        Ok(transcript) => transcript,
+        Ok(transcription) => transcription,
         Err(error) => {
             repos
                 .set_note_status(
@@ -319,10 +319,17 @@ pub async fn process_saved_audio(
             return Err(error);
         }
     };
+    persist_microphone_only_transcript_coverage(
+        repos,
+        session_id,
+        "microphone",
+        &transcription.chunk_outcomes,
+    )
+    .await;
     let _ = std::fs::remove_dir_all(&temp_dir);
     let transcript = maybe_post_process_note_transcript(
         &transcription_provider,
-        transcript,
+        transcription.transcript,
         dictionary_context.as_deref(),
     )
     .await;
@@ -858,6 +865,83 @@ struct TranscriptCoverageSource {
     failed_turns: i64,
 }
 
+fn compute_chunk_transcript_coverage(
+    source: &str,
+    chunk_outcomes: &[TranscriptionChunkOutcome],
+) -> TranscriptCoverageCheckpoint {
+    let detected_speech_ms = chunk_outcomes
+        .iter()
+        .filter(|chunk| !chunk.locally_silent)
+        .map(|chunk| span_ms(chunk.start_ms, chunk.end_ms))
+        .sum();
+    let transcribed_ms = chunk_outcomes
+        .iter()
+        .filter(|chunk| !chunk.locally_silent && chunk.provider_returned_text)
+        .map(|chunk| span_ms(chunk.start_ms, chunk.end_ms))
+        .sum();
+    let detected_turns = chunk_outcomes
+        .iter()
+        .filter(|chunk| !chunk.locally_silent)
+        .count() as i64;
+    let transcribed_turns = chunk_outcomes
+        .iter()
+        .filter(|chunk| !chunk.locally_silent && chunk.provider_returned_text)
+        .count() as i64;
+    let failed_turns = chunk_outcomes
+        .iter()
+        .filter(|chunk| !chunk.locally_silent && !chunk.provider_returned_text)
+        .count() as i64;
+    let warning = transcript_coverage_warning(detected_speech_ms, transcribed_ms);
+    TranscriptCoverageCheckpoint {
+        sources: vec![TranscriptCoverageSource {
+            source: source.to_string(),
+            detected_speech_ms,
+            transcribed_ms,
+            detected_turns,
+            transcribed_turns,
+            failed_turns,
+        }],
+        total_detected_speech_ms: detected_speech_ms,
+        total_transcribed_ms: transcribed_ms,
+        total_detected_turns: detected_turns,
+        total_transcribed_turns: transcribed_turns,
+        total_failed_turns: failed_turns,
+        warning,
+    }
+}
+
+// Coverage is diagnostic only and must never fail note processing: a
+// checkpoint that cannot be serialized or persisted is logged and skipped.
+async fn persist_microphone_only_transcript_coverage(
+    repos: &Repositories,
+    session_id: &str,
+    source: &str,
+    chunk_outcomes: &[TranscriptionChunkOutcome],
+) {
+    let coverage = compute_chunk_transcript_coverage(source, chunk_outcomes);
+    match serde_json::to_string(&coverage) {
+        Ok(payload) => {
+            if let Err(error) = repos
+                .add_checkpoint(session_id, "transcript_coverage", Some(payload))
+                .await
+            {
+                tracing::warn!(
+                    error = %error,
+                    session_id = %session_id,
+                    "failed to persist transcript_coverage checkpoint"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                session_id = %session_id,
+                "failed to serialize transcript_coverage checkpoint"
+            );
+        }
+    }
+}
+
 fn compute_transcript_coverage(
     sources: &[(String, String, PathBuf)],
     detected_turns: &[AudioTurn],
@@ -1080,6 +1164,21 @@ struct TranscribePreparedAudioRequest {
     turn_index: Option<i64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TranscriptionChunkOutcome {
+    start_ms: i64,
+    end_ms: i64,
+    locally_silent: bool,
+    provider_returned_text: bool,
+    provider_no_speech: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TranscribePreparedAudioResult {
+    transcript: TranscriptionProviderResult,
+    chunk_outcomes: Vec<TranscriptionChunkOutcome>,
+}
+
 /// Full-source normalized audio, prepared once per source. The per-turn job
 /// loop used to normalize the WHOLE source recording again for every turn —
 /// the output name carried the turn index, so nothing was ever reused — and
@@ -1109,7 +1208,7 @@ fn normalized_full_source(
 async fn transcribe_prepared_audio(
     transcriber: TurnTranscriber,
     request: TranscribePreparedAudioRequest,
-) -> Result<TranscriptionProviderResult, AppError> {
+) -> Result<TranscribePreparedAudioResult, AppError> {
     let request_language = crate::dictation::configured_transcription_language();
     let chunk_dir = request.temp_dir.join("chunks");
     let audio_paths = if request.audio_path.exists() {
@@ -1118,11 +1217,13 @@ async fn transcribe_prepared_audio(
         vec![request.audio_path.clone()]
     };
     if audio_paths.len() == 1 {
-        return transcribe_with_transient_retries(
+        let audio_path = audio_paths.into_iter().next().unwrap_or(request.audio_path);
+        let duration_ms = source_wav_duration_ms(&audio_path).unwrap_or_default();
+        let transcript = transcribe_with_transient_retries(
             &transcriber,
             TranscriptionRequest {
                 provider: request.provider,
-                audio_path: audio_paths.into_iter().next().unwrap_or(request.audio_path),
+                audio_path,
                 title: request.title,
                 context: request.base_context,
                 language: request_language,
@@ -1130,20 +1231,42 @@ async fn transcribe_prepared_audio(
                 preview: false,
             },
         )
-        .await;
+        .await?;
+        return Ok(TranscribePreparedAudioResult {
+            chunk_outcomes: vec![TranscriptionChunkOutcome {
+                start_ms: 0,
+                end_ms: duration_ms,
+                locally_silent: false,
+                provider_returned_text: !transcript.text.trim().is_empty(),
+                provider_no_speech: false,
+            }],
+            transcript,
+        });
     }
 
     let mut previous = Vec::new();
     let mut text_parts = Vec::new();
     let mut language = None;
     let mut provider_name = request.provider.clone();
+    let mut chunk_outcomes = Vec::new();
+    let mut chunk_start_ms = 0_i64;
     for (index, audio_path) in audio_paths.into_iter().enumerate() {
+        let duration_ms = source_wav_duration_ms(&audio_path).unwrap_or_default();
+        let chunk_end_ms = chunk_start_ms.saturating_add(duration_ms);
         // Skip clearly-silent chunks before any API call. Fixed-size splitting of
         // a long (or fully silent) source leaves quiet boundary chunks, and each
         // request authorizes a credit hold that a no-speech response never
         // settles — so sending every silent chunk of a silent source would strand
         // holds until TTL and can trip `authorization_denied` on later work.
         if crate::audio::turns::source_is_effectively_silent(&audio_path) {
+            chunk_outcomes.push(TranscriptionChunkOutcome {
+                start_ms: chunk_start_ms,
+                end_ms: chunk_end_ms,
+                locally_silent: true,
+                provider_returned_text: false,
+                provider_no_speech: false,
+            });
+            chunk_start_ms = chunk_end_ms;
             continue;
         }
         let context = merge_transcription_context(
@@ -1168,7 +1291,17 @@ async fn transcribe_prepared_audio(
             // Backstop for a chunk the local silence check judged audible but the
             // provider still reports as no-speech: skip it so earlier chunks' text
             // survives, rather than aborting and dropping the whole turn.
-            Err(error) if is_no_speech_error(&error) => continue,
+            Err(error) if is_no_speech_error(&error) => {
+                chunk_outcomes.push(TranscriptionChunkOutcome {
+                    start_ms: chunk_start_ms,
+                    end_ms: chunk_end_ms,
+                    locally_silent: false,
+                    provider_returned_text: false,
+                    provider_no_speech: true,
+                });
+                chunk_start_ms = chunk_end_ms;
+                continue;
+            }
             Err(error) => return Err(error),
         };
         if language.is_none() {
@@ -1176,6 +1309,14 @@ async fn transcribe_prepared_audio(
         }
         provider_name = transcript.provider.clone();
         let text = transcript.text.trim().to_string();
+        chunk_outcomes.push(TranscriptionChunkOutcome {
+            start_ms: chunk_start_ms,
+            end_ms: chunk_end_ms,
+            locally_silent: false,
+            provider_returned_text: !text.is_empty(),
+            provider_no_speech: false,
+        });
+        chunk_start_ms = chunk_end_ms;
         previous.push(SourceTranscriptInput {
             source: request.source.clone(),
             text: text.clone(),
@@ -1196,10 +1337,13 @@ async fn transcribe_prepared_audio(
         // generic error that would fail the whole note.
         return Err(AppError::new("no_speech", "no_speech"));
     }
-    Ok(TranscriptionProviderResult {
-        text: text_parts.join("\n"),
-        language,
-        provider: provider_name,
+    Ok(TranscribePreparedAudioResult {
+        transcript: TranscriptionProviderResult {
+            text: text_parts.join("\n"),
+            language,
+            provider: provider_name,
+        },
+        chunk_outcomes,
     })
 }
 
@@ -1472,7 +1616,7 @@ async fn transcribe_one_turn_job(
     } else {
         turn_operation_id(&job)
     };
-    let transcript = match transcribe_prepared_audio(
+    let transcription = match transcribe_prepared_audio(
         Arc::clone(&transcriber),
         TranscribePreparedAudioRequest {
             provider: provider.clone(),
@@ -1490,7 +1634,7 @@ async fn transcribe_one_turn_job(
     )
     .await
     {
-        Ok(transcript) => transcript,
+        Ok(transcription) => transcription,
         Err(error) => {
             let warning = user_facing_transcription_failure_message(&error.code, &error.message);
             let input = SourceTranscriptInput {
@@ -1512,7 +1656,8 @@ async fn transcribe_one_turn_job(
         }
     };
     let transcript =
-        maybe_post_process_note_transcript(&provider, transcript, context.as_deref()).await;
+        maybe_post_process_note_transcript(&provider, transcription.transcript, context.as_deref())
+            .await;
     let input = SourceTranscriptInput {
         source: job.source,
         text: transcript.text,
@@ -2956,6 +3101,115 @@ mod tests {
         assert!(transcript_coverage_warning(100_000, 40_000));
     }
 
+    #[tokio::test]
+    async fn microphone_only_coverage_persists_provider_no_speech_gap() {
+        let pool = sqlx_sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite memory");
+        crate::db::migrations::run_migrations(&pool)
+            .await
+            .expect("migrations");
+        let repos = Repositories::new(pool);
+        let note = repos.create_note(None).await.expect("note");
+        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        repos
+            .create_recording_session(
+                &note.id,
+                &session_id,
+                RecordingSourceMode::MicrophoneOnly,
+                "microphone.partial.wav",
+                "microphone.wav",
+                None,
+            )
+            .await
+            .expect("recording session");
+
+        persist_microphone_only_transcript_coverage(
+            &repos,
+            &session_id,
+            "microphone",
+            &[
+                TranscriptionChunkOutcome {
+                    start_ms: 0,
+                    end_ms: 30_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 30_000,
+                    end_ms: 120_000,
+                    locally_silent: false,
+                    provider_returned_text: false,
+                    provider_no_speech: true,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 120_000,
+                    end_ms: 150_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+            ],
+        )
+        .await;
+
+        let note = repos.get_note(&note.id).await.expect("note with coverage");
+        let coverage = note.transcript_coverage.expect("coverage dto");
+        assert_eq!(coverage.detected_speech_ms, 150_000);
+        assert_eq!(coverage.transcribed_ms, 60_000);
+        assert!(coverage.warning);
+
+        let details: String = sqlx::query_scalar::query_scalar(
+            "SELECT details FROM recording_checkpoints WHERE recording_session_id = ? AND kind = 'transcript_coverage'",
+        )
+        .bind(&session_id)
+        .fetch_one(&repos.pool)
+        .await
+        .expect("checkpoint details");
+        let checkpoint: serde_json::Value =
+            serde_json::from_str(&details).expect("checkpoint json");
+        assert_eq!(checkpoint["totalFailedTurns"], 1);
+        assert_eq!(checkpoint["sources"][0]["failedTurns"], 1);
+    }
+
+    #[test]
+    fn microphone_only_coverage_ignores_locally_silent_chunks() {
+        let coverage = compute_chunk_transcript_coverage(
+            "microphone",
+            &[
+                TranscriptionChunkOutcome {
+                    start_ms: 0,
+                    end_ms: 30_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 30_000,
+                    end_ms: 120_000,
+                    locally_silent: true,
+                    provider_returned_text: false,
+                    provider_no_speech: false,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 120_000,
+                    end_ms: 150_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+            ],
+        );
+
+        assert_eq!(coverage.total_detected_speech_ms, 60_000);
+        assert_eq!(coverage.total_transcribed_ms, 60_000);
+        assert_eq!(coverage.total_failed_turns, 0);
+        assert!(!coverage.warning);
+    }
+
     #[test]
     fn source_failure_summary_suppresses_silent_system_when_microphone_failed() {
         let summary = source_failure_summary(&[
@@ -3184,7 +3438,26 @@ mod tests {
         .await
         .expect("a trailing no-speech chunk must not fail the whole turn");
 
-        assert_eq!(result.text, "first chunk speech");
+        assert_eq!(result.transcript.text, "first chunk speech");
+        assert_eq!(
+            result.chunk_outcomes,
+            vec![
+                TranscriptionChunkOutcome {
+                    start_ms: 0,
+                    end_ms: 30_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 30_000,
+                    end_ms: 31_000,
+                    locally_silent: false,
+                    provider_returned_text: false,
+                    provider_no_speech: true,
+                },
+            ]
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -3287,7 +3560,33 @@ mod tests {
 
         // Only the two audible chunks reach the API; the silent middle is skipped.
         assert_eq!(calls.load(Ordering::SeqCst), 2);
-        assert_eq!(result.text, "chunk text 0\nchunk text 1");
+        assert_eq!(result.transcript.text, "chunk text 0\nchunk text 1");
+        assert_eq!(
+            result.chunk_outcomes,
+            vec![
+                TranscriptionChunkOutcome {
+                    start_ms: 0,
+                    end_ms: 30_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 30_000,
+                    end_ms: 60_000,
+                    locally_silent: true,
+                    provider_returned_text: false,
+                    provider_no_speech: false,
+                },
+                TranscriptionChunkOutcome {
+                    start_ms: 60_000,
+                    end_ms: 62_000,
+                    locally_silent: false,
+                    provider_returned_text: true,
+                    provider_no_speech: false,
+                },
+            ]
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src-tauri/src/domain/processing.rs
+++ b/src-tauri/src/domain/processing.rs
@@ -278,6 +278,7 @@ pub async fn process_saved_audio(
     title: String,
     existing_generated_note: Option<String>,
     manual_notes: Option<String>,
+    recorded_silence: bool,
 ) -> Result<NoteDto, AppError> {
     repos
         .set_note_status(note_id, ProcessingStatus::Transcribing, None)
@@ -313,14 +314,27 @@ pub async fn process_saved_audio(
     {
         Ok(transcription) => transcription,
         Err(error) => {
+            let user_message = user_facing_transcription_failure_message(
+                &error.code,
+                &error.message,
+                recorded_silence,
+                "microphone",
+            );
+            // A no-speech outcome is a coverage decision, not just a failure:
+            // persist the zero-detected-speech checkpoint so the call is
+            // documented the same way a chunked pass would document it.
+            if is_no_speech_error(&error) {
+                persist_microphone_only_transcript_coverage(repos, session_id, "microphone", &[])
+                    .await;
+            }
             repos
                 .set_note_status(
                     note_id,
                     ProcessingStatus::Failed,
-                    Some(error.message.clone()),
+                    Some(user_message.clone()),
                 )
                 .await?;
-            return Err(error);
+            return Err(AppError::new(&error.code, user_message));
         }
     };
     persist_microphone_only_transcript_coverage(
@@ -3246,6 +3260,14 @@ mod tests {
             serde_json::from_str(&details).expect("checkpoint json");
         assert_eq!(checkpoint["totalFailedTurns"], 1);
         assert_eq!(checkpoint["sources"][0]["failedTurns"], 1);
+    }
+
+    #[test]
+    fn microphone_only_coverage_with_no_chunks_documents_zero_detected_speech() {
+        let coverage = compute_chunk_transcript_coverage("microphone", &[]);
+        assert_eq!(coverage.total_detected_speech_ms, 0);
+        assert_eq!(coverage.total_transcribed_ms, 0);
+        assert!(!coverage.warning);
     }
 
     #[test]

--- a/src-tauri/src/domain/types.rs
+++ b/src-tauri/src/domain/types.rs
@@ -347,6 +347,8 @@ pub struct TranscriptDto {
     pub language: Option<String>,
     pub status: String,
     pub last_error: Option<String>,
+    #[serde(default)]
+    pub recorded_silence: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -424,6 +426,7 @@ pub struct SourceValidationDto {
     pub actual_duration_ms: Option<i64>,
     pub duration_within_tolerance: bool,
     pub non_silent_signal: bool,
+    pub recorded_silence: bool,
     pub peak_amplitude: Option<f32>,
     pub rms_amplitude: Option<f32>,
     pub warnings: Vec<String>,
@@ -448,6 +451,8 @@ pub struct AudioValidationDto {
     pub actual_duration_ms: i64,
     pub duration_within_tolerance: bool,
     pub non_silent_signal: bool,
+    #[serde(default)]
+    pub recorded_silence: bool,
     pub peak_amplitude: f32,
     pub rms_amplitude: f32,
     pub warnings: Vec<String>,

--- a/src-tauri/src/hermes/june_recorder_mcp.py
+++ b/src-tauri/src/hermes/june_recorder_mcp.py
@@ -173,10 +173,11 @@ def call_tool(
                 "POST",
                 "/recorder/start",
                 {"sourceMode": source_mode},
+                retry_5xx=False,
             )
             return tool_text_result(request_id, render_start_result(result))
         if name == "stop_recording":
-            result = proxy_json(base_url, token, "POST", "/recorder/stop", {})
+            result = proxy_json(base_url, token, "POST", "/recorder/stop", {}, retry_5xx=False)
             return tool_text_result(request_id, render_stop_result(result))
         if name == "recording_status":
             result = proxy_json(base_url, token, "GET", "/recorder/status", None)
@@ -199,7 +200,12 @@ def proxy_json(
     method: str,
     path: str,
     payload: dict[str, Any] | None,
+    retry_5xx: bool = True,
 ) -> dict[str, Any]:
+    # start/stop are not idempotent: a retried POST after a lease-expiry 504
+    # mints a NEW recorder request while the first may still be in flight,
+    # so mutations must pass retry_5xx=False (status stays retryable).
+    max_attempts = REQUEST_MAX_ATTEMPTS if retry_5xx else 1
     url = f"{base_url}{path}"
     data = None
     headers = {"Authorization": f"Bearer {token}"}
@@ -208,7 +214,7 @@ def proxy_json(
         headers["Content-Type"] = "application/json"
     request = urllib.request.Request(url, data=data, headers=headers, method=method)
     last_error: Exception | None = None
-    for attempt in range(REQUEST_MAX_ATTEMPTS):
+    for attempt in range(max_attempts):
         try:
             with urllib.request.urlopen(
                 request, timeout=REQUEST_TIMEOUT_SECONDS
@@ -220,12 +226,12 @@ def proxy_json(
                 parsed = json.loads(body)
             except json.JSONDecodeError:
                 parsed = {"success": False, "message": body or exc.reason}
-            if exc.code < 500 or attempt == REQUEST_MAX_ATTEMPTS - 1:
+            if exc.code < 500 or attempt == max_attempts - 1:
                 return parsed
             last_error = exc
         except urllib.error.URLError as exc:
             last_error = exc
-        if attempt < REQUEST_MAX_ATTEMPTS - 1:
+        if attempt < max_attempts - 1:
             time.sleep(REQUEST_RETRY_DELAY_SECONDS)
     raise ToolError(f"June recorder proxy is unavailable: {last_error}")
 

--- a/src-tauri/src/hermes/june_recorder_mcp.py
+++ b/src-tauri/src/hermes/june_recorder_mcp.py
@@ -23,10 +23,11 @@ from typing import Any
 
 PROTOCOL_VERSION = "2025-03-26"
 SERVER_INFO = {"name": "june-recorder", "version": "0.1.0"}
-# Must outlive the proxy's 240s request lease (readiness probe + first-run
-# microphone permission prompt + capture start), or the tool gives up while
-# June is still legitimately waiting on the user.
-REQUEST_TIMEOUT_SECONDS = 300
+# Must outlive the proxy's 420s request lease (two readiness passes with the
+# system-audio permission probe, the first-run microphone prompt, and capture
+# start), or the tool gives up while June is still legitimately waiting on
+# the user. The Hermes-side tool timeout (620s) sits above this in turn.
+REQUEST_TIMEOUT_SECONDS = 480
 REQUEST_MAX_ATTEMPTS = 2
 REQUEST_RETRY_DELAY_SECONDS = 0.25
 TOKEN_ENV_VAR = "JUNE_RECORDER_PROXY_TOKEN"

--- a/src-tauri/src/hermes/june_recorder_mcp.py
+++ b/src-tauri/src/hermes/june_recorder_mcp.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""MCP server exposing June local recording controls.
+
+The June app writes this script into the managed Hermes home and registers it as
+the built-in `june_recorder` MCP server. Its tools call the June app's local
+provider proxy (loopback only), which emits a frontend event and waits for the
+main June window to run the same visible recording flows the UI uses.
+
+It depends only on the Python standard library so it can run inside the Hermes
+runtime venv without extra packaging.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+PROTOCOL_VERSION = "2025-03-26"
+SERVER_INFO = {"name": "june-recorder", "version": "0.1.0"}
+REQUEST_TIMEOUT_SECONDS = 20
+REQUEST_MAX_ATTEMPTS = 2
+REQUEST_RETRY_DELAY_SECONDS = 0.25
+TOKEN_ENV_VAR = "JUNE_RECORDER_PROXY_TOKEN"
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "start_recording",
+        "description": (
+            "Start a visible June recording only when the user explicitly asks "
+            "you to start recording, record a meeting, or begin capture now. "
+            "Never call this proactively. Use source_mode meeting for meeting "
+            "mode with microphone and system audio, or microphone for "
+            "microphone-only recording. Returns the new note id and title."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source_mode": {
+                    "type": "string",
+                    "enum": ["microphone", "meeting"],
+                    "description": "The recording source mode to start.",
+                },
+            },
+            "required": ["source_mode"],
+        },
+    },
+    {
+        "name": "stop_recording",
+        "description": (
+            "Stop the active June recording when the user asks you to stop it. "
+            "This starts note processing. Returns an error when no recording "
+            "is running."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "recording_status",
+        "description": (
+            "Check whether June is currently recording. Returns none, or the "
+            "active note id, elapsed milliseconds, and source mode."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+]
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: june_recorder_mcp.py <proxy_base_url>")
+
+    base_url = sys.argv[1].rstrip("/")
+    token = os.environ.get(TOKEN_ENV_VAR, "")
+    while True:
+        message = read_message()
+        if message is None:
+            return
+        response_message = handle_message(base_url, token, message)
+        if response_message is not None:
+            write_message(response_message)
+
+
+def read_message() -> dict[str, Any] | None:
+    while True:
+        first = sys.stdin.buffer.readline()
+        if first == b"":
+            return None
+        if first.strip():
+            break
+    if not first.lower().startswith(b"content-length:"):
+        return json.loads(first.strip().decode("utf-8"))
+
+    headers: dict[str, str] = {}
+    name, _, value = first.decode("ascii", "replace").partition(":")
+    headers[name.lower()] = value.strip()
+    while True:
+        line = sys.stdin.buffer.readline()
+        if line == b"":
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, _, value = line.decode("ascii", "replace").partition(":")
+        headers[name.lower()] = value.strip()
+
+    length = int(headers.get("content-length", "0"))
+    if length <= 0:
+        return None
+    body = sys.stdin.buffer.read(length)
+    return json.loads(body.decode("utf-8"))
+
+
+def write_message(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def handle_message(
+    base_url: str,
+    token: str,
+    message: dict[str, Any],
+) -> dict[str, Any] | None:
+    method = message.get("method")
+    request_id = message.get("id")
+
+    if method == "initialize":
+        return response(
+            request_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": SERVER_INFO,
+            },
+        )
+    if method == "notifications/initialized":
+        return None
+    if method == "ping":
+        return response(request_id, {})
+    if method == "tools/list":
+        return response(request_id, {"tools": TOOLS})
+    if method == "tools/call":
+        return call_tool(base_url, token, request_id, message.get("params") or {})
+
+    if request_id is None:
+        return None
+    return error_response(request_id, -32601, f"Unknown method: {method}")
+
+
+def call_tool(
+    base_url: str,
+    token: str,
+    request_id: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+    try:
+        if name == "start_recording":
+            source_mode = arguments.get("source_mode")
+            if source_mode not in ("microphone", "meeting"):
+                raise ToolError("source_mode must be microphone or meeting.")
+            result = proxy_json(
+                base_url,
+                token,
+                "POST",
+                "/recorder/start",
+                {"sourceMode": source_mode},
+            )
+            return tool_text_result(request_id, render_start_result(result))
+        if name == "stop_recording":
+            result = proxy_json(base_url, token, "POST", "/recorder/stop", {})
+            return tool_text_result(request_id, render_stop_result(result))
+        if name == "recording_status":
+            result = proxy_json(base_url, token, "GET", "/recorder/status", None)
+            return tool_text_result(request_id, render_status_result(result))
+    except ToolError as exc:
+        return tool_text_result(request_id, str(exc), is_error=True)
+    except Exception as exc:
+        return tool_text_result(
+            request_id,
+            f"June recorder request failed: {exc}",
+            is_error=True,
+        )
+
+    return error_response(request_id, -32602, f"Unknown tool: {name}")
+
+
+def proxy_json(
+    base_url: str,
+    token: str,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    url = f"{base_url}{path}"
+    data = None
+    headers = {"Authorization": f"Bearer {token}"}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    last_error: Exception | None = None
+    for attempt in range(REQUEST_MAX_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(
+                request, timeout=REQUEST_TIMEOUT_SECONDS
+            ) as response_value:
+                return json.loads(response_value.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", "replace")
+            try:
+                parsed = json.loads(body)
+            except json.JSONDecodeError:
+                parsed = {"success": False, "message": body or exc.reason}
+            if exc.code < 500 or attempt == REQUEST_MAX_ATTEMPTS - 1:
+                return parsed
+            last_error = exc
+        except urllib.error.URLError as exc:
+            last_error = exc
+        if attempt < REQUEST_MAX_ATTEMPTS - 1:
+            time.sleep(REQUEST_RETRY_DELAY_SECONDS)
+    raise ToolError(f"June recorder proxy is unavailable: {last_error}")
+
+
+def render_start_result(result: dict[str, Any]) -> str:
+    data = require_success(result)
+    note_id = data.get("noteId") or "unknown"
+    title = data.get("noteTitle") or "Untitled"
+    return (
+        f"Started recording: {title} ({note_id}). "
+        "The recording is now visible in the recorder bar."
+    )
+
+
+def render_stop_result(result: dict[str, Any]) -> str:
+    data = require_success(result)
+    note_id = data.get("noteId") or "unknown"
+    title = data.get("noteTitle") or "Untitled"
+    return f"Stopped recording: {title} ({note_id}). Note processing has started."
+
+
+def render_status_result(result: dict[str, Any]) -> str:
+    data = require_success(result)
+    if data.get("state") == "none":
+        return "No recording is currently running."
+    note_id = data.get("noteId") or "unknown"
+    elapsed = data.get("elapsed") or 0
+    source_mode = data.get("sourceMode") or "microphoneOnly"
+    return (
+        "Recording is running: "
+        f"note {note_id}, elapsed {elapsed} ms, source mode {source_mode}."
+    )
+
+
+def require_success(result: dict[str, Any]) -> dict[str, Any]:
+    if result.get("success") is True:
+        data = result.get("data")
+        return data if isinstance(data, dict) else {}
+    message = result.get("message") or "June recorder request failed."
+    raise ToolError(str(message))
+
+
+def response(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def error_response(request_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def tool_text_result(
+    request_id: Any,
+    text: str,
+    is_error: bool = False,
+) -> dict[str, Any]:
+    return response(
+        request_id,
+        {"content": [{"type": "text", "text": text}], "isError": is_error},
+    )
+
+
+class ToolError(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/src/hermes/june_recorder_mcp.py
+++ b/src-tauri/src/hermes/june_recorder_mcp.py
@@ -23,7 +23,10 @@ from typing import Any
 
 PROTOCOL_VERSION = "2025-03-26"
 SERVER_INFO = {"name": "june-recorder", "version": "0.1.0"}
-REQUEST_TIMEOUT_SECONDS = 20
+# Must outlive the proxy's 240s request lease (readiness probe + first-run
+# microphone permission prompt + capture start), or the tool gives up while
+# June is still legitimately waiting on the user.
+REQUEST_TIMEOUT_SECONDS = 300
 REQUEST_MAX_ATTEMPTS = 2
 REQUEST_RETRY_DELAY_SECONDS = 0.25
 TOKEN_ENV_VAR = "JUNE_RECORDER_PROXY_TOKEN"

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -107,6 +107,10 @@ const JUNE_RECORDER_MCP_SCRIPT: &str = include_str!("hermes/june_recorder_mcp.py
 /// Environment variable the `june_recorder` MCP reads its loopback proxy token
 /// from. Kept out of argv so it does not appear in process listings.
 const JUNE_RECORDER_MCP_TOKEN_ENV: &str = "JUNE_RECORDER_PROXY_TOKEN";
+/// Hermes-side per-tool-call timeout for `june_recorder`; the top of the
+/// timeout stack (proxy lease < python client < this), pinned by
+/// `recorder_timeout_stack_ordering_holds`.
+const JUNE_RECORDER_MCP_TOOL_TIMEOUT_SECS: u64 = 620;
 const AGENT_RECORDER_REQUEST_EVENT: &str = "june://agent-recorder-request";
 // The frontend start path can legitimately take minutes: readiness runs
 // twice (React probes before startRecording, then the command re-probes) and
@@ -6782,10 +6786,11 @@ fn render_recorder_mcp_entry(
     env:
       PYTHONUNBUFFERED: "1"
       {token_env}: {token}
-    timeout: 620
+    timeout: {tool_timeout}
     connect_timeout: 10
 "#,
         server_name = JUNE_RECORDER_MCP_SERVER_NAME,
+        tool_timeout = JUNE_RECORDER_MCP_TOOL_TIMEOUT_SECS,
         command = yaml_string(&config.command),
         script_path = yaml_string(&config.script_path.to_string_lossy()),
         base_url = yaml_string(base_url),
@@ -8810,6 +8815,28 @@ mod tests {
     }
 
     #[test]
+    fn recorder_timeout_stack_ordering_holds() {
+        // Parse the python client's timeout out of the embedded script so a
+        // bump of any leg fails a test instead of drifting by comment.
+        let python_timeout: u64 = JUNE_RECORDER_MCP_SCRIPT
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("REQUEST_TIMEOUT_SECONDS = "))
+            .expect("script declares REQUEST_TIMEOUT_SECONDS")
+            .trim()
+            .parse()
+            .expect("timeout is an integer");
+        let lease = AGENT_RECORDER_REQUEST_TIMEOUT.as_secs();
+        assert!(
+            lease + 30 <= python_timeout,
+            "python client ({python_timeout}s) must outlive the proxy lease ({lease}s) with slack"
+        );
+        assert!(
+            python_timeout + 30 <= JUNE_RECORDER_MCP_TOOL_TIMEOUT_SECS,
+            "hermes tool timeout ({JUNE_RECORDER_MCP_TOOL_TIMEOUT_SECS}s) must outlive the python client ({python_timeout}s) with slack"
+        );
+    }
+
+    #[test]
     fn agent_recorder_lease_outlives_the_worst_honest_start_path() {
         // Readiness runs twice on the agent start path (React probes before
         // startRecording, the command re-probes), each pass can wait the full
@@ -9667,10 +9694,13 @@ mcp_servers:
         // general provider token.
         assert!(config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"recorder-proxy-tok\"\n"));
         assert!(!config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"proxy-tok\"\n"));
-        // The Hermes-side tool timeout must outlive the proxy lease (240s)
-        // plus the Python client's attempt (300s), or Hermes reports failure
-        // while June is still honestly waiting on the permission prompt.
-        assert!(config.contains("    timeout: 620\n"));
+        // The Hermes-side tool timeout must sit at the top of the stack
+        // (proxy lease < python client < hermes), or Hermes reports failure
+        // while June is still honestly waiting on the permission prompt;
+        // `recorder_timeout_stack_ordering_holds` pins the full ordering.
+        assert!(config.contains(&format!(
+            "    timeout: {JUNE_RECORDER_MCP_TOOL_TIMEOUT_SECS}\n"
+        )));
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -101,6 +101,14 @@ const JUNE_WORKSPACE_UPLOADS_DIR_NAME: &str = "uploads";
 /// Environment variable the `june_image` MCP reads its loopback proxy token
 /// from. Kept out of argv so it does not appear in process listings.
 const JUNE_IMAGE_MCP_TOKEN_ENV: &str = "JUNE_IMAGE_PROXY_TOKEN";
+const JUNE_RECORDER_MCP_SERVER_NAME: &str = "june_recorder";
+const JUNE_RECORDER_MCP_SCRIPT_NAME: &str = "june_recorder_mcp.py";
+const JUNE_RECORDER_MCP_SCRIPT: &str = include_str!("hermes/june_recorder_mcp.py");
+/// Environment variable the `june_recorder` MCP reads its loopback proxy token
+/// from. Kept out of argv so it does not appear in process listings.
+const JUNE_RECORDER_MCP_TOKEN_ENV: &str = "JUNE_RECORDER_PROXY_TOKEN";
+const AGENT_RECORDER_REQUEST_EVENT: &str = "june://agent-recorder-request";
+const AGENT_RECORDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Identity injected into every Hermes session via `SOUL.md`. Hermes loads
 /// this file from `HERMES_HOME` at prompt-build time; without it the runtime
@@ -157,6 +165,14 @@ Use this toolset instead of any generic image, media, or vision-analysis tool fo
 Do not add a separate content refusal layer before calling these tools. The user's selected image model and image safe-mode setting are authoritative for what the image provider should attempt. If the selected model and setting may support the request, call the image tool with the user's prompt instead of substituting a clothed or sanitized alternative. If the image provider rejects the request, briefly report that provider rejection.
 Set `may_be_explicit` honestly on every `generate_image` or `edit_image` call, judging whether the requested image could contain adult, sexual, or otherwise explicit content from the request itself rather than only its wording.
 When the user asks to change, adjust, refine, or reframe an image you just made with `generate_image` or `edit_image`, or an image the user attached or pasted into the conversation, including "make it bigger/wider", "zoom out", "from a bigger perspective", "closer", "another angle", "different color", "add/remove X", or "make it a cartoon", call `edit_image` with the exact source image as `source_filename` and an `instruction` describing the change. `edit_image` transforms the existing image file directly (image to image): you do NOT need to see, view, analyze, or describe the image to edit it, and you must not ask the user to describe it or call any vision or image-analysis tool first. Prefer `edit_image` over `generate_image` for any follow-up tweak to an image this toolset already produced or the user attached, even if you cannot see it. Pass exactly one of two `source_filename` values: the edit-safe filename from a prior `june_image` tool result, or the plain filename of an image the user attached to the conversation as shown in its context, such as `upload_20260707_113453_1.png`. Never pass a full path or an invented name.
+"#;
+
+/// Appended to `SOUL.md` for every runtime. The `june_recorder` MCP server can
+/// start and stop local recording, but only by routing through the frontend so
+/// the recorder bar and HUD stay visible to the user.
+const JUNE_SOUL_RECORDER_MD: &str = r#"
+Recording tools: you have a `june_recorder` MCP toolset with `start_recording`, `stop_recording`, and `recording_status`. Only call `start_recording` when the user explicitly asks you to start recording, record a meeting, or begin capture now. Never start recording proactively or because recording might be useful. If the user asks you to stop the current recording, call `stop_recording`.
+When the user asks how to record a meeting, explain the normal UI path accurately: open or create a note, press the Record button in the note editor, and use Recording options if they want to choose microphone-only or meeting mode. While recording is active, June shows the recorder bar on the note and a recorder presence in the sidebar or floating recorder pill when they browse away.
 "#;
 
 /// Appended to `SOUL.md` only when the Seatbelt write-jail engages on this
@@ -314,6 +330,7 @@ pub struct HermesBridge {
     /// per-process proxy would rewrite the file under the other process.
     /// Started lazily on the first spawn, lives until app shutdown.
     provider_proxy: Mutex<Option<SharedProviderProxy>>,
+    recorder_requests: Arc<Mutex<HashMap<String, oneshot::Sender<AgentRecorderResolution>>>>,
 }
 
 struct HermesProcess {
@@ -337,6 +354,7 @@ struct ProviderProxyState {
     /// of the same request replays the same shape even if the user flipped
     /// the toggle in between (June API bills a changed shape as a new call).
     image_safe_mode_pins: Arc<Mutex<VecDeque<(String, bool)>>>,
+    recorder_requests: Arc<Mutex<HashMap<String, oneshot::Sender<AgentRecorderResolution>>>>,
 }
 
 #[derive(Clone, Serialize)]
@@ -821,6 +839,31 @@ pub async fn ensure_hermes_bridge_gateway(bridge: State<'_, HermesBridge>) -> Re
     ensure_hermes_gateway_running(connection).await
 }
 
+#[tauri::command]
+pub fn resolve_agent_recorder_request(
+    bridge: State<'_, HermesBridge>,
+    request: ResolveAgentRecorderRequest,
+) -> Result<(), AppError> {
+    let sender = bridge
+        .recorder_requests
+        .lock()
+        .map_err(|_| {
+            AppError::new(
+                "agent_recorder_unavailable",
+                "Recorder request lock failed.",
+            )
+        })?
+        .remove(&request.request_id)
+        .ok_or_else(|| {
+            AppError::new(
+                "agent_recorder_request_not_found",
+                "Recorder request was not found or has already timed out.",
+            )
+        })?;
+    let _ = sender.send(request);
+    Ok(())
+}
+
 async fn start_hermes_bridge_inner(
     app: &AppHandle,
     bridge: &HermesBridge,
@@ -871,6 +914,7 @@ async fn start_hermes_bridge_inner(
     let june_context_mcp = sync_june_context_mcp(app, &command)?;
     let june_web_mcp = sync_june_web_mcp(app, &command)?;
     let june_image_mcp = sync_june_image_mcp(app, &hermes_home, &command)?;
+    let june_recorder_mcp = sync_june_recorder_mcp(app, &command)?;
     sync_hermes_config(
         app,
         &hermes_home,
@@ -879,6 +923,7 @@ async fn start_hermes_bridge_inner(
         &june_context_mcp,
         &june_web_mcp,
         &june_image_mcp,
+        &june_recorder_mcp,
     )?;
 
     // Wrap the spawn in a macOS Seatbelt write-jail when possible. The model,
@@ -1035,8 +1080,13 @@ async fn ensure_provider_proxy(
         images_dir: hermes_home.join(JUNE_IMAGE_MCP_IMAGES_DIR_NAME),
         secret: load_or_create_image_source_capability_secret(&app_data_dir)?,
     };
-    let started =
-        start_june_provider_proxy(token.clone(), image_sources, Some(app.clone())).await?;
+    let started = start_june_provider_proxy(
+        token.clone(),
+        image_sources,
+        Some(app.clone()),
+        Arc::clone(&bridge.recorder_requests),
+    )
+    .await?;
     let mut guard = bridge
         .provider_proxy
         .lock()
@@ -1078,6 +1128,45 @@ struct JuneImageMcpConfig {
     script_path: PathBuf,
     images_dir: PathBuf,
 }
+
+#[derive(Debug, Clone)]
+struct JuneRecorderMcpConfig {
+    command: String,
+    script_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentRecorderRequestPayload {
+    request_id: String,
+    action: AgentRecorderAction,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_mode: Option<crate::domain::types::RecordingSourceMode>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+enum AgentRecorderAction {
+    Start,
+    Stop,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveAgentRecorderRequest {
+    pub request_id: String,
+    pub ok: bool,
+    #[serde(default)]
+    pub note_id: Option<String>,
+    #[serde(default)]
+    pub note_title: Option<String>,
+    #[serde(default)]
+    pub error_code: Option<String>,
+    #[serde(default)]
+    pub error_message: Option<String>,
+}
+
+type AgentRecorderResolution = ResolveAgentRecorderRequest;
 
 #[tauri::command]
 pub async fn stop_hermes_bridge(
@@ -6278,6 +6367,25 @@ fn sync_june_image_mcp(
     })
 }
 
+fn sync_june_recorder_mcp(
+    app: &AppHandle,
+    hermes_command: &str,
+) -> Result<JuneRecorderMcpConfig, AppError> {
+    let data_dir = crate::app_paths::app_data_dir(app)
+        .map_err(|error| AppError::new("june_recorder_mcp_failed", error.to_string()))?;
+    let mcp_dir = data_dir.join(JUNE_CONTEXT_MCP_DIR_NAME);
+    fs::create_dir_all(&mcp_dir)
+        .map_err(|error| AppError::new("june_recorder_mcp_failed", error.to_string()))?;
+    let script_path = mcp_dir.join(JUNE_RECORDER_MCP_SCRIPT_NAME);
+    fs::write(&script_path, JUNE_RECORDER_MCP_SCRIPT)
+        .map_err(|error| AppError::new("june_recorder_mcp_failed", error.to_string()))?;
+
+    Ok(JuneRecorderMcpConfig {
+        command: hermes_python_command(hermes_command),
+        script_path,
+    })
+}
+
 fn remove_legacy_image_source_secret(hermes_home: &Path) -> Result<(), AppError> {
     let path = hermes_home.join(LEGACY_IMAGE_SOURCE_SECRET_FILE);
     match fs::remove_file(&path) {
@@ -6327,6 +6435,7 @@ fn sync_hermes_config(
     june_context_mcp: &JuneContextMcpConfig,
     june_web_mcp: &JuneWebMcpConfig,
     june_image_mcp: &JuneImageMcpConfig,
+    june_recorder_mcp: &JuneRecorderMcpConfig,
 ) -> Result<(), AppError> {
     sync_hermes_config_with_external_dirs(
         hermes_home,
@@ -6335,6 +6444,7 @@ fn sync_hermes_config(
         june_context_mcp,
         june_web_mcp,
         june_image_mcp,
+        june_recorder_mcp,
         &external_skill_dirs(app),
     )
 }
@@ -6346,6 +6456,7 @@ fn sync_hermes_config_with_external_dirs(
     june_context_mcp: &JuneContextMcpConfig,
     june_web_mcp: &JuneWebMcpConfig,
     june_image_mcp: &JuneImageMcpConfig,
+    june_recorder_mcp: &JuneRecorderMcpConfig,
     external_skill_dirs: &[PathBuf],
 ) -> Result<(), AppError> {
     let model = crate::providers::generation_model();
@@ -6359,6 +6470,7 @@ fn sync_hermes_config_with_external_dirs(
         Some(june_context_mcp),
         Some(june_web_mcp),
         Some(june_image_mcp),
+        Some(june_recorder_mcp),
     );
     let config_path = hermes_home.join("config.yaml");
     // MERGE over the existing config, never replace it: the jailed dashboard
@@ -6415,6 +6527,7 @@ fn deep_merge_yaml(base: serde_yaml::Value, overlay: serde_yaml::Value) -> serde
 /// rendered YAML (including the `skills.external_dirs` block) can be asserted in
 /// tests. Hermes deep-merges these keys over its own defaults, so June only
 /// writes the values it controls.
+#[allow(clippy::too_many_arguments)]
 fn render_hermes_config(
     model: &str,
     base_url: &str,
@@ -6424,6 +6537,7 @@ fn render_hermes_config(
     june_context_mcp: Option<&JuneContextMcpConfig>,
     june_web_mcp: Option<&JuneWebMcpConfig>,
     june_image_mcp: Option<&JuneImageMcpConfig>,
+    june_recorder_mcp: Option<&JuneRecorderMcpConfig>,
 ) -> String {
     let skills_block = if external_skill_dirs.is_empty() {
         "  external_dirs: []\n".to_string()
@@ -6438,6 +6552,7 @@ fn render_hermes_config(
         june_context_mcp,
         june_web_mcp,
         june_image_mcp,
+        june_recorder_mcp,
         base_url,
         provider_proxy_token,
     );
@@ -6469,6 +6584,7 @@ fn render_mcp_servers_config(
     context: Option<&JuneContextMcpConfig>,
     web: Option<&JuneWebMcpConfig>,
     image: Option<&JuneImageMcpConfig>,
+    recorder: Option<&JuneRecorderMcpConfig>,
     base_url: &str,
     proxy_token: &str,
 ) -> String {
@@ -6481,6 +6597,9 @@ fn render_mcp_servers_config(
     }
     if let Some(config) = image {
         entries.push_str(&render_image_mcp_entry(config, base_url, proxy_token));
+    }
+    if let Some(config) = recorder {
+        entries.push_str(&render_recorder_mcp_entry(config, base_url, proxy_token));
     }
     if entries.is_empty() {
         return "mcp_servers: {}\n".to_string();
@@ -6568,6 +6687,33 @@ fn render_image_mcp_entry(
     )
 }
 
+fn render_recorder_mcp_entry(
+    config: &JuneRecorderMcpConfig,
+    base_url: &str,
+    proxy_token: &str,
+) -> String {
+    format!(
+        r#"  {server_name}:
+    enabled: true
+    command: {command}
+    args:
+      - {script_path}
+      - {base_url}
+    env:
+      PYTHONUNBUFFERED: "1"
+      {token_env}: {token}
+    timeout: 30
+    connect_timeout: 10
+"#,
+        server_name = JUNE_RECORDER_MCP_SERVER_NAME,
+        command = yaml_string(&config.command),
+        script_path = yaml_string(&config.script_path.to_string_lossy()),
+        base_url = yaml_string(base_url),
+        token_env = JUNE_RECORDER_MCP_TOKEN_ENV,
+        token = yaml_string(proxy_token),
+    )
+}
+
 /// External skill directories Hermes loads in addition to its built-in
 /// `$HERMES_HOME/skills`. User-global `~/.agents/skills` entries stay first so
 /// user/team skills can shadow app-bundled skills when names collide. The
@@ -6627,10 +6773,10 @@ fn sync_june_soul(
             JUNE_SOUL_CLI_BLOCKED_MD
         };
         format!(
-            "{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_IMAGE_MD}{JUNE_SOUL_SANDBOX_MD}{cli_section}"
+            "{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_IMAGE_MD}{JUNE_SOUL_RECORDER_MD}{JUNE_SOUL_SANDBOX_MD}{cli_section}"
         )
     } else {
-        format!("{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_IMAGE_MD}")
+        format!("{JUNE_SOUL_MD}{JUNE_SOUL_CONTEXT_MD}{JUNE_SOUL_CLARIFY_MD}{JUNE_SOUL_WEB_MD}{JUNE_SOUL_IMAGE_MD}{JUNE_SOUL_RECORDER_MD}")
     };
     std::fs::write(hermes_home.join("SOUL.md"), soul)
         .map_err(|error| AppError::new("hermes_bridge_soul_failed", error.to_string()))
@@ -6789,6 +6935,7 @@ async fn start_june_provider_proxy(
     token: String,
     image_sources: ImageSourceCapabilities,
     app: Option<AppHandle>,
+    recorder_requests: Arc<Mutex<HashMap<String, oneshot::Sender<AgentRecorderResolution>>>>,
 ) -> Result<RunningJuneProviderProxy, AppError> {
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .map_err(|error| AppError::new("june_provider_proxy_failed", error.to_string()))?;
@@ -6809,6 +6956,7 @@ async fn start_june_provider_proxy(
             image_sources,
             app,
             image_safe_mode_pins: Arc::new(Mutex::new(VecDeque::new())),
+            recorder_requests,
         }),
         shutdown_rx,
     ));
@@ -6981,6 +7129,23 @@ async fn handle_june_provider_connection(
             }
             forward_image_tool(&mut stream, "/v1/image/edit", &body, &state.image_sources).await?;
         }
+        ("POST", "/v1/recorder/start") => {
+            let body = serde_json::from_slice::<serde_json::Value>(&request.body)
+                .unwrap_or_else(|_| serde_json::json!({}));
+            handle_recorder_action(&mut stream, state, AgentRecorderAction::Start, &body).await?;
+        }
+        ("POST", "/v1/recorder/stop") => {
+            handle_recorder_action(
+                &mut stream,
+                state,
+                AgentRecorderAction::Stop,
+                &serde_json::json!({}),
+            )
+            .await?;
+        }
+        ("GET", "/v1/recorder/status") => {
+            write_json_response(&mut stream, 200, recorder_status_body()).await?;
+        }
         _ => {
             write_json_response(
                 &mut stream,
@@ -6991,6 +7156,198 @@ async fn handle_june_provider_connection(
         }
     }
     Ok(())
+}
+
+async fn handle_recorder_action(
+    stream: &mut tokio::net::TcpStream,
+    state: Arc<ProviderProxyState>,
+    action: AgentRecorderAction,
+    body: &serde_json::Value,
+) -> io::Result<()> {
+    let source_mode = match action {
+        AgentRecorderAction::Start => match recorder_source_mode_from_body(body) {
+            Ok(source_mode) => Some(source_mode),
+            Err(message) => {
+                write_json_response(
+                    stream,
+                    400,
+                    serde_json::json!({ "success": false, "message": message }),
+                )
+                .await?;
+                return Ok(());
+            }
+        },
+        AgentRecorderAction::Stop => None,
+    };
+
+    if action == AgentRecorderAction::Start {
+        if let Some(status) = crate::audio::capture::current_status() {
+            let note = status.note_id.unwrap_or_else(|| status.session_id.clone());
+            write_json_response(
+                stream,
+                409,
+                serde_json::json!({
+                    "success": false,
+                    "message": format!("A recording is already running for note {note}."),
+                    "errorCode": "recording_already_running",
+                }),
+            )
+            .await?;
+            return Ok(());
+        }
+    }
+
+    if action == AgentRecorderAction::Stop && crate::audio::capture::current_status().is_none() {
+        write_json_response(
+            stream,
+            409,
+            serde_json::json!({
+                "success": false,
+                "message": "No recording is currently running.",
+                "errorCode": "recording_not_found",
+            }),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (sender, receiver) = oneshot::channel();
+    {
+        let mut pending = state
+            .recorder_requests
+            .lock()
+            .map_err(|_| io::Error::other("Recorder request lock failed."))?;
+        pending.insert(request_id.clone(), sender);
+    }
+    let payload = AgentRecorderRequestPayload {
+        request_id: request_id.clone(),
+        action,
+        source_mode,
+    };
+    let emit_result = state
+        .app
+        .as_ref()
+        .and_then(|app| app.get_webview_window("main"))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Main window is unavailable."))
+        .and_then(|window| {
+            window
+                .emit(AGENT_RECORDER_REQUEST_EVENT, payload)
+                .map_err(io::Error::other)
+        });
+    if let Err(error) = emit_result {
+        remove_pending_recorder_request(&state.recorder_requests, &request_id);
+        write_json_response(
+            stream,
+            503,
+            serde_json::json!({
+                "success": false,
+                "message": format!("Recorder request could not reach the June window: {error}"),
+                "errorCode": "agent_recorder_window_unavailable",
+            }),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    match tokio::time::timeout(AGENT_RECORDER_REQUEST_TIMEOUT, receiver).await {
+        Ok(Ok(resolution)) => {
+            let status = if resolution.ok { 200 } else { 409 };
+            write_json_response(stream, status, recorder_resolution_body(resolution)).await?;
+        }
+        Ok(Err(_)) => {
+            write_json_response(
+                stream,
+                500,
+                serde_json::json!({
+                    "success": false,
+                    "message": "Recorder request was cancelled before June answered.",
+                    "errorCode": "agent_recorder_cancelled",
+                }),
+            )
+            .await?;
+        }
+        Err(_) => {
+            remove_pending_recorder_request(&state.recorder_requests, &request_id);
+            write_json_response(
+                stream,
+                504,
+                serde_json::json!({
+                    "success": false,
+                    "message": "Recorder request timed out waiting for June.",
+                    "errorCode": "agent_recorder_timeout",
+                }),
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_pending_recorder_request(
+    pending: &Mutex<HashMap<String, oneshot::Sender<AgentRecorderResolution>>>,
+    request_id: &str,
+) {
+    if let Ok(mut pending) = pending.lock() {
+        pending.remove(request_id);
+    }
+}
+
+fn recorder_source_mode_from_body(
+    body: &serde_json::Value,
+) -> Result<crate::domain::types::RecordingSourceMode, String> {
+    let mode = body
+        .get("sourceMode")
+        .or_else(|| body.get("source_mode"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("microphone");
+    match mode {
+        "microphone" | "microphoneOnly" | "microphone_only" => {
+            Ok(crate::domain::types::RecordingSourceMode::MicrophoneOnly)
+        }
+        "meeting" | "microphonePlusSystem" | "microphone_plus_system" => {
+            Ok(crate::domain::types::RecordingSourceMode::MicrophonePlusSystem)
+        }
+        _ => Err("source_mode must be microphone or meeting.".to_string()),
+    }
+}
+
+fn recorder_resolution_body(resolution: AgentRecorderResolution) -> serde_json::Value {
+    if resolution.ok {
+        serde_json::json!({
+            "success": true,
+            "data": {
+                "noteId": resolution.note_id,
+                "noteTitle": resolution.note_title,
+            }
+        })
+    } else {
+        serde_json::json!({
+            "success": false,
+            "message": resolution.error_message.unwrap_or_else(|| "Recorder request failed.".to_string()),
+            "errorCode": resolution.error_code.unwrap_or_else(|| "agent_recorder_failed".to_string()),
+        })
+    }
+}
+
+fn recorder_status_body() -> serde_json::Value {
+    match crate::audio::capture::current_status() {
+        Some(status) => serde_json::json!({
+            "success": true,
+            "data": {
+                "state": "recording",
+                "noteId": status.note_id,
+                "elapsed": status.elapsed_ms,
+                "sourceMode": status.source_mode,
+            }
+        }),
+        None => serde_json::json!({
+            "success": true,
+            "data": {
+                "state": "none",
+            }
+        }),
+    }
 }
 
 struct HttpRequest {
@@ -8583,6 +8940,51 @@ mod tests {
         assert_eq!(pins.back().map(|(id, _)| id.as_str()), Some("req-new"));
     }
 
+    #[test]
+    fn recorder_source_mode_accepts_tool_and_wire_values() {
+        assert_eq!(
+            recorder_source_mode_from_body(&serde_json::json!({ "sourceMode": "microphone" }))
+                .expect("microphone mode"),
+            crate::domain::types::RecordingSourceMode::MicrophoneOnly
+        );
+        assert_eq!(
+            recorder_source_mode_from_body(&serde_json::json!({ "source_mode": "meeting" }))
+                .expect("meeting mode"),
+            crate::domain::types::RecordingSourceMode::MicrophonePlusSystem
+        );
+        assert!(recorder_source_mode_from_body(&serde_json::json!({
+            "sourceMode": "desktop"
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn recorder_resolution_body_keeps_structured_success_and_error() {
+        let success = recorder_resolution_body(ResolveAgentRecorderRequest {
+            request_id: "req-1".to_string(),
+            ok: true,
+            note_id: Some("note-1".to_string()),
+            note_title: Some("Planning".to_string()),
+            error_code: None,
+            error_message: None,
+        });
+        assert_eq!(success["success"], true);
+        assert_eq!(success["data"]["noteId"], "note-1");
+        assert_eq!(success["data"]["noteTitle"], "Planning");
+
+        let failure = recorder_resolution_body(ResolveAgentRecorderRequest {
+            request_id: "req-2".to_string(),
+            ok: false,
+            note_id: None,
+            note_title: None,
+            error_code: Some("recording_not_found".to_string()),
+            error_message: Some("No recording is currently running.".to_string()),
+        });
+        assert_eq!(failure["success"], false);
+        assert_eq!(failure["errorCode"], "recording_not_found");
+        assert_eq!(failure["message"], "No recording is currently running.");
+    }
+
     fn test_png_bytes(label: &[u8]) -> Vec<u8> {
         let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
         bytes.extend_from_slice(label);
@@ -8933,6 +9335,7 @@ mcp_servers:
             Some(&test_june_context_mcp_config()),
             None,
             None,
+            None,
         );
         let merged = merge_hermes_config(&config_path, &rendered);
         let value: serde_yaml::Value = serde_yaml::from_str(&merged).expect("merged parses");
@@ -8989,6 +9392,7 @@ mcp_servers:
             None,
             None,
             None,
+            None,
         );
 
         assert!(config.contains("model:\n  default: \"glm\""));
@@ -9019,6 +9423,7 @@ mcp_servers:
             None,
             None,
             None,
+            None,
         );
 
         assert!(config.contains("skills:\n  external_dirs: []\n"));
@@ -9040,11 +9445,19 @@ mcp_servers:
         }
     }
 
+    fn test_june_recorder_mcp_config() -> JuneRecorderMcpConfig {
+        JuneRecorderMcpConfig {
+            command: "/tmp/hermes/venv/bin/python".to_string(),
+            script_path: PathBuf::from("/tmp/june/hermes-mcp/june_recorder_mcp.py"),
+        }
+    }
+
     #[test]
     fn render_hermes_config_registers_june_context_mcp_server() {
         let context = test_june_context_mcp_config();
         let web = test_june_web_mcp_config();
         let image = test_june_image_mcp_config();
+        let recorder = test_june_recorder_mcp_config();
         let config = render_hermes_config(
             "glm",
             "http://127.0.0.1:9/v1",
@@ -9054,11 +9467,13 @@ mcp_servers:
             Some(&context),
             Some(&web),
             Some(&image),
+            Some(&recorder),
         );
 
-        // All three built-in servers live under one mcp_servers map.
+        // All four built-in servers live under one mcp_servers map.
         assert!(config.contains("mcp_servers:\n  june_context:\n"));
         assert!(config.contains("  june_web:\n"));
+        assert!(config.contains("  june_recorder:\n"));
         assert!(config.contains("    command: \"/tmp/hermes/venv/bin/python\"\n"));
         assert!(config.contains("      - \"/tmp/june/hermes-mcp/june_context_mcp.py\"\n"));
         assert!(config.contains("      - \"/tmp/june/notes.sqlite3\"\n"));
@@ -9076,6 +9491,8 @@ mcp_servers:
         assert!(!config.contains("workspace/uploads"));
         assert!(config.contains("      JUNE_IMAGE_PROXY_TOKEN: \"proxy-tok\"\n"));
         assert!(config.contains("    timeout: 660\n"));
+        assert!(config.contains("      - \"/tmp/june/hermes-mcp/june_recorder_mcp.py\"\n"));
+        assert!(config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"proxy-tok\"\n"));
     }
 
     #[test]
@@ -9086,6 +9503,7 @@ mcp_servers:
             "tok",
             "web",
             &[],
+            None,
             None,
             None,
             None,
@@ -9381,6 +9799,7 @@ mcp_servers:
         let mcp = test_june_context_mcp_config();
         let web = test_june_web_mcp_config();
         let image = test_june_image_mcp_config();
+        let recorder = test_june_recorder_mcp_config();
         sync_hermes_config_with_external_dirs(
             home.path(),
             4242,
@@ -9388,6 +9807,7 @@ mcp_servers:
             &mcp,
             &web,
             &image,
+            &recorder,
             &[],
         )
         .expect("sync config");
@@ -9522,6 +9942,20 @@ mcp_servers:
         assert!(
             !soul.contains("Only pass a `source_filename` from a prior `june_image` tool result")
         );
+    }
+
+    #[test]
+    fn june_soul_describes_recorder_tools() {
+        let home = tempfile::tempdir().expect("tempdir");
+
+        sync_june_soul(home.path(), false, false).expect("sync soul");
+
+        let soul = std::fs::read_to_string(home.path().join("SOUL.md")).expect("read soul");
+        assert!(soul.contains("june_recorder"));
+        assert!(soul.contains("Only call `start_recording` when the user explicitly asks"));
+        assert!(soul.contains("press the Record button"));
+        assert!(soul.contains("Recording options"));
+        assert!(soul.contains("recorder bar"));
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -870,7 +870,14 @@ pub fn resolve_agent_recorder_request(
                 "Recorder request was not found or has already timed out.",
             )
         })?;
-    let _ = sender.send(request);
+    // A dead receiver means the lease just expired: the proxy has already
+    // answered failure, so the frontend must see not_found and roll back.
+    sender.send(request).map_err(|_| {
+        AppError::new(
+            "agent_recorder_request_not_found",
+            "Recorder request was not found or has already timed out.",
+        )
+    })?;
     Ok(())
 }
 
@@ -6733,7 +6740,7 @@ fn render_recorder_mcp_entry(
     env:
       PYTHONUNBUFFERED: "1"
       {token_env}: {token}
-    timeout: 30
+    timeout: 620
     connect_timeout: 10
 "#,
         server_name = JUNE_RECORDER_MCP_SERVER_NAME,
@@ -7047,14 +7054,8 @@ async fn handle_june_provider_connection(
             return Ok(());
         }
     };
-    // Recorder mutations require the recorder-scoped secret; every other
-    // route keeps the general provider token. Distinct secrets, so neither
-    // authorizes the other's surface.
-    let required_token = if request.path.starts_with("/v1/recorder/") {
-        &state.recorder_token
-    } else {
-        &state.token
-    };
+    let required_token =
+        provider_proxy_required_token(&request.path, &state.token, &state.recorder_token);
     if !provider_proxy_authorized(&request, required_token) {
         write_json_response(
             &mut stream,
@@ -7563,6 +7564,21 @@ fn provider_models_body(model: String, context_tokens: Option<i64>) -> serde_jso
         entry["context_length"] = serde_json::json!(context_tokens);
     }
     serde_json::json!({ "object": "list", "data": [entry] })
+}
+
+/// Recorder mutations require the recorder-scoped secret; every other route
+/// keeps the general provider token. Distinct secrets, so neither authorizes
+/// the other's surface.
+fn provider_proxy_required_token<'a>(
+    path: &str,
+    provider_token: &'a str,
+    recorder_token: &'a str,
+) -> &'a str {
+    if path.starts_with("/v1/recorder/") {
+        recorder_token
+    } else {
+        provider_token
+    }
 }
 
 fn provider_proxy_authorized(request: &HttpRequest, token: &str) -> bool {
@@ -8752,6 +8768,57 @@ mod tests {
     }
 
     #[test]
+    fn recorder_routes_require_the_recorder_scoped_token_and_vice_versa() {
+        // The general provider token every model call carries must never
+        // authorize microphone control, and the recorder secret must not
+        // open the provider surface.
+        for path in [
+            "/v1/recorder/start",
+            "/v1/recorder/stop",
+            "/v1/recorder/status",
+        ] {
+            assert_eq!(
+                provider_proxy_required_token(path, "provider-tok", "recorder-tok"),
+                "recorder-tok"
+            );
+        }
+        for path in [
+            "/v1/models",
+            "/v1/chat/completions",
+            "/v1/image/generate",
+            "/v1/recorder",
+        ] {
+            assert_eq!(
+                provider_proxy_required_token(path, "provider-tok", "recorder-tok"),
+                "provider-tok"
+            );
+        }
+
+        let provider_bearer = request_with_authorization("Bearer provider-tok");
+        let recorder_bearer = request_with_authorization("Bearer recorder-tok");
+        let recorder_required =
+            provider_proxy_required_token("/v1/recorder/start", "provider-tok", "recorder-tok");
+        let provider_required =
+            provider_proxy_required_token("/v1/models", "provider-tok", "recorder-tok");
+        assert!(!provider_proxy_authorized(
+            &provider_bearer,
+            recorder_required
+        ));
+        assert!(provider_proxy_authorized(
+            &recorder_bearer,
+            recorder_required
+        ));
+        assert!(!provider_proxy_authorized(
+            &recorder_bearer,
+            provider_required
+        ));
+        assert!(provider_proxy_authorized(
+            &provider_bearer,
+            provider_required
+        ));
+    }
+
+    #[test]
     fn provider_proxy_rejects_missing_or_malformed_authorization() {
         let missing = HttpRequest {
             method: "GET".to_string(),
@@ -9541,6 +9608,10 @@ mcp_servers:
         // general provider token.
         assert!(config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"recorder-proxy-tok\"\n"));
         assert!(!config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"proxy-tok\"\n"));
+        // The Hermes-side tool timeout must outlive the proxy lease (240s)
+        // plus the Python client's attempt (300s), or Hermes reports failure
+        // while June is still honestly waiting on the permission prompt.
+        assert!(config.contains("    timeout: 620\n"));
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -108,12 +108,15 @@ const JUNE_RECORDER_MCP_SCRIPT: &str = include_str!("hermes/june_recorder_mcp.py
 /// from. Kept out of argv so it does not appear in process listings.
 const JUNE_RECORDER_MCP_TOKEN_ENV: &str = "JUNE_RECORDER_PROXY_TOKEN";
 const AGENT_RECORDER_REQUEST_EVENT: &str = "june://agent-recorder-request";
-// The frontend start path can legitimately take minutes: the readiness probe
-// waits on the system-audio helper (tens of seconds), a fresh install blocks
-// up to 120s on the macOS microphone prompt, and capture start itself is
-// bounded at 10s. The lease must outlive the worst honest case, or the tool
-// reports failure for a recording that then visibly starts.
-const AGENT_RECORDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(240);
+// The frontend start path can legitimately take minutes: readiness runs
+// twice (React probes before startRecording, then the command re-probes) and
+// each pass can wait the full system-audio permission probe, a fresh install
+// then blocks on the macOS microphone prompt, and capture start has its own
+// watchdog. The lease must outlive that worst honest case, or the tool
+// reports failure for a recording that then visibly starts —
+// `agent_recorder_lease_outlives_the_worst_honest_start_path` pins the
+// budget against the real constants.
+const AGENT_RECORDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(420);
 
 /// Identity injected into every Hermes session via `SOUL.md`. Hermes loads
 /// this file from `HERMES_HOME` at prompt-build time; without it the runtime
@@ -336,6 +339,9 @@ pub struct HermesBridge {
     /// Started lazily on the first spawn, lives until app shutdown.
     provider_proxy: Mutex<Option<SharedProviderProxy>>,
     recorder_requests: Arc<Mutex<HashMap<String, oneshot::Sender<AgentRecorderResolution>>>>,
+    /// Recently delivered recorder request ids (see
+    /// `recorder_request_recently_completed`).
+    recorder_completed: Mutex<std::collections::VecDeque<String>>,
 }
 
 struct HermesProcess {
@@ -854,22 +860,30 @@ pub fn resolve_agent_recorder_request(
     bridge: State<'_, HermesBridge>,
     request: ResolveAgentRecorderRequest,
 ) -> Result<(), AppError> {
-    let sender = bridge
-        .recorder_requests
-        .lock()
-        .map_err(|_| {
+    let request_id = request.request_id.clone();
+    let sender = {
+        let mut pending = bridge.recorder_requests.lock().map_err(|_| {
             AppError::new(
                 "agent_recorder_unavailable",
                 "Recorder request lock failed.",
             )
-        })?
-        .remove(&request.request_id)
-        .ok_or_else(|| {
-            AppError::new(
-                "agent_recorder_request_not_found",
-                "Recorder request was not found or has already timed out.",
-            )
         })?;
+        let Some(sender) = pending.remove(&request_id) else {
+            // Distinguish "you already delivered this" (a retried resolve
+            // whose first attempt landed despite a transport error) from
+            // "the lease expired": rolling back a delivered success stops a
+            // healthy recording.
+            return if recorder_request_recently_completed(&bridge.recorder_completed, &request_id) {
+                Ok(())
+            } else {
+                Err(AppError::new(
+                    "agent_recorder_request_not_found",
+                    "Recorder request was not found or has already timed out.",
+                ))
+            };
+        };
+        sender
+    };
     // A dead receiver means the lease just expired: the proxy has already
     // answered failure, so the frontend must see not_found and roll back.
     sender.send(request).map_err(|_| {
@@ -878,7 +892,35 @@ pub fn resolve_agent_recorder_request(
             "Recorder request was not found or has already timed out.",
         )
     })?;
+    record_completed_recorder_request(&bridge.recorder_completed, &request_id);
     Ok(())
+}
+
+/// Recently delivered recorder request ids, so an ambiguous resolve retry is
+/// answered idempotently instead of being mistaken for a lease expiry. Small
+/// FIFO cap: entries only need to survive one retry round-trip.
+const RECORDER_COMPLETED_CAP: usize = 32;
+
+fn record_completed_recorder_request(
+    completed: &Mutex<std::collections::VecDeque<String>>,
+    request_id: &str,
+) {
+    if let Ok(mut completed) = completed.lock() {
+        completed.push_back(request_id.to_string());
+        while completed.len() > RECORDER_COMPLETED_CAP {
+            completed.pop_front();
+        }
+    }
+}
+
+fn recorder_request_recently_completed(
+    completed: &Mutex<std::collections::VecDeque<String>>,
+    request_id: &str,
+) -> bool {
+    completed
+        .lock()
+        .map(|completed| completed.iter().any(|id| id == request_id))
+        .unwrap_or(false)
 }
 
 async fn start_hermes_bridge_inner(
@@ -8765,6 +8807,23 @@ mod tests {
 
         assert!(provider_proxy_authorized(&request, "proxy-secret"));
         assert!(!provider_proxy_authorized(&request, "other-secret"));
+    }
+
+    #[test]
+    fn agent_recorder_lease_outlives_the_worst_honest_start_path() {
+        // Readiness runs twice on the agent start path (React probes before
+        // startRecording, the command re-probes), each pass can wait the full
+        // system-audio permission probe, then the first-run microphone prompt
+        // and the capture watchdog run in sequence.
+        let worst_case = crate::audio::system_macos::SYSTEM_AUDIO_PERMISSION_PROBE_TIMEOUT * 2
+            + crate::audio::capture::MICROPHONE_PROMPT_TIMEOUT
+            + crate::audio::capture::CAPTURE_START_TIMEOUT;
+        assert!(
+            AGENT_RECORDER_REQUEST_TIMEOUT > worst_case + Duration::from_secs(30),
+            "lease {}s must exceed worst honest start path {}s plus slack",
+            AGENT_RECORDER_REQUEST_TIMEOUT.as_secs(),
+            worst_case.as_secs()
+        );
     }
 
     #[test]

--- a/src-tauri/src/hermes_bridge.rs
+++ b/src-tauri/src/hermes_bridge.rs
@@ -108,7 +108,12 @@ const JUNE_RECORDER_MCP_SCRIPT: &str = include_str!("hermes/june_recorder_mcp.py
 /// from. Kept out of argv so it does not appear in process listings.
 const JUNE_RECORDER_MCP_TOKEN_ENV: &str = "JUNE_RECORDER_PROXY_TOKEN";
 const AGENT_RECORDER_REQUEST_EVENT: &str = "june://agent-recorder-request";
-const AGENT_RECORDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+// The frontend start path can legitimately take minutes: the readiness probe
+// waits on the system-audio helper (tens of seconds), a fresh install blocks
+// up to 120s on the macOS microphone prompt, and capture start itself is
+// bounded at 10s. The lease must outlive the worst honest case, or the tool
+// reports failure for a recording that then visibly starts.
+const AGENT_RECORDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(240);
 
 /// Identity injected into every Hermes session via `SOUL.md`. Hermes loads
 /// this file from `HERMES_HOME` at prompt-build time; without it the runtime
@@ -342,12 +347,17 @@ struct HermesProcess {
 struct SharedProviderProxy {
     port: u16,
     token: String,
+    recorder_token: String,
     shutdown: Option<oneshot::Sender<()>>,
 }
 
 #[derive(Clone)]
 struct ProviderProxyState {
     token: String,
+    /// Recorder routes require this dedicated secret, handed only to the
+    /// `june_recorder` MCP: microphone control must not be reachable with the
+    /// general provider token every model call carries.
+    recorder_token: String,
     image_sources: ImageSourceCapabilities,
     app: Option<AppHandle>,
     /// Safe-mode values already injected, keyed by requestId, so an MCP retry
@@ -920,6 +930,7 @@ async fn start_hermes_bridge_inner(
         &hermes_home,
         provider_proxy.port,
         &provider_proxy.token,
+        &provider_proxy.recorder_token,
         &june_context_mcp,
         &june_web_mcp,
         &june_image_mcp,
@@ -1070,10 +1081,12 @@ async fn ensure_provider_proxy(
             return Ok(SharedProviderProxyInfo {
                 port: proxy.port,
                 token: proxy.token.clone(),
+                recorder_token: proxy.recorder_token.clone(),
             });
         }
     }
     let token = random_token();
+    let recorder_token = random_token();
     let app_data_dir = crate::app_paths::app_data_dir(app)
         .map_err(|error| AppError::new("june_provider_proxy_failed", error.to_string()))?;
     let image_sources = ImageSourceCapabilities {
@@ -1082,6 +1095,7 @@ async fn ensure_provider_proxy(
     };
     let started = start_june_provider_proxy(
         token.clone(),
+        recorder_token.clone(),
         image_sources,
         Some(app.clone()),
         Arc::clone(&bridge.recorder_requests),
@@ -1096,17 +1110,20 @@ async fn ensure_provider_proxy(
     *guard = Some(SharedProviderProxy {
         port: started.port,
         token: token.clone(),
+        recorder_token: recorder_token.clone(),
         shutdown: Some(started.shutdown),
     });
     Ok(SharedProviderProxyInfo {
         port: started.port,
         token,
+        recorder_token,
     })
 }
 
 struct SharedProviderProxyInfo {
     port: u16,
     token: String,
+    recorder_token: String,
 }
 
 #[derive(Debug, Clone)]
@@ -6427,11 +6444,13 @@ fn default_python_command() -> &'static str {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sync_hermes_config(
     app: &AppHandle,
     hermes_home: &std::path::Path,
     provider_proxy_port: u16,
     provider_proxy_token: &str,
+    recorder_proxy_token: &str,
     june_context_mcp: &JuneContextMcpConfig,
     june_web_mcp: &JuneWebMcpConfig,
     june_image_mcp: &JuneImageMcpConfig,
@@ -6441,6 +6460,7 @@ fn sync_hermes_config(
         hermes_home,
         provider_proxy_port,
         provider_proxy_token,
+        recorder_proxy_token,
         june_context_mcp,
         june_web_mcp,
         june_image_mcp,
@@ -6449,10 +6469,12 @@ fn sync_hermes_config(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sync_hermes_config_with_external_dirs(
     hermes_home: &std::path::Path,
     provider_proxy_port: u16,
     provider_proxy_token: &str,
+    recorder_proxy_token: &str,
     june_context_mcp: &JuneContextMcpConfig,
     june_web_mcp: &JuneWebMcpConfig,
     june_image_mcp: &JuneImageMcpConfig,
@@ -6465,6 +6487,7 @@ fn sync_hermes_config_with_external_dirs(
         &model,
         &base_url,
         provider_proxy_token,
+        recorder_proxy_token,
         &CRON_SANDBOXED_TOOLSETS.join(", "),
         external_skill_dirs,
         Some(june_context_mcp),
@@ -6532,6 +6555,7 @@ fn render_hermes_config(
     model: &str,
     base_url: &str,
     provider_proxy_token: &str,
+    recorder_proxy_token: &str,
     cron_toolsets: &str,
     external_skill_dirs: &[PathBuf],
     june_context_mcp: Option<&JuneContextMcpConfig>,
@@ -6555,6 +6579,7 @@ fn render_hermes_config(
         june_recorder_mcp,
         base_url,
         provider_proxy_token,
+        recorder_proxy_token,
     );
     format!(
         r#"model:
@@ -6580,6 +6605,7 @@ skills:
 /// Renders the `mcp_servers:` block listing every built-in MCP server June
 /// registers. Both entries live under one key so Hermes deep-merges a single
 /// map; an empty map is emitted when neither is configured.
+#[allow(clippy::too_many_arguments)]
 fn render_mcp_servers_config(
     context: Option<&JuneContextMcpConfig>,
     web: Option<&JuneWebMcpConfig>,
@@ -6587,6 +6613,7 @@ fn render_mcp_servers_config(
     recorder: Option<&JuneRecorderMcpConfig>,
     base_url: &str,
     proxy_token: &str,
+    recorder_proxy_token: &str,
 ) -> String {
     let mut entries = String::new();
     if let Some(config) = context {
@@ -6599,7 +6626,11 @@ fn render_mcp_servers_config(
         entries.push_str(&render_image_mcp_entry(config, base_url, proxy_token));
     }
     if let Some(config) = recorder {
-        entries.push_str(&render_recorder_mcp_entry(config, base_url, proxy_token));
+        entries.push_str(&render_recorder_mcp_entry(
+            config,
+            base_url,
+            recorder_proxy_token,
+        ));
     }
     if entries.is_empty() {
         return "mcp_servers: {}\n".to_string();
@@ -6933,6 +6964,7 @@ fn yaml_string(value: &str) -> String {
 
 async fn start_june_provider_proxy(
     token: String,
+    recorder_token: String,
     image_sources: ImageSourceCapabilities,
     app: Option<AppHandle>,
     recorder_requests: Arc<Mutex<HashMap<String, oneshot::Sender<AgentRecorderResolution>>>>,
@@ -6953,6 +6985,7 @@ async fn start_june_provider_proxy(
         listener,
         Arc::new(ProviderProxyState {
             token,
+            recorder_token,
             image_sources,
             app,
             image_safe_mode_pins: Arc::new(Mutex::new(VecDeque::new())),
@@ -7014,7 +7047,15 @@ async fn handle_june_provider_connection(
             return Ok(());
         }
     };
-    if !provider_proxy_authorized(&request, &state.token) {
+    // Recorder mutations require the recorder-scoped secret; every other
+    // route keeps the general provider token. Distinct secrets, so neither
+    // authorizes the other's surface.
+    let required_token = if request.path.starts_with("/v1/recorder/") {
+        &state.recorder_token
+    } else {
+        &state.token
+    };
+    if !provider_proxy_authorized(&request, required_token) {
         write_json_response(
             &mut stream,
             401,
@@ -9330,6 +9371,7 @@ mcp_servers:
             "new-model",
             "http://127.0.0.1:9/v1",
             "new-token",
+            "recorder-token",
             "web",
             &[],
             Some(&test_june_context_mcp_config()),
@@ -9387,6 +9429,7 @@ mcp_servers:
             "glm",
             "http://127.0.0.1:9/v1",
             "tok",
+            "recorder-tok",
             "web, memory",
             &dirs,
             None,
@@ -9418,6 +9461,7 @@ mcp_servers:
             "glm",
             "http://127.0.0.1:9/v1",
             "tok",
+            "recorder-tok",
             "web",
             &[],
             None,
@@ -9462,6 +9506,7 @@ mcp_servers:
             "glm",
             "http://127.0.0.1:9/v1",
             "proxy-tok",
+            "recorder-proxy-tok",
             "web",
             &[],
             Some(&context),
@@ -9492,7 +9537,10 @@ mcp_servers:
         assert!(config.contains("      JUNE_IMAGE_PROXY_TOKEN: \"proxy-tok\"\n"));
         assert!(config.contains("    timeout: 660\n"));
         assert!(config.contains("      - \"/tmp/june/hermes-mcp/june_recorder_mcp.py\"\n"));
-        assert!(config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"proxy-tok\"\n"));
+        // The recorder MCP must get the recorder-scoped secret, never the
+        // general provider token.
+        assert!(config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"recorder-proxy-tok\"\n"));
+        assert!(!config.contains("      JUNE_RECORDER_PROXY_TOKEN: \"proxy-tok\"\n"));
     }
 
     #[test]
@@ -9501,6 +9549,7 @@ mcp_servers:
             "glm",
             "http://127.0.0.1:9/v1",
             "tok",
+            "recorder-tok",
             "web",
             &[],
             None,
@@ -9804,6 +9853,7 @@ mcp_servers:
             home.path(),
             4242,
             "proxy-token",
+            "recorder-proxy-token",
             &mcp,
             &web,
             &image,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,6 +170,7 @@ pub fn run() {
             commands::list_agent_tool_events,
             hermes_bridge::hermes_bridge_status,
             hermes_bridge::ensure_hermes_bridge_gateway,
+            hermes_bridge::resolve_agent_recorder_request,
             hermes_bridge::hermes_admin_request,
             hermes_bridge::hermes_mcp_oauth_login,
             hermes_bridge::hermes_reset_bundled_skill,

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -270,7 +270,7 @@ fn accepts_silent_audio_for_provider_decision() {
 
     assert!(result.readable_audio);
     // A structurally valid silent file is flagged, never failed: the
-    // provider decision (and the silent-track messaging) happens later.
+    // provider decision (and the silent-source messaging) happens later.
     assert!(!result.non_silent_signal);
     assert!(result.recorded_silence);
     assert!(source_audio_passes_validation(

--- a/src-tauri/tests/recording_validation.rs
+++ b/src-tauri/tests/recording_validation.rs
@@ -93,6 +93,7 @@ fn readable_validation(expected_duration_ms: i64, actual_duration_ms: i64) -> Au
         actual_duration_ms,
         duration_within_tolerance: false,
         non_silent_signal: true,
+        recorded_silence: false,
         peak_amplitude: 0.2,
         rms_amplitude: 0.1,
         warnings: vec!["audio duration mismatch".to_string()],
@@ -268,11 +269,10 @@ fn accepts_silent_audio_for_provider_decision() {
         .expect("validation should run");
 
     assert!(result.readable_audio);
-    assert!(result.non_silent_signal);
-    assert!(!result
-        .warnings
-        .iter()
-        .any(|warning| warning.contains("silent")));
+    // A structurally valid silent file is flagged, never failed: the
+    // provider decision (and the silent-track messaging) happens later.
+    assert!(!result.non_silent_signal);
+    assert!(result.recorded_silence);
     assert!(source_audio_passes_validation(
         RecordingSource::Microphone,
         &result

--- a/src-tauri/tests/source_processing.rs
+++ b/src-tauri/tests/source_processing.rs
@@ -27,6 +27,7 @@ fn labeled_transcript_keeps_microphone_and_system_sections() {
             start_ms: Some(2_000),
             end_ms: Some(3_000),
             turn_index: Some(1),
+            recorded_silence: false,
         },
         SourceTranscriptInput {
             source: "system".to_string(),
@@ -36,6 +37,7 @@ fn labeled_transcript_keeps_microphone_and_system_sections() {
             start_ms: Some(1_000),
             end_ms: Some(1_800),
             turn_index: Some(0),
+            recorded_silence: false,
         },
     ]);
 
@@ -56,6 +58,7 @@ fn processing_uses_only_valid_source_transcripts() {
             start_ms: None,
             end_ms: None,
             turn_index: None,
+            recorded_silence: false,
         },
         SourceTranscriptInput {
             source: "system".to_string(),
@@ -65,6 +68,7 @@ fn processing_uses_only_valid_source_transcripts() {
             start_ms: None,
             end_ms: None,
             turn_index: None,
+            recorded_silence: false,
         },
     ]);
 
@@ -83,6 +87,7 @@ fn coalesces_consecutive_same_source_transcripts_for_display() {
             start_ms: Some(1_000),
             end_ms: Some(3_000),
             turn_index: Some(0),
+            recorded_silence: false,
         },
         SourceTranscriptInput {
             source: "system".to_string(),
@@ -92,6 +97,7 @@ fn coalesces_consecutive_same_source_transcripts_for_display() {
             start_ms: Some(4_000),
             end_ms: Some(5_000),
             turn_index: Some(1),
+            recorded_silence: false,
         },
         SourceTranscriptInput {
             source: "microphone".to_string(),
@@ -101,6 +107,7 @@ fn coalesces_consecutive_same_source_transcripts_for_display() {
             start_ms: Some(7_000),
             end_ms: Some(8_000),
             turn_index: Some(2),
+            recorded_silence: false,
         },
     ]);
 
@@ -124,6 +131,7 @@ fn builds_transcription_context_from_previous_turns() {
             start_ms: Some(1_000),
             end_ms: Some(5_000),
             turn_index: Some(0),
+            recorded_silence: false,
         },
         SourceTranscriptInput {
             source: "microphone".to_string(),
@@ -133,6 +141,7 @@ fn builds_transcription_context_from_previous_turns() {
             start_ms: Some(6_000),
             end_ms: Some(7_000),
             turn_index: Some(1),
+            recorded_silence: false,
         },
     ])
     .expect("context should be built");

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -93,7 +93,7 @@ import {
   type AgentSessionStatusDetail,
 } from "../lib/agent-events";
 import { notifyAgentSessionStatus } from "../lib/agent-notifications";
-import { messageFromError } from "../lib/errors";
+import { errorCode, messageFromError } from "../lib/errors";
 import { parseDictationHelperEvent } from "../lib/dictation-events";
 import { listHermesSessions, titleFromPrompt } from "../lib/hermes-adapter";
 import { upsertLiveTranscriptEvent } from "../lib/live-transcript-preview";
@@ -2531,90 +2531,112 @@ export function App() {
     };
   }, [appBlocked, bootstrapped, handleStartMeetingDetectedRecording]);
 
+  // The handler closes over frequently-changing state, but the Tauri listener
+  // must register exactly once: re-subscribing tears the listener down and
+  // events emitted in the gap are silently dropped (a dropped request costs
+  // the agent a full proxy lease). The ref always holds the latest closure.
+  const agentRecorderHandlerRef = useRef<(payload: AgentRecorderRequestPayload) => Promise<void>>(
+    async () => {},
+  );
+  agentRecorderHandlerRef.current = async (payload: AgentRecorderRequestPayload) => {
+    const requestId = typeof payload.requestId === "string" ? payload.requestId : "";
+    if (!requestId) return;
+
+    const resolve = (result: {
+      ok: boolean;
+      noteId?: string;
+      noteTitle?: string;
+      errorCode?: string;
+      errorMessage?: string;
+    }) => {
+      void resolveAgentRecorderRequest({ requestId, ...result }).catch(async (err) => {
+        console.warn("Failed to resolve agent recorder request", err);
+        // A transient resolve failure (IPC hiccup, poisoned lock) happens
+        // while the proxy is still waiting inside its lease: retry once
+        // instead of treating it as an expired request.
+        if (errorCode(err) !== "agent_recorder_request_not_found") {
+          try {
+            await resolveAgentRecorderRequest({ requestId, ...result });
+            return;
+          } catch (retryErr) {
+            if (errorCode(retryErr) !== "agent_recorder_request_not_found") {
+              console.warn("Agent recorder resolve retry failed", retryErr);
+              return;
+            }
+          }
+        }
+        // Lease expired: the proxy already told the agent this request
+        // failed. Leaving a recording running that the agent believes never
+        // started diverges tool state from app state, so stop a successful
+        // late start. The note (and any audio it captured) is kept: it is
+        // real user data and the recorder was visibly running.
+        if (result.ok && payload.action === "start") {
+          const active = recordingStatusRef.current;
+          if (active && recordingNoteIdRef.current === result.noteId) {
+            try {
+              await handleFinishRecording(active.sessionId, { rethrow: true });
+            } catch (rollbackErr) {
+              console.warn("Failed to stop expired agent recording", rollbackErr);
+            }
+          }
+        }
+      });
+    };
+
+    if (appBlocked || !bootstrapped) {
+      resolve({
+        ok: false,
+        errorCode: "app_not_ready",
+        errorMessage: "June is not ready to start or stop recording yet.",
+      });
+      return;
+    }
+
+    try {
+      if (payload.action === "start") {
+        const requestedSourceMode: RecordingSourceMode =
+          payload.sourceMode === "microphonePlusSystem" ? "microphonePlusSystem" : "microphoneOnly";
+        const note = await handleStartAgentRecording(requestedSourceMode);
+        resolve({ ok: true, noteId: note.id, noteTitle: note.title });
+        return;
+      }
+      if (payload.action === "stop") {
+        const activeRecording = recordingStatusRef.current;
+        const noteId = recordingNoteIdRef.current ?? activeRecording?.noteId;
+        const noteTitle = noteId
+          ? (state.notes.find((note) => note.id === noteId)?.title ?? selectedNote?.title)
+          : undefined;
+        if (!activeRecording) {
+          resolve({
+            ok: false,
+            errorCode: "recording_not_found",
+            errorMessage: "No recording is currently running.",
+          });
+          return;
+        }
+        await handleFinishRecording(activeRecording.sessionId, { rethrow: true });
+        resolve({ ok: true, noteId, noteTitle });
+        return;
+      }
+      resolve({
+        ok: false,
+        errorCode: "invalid_action",
+        errorMessage: "Recorder action must be start or stop.",
+      });
+    } catch (err) {
+      resolve({
+        ok: false,
+        errorCode: "agent_recorder_failed",
+        errorMessage: messageFromError(err),
+      });
+    }
+  };
+
   useEffect(() => {
     let aborted = false;
     let unlisten: (() => void) | undefined;
-    void listen(AGENT_RECORDER_REQUEST_EVENT, async (event) => {
-      const payload = (event.payload ?? {}) as AgentRecorderRequestPayload;
-      const requestId = typeof payload.requestId === "string" ? payload.requestId : "";
-      if (!requestId) return;
-
-      const resolve = (result: {
-        ok: boolean;
-        noteId?: string;
-        noteTitle?: string;
-        errorCode?: string;
-        errorMessage?: string;
-      }) => {
-        void resolveAgentRecorderRequest({ requestId, ...result }).catch(async (err) => {
-          console.warn("Failed to resolve agent recorder request", err);
-          // The proxy already told the agent this request failed. Leaving a
-          // recording running that the agent believes never started diverges
-          // tool state from app state, so stop a successful late start. The
-          // note (and any audio it captured) is kept: it is real user data
-          // and the recorder was visibly running.
-          if (result.ok && payload.action === "start") {
-            const active = recordingStatusRef.current;
-            if (active && recordingNoteIdRef.current === result.noteId) {
-              try {
-                await handleFinishRecording(active.sessionId, { rethrow: true });
-              } catch (rollbackErr) {
-                console.warn("Failed to stop expired agent recording", rollbackErr);
-              }
-            }
-          }
-        });
-      };
-
-      if (appBlocked || !bootstrapped) {
-        resolve({
-          ok: false,
-          errorCode: "app_not_ready",
-          errorMessage: "June is not ready to start or stop recording yet.",
-        });
-        return;
-      }
-
-      try {
-        if (payload.action === "start") {
-          const requestedSourceMode: RecordingSourceMode =
-            payload.sourceMode === "microphonePlusSystem"
-              ? "microphonePlusSystem"
-              : "microphoneOnly";
-          const note = await handleStartAgentRecording(requestedSourceMode);
-          resolve({ ok: true, noteId: note.id, noteTitle: note.title });
-          return;
-        }
-        if (payload.action === "stop") {
-          const activeRecording = recordingStatusRef.current;
-          const noteId = recordingNoteIdRef.current ?? activeRecording?.noteId;
-          const noteTitle = noteId
-            ? (state.notes.find((note) => note.id === noteId)?.title ?? selectedNote?.title)
-            : undefined;
-          if (!activeRecording) {
-            resolve({
-              ok: false,
-              errorCode: "recording_not_found",
-              errorMessage: "No recording is currently running.",
-            });
-            return;
-          }
-          await handleFinishRecording(activeRecording.sessionId, { rethrow: true });
-          resolve({ ok: true, noteId, noteTitle });
-          return;
-        }
-        resolve({
-          ok: false,
-          errorCode: "invalid_action",
-          errorMessage: "Recorder action must be start or stop.",
-        });
-      } catch (err) {
-        resolve({
-          ok: false,
-          errorCode: "agent_recorder_failed",
-          errorMessage: messageFromError(err),
-        });
-      }
+    void listen(AGENT_RECORDER_REQUEST_EVENT, (event) => {
+      void agentRecorderHandlerRef.current((event.payload ?? {}) as AgentRecorderRequestPayload);
     }).then((cleanup) => {
       if (aborted) cleanup();
       else unlisten = cleanup;
@@ -2623,7 +2645,7 @@ export function App() {
       aborted = true;
       unlisten?.();
     };
-  }, [appBlocked, bootstrapped, handleStartAgentRecording, selectedNote?.title, state.notes]);
+  }, []);
 
   async function handleFinishRecording(sessionId: string, options: { rethrow?: boolean } = {}) {
     // The recorder bar stays mounted (and clickable) for the duration of its

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -72,6 +72,7 @@ import {
   removeSessionFromFolder,
   recoverRecording,
   renameFolder,
+  resolveAgentRecorderRequest,
   resumeRecording,
   retryProcessing,
   startRecording,
@@ -82,7 +83,7 @@ import {
 } from "../lib/tauri";
 import { playRecordingSound, preloadRecordingSounds } from "../lib/recording-sounds";
 import { isMacLikePlatform, isPrimaryShortcut } from "../lib/platform";
-import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
+import { AGENT_RECORDER_REQUEST_EVENT, MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import {
   AGENT_GALLERY_EVENT,
   AGENT_OPEN_EVENT,
@@ -204,6 +205,12 @@ const TAB_ICON_SIZE = 14;
 type RecordingInactivityPrompt = {
   sessionId: string;
   expiresAt: number;
+};
+
+type AgentRecorderRequestPayload = {
+  requestId?: unknown;
+  action?: unknown;
+  sourceMode?: unknown;
 };
 
 function agentSessionTabTitle(session?: HermesSessionInfo): string | undefined {
@@ -2309,8 +2316,12 @@ export function App() {
   }
 
   const handleStartRecordingForNote = useCallback(
-    async (noteId: string, options: { startAlreadyClaimed?: boolean } = {}): Promise<boolean> => {
+    async (
+      noteId: string,
+      options: { startAlreadyClaimed?: boolean; sourceMode?: RecordingSourceMode } = {},
+    ): Promise<boolean> => {
       const startAlreadyClaimed = options.startAlreadyClaimed ?? false;
+      const requestedSourceMode = options.sourceMode ?? sourceMode;
       if (
         recordingStatusRef.current ||
         (!startAlreadyClaimed && recordingStartInFlightRef.current)
@@ -2325,7 +2336,7 @@ export function App() {
       }
       setLiveTranscriptEvents([]);
       setRecordingNote(noteId);
-      const startingStatus = startingRecordingStatus(noteId, sourceMode);
+      const startingStatus = startingRecordingStatus(noteId, requestedSourceMode);
       recordingStatusRef.current = startingStatus;
       dispatch({
         type: "recordingStatusChanged",
@@ -2333,7 +2344,7 @@ export function App() {
       });
       try {
         setCheckingSourceReadiness(true);
-        const readiness = await checkRecordingSourceReadiness(sourceMode);
+        const readiness = await checkRecordingSourceReadiness(requestedSourceMode);
         setSourceReadiness(readiness);
 
         const micSource = readiness.sources.find((source) => source.source === "microphone");
@@ -2351,9 +2362,9 @@ export function App() {
         // setSourceReadiness above.
         const systemSource = readiness.sources.find((source) => source.source === "system");
         const effectiveMode: RecordingSourceMode =
-          sourceMode === "microphonePlusSystem" && !systemSource?.ready
+          requestedSourceMode === "microphonePlusSystem" && !systemSource?.ready
             ? "microphoneOnly"
-            : sourceMode;
+            : requestedSourceMode;
 
         const recording = await startRecording(noteId, effectiveMode);
         setRecordingNote(noteId);
@@ -2427,6 +2438,65 @@ export function App() {
     }
   }, [handleStartRecordingForNote, selectedNoteId]);
 
+  const handleStartAgentRecording = useCallback(
+    async (requestedSourceMode: RecordingSourceMode) => {
+      if (recordingStartInFlightRef.current || recordingStatusRef.current) {
+        throw new Error(
+          `A recording is already running for note ${recordingNoteIdRef.current ?? "unknown"}.`,
+        );
+      }
+      recordingStartInFlightRef.current = true;
+      const previousNoteId = selectedNoteId;
+      let handedStartClaimToRecorder = false;
+      let createdNoteId: string | undefined;
+      try {
+        const note = await createNote(undefined);
+        createdNoteId = note.id;
+        dispatch({ type: "noteLoaded", note });
+        setOriginFolderId(undefined);
+        setOriginAllNotes(false);
+        setActiveView("meetings");
+        handedStartClaimToRecorder = true;
+        const started = await handleStartRecordingForNote(note.id, {
+          startAlreadyClaimed: true,
+          sourceMode: requestedSourceMode,
+        });
+        if (started) return note;
+
+        try {
+          await deleteNote(note.id);
+        } catch (deleteErr) {
+          console.warn("Failed to delete meeting note after recording start failed", deleteErr);
+        }
+        const response = await listNotes();
+        dispatch({ type: "notesLoaded", notes: response.items });
+        const restoreNoteId =
+          previousNoteId && previousNoteId !== note.id ? previousNoteId : response.items[0]?.id;
+        if (restoreNoteId) {
+          const restored = await getNote(restoreNoteId);
+          dispatch({ type: "noteLoaded", note: restored });
+        } else {
+          handleEmptyNotesAfterDelete();
+        }
+        throw new Error("Recording did not start.");
+      } catch (err) {
+        if (createdNoteId && !handedStartClaimToRecorder) {
+          try {
+            await deleteNote(createdNoteId);
+          } catch (deleteErr) {
+            console.warn("Failed to delete meeting note after recording start failed", deleteErr);
+          }
+        }
+        throw err;
+      } finally {
+        if (!handedStartClaimToRecorder) {
+          recordingStartInFlightRef.current = false;
+        }
+      }
+    },
+    [handleStartRecordingForNote, selectedNoteId],
+  );
+
   // Click the floating global recorder pill to jump back to the note the
   // recording belongs to (it lives wherever you started it, which may not be
   // the note you're currently looking at).
@@ -2461,7 +2531,86 @@ export function App() {
     };
   }, [appBlocked, bootstrapped, handleStartMeetingDetectedRecording]);
 
-  async function handleFinishRecording(sessionId: string) {
+  useEffect(() => {
+    let aborted = false;
+    let unlisten: (() => void) | undefined;
+    void listen(AGENT_RECORDER_REQUEST_EVENT, async (event) => {
+      const payload = (event.payload ?? {}) as AgentRecorderRequestPayload;
+      const requestId = typeof payload.requestId === "string" ? payload.requestId : "";
+      if (!requestId) return;
+
+      const resolve = (result: {
+        ok: boolean;
+        noteId?: string;
+        noteTitle?: string;
+        errorCode?: string;
+        errorMessage?: string;
+      }) => {
+        void resolveAgentRecorderRequest({ requestId, ...result }).catch((err) => {
+          console.warn("Failed to resolve agent recorder request", err);
+        });
+      };
+
+      if (appBlocked || !bootstrapped) {
+        resolve({
+          ok: false,
+          errorCode: "app_not_ready",
+          errorMessage: "June is not ready to start or stop recording yet.",
+        });
+        return;
+      }
+
+      try {
+        if (payload.action === "start") {
+          const requestedSourceMode: RecordingSourceMode =
+            payload.sourceMode === "microphonePlusSystem"
+              ? "microphonePlusSystem"
+              : "microphoneOnly";
+          const note = await handleStartAgentRecording(requestedSourceMode);
+          resolve({ ok: true, noteId: note.id, noteTitle: note.title });
+          return;
+        }
+        if (payload.action === "stop") {
+          const activeRecording = recordingStatusRef.current;
+          const noteId = recordingNoteIdRef.current ?? activeRecording?.noteId;
+          const noteTitle = noteId
+            ? (state.notes.find((note) => note.id === noteId)?.title ?? selectedNote?.title)
+            : undefined;
+          if (!activeRecording) {
+            resolve({
+              ok: false,
+              errorCode: "recording_not_found",
+              errorMessage: "No recording is currently running.",
+            });
+            return;
+          }
+          await handleFinishRecording(activeRecording.sessionId, { rethrow: true });
+          resolve({ ok: true, noteId, noteTitle });
+          return;
+        }
+        resolve({
+          ok: false,
+          errorCode: "invalid_action",
+          errorMessage: "Recorder action must be start or stop.",
+        });
+      } catch (err) {
+        resolve({
+          ok: false,
+          errorCode: "agent_recorder_failed",
+          errorMessage: messageFromError(err),
+        });
+      }
+    }).then((cleanup) => {
+      if (aborted) cleanup();
+      else unlisten = cleanup;
+    });
+    return () => {
+      aborted = true;
+      unlisten?.();
+    };
+  }, [appBlocked, bootstrapped, handleStartAgentRecording, selectedNote?.title, state.notes]);
+
+  async function handleFinishRecording(sessionId: string, options: { rethrow?: boolean } = {}) {
     // The recorder bar stays mounted (and clickable) for the duration of its
     // exit animation after the first stop click, so a fast double-click would
     // fire finishRecording twice — the second call fails with a scary
@@ -2496,6 +2645,7 @@ export function App() {
       if (!owningNoteId || !(await applyNoteScopedProcessingFailure(owningNoteId, err))) {
         setError(messageFromError(err));
       }
+      if (options.rethrow) throw err;
     } finally {
       finishingSessionsRef.current.delete(sessionId);
     }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2403,7 +2403,11 @@ export function App() {
       });
       if (started) return;
 
-      await deleteNote(note.id);
+      try {
+        await deleteNote(note.id);
+      } catch (deleteErr) {
+        console.warn("Failed to delete meeting note after recording start failed", deleteErr);
+      }
       const response = await listNotes();
       dispatch({ type: "notesLoaded", notes: response.items });
       const restoreNoteId =

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2417,7 +2417,7 @@ export function App() {
       try {
         await deleteNote(note.id);
       } catch (deleteErr) {
-        console.warn("Failed to delete meeting note after recording start failed", deleteErr);
+        console.warn("Failed to delete note after recording start failed", deleteErr);
       }
       const response = await listNotes();
       dispatch({ type: "notesLoaded", notes: response.items });
@@ -2466,7 +2466,7 @@ export function App() {
         try {
           await deleteNote(note.id);
         } catch (deleteErr) {
-          console.warn("Failed to delete meeting note after recording start failed", deleteErr);
+          console.warn("Failed to delete note after recording start failed", deleteErr);
         }
         const response = await listNotes();
         dispatch({ type: "notesLoaded", notes: response.items });
@@ -2484,7 +2484,7 @@ export function App() {
           try {
             await deleteNote(createdNoteId);
           } catch (deleteErr) {
-            console.warn("Failed to delete meeting note after recording start failed", deleteErr);
+            console.warn("Failed to delete note after recording start failed", deleteErr);
           }
         }
         throw err;
@@ -2546,8 +2546,23 @@ export function App() {
         errorCode?: string;
         errorMessage?: string;
       }) => {
-        void resolveAgentRecorderRequest({ requestId, ...result }).catch((err) => {
+        void resolveAgentRecorderRequest({ requestId, ...result }).catch(async (err) => {
           console.warn("Failed to resolve agent recorder request", err);
+          // The proxy already told the agent this request failed. Leaving a
+          // recording running that the agent believes never started diverges
+          // tool state from app state, so stop a successful late start. The
+          // note (and any audio it captured) is kept: it is real user data
+          // and the recorder was visibly running.
+          if (result.ok && payload.action === "start") {
+            const active = recordingStatusRef.current;
+            if (active && recordingNoteIdRef.current === result.noteId) {
+              try {
+                await handleFinishRecording(active.sessionId, { rethrow: true });
+              } catch (rollbackErr) {
+                console.warn("Failed to stop expired agent recording", rollbackErr);
+              }
+            }
+          }
         });
       };
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5666,22 +5666,15 @@ export function AgentWorkspace({
       misses.delete(sessionId);
       const freshMessages = await refreshHermesSession(sessionId);
       if (!freshMessages) continue;
-      const title =
-        hermesSessionItems.find((session) => session.id === sessionId)?.title ?? "Agent session";
       if (sessionHasAssistantAfterLatestUser(freshMessages)) {
-        const activityCounts = clearSessionActivity(sessionId);
-        // "completed" (not "failed") keeps the status quiet: its title falls back
-        // to lastStatus when nothing is active, and a stale "running" there
-        // would still render "Working…".
-        dispatchAgentSessionStatus({
-          sessionId,
-          title,
-          status: "completed",
-          summary: "June stopped.",
-          ...activityCounts,
-        });
+        // refreshHermesSession already saw the assistant reply while this
+        // session still counted as active, so it dispatched the terminal
+        // "June finished." status and cleared activity — dispatching a
+        // second completed status here would overwrite that summary.
         continue;
       }
+      const title =
+        hermesSessionItems.find((session) => session.id === sessionId)?.title ?? "Agent session";
       const summary = "June stopped before replying.";
       recordSessionErrorActivity(sessionId, summary);
       setError(summary, { sessionId });

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -230,6 +230,8 @@ import {
 import { preferredVisionFallbackModel } from "../../lib/suggested-models";
 import { modelOptions, selectedModel as selectedModelOption } from "../settings/ModelPickerDialog";
 import {
+  HERMES_SERVER_ERROR_MESSAGE,
+  describeHermesError,
   isHermesServerError,
   isHermesSessionsStartupRequestError,
   isTopUpRequiresMaxError,
@@ -340,22 +342,6 @@ const SESSION_NOT_AVAILABLE_MESSAGE =
 
 function isSessionGoneError(message: string): boolean {
   return message.toLowerCase().includes("session not found");
-}
-
-// A Hermes REST 5xx (`Hermes API returned 5xx: …`) is a transient server-side
-// fault, so session-load handlers show this June-branded line instead of the raw
-// wire string — which read as a doubled "500 Internal Server Error: Internal
-// Server Error" before the bridge deduped it (JUN-167). The banner's own
-// "Try again" button provides the retry, so the message stays a plain
-// description. `visibleErrorRetryable` keys off this
-// constant to offer that retry.
-const HERMES_SERVER_ERROR_MESSAGE = "June ran into a problem with that request.";
-
-// Picks the banner text for a caught session-command error: a transient Hermes
-// 5xx becomes the friendly retryable line; anything else passes through raw.
-function describeAgentError(err: unknown): string {
-  const message = messageFromError(err);
-  return isHermesServerError(message) ? HERMES_SERVER_ERROR_MESSAGE : message;
 }
 
 // Dev-tools response gallery handle. Registered at module scope so
@@ -2893,7 +2879,7 @@ export function AgentWorkspace({
         if (options.suppressSessionGoneError && isSessionGoneError(message)) {
           return "failed";
         }
-        setError(describeAgentError(err), reportableAgentErrorOptions(err));
+        setError(describeHermesError(err), reportableAgentErrorOptions(err));
         return "failed";
       } finally {
         if (!keepLoading) {
@@ -3410,7 +3396,7 @@ export function AgentWorkspace({
         // an error banner (JUN-116).
         if (isSessionGoneError(message)) return;
         setError(
-          describeAgentError(err),
+          describeHermesError(err),
           reportableAgentErrorOptions(err, { sessionId: selectedHermesSessionId }),
         );
       });
@@ -3440,7 +3426,7 @@ export function AgentWorkspace({
         }
       })
       .catch((err: unknown) => {
-        if (!cancelled) setError(describeAgentError(err), reportableAgentErrorOptions(err));
+        if (!cancelled) setError(describeHermesError(err), reportableAgentErrorOptions(err));
       });
     return () => {
       cancelled = true;
@@ -3462,7 +3448,7 @@ export function AgentWorkspace({
         if (cancelled) return;
         setBridge(status);
       } catch (err) {
-        if (!cancelled) setError(describeAgentError(err), reportableAgentErrorOptions(err));
+        if (!cancelled) setError(describeHermesError(err), reportableAgentErrorOptions(err));
       }
     })();
     return () => {
@@ -5531,7 +5517,7 @@ export function AgentWorkspace({
         await refreshHermesSession(sessionId);
       }
     } catch (err) {
-      setError(describeAgentError(err), reportableAgentErrorOptions(err));
+      setError(describeHermesError(err), reportableAgentErrorOptions(err));
     }
   }
 
@@ -5766,7 +5752,7 @@ export function AgentWorkspace({
       // "Session not found" 404 resolves on the next poll, so don't surface
       // it as an error banner (JUN-116).
       if (isSessionGoneError(message)) return;
-      setError(describeAgentError(err), reportableAgentErrorOptions(err, { sessionId }));
+      setError(describeHermesError(err), reportableAgentErrorOptions(err, { sessionId }));
     }
   }
 

--- a/src/components/agent/AgentWorkspace.tsx
+++ b/src/components/agent/AgentWorkspace.tsx
@@ -5664,17 +5664,33 @@ export function AgentWorkspace({
         continue;
       }
       misses.delete(sessionId);
-      const activityCounts = clearSessionActivity(sessionId);
-      // "completed" (not "failed") keeps the status quiet: its title falls back
-      // to lastStatus when nothing is active, and a stale "running" there
-      // would still render "Working…".
+      const freshMessages = await refreshHermesSession(sessionId);
+      if (!freshMessages) continue;
+      const title =
+        hermesSessionItems.find((session) => session.id === sessionId)?.title ?? "Agent session";
+      if (sessionHasAssistantAfterLatestUser(freshMessages)) {
+        const activityCounts = clearSessionActivity(sessionId);
+        // "completed" (not "failed") keeps the status quiet: its title falls back
+        // to lastStatus when nothing is active, and a stale "running" there
+        // would still render "Working…".
+        dispatchAgentSessionStatus({
+          sessionId,
+          title,
+          status: "completed",
+          summary: "June stopped.",
+          ...activityCounts,
+        });
+        continue;
+      }
+      const summary = "June stopped before replying.";
+      recordSessionErrorActivity(sessionId, summary);
+      setError(summary, { sessionId });
       dispatchAgentSessionStatus({
         sessionId,
-        title:
-          hermesSessionItems.find((session) => session.id === sessionId)?.title ?? "Agent session",
-        status: "completed",
-        summary: "June stopped.",
-        ...activityCounts,
+        title,
+        status: "failed",
+        summary,
+        ...agentActivityCountsFromStore(),
       });
     }
   }
@@ -5702,11 +5718,12 @@ export function AgentWorkspace({
   async function refreshHermesSession(sessionId: string) {
     try {
       const messages = await listSessionMessagesOrdered(sessionId);
-      if (!messages) return;
+      if (!messages) return undefined;
       const retainedPending = retainUnpersistedPendingMessages(
         pendingHermesMessagesRef.current[sessionId] ?? [],
         messages,
       );
+      const combined = [...messages, ...retainedPending];
       setHermesSessionMessages((current) => ({
         ...current,
         [sessionId]: messages,
@@ -5720,7 +5737,7 @@ export function AgentWorkspace({
         return next;
       });
       void suggestTitleForUntitledSession(sessionId, messages);
-      if (sessionHasAssistantAfterLatestUser([...messages, ...retainedPending])) {
+      if (sessionHasAssistantAfterLatestUser(combined)) {
         promotePendingIssueReportToReview(sessionId, {
           queueDiagnosisRefresh: false,
         });
@@ -5746,13 +5763,15 @@ export function AgentWorkspace({
         setLiveEvents(liveEventsRef.current);
       }
       await loadHermesSessions();
+      return combined;
     } catch (err) {
       const message = messageFromError(err);
       // Background refresh racing a just-created session: a transient
       // "Session not found" 404 resolves on the next poll, so don't surface
       // it as an error banner (JUN-116).
-      if (isSessionGoneError(message)) return;
+      if (isSessionGoneError(message)) return undefined;
       setError(describeHermesError(err), reportableAgentErrorOptions(err, { sessionId }));
+      return undefined;
     }
   }
 

--- a/src/components/note-editor/NoteEditor.tsx
+++ b/src/components/note-editor/NoteEditor.tsx
@@ -280,6 +280,7 @@ export function NoteEditor({
   const processingText = processingMessage(note.processingStatus);
   const transcriptText = transcriptToText(note, liveTranscriptTurns);
   const transcriptCoverageNotice = transcriptCoverageNoticeText(note);
+  const silentSourceNotice = silentSourceNoticeText(note);
   const showTranscriptProcessing = processingStatus !== null;
   const showLivePreviewWaiting =
     recordingForNote?.livePreviewEnabled === true && liveTranscriptTurns.length === 0;
@@ -377,6 +378,9 @@ export function NoteEditor({
             ) : null}
             {transcriptCoverageNotice ? (
               <p className="transcript-coverage-notice">{transcriptCoverageNotice}</p>
+            ) : null}
+            {silentSourceNotice ? (
+              <p className="transcript-coverage-notice">{silentSourceNotice}</p>
             ) : null}
             {visibleTurns.length ? (
               <div className="source-transcripts">
@@ -894,6 +898,16 @@ function transcriptCoverageNoticeText(note: NoteDto): string | null {
   const missingMinutes = Math.max(1, Math.floor(missingMs / 60_000));
   const detectedMinutes = Math.max(1, Math.floor(detectedSpeechMs / 60_000));
   return `Parts of this recording could not be transcribed. About ${missingMinutes} of ${detectedMinutes} minutes of detected speech are missing from this transcript.`;
+}
+
+// A source that recorded pure silence fails transcription with a targeted
+// message, but a note can still finish ready on its other source; surface
+// that message as a notice instead of leaving it buried in the turn list.
+function silentSourceNoticeText(note: NoteDto): string | null {
+  const silent = (note.sourceTranscripts ?? []).find(
+    (turn) => turn.recordedSilence && !turn.text.trim() && turn.lastError,
+  );
+  return silent?.lastError ?? null;
 }
 
 function orderedVisibleSourceTranscripts(note: NoteDto): RenderedTranscriptTurn[] {

--- a/src/components/recorder/GlobalRecorderPill.tsx
+++ b/src/components/recorder/GlobalRecorderPill.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import type { RecordingStatusDto } from "../../lib/tauri";
 import { combineSourceAudioLevels, Waveform } from "./Waveform";
 import { useRecordingPresenceBounds } from "../../lib/recording-presence-bounds";
+import { hasMicrophoneSilenceWarning } from "./RecorderBar";
 
 type GlobalRecorderPillProps = {
   status: RecordingStatusDto;
@@ -19,6 +20,7 @@ type GlobalRecorderPillProps = {
 export function GlobalRecorderPill({ status, title, onOpen }: GlobalRecorderPillProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
   const recording = status.state === "recording";
+  const microphoneSilent = hasMicrophoneSilenceWarning(status);
   useRecordingPresenceBounds(buttonRef);
   // status.level is mic-only; status.sources carries mic+system when available.
   const meterLevel =
@@ -34,9 +36,11 @@ export function GlobalRecorderPill({ status, title, onOpen }: GlobalRecorderPill
       data-state={status.state}
       onClick={onOpen}
       aria-label={`Open recording: ${title}`}
-      title="Open recording"
+      title={microphoneSilent ? "Mic looks silent" : "Open recording"}
+      data-warning={microphoneSilent ? "silence" : undefined}
     >
       <Waveform level={meterLevel} active={recording} />
+      {microphoneSilent ? <span className="global-recorder-warning">Mic looks silent</span> : null}
     </button>
   );
 }

--- a/src/components/recorder/RecorderBar.tsx
+++ b/src/components/recorder/RecorderBar.tsx
@@ -14,6 +14,7 @@ type RecorderBarProps = {
 export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarProps) {
   const paused = status.state === "paused";
   const controlsEnabled = status.state === "recording" || status.state === "paused";
+  const microphoneSilent = hasMicrophoneSilenceWarning(status);
   // status.level is mic-only; status.sources carries mic+system when available.
   const meterLevel =
     status.sources && status.sources.length > 0
@@ -42,6 +43,9 @@ export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarPr
       <div className="recorder-meter">
         <span className="elapsed">{formatElapsed(status.elapsedMs)}</span>
         <Waveform level={meterLevel} active={status.state === "recording"} />
+        {microphoneSilent ? (
+          <span className="recorder-silence-warning">Mic looks silent</span>
+        ) : null}
       </div>
       <button
         type="button"
@@ -55,6 +59,11 @@ export function RecorderBar({ status, onPause, onResume, onDone }: RecorderBarPr
       </button>
     </div>
   );
+}
+
+export function hasMicrophoneSilenceWarning(status: RecordingStatusDto) {
+  const microphone = status.sources?.find((source) => source.source === "microphone");
+  return microphone?.silenceWarning ?? status.silenceWarning;
 }
 
 export function formatElapsed(ms: number) {

--- a/src/components/routines/RoutineDetail.tsx
+++ b/src/components/routines/RoutineDetail.tsx
@@ -22,6 +22,7 @@ import { BreadcrumbBar } from "../ui/BreadcrumbBar";
 import { HoverTip } from "../ui/HoverTip";
 import { Switch } from "../ui/Switch";
 import { userFacingFailureMessage } from "../note-editor/NoteFailureBanner";
+import { HERMES_SERVER_ERROR_MESSAGE, isHermesServerError } from "../../lib/errors";
 import { GrowingTextarea } from "./GrowingTextarea";
 import { RoutineModePicker } from "./RoutineModePicker";
 import { formatRunTime, RoutineRunList } from "./RoutineRunList";
@@ -146,10 +147,17 @@ export function RoutineDetail({
     queueTimer.current = window.setTimeout(() => setQueued(false), 5000);
   }
 
-  const failure =
+  const storedFailure =
     routine.last_status === "error"
-      ? userFacingFailureMessage(routine.last_error || routine.last_delivery_error || undefined)
-      : null;
+      ? routine.last_error || routine.last_delivery_error || undefined
+      : undefined;
+  // A stored Hermes 5xx reads as raw wire text; classify it before the
+  // generic failure wrapper (JUN-196).
+  const failure = storedFailure
+    ? isHermesServerError(storedFailure)
+      ? HERMES_SERVER_ERROR_MESSAGE
+      : userFacingFailureMessage(storedFailure)
+    : null;
 
   return (
     <section className="routine-detail" aria-label={routine.name}>

--- a/src/components/routines/RoutineDetail.tsx
+++ b/src/components/routines/RoutineDetail.tsx
@@ -1,4 +1,5 @@
 import { IconDotGrid1x3Horizontal } from "central-icons/IconDotGrid1x3Horizontal";
+import { IconArrowRotateClockwise } from "central-icons/IconArrowRotateClockwise";
 import { IconCalendarRepeat } from "central-icons/IconCalendarRepeat";
 import { IconPlay } from "central-icons/IconPlay";
 import { IconShieldCrossed } from "central-icons/IconShieldCrossed";
@@ -39,6 +40,8 @@ type RoutineDetailProps = {
   onRunNow: () => Promise<void>;
   onDelete: () => void;
   onOpenRun: (run: HermesSessionInfo) => void;
+  onRetryLoad?: () => void;
+  retrying?: boolean;
 };
 
 /** One routine, fully editable in place: schedule, instructions, access and
@@ -58,6 +61,8 @@ export function RoutineDetail({
   onRunNow,
   onDelete,
   onOpenRun,
+  onRetryLoad,
+  retrying,
 }: RoutineDetailProps) {
   const [name, setName] = useState(routine.name);
   const [draft, setDraft] = useState<ScheduleDraft>(() => draftFromSchedule(routine.schedule));
@@ -258,7 +263,23 @@ export function RoutineDetail({
           ) : null}
         </div>
 
-        {error ? <p className="error-banner">{error}</p> : null}
+        {error ? (
+          <div className="error-banner routines-error-banner" role="alert">
+            <p>{error}</p>
+            {onRetryLoad ? (
+              <button
+                type="button"
+                className="btn btn-ghost"
+                onClick={onRetryLoad}
+                disabled={retrying}
+                aria-busy={retrying || undefined}
+              >
+                <IconArrowRotateClockwise size={14} className="balance-refresh-icon" aria-hidden />
+                Try again
+              </button>
+            ) : null}
+          </div>
+        ) : null}
         {failure ? (
           <div className="routine-detail-failure" role="status">
             <strong>Last run failed.</strong> {failure}

--- a/src/components/routines/RoutinesView.tsx
+++ b/src/components/routines/RoutinesView.tsx
@@ -14,6 +14,7 @@ import { IconTrashCan } from "central-icons/IconTrashCan";
 import { IconZap } from "central-icons/IconZap";
 import { IconPause } from "central-icons/IconPause";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { describeHermesError } from "../../lib/errors";
 import {
   isReplaceableScheduledRunTitle,
   listScheduledRunSessions,
@@ -66,6 +67,7 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
   const [loadingState, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorRetryable, setErrorRetryable] = useState(false);
   const [query, setQuery] = useState("");
   const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
   const [pendingDelete, setPendingDelete] = useState<RoutineJob | null>(null);
@@ -74,6 +76,7 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
   const [createError, setCreateError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [detailErrorRetryable, setDetailErrorRetryable] = useState(false);
   const [describeDraft, setDescribeDraft] = useState("");
   const [refreshSpins, setRefreshSpins] = useState(0);
   // Per-routine mode choice for the routine being described. Defaults to
@@ -101,10 +104,12 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
       const jobs = await listRoutines();
       setRoutines(sortRoutines(jobs));
       setError(null);
+      setErrorRetryable(false);
       return null;
     } catch (err) {
-      const message = messageFromError(err);
+      const message = describeRoutineError(err);
       setError(message);
+      setErrorRetryable(true);
       return message;
     } finally {
       setLoading(false);
@@ -199,9 +204,13 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
       // sets on failure) — clearing here would mask a failed reload.
       const reloadError = await loadRoutines();
       setDetailError(reloadError);
+      setDetailErrorRetryable(reloadError !== null);
     } catch (err) {
-      setError(messageFromError(err));
-      setDetailError(messageFromError(err));
+      const message = describeRoutineError(err);
+      setError(message);
+      setErrorRetryable(false);
+      setDetailError(message);
+      setDetailErrorRetryable(false);
     } finally {
       markBusy(routine.job_id, false);
     }
@@ -212,8 +221,10 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
     try {
       await triggerRoutine(routine.job_id);
       setDetailError(null);
+      setDetailErrorRetryable(false);
     } catch (err) {
-      setDetailError(messageFromError(err));
+      setDetailError(describeRoutineError(err));
+      setDetailErrorRetryable(false);
       throw err;
     } finally {
       markBusy(routine.job_id, false);
@@ -224,10 +235,12 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
     setSaving(true);
     try {
       await updateRoutine(jobId, updates);
-      await loadRoutines();
-      setDetailError(null);
+      const reloadError = await loadRoutines();
+      setDetailError(reloadError);
+      setDetailErrorRetryable(reloadError !== null);
     } catch (err) {
-      setDetailError(messageFromError(err));
+      setDetailError(describeRoutineError(err));
+      setDetailErrorRetryable(false);
     } finally {
       setSaving(false);
     }
@@ -240,9 +253,10 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
       await loadRoutines();
       setCreateError(null);
       setDetailError(null);
+      setDetailErrorRetryable(false);
       setPage({ kind: "detail", jobId: created.job_id });
     } catch (err) {
-      setCreateError(messageFromError(err));
+      setCreateError(describeRoutineError(err));
     } finally {
       setCreating(false);
     }
@@ -257,12 +271,16 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
       await removeRoutine(routine.job_id);
       setRoutines((prev) => prev.filter((entry) => entry.job_id !== routine.job_id));
       setError(null);
+      setErrorRetryable(false);
       setPage((current) =>
         current.kind === "detail" && current.jobId === routine.job_id ? { kind: "list" } : current,
       );
     } catch (err) {
-      setError(messageFromError(err));
-      setDetailError(messageFromError(err));
+      const message = describeRoutineError(err);
+      setError(message);
+      setErrorRetryable(false);
+      setDetailError(message);
+      setDetailErrorRetryable(false);
     }
   }
 
@@ -284,12 +302,26 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
 
   function openDetail(routine: RoutineJob) {
     setDetailError(null);
+    setDetailErrorRetryable(false);
     setPage({ kind: "detail", jobId: routine.job_id });
   }
 
   function refreshNow() {
     setRefreshSpins((spins) => spins + 1);
     void refresh();
+  }
+
+  function retryListLoad() {
+    setRefreshSpins((spins) => spins + 1);
+    void loadRoutines();
+  }
+
+  function retryDetailLoad() {
+    setRefreshSpins((spins) => spins + 1);
+    void loadRoutines().then((reloadError) => {
+      setDetailError(reloadError);
+      setDetailErrorRetryable(reloadError !== null);
+    });
   }
 
   const detailRoutine = page.kind === "detail" ? (routinesById.get(page.jobId) ?? null) : null;
@@ -362,6 +394,8 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
           onRunNow={() => runNow(detailRoutine)}
           onDelete={() => setPendingDelete(detailRoutine)}
           onOpenRun={onOpenRun}
+          onRetryLoad={detailErrorRetryable ? retryDetailLoad : undefined}
+          retrying={refreshing}
         />
         {dialogs}
       </>
@@ -413,7 +447,13 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
         </div>
       ) : null}
 
-      {error ? <p className="error-banner">{error}</p> : null}
+      {error ? (
+        <RoutineErrorBanner
+          message={error}
+          onRetry={errorRetryable ? retryListLoad : undefined}
+          retrying={refreshing}
+        />
+      ) : null}
 
       {loading ? (
         <div className="folders-empty">
@@ -435,7 +475,12 @@ export function RoutinesView({ onCreateRoutine, onOpenRun }: RoutinesViewProps) 
               routine={routine}
               busy={busyIds.has(routine.job_id)}
               onOpen={() => openDetail(routine)}
-              onRunNow={() => void runNow(routine).catch((err) => setError(messageFromError(err)))}
+              onRunNow={() =>
+                void runNow(routine).catch((err) => {
+                  setError(describeRoutineError(err));
+                  setErrorRetryable(false);
+                })
+              }
               onDelete={() => setPendingDelete(routine)}
             />
           ))}
@@ -680,12 +725,40 @@ function timeValue(iso: string | null | undefined) {
   return Number.isNaN(time) ? Number.MAX_SAFE_INTEGER : time;
 }
 
-function messageFromError(err: unknown) {
+function describeRoutineError(err: unknown) {
   if (err && typeof err === "object" && "message" in err) {
     const message = (err as { message?: unknown }).message;
-    if (typeof message === "string" && message) return message;
+    if (typeof message === "string" && message) return describeHermesError(err);
   }
   return "Routines are unavailable. Is June's agent running?";
+}
+
+function RoutineErrorBanner({
+  message,
+  onRetry,
+  retrying,
+}: {
+  message: string;
+  onRetry?: () => void;
+  retrying?: boolean;
+}) {
+  return (
+    <div className="error-banner routines-error-banner" role="alert">
+      <p>{message}</p>
+      {onRetry ? (
+        <button
+          type="button"
+          className="btn btn-ghost"
+          onClick={onRetry}
+          disabled={retrying}
+          aria-busy={retrying || undefined}
+        >
+          <IconArrowRotateClockwise size={14} className="balance-refresh-icon" aria-hidden />
+          Try again
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 const DEJUNE_MODE_OPTIONS = [

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -72,6 +72,16 @@ export function isHermesServerError(message?: string) {
   return /Hermes API returned 5\d\d\b/.test(message);
 }
 
+export const HERMES_SERVER_ERROR_MESSAGE = "June ran into a problem with that request.";
+
+/** Human-readable Hermes command error. Transient Hermes REST 5xx errors are
+ * local runtime faults, so user-facing surfaces should not leak the raw bridge
+ * wire string (`Hermes API returned 500: ...`). */
+export function describeHermesError(err: unknown): string {
+  const message = messageFromError(err);
+  return isHermesServerError(message) ? HERMES_SERVER_ERROR_MESSAGE : message;
+}
+
 /** Whether an error message means the request outgrew the model's context (or
  * the agent request-size limit) — a hard size failure the user must act on
  * (trim the input, attach a smaller file, start a fresh session), NOT something

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,1 +1,2 @@
 export const MEETING_START_TRANSCRIPTION_EVENT = "june://meeting-start-transcription";
+export const AGENT_RECORDER_REQUEST_EVENT = "june://agent-recorder-request";

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -59,6 +59,7 @@ export type TranscriptDto = {
   language?: string;
   status: "pending" | "running" | "succeeded" | "failed";
   lastError?: string;
+  recordedSilence?: boolean;
 };
 
 export const LIVE_TRANSCRIPT_EVENT = "live-transcript-event";
@@ -619,6 +620,7 @@ export type AudioValidationDto = {
   actualDurationMs: number;
   durationWithinTolerance: boolean;
   nonSilentSignal: boolean;
+  recordedSilence?: boolean;
   peakAmplitude: number;
   rmsAmplitude: number;
   warnings: string[];
@@ -633,6 +635,7 @@ export type SourceValidationDto = {
   actualDurationMs?: number;
   durationWithinTolerance: boolean;
   nonSilentSignal: boolean;
+  recordedSilence?: boolean;
   peakAmplitude?: number;
   rmsAmplitude?: number;
   warnings: string[];

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1462,6 +1462,19 @@ export async function finishRecording(sessionId: string) {
   });
 }
 
+export type ResolveAgentRecorderRequestInput = {
+  requestId: string;
+  ok: boolean;
+  noteId?: string;
+  noteTitle?: string;
+  errorCode?: string;
+  errorMessage?: string;
+};
+
+export async function resolveAgentRecorderRequest(request: ResolveAgentRecorderRequestInput) {
+  return invoke<void>("resolve_agent_recorder_request", { request });
+}
+
 export async function retryProcessing(noteId: string) {
   return invoke<NoteDto>("retry_processing", {
     request: { noteId, step: "all" },

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9454,6 +9454,15 @@ input:focus-visible,
   font-weight: 400;
 }
 
+/* A live mic that has produced only silence is a session about to be lost;
+ * the hint reads as a problem (destructive), not ambience. */
+.recorder-silence-warning,
+.global-recorder-warning {
+  color: var(--destructive);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+}
+
 /* Waveform ---------------------------------------------------------- */
 
 /* Mirrors the dictation HUD bars (.hud-bar) so the recorder waveform reads as

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -9688,6 +9688,21 @@ input:focus-visible,
   font-size: var(--fs-md);
 }
 
+.routines-error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.routines-error-banner p {
+  margin: 0;
+}
+
+.routines-error-banner .btn {
+  flex: 0 0 auto;
+}
+
 /* Positive sibling of .error-banner for transient good news (billing
  * feedback like "You are on Max now"). Same geometry, success palette. */
 .notice-banner {

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5517,19 +5517,15 @@ describe("AgentWorkspace", () => {
 
       expect(screen.getByText("Here is the answer.")).toBeInTheDocument();
       expect(screen.queryByText("June stopped before replying.")).toBeNull();
-      expect(statusDetails).toContainEqual(
-        expect.objectContaining({
-          sessionId: "session-1",
-          status: "completed",
-        }),
+      const terminal = statusDetails.filter(
+        (detail) =>
+          detail.sessionId === "session-1" &&
+          (detail.status === "completed" || detail.status === "failed"),
       );
-      expect(statusDetails).not.toContainEqual(
-        expect.objectContaining({
-          sessionId: "session-1",
-          status: "failed",
-          summary: "June stopped before replying.",
-        }),
-      );
+      // Exactly one terminal dispatch, from refreshHermesSession seeing the
+      // reply — a second "June stopped." would overwrite the finished summary.
+      expect(terminal).toHaveLength(1);
+      expect(terminal[0]).toMatchObject({ status: "completed", summary: "June finished." });
     } finally {
       window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
       vi.useRealTimers();

--- a/src/test/agent-workspace.test.tsx
+++ b/src/test/agent-workspace.test.tsx
@@ -5402,14 +5402,19 @@ describe("AgentWorkspace", () => {
     expect(screen.getByText("open the release notes")).toBeInTheDocument();
   });
 
-  it("clears a working session the runtime is no longer running", async () => {
+  it("marks a disappeared working session failed when no assistant reply persisted", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
     // A recent trailing user message with no reply resumes the session as
     // working on mount — the exact state a dead run (provider failure, app
     // quit mid-turn) leaves behind.
     mocks.listHermesSessionMessages.mockResolvedValue([
       {
         id: "m1",
-        role: "user",
+        role: "user" as const,
         content: "still waiting on this",
         timestamp: new Date().toISOString(),
       },
@@ -5443,7 +5448,90 @@ describe("AgentWorkspace", () => {
 
       expect(mocks.gatewayRequest).toHaveBeenCalledWith("session.active_list", {});
       expect(screen.queryByText("Thinking…")).toBeNull();
+      expect(screen.getByText("June stopped before replying.")).toBeInTheDocument();
+      expect(statusDetails).toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-1",
+          status: "failed",
+          summary: "June stopped before replying.",
+        }),
+      );
+      expect(hermesActivityStore.getRecord("session-1")?.phase).toBe("error");
+      expect(statusDetails).not.toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-1",
+          status: "completed",
+          summary: "June stopped.",
+        }),
+      );
     } finally {
+      window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps disappeared working sessions quiet when an assistant reply persisted", async () => {
+    const statusDetails: AgentSessionStatusDetail[] = [];
+    const handleStatus = (event: Event) => {
+      statusDetails.push((event as CustomEvent<AgentSessionStatusDetail>).detail);
+    };
+    window.addEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
+    const userOnly = [
+      {
+        id: "m1",
+        role: "user",
+        content: "still waiting on this",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    mocks.listHermesSessionMessages.mockResolvedValueOnce(userOnly).mockResolvedValue([
+      ...userOnly,
+      {
+        id: "m2",
+        role: "assistant" as const,
+        content: "Here is the answer.",
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+    mocks.gatewayRequest.mockImplementation((method: string) => {
+      if (method === "session.active_list") {
+        return Promise.resolve({ sessions: [] });
+      }
+      return Promise.resolve({});
+    });
+
+    vi.useFakeTimers();
+    try {
+      render(<AgentWorkspace />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+      expect(screen.getByText("Thinking…")).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(screen.getByText("Here is the answer.")).toBeInTheDocument();
+      expect(screen.queryByText("June stopped before replying.")).toBeNull();
+      expect(statusDetails).toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-1",
+          status: "completed",
+        }),
+      );
+      expect(statusDetails).not.toContainEqual(
+        expect.objectContaining({
+          sessionId: "session-1",
+          status: "failed",
+          summary: "June stopped before replying.",
+        }),
+      );
+    } finally {
+      window.removeEventListener(AGENT_SESSION_STATUS_EVENT, handleStatus);
       vi.useRealTimers();
     }
   });

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -391,15 +391,11 @@ describe("agent recorder request event", () => {
 
   async function renderUntilAgentRecorderListener() {
     render(<App />);
+    // The listener registers exactly once; its handler reads app state
+    // through a latest-closure ref, so waiting for bootstrap data (getNote)
+    // is enough for the handler to see the ready app.
+    await waitForLoaded(() => expect(mocks.listeners.has(AGENT_RECORDER_REQUEST_EVENT)).toBe(true));
     await waitForLoaded(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
-    // The listener registers once before bootstrap resolves (its closure acks
-    // app_not_ready) and re-registers after `bootstrapped` flips. Waiting for
-    // the second registration guarantees the handler sees the ready app.
-    await waitForLoaded(() =>
-      expect(
-        mocks.listen.mock.calls.filter(([event]) => event === AGENT_RECORDER_REQUEST_EVENT).length,
-      ).toBeGreaterThanOrEqual(2),
-    );
   }
 
   it("starts a requested recording and acks with the created note", async () => {

--- a/src/test/app-meeting-start.test.tsx
+++ b/src/test/app-meeting-start.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../app/App";
-import { MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
+import { AGENT_RECORDER_REQUEST_EVENT, MEETING_START_TRANSCRIPTION_EVENT } from "../lib/events";
 import type { AccountStatus, BootstrapResponse, NoteDto, RecordingSessionDto } from "../lib/tauri";
 
 type TauriListener = (event: { payload: unknown }) => unknown;
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   finishRecording: vi.fn(),
   retryProcessing: vi.fn(),
   recoverRecording: vi.fn(),
+  resolveAgentRecorderRequest: vi.fn(),
   dictationHelperCommand: vi.fn(),
   listDictationHistory: vi.fn(),
   osAccountsStatus: vi.fn(),
@@ -84,6 +85,7 @@ vi.mock("../lib/tauri", () => ({
   finishRecording: mocks.finishRecording,
   retryProcessing: mocks.retryProcessing,
   recoverRecording: mocks.recoverRecording,
+  resolveAgentRecorderRequest: mocks.resolveAgentRecorderRequest,
   dictationHelperCommand: mocks.dictationHelperCommand,
   listDictationHistory: mocks.listDictationHistory,
   osAccountsStatus: mocks.osAccountsStatus,
@@ -312,5 +314,183 @@ describe("meeting start transcription event", () => {
     for (const cleanup of cleanups) {
       expect(cleanup).toHaveBeenCalledOnce();
     }
+  });
+});
+
+describe("agent recorder request event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listeners.clear();
+
+    const first = note();
+    const payload: BootstrapResponse = {
+      folders: [],
+      notes: [first],
+      activeRecoveries: [],
+      providerConfigured: true,
+    };
+    const account: AccountStatus = {
+      signedIn: true,
+      configured: true,
+      user: { id: "usr_123", handle: "alex", email: "alex@example.com" },
+      balance: { usdMillis: 1200 },
+      subscription: { subscribed: true, status: "active" },
+    };
+
+    mocks.getCurrentWindow.mockReturnValue({
+      show: vi.fn().mockResolvedValue(undefined),
+      unminimize: vi.fn().mockResolvedValue(undefined),
+      setFocus: vi.fn().mockResolvedValue(undefined),
+      startDragging: vi.fn().mockResolvedValue(undefined),
+    });
+    mocks.bootstrapApp.mockResolvedValue(payload);
+    mocks.getNote.mockResolvedValue(first);
+    mocks.createNote.mockResolvedValue(
+      note({ id: "note-agent", title: "Agent recording", generatedContent: undefined }),
+    );
+    mocks.checkRecordingSourceReadiness.mockResolvedValue({
+      sourceMode: "microphonePlusSystem",
+      sources: [
+        { source: "microphone", ready: true },
+        { source: "system", ready: true },
+      ],
+    });
+    mocks.startRecording.mockResolvedValue(recording({ id: "rec-agent", noteId: "note-agent" }));
+    mocks.getRecordingStatus.mockResolvedValue({
+      sessionId: "rec-agent",
+      noteId: "note-agent",
+      sourceMode: "microphonePlusSystem",
+      state: "recording",
+      elapsedMs: 500,
+      level: { peak: 0.2, rms: 0.1, recentPeaks: [0.2] },
+      silenceWarning: false,
+      bytesWritten: 2048,
+    });
+    mocks.finishRecording.mockResolvedValue({
+      note: note({ id: "note-agent", title: "Agent recording", processingStatus: "transcribing" }),
+      recording: recording({ id: "rec-agent", noteId: "note-agent" }),
+      validation: {},
+      validations: [],
+      processingStarted: true,
+      warnings: [],
+    });
+    mocks.dictationHelperCommand.mockResolvedValue(undefined);
+    mocks.listDictationHistory.mockResolvedValue({ items: [], retentionDays: 7 });
+    mocks.osAccountsStatus.mockResolvedValue(account);
+    mocks.osAccountsLogin.mockResolvedValue(account);
+    mocks.osAccountsLogout.mockResolvedValue(undefined);
+    mocks.osAccountsCancelLogin.mockResolvedValue(undefined);
+    mocks.osAccountsUpgrade.mockResolvedValue(undefined);
+    mocks.updateNote.mockImplementation(async (input) => ({ ...first, ...input }));
+    mocks.resolveAgentRecorderRequest.mockResolvedValue(undefined);
+  });
+
+  // The agent-recorder chain is fully mocked but multi-hop async; the 1s
+  // default waitFor timeout flakes under full-suite machine load.
+  const waitForLoaded = <T,>(callback: () => T) => waitFor(callback, { timeout: 5_000 });
+
+  async function renderUntilAgentRecorderListener() {
+    render(<App />);
+    await waitForLoaded(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+    // The listener registers once before bootstrap resolves (its closure acks
+    // app_not_ready) and re-registers after `bootstrapped` flips. Waiting for
+    // the second registration guarantees the handler sees the ready app.
+    await waitForLoaded(() =>
+      expect(
+        mocks.listen.mock.calls.filter(([event]) => event === AGENT_RECORDER_REQUEST_EVENT).length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+  }
+
+  it("starts a requested recording and acks with the created note", async () => {
+    await renderUntilAgentRecorderListener();
+
+    await act(async () => {
+      await mocks.listeners.get(AGENT_RECORDER_REQUEST_EVENT)?.({
+        payload: {
+          requestId: "req-start",
+          action: "start",
+          sourceMode: "microphonePlusSystem",
+        },
+      });
+    });
+
+    await waitForLoaded(() => {
+      expect(mocks.startRecording).toHaveBeenCalledWith("note-agent", "microphonePlusSystem");
+      expect(mocks.resolveAgentRecorderRequest).toHaveBeenCalledWith({
+        requestId: "req-start",
+        ok: true,
+        noteId: "note-agent",
+        noteTitle: "Agent recording",
+      });
+    });
+  });
+
+  it("acks start with an error when recording is already running", async () => {
+    await renderUntilAgentRecorderListener();
+    await act(async () => {
+      await mocks.listeners.get(AGENT_RECORDER_REQUEST_EVENT)?.({
+        payload: {
+          requestId: "req-first",
+          action: "start",
+          sourceMode: "microphonePlusSystem",
+        },
+      });
+    });
+    await waitForLoaded(() => expect(mocks.startRecording).toHaveBeenCalledOnce());
+
+    await act(async () => {
+      await mocks.listeners.get(AGENT_RECORDER_REQUEST_EVENT)?.({
+        payload: {
+          requestId: "req-second",
+          action: "start",
+          sourceMode: "microphonePlusSystem",
+        },
+      });
+    });
+
+    expect(mocks.resolveAgentRecorderRequest).toHaveBeenLastCalledWith({
+      requestId: "req-second",
+      ok: false,
+      errorCode: "agent_recorder_failed",
+      errorMessage: "A recording is already running for note note-agent.",
+    });
+  });
+
+  it("stops the active recording and acks the owning note", async () => {
+    await renderUntilAgentRecorderListener();
+    await act(async () => {
+      await mocks.listeners.get(AGENT_RECORDER_REQUEST_EVENT)?.({
+        payload: {
+          requestId: "req-start",
+          action: "start",
+          sourceMode: "microphonePlusSystem",
+        },
+      });
+    });
+    // Wait for the start ACK (not just the startRecording call): the stop
+    // below must see the recording status already reflected, or it races
+    // into the recording_not_found branch under suite load.
+    await waitForLoaded(() =>
+      expect(mocks.resolveAgentRecorderRequest).toHaveBeenLastCalledWith(
+        expect.objectContaining({ requestId: "req-start", ok: true }),
+      ),
+    );
+
+    await act(async () => {
+      await mocks.listeners.get(AGENT_RECORDER_REQUEST_EVENT)?.({
+        payload: { requestId: "req-stop", action: "stop" },
+      });
+    });
+
+    await waitForLoaded(() => {
+      expect(mocks.finishRecording).toHaveBeenCalledWith("rec-agent");
+      expect(mocks.resolveAgentRecorderRequest).toHaveBeenLastCalledWith({
+        requestId: "req-stop",
+        ok: true,
+        noteId: "note-agent",
+        noteTitle: "Agent recording",
+      });
+    });
   });
 });

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -571,7 +571,7 @@ describe("notes recording reliability", () => {
     expect(mocks.startRecording).not.toHaveBeenCalled();
   });
 
-  it("removes the fresh meeting note when recording start times out and releases the start latch", async () => {
+  it("removes the fresh note when recording start times out and releases the start latch", async () => {
     const fresh = note({
       id: "fresh-note",
       title: "New note",
@@ -656,7 +656,7 @@ describe("notes recording reliability", () => {
       expect(mocks.listNotes).toHaveBeenCalled();
     });
     expect(warn).toHaveBeenCalledWith(
-      "Failed to delete meeting note after recording start failed",
+      "Failed to delete note after recording start failed",
       expect.any(Error),
     );
     expect(screen.getByLabelText("Note title")).toHaveValue("First note");

--- a/src/test/app-notes-reliability.test.tsx
+++ b/src/test/app-notes-reliability.test.tsx
@@ -571,6 +571,98 @@ describe("notes recording reliability", () => {
     expect(mocks.startRecording).not.toHaveBeenCalled();
   });
 
+  it("removes the fresh meeting note when recording start times out and releases the start latch", async () => {
+    const fresh = note({
+      id: "fresh-note",
+      title: "New note",
+      generatedContent: undefined,
+      processingStatus: "draft",
+    });
+    mocks.createNote
+      .mockResolvedValueOnce(fresh)
+      .mockResolvedValueOnce(note({ id: "second-fresh-note", title: "Second fresh note" }));
+    mocks.getNote.mockImplementation(async (noteId: string) => {
+      if (noteId === "fresh-note") return fresh;
+      if (noteId === "note-2") return second;
+      return first;
+    });
+    mocks.startRecording
+      .mockRejectedValueOnce({
+        code: "capture_start_timeout",
+        message: "Could not start the microphone. Try again, or check the selected input device.",
+      })
+      .mockResolvedValueOnce(recording({ noteId: "second-fresh-note" }));
+
+    render(<App />);
+    await waitFor(() => expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true));
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await waitFor(async () => {
+      if (mocks.deleteNote.mock.calls.length === 0) {
+        await act(async () => {
+          await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+            payload: undefined,
+          });
+        });
+      }
+      expect(mocks.deleteNote).toHaveBeenCalledWith("fresh-note");
+    });
+    expect(mocks.startRecording).toHaveBeenCalledTimes(1);
+
+    await waitFor(async () => {
+      if (mocks.startRecording.mock.calls.length < 2) {
+        await act(async () => {
+          await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+            payload: undefined,
+          });
+        });
+      }
+      expect(mocks.startRecording).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("restores the previous meeting selection when cleanup deletion fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fresh = note({
+      id: "fresh-note",
+      title: "New note",
+      generatedContent: undefined,
+      processingStatus: "draft",
+    });
+    mocks.createNote.mockResolvedValue(fresh);
+    mocks.deleteNote.mockRejectedValue(new Error("delete failed"));
+    mocks.getNote.mockImplementation(async (noteId: string) => {
+      if (noteId === "fresh-note") return fresh;
+      if (noteId === "note-2") return second;
+      return first;
+    });
+    mocks.startRecording.mockRejectedValue({
+      code: "capture_start_timeout",
+      message: "Could not start the microphone. Try again, or check the selected input device.",
+    });
+
+    render(<App />);
+    await waitFor(() => expect(mocks.listeners.has(MEETING_START_TRANSCRIPTION_EVENT)).toBe(true));
+    await waitFor(() => expect(mocks.getNote).toHaveBeenCalledWith("note-1"));
+
+    await waitFor(async () => {
+      if (mocks.listNotes.mock.calls.length === 0) {
+        await act(async () => {
+          await mocks.listeners.get(MEETING_START_TRANSCRIPTION_EVENT)?.({
+            payload: undefined,
+          });
+        });
+      }
+      expect(mocks.listNotes).toHaveBeenCalled();
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to delete meeting note after recording start failed",
+      expect.any(Error),
+    );
+    expect(screen.getByLabelText("Note title")).toHaveValue("First note");
+    warn.mockRestore();
+  });
+
   it("clears the recorder presence and disables retry when a recovery is discarded", async () => {
     mocks.bootstrapApp.mockResolvedValue({
       folders: [],

--- a/src/test/note-editor.test.tsx
+++ b/src/test/note-editor.test.tsx
@@ -150,6 +150,46 @@ describe("NoteEditor", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a notice when a source recorded pure silence but the note is ready", () => {
+    render(
+      <NoteEditor
+        {...props}
+        note={note({
+          activeTab: "transcription",
+          sourceTranscripts: [
+            {
+              id: "turn-mic",
+              text: "",
+              source: "microphone",
+              startMs: 0,
+              endMs: 23_000,
+              turnIndex: 0,
+              status: "failed",
+              lastError:
+                "The microphone recorded silence for the whole session. Check that the right microphone is selected in Settings and that macOS input volume is up.",
+              recordedSilence: true,
+            },
+            {
+              id: "turn-system",
+              text: "System side text",
+              source: "system",
+              startMs: 0,
+              endMs: 23_000,
+              turnIndex: 1,
+              status: "succeeded",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(
+      screen.getAllByText(
+        "The microphone recorded silence for the whole session. Check that the right microphone is selected in Settings and that macOS input volume is up.",
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
   it("does not show transcript coverage notice without a warning", () => {
     const { rerender } = render(
       <NoteEditor

--- a/src/test/recorder.test.tsx
+++ b/src/test/recorder.test.tsx
@@ -60,6 +60,68 @@ describe("RecorderBar", () => {
     expect(onDone).toHaveBeenCalledWith("session-1");
   });
 
+  it("shows the mic silence warning when the microphone source reports it", () => {
+    render(
+      <RecorderBar
+        status={{
+          sessionId: "session-1",
+          state: "recording",
+          elapsedMs: 15_000,
+          level: { peak: 0, rms: 0, recentPeaks: [] },
+          silenceWarning: false,
+          sources: [
+            {
+              source: "microphone",
+              state: "recording",
+              elapsedMs: 15_000,
+              bytesWritten: 4096,
+              level: { peak: 0, rms: 0, recentPeaks: [] },
+              silenceWarning: true,
+              pathFinalized: false,
+            },
+          ],
+          bytesWritten: 4096,
+        }}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Mic looks silent")).toBeInTheDocument();
+  });
+
+  it("does not show the mic silence warning while the mic has signal", () => {
+    render(
+      <RecorderBar
+        status={{
+          sessionId: "session-1",
+          state: "recording",
+          elapsedMs: 15_000,
+          level: { peak: 0.7, rms: 0.3, recentPeaks: [0.4] },
+          silenceWarning: false,
+          sources: [
+            {
+              source: "microphone",
+              state: "recording",
+              elapsedMs: 15_000,
+              bytesWritten: 4096,
+              level: { peak: 0.7, rms: 0.3, recentPeaks: [0.4] },
+              silenceWarning: false,
+              pathFinalized: false,
+            },
+          ],
+          bytesWritten: 4096,
+        }}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onDone={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Mic looks silent")).not.toBeInTheDocument();
+  });
+
   it("uses resume action when paused", async () => {
     const user = userEvent.setup();
     const onResume = vi.fn();

--- a/src/test/routines-view.test.tsx
+++ b/src/test/routines-view.test.tsx
@@ -240,6 +240,29 @@ describe("RoutinesView list", () => {
     renderView();
     expect(await screen.findByText("gateway down")).toBeInTheDocument();
   });
+
+  it("wraps a Hermes server load error and retries the list", async () => {
+    const rawError = "Hermes API returned 500: Internal Server Error";
+    mocks.listRoutines.mockRejectedValueOnce(new Error(rawError)).mockResolvedValueOnce([job()]);
+    renderView();
+
+    expect(
+      await screen.findByText("June ran into a problem with that request."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(rawError, { exact: false })).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(mocks.listRoutines).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Morning summary")).toBeInTheDocument();
+  });
+
+  it("keeps non-Hermes load errors unchanged", async () => {
+    mocks.listRoutines.mockRejectedValue(new Error("gateway down"));
+    renderView();
+
+    expect(await screen.findByText("gateway down")).toBeInTheDocument();
+  });
 });
 
 describe("RoutinesView templates and creation", () => {
@@ -547,6 +570,28 @@ describe("RoutinesView detail", () => {
     expect(screen.getByText(/Model quota exhausted/)).toBeInTheDocument();
   });
 
+  it("wraps a detail reload Hermes server error and retries the detail", async () => {
+    const rawError = "Hermes API returned 500: Internal Server Error";
+    mocks.listRoutines.mockResolvedValueOnce([job()]);
+    renderView();
+    await openDetail("Morning summary");
+
+    mocks.listRoutines
+      .mockRejectedValueOnce(new Error(rawError))
+      .mockResolvedValueOnce([job({ state: "paused" })]);
+    await userEvent.click(screen.getByRole("switch", { name: "Morning summary active" }));
+
+    expect(
+      await screen.findByText("June ran into a problem with that request."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(rawError, { exact: false })).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    await waitFor(() => expect(mocks.listRoutines).toHaveBeenCalledTimes(3));
+    expect(await screen.findByText("Paused")).toBeInTheDocument();
+  });
+
   it("deletes a routine after confirmation and returns to the list", async () => {
     mocks.listRoutines.mockResolvedValue([job()]);
     renderView();
@@ -574,6 +619,7 @@ describe("RoutinesView detail", () => {
     await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
 
     expect(await screen.findByText("remove failed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
     expect(screen.getByRole("textbox", { name: "Routine name" })).toHaveValue("Morning summary");
   });
 });


### PR DESCRIPTION
Closes JUN-190, JUN-191, JUN-192, JUN-193, JUN-195, JUN-196, JUN-221.

## What changed

One integration branch fixing the recording/dictation reliability report cluster plus the agent recording gap, built as reviewed chunks:

- **JUN-221 - mic-only transcript coverage.** `transcribe_prepared_audio` now reports per-chunk outcomes (attempted / locally silent / provider no-speech), and `process_saved_audio` persists the same `transcript_coverage` checkpoint the dual-source path uses. Locally silent chunks are never counted as missing speech (CONTEXT.md coverage rule); the existing UI notice works unchanged.
- **JUN-190 - one truth for mic permission.** Meeting recording previously reported "granted" from cpal device presence. It now reads real TCC authorization (`AVCaptureDevice.authorizationStatusForMediaType` via objc2, AVFoundation linked with a regression probe test).
- **JUN-190/191 - the main app owns its own TCC prompt.** TCC grants are bundle-scoped; onboarding prompts through the dictation helper bundle, which never authorized the main app - the likely root cause of "granted but peak=0.0" recordings (an unauthorized app records zeros). `start_recording` now resolves `not_determined` with the app's own prompt before capture; denial is a structured error instead of a silent-zero recording. CONTEXT.md's Permission entry now states the bundle-scoped rule.
- **JUN-195 - dictation shortcut race.** Swift: a synchronous `startPending` closes the async `requestAccess` guard gap, toggle routing uses split state (a press during finalize is ignored, not errored), and a stop during a pending start cancels it. Rust: a toggle gate with in-flight tracking acked by real helper events, a 275ms debounce, and expiry for lost acks and stuck finalizing so a dead helper can't wedge the shortcut.
- **JUN-191/192 - silent capture is detected and said out loud.** Validation flags structurally-valid-but-silent artifacts (never fails them - silence is legitimate); a no-speech failure on a flagged source gets a targeted dead-capture message (start, retry, and recover paths all carry the flag); the already-computed live `silenceWarning` finally renders in the recorder bar and global pill; a ready note with a silent source shows a notice instead of burying the error; silent single-chunk files skip the metered provider call.
- **JUN-192 - no more orphaned draft notes.** `start_capture` gets a cancellation handshake and a 10s watchdog. The watchdog and builder share a tri-state commit (Pending/Published/Abandoned): a timed-out build tears itself down and can never register as the active capture, and a build that publishes just before the timeout is returned as success rather than stranded. The meeting-detected flow's note cleanup is reachable and best-effort.
- **JUN-196 - Routines errors are friendly and retryable.** The Hermes 5xx wrapper moved to `src/lib/errors.ts` and Routines adopts it across list/create/detail/run/delete plus the persisted last-run failure; list and detail load failures get a "Try again" action. The underlying cron 500 was fixed separately (#617) and ships with the next release - this PR owns the UI half.
- **JUN-193 - agent sessions fail loudly, and the agent can record.** A working session that vanishes from the runtime without an assistant reply now dispatches `failed` ("June stopped before replying."), records an error activity, and shows the session banner; an out-of-band completion stays quiet with exactly one terminal dispatch. New `june_recorder` MCP server (ADR-0013): start/stop/status tools route through the loopback proxy -> frontend event -> the existing visible recording flow, so agent-initiated capture always shows the recorder UI and reuses the tested self-heal. Recorder routes require a dedicated recorder-scoped token (mic control is not reachable with the general provider token). SOUL.md gains recording guidance with a never-proactive rule.

## Root causes (short version)

Draft orphans: note creation and recording-session creation are separate operations with an unbounded capture start between them. Dead mic at "granted": device-presence proxy for bundle-scoped TCC. Shortcut errors: two state machines with no shared truth and a finalize window that mis-routed presses. Raw 500s: Routines never adopted the existing error wrapper. Silent agent death: runtime disappearance was deliberately quiet with no reply-presence check.

## Validation

- `make verify` green (Biome, typecheck, vitest 134 files / 2134 passed, cargo fmt/clippy/test for both crates).
- Review battery (with-codex mode): Standards, Spec, and adversarial axes on codex; per-chunk adversarial passes during the build; convergence re-runs alternating harness (claude/codex) for three rounds. Every finding triaged: the battery caught and we fixed, among others, the bundle-scoped TCC gap, a dictation wedge on lost helper acks, a capture-start publish race, a reconcile double-dispatch, the recorder timeout-stack inconsistency (Hermes 30s vs proxy lease), non-idempotent start retries, and rollback misclassification (now idempotent via completed-request tombstones, lease pinned by a budget test against the real constants).
- Visual evidence (Chromium + faked IPC bridge): recorder silence warning, note silent-source notice, Routines friendly error + retry. Screenshots shared in the session; happy to attach here.
- **Native live QA: BLOCKED** without user-present hardware - dictation shortcut racing, real TCC prompts, Bluetooth device switching, and agent-initiated capture need a human with a mic and permission dialogs. The deterministic suites plus the adversarial battery carry these; the manual test plan below covers the rest.

## Manual test plan (needs a human + mic)

1. Fresh install (or `tccutil reset Microphone co.opensoftware.june`): press record on a note - expect the macOS mic prompt from June itself; deny -> clear error; allow -> recording starts.
2. Rapid dictation shortcut mashing (5+ presses in 2s) - expect no already_listening/not_listening error spam; dictation starts once and stops cleanly.
3. Record with input volume at zero - expect "Mic looks silent" in the recorder bar within ~10s, and after stop a note notice saying the microphone recorded silence (system text intact in meeting mode).
4. Ask the agent to "record this meeting" - expect a visible recording to start on a fresh note and the agent to confirm with the note title; "stop recording" ends it and processing starts.
5. Routines with the Hermes runtime stopped - expect the friendly error with Try again, no raw "Hermes API returned 500".

## Deliberate decisions / assumptions

- **Spec deviation (documented):** JUN-190's letter says the dictation helper is the authoritative mic-permission source. TCC grants are bundle-scoped, so the helper's grant cannot answer for the main app's capture; the correct rule ("the bundle that captures owns its authorization") is now in CONTEXT.md. Flagging for reviewer attention.
- Silent tracks are flagged, never failed - a silent source is still legitimately "the user didn't talk".
- Orphan cleanup happens only at the failure point; no background deletion of user data.
- An agent-started recording that outlives its request lease is stopped but its note is kept (real user data, visibly recorded).

## Out of scope / followups

- **Mic input-device-change rebuild** (Bluetooth handoff mid-recording): deliberately deferred - detection shipped, recovery needs live hardware QA. Follow-up issue drafted (attached in session; happy to file): mirror the Swift helper's CoreAudio default-device listener on the cpal side.
- Whether `microphone_plus_system` should be the default source mode (raised in JUN-195's report) - product question, untouched.
- The backend half of JUN-196 (cron import shadowing) shipped in #617.

## Needs June API deploy?

No. Everything is desktop-side (`src/`, `src-tauri/`); no `/v1/*` contract changes.

https://claude.ai/code/session_01Hxf2MWc3Q5fbLqdioXfgKk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786025821&installation_id=144203540&pr_number=650&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F650&signature=a7277ce7b24c3e434e1afcde47da525cb908057b53629172a54afc707ade1bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->