### PR TITLE
Document local tool-calling agent models

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ Per-repo config the engineering skills read before acting (see the
 
 - [hermes-architecture.md](hermes-architecture.md) — the agent runtime: bridge, gateway, control plane, sessions, models
 - [hermes-gateway-gotchas.md](hermes-gateway-gotchas.md) — integration gotchas: restart discipline, config contract, MCP OAuth, event types, upstream tool-schema quirks
+- [local-agent-models.md](local-agent-models.md) — local OpenAI-compatible agent models, including tool-calling setup and live verification
 - [audio-pipeline.md](audio-pipeline.md) — capture → source separation → turns → transcription → note
 - [june-api-prd.md](june-api-prd.md) — June API: upstream proxy + OS Accounts authorize/charge (the canonical backend spec)
 - [configuration.md](configuration.md) — env + config reference (desktop client + June API)

--- a/docs/local-agent-models.md
+++ b/docs/local-agent-models.md
@@ -1,0 +1,68 @@
+# Local agent models
+
+June can route Hermes agent chat through a user-supplied OpenAI-compatible
+endpoint. This is useful for local models served by tools such as vLLM, as long
+as the server supports the Chat Completions API shape Hermes uses:
+
+- `POST /v1/chat/completions`
+- OpenAI-style `tools` requests
+- OpenAI-style `tool_calls` responses
+- Optional `stream: true` server-sent events
+
+The local endpoint is only used after the user opts in from Settings. June still
+runs its built-in MCP servers through the June loopback proxy, so note search,
+web tools, image tools, and other Hermes tools continue to register separately
+from the local model endpoint.
+
+## GLM-4.5-Air with vLLM
+
+For GLM-4.5-Air, prefer vLLM because it has a GLM-4.5 tool parser. Start the
+server with automatic tool choice enabled:
+
+```bash
+vllm serve zai-org/GLM-4.5-Air \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --enable-auto-tool-choice \
+  --tool-call-parser glm45
+```
+
+If the server requires a bearer token, also pass vLLM's API key option and enter
+the same key in June's local model settings.
+
+## June settings
+
+Open Settings > Models > More options > Local model and enter:
+
+- Endpoint: `http://127.0.0.1:8000/v1`
+- Model ID: `zai-org/GLM-4.5-Air`
+- API key: blank, unless the local server requires one
+
+Use Test connection to read `/v1/models`, save the settings, then enable the
+local model. A loopback endpoint enables in one step. A non-loopback endpoint
+requires an extra confirmation because prompts leave this machine.
+
+For a running agent session, switch models from the composer model picker after
+enabling the local model. New sessions use the active Settings selection.
+
+## Live verification
+
+The local proxy has ignored tests for live endpoints. With the vLLM server above
+running:
+
+```bash
+JUNE_QA_LOCAL_BASE_URL=http://127.0.0.1:8000/v1 \
+JUNE_QA_LOCAL_MODEL=zai-org/GLM-4.5-Air \
+cargo test --manifest-path src-tauri/Cargo.toml --locked \
+  live_local_agent_proxy_returns_tool_calls -- --ignored --nocapture
+```
+
+If the local endpoint uses a bearer token, add:
+
+```bash
+JUNE_QA_LOCAL_API_KEY=<token>
+```
+
+The test sends an OpenAI-style tool schema through June's agent proxy and
+expects the model response to contain a `tool_calls` entry. This verifies the
+piece June needs for Hermes tools to execute.

--- a/src-tauri/src/june_api.rs
+++ b/src-tauri/src/june_api.rs
@@ -2124,6 +2124,37 @@ mod tests {
     }
 
     #[test]
+    fn agent_proxy_preserves_tool_request_fields() {
+        let mut body = serde_json::json!({
+            "model": "hermes-selected-model",
+            "messages": [{ "role": "user", "content": "call the tool" }],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "june_test_tool",
+                    "description": "Test tool",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "value": { "type": "string" }
+                        },
+                        "required": ["value"]
+                    }
+                }
+            }],
+            "tool_choice": "auto"
+        });
+
+        normalize_agent_chat_request_for_proxy(&mut body);
+
+        assert_eq!(body["tool_choice"], serde_json::json!("auto"));
+        assert_eq!(
+            body["tools"][0]["function"]["name"],
+            serde_json::json!("june_test_tool")
+        );
+    }
+
+    #[test]
     fn agent_proxy_caps_float_output_token_budgets_over_the_limit() {
         let mut body = serde_json::json!({
             "model": "hermes-selected-model",
@@ -2343,9 +2374,17 @@ mod live_local_tests {
             .unwrap_or_else(|| DEFAULT_LIVE_MODEL.to_string())
     }
 
+    fn live_api_key() -> String {
+        std::env::var("JUNE_QA_LOCAL_API_KEY")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_default()
+    }
+
     /// True when the live endpoint answers `GET {base}/models`. Used to skip
     /// gracefully instead of failing when no server is running.
-    async fn live_server_reachable(base_url: &str) -> bool {
+    async fn live_server_reachable(base_url: &str, api_key: &str) -> bool {
         let Ok(client) = reqwest::Client::builder()
             .no_proxy()
             .timeout(Duration::from_secs(3))
@@ -2353,7 +2392,11 @@ mod live_local_tests {
         else {
             return false;
         };
-        match client.get(format!("{base_url}/models")).send().await {
+        let mut request = client.get(format!("{base_url}/models"));
+        if !api_key.trim().is_empty() {
+            request = request.bearer_auth(api_key.trim());
+        }
+        match request.send().await {
             Ok(response) => response.status().is_success(),
             Err(_) => false,
         }
@@ -2362,7 +2405,9 @@ mod live_local_tests {
     fn skip_message(base_url: &str) -> String {
         format!(
             "SKIPPED: no OpenAI-compatible server reachable at {base_url}. \
-             Start one (e.g. `ollama serve`) or set JUNE_QA_LOCAL_BASE_URL."
+             Start one or set JUNE_QA_LOCAL_BASE_URL. For a tool-calling \
+             GLM-4.5-Air run, use vLLM with --enable-auto-tool-choice \
+             --tool-call-parser glm45."
         )
     }
 
@@ -2378,7 +2423,11 @@ mod live_local_tests {
         }
     }
 
-    fn install_live_local_provider(base_url: &str, model_id: &str) -> LiveSettingsGuard {
+    fn install_live_local_provider(
+        base_url: &str,
+        model_id: &str,
+        api_key: &str,
+    ) -> LiveSettingsGuard {
         static LOCK: Mutex<()> = Mutex::new(());
         let guard = LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut settings = crate::providers::default_settings_for_tests();
@@ -2387,7 +2436,7 @@ mod live_local_tests {
         settings.local_generation = LocalGenerationSettings {
             base_url: base_url.to_string(),
             model_id: model_id.to_string(),
-            api_key: String::new(),
+            api_key: api_key.to_string(),
         };
         crate::providers::replace_current_settings_for_tests(settings);
         LiveSettingsGuard(guard)
@@ -2400,14 +2449,15 @@ mod live_local_tests {
     #[ignore = "requires a live local OpenAI-compatible server"]
     async fn live_local_probe_lists_pulled_models() {
         let base_url = live_base_url();
-        if !live_server_reachable(&base_url).await {
+        let api_key = live_api_key();
+        if !live_server_reachable(&base_url, &api_key).await {
             eprintln!("{}", skip_message(&base_url));
             return;
         }
 
         let probe = probe_local_generation_endpoint(ProbeLocalGenerationEndpointRequest {
             base_url: base_url.clone(),
-            api_key: String::new(),
+            api_key,
         })
         .await
         .expect("probe against the live endpoint should succeed");
@@ -2432,12 +2482,13 @@ mod live_local_tests {
     #[ignore = "requires a live local OpenAI-compatible server"]
     async fn live_local_note_generation_returns_clean_markdown() {
         let base_url = live_base_url();
-        if !live_server_reachable(&base_url).await {
+        let api_key = live_api_key();
+        if !live_server_reachable(&base_url, &api_key).await {
             eprintln!("{}", skip_message(&base_url));
             return;
         }
         let model = live_model();
-        let _guard = install_live_local_provider(&base_url, &model);
+        let _guard = install_live_local_provider(&base_url, &model, &api_key);
 
         let transcript = "\
 Microphone: Alright, let's kick off the weekly sync. First up is the release timeline.
@@ -2487,12 +2538,13 @@ Microphone: Great. Let's ship the feed fix this week, then review the onboarding
     #[ignore = "requires a live local OpenAI-compatible server"]
     async fn live_local_agent_proxy_completes_buffered_and_streaming() {
         let base_url = live_base_url();
-        if !live_server_reachable(&base_url).await {
+        let api_key = live_api_key();
+        if !live_server_reachable(&base_url, &api_key).await {
             eprintln!("{}", skip_message(&base_url));
             return;
         }
         let model = live_model();
-        let _guard = install_live_local_provider(&base_url, &model);
+        let _guard = install_live_local_provider(&base_url, &model, &api_key);
 
         // Buffered request, exactly what the session-title path sends.
         let response = proxy_agent_chat_completions(serde_json::json!({
@@ -2561,6 +2613,84 @@ Microphone: Great. Let's ship the feed fix this week, then review the onboarding
         assert!(
             has_parseable_delta,
             "SSE stream should contain at least one parseable chat.completion.chunk"
+        );
+    }
+
+    /// Drives a real local endpoint through June's agent proxy with OpenAI-style
+    /// tools. This is the live proof needed for local tool-calling models such as
+    /// GLM-4.5-Air served by vLLM with `--enable-auto-tool-choice
+    /// --tool-call-parser glm45`.
+    #[tokio::test]
+    #[ignore = "requires a live local OpenAI-compatible server with tool calling enabled"]
+    async fn live_local_agent_proxy_returns_tool_calls() {
+        let base_url = live_base_url();
+        let api_key = live_api_key();
+        if !live_server_reachable(&base_url, &api_key).await {
+            eprintln!("{}", skip_message(&base_url));
+            return;
+        }
+        let model = live_model();
+        let _guard = install_live_local_provider(&base_url, &model, &api_key);
+
+        let response = proxy_agent_chat_completions(serde_json::json!({
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Use the june_test_weather tool for New York City. Do not answer directly."
+                }
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "june_test_weather",
+                        "description": "Gets the current weather for one city.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "city": {
+                                    "type": "string",
+                                    "description": "The city to check."
+                                }
+                            },
+                            "required": ["city"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            ],
+            "tool_choice": "auto",
+            "stream": false,
+            "max_tokens": 512,
+        }))
+        .await
+        .expect("live local tool-call proxy call should succeed");
+
+        assert_eq!(response.status, 200);
+        let body = response
+            .collect_body()
+            .await
+            .expect("proxy body should be readable");
+        let value: serde_json::Value =
+            serde_json::from_slice(&body).expect("proxy body should be an OpenAI completion");
+        let tool_calls = value
+            .get("choices")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("tool_calls"))
+            .and_then(serde_json::Value::as_array)
+            .expect("completion should include tool_calls");
+
+        assert!(
+            tool_calls.iter().any(|tool_call| {
+                tool_call
+                    .get("function")
+                    .and_then(|function| function.get("name"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some("june_test_weather")
+            }),
+            "expected june_test_weather tool call in {value:#}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a local agent model runbook with the vLLM GLM-4.5-Air tool-calling command, June settings values, and live verification command.
- Adds Rust coverage that June's agent proxy preserves OpenAI-style tool request fields.
- Extends ignored live local endpoint tests to support optional bearer auth and assert real `tool_calls` responses through June's proxy.

## Root cause

June already had the local generation path, but the GLM-4.5-Air tool-calling setup and the exact proxy-level proof were not documented or directly testable. That made it hard to verify whether a local OpenAI-compatible server could power Hermes tools.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked agent_proxy_preserves_tool_request_fields`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked live_local_agent_proxy_returns_tool_calls -- --ignored --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked agent_proxy`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked local_generation`
- `git diff --check`

- [x] Tested visually where it matters (UI changes: attach a screenshot or recording). Not applicable: docs and Rust proxy tests only.
- [ ] Needs a June API (backend) deploy before it works end to end. Desktop-only docs/tests; no backend deploy required.

## Out of scope

- Does not change the local model UI or Hermes runtime behavior.
- Does not bundle or install vLLM or GLM-4.5-Air.

## Followups

- Run the documented live test with `JUNE_QA_LOCAL_BASE_URL=http://127.0.0.1:8000/v1` and `JUNE_QA_LOCAL_MODEL=zai-org/GLM-4.5-Air` when a vLLM GLM-4.5-Air server is available.

## Security and release checklist

- [x] No secrets, local `.env` values, signing material, tokens, or customer data are committed.
- [ ] Security-sensitive changes were called out in the summary.
- [ ] Workflow action references are pinned to full-length commit SHAs.
- [ ] Desktop signing, updater, entitlement, capability, or release changes have owner review.
- [ ] Backend auth, billing, metering, CORS, rate limit, or logging changes have owner review.
- [x] User-facing copy follows the repo UI conventions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-software-network/codesmith/os-june/pr/653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786040251&installation_id=144203540&pr_number=653&repository=open-software-network%2Fos-june&return_to=https%3A%2F%2Fgithub.com%2Fopen-software-network%2Fos-june%2Fpull%2F653&signature=393982cd35e783344b2dccb8cb737e82ac95fb0152d854cf2d8310a4898ab5de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->